### PR TITLE
Theme Picker: Open links in the dropdown on a new tab

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
@@ -35,8 +35,13 @@ const ThemeInfoPopup = ( { slug }: ThemeInfoPopupProps ) => {
 			<div className="theme-info-popup__support-links popup-item">
 				<h2>Support</h2>
 				<p>
-					<a href="https://wordpress.com/help/contact/">Contact us</a> or visit the{ ' ' }
-					<a href="https://en.forums.wordpress.com/forum/themes">support forum</a>
+					<a href="https://wordpress.com/help/contact/" target="__blank">
+						Contact us
+					</a>{ ' ' }
+					or visit the{ ' ' }
+					<a href="https://en.forums.wordpress.com/forum/themes" target="__blank">
+						support forum
+					</a>
 				</p>
 			</div>
 		);


### PR DESCRIPTION
#### Proposed Changes

* The links in the dropdown, on the Theme preview page, should open on a new tab instead of redirecting the current page.

<img width="652" alt="Screen Shot 2022-07-04 at 16 35 01" src="https://user-images.githubusercontent.com/1234758/177209504-93898d5e-4768-4683-9b9b-e97124e0e0de.png">

#### Testing Instructions

* Go to `/setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`
* Select any theme.
* On the theme preview page, click on the `i` button and check if the links are opening on a new tab instead of redirecting from the current page.

Closes #65135
