### PR TITLE
Checkout: Always show remove coupon button

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -127,7 +127,7 @@ export function WPOrderReviewLineItems( {
 					<CouponLineItem
 						lineItem={ couponLineItem }
 						isSummary={ isSummary }
-						hasDeleteButton={ ! isSummary }
+						hasDeleteButton
 						removeProductFromCart={ removeCoupon }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						isPwpoUser={ isPwpoUser }


### PR DESCRIPTION
#### Proposed Changes

As various changes have been made, the "Edit" mode of the first step of checkout has been made less and less useful and its features have been moved more to its inactive state. Notably, the "Remove from cart" button for each product was made accessible without clicking "Edit" in https://github.com/Automattic/wp-calypso/pull/52850. Jetpack checkout hides the "Edit" mode completely as of https://github.com/Automattic/wp-calypso/pull/59838 / https://github.com/Automattic/wp-calypso/pull/60206. However, the "Edit" mode is still required to show the "Remove from cart" button next to an applied coupon.

The "Edit" mode is more cognitive load for a user of checkout and is largely unnecessary with recent advances in variant pickers (see Jetpack checkout's drop-down in https://github.com/Automattic/wp-calypso/pull/62893). As part of an effort to normalize when the "Remove from cart" button is available for different items and to help eventually remove the "Edit" mode for checkout entirely (see 743-gh-Automattic/martech), this PR makes the "Remove from cart" button for coupons always visible.

Before:
<img width="569" alt="before-coupon-2" src="https://user-images.githubusercontent.com/2036909/176799176-7aba990b-f8f0-4e27-ad2c-3336dc8a0b78.png">

After:
<img width="573" alt="after-coupon-2" src="https://user-images.githubusercontent.com/2036909/176799184-d6107ace-34ec-43da-a271-28619f609ddf.png">

#### Testing Instructions

1. On this branch, add a product to your cart and visit checkout.
2. Find a valid coupon using the MC coupons tool. If you are not sure how to do that, ping me in Slack.
3. Add a valid coupon to the cart using the first step of the checkout page.
4. Verify that you see a "Remove from cart" button below the coupon once it is applied, without having to click "Edit".
5. Click to remove the coupon from the cart and verify that it goes away.
