### PR TITLE
Goals Capture: Enable Goals Step i2 layout based on the feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
@@ -1,0 +1,69 @@
+import { StepContainer } from '@automattic/onboarding';
+import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
+import FormattedHeader from 'calypso/components/formatted-header';
+
+type GoalsCaptureContainerProps = {
+	displayAllGoals?: boolean;
+	welcomeText: string;
+	whatAreYourGoalsText: string;
+	subHeaderText: string;
+	stepName: string;
+	goNext: () => void;
+	skipLabelText: string;
+	skipButtonAlign?: 'top' | 'bottom';
+	hideBack: boolean;
+	stepContent: React.ReactElement;
+	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
+};
+
+// Goals Capture: Iteration 1 UI, one column layout
+const GCOneColumnContainer: React.VFC< GoalsCaptureContainerProps > = ( {
+	welcomeText,
+	whatAreYourGoalsText,
+	subHeaderText,
+	...otherProps
+} ) => (
+	<StepContainer
+		{ ...otherProps }
+		isHorizontalLayout={ true }
+		headerImageUrl={ intentImageUrl }
+		className={ 'goals__container one-column' }
+		formattedHeader={
+			<FormattedHeader
+				id={ 'goals-header' }
+				headerText={
+					<>
+						{ welcomeText } <br /> { whatAreYourGoalsText }
+					</>
+				}
+				subHeaderText={ subHeaderText }
+			/>
+		}
+	/>
+);
+
+// Goals Capture: Iteration 2 UI, two columns layout
+const GCTwoColumnContainer: React.VFC< GoalsCaptureContainerProps > = ( {
+	whatAreYourGoalsText,
+	subHeaderText,
+	...otherProps
+} ) => (
+	<StepContainer
+		{ ...otherProps }
+		isHorizontalLayout={ false }
+		className={ 'goals__container two-columns' }
+		formattedHeader={
+			<FormattedHeader
+				id={ 'goals-header' }
+				headerText={ whatAreYourGoalsText }
+				subHeaderText={ subHeaderText }
+			/>
+		}
+	/>
+);
+
+export const GoalsCaptureContainer: React.VFC< GoalsCaptureContainerProps > = ( {
+	displayAllGoals,
+	...props
+} ) =>
+	displayAllGoals ? <GCTwoColumnContainer { ...props } /> : <GCOneColumnContainer { ...props } />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -7,9 +7,9 @@ const HIDE_GOALS = [ SiteGoal.DIFM, SiteGoal.Import ];
 
 const shouldDisplayGoal = ( { key }: Goal ) => ! HIDE_GOALS.includes( key );
 
