### PR TITLE
Plugins: Add eligibility exception for Starter plans

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -70,9 +70,27 @@ const PluginDetailsCTA = ( {
 		! isJetpackSelfHosted;
 
 	// Eligibilities for Simple Sites.
-	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>
+	// eslint-disable-next-line prefer-const
+	let { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>
 		getEligibility( state, selectedSite?.ID )
 	);
+
+	/*
+	 * Remove 'NO_BUSINESS_PLAN' holds if the INSTALL_PURCHASED_PLUGINS feature is present.
+	 *
+	 * Starter plans do not have the ATOMIC feature, but they have the
+	 * INSTALL_PURCHASED_PLUGINS feature which allows them to buy marketplace
+	 * addons (which do have the ATOMIC feature).
+	 *
+	 * This means a Starter plan about to purchase a marketplace addon might get a
+	 * 'NO_BUSINESS_PLAN' hold on atomic transfer; however, if we're about to buy a
+	 * marketplace addon which provides the ATOMIC feature, then we can ignore this
+	 * hold.
+	 */
+	if ( typeof eligibilityHolds !== 'undefined' && isMarketplaceProduct && ! shouldUpgrade ) {
+		eligibilityHolds = eligibilityHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
+	}
+
 	const hasEligibilityMessages =
 		! isAtomic && ! isJetpack && ( eligibilityHolds?.length || eligibilityWarnings?.length );
 


### PR DESCRIPTION
#### Proposed Changes

* Adds a marketplace plugin exception at the point where it's determined whether there are eligibility messages.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://container-admiring-saha.calypso.live/
* Switch to a Simple site.
* Purchase a Starter plan and set up a custom domain as the primary address.
* Go to Plugins.
* Select a paid plugin.
* Click on the "Purchase and activate" button.
* Make sure you're taken directly to the cart, no modal showing.
* Test with other sites, including free sites and WoA sites to make sure the modal is still showing correctly in these scenarios.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65153.
See #65092.