### PR TITLE
Import: skip WordPress Migration selector for WP imports starting from I don't have a website

### DIFF
--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -95,6 +95,7 @@ const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 			{ isModalDetailsOpen && (
 				<ImportPlatformDetails
 					platform={ urlData.platform }
+					fromSite={ urlData?.url }
 					onClose={ setIsModalDetailsOpen.bind( this, false ) }
 				/>
 			) }
@@ -163,10 +164,11 @@ interface ReadyProps {
 	platform: ImporterPlatform;
 	goToImporterPage: ( platform: ImporterPlatform ) => void;
 	recordTracksEvent: RecordTracksEvent;
+	fromSite: UrlData[ 'url' ];
 }
 
 const ReadyStep: React.FunctionComponent< ReadyProps > = ( props ) => {
-	const { platform, goToImporterPage, recordTracksEvent } = props;
+	const { platform, goToImporterPage, recordTracksEvent, fromSite } = props;
 	const { __ } = useI18n();
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = React.useState( false );
 
@@ -214,6 +216,7 @@ const ReadyStep: React.FunctionComponent< ReadyProps > = ( props ) => {
 			{ isModalDetailsOpen && (
 				<ImportPlatformDetails
 					platform={ platform }
+					fromSite={ fromSite }
 					onClose={ setIsModalDetailsOpen.bind( this, false ) }
 				/>
 			) }

--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -42,7 +42,7 @@ const platformFeatureList: { [ key: string ]: { [ key: string ]: FeatureName[] }
 const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) => {
 	const { __ } = useI18n();
 	const { platform, onClose, fromSite } = data;
-  const learnMoreHref = localizeUrl( 'https://wordpress.com/support/import' );
+	const learnMoreHref = localizeUrl( 'https://wordpress.com/support/import' );
 
 	const translatedFeatureList: FeatureList = {
 		tags: __( 'Tags' ),

--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -2,13 +2,14 @@ import { Modal } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, close, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { FeatureName, FeatureList, ImporterPlatform } from '../types';
+import { FeatureName, FeatureList, ImporterPlatform, UrlData } from '../types';
 import type * as React from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface DetailsProps {
 	platform: ImporterPlatform;
+	fromSite: UrlData[ 'url' ];
 	onClose: () => void;
 }
 
@@ -39,7 +40,7 @@ const platformFeatureList: { [ key: string ]: { [ key: string ]: FeatureName[] }
 
 const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) => {
 	const { __ } = useI18n();
-	const { platform, onClose } = data;
+	const { platform, onClose, fromSite } = data;
 	const learnMoreHref = 'https://wordpress.com/support/import';
 
 	const translatedFeatureList: FeatureList = {
@@ -77,7 +78,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 		}
 	};
 
-	const getInfo = ( _platform: ImporterPlatform ): string => {
+	const getInfo = ( _platform: ImporterPlatform, _fromSite: UrlData[ 'url' ] ): string => {
 		switch ( _platform ) {
 			case 'wix':
 				return __(
@@ -92,8 +93,13 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 					"Our Blogger content importer is the quickest way to move your content. Simply export the contents from Blogger as a XML file, then click 'Import your content' and upload it to our importer."
 				);
 			case 'wordpress':
+				if ( _fromSite ) {
+					return __(
+						"Our Self-Hosted WordPress content importer is the quickest way to move your content. After clicking 'Import your content', you will have two options:"
+					);
+				}
 				return __(
-					"Our Self-Hosted WordPress content importer is the quickest way to move your content. After clicking 'Import your content', you will have two options:"
+					'Our Self-Hosted WordPress content importer is the quickest way to move your content.'
 				);
 			case 'medium':
 				return __(
@@ -111,7 +117,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 			onRequestClose={ onClose }
 		>
 			<div className="import__details-modal-content">
-				<p>{ getInfo( platform ) }</p>
+				<p>{ getInfo( platform, fromSite ) }</p>
 
 				<a
 					className="import__details-learn-more"
@@ -169,25 +175,28 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 								</li>
 							) ) }
 						</ul>
-
-						<p>
-							{ createInterpolateElement( __( 'Import <strong>Everything*</strong>:' ), {
-								strong: createElement( 'strong' ),
-							} ) }
-						</p>
-						<ul className={ 'import__details-list' }>
-							{ platformFeatureList[ platform ].supported
-								.concat( platformFeatureList[ platform ].unsupported )
-								.map( ( key ) => (
-									<li key={ key }>
-										<Icon size={ 20 } icon={ check } />{ ' ' }
-										{ translatedFeatureList[ key as FeatureName ] }
-									</li>
-								) ) }
-						</ul>
-						<div className={ 'import__details-footer' }>
-							<i>*{ __( 'Requires a Pro plan.' ) }</i>
-						</div>
+						{ fromSite && (
+							<>
+								<p>
+									{ createInterpolateElement( __( 'Import <strong>Everything*</strong>:' ), {
+										strong: createElement( 'strong' ),
+									} ) }
+								</p>
+								<ul className={ 'import__details-list' }>
+									{ platformFeatureList[ platform ].supported
+										.concat( platformFeatureList[ platform ].unsupported )
+										.map( ( key ) => (
+											<li key={ key }>
+												<Icon size={ 20 } icon={ check } />{ ' ' }
+												{ translatedFeatureList[ key as FeatureName ] }
+											</li>
+										) ) }
+								</ul>
+								<div className={ 'import__details-footer' }>
+									<i>*{ __( 'Requires a Pro plan.' ) }</i>
+								</div>
+							</>
+						) }
 					</div>
 				) }
 			</div>

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -109,7 +109,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 			{ ( () => {
 				if ( isNotAtomicJetpack() ) {
 					return <LoadingEllipsis />;
-				} else if ( undefined === option ) {
+				} else if ( undefined === option && fromSite ) {
 					return (
 						<ContentChooser
 							onJetpackSelection={ installJetpack }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -54,6 +54,7 @@ const ImportReady: Step = function ImportStep( props ) {
 				platform={ urlData?.platform }
 				goToImporterPage={ goToImporterPage }
 				recordTracksEvent={ recordTracksEvent }
+				fromSite={ urlData?.url }
 			/>
 		</ImportWrapper>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { addQueryArgs } from '@wordpress/url';
 import { camelCase } from 'lodash';
 import { ImporterPlatform } from 'calypso/blocks/import/types';
 import {
@@ -6,6 +7,7 @@ import {
 	getWpComOnboardingUrl,
 	getWpOrgImporterUrl,
 } from 'calypso/blocks/import/util';
+import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
 import { BASE_ROUTE } from './config';
 import type { StepPath } from '../../steps-repository';
 
@@ -28,6 +30,11 @@ export function getFinalImporterUrl(
 		)
 	) {
 		importerUrl = getWpComOnboardingUrl( targetSlug, platform, fromSite, framework );
+		if ( platform === 'wordpress' && ! fromSite ) {
+			importerUrl = addQueryArgs( importerUrl, {
+				option: WPImportOption.CONTENT_ONLY,
+			} );
+		}
 	} else {
 		importerUrl = getImporterUrl( targetSlug, platform, fromSite );
 	}


### PR DESCRIPTION
#### Proposed Changes

-  When a user starts the import flow from "I don't have a site address" and click WordPress later to import their content, the migration selector screen is shown for two options "Import everything" and "import content only", which "import everything" option doesn't make sense in this particular flow. 
- Redirect user to import content only block if a user doesn't have a site address.
- Remove the "Import Everything" part from "View the import guide" modal if a user doesn't have a site address.
#### Testing Instructions

1. Navigate to `/setup/import?siteSlug={SLUG}`.
2. Click "I don't have a site address" on the right top corner.
3. Click WordPress option.
4. Click "View the import guide" to see if there's only "Import Content Only" description.
5. Click "Import your content" -> you should be pointed to "Import content from WordPress page" directly.
6. Click "< Back" on the left top corner.
7. Type in a site address and hit enter.
8. Click "What can be imported" to see if there are both "Import Content Only" and "Import Everything".
9. Click "Import your content" -> you will be brought to the original migration selector page.

Before:

https://user-images.githubusercontent.com/4074459/176810574-320f9a08-b141-4299-b804-eab006bdc52a.mov

After:

https://user-images.githubusercontent.com/4074459/176810626-d648ed01-2dae-45ea-a063-412f1200fd8e.mov

Screenshot for the wording changed:

<img width="1325" alt="Screen Shot 2022-07-04 at 3 50 13 PM" src="https://user-images.githubusercontent.com/4074459/177108044-a6a3e993-1217-4e5e-98bf-dfa7201ac513.png">


Related to #64364
