### PR TITLE
Design Picker: Removes the pricing information from premium themes

### DIFF
--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -102,13 +102,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		if ( design.is_premium ) {
 			text = createInterpolateElement(
 				shouldUpgrade
-					? sprintf(
-							/* translators: %(price)s - the price of the theme */
-							__( '%(price)s per year or <button>included in the Pro plan</button>' ),
-							{
-								price: design.price,
-							}
-					  )
+					? __( '<button>Included in the Pro plan</button>' )
 					: __( 'Included in the Pro plan' ),
 				{
 					button: (


### PR DESCRIPTION
#### Proposed Changes

* Removes the pricing information from the premium themes since we are not using it yet.

<img width="595" alt="Screen Shot 2022-07-04 at 16 09 54" src="https://user-images.githubusercontent.com/1234758/177207989-fee0d7b2-e8a8-4260-8f92-6c78c529b899.png">

#### Testing Instructions

* Go to on a free site `/setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`.
* Find a paid theme and verify if the description only says: `Included in the Pro plan`.

Closes #65134
