### PR TITLE
Editing Toolkit: Add feature flags to the help center

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -38,6 +38,18 @@ class Help_Center {
 	}
 
 	/**
+	 * Acts as a feature flag, returning a boolean for whether we should show the next steps tutorial UI.
+	 *
+	 * @return boolean
+	 */
+	public static function is_next_steps_tutorial_enabled() {
+		return apply_filters(
+			'help_center_should_enable_next_steps_tutorial',
+			false
+		);
+	}
+
+	/**
 	 * Enqueue block editor assets.
 	 */
 	public function enqueue_script() {
@@ -65,6 +77,12 @@ class Help_Center {
 			'helpCenterLocale',
 			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
 		);
+
+		// Adds feature flags for development
+		wp_add_inline_script( 'help-center-script', 'const helpCenterFeatureFlags = ' . json_encode( array(
+			'loadNextStepsTutorial' => self::is_next_steps_tutorial_enabled(),
+		) ), 'before' );
+
 
 		wp_set_script_translations( 'help-center-script', 'full-site-editing' );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -78,11 +78,16 @@ class Help_Center {
 			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
 		);
 
-		// Adds feature flags for development
-		wp_add_inline_script( 'help-center-script', 'const helpCenterFeatureFlags = ' . json_encode( array(
-			'loadNextStepsTutorial' => self::is_next_steps_tutorial_enabled(),
-		) ), 'before' );
-
+		// Adds feature flags for development.
+		wp_add_inline_script(
+			'help-center-script',
+			'const helpCenterFeatureFlags = ' . wp_json_encode(
+				array(
+					'loadNextStepsTutorial' => self::is_next_steps_tutorial_enabled(),
+				)
+			),
+			'before'
+		);
 
 		wp_set_script_translations( 'help-center-script', 'full-site-editing' );
 	}

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -11,6 +11,7 @@ import { MemoryRouter } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
+import { FeatureFlagProvider } from '../contexts/FeatureFlagContext';
 import { Container } from '../types';
 import HelpCenterContent from './help-center-content';
 import HelpCenterFooter from './help-center-footer';
@@ -54,30 +55,32 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 
 	return (
 		<MemoryRouter>
-			<OptionalDraggable
-				draggable={ ! isMobile }
-				handle=".help-center__container-header"
-				bounds="body"
-			>
-				<Card className={ classNames } { ...animationProps }>
-					<HelpCenterHeader
-						isMinimized={ isMinimized }
-						onMinimize={ () => setIsMinimized( true ) }
-						onMaximize={ () => setIsMinimized( false ) }
-						onDismiss={ onDismiss }
-					/>
-					{ isLoading ? (
-						<div className="help-center-container__loading">
-							<Spinner baseClassName="" className="help-center-container__spinner" />
-						</div>
-					) : (
-						<>
-							<HelpCenterContent isMinimized={ isMinimized } />
-							{ ! isMinimized && <HelpCenterFooter /> }
-						</>
-					) }
-				</Card>
-			</OptionalDraggable>
+			<FeatureFlagProvider>
+				<OptionalDraggable
+					draggable={ ! isMobile }
+					handle=".help-center__container-header"
+					bounds="body"
+				>
+					<Card className={ classNames } { ...animationProps }>
+						<HelpCenterHeader
+							isMinimized={ isMinimized }
+							onMinimize={ () => setIsMinimized( true ) }
+							onMaximize={ () => setIsMinimized( false ) }
+							onDismiss={ onDismiss }
+						/>
+						{ isLoading ? (
+							<div className="help-center-container__loading">
+								<Spinner baseClassName="" className="help-center-container__spinner" />
+							</div>
+						) : (
+							<>
+								<HelpCenterContent isMinimized={ isMinimized } />
+								{ ! isMinimized && <HelpCenterFooter /> }
+							</>
+						) }
+					</Card>
+				</OptionalDraggable>
+			</FeatureFlagProvider>
 		</MemoryRouter>
 	);
 };

