### PR TITLE
Fix issue where browser URL would not reflect internal page state

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -185,11 +185,14 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 			( domainsWithEmail[ 0 ].titanMailSubscription?.maximumMailboxCount ?? 0 ) > 0 &&
 			domainsWithEmail[ 0 ].titanMailSubscription?.numberOfMailboxes === 0
 		) {
-			page( emailManagementTitanSetUpMailbox( selectedSite.slug, domainsWithEmail[ 0 ].domain ) );
+			page.redirect(
+				emailManagementTitanSetUpMailbox( selectedSite.slug, domainsWithEmail[ 0 ].domain )
+			);
 			return null;
 		}
 
-		page( emailManagement( selectedSite.slug, domainsWithEmail[ 0 ].domain ) );
+		page.redirect( emailManagement( selectedSite.slug, domainsWithEmail[ 0 ].domain ) );
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

For users that have a single domain and that have email for that domain, we implemented a change in #64933 where they are immediately redirected to the management view for that domain as opposed to the initial domain list.

Because of the immediate nature of the `page` function call that performs the redirect, the browser URL would sometimes not be updated to reflect the internal state of `page`. Using `page.redirect` instead seems to fix that problem.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with a single domain and an email solution for that domain
2. Click Upgrades > Emails in the sidebar
3. Ensure that you are taken directly to `/email/:domain/manage/:site_slug`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64933
