### PR TITLE
Generated design picker: Add translation to buttons

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -582,7 +582,9 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			hideNext={ ! isPreviewingGeneratedDesign }
 			skipButtonAlign={ 'top' }
 			hideFormattedHeader
-			backLabelText={ isPreviewingGeneratedDesign ? 'Pick another' : 'Back' }
+			backLabelText={
+				isPreviewingGeneratedDesign ? translate( 'Pick another' ) : translate( 'Back' )
+			}
 			skipLabelText={ intent === 'write' ? translate( 'Skip and draft first post' ) : undefined }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }


### PR DESCRIPTION
#### Proposed Changes

This PR adds translation to two button labels: "Back" and "Pick another". The former is already translated, while "Pick another" is not. See screenshot of where it shows up:

![Screen Shot 2022-07-01 at 6 36 18 PM](https://user-images.githubusercontent.com/797888/176878822-c016add6-b380-4c0c-8b9b-6fa7e03baa04.png)

"Pick another" is used to indicate users that they can exit the design preview, and go back to select another design to preview.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the generated design picker with an eligible vertical set.
* In the mobile view, select any thumbnail from the list. 
* Expect to see the button "Pick another" translated.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