-export const useGoals = (): Goal[] => {
+export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const translate = useTranslate();
-	return [
+	const goals = [
 		{
 			key: SiteGoal.Write,
 			title: translate( 'Write & Publish' ),
@@ -35,5 +35,6 @@ export const useGoals = (): Goal[] => {
 			key: SiteGoal.Other,
 			title: translate( 'Other' ),
 		},
-	].filter( shouldDisplayGoal );
+	];
+	return displayAllGoals ? goals : goals.filter( shouldDisplayGoal );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -27,6 +27,7 @@ type TracksGoalsSelectEventProperties = {
 const SiteGoal = Onboard.SiteGoal;
 const { serializeGoals, goalsToIntent } = Onboard.utils;
 
+const displayAllGoals = isEnabled( 'signup/goals-step-2' );
 const refGoals: Record< string, Onboard.SiteGoal[] > = {
 	'create-blog-lp': [ SiteGoal.Write ],
 };
@@ -39,7 +40,6 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const welcomeText = translate( 'Welcome!' );
 	const whatAreYourGoalsText = translate( 'What are your goals?' );
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
-	const displayAllGoals = isEnabled( 'signup/goals-step-2' );
 
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 	const { setGoals, setIntent, clearImportGoal, clearDIFMGoal, resetIntent } =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,14 +1,13 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
-import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { GoalsCaptureContainer } from './goals-capture-container';
 import SelectGoals from './select-goals';
 import type { Step } from '../../types';
 import './style.scss';
@@ -39,12 +38,8 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const translate = useTranslate();
 	const welcomeText = translate( 'Welcome!' );
 	const whatAreYourGoalsText = translate( 'What are your goals?' );
-	const headerText = (
-		<>
-			{ welcomeText } <br /> { whatAreYourGoalsText }
-		</>
-	);
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
+	const displayAllGoals = isEnabled( 'signup/goals-step-2' );
 
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 	const { setGoals, setIntent, clearImportGoal, clearDIFMGoal, resetIntent } =
@@ -52,10 +47,17 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const refParameter = getQueryArgs()?.ref as string;
 
 	useEffect( () => {
-		clearDIFMGoal();
-		clearImportGoal();
+		if ( ! displayAllGoals ) {
+			clearDIFMGoal();
+			clearImportGoal();
+		}
+
 		resetIntent();
-	}, [ clearDIFMGoal, clearImportGoal, resetIntent ] );
+
+		// Delibirately not including all deps in the deps array
+		// This hook is only meant to be executed in the first render
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const recordGoalsSelectTracksEvent = (
 		goals: Onboard.SiteGoal[],
@@ -104,7 +106,12 @@ const GoalsStep: Step = ( { navigation } ) => {
 	};
 
 	const stepContent = (
-		<SelectGoals selectedGoals={ goals } onChange={ setGoals } onSubmit={ handleSubmit } />
+		<SelectGoals
+			displayAllGoals={ displayAllGoals }
+			selectedGoals={ goals }
+			onChange={ setGoals }
+			onSubmit={ handleSubmit }
+		/>
 	);
 
 	useEffect( () => {
@@ -122,22 +129,16 @@ const GoalsStep: Step = ( { navigation } ) => {
 		<>
 			<DocumentHead title={ whatAreYourGoalsText } />
 
-			<StepContainer
+			<GoalsCaptureContainer
+				displayAllGoals={ displayAllGoals }
+				welcomeText={ welcomeText }
+				whatAreYourGoalsText={ whatAreYourGoalsText }
+				subHeaderText={ subHeaderText }
 				stepName={ 'goals-step' }
 				goNext={ navigation.goNext }
 				skipLabelText={ translate( 'Skip to dashboard' ) }
 				skipButtonAlign={ 'top' }
 				hideBack={ true }
-				isHorizontalLayout={ true }
-				headerImageUrl={ intentImageUrl }
-				className={ 'goals__container' }
-				formattedHeader={
-					<FormattedHeader
-						id={ 'goals-header' }
-						headerText={ headerText }
-						subHeaderText={ subHeaderText }
-					/>
-				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -7,6 +7,7 @@ import ImportLink from './import-link';
 import SelectCard from './select-card';
 
 type SelectGoalsProps = {
+	displayAllGoals: boolean;
 	onChange: ( selectedGoals: Onboard.SiteGoal[] ) => void;
 	onSubmit: ( selectedGoals: Onboard.SiteGoal[] ) => void;
 	selectedGoals: Onboard.SiteGoal[];
@@ -14,9 +15,14 @@ type SelectGoalsProps = {
 
 const SiteGoal = Onboard.SiteGoal;
 
-export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsProps ) => {
+export const SelectGoals = ( {
+	displayAllGoals,
+	onChange,
+	onSubmit,
+	selectedGoals,
+}: SelectGoalsProps ) => {
 	const translate = useTranslate();
-	const goalOptions = useGoals();
+	const goalOptions = useGoals( displayAllGoals );
 
 	const addGoal = ( goal: Onboard.SiteGoal ) => {
 		const goalSet = new Set( selectedGoals );
@@ -51,6 +57,10 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 
 	return (
 		<>
+			{ displayAllGoals && (
+				<div className="select-goals__cards-hint">{ translate( 'Select all that apply' ) }</div>
+			) }
+
 			<div className="select-goals__cards-container">
 				{ goalOptions.map( ( { key, title, isPremium } ) => (
 					<SelectCard
@@ -72,10 +82,13 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>
-			<div className="select-goals__links-container">
-				<ImportLink onClick={ handleImportLinkClick } />
-				<DIFMLink onClick={ handleDIFMLinkClick } />
-			</div>
+
+			{ ! displayAllGoals && (
+				<div className="select-goals__links-container">
+					<ImportLink onClick={ handleImportLinkClick } />
+					<DIFMLink onClick={ handleDIFMLinkClick } />
+				</div>
+			) }
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -5,22 +5,55 @@
 .goals__container {
 	padding: 0 20px;
 
-	.step-container__header {
-		.formatted-header {
-			// i2: padding-top: 44px;
-			// i2: text-align: left;
-			text-align: left;
+	&.two-columns {
+		.step-container__header {
+			margin-bottom: 64px;
 
-			.formatted-header__subtitle,
-			.formatted-header__title {
+			.formatted-header {
+				padding-top: 44px;
+
+				.formatted-header__subtitle,
+				.formatted-header__title {
+					@include break-mobile {
+						text-align: center;
+					}
+				}
+
 				@include break-mobile {
-					// i2: text-align: center;
+					padding-top: 72px;
 				}
 			}
+		}
 
-			@include break-mobile {
-				// i2: padding-top: 72px;
+		.select-goals__cards-hint {
+			font-weight: 400;
+			line-height: 24px;
+			color: #787c82;
+		}
+
+		.select-goals__cards-container {
+			padding-top: 16px;
+
+			@include break-small {
+				grid-template-columns: repeat( 2, 1fr );
 			}
+		}
+
+		.select-goals__actions-container {
+			padding-top: 32px;
+			padding-bottom: 60px + 48px; // height of sticky footer + height of bottom whitespace
+
+			@include break-small {
+				padding-top: 48px;
+				padding-bottom: 48px;
+				justify-content: center;
+			}
+		}
+	}
+
+	.step-container__header {
+		.formatted-header {
+			text-align: left;
 		}
 	}
 
@@ -46,7 +79,6 @@
 		}
 
 		@include break-small {
-			// i2: grid-template-columns: repeat( 2, 1fr );
 			grid-template-columns: repeat( 1, 1fr );
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR enables Goals Step i2 layout based on the feature flag `signup/goals-step-2`:
- Creates a `GoalsCaptureContainer` component, which conditionally renders the **one column layout** if the flag is **disabled** and the **two columns layout** if the flag is **enabled**
- Applies the `GoalsCaptureContainer` on `GoalsStep` component, defining the `displayAllGoals` as true if the flag is enabled
  - Updates `useEffect` to not delete the **DIFM** and **Import** goals when the flag is true
- Restores the i2 styling in the _scss_ file, but now it's specified for a `.two-columns` parent selector
- Updates the `SelectGoals` component to render the UI based on the flag
  - If true: renders the "Select all that apply" hint on top of the goals list
  - If false: renders the bottom links for DIFM and Import

#### Testing Instructions

##### Testing with the flag enabled

1. Navigate to `http://calypso.localhost:3000/setup/goals?siteSlug=<YOUR-SITE>&flags=signup/goals-step-2`
2. Check if the **two columns layout** appears as expected
<img width="1118" alt="Screen Shot 2022-07-01 at 10 50 51" src="https://user-images.githubusercontent.com/3113712/176909728-d825515b-ebc1-4d64-b2a5-62339fa8ab96.png">

3. Check if the **mobile layout** appears as expected
<img width="475" alt="Screen Shot 2022-07-01 at 11 03 06" src="https://user-images.githubusercontent.com/3113712/176909863-25716f0c-6821-485c-a346-d992dc69e697.png">

4. Select **DIFM** and **Import** goals and refresh the page
5. Check if the selected goals persisted

##### Testing with the flag disabled

1. Navigate to `http://calypso.localhost:3000/setup/goals?siteSlug=<YOUR-SITE>`
2. Check if the **one column layout** appears as expected
<img width="1102" alt="Screen Shot 2022-07-01 at 11 01 32" src="https://user-images.githubusercontent.com/3113712/176910075-2d5cfb3d-50a4-48e9-80a4-82edacc3cd48.png">

3. Check if the **mobile layout** appears as expected
<img width="483" alt="Screen Shot 2022-07-01 at 11 05 27" src="https://user-images.githubusercontent.com/3113712/176910267-afdb40a8-1c84-4916-a051-359ecbc050e5.png">


Related to #64997