### PR TITLE
Licensing Portal: Skip the assign license step when there are no sites

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import { isPaymentMethodRequired } from 'calypso/state/partner-portal/partner/selectors';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import type { ReactChild, ReactElement } from 'react';
 import './style.scss';
@@ -51,7 +51,7 @@ interface Props {
 
 export default function AssignLicenseStepProgress( { currentStep }: Props ): ReactElement | null {
 	const translate = useTranslate();
-	const paymentMethodRequired = useSelector( isPaymentMethodRequired );
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const sites = useSelector( getSites ).length;
 
 	const steps: Step[] = [ { key: 'issueLicense', label: translate( 'Issue new license' ) } ];

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -3,10 +3,8 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import {
-	hasValidPaymentMethod,
-	isAgencyUser,
-} from 'calypso/state/partner-portal/partner/selectors';
+import { isPaymentMethodRequired } from 'calypso/state/partner-portal/partner/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
 import type { ReactChild, ReactElement } from 'react';
 import './style.scss';
 
@@ -51,19 +49,25 @@ interface Props {
 	currentStep: StepKey;
 }
 
-export default function AssignLicenseStepProgress( { currentStep }: Props ): ReactElement {
+export default function AssignLicenseStepProgress( { currentStep }: Props ): ReactElement | null {
 	const translate = useTranslate();
-	const isAgency = useSelector( isAgencyUser );
-	const hasPaymentMethod = useSelector( hasValidPaymentMethod );
-	const paymentMethodRequired = isAgency && ! hasPaymentMethod;
+	const paymentMethodRequired = useSelector( isPaymentMethodRequired );
+	const sites = useSelector( getSites ).length;
 
-	const steps: Step[] = [
-		{ key: 'issueLicense', label: translate( 'Issue new license' ) },
-		...( paymentMethodRequired
-			? [ { key: 'addPaymentMethod', label: translate( 'Add Payment Method' ) } as Step ]
-			: [] ),
-		{ key: 'assignLicense', label: translate( 'Assign license' ) },
-	];
+	const steps: Step[] = [ { key: 'issueLicense', label: translate( 'Issue new license' ) } ];
+
+	if ( paymentMethodRequired ) {
+		steps.push( { key: 'addPaymentMethod', label: translate( 'Add Payment Method' ) } );
+	}
+
+	if ( sites > 0 ) {
+		steps.push( { key: 'assignLicense', label: translate( 'Assign license' ) } );
+	}
+
+	// Don't show the breadcrumbs if we have less than 2 as they are not very informative in this case.
+	if ( steps.length < 2 ) {
+		return null;
+	}
 
 	const currentStepIndex = Math.max(
 		steps.findIndex( ( step ) => step.key === currentStep ),

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -27,7 +27,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import {
 	getCurrentPartner,
 	hasActivePartnerKey,
-	isPaymentMethodRequired,
+	doesPartnerRequireAPaymentMethod,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -241,7 +241,7 @@ export function requireSelectedPartnerKeyContext(
  */
 export function requireValidPaymentMethod( context: PageJS.Context, next: () => void ) {
 	const state = context.store.getState();
-	const paymentMethodRequired = isPaymentMethodRequired( state );
+	const paymentMethodRequired = doesPartnerRequireAPaymentMethod( state );
 	const { pathname, search } = window.location;
 
 	if ( paymentMethodRequired ) {

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -27,8 +27,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import {
 	getCurrentPartner,
 	hasActivePartnerKey,
-	hasValidPaymentMethod,
-	isAgencyUser,
+	isPaymentMethodRequired,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -242,11 +241,10 @@ export function requireSelectedPartnerKeyContext(
  */
 export function requireValidPaymentMethod( context: PageJS.Context, next: () => void ) {
 	const state = context.store.getState();
-	const validPaymentMethod = hasValidPaymentMethod( state );
-	const isAgency = isAgencyUser( state );
+	const paymentMethodRequired = isPaymentMethodRequired( state );
 	const { pathname, search } = window.location;
 
-	if ( isAgency && ! validPaymentMethod ) {
+	if ( paymentMethodRequired ) {
 		const returnUrl = ensurePartnerPortalReturnUrl( pathname + search );
 
 		page.redirect(
@@ -261,5 +259,4 @@ export function requireValidPaymentMethod( context: PageJS.Context, next: () => 
 	}
 
 	next();
-	return;
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -14,7 +14,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import useAssignLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-assign-license-mutation';
 import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { isPaymentMethodRequired } from 'calypso/state/partner-portal/partner/selectors';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import {
 	APIError,
 	APIProductFamily,
@@ -43,7 +43,7 @@ export default function IssueLicenseForm( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const sites = useSelector( getSites ).length;
-	const paymentMethodRequired = useSelector( isPaymentMethodRequired );
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const products = useProductsQuery( {
 		select: alphabeticallySortedProductOptions,
 	} );

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -15,10 +15,7 @@ import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/u
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
-import {
-	hasValidPaymentMethod,
-	isAgencyUser,
-} from 'calypso/state/partner-portal/partner/selectors';
+import { isPaymentMethodRequired } from 'calypso/state/partner-portal/partner/selectors';
 import './style.scss';
 
 interface Props {
@@ -48,8 +45,7 @@ export default function LicensePreview( {
 	const dispatch = useDispatch();
 	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
 	const [ isOpen, setOpen ] = useState( isHighlighted );
-	const validPaymentMethod = useSelector( hasValidPaymentMethod );
-	const isAgency = useSelector( isAgencyUser );
+	const paymentMethodRequired = useSelector( isPaymentMethodRequired );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 	const showDomain =
@@ -73,7 +69,7 @@ export default function LicensePreview( {
 
 	const assign = useCallback( () => {
 		const redirectUrl = addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' );
-		if ( isAgency && ! validPaymentMethod ) {
+		if ( paymentMethodRequired ) {
 			const noticeLinkHref = addQueryArgs(
 				{
 					return: redirectUrl,
@@ -96,7 +92,7 @@ export default function LicensePreview( {
 		}
 
 		page.redirect( redirectUrl );
-	}, [ isAgency, validPaymentMethod, translate, dispatch, errorNotice, licenseKey ] );
+	}, [ paymentMethodRequired, translate, dispatch, errorNotice, licenseKey ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -15,7 +15,7 @@ import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/u
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
-import { isPaymentMethodRequired } from 'calypso/state/partner-portal/partner/selectors';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import './style.scss';
 
 interface Props {
@@ -45,7 +45,7 @@ export default function LicensePreview( {
 	const dispatch = useDispatch();
 	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
 	const [ isOpen, setOpen ] = useState( isHighlighted );
-	const paymentMethodRequired = useSelector( isPaymentMethodRequired );
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 	const showDomain =

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -36,6 +36,6 @@ export const socialBasePath = () => '/jetpack-social';
 export const socialPath = ( siteSlug?: string ): string =>
 	siteSlug ? `${ socialBasePath() }/${ siteSlug }` : socialBasePath();
 
-export const partnerPortalBasePath = () => '/partner-portal';
+export const partnerPortalBasePath = ( path = '' ) => `/partner-portal${ path }`;
 
 export const agencySignupBasePath = () => '/agency/signup';

--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -63,3 +63,10 @@ export function hasValidPaymentMethod( state: PartnerPortalStore ): boolean {
 	const partner = getCurrentPartner( state );
 	return partner?.has_valid_payment_method || false;
 }
+
+export function isPaymentMethodRequired( state: PartnerPortalStore ): boolean {
+	const isAgency = isAgencyUser( state );
+	const hasPaymentMethod = hasValidPaymentMethod( state );
+
+	return isAgency && ! hasPaymentMethod;
+}

--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -64,7 +64,7 @@ export function hasValidPaymentMethod( state: PartnerPortalStore ): boolean {
 	return partner?.has_valid_payment_method || false;
 }
 
-export function isPaymentMethodRequired( state: PartnerPortalStore ): boolean {
+export function doesPartnerRequireAPaymentMethod( state: PartnerPortalStore ): boolean {
 	const isAgency = isAgencyUser( state );
 	const hasPaymentMethod = hasValidPaymentMethod( state );
 


### PR DESCRIPTION
#### Proposed Changes

* Licensing Portal: When issuing a license, skip the assign license step if there are no sites to assign the license to.

#### Testing Instructions

To test through the cases make sure you switch your partner type and refresh. You will also need to remove your test sites or modify Calypso's store so it thinks you have no sites, e.g. by running this in your console:
```
dispatch({
  type: 'SITES_RECEIVE',
  sites: [],
});
```

Case 1: Internal partner; with or without payment method on file; at least one site connected.
Expected breadcrumbs UI: 1 Issue a License - 2 Assign License
Expected Flow: Issue a License -> Assign License -> Licenses list

Case 2: Internal partner; with or without payment method on file; no sites.
Expected breadcrumbs UI: None
Expected Flow: Issue a License -> Licenses list

Case 3: Agency partner; no payment method on file; at least one site connected.
Expected breadcrumbs UI: 1 Issue a License - 2 Add Payment Method - 3 Assign License
Expected Flow: Issue a License -> Add Payment Method -> Assign License -> Licenses list

Case 4: Agency partner; payment method on file; at least one site connected.
Expected breadcrumbs UI: 1 Issue a License - 2 Assign License
Expected Flow: Issue a License -> Assign License -> Licenses list

Case 5: Agency partner; no payment method on file; no sites.
Expected breadcrumbs UI: 1 Issue a License - 2 Add Payment Method
Expected Flow: Issue a License -> Add Payment Method -> Licenses list

Case 6: Agency partner; payment method on file; no sites.
Expected breadcrumbs UI: None
Expected Flow: Issue a License -> Licenses list

![Screen Shot 2022-06-30 at 20 25 36](https://user-images.githubusercontent.com/22746396/176739893-77a76a0e-c92a-4a38-9b95-af0ea0c3299f.png)
