### PR TITLE
Help Contact Form: Allow eligible users to connect to happy chat when jetpack connection is broken

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -733,6 +733,7 @@ class HelpContact extends Component {
 export default connect(
 	( state ) => {
 		const selectedSite = getHelpSelectedSite( state );
+		const isChatEligible = isHappychatUserEligible( state );
 		return {
 			selectedSite,
 			currentUserLocale: getCurrentUserLocale( state ),
@@ -744,12 +745,12 @@ export default connect(
 			isDirectlyReady: isDirectlyReady( state ),
 			isDirectlyUninitialized: isDirectlyUninitialized( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
-			isHappychatUserEligible: isHappychatUserEligible( state ),
+			isHappychatUserEligible: isChatEligible,
 			localizedLanguageNames: getLocalizedLanguageNames( state ),
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
-			shouldStartHappychatConnection: ! isRequestingSites( state ),
+			shouldStartHappychatConnection: ! isRequestingSites( state ) && isChatEligible,
 			isRequestingSites: isRequestingSites( state ),
 			supportVariation: getInlineHelpSupportVariation( state ),
 		};

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -749,7 +749,7 @@ export default connect(
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
-			shouldStartHappychatConnection: ! isRequestingSites( state ) && selectedSite,
+			shouldStartHappychatConnection: ! isRequestingSites( state ),
 			isRequestingSites: isRequestingSites( state ),
 			supportVariation: getInlineHelpSupportVariation( state ),
 		};


### PR DESCRIPTION


#### Proposed Changes
whenever a user has a single site and the jetpack connection is broken then Calypso cannot read that users site hence the user is loaded as not having any sites and a happy chat connection is not established even though the user has a plan that supports chat.

* Establish a happy chat connection even if no sites are available once the user is happy chat eligible.

#### Testing Instructions

1. Set up a user with an AT site and plan that includes chat support (pro/bus/ecom) - _This must be the only site the user has_
2. goto [calypso.localhost:3000/help/contact ](url)and verify that chat available - ensure you are logged into [happy chat](https://hud-staging.happychat.io)
3. break Jetpack connection for user on site above. Go to (https://wordpress.com/wp-admin/network/admin.php?page=jetpack) enter user_id and the disconnect.
4. Go back to [calypso.localhost:3000/help/contact ](url) and verify the `Chat with us` button is still available
5. Verify in devtools network tab `async-load-calypso-lib-happychat-connection.js` is loaded
6. With a free tier user go to  [calypso.localhost:3000/help/contact ](url) 
7. Verify `Chat with us` button is not available and `async-load-calypso-lib-happychat-connection.js` is not loaded



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63210
