### PR TITLE
Goals Capture: Add `useSiteGoals` hook

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -22,6 +22,7 @@ export { useSiteAnalysis } from './queries/use-site-analysis';
 export type { AnalysisReport } from './queries/use-site-analysis';
 export { useHasSeenWhatsNewModalQuery } from './queries/use-has-seen-whats-new-modal-query';
 export { useSiteIntent } from './queries/use-site-intent';
+export { useSiteGoals } from './queries/use-site-goals';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';

--- a/packages/data-stores/src/queries/use-site-goals.ts
+++ b/packages/data-stores/src/queries/use-site-goals.ts
@@ -1,0 +1,17 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export function useSiteGoals( siteId: string | number | undefined ) {
+	return useQuery(
+		'site-goals-' + siteId,
+		async () =>
+			await wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId as string ) }/site-goals`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			refetchOnWindowFocus: false,
+			enabled: !! siteId,
+		}
+	);
+}

--- a/packages/data-stores/test/use-site-goals.test.tsx
+++ b/packages/data-stores/test/use-site-goals.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import { useSiteGoals } from '../src/queries/use-site-goals';
+
+jest.mock( 'wpcom-proxy-request' );
+
+const queryClient = new QueryClient();
+const wrapper = ( { children } ) => (
+	<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+);
+
+const siteId = 1;
+
+describe( 'useSiteGoals', () => {
+	it( `returns empty array of goals if no goal was selected`, async () => {
+		const goals = [];
+
+		wpcomRequest.mockImplementation( () => Promise.resolve( goals ) );
+
+		const { result } = renderHook( () => useSiteGoals( siteId ), { wrapper } );
+
+		await waitFor( () => {
+			return result.current.isSuccess;
+		} );
+
+		expect( result.current.data ).toHaveLength( 0 );
+		expect( result.current.data ).toEqual( [] );
+	} );
+
+	it( `returns the array of goals if any`, async () => {
+		const goals = [ 'promote', 'write' ];
+
+		wpcomRequest.mockImplementation( () => Promise.resolve( goals ) );
+
+		const { result } = renderHook( () => useSiteGoals( siteId ), { wrapper } );
+
+		await waitFor( () => {
+			return result.current.isSuccess;
+		} );
+
+		expect( result.current.data ).toHaveLength( 2 );
+		expect( result.current.data ).toEqual( [ 'promote', 'write' ] );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

For task: https://github.com/Automattic/wp-calypso/issues/65244

The changes proposed in this PR add a hook for retrieving the goals the user selected when they was in the onboarding flow, so we can use those values in other parts of Calypso.

#### Testing Instructions

* There are automatic test on `packages/data-stores/test/use-site-goals.test.tsx` that you can run with `yarn test-packages`
* You could test manually the hook by:
  - importing the `useSiteGoals` hook into any component that have access to the site ID, so you can pass that as parameter to the hook (like `const { result } = useSiteGoals( siteId )`).
  - checking that the hook is retrieving the correct goals information used in the onboarding flow of the selected blog

Related: pdDOJh-lY-p2