### PR TITLE
Generated design picker: Validate the pre-selected design

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -144,10 +144,19 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const showGeneratedDesigns =
 		enabledGeneratedDesigns && generatedDesigns.length > 0 && ! isForceStaticDesigns;
 
-	const selectedGeneratedDesign = useMemo(
-		() => selectedDesign ?? ( ! isMobile ? generatedDesigns[ 0 ] : undefined ),
-		[ selectedDesign, generatedDesigns, isMobile ]
-	);
+	const selectedGeneratedDesign = useMemo( () => {
+		const defaultDesign = ! isMobile ? generatedDesigns[ 0 ] : undefined;
+
+		// Check if the selected design is a generated design, if not then select the default design.
+		if (
+			selectedDesign &&
+			! generatedDesigns.find( ( _design ) => _design.slug === selectedDesign.slug )
+		) {
+			return defaultDesign;
+		}
+
+		return selectedDesign ?? defaultDesign;
+	}, [ selectedDesign, generatedDesigns, isMobile ] );
 
 	const isPreviewingGeneratedDesign = isMobile && showGeneratedDesigns && !! selectedDesign;
 


### PR DESCRIPTION
#### Proposed Changes

This PR checks that the pre-selected design is a generated design. If that's not the case, then the pre-selected design falls back to the default selected design. This is to avoid cases where the pre-selected design would be a static design, due to both design pickers sharing the same pre-selected design state.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the generated design picker `/setup/designSetup?siteSlug=${site_title}` with an eligible vertical set.
* Click on the "View more options" button to switch to the static design picker.
* Preview one of the static designs.
* While in full-screen preview mode, refresh the page.
* Expect that after the page has refreshed, you'll be back at the generated design picker.
* Expect to see that now the selected design is the top-most thumbnail, and that the large preview matches with the selected design. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#65118](https://github.com/Automattic/wp-calypso/issues/65118)
