### PR TITLE
Marketplace: Add Support for Preinstalled Premium Plugins

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -15,6 +15,7 @@ import {
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { PREINSTALLED_PREMIUM_PLUGINS } from 'calypso/my-sites/plugins/constants';
 import { sanitizeSectionContent } from './sanitize-section-content';
 
 /**
@@ -182,6 +183,16 @@ export function normalizeCompatibilityList( compatibilityList ) {
 
 export function normalizePluginData( plugin, pluginData ) {
 	plugin = getAllowedPluginData( { ...plugin, ...pluginData } );
+
+	// Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
+	// but require a paid upgrade to function.
+	if ( !! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] && ! plugin.variations ) {
+		const { monthly, yearly } = PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].products;
+		plugin.variations = {
+			monthly: { product_slug: monthly },
+			yearly: { product_slug: yearly },
+		};
+	}
 
 	return Object.entries( plugin ).reduce( ( returnData, [ key, item ] ) => {
 		switch ( key ) {

--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -1,3 +1,8 @@
+import {
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	WPCOM_FEATURES_INSTANT_SEARCH,
+} from '@automattic/calypso-products';
+
 export const PREINSTALLED_PLUGINS = [
 	'jetpack',
 	'akismet',
@@ -7,3 +12,10 @@ export const PREINSTALLED_PLUGINS = [
 	'layout-grid',
 	'page-optimize',
 ];
+
+export const PREINSTALLED_PREMIUM_PLUGINS = {
+	'jetpack-search': {
+		feature: WPCOM_FEATURES_INSTANT_SEARCH,
+		product: PRODUCT_JETPACK_SEARCH_MONTHLY,
+	},
+};

--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -1,4 +1,5 @@
 import {
+	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	WPCOM_FEATURES_INSTANT_SEARCH,
 } from '@automattic/calypso-products';
@@ -16,6 +17,9 @@ export const PREINSTALLED_PLUGINS = [
 export const PREINSTALLED_PREMIUM_PLUGINS = {
 	'jetpack-search': {
 		feature: WPCOM_FEATURES_INSTANT_SEARCH,
-		product: PRODUCT_JETPACK_SEARCH_MONTHLY,
+		products: {
+			monthly: PRODUCT_JETPACK_SEARCH_MONTHLY,
+			yearly: PRODUCT_JETPACK_SEARCH,
+		},
 	},
 };

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -15,9 +15,9 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
 import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { getPeriodVariationValue } from '../plugin-price';
+import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 
 export default function CTAButton( {
 	plugin,
@@ -68,7 +68,8 @@ export default function CTAButton( {
 		[ dispatch, keepMeUpdatedPreferenceId, userId ]
 	);
 
-	const isPreinstalledPremiumPlugin = !! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ];
+	const { isPreinstalledPremiumPlugin, preinstalledPremiumPluginProduct } =
+		usePreinstalledPremiumPlugin( plugin.slug );
 
 	return (
 		<>
@@ -135,6 +136,7 @@ export default function CTAButton( {
 						billingPeriod,
 						eligibleForProPlan,
 						isPreinstalledPremiumPlugin,
+						preinstalledPremiumPluginProduct,
 					} );
 				} }
 				disabled={ ( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false }
@@ -179,6 +181,7 @@ function onClickInstallPlugin( {
 	billingPeriod,
 	eligibleForProPlan,
 	isPreinstalledPremiumPlugin,
+	preinstalledPremiumPluginProduct,
 } ) {
 	dispatch( removePluginStatuses( 'completed', 'error' ) );
 
@@ -228,10 +231,7 @@ function onClickInstallPlugin( {
 	}
 
 	if ( isPreinstalledPremiumPlugin ) {
-		const variationPeriod = getPeriodVariationValue( billingPeriod );
-		const checkoutUrl = `/checkout/${ selectedSite.slug }/${
-			PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].products[ variationPeriod ]
-		}`;
+		const checkoutUrl = `/checkout/${ selectedSite.slug }/${ preinstalledPremiumPluginProduct }`;
 		const installUrl = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
 		return page( `${ checkoutUrl }?redirect_to=${ installUrl }#step2` );
 	}

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -228,8 +228,9 @@ function onClickInstallPlugin( {
 	}
 
 	if ( isPreinstalledPremiumPlugin ) {
+		const variationPeriod = getPeriodVariationValue( billingPeriod );
 		const checkoutUrl = `/checkout/${ selectedSite.slug }/${
-			PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].product
+			PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].products[ variationPeriod ]
 		}`;
 		const installUrl = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
 		return page( `${ checkoutUrl }?redirect_to=${ installUrl }#step2` );

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -1,0 +1,253 @@
+import { Button, Dialog } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useCallback, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import { businessPlanToAdd } from 'calypso/lib/plugins/utils';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
+import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
+import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
+import { getPeriodVariationValue } from '../plugin-price';
+
+export default function CTAButton( {
+	plugin,
+	selectedSite,
+	shouldUpgrade,
+	hasEligibilityMessages,
+	isMarketplaceProduct,
+	billingPeriod,
+	isJetpackSelfHosted,
+	isSiteConnected,
+} ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const [ showEligibility, setShowEligibility ] = useState( false );
+	const [ showAddCustomDomain, setShowAddCustomDomain ] = useState( false );
+
+	// Keep me updated
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const keepMeUpdatedPreferenceId = `jetpack-self-hosted-keep-updated-${ userId }`;
+	const keepMeUpdatedPreference = useSelector( ( state ) =>
+		getPreference( state, keepMeUpdatedPreferenceId )
+	);
+	const hasPreferences = useSelector( hasReceivedRemotePreferences );
+
+	const primaryDomain = useSelector( ( state ) =>
+		getPrimaryDomainBySiteId( state, selectedSite?.ID )
+	);
+
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+
+	const pluginRequiresCustomPrimaryDomain =
+		( primaryDomain?.isWPCOMDomain || primaryDomain?.isWpcomStagingDomain ) &&
+		plugin?.requirements?.required_primary_domain;
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+
+	const updatedKeepMeUpdatedPreference = useCallback(
+		( isChecked ) => {
+			dispatch( savePreference( keepMeUpdatedPreferenceId, isChecked ) );
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_availability_jetpack_self_hosted', {
+					user_id: userId,
+					value: isChecked,
+				} )
+			);
+		},
+		[ dispatch, keepMeUpdatedPreferenceId, userId ]
+	);
+
+	const isPreinstalledPremiumPlugin = !! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ];
+
+	return (
+		<>
+			<PluginCustomDomainDialog
+				onProceed={ () => {
+					if ( hasEligibilityMessages ) {
+						return setShowEligibility( true );
+					}
+					onClickInstallPlugin( {
+						dispatch,
+						selectedSite,
+						plugin,
+						upgradeAndInstall: shouldUpgrade,
+						isMarketplaceProduct,
+						billingPeriod,
+						eligibleForProPlan,
+					} );
+				} }
+				isDialogVisible={ showAddCustomDomain }
+				plugin={ plugin }
+				domains={ domains }
+				closeDialog={ () => setShowAddCustomDomain( false ) }
+			/>
+			<Dialog
+				additionalClassNames={ 'plugin-details-CTA__dialog-content' }
+				additionalOverlayClassNames={ 'plugin-details-CTA__modal-overlay' }
+				isVisible={ showEligibility }
+				title={ translate( 'Eligibility' ) }
+				onClose={ () => setShowEligibility( false ) }
+			>
+				<EligibilityWarnings
+					currentContext={ 'plugin-details' }
+					isMarketplace={ isMarketplaceProduct }
+					standaloneProceed
+					onProceed={ () =>
+						onClickInstallPlugin( {
+							dispatch,
+							selectedSite,
+							plugin,
+							upgradeAndInstall: shouldUpgrade,
+							isMarketplaceProduct,
+							billingPeriod,
+							eligibleForProPlan,
+						} )
+					}
+				/>
+			</Dialog>
+			<Button
+				className="plugin-details-CTA__install-button"
+				primary
+				onClick={ () => {
+					if ( pluginRequiresCustomPrimaryDomain ) {
+						return setShowAddCustomDomain( true );
+					}
+					if ( hasEligibilityMessages ) {
+						return setShowEligibility( true );
+					}
+					onClickInstallPlugin( {
+						dispatch,
+						selectedSite,
+						plugin,
+						upgradeAndInstall: shouldUpgrade,
+						isMarketplaceProduct,
+						billingPeriod,
+						eligibleForProPlan,
+						isPreinstalledPremiumPlugin,
+					} );
+				} }
+				disabled={ ( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false }
+			>
+				{
+					// eslint-disable-next-line no-nested-ternary
+					isMarketplaceProduct || isPreinstalledPremiumPlugin
+						? translate( 'Purchase and activate' )
+						: shouldUpgrade
+						? translate( 'Upgrade and activate' )
+						: translate( 'Install and activate' )
+				}
+			</Button>
+			{ isJetpackSelfHosted && isMarketplaceProduct && (
+				<div className="plugin-details-CTA__not-available">
+					<p className="plugin-details-CTA__not-available-text">
+						{ translate( 'Thanks for your interest. ' ) }
+						{ translate(
+							'Paid plugins are not yet available for Jetpack Sites but we can notify you when they are ready.'
+						) }
+					</p>
+					{ hasPreferences && (
+						<ToggleControl
+							className="plugin-details-CTA__follow-toggle"
+							label={ translate( 'Keep me updated' ) }
+							checked={ keepMeUpdatedPreference }
+							onChange={ updatedKeepMeUpdatedPreference }
+						/>
+					) }
+				</div>
+			) }
+		</>
+	);
+}
+
+function onClickInstallPlugin( {
+	dispatch,
+	selectedSite,
+	plugin,
+	upgradeAndInstall,
+	isMarketplaceProduct,
+	billingPeriod,
+	eligibleForProPlan,
+	isPreinstalledPremiumPlugin,
+} ) {
+	dispatch( removePluginStatuses( 'completed', 'error' ) );
+
+	dispatch(
+		recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', plugin.slug )
+	);
+	dispatch(
+		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
+			site: selectedSite?.ID,
+			plugin: plugin.slug,
+		} )
+	);
+	dispatch(
+		recordTracksEvent( 'calypso_plugin_install_activate_click', {
+			plugin: plugin.slug,
+			blog_id: selectedSite?.ID,
+			marketplace_product: isMarketplaceProduct,
+			needs_plan_upgrade: upgradeAndInstall,
+		} )
+	);
+
+	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
+
+	if ( isMarketplaceProduct ) {
+		// We need to add the product to the  cart.
+		// Plugin install is handled on the backend by activating the subscription.
+		const variationPeriod = getPeriodVariationValue( billingPeriod );
+		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
+
+		if ( upgradeAndInstall ) {
+			// We also need to add a business plan to the cart.
+			return page(
+				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
+					selectedSite?.plan,
+					billingPeriod,
+					eligibleForProPlan,
+					true
+				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
+					selectedSite.slug
+				}`
+			);
+		}
+
+		return page(
+			`/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
+		);
+	}
+
+	if ( isPreinstalledPremiumPlugin ) {
+		const checkoutUrl = `/checkout/${ selectedSite.slug }/${
+			PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].product
+		}`;
+		const installUrl = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
+		return page( `${ checkoutUrl }?redirect_to=${ installUrl }#step2` );
+	}
+
+	// After buying a plan we need to redirect to the plugin install page.
+	const installPluginURL = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
+	if ( upgradeAndInstall ) {
+		// We also need to add a business plan to the cart.
+		return page(
+			`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
+				selectedSite?.plan,
+				billingPeriod,
+				eligibleForProPlan
+			) }?redirect_to=${ installPluginURL }#step2`
+		);
+	}
+
+	// No need to go through chekout, go to install page directly.
+	return page( installPluginURL );
+}

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -4,35 +4,21 @@ import {
 	FEATURE_INSTALL_PLUGINS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
-import { Button, Dialog } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
-import { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
-import { businessPlanToAdd } from 'calypso/lib/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
-import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
-import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
-import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
-import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { PREINSTALLED_PLUGINS } from '../constants';
-import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
-import { PluginPrice, getPeriodVariationValue } from '../plugin-price';
+import { PREINSTALLED_PLUGINS, PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
+import { PluginPrice } from '../plugin-price';
+import CTAButton from './CTA-button';
+import PluginDetailsCTAPreinstalledPremiumPlugins from './preinstalled-premium-plugins-CTA';
 import USPS from './usps';
 import './style.scss';
 
@@ -119,6 +105,19 @@ const PluginDetailsCTA = ( {
 		return null;
 	}
 
+	// Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
+	// but require a paid upgrade to function.
+	if ( PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] ) {
+		return (
+			<div className="plugin-details-CTA__container">
+				<PluginDetailsCTAPreinstalledPremiumPlugins
+					isPluginInstalledOnsite={ isPluginInstalledOnsite }
+					plugin={ plugin }
+				/>
+			</div>
+		);
+	}
+
 	if ( isPluginInstalledOnsite ) {
 		// Check if already instlaled on the site
 		return null;
@@ -130,7 +129,7 @@ const PluginDetailsCTA = ( {
 			<div className="plugin-details-CTA__container">
 				<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
 				<span className="plugin-details-CTA__preinstalled">
-					{ plugin.name + translate( ' is automatically managed for you.' ) }
+					{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }
 				</span>
 			</div>
 		);
@@ -225,227 +224,6 @@ function PluginDetailsCTAPlaceholder() {
 			<div className="plugin-details-CTA__t-and-c">...</div>
 		</div>
 	);
-}
-
-function CTAButton( {
-	plugin,
-	selectedSite,
-	shouldUpgrade,
-	hasEligibilityMessages,
-	isMarketplaceProduct,
-	billingPeriod,
-	isJetpackSelfHosted,
-	isSiteConnected,
-} ) {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const [ showEligibility, setShowEligibility ] = useState( false );
-	const [ showAddCustomDomain, setShowAddCustomDomain ] = useState( false );
-
-	// Keep me updated
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
-	const keepMeUpdatedPreferenceId = `jetpack-self-hosted-keep-updated-${ userId }`;
-	const keepMeUpdatedPreference = useSelector( ( state ) =>
-		getPreference( state, keepMeUpdatedPreferenceId )
-	);
-	const hasPreferences = useSelector( hasReceivedRemotePreferences );
-
-	const primaryDomain = useSelector( ( state ) =>
-		getPrimaryDomainBySiteId( state, selectedSite?.ID )
-	);
-
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, selectedSite?.ID )
-	);
-
-	const pluginRequiresCustomPrimaryDomain =
-		( primaryDomain?.isWPCOMDomain || primaryDomain?.isWpcomStagingDomain ) &&
-		plugin?.requirements?.required_primary_domain;
-	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
-
-	const updatedKeepMeUpdatedPreference = useCallback(
-		( isChecked ) => {
-			dispatch( savePreference( keepMeUpdatedPreferenceId, isChecked ) );
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_availability_jetpack_self_hosted', {
-					user_id: userId,
-					value: isChecked,
-				} )
-			);
-		},
-		[ keepMeUpdatedPreferenceId, userId ]
-	);
-
-	return (
-		<>
-			<PluginCustomDomainDialog
-				onProceed={ () => {
-					if ( hasEligibilityMessages ) {
-						return setShowEligibility( true );
-					}
-					onClickInstallPlugin( {
-						dispatch,
-						selectedSite,
-						plugin,
-						upgradeAndInstall: shouldUpgrade,
-						isMarketplaceProduct,
-						billingPeriod,
-						eligibleForProPlan,
-					} );
-				} }
-				isDialogVisible={ showAddCustomDomain }
-				plugin={ plugin }
-				domains={ domains }
-				closeDialog={ () => setShowAddCustomDomain( false ) }
-			/>
-			<Dialog
-				additionalClassNames={ 'plugin-details-CTA__dialog-content' }
-				additionalOverlayClassNames={ 'plugin-details-CTA__modal-overlay' }
-				isVisible={ showEligibility }
-				title={ translate( 'Eligibility' ) }
-				onClose={ () => setShowEligibility( false ) }
-			>
-				<EligibilityWarnings
-					currentContext={ 'plugin-details' }
-					isMarketplace={ isMarketplaceProduct }
-					standaloneProceed
-					onProceed={ () =>
-						onClickInstallPlugin( {
-							dispatch,
-							selectedSite,
-							plugin,
-							upgradeAndInstall: shouldUpgrade,
-							isMarketplaceProduct,
-							billingPeriod,
-							eligibleForProPlan,
-						} )
-					}
-				/>
-			</Dialog>
-			<Button
-				className="plugin-details-CTA__install-button"
-				primary
-				onClick={ () => {
-					if ( pluginRequiresCustomPrimaryDomain ) {
-						return setShowAddCustomDomain( true );
-					}
-					if ( hasEligibilityMessages ) {
-						return setShowEligibility( true );
-					}
-					onClickInstallPlugin( {
-						dispatch,
-						selectedSite,
-						plugin,
-						upgradeAndInstall: shouldUpgrade,
-						isMarketplaceProduct,
-						billingPeriod,
-						eligibleForProPlan,
-					} );
-				} }
-				disabled={ ( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false }
-			>
-				{
-					// eslint-disable-next-line no-nested-ternary
-					isMarketplaceProduct
-						? translate( 'Purchase and activate' )
-						: shouldUpgrade
-						? translate( 'Upgrade and activate' )
-						: translate( 'Install and activate' )
-				}
-			</Button>
-			{ isJetpackSelfHosted && isMarketplaceProduct && (
-				<div className="plugin-details-CTA__not-available">
-					<p className="plugin-details-CTA__not-available-text">
-						{ translate( 'Thanks for your interest. ' ) }
-						{ translate(
-							'Paid plugins are not yet available for Jetpack Sites but we can notify you when they are ready.'
-						) }
-					</p>
-					{ hasPreferences && (
-						<ToggleControl
-							className="plugin-details-CTA__follow-toggle"
-							label={ translate( 'Keep me updated' ) }
-							checked={ keepMeUpdatedPreference }
-							onChange={ updatedKeepMeUpdatedPreference }
-						/>
-					) }
-				</div>
-			) }
-		</>
-	);
-}
-
-function onClickInstallPlugin( {
-	dispatch,
-	selectedSite,
-	plugin,
-	upgradeAndInstall,
-	isMarketplaceProduct,
-	billingPeriod,
-	eligibleForProPlan,
-} ) {
-	dispatch( removePluginStatuses( 'completed', 'error' ) );
-
-	dispatch(
-		recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', plugin.slug )
-	);
-	dispatch(
-		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
-			site: selectedSite?.ID,
-			plugin: plugin.slug,
-		} )
-	);
-	dispatch(
-		recordTracksEvent( 'calypso_plugin_install_activate_click', {
-			plugin: plugin.slug,
-			blog_id: selectedSite?.ID,
-			marketplace_product: isMarketplaceProduct,
-			needs_plan_upgrade: upgradeAndInstall,
-		} )
-	);
-
-	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
-
-	if ( isMarketplaceProduct ) {
-		// We need to add the product to the  cart.
-		// Plugin install is handled on the backend by activating the subscription.
-		const variationPeriod = getPeriodVariationValue( billingPeriod );
-		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
-
-		if ( upgradeAndInstall ) {
-			// We also need to add a business plan to the cart.
-			return page(
-				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
-					selectedSite?.plan,
-					billingPeriod,
-					eligibleForProPlan,
-					true
-				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
-					selectedSite.slug
-				}`
-			);
-		}
-
-		return page(
-			`/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
-		);
-	}
-
-	// After buying a plan we need to redirect to the plugin install page.
-	const installPluginURL = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
-	if ( upgradeAndInstall ) {
-		// We also need to add a business plan to the cart.
-		return page(
-			`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
-				selectedSite?.plan,
-				billingPeriod,
-				eligibleForProPlan
-			) }?redirect_to=${ installPluginURL }#step2`
-		);
-	}
-
-	// No need to go through chekout, go to install page directly.
-	return page( installPluginURL );
 }
 
 export default PluginDetailsCTA;

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -15,8 +15,9 @@ import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors'
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { PREINSTALLED_PLUGINS, PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
+import { PREINSTALLED_PLUGINS } from '../constants';
 import { PluginPrice } from '../plugin-price';
+import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 import CTAButton from './CTA-button';
 import PluginDetailsCTAPreinstalledPremiumPlugins from './preinstalled-premium-plugins-CTA';
 import USPS from './usps';
@@ -61,6 +62,8 @@ const PluginDetailsCTA = ( {
 	);
 	const hasEligibilityMessages =
 		! isAtomic && ! isJetpack && ( eligibilityHolds?.length || eligibilityWarnings?.length );
+
+	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsCTAPlaceholder />;
@@ -107,7 +110,7 @@ const PluginDetailsCTA = ( {
 
 	// Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
 	// but require a paid upgrade to function.
-	if ( PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] ) {
+	if ( isPreinstalledPremiumPlugin ) {
 		return (
 			<div className="plugin-details-CTA__container">
 				<PluginDetailsCTAPreinstalledPremiumPlugins

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -1,6 +1,9 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -19,6 +22,8 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 	isPluginInstalledOnsite,
 	plugin,
 } ) {
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );
@@ -47,39 +52,52 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		</span>
 	);
 	const pluginPrice = (
-		<div className="plugin-details-CTA__price">
-			<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
-				{ ( { isFetching, price, period } ) =>
-					isFetching ? (
-						<div className="plugin-details-CTA__price-placeholder">...</div>
-					) : (
-						<>
-							{ price + ' ' }
-							<span className="plugin-details-CTA__period">{ period }</span>
-						</>
-					)
-				}
-			</PluginPrice>
-		</div>
+		<>
+			<div className="plugin-details-CTA__price">
+				<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
+					{ ( { isFetching, price, period } ) =>
+						isFetching ? (
+							<div className="plugin-details-CTA__price-placeholder">...</div>
+						) : (
+							<>
+								{ price + ' ' }
+								<span className="plugin-details-CTA__period">{ period }</span>
+							</>
+						)
+					}
+				</PluginPrice>
+			</div>
+			{ ! legacyVersion && (
+				<BillingIntervalSwitcher
+					billingPeriod={ billingPeriod }
+					onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
+					plugin={ plugin }
+				/>
+			) }
+		</>
 	);
 
 	const upgradeButton = (
-		<Button
-			className="plugin-details-CTA__install-button"
-			href={ `/checkout/${ selectedSiteSlug }/${ pluginProduct }` }
-			primary
-		>
-			{ translate( 'Upgrade %s', { args: plugin.name } ) }
-		</Button>
+		<div className="plugin-details-CTA__install">
+			<Button
+				className="plugin-details-CTA__install-button"
+				href={ `/checkout/${ selectedSiteSlug }/${ pluginProduct }` }
+				primary
+			>
+				{ translate( 'Upgrade %s', { args: plugin.name } ) }
+			</Button>
+		</div>
 	);
 	const activateButton = (
-		<CTAButton
-			billingPeriod={ billingPeriod }
-			isJetpackSelfHosted={ isJetpackSelfHosted }
-			isSiteConnected={ isSiteConnected }
-			plugin={ plugin }
-			selectedSite={ selectedSite }
-		/>
+		<div className="plugin-details-CTA__install">
+			<CTAButton
+				billingPeriod={ billingPeriod }
+				isJetpackSelfHosted={ isJetpackSelfHosted }
+				isSiteConnected={ isSiteConnected }
+				plugin={ plugin }
+				selectedSite={ selectedSite }
+			/>
+		</div>
 	);
 
 	if ( isSimple && hasFeature ) {

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -1,0 +1,83 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+import { PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
+import CTAButton from './CTA-button';
+
+export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
+	isPluginInstalledOnsite,
+	plugin,
+} ) {
+	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSiteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
+	const isJetpackSelfHosted = selectedSiteId && isJetpack && ! isAtomic;
+	const isSimple = selectedSiteId && ! isAtomic && ! isJetpack;
+	const isSiteConnected = useSelector( ( state ) =>
+		getSiteConnectionStatus( state, selectedSiteId )
+	);
+	const hasFeature = useSelector( ( state ) =>
+		siteHasFeature( state, selectedSiteId, PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].feature )
+	);
+
+	const managedPluginMessage = (
+		<span className="plugin-details-CTA__preinstalled">
+			{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }
+		</span>
+	);
+	const upgradeButton = (
+		<Button
+			className="plugin-details-CTA__install-button"
+			href={ `/checkout/${ selectedSiteSlug }/${
+				PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].product
+			}` }
+			primary
+		>
+			{ translate( 'Upgrade %s', { args: plugin.name } ) }
+		</Button>
+	);
+	const activateButton = (
+		<CTAButton
+			isJetpackSelfHosted={ isJetpackSelfHosted }
+			isSiteConnected={ isSiteConnected }
+			isPreinstalledPremiumPlugin
+			plugin={ plugin }
+			selectedSite={ selectedSite }
+		/>
+	);
+
+	if ( isSimple && hasFeature ) {
+		return managedPluginMessage;
+	}
+	if ( isSimple && ! hasFeature ) {
+		return (
+			<>
+				{ managedPluginMessage }
+				{ upgradeButton }
+			</>
+		);
+	}
+
+	if ( ! isSimple && ! isPluginInstalledOnsite ) {
+		return { activateButton };
+	}
+
+	if ( ! isSimple && isPluginInstalledOnsite && ! hasFeature ) {
+		return upgradeButton;
+	}
+
+	return null;
+}

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -7,15 +7,14 @@ import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/a
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import { PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
-import { getPeriodVariationValue, PluginPrice } from '../plugin-price';
+import { PluginPrice } from '../plugin-price';
+import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 import CTAButton from './CTA-button';
 
 export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
@@ -38,13 +37,8 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 	);
 
 	const billingPeriod = useSelector( getBillingInterval );
-	const { feature: pluginFeature, products: pluginProducts } =
-		PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ];
-	const pluginProduct = pluginProducts[ getPeriodVariationValue( billingPeriod ) ];
-
-	const hasFeature = useSelector( ( state ) =>
-		siteHasFeature( state, selectedSiteId, pluginFeature )
-	);
+	const { isPreinstalledPremiumPluginUpgraded, preinstalledPremiumPluginProduct } =
+		usePreinstalledPremiumPlugin( plugin.slug );
 
 	const managedPluginMessage = (
 		<span className="plugin-details-CTA__preinstalled">
@@ -81,7 +75,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		<div className="plugin-details-CTA__install">
 			<Button
 				className="plugin-details-CTA__install-button"
-				href={ `/checkout/${ selectedSiteSlug }/${ pluginProduct }` }
+				href={ `/checkout/${ selectedSiteSlug }/${ preinstalledPremiumPluginProduct }` }
 				primary
 			>
 				{ translate( 'Upgrade %s', { args: plugin.name } ) }
@@ -100,10 +94,10 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		</div>
 	);
 
-	if ( isSimple && hasFeature ) {
+	if ( isSimple && isPreinstalledPremiumPluginUpgraded ) {
 		return managedPluginMessage;
 	}
-	if ( isSimple && ! hasFeature ) {
+	if ( isSimple && ! isPreinstalledPremiumPluginUpgraded ) {
 		return (
 			<>
 				{ pluginPrice }
@@ -122,7 +116,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		);
 	}
 
-	if ( ! isSimple && isPluginInstalledOnsite && ! hasFeature ) {
+	if ( ! isSimple && isPluginInstalledOnsite && ! isPreinstalledPremiumPluginUpgraded ) {
 		return (
 			<>
 				{ pluginPrice }

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -72,7 +72,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 	}
 
 	if ( ! isSimple && ! isPluginInstalledOnsite ) {
-		return { activateButton };
+		return activateButton;
 	}
 
 	if ( ! isSimple && isPluginInstalledOnsite && ! hasFeature ) {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -65,6 +65,7 @@ import {
 	isRequestingSites as checkRequestingSites,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { PREINSTALLED_PREMIUM_PLUGINS } from './constants';
 import NoPermissionsError from './no-permissions-error';
 
 function PluginDetails( props ) {
@@ -206,6 +207,14 @@ function PluginDetails( props ) {
 		requestingPluginsForSites,
 	] );
 
+	const isUpgradeablePreinstalledPremiumPlugin = useSelector( ( state ) => {
+		const preinstalledPremiumPlugin = PREINSTALLED_PREMIUM_PLUGINS[ fullPlugin.slug ];
+		return (
+			!! preinstalledPremiumPlugin &&
+			! siteHasFeature( state, selectedSite?.ID, preinstalledPremiumPlugin.feature )
+		);
+	} );
+
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
 			dispatch(
@@ -270,6 +279,7 @@ function PluginDetails( props ) {
 				showPlaceholder={ showPlaceholder }
 				isJetpackSelfHosted={ isJetpackSelfHosted }
 				isWpcom={ isWpcom }
+				isUpgradeablePreinstalledPremiumPlugin={ isUpgradeablePreinstalledPremiumPlugin }
 				{ ...props }
 			/>
 		);
@@ -388,10 +398,15 @@ function LegacyPluginDetails( props ) {
 		showPlaceholder,
 		isJetpackSelfHosted,
 		isWpcom,
+		isUpgradeablePreinstalledPremiumPlugin,
 	} = props;
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const showBillingIntervalSwitcher =
+		isUpgradeablePreinstalledPremiumPlugin ||
+		( isMarketplaceProduct && ! requestingPluginsForSites && ! isPluginInstalledOnsite );
 
 	return (
 		<MainComponent wideLayout>
@@ -402,7 +417,7 @@ function LegacyPluginDetails( props ) {
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist />
 			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs }>
-				{ isMarketplaceProduct && ! requestingPluginsForSites && ! isPluginInstalledOnsite && (
+				{ showBillingIntervalSwitcher && (
 					<BillingIntervalSwitcher
 						billingPeriod={ billingPeriod }
 						onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -65,8 +65,8 @@ import {
 	isRequestingSites as checkRequestingSites,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { PREINSTALLED_PREMIUM_PLUGINS } from './constants';
 import NoPermissionsError from './no-permissions-error';
+import usePreinstalledPremiumPlugin from './use-preinstalled-premium-plugin';
 
 function PluginDetails( props ) {
 	const dispatch = useDispatch();
@@ -207,13 +207,7 @@ function PluginDetails( props ) {
 		requestingPluginsForSites,
 	] );
 
-	const isUpgradeablePreinstalledPremiumPlugin = useSelector( ( state ) => {
-		const preinstalledPremiumPlugin = PREINSTALLED_PREMIUM_PLUGINS[ fullPlugin.slug ];
-		return (
-			!! preinstalledPremiumPlugin &&
-			! siteHasFeature( state, selectedSite?.ID, preinstalledPremiumPlugin.feature )
-		);
-	} );
+	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( fullPlugin.slug );
 
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
@@ -279,7 +273,7 @@ function PluginDetails( props ) {
 				showPlaceholder={ showPlaceholder }
 				isJetpackSelfHosted={ isJetpackSelfHosted }
 				isWpcom={ isWpcom }
-				isUpgradeablePreinstalledPremiumPlugin={ isUpgradeablePreinstalledPremiumPlugin }
+				isPreinstalledPremiumPluginUpgraded={ isPreinstalledPremiumPluginUpgraded }
 				{ ...props }
 			/>
 		);
@@ -398,14 +392,14 @@ function LegacyPluginDetails( props ) {
 		showPlaceholder,
 		isJetpackSelfHosted,
 		isWpcom,
-		isUpgradeablePreinstalledPremiumPlugin,
+		isPreinstalledPremiumPluginUpgraded,
 	} = props;
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const showBillingIntervalSwitcher =
-		isUpgradeablePreinstalledPremiumPlugin ||
+		! isPreinstalledPremiumPluginUpgraded ||
 		( isMarketplaceProduct && ! requestingPluginsForSites && ! isPluginInstalledOnsite );
 
 	return (

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -23,6 +23,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { PREINSTALLED_PLUGINS } from '../constants';
+import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 import { PluginsBrowserElementVariant } from './types';
 
 import './style.scss';
@@ -224,12 +225,29 @@ const InstalledInOrPricing = ( {
 } ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const isPluginAtive = useSelector( ( state ) =>
+	const isPluginActive = useSelector( ( state ) =>
 		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
 	)?.active;
-	const active = isWpcomPreinstalled || isPluginAtive;
+	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( plugin.slug );
+	const active = isWpcomPreinstalled || isPluginActive;
 
 	let checkmarkColorClass = 'checkmark--active';
+
+	if ( isPreinstalledPremiumPluginUpgraded && selectedSiteId ) {
+		/* eslint-disable wpcalypso/jsx-gridicon-size */
+		return (
+			<div className="plugins-browser-item__installed-and-active-container">
+				<div className="plugins-browser-item__installed ">
+					<Gridicon icon="checkmark" className={ checkmarkColorClass } size={ 14 } />
+					{ translate( 'Installed' ) }
+				</div>
+				<div className="plugins-browser-item__active">
+					<Badge type="success">{ translate( 'Active' ) }</Badge>
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-gridicon-size */
+	}
 
 	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -228,12 +228,13 @@ const InstalledInOrPricing = ( {
 	const isPluginActive = useSelector( ( state ) =>
 		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
 	)?.active;
-	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( plugin.slug );
+	const { isPreinstalledPremiumPlugin, isPreinstalledPremiumPluginUpgraded } =
+		usePreinstalledPremiumPlugin( plugin.slug );
 	const active = isWpcomPreinstalled || isPluginActive;
 
 	let checkmarkColorClass = 'checkmark--active';
 
-	if ( isPreinstalledPremiumPluginUpgraded && selectedSiteId ) {
+	if ( isPreinstalledPremiumPluginUpgraded ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
@@ -242,14 +243,19 @@ const InstalledInOrPricing = ( {
 					{ translate( 'Installed' ) }
 				</div>
 				<div className="plugins-browser-item__active">
-					<Badge type="success">{ translate( 'Active' ) }</Badge>
+					<Badge type={ active ? 'success' : 'info' }>
+						{ active ? translate( 'Active' ) : translate( 'Inactive' ) }
+					</Badge>
 				</div>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-gridicon-size */
 	}
 
-	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
+	if (
+		( ! isPreinstalledPremiumPlugin && sitesWithPlugin && sitesWithPlugin.length > 0 ) ||
+		isWpcomPreinstalled
+	) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		if ( selectedSiteId ) {
 			checkmarkColorClass = active ? 'checkmark--active' : 'checkmark--inactive';

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -14,8 +14,7 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 	const isPreinstalledPremiumPluginUpgraded = useSelector(
 		( state ) =>
 			!! preinstalledPremiumPlugin &&
-			siteHasFeature( state, selectedSiteId, preinstalledPremiumPlugin.feature ),
-		[ pluginSlug, selectedSiteId ]
+			siteHasFeature( state, selectedSiteId, preinstalledPremiumPlugin.feature )
 	);
 
 	const preinstalledPremiumPluginFeature = preinstalledPremiumPlugin?.feature;

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -20,7 +20,7 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 	const preinstalledPremiumPluginFeature = preinstalledPremiumPlugin?.feature;
 
 	const preinstalledPremiumPluginProduct =
-		preinstalledPremiumPlugin?.product?.[ getPeriodVariationValue( billingPeriod ) ];
+		preinstalledPremiumPlugin?.products?.[ getPeriodVariationValue( billingPeriod ) ];
 
 	return {
 		isPreinstalledPremiumPlugin: !! preinstalledPremiumPlugin,

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -1,0 +1,32 @@
+import { useSelector } from 'react-redux';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
+import { getPeriodVariationValue } from '../plugin-price';
+
+export default function usePreinstalledPremiumPlugin( pluginSlug ) {
+	const preinstalledPremiumPlugin = PREINSTALLED_PREMIUM_PLUGINS[ pluginSlug ];
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const billingPeriod = useSelector( getBillingInterval );
+
+	const isPreinstalledPremiumPluginUpgraded = useSelector(
+		( state ) =>
+			!! preinstalledPremiumPlugin &&
+			siteHasFeature( state, selectedSiteId, preinstalledPremiumPlugin.feature ),
+		[ pluginSlug, selectedSiteId ]
+	);
+
+	const preinstalledPremiumPluginFeature = preinstalledPremiumPlugin?.feature;
+
+	const preinstalledPremiumPluginProduct =
+		preinstalledPremiumPlugin?.product?.[ getPeriodVariationValue( billingPeriod ) ];
+
+	return {
+		isPreinstalledPremiumPlugin: !! preinstalledPremiumPlugin,
+		isPreinstalledPremiumPluginUpgraded,
+		preinstalledPremiumPluginFeature,
+		preinstalledPremiumPluginProduct,
+	};
+}


### PR DESCRIPTION
#### Proposed Changes

* Add support for preinstalled premium plugins (namely: Jetpack Search) to the Marketplace.

This is an alternative, generalized approach to #64828.

The main problem of the previous PR was overthinking the many different possible versions of Jetpack Search. After an internal discussion (pdh6GB-1iz-p2), I've decided to remove the deprecated versions from the equation, consolidating the system into two different items, both requiring a paid upgrade:
- The preinstalled version on Simple sites.
- The standalone version on Jetpack and Atomic.

##### What factors I've removed?

- Classic Search is not considered anymore: users with Classic Search that stumble upon Jetpack Search in the Marketplace will be prompted to upgrade just like anyone else.
- Jetpack and Atomic now work exactly in the same way, both using the standalone version — despite it being technically preinstalled on Atomic.
  - Installing the standalone version on Atomic doesn't create any conflicts (bugs notwithstanding), and at the same time contributes to boosting the active installation count on WPORG, which doesn't consider the WPCOM preinstalled version.

##### Anything else of note?

- Compared to the previous version (and what I said in the internal discussion), now Jetpack and Atomic sites have a 1-click process for "purchase -> install -> activate".
- The pricing support both monthly and yearly variations. 
- This approach is ready for other (internal) preinstalled/premium/standalone features/plugins which might or might not exist in the future.
- They also work with the redesigned plugin layout (see `plugins/plugin-details-layout` feature flag).
- I've intentionally not handled the plugin page's site list, as that will require something more clever.

##### List of changes for Simple sites

| Upgraded? | List | Page |
| - | - | - |
| No | <img width="526" alt="Screenshot 2022-07-01 at 12 49 36" src="https://user-images.githubusercontent.com/2070010/176889058-72d1d0c3-bfec-4c1f-b4b1-2116541fb43c.png"> | <img width="1070" alt="Screenshot 2022-07-01 at 12 47 51" src="https://user-images.githubusercontent.com/2070010/176888800-17c3a01d-8e52-46f5-9657-476519235353.png"> |
| Yes | <img width="525" alt="Screenshot 2022-07-01 at 12 50 00" src="https://user-images.githubusercontent.com/2070010/176889096-ef0ed442-e6cb-4d17-8ec0-e2b12d6f0be7.png"> | <img width="1068" alt="Screenshot 2022-07-01 at 12 47 44" src="https://user-images.githubusercontent.com/2070010/176888817-bac2e482-85d6-4b8d-b3ba-5f242821266b.png"> | 

##### List of changes for Jetpack and Atomic sites

| Installed? | Active? | Upgraded? | List | Page |
| - | - | - | - | - |
| No | No | No | <img width="528" alt="list-not-installed" src="https://user-images.githubusercontent.com/2070010/176901063-e1d15f76-4184-4d3b-8868-f28067ffa51d.png"> | <img width="1066" alt="page-not-installed" src="https://user-images.githubusercontent.com/2070010/176901487-8343276f-6773-4d94-91d1-56f86d69606d.png"> |
| Yes | No | No | <img width="527" alt="list-not-upgraded" src="https://user-images.githubusercontent.com/2070010/176901213-a74f7fa2-8487-42c9-b74a-44631203368d.png"> | <img width="1067" alt="page-not-upgraded" src="https://user-images.githubusercontent.com/2070010/176901590-d7b8050e-ce19-4c15-bb98-989880f66fb7.png"> |
| Yes | Yes | No | <img width="527" alt="list-not-upgraded" src="https://user-images.githubusercontent.com/2070010/176901213-a74f7fa2-8487-42c9-b74a-44631203368d.png"> | <img width="1067" alt="page-not-upgraded" src="https://user-images.githubusercontent.com/2070010/176901590-d7b8050e-ce19-4c15-bb98-989880f66fb7.png"> |
| Yes | No | Yes | <img width="527" alt="list-upgraded-inactive" src="https://user-images.githubusercontent.com/2070010/176901345-7bfa1310-6b85-432f-8f86-6aae491dc5a7.png"> | <img width="1058" alt="page-upgraded-inactive" src="https://user-images.githubusercontent.com/2070010/176901742-4d60f157-62e5-4e6e-9510-24f06b3ba339.png"> |
| Yes | Yes | Yes | <img width="529" alt="list-installed-upgraded" src="https://user-images.githubusercontent.com/2070010/176901371-18c39772-d049-417f-8969-1f47ff32546d.png"> | <img width="1068" alt="page-installed-upgraded" src="https://user-images.githubusercontent.com/2070010/176901416-d488b9a2-86d5-415d-96ff-5752813401a7.png"> |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare Simple, Atomic, and Jetpack self-hosted test sites.
* Navigate to the Plugins section, and search for Jetpack Search.
* The plugin page's CTA should be:
  * Simple site without Jetpack Search upgraded:
    * "Jetpack Search is automatically managed for you."
    * [Upgrade Jetpack Search] sending to `/checkout/SITE/jetpack_search_monthly`.
  * Simple site with Jetpack Search upgraded:
    * "Jetpack Search is automatically managed for you."
  * Atomic/Jetpack site without the Jetpack Search plugin installed:
    * [Purchase and activate] sending to `/checkout/SITE/jetpack_search_monthly?redirect_to=/marketplace/jetpack-search/install/SITE`.
  * Atomic/Jetpack with the Jetpack Search plugin installed but not upgraded:
    * [Upgrade Jetpack Search] sending to `/checkout/SITE/jetpack_search_monthly`.
  * Atomic/Jetpack with the Jetpack Search plugin installed and upgraded:
    * Nothing.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62025
