### PR TITLE
Onboarding: Remove redirect to site editor

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -7,7 +7,6 @@ import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { useFSEStatus } from '../hooks/use-fse-status';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
@@ -97,7 +96,6 @@ export const siteSetupFlow: Flow = {
 		const { setPendingAction, setStepProgress, resetGoals, resetIntent } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
-		const { FSEActive } = useFSEStatus();
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
@@ -190,10 +188,6 @@ export const siteSetupFlow: Flow = {
 							return navigate( 'wooVerifyEmail' );
 						}
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
-					}
-
-					if ( FSEActive && intent !== 'write' ) {
-						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 
 					return exitFlow( `/home/${ siteSlug }` );


### PR DESCRIPTION
#### Proposed Changes

There has been some reported confusion about redirecting users to the editor at the end of onboarding. It was suggested to redirect users to My Home for the time being which has an edit site step. Then, once we launch Launch Pad, to send users there.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Here is for one specific flow:

- Create a new site by going to `http://calypso.localhost:3000/start/domains`
- Enter domain
- Select the free domain
- Select free plan
- Click `Other` goal to end up in build flow
- Follow any further steps
- Ensure that you end up in My Home at the end

I also tested by using other goals and verifying that when I hit the site editor in production that I instead hit my home in dev.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