--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+import { FeatureFlags } from '../types';
+
+const FeatureFlagContext = React.createContext( {
+	loadNextStepsTutorial: false,
+} );
+
+export const FeatureFlagProvider: React.FC< FeatureFlags > = function ( { children } ) {
+	// The helpCenterFeatureFlags value is added as a global through the help-center-script
+	return (
+		<FeatureFlagContext.Provider value={ helpCenterFeatureFlags }>
+			{ children }
+		</FeatureFlagContext.Provider>
+	);
+};
+
+export function useFeatureFlags() {
+	const featureFlags = useContext( FeatureFlagContext );
+	return featureFlags;
+}

--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -9,7 +9,9 @@ const FeatureFlagContext = React.createContext( {
 	loadNextStepsTutorial: false,
 } );
 
-export const FeatureFlagProvider: React.FC< FeatureFlags > = function ( { children } ) {
+export const FeatureFlagProvider: React.FC< { children: JSX.Element } > = function ( {
+	children,
+} ) {
 	return (
 		<FeatureFlagContext.Provider value={ helpCenterFeatureFlags }>
 			{ children }

--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useContext } from 'react';
 import { FeatureFlags } from '../types';
 

--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { FeatureFlags } from '../types';
 
+// Lets typescript know about the feature flags global added through the help-center-script
+declare const helpCenterFeatureFlags: FeatureFlags;
+
 const FeatureFlagContext = React.createContext( {
 	loadNextStepsTutorial: false,
 } );
 
 export const FeatureFlagProvider: React.FC< FeatureFlags > = function ( { children } ) {
-	// The helpCenterFeatureFlags value is added as a global through the help-center-script
 	return (
 		<FeatureFlagContext.Provider value={ helpCenterFeatureFlags }>
 			{ children }

--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -16,5 +16,11 @@ export const FeatureFlagProvider: React.FC< FeatureFlags > = function ( { childr
 
 export function useFeatureFlags() {
 	const featureFlags = useContext( FeatureFlagContext );
+
+	// Trying to call hook outside of component that renders FeatureFlagProvider
+	if ( featureFlags === undefined ) {
+		throw new Error( 'useFeatureFlags must be used within a FeatureFlagProvider' );
+	}
+
 	return featureFlags;
 }

--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -5,9 +5,7 @@ import { FeatureFlags } from '../types';
 // Lets typescript know about the feature flags global added through the help-center-script
 declare const helpCenterFeatureFlags: FeatureFlags;
 
-const FeatureFlagContext = React.createContext( {
-	loadNextStepsTutorial: false,
-} );
+const FeatureFlagContext = React.createContext< FeatureFlags | undefined >( undefined );
 
 export const FeatureFlagProvider: React.FC< { children: JSX.Element } > = function ( {
 	children,

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -35,3 +35,7 @@ export interface Article {
 	post_id?: string;
 	blog_id?: string;
 }
+
+export interface FeatureFlags {
+	loadNextStepsTutorial: boolean;
+}


### PR DESCRIPTION
#### Context

The help center is being displayed to the general public. Next Steps tutorials frontend development should be hidden from users until it's ready to be released.

paYE8P-1Hx-p2

#### Proposed Changes

* Adds a backend filter that can be toggled as a feature flag for the next steps tutorial UI
* Adds frontend context to retrieve the flag from an enqueued help center script

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Sandbox a site
* Run `yarn dev --sync` in `apps/editing-toolkit`
* Import the `useFeatureFlags` hook from `help-center/src/contexts/FeatureFlagContext.tsx` into any functional component
* console log the result of `useFeatureFlags()` in the functional component
* Navigate to the site editor in the sandboxed site
* Navigate to the help center in the sandboxed site ( question mark icon at the top right hand corner of the screen )
* Open the developer console and note the feature flag boolean being logged out
* Update the value of `apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php:48` to `true`
* Verify that the feature flag boolean has changed values

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65130