### PR TITLE
Wrap importer descriptions in translate function

### DIFF
--- a/client/blocks/importer/components/importer-drag/config.tsx
+++ b/client/blocks/importer/components/importer-drag/config.tsx
@@ -5,45 +5,7 @@ import importerConfig, { ImporterConfig } from 'calypso/lib/importer/importer-co
 import SupportLink from '../support-link';
 import type { Importer } from 'calypso/blocks/importer/types';
 
-const translateConfig: { [ key: string ]: Partial< ImporterConfig > } = {
-	blogger: {
-		description:
-			'Import posts, pages, comments, tags, and images from a %(importerName)s export file.',
-		uploadDescription:
-			'A %(importerName)s export is ' +
-			'an XML file with your page and post content, or a zip archive ' +
-			'containing several XML files. ' +
-			'{{supportLink/}}',
-	},
-	medium: {
-		description:
-			'Import your posts, tags, images, and videos from your %(importerName)s export file',
-		uploadDescription:
-			'A %(importerName)s export file is a ZIP file containing several HTML files with your stories. ' +
-			'{{supportLink/}}',
-	},
-	squarespace: {
-		description:
-			'Import posts, pages, comments, tags, and images from a %(importerName)s export file.',
-		uploadDescription:
-			'A %(importerName)s export is ' +
-			'an XML file with your page and post content, or a zip archive ' +
-			'containing several XML files. ' +
-			'{{supportLink/}}',
-	},
-	wordpress: {
-		description: 'Import posts, pages, and media from your %(importerName)s export file.',
-		uploadDescription:
-			'A %(importerName)s export is ' +
-			'an XML file with your page and post content, or a zip archive ' +
-			'containing several XML files. ' +
-			'{{supportLink/}}',
-	},
-};
-
 export function getImportDragConfig( importer: Importer, supportLinkModal?: boolean ) {
-	const importerData = importerConfig()[ importer ];
-
 	const options: TranslateOptions = {
 		args: {
 			importerName: convertPlatformName( importer ),
@@ -52,23 +14,67 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 			supportLink: <SupportLink importer={ importer } supportLinkModal={ supportLinkModal } />,
 		},
 	};
+	const translateConfig: { [ key: string ]: Partial< ImporterConfig > } = {
+		blogger: {
+			description: translate(
+				'Import posts, pages, comments, tags, and images from a %(importerName)s export file.',
+				options
+			),
+			uploadDescription: translate(
+				'A %(importerName)s export is ' +
+					'an XML file with your page and post content, or a zip archive ' +
+					'containing several XML files. ' +
+					'{{supportLink/}}',
+				options
+			),
+		},
+		medium: {
+			description: translate(
+				'Import your posts, tags, images, and videos from your %(importerName)s export file',
+				options
+			),
+			uploadDescription: translate(
+				'A %(importerName)s export file is a ZIP file containing several HTML files with your stories. ' +
+					'{{supportLink/}}',
+				options
+			),
+		},
+		squarespace: {
+			description: translate(
+				'Import posts, pages, comments, tags, and images from a %(importerName)s export file.',
+				options
+			),
+			uploadDescription: translate(
+				'A %(importerName)s export is ' +
+					'an XML file with your page and post content, or a zip archive ' +
+					'containing several XML files. ' +
+					'{{supportLink/}}',
+				options
+			),
+		},
+		wordpress: {
+			description: translate(
+				'Import posts, pages, and media from your %(importerName)s export file.',
+				options
+			),
+			uploadDescription: translate(
+				'A %(importerName)s export is ' +
+					'an XML file with your page and post content, or a zip archive ' +
+					'containing several XML files. ' +
+					'{{supportLink/}}',
+				options
+			),
+		},
+	};
+	const importerData = importerConfig()[ importer ];
 
 	importerData.title = translate( 'Import content from %(importerName)s', {
 		...options,
 		textOnly: true,
 	} as TranslateOptionsText ) as string;
 
-	importerData.description = translate(
-		// eslint-disable-next-line wpcalypso/i18n-no-variables
-		translateConfig[ importer ].description as string,
-		options
-	);
-
-	importerData.uploadDescription = translate(
-		// eslint-disable-next-line wpcalypso/i18n-no-variables
-		translateConfig[ importer ].uploadDescription as string,
-		options
-	);
+	importerData.description = translateConfig[ importer ].description as string;
+	importerData.uploadDescription = translateConfig[ importer ].uploadDescription as string;
 
 	return importerData;
 }


### PR DESCRIPTION
Currently the `description` and `uploadDescription` properties for various importers are defined as untranslated strings and their value is then passed to `translate` function (e.g. `translate( translateConfig[ importer ].description, options )`), which means that the translatable strings are not extracted from the code and no translations exist for them.

#### Proposed Changes

* Refactor the code to wrap all the strings in `translate` function

#### Testing Instructions

* Checkout the branch and run `yarn translate`
* Open the generated `public/calypso-strings.pot` file and search for `importer-drag/config.tsx`. Confirm that all the strings are present in the POT file.
* Switch to a Mag-16 locale and use either calypso.localhost or calypso.live
* Create a new site and on the “Where will you start” page, select “Import your site content” at the bottom of the list of options, or build and navigate to a URL like [http://calypso.localhost:3000/setup/importReadyPreview?siteSlug=[my-existing-test-site].wordpress.com](http://calypso.localhost:3000/setup/importReadyPreview?siteSlug=%5Bmy-existing-test-site%5D.wordpress.com)
* When prompted for the site URL, use https://medium.com/forge/ and go to the next page
* Click the blue import button and check that on the next screen everything is translated, except for `Import your posts, tags, images, and videos from your Medium export file`, which doesn't have translations yet.

<img width="763" alt="Screenshot 2022-07-01 at 13 03 22" src="https://user-images.githubusercontent.com/7847633/176882565-41df930e-c12f-4156-a96f-c4fc6d558d94.png">


