### PR TITLE
Checkout: Add purchase success notice to manual renewals with async payment methods

### DIFF
--- a/client/lib/checkout/use-display-purchase-success.ts
+++ b/client/lib/checkout/use-display-purchase-success.ts
@@ -3,10 +3,12 @@ import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { successNotice } from 'calypso/state/notices/actions';
 
-export function useDisplayPurchaseSuccess( noticeType: string | undefined ): void {
+export function useDisplayPurchaseSuccess( areNoticesAllowed = true ): void {
+	const queryString = new URLSearchParams( window?.location?.search );
+	const noticeType = queryString.get( 'notice' ) ?? undefined;
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
-	const shouldShowNotice = Boolean( noticeType );
+	const shouldShowNotice = Boolean( areNoticesAllowed && noticeType === 'purchase-success' );
 	const lastShownNotice = useRef< string | undefined >();
 
 	useEffect( () => {
@@ -14,10 +16,8 @@ export function useDisplayPurchaseSuccess( noticeType: string | undefined ): voi
 			return;
 		}
 
-		if ( noticeType === 'purchase-success' ) {
-			lastShownNotice.current = noticeType;
-			const successMessage = translate( 'Your purchase has been completed!' );
-			reduxDispatch( successNotice( successMessage ) );
-		}
+		lastShownNotice.current = noticeType;
+		const successMessage = translate( 'Your purchase has been completed!' );
+		reduxDispatch( successNotice( successMessage ) );
 	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
 }

--- a/client/lib/checkout/use-display-purchase-success.ts
+++ b/client/lib/checkout/use-display-purchase-success.ts
@@ -3,6 +3,11 @@ import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { successNotice } from 'calypso/state/notices/actions';
 
+/**
+ * Display a purchase success notice if the URL query string includes `notice=purchase-success`.
+ *
+ * This is intended to be used by post-checkout pages.
+ */
 export function useDisplayPurchaseSuccess( areNoticesAllowed = true ): void {
 	const queryParams = new URLSearchParams( window?.location?.search );
 	const noticeType = queryParams.get( 'notice' ) ?? undefined;

--- a/client/lib/checkout/use-display-purchase-success.ts
+++ b/client/lib/checkout/use-display-purchase-success.ts
@@ -1,0 +1,23 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { successNotice } from 'calypso/state/notices/actions';
+
+export function useDisplayPurchaseSuccess( noticeType: string | undefined ): void {
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+	const shouldShowNotice = Boolean( noticeType );
+	const lastShownNotice = useRef< string | undefined >();
+
+	useEffect( () => {
+		if ( ! shouldShowNotice || lastShownNotice.current === noticeType ) {
+			return;
+		}
+
+		if ( noticeType === 'purchase-success' ) {
+			lastShownNotice.current = noticeType;
+			const successMessage = translate( 'Your purchase has been completed!' );
+			reduxDispatch( successNotice( successMessage ) );
+		}
+	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
+}

--- a/client/lib/checkout/use-display-purchase-success.ts
+++ b/client/lib/checkout/use-display-purchase-success.ts
@@ -4,8 +4,8 @@ import { useDispatch } from 'react-redux';
 import { successNotice } from 'calypso/state/notices/actions';
 
 export function useDisplayPurchaseSuccess( areNoticesAllowed = true ): void {
-	const queryString = new URLSearchParams( window?.location?.search );
-	const noticeType = queryString.get( 'notice' ) ?? undefined;
+	const queryParams = new URLSearchParams( window?.location?.search );
+	const noticeType = queryParams.get( 'notice' ) ?? undefined;
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const shouldShowNotice = Boolean( areNoticesAllowed && noticeType === 'purchase-success' );
@@ -19,5 +19,11 @@ export function useDisplayPurchaseSuccess( areNoticesAllowed = true ): void {
 		lastShownNotice.current = noticeType;
 		const successMessage = translate( 'Your purchase has been completed!' );
 		reduxDispatch( successNotice( successMessage ) );
+
+		// Remove the notice query string from the URL after displaying the message
+		// so that it will not be included in bookmarks or browser history.
+		const currentUrl = new URL( window?.location?.href ?? 'https://wordpress.com' );
+		currentUrl.searchParams.delete( 'notice' );
+		window?.history?.replaceState?.( null, '', currentUrl );
 	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
 }

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -7,14 +7,12 @@ export default async function ( context, next ) {
 	const state = await context.store.getState();
 	const siteId = await getSelectedSiteId( state );
 
-	const noticeType = context.query.notice;
-
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome key={ siteId } noticeType={ noticeType } />;
+	context.primary = <CustomerHome key={ siteId } />;
 
 	next();
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -37,7 +37,6 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
-	noticeType,
 	sitePlanSlug,
 	isNew7DUser,
 } ) => {
@@ -46,7 +45,7 @@ const Home = ( {
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
 
 	const shouldShowNotice = Boolean( canUserUseCustomerHome && layout );
-	useDisplayPurchaseSuccess( shouldShowNotice ? noticeType : undefined );
+	useDisplayPurchaseSuccess( shouldShowNotice );
 
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	useEffect( () => {

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -2,8 +2,8 @@ import { Button } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { connect, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
@@ -14,13 +14,13 @@ import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
+import { useDisplayPurchaseSuccess } from 'calypso/lib/checkout/use-display-purchase-success';
 import { preventWidows } from 'calypso/lib/formatting';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
-import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import {
@@ -42,26 +42,11 @@ const Home = ( {
 	isNew7DUser,
 } ) => {
 	const translate = useTranslate();
-	const reduxDispatch = useDispatch();
 
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
 
-	const shouldShowNotice = Boolean( canUserUseCustomerHome && layout && noticeType );
-	const lastShownNotice = useRef( null );
-	useEffect( () => {
-		if ( ! shouldShowNotice || lastShownNotice.current === noticeType ) {
-			return;
-		}
-
-		if ( noticeType === 'purchase-success' ) {
-			lastShownNotice.current = noticeType;
-			const successMessage = translate( 'Your purchase has been completed!' );
-			reduxDispatch( successNotice( successMessage ) );
-			return;
-		}
-
-		return;
-	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
+	const shouldShowNotice = Boolean( canUserUseCustomerHome && layout );
+	useDisplayPurchaseSuccess( shouldShowNotice ? noticeType : undefined );
 
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	useEffect( () => {

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -28,12 +28,10 @@ export const purchases = ( context, next ) => {
 };
 
 export const purchaseDetails = ( context, next ) => {
-	const noticeType = context.query.notice;
 	context.primary = (
 		<PurchaseDetails
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			noticeType={ noticeType }
 		/>
 	);
 	next();

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -28,10 +28,12 @@ export const purchases = ( context, next ) => {
 };
 
 export const purchaseDetails = ( context, next ) => {
+	const noticeType = context.query.notice;
 	context.primary = (
 		<PurchaseDetails
 			siteSlug={ context.params.site }
 			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			noticeType={ noticeType }
 		/>
 	);
 	next();

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -1,14 +1,15 @@
 import config from '@automattic/calypso-config';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useDisplayPurchaseSuccess } from 'calypso/lib/checkout/use-display-purchase-success';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -18,7 +19,6 @@ import ManagePurchase from 'calypso/me/purchases/manage-purchase';
 import ChangePaymentMethod from 'calypso/me/purchases/manage-purchase/change-payment-method';
 import titles from 'calypso/me/purchases/titles';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
-import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	getPurchaseListUrlFor,
@@ -102,23 +102,7 @@ export function PurchaseDetails( {
 	const redirectTo = getManagePurchaseUrlFor( siteSlug, purchaseId );
 	const redirectToWithSuccess = addQueryArgs( { notice: 'purchase-success' }, redirectTo );
 
-	const reduxDispatch = useDispatch();
-	const shouldShowNotice = Boolean( noticeType );
-	const lastShownNotice = useRef< string | undefined >();
-	useEffect( () => {
-		if ( ! shouldShowNotice || lastShownNotice.current === noticeType ) {
-			return;
-		}
-
-		if ( noticeType === 'purchase-success' ) {
-			lastShownNotice.current = noticeType;
-			const successMessage = translate( 'Your purchase has been completed!' );
-			reduxDispatch( successNotice( successMessage ) );
-			return;
-		}
-
-		return;
-	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
+	useDisplayPurchaseSuccess( noticeType );
 
 	return (
 		<Main wideLayout className="purchases manage-purchase">

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -91,18 +91,16 @@ export function Purchases() {
 export function PurchaseDetails( {
 	purchaseId,
 	siteSlug,
-	noticeType,
 }: {
 	purchaseId: number;
 	siteSlug: string;
-	noticeType?: string;
 } ) {
 	const translate = useTranslate();
 	const logPurchasesError = useLogPurchasesError( 'site level purchase details load error' );
 	const redirectTo = getManagePurchaseUrlFor( siteSlug, purchaseId );
 	const redirectToWithSuccess = addQueryArgs( { notice: 'purchase-success' }, redirectTo );
 
-	useDisplayPurchaseSuccess( noticeType );
+	useDisplayPurchaseSuccess();
 
 	return (
 		<Main wideLayout className="purchases manage-purchase">


### PR DESCRIPTION
#### Proposed Changes

When using a "renew now" link from the "manage purchase" page in calypso, after checkout you are redirected back to the "manage purchase" page thanks to a `redirect_to` query param added by the link. A "success" notice is displayed by [a deferred action](https://github.com/Automattic/wp-calypso/blob/b1e9be142bc79c6c2abcef96e5212c76eec11092/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L178-L187) triggered from inside checkout's `onPaymentComplete` function. However, for async payment methods like 3DS cards, PayPal, or other redirect methods, that function is never called. In that case, the user is redirected to the "manage purchase" page with no notification that their purchase was successful.

In this PR, we modify the `redirect_to` links for renewals on the "manage purchase" page to include a new `notice=purchase-success` query param of their own which causes the "manage purchase" page to display a success notice. (This is [the same pattern](https://github.com/Automattic/wp-calypso/blob/28bf4a84b956f9ad0df74bc826239173eec31ddc/client/my-sites/customer-home/main.jsx#L56-L61) used by the "customer home" page and this PR also abstracts that page's logic into a reusable hook for both pages.)

Fixes 553-gh-Automattic/payments-shilling

After this PR:

<img width="685" alt="Screen Shot 2022-07-01 at 4 17 54 PM" src="https://user-images.githubusercontent.com/2036909/176974374-ae50d2db-e3ec-4677-bf8e-edb5685a3370.png">

To do:

 - [x] Abstract this behavior from both customer home and manage purchases into a single function.
 - [x] We should remove the `notice` query param from the URL once the message has been displayed to avoid reloads or bookmarks displaying the message unintentionally.
 - [x] If the redirect happens from a sync payment method, the user will get two success messages instead of one, which is not terrible but we should be able to better handle this situation. (This is not actually resolved but I don't think it can be resolved without changing how checkout works. See https://github.com/Automattic/wp-calypso/pull/65164#issuecomment-1173983371) See the following screenshot:
<img width="1105" alt="Screen_Shot_2022-07-01_at_4_22_34_PM" src="https://user-images.githubusercontent.com/2036909/176974626-b8dccf73-5518-47a2-bcf6-696f33240d74.png">

#### Testing Instructions

- Use an account that owns a subscription to a product.
- On this branch, visit the product's purchase management page in calypso. You can find a link to each subscription's purchase management page under `/me/purchases`.
- Click any "Renew now" link on the purchase management page.
- Complete the checkout form and pay using a 3DS card. If your API and store are sandboxed, you can use a [Stripe test card](https://stripe.com/docs/testing) like `4000000000003063`.
- Confirm the payment as required by the 3DS card. For test cards this will be a dialog box that appears over checkout.
- Once the payment is complete, verify that you are redirected back to the purchase management page, and that you see a success message displayed.