### PR TITLE
`SiteSettingsSecurity`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/my-sites/site-settings/settings-security/test/main.jsx
+++ b/client/my-sites/site-settings/settings-security/test/main.jsx
@@ -2,8 +2,12 @@
  * @jest-environment jsdom
  */
 import { PLAN_FREE } from '@automattic/calypso-products';
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SiteSettingsSecurity } from '../main';
+
+const render = ( el, options ) => renderWithProvider( el, { ...options, reducers: { ui } } );
 
 const props = {
 	site: {
@@ -12,13 +16,19 @@ const props = {
 	translate: ( x ) => x,
 };
 
+jest.mock( 'calypso/my-sites/site-settings/form-security', () => () => null );
+jest.mock( 'calypso/my-sites/site-settings/form-jetpack-monitor', () => () => null );
+jest.mock( 'calypso/my-sites/site-settings/jetpack-dev-mode-notice', () => () => null );
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/components/empty-content', () => () => <div data-testid="empty-content" /> );
+
 describe( 'SiteSettingsSecurity basic tests', () => {
 	test( 'error page should not show if active security settings feature', () => {
-		const comp = shallow( <SiteSettingsSecurity { ...props } hasSecuritySettings={ true } /> );
-		expect( comp.find( 'EmptyContent' ) ).toHaveLength( 0 );
+		render( <SiteSettingsSecurity { ...props } hasSecuritySettings={ true } /> );
+		expect( screen.queryByTestId( 'empty-content' ) ).not.toBeInTheDocument();
 	} );
 	test( 'error page should show if no active security settings feature', () => {
-		const comp = shallow( <SiteSettingsSecurity { ...props } hasSecuritySettings={ false } /> );
-		expect( comp.find( 'EmptyContent' ) ).toHaveLength( 1 );
+		render( <SiteSettingsSecurity { ...props } hasSecuritySettings={ false } /> );
+		expect( screen.queryByTestId( 'empty-content' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `SiteSettingsSecurity`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 
