### PR TITLE
Checkout: Remove invalid urls from getThankYouPageUrl

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -70,12 +70,13 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 				const { receiptId } = transaction;
 
 				didRedirect.current = true;
-				const redirectUrl = redirectTo || `/checkout/thank-you/${ siteSlug }/${ receiptId }`;
-				if ( redirectUrl.startsWith( '/' ) ) {
-					page( redirectUrl );
+
+				if ( redirectTo ) {
+					performRedirect( redirectTo.replace( ':receiptId', String( receiptId ) ) );
 					return;
 				}
-				window.location.href = redirectUrl;
+
+				performRedirect( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
 				return;
 			}
 
@@ -134,6 +135,14 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 			/>
 		</Main>
 	);
+}
+
+function performRedirect( url: string ): void {
+	if ( url.startsWith( '/' ) ) {
+		page( url );
+		return;
+	}
+	window.location.href = url;
 }
 
 export default function CheckoutPendingWrapper( props: CheckoutPendingProps ) {

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -40,9 +40,9 @@ interface CheckoutPendingProps {
  * site.
  *
  * The `redirectTo` prop comes from the query string parameter of the same
- * name. It may include a literal `:receiptId` as part of the URL; if that's
- * the case, that string will be replaced by the receipt ID when the
- * transaction completes.
+ * name. It may include a literal `/pending` as part of the URL; if that's the
+ * case, that string will be replaced by the receipt ID when the transaction
+ * completes.
  */
 function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProps ) {
 	const translate = useTranslate();
@@ -91,8 +91,16 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 
 				didRedirect.current = true;
 
+				// Only treat `/pending` as a placeholder if it's the end of the URL
+				// pathname, but preserve query strings or hashes.
+				const receiptPlaceholderRegexp = /\/pending([?#]|$)/;
+				if ( redirectTo && receiptPlaceholderRegexp.test( redirectTo ) ) {
+					performRedirect( redirectTo.replace( receiptPlaceholderRegexp, `/${ receiptId }$1` ) );
+					return;
+				}
+
 				if ( redirectTo ) {
-					performRedirect( redirectTo.replace( ':receiptId', String( receiptId ) ) );
+					performRedirect( redirectTo );
 					return;
 				}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -222,9 +222,7 @@ export default function getThankYouPageUrl( {
 
 		return addQueryArgs(
 			{
-				receiptId: Number.isInteger( pendingOrReceiptId )
-					? Number( pendingOrReceiptId )
-					: undefined,
+				receiptId: isReceiptIdOrPlaceholder( pendingOrReceiptId ) ? pendingOrReceiptId : undefined,
 				siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
 			},
 			thankYouUrl

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -1613,7 +1613,7 @@ describe( 'getThankYouPageUrl', () => {
 				isJetpackCheckout: true,
 			} );
 			expect( url ).toBe(
-				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily'
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=%3AreceiptId'
 			);
 		} );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -94,8 +94,10 @@ describe( 'getThankYouPageUrl', () => {
 	} );
 
 	// Note: This just verifies the existing behavior; this URL is invalid unless
-	// placed after a `redirectTo` query string; see the redirect payment
-	// processor
+	// the `:receiptId` is replaced with a valid receipt ID by the PayPal
+	// transaction flow. When returning from PayPal, the user is redirected
+	// briefly to a backend page that replaces `:receiptId` and 302 redirects to
+	// the updated URL.
 	it( 'redirects to the business plan bump offer page with a placeholder receipt id when a site but no orderId is set and the cart contains the premium plan', () => {
 		const cart = {
 			...getEmptyResponseCart(),
@@ -147,16 +149,14 @@ describe( 'getThankYouPageUrl', () => {
 		);
 	} );
 
-	it( 'redirects to the thank-you pending page with a feature when a site, an order id, and a valid feature is set', () => {
+	it( 'redirects to the thank-you feature page with a feature when a site, an order id, and a valid feature is set', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
 			orderId: samplePurchaseId,
 		} );
-		expect( url ).toBe(
-			`/checkout/thank-you/features/all-free-features/foo.bar/pending/${ samplePurchaseId }`
-		);
+		expect( url ).toBe( `/checkout/thank-you/features/all-free-features/foo.bar` );
 	} );
 
 	it( 'redirects to the thank-you page with a feature when a site and a valid feature is set with no receipt but the cart is not empty', () => {
@@ -1613,7 +1613,7 @@ describe( 'getThankYouPageUrl', () => {
 				isJetpackCheckout: true,
 			} );
 			expect( url ).toBe(
-				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=%3AreceiptId'
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily'
 			);
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

`getThankYouPageUrl()` is used by checkout to generate the post-checkout redirect URL. It is quite complex and much of its logic is very old (it existed prior to the conversion to "new checkout" using the `@automattic/composite-checkout` package). It has always been known that it was possible for it to generate invalid URLs in some circumstances. In this PR we remove several invalid URLs and further clarify the types of the function to make it less likely for such URLs to be generated in the future.

Specifically, for a Stripe redirect payment method like Bancontact we will not have the receipt ID available when the function is called. Therefore we send the user to a "pending" page that includes the order ID to poll our orders endpoint until we know if the payment was complete. The pending page URL is `/checkout/thank-you/:site/pending/:orderId`. The way that `getThankYouPageUrl()` is written, it was possible for that pending page URL fragment (`pending/:orderId`) to end up being used as a receipt ID, leading to URLs that do not exist. This would have led users to a blank calypso page.

This also fixes a regression introduced by #65179. Because of the convoluted nature of the multiple redirects, it was not clear how or why we would need to replace the word `pending` with a receipt ID inside the `CheckoutPending` component. It was also risky since a common word like `pending` could show up anywhere in a URL. Therefore that behavior was removed. However, it turns out that there is a subtle case inside the pseudo-endpoint that adds the order ID to the URL (this pseudo-endpoint is where the payment partner sends the browser after the transaction – it injects the order ID into the URL and performs a 302 redirect to the "pending" page); if the receipt ID does not exist, it strips out the `:receiptId` placeholder, leaving a bare `/pending` in the URL. The replacement in the `CheckoutPending` component was treating that `/pending` fragment as the placeholder.

In this PR we restore treating `/pending` as a placeholder but make it a little more precise by only matching it at the end of the URL pathname. In a future work it would be nice to modify the backend to not remove the `:receiptId` and then use that as the placeholder on the frontend instead.

#### Testing Instructions

The significant changes should already be covered by unit tests.

One thing to check is that the redirect payment processors still work as expected since those often use the "pending" feature that this PR modifies. Here's instructions for Bancontact:

- Apply D45443-code to force Bancontact to be available and sandbox the API.
- Change your user's currency to `EUR`.
- Add a product to your cart and visit checkout.
- Complete the checkout form and select "Bancontact" as the payment method.
- Fill out the "Name" field and submit the payment. You should be redirected to a Stripe test page.
- Click to accept the payment. You should be redirected to a "Processing..." page briefly (this is the pending component) before being redirected to some post-checkout page (which page will vary based on many factors but is not that important).