### PR TITLE
Refactor `BusinessATStep` tests to @testing-library/react

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
@@ -1,75 +1,84 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BusinessATStep } from '../business-at-step';
 
 const noop = () => {};
 
-describe( 'BusinessATStep', () => {
-	describe( 'rendering translated content', () => {
-		let wrapper;
-		const translate = ( content ) => `Translated: ${ content }`;
+describe( 'rendering translated content', () => {
+	const translate = ( content ) => `Translated: ${ content }`;
 
-		beforeEach( () => {
-			wrapper = shallow( <BusinessATStep recordTracksEvent={ noop } translate={ translate } /> );
-		} );
-
-		test( 'should render translated heading content', () => {
-			expect( wrapper.find( 'FormSectionHeading' ).props().children ).toEqual(
-				'Translated: New! Install Custom Plugins and Themes'
-			);
-		} );
-
-		test( 'should render translated link content', () => {
-			expect( wrapper.find( 'FormFieldset > p' ).at( 0 ).props().children ).toEqual(
-				'Translated: Have a theme or plugin you need to install to build the site you want? ' +
-					'Now you can! ' +
-					'Learn more about {{pluginLink}}installing plugins{{/pluginLink}} and ' +
-					'{{themeLink}}uploading themes{{/themeLink}} today.'
-			);
-		} );
-
-		test( 'should render translated confirmation content', () => {
-			expect( wrapper.find( 'FormFieldset > p' ).at( 1 ).props().children ).toEqual(
-				'Translated: Are you sure you want to cancel your subscription and lose access to these new features?'
-			);
-		} );
+	test( 'should render translated heading content', () => {
+		const { container } = render(
+			<BusinessATStep recordTracksEvent={ noop } translate={ translate } />
+		);
+		expect( container.firstChild ).toHaveTextContent(
+			'Translated: New! Install Custom Plugins and Themes'
+		);
 	} );
 
-	describe( 'rendered links', () => {
-		const translate = ( content, params ) => {
-			if ( params && params.components ) {
-				return (
-					<div>
-						{ params.components.pluginLink }
-						{ params.components.themeLink }
-					</div>
-				);
-			}
-			return null;
-		};
-		let recordTracksEvent;
-		let wrapper;
+	test( 'should render translated link content', () => {
+		render( <BusinessATStep recordTracksEvent={ noop } translate={ translate } /> );
+		expect( screen.queryByRole( 'group' ) ).toHaveTextContent(
+			'Translated: Have a theme or plugin you need to install to build the site you want? ' +
+				'Now you can! ' +
+				'Learn more about {{pluginLink}}installing plugins{{/pluginLink}} and ' +
+				'{{themeLink}}uploading themes{{/themeLink}} today.'
+		);
+	} );
 
-		beforeEach( () => {
-			recordTracksEvent = jest.fn();
-			wrapper = shallow(
-				<BusinessATStep translate={ translate } recordTracksEvent={ recordTracksEvent } />
+	test( 'should render translated confirmation content', () => {
+		render( <BusinessATStep recordTracksEvent={ noop } translate={ translate } /> );
+		expect(
+			screen.getByText(
+				'Translated: Are you sure you want to cancel your subscription and lose access to these new features?'
+			)
+		).toBeVisible();
+	} );
+} );
+
+describe( 'rendered links', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	const translate = ( content, params ) => {
+		if ( params && params.components ) {
+			return (
+				<>
+					{ params.components.pluginLink }
+					{ params.components.themeLink }
+				</>
 			);
-		} );
+		}
+		return null;
+	};
+	const recordTracksEvent = jest.fn();
 
-		test( 'should fire tracks event for plugin support link when clicked', () => {
-			wrapper.find( 'a' ).at( 0 ).simulate( 'click' );
+	test( 'should fire tracks event for plugin support link when clicked', async () => {
+		render( <BusinessATStep translate={ translate } recordTracksEvent={ recordTracksEvent } /> );
+		const link = screen.queryAllByRole( 'link' )[ 0 ];
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'calypso_cancellation_business_at_plugin_support_click'
-			);
-		} );
+		link.addEventListener( 'click', ( event ) => event.preventDefault(), false );
+		await userEvent.click( link );
 
-		test( 'should fire tracks event for theme support link when clicked', () => {
-			wrapper.find( 'a' ).at( 1 ).simulate( 'click' );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_cancellation_business_at_plugin_support_click'
+		);
+	} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'calypso_cancellation_business_at_theme_support_click'
-			);
-		} );
+	test( 'should fire tracks event for theme support link when clicked', async () => {
+		render( <BusinessATStep translate={ translate } recordTracksEvent={ recordTracksEvent } /> );
+		const link = screen.queryAllByRole( 'link' )[ 1 ];
+
+		link.addEventListener( 'click', ( event ) => event.preventDefault(), false );
+		await userEvent.click( link );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_cancellation_business_at_theme_support_click'
+		);
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx
@@ -9,21 +9,21 @@ import { BusinessATStep } from '../business-at-step';
 const noop = () => {};
 
 describe( 'rendering translated content', () => {
-	const translate = ( content ) => `Translated: ${ content }`;
+	const translate = jest.fn( ( content ) => content );
 
 	test( 'should render translated heading content', () => {
 		const { container } = render(
 			<BusinessATStep recordTracksEvent={ noop } translate={ translate } />
 		);
-		expect( container.firstChild ).toHaveTextContent(
-			'Translated: New! Install Custom Plugins and Themes'
-		);
+		expect( translate ).toHaveBeenCalled();
+		expect( container.firstChild ).toHaveTextContent( 'New! Install Custom Plugins and Themes' );
 	} );
 
 	test( 'should render translated link content', () => {
 		render( <BusinessATStep recordTracksEvent={ noop } translate={ translate } /> );
+		expect( translate ).toHaveBeenCalled();
 		expect( screen.queryByRole( 'group' ) ).toHaveTextContent(
-			'Translated: Have a theme or plugin you need to install to build the site you want? ' +
+			'Have a theme or plugin you need to install to build the site you want? ' +
 				'Now you can! ' +
 				'Learn more about {{pluginLink}}installing plugins{{/pluginLink}} and ' +
 				'{{themeLink}}uploading themes{{/themeLink}} today.'
@@ -32,9 +32,10 @@ describe( 'rendering translated content', () => {
 
 	test( 'should render translated confirmation content', () => {
 		render( <BusinessATStep recordTracksEvent={ noop } translate={ translate } /> );
+		expect( translate ).toHaveBeenCalled();
 		expect(
 			screen.getByText(
-				'Translated: Are you sure you want to cancel your subscription and lose access to these new features?'
+				'Are you sure you want to cancel your subscription and lose access to these new features?'
 			)
 		).toBeVisible();
 	} );
@@ -54,16 +55,17 @@ describe( 'rendered links', () => {
 				</>
 			);
 		}
-		return null;
+		return content;
 	};
 	const recordTracksEvent = jest.fn();
+	const user = userEvent.setup();
 
 	test( 'should fire tracks event for plugin support link when clicked', async () => {
 		render( <BusinessATStep translate={ translate } recordTracksEvent={ recordTracksEvent } /> );
 		const link = screen.queryAllByRole( 'link' )[ 0 ];
 
 		link.addEventListener( 'click', ( event ) => event.preventDefault(), false );
-		await userEvent.click( link );
+		await user.click( link );
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_cancellation_business_at_plugin_support_click'
@@ -75,7 +77,7 @@ describe( 'rendered links', () => {
 		const link = screen.queryAllByRole( 'link' )[ 1 ];
 
 		link.addEventListener( 'click', ( event ) => event.preventDefault(), false );
-		await userEvent.click( link );
+		await user.click( link );
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_cancellation_business_at_theme_support_click'


### PR DESCRIPTION
#### Proposed Changes

* This PR refactors the `BusinessATStep` component to use `@testing-library/react` instead of `enzyme`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify tests still pass: `yarn test-client client/components/marketing-survey/cancel-purchase-form/step-components/test/business-at-step.jsx`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
