### PR TITLE
i18n: Place the WordPress logo in the correct location during onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -86,6 +86,11 @@ button {
 			fill: var( --color-text );
 			stroke: var( --color-text );
 			transform-origin: 0 0;
+
+			.rtl & {
+				/*rtl:ignore*/
+				transform-origin: 100% 0;
+			}
 		}
 
 		.signup-header__right {


### PR DESCRIPTION
#### Problem
During the onboarding process, the WordPress logo is placed incorrectly in RTL languages (e.g. Arabic or Hebrew). 
[Previously](https://github.com/Automattic/wp-calypso/pull/64463), we used [CSS Logical Properties and Values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) to solve this issue. Unfortunately, the [transform-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin) property has [no logical equivalent](https://github.com/w3c/csswg-drafts/issues/1544).

#### Proposed Changes

Provide the correct `transform-origin` value for RTL languages in instances where the incorrect CSS is used in the DOM.

#### Testing Instructions

1. Set language to Arabic or Hebrew
2. Create new site at /start
3. Select domain and free plan
4. Select "Build" from the Where to start page
5. Verify the the WordPress logo is in the correct location (the top right corner)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before:
![Before CSS update](https://user-images.githubusercontent.com/31164683/177010735-b20764a9-ce93-4b97-9700-a57fe1df7318.png)

After:
![After CSS update](https://user-images.githubusercontent.com/31164683/177010760-c347eea1-0312-4dbd-bd87-0a1835f0a2a6.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 437-gh-Automattic/i18n-issues