### PR TITLE
Fix issue with not working autocomplete for Posts Carousel block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/index.php
@@ -66,7 +66,7 @@ function newspack_blocks_block_args( $args, $name ) {
 			array(
 				'posts_rest_url'          => rest_url( 'newspack-blocks/v1/newspack-blocks-posts' ),
 				'specific_posts_rest_url' => rest_url( 'newspack-blocks/v1/newspack-blocks-specific-posts' ),
-				// define URL to core one to make autocomplete working for newspack-blocks installed via ETK
+				// Define URL to core one to make autocomplete working for newspack-blocks installed via ETK.
 				'authors_rest_url'        => rest_url() . 'wp/v2/users',
 			)
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/index.php
@@ -66,6 +66,8 @@ function newspack_blocks_block_args( $args, $name ) {
 			array(
 				'posts_rest_url'          => rest_url( 'newspack-blocks/v1/newspack-blocks-posts' ),
 				'specific_posts_rest_url' => rest_url( 'newspack-blocks/v1/newspack-blocks-specific-posts' ),
+				// define URL to core one to make autocomplete working for newspack-blocks installed via ETK
+				'authors_rest_url'        => rest_url() . 'wp/v2/users',
 			)
 		);
 	}


### PR DESCRIPTION
#### Proposed Changes

Posts Carousel block is synchronized from newspack-blocks plugin. It uses a custom API endpoint for authors autocomplete. Only selected files are synchronized from newspack-block plugin to ETK, so autocomplete for authors field doesn't work.

This PR sets the endpoint to the core one, to let JS logic get authors data on WPCOM and Jetpack sites. There is no need to bring a custom endpoint to WPCOM as the custom endpoint was added to add compatibility for another module in newspack-blocks stand-alone module.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sandbox the site
2. Install ETK from the branch
```
install-plugin.sh editing-toolkit fix/newspack-block-authors-autocomplete
```
4. Go to "Add New" post form
5. Add a "Post Carousel" block
6. Open the block settings sidebar and locate the "Authors" field
7. Start writing a username that exists in your blog and has some posts (it may be your username)
8. Click the username which was displayed in a dropdown
9. Check if posts in the carousel were reloaded to show only those added by the selected user

It can be also tested in the WoA dev site or local Jetpack environment - you can install the ETK plugin from the branch manually.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61398
