### PR TITLE
Atomic: Use allowed mime types set by site

### DIFF
--- a/client/lib/media/utils/is-site-allowed-file-types-to-be-trusted.js
+++ b/client/lib/media/utils/is-site-allowed-file-types-to-be-trusted.js
@@ -10,7 +10,7 @@
  */
 export function isSiteAllowedFileTypesToBeTrusted( site ) {
 	if ( ! site ) {
-		return false;
+		return true;
 	}
 
 	if ( site.jetpack && ! site.is_wpcom_atomic ) {

--- a/client/lib/media/utils/is-site-allowed-file-types-to-be-trusted.js
+++ b/client/lib/media/utils/is-site-allowed-file-types-to-be-trusted.js
@@ -9,11 +9,7 @@
  * @returns {boolean}      Site allowed file types are accurate
  */
 export function isSiteAllowedFileTypesToBeTrusted( site ) {
-	if ( ! site ) {
-		return true;
-	}
-
-	if ( site.jetpack && ! site.is_wpcom_atomic ) {
+	if ( site?.jetpack && ! site?.is_wpcom_atomic ) {
 		return false;
 	}
 

--- a/client/lib/media/utils/is-site-allowed-file-types-to-be-trusted.js
+++ b/client/lib/media/utils/is-site-allowed-file-types-to-be-trusted.js
@@ -9,5 +9,13 @@
  * @returns {boolean}      Site allowed file types are accurate
  */
 export function isSiteAllowedFileTypesToBeTrusted( site ) {
-	return ! site || ! site.jetpack;
+	if ( ! site ) {
+		return false;
+	}
+
+	if ( site.jetpack && ! site.is_wpcom_atomic ) {
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65120

#### Proposed Changes

Ensures that the allowed mime types returned by the site options of an Atomic site are used to determine whether a file upload is restricted, effectively solving a bug that was allowing to initiate the upload of video files on lower-tier plans.

Before | After
--- | ---
<img width="1269" alt="Screen Shot 2022-06-30 at 13 39 29" src="https://user-images.githubusercontent.com/1233880/176671352-ee9d29ff-bb32-43ce-bda0-55336f5686aa.png"> | <img width="1268" alt="Screen Shot 2022-07-04 at 11 11 12" src="https://user-images.githubusercontent.com/1233880/177124518-d3a57409-fcb2-4dfb-9b14-7970d5f0ea9b.png">

It seems that we were previously considering these allowed mime types as untrustworthy because the allowed file types option was not synced on Jetpack sites, but that shouldn't be a problem on Atomic sites since we have code ensuring that the option matches the restrictions we have on Simple sites (834-gh-Automattic/wpcomsh).

#### Testing Instructions

- Use the Calypso live link below.
- Switch to an Atomic site with a Starter plan.
- Go to Media.
- Upload a video file.
- Make sure you got a warning asking you to upgrade.
- Switch to an Atomic site with a Pro plan.
- Upload a video file.
- Make sure it gets uploaded successfully.