### PR TITLE
Google Sign-in: enable migration feature flag on every environment

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -104,7 +104,7 @@ class GoogleLoginButton extends Component {
 	}
 
 	async loadGoogleIdentityServicesAPI() {
-		if ( ! window.google?.accounts.oauth2 ) {
+		if ( ! window.google?.accounts?.oauth2 ) {
 			await loadScript( 'https://accounts.google.com/gsi/client' );
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -110,7 +110,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,7 @@
 		"marketplace-starter-plan": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2/p2-plus": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -53,7 +53,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -47,7 +47,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -49,7 +49,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -50,7 +50,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/production.json
+++ b/config/production.json
@@ -78,7 +78,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"p2/p2-plus": true,
 		"plans/starter-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -76,7 +76,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"p2/p2-plus": true,
 		"page/export": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,7 +60,7 @@
 		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"plans/starter-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -87,7 +87,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": false,
+		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2/p2-plus": true,


### PR DESCRIPTION
#### Proposed Changes

* Enable `migration/sign-in-with-google` in all the environments.

We will enable this feature flag to start using the new Google Sign-in API, after few weeks we will monitor `calypso_login_social_login_success` and `calypso_login_social_login_failure` on tracks.
If everything works as expected we will remove this feature flag and let the final code in production.

#### Testing Instructions

- Make sure the flows described in #65086 is still working. (Pop-up)
- Make sure the flows described in  #64957 is still working. (Redirect)
---

- Related to #64538 and #64791
