### PR TITLE
Localize the 'Learn More' link in 'What can be imported?' popup

### DIFF
--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Modal } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, close, check } from '@wordpress/icons';
@@ -40,7 +41,7 @@ const platformFeatureList: { [ key: string ]: { [ key: string ]: FeatureName[] }
 const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) => {
 	const { __ } = useI18n();
 	const { platform, onClose } = data;
-	const learnMoreHref = 'https://wordpress.com/support/import';
+	const learnMoreHref = localizeUrl( 'https://wordpress.com/support/import' );
 
 	const translatedFeatureList: FeatureList = {
 		tags: __( 'Tags' ),


### PR DESCRIPTION
#### Proposed Changes

* Localize the "Learn More" link (https://wordpress.com/support/import) which is shown in the 'What can be imported?' popup in the importer flow

#### Testing Instructions

* Switch your WordPress.com account to a Mag-16 locale
* Checkout the branch on a local Calypso instance or use calypso.live
* On the “Where will you start” page, select “Import your site content” at the bottom of the list of options, or build and navigate to a URL like http://calypso.localhost:3000/setup/importReadyPreview?siteSlug=[my-existing-test-site].wordpress.com
* When prompted for the site URL, use https://www.loveandlemons.com/ and go to the next page
* On that page click on "What can be imported?" and confirm that "Learn More" link is pointing to a localized page.
<img width="972" alt="Screenshot 2022-06-30 at 23 55 14" src="https://user-images.githubusercontent.com/7847633/176785606-6f6637a6-6b3e-403e-8eb0-a549d424e24d.png">

