### PR TITLE
`GoogleAnalytics(Simple|Jetpack)Form`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -75,7 +75,11 @@ const GoogleAnalyticsJetpackForm = ( {
 
 	const renderForm = () => {
 		return (
-			<form id="analytics" onSubmit={ handleSubmitForm }>
+			<form
+				aria-label="Google Analytics Site Settings"
+				id="analytics"
+				onSubmit={ handleSubmitForm }
+			>
 				<QueryJetpackModules siteId={ siteId } />
 
 				<SettingsSectionHeader

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -79,7 +79,11 @@ const GoogleAnalyticsSimpleForm = ( {
 			/>
 		);
 		return (
-			<form id="analytics" onSubmit={ handleSubmitForm }>
+			<form
+				aria-label="Google Analytics Site Settings"
+				id="analytics"
+				onSubmit={ handleSubmitForm }
+			>
 				<SettingsSectionHeader
 					disabled={ isSubmitButtonDisabled }
 					isSaving={ isSavingSettings }

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -1,10 +1,17 @@
 /**
  * @jest-environment jsdom
  */
-jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
-jest.mock( 'calypso/components/notice', () => 'Notice' );
-jest.mock( 'calypso/components/notice/notice-action', () => 'NoticeAction' );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => 'PageViewTracker' );
+jest.mock( 'calypso/blocks/upsell-nudge', () =>
+	jest.fn( () => <div data-testid="UpsellNudge" /> )
+);
+jest.mock( 'calypso/components/notice', () => () => 'Notice' );
+jest.mock( 'calypso/components/notice/notice-action', () => () => 'NoticeAction' );
+jest.mock( 'calypso/components/data/query-jetpack-modules', () => () => 'QueryJetpackModules' );
+jest.mock(
+	'calypso/my-sites/site-settings/jetpack-module-toggle',
+	() => () => 'JetpackModuleToggle'
+);
 
 import {
 	PLAN_FREE,
@@ -19,7 +26,8 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import GoogleAnalyticsJetpackForm from '../analytics/form-google-analytics-jetpack';
 import GoogleAnalyticsSimpleForm from '../analytics/form-google-analytics-simple';
 
@@ -33,24 +41,25 @@ const props = {
 	eventTracker: ( x ) => x,
 	uniqueEventTracker: ( x ) => x,
 	fields: {},
+	setDisplayForm: () => {},
 };
 
 describe( 'GoogleAnalyticsForm basic tests', () => {
 	test( 'simple form should not blow up and have proper CSS class', () => {
-		const comp = shallow( <GoogleAnalyticsSimpleForm { ...props } /> );
-		expect( comp.find( '#analytics' ) ).toHaveLength( 1 );
+		const { container } = render( <GoogleAnalyticsSimpleForm { ...props } /> );
+		expect( container.querySelectorAll( '#analytics' ) ).toHaveLength( 1 );
 	} );
 	test( 'jetpack form should not blow up and have proper CSS class', () => {
-		const comp = shallow( <GoogleAnalyticsJetpackForm { ...props } /> );
-		expect( comp.find( '#analytics' ) ).toHaveLength( 1 );
+		const { container } = render( <GoogleAnalyticsJetpackForm { ...props } /> );
+		expect( container.querySelectorAll( '#analytics' ) ).toHaveLength( 1 );
 	} );
 	test( 'simple form should not show upgrade nudge if disabled', () => {
-		const comp = shallow( <GoogleAnalyticsSimpleForm { ...props } showUpgradeNudge={ false } /> );
-		expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
+		render( <GoogleAnalyticsSimpleForm { ...props } showUpgradeNudge={ false } /> );
+		expect( screen.queryByTestId( 'UpsellNudge' ) ).not.toBeInTheDocument();
 	} );
 	test( 'jetpack form should not show upgrade nudge if disabled', () => {
-		const comp = shallow( <GoogleAnalyticsJetpackForm { ...props } showUpgradeNudge={ false } /> );
-		expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
+		render( <GoogleAnalyticsJetpackForm { ...props } showUpgradeNudge={ false } /> );
+		expect( screen.queryByTestId( 'UpsellNudge' ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -60,41 +69,40 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 		showUpgradeNudge: true,
 	};
 
-	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL ].forEach( ( product_slug ) => {
-		test( `Business 1 year for (${ product_slug })`, () => {
-			const comp = shallow(
-				<GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } />
-			);
-			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
-				PLAN_PREMIUM
-			);
-		} );
-	} );
-
-	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS ].forEach( ( product_slug ) => {
-		test( `Business 2 year for (${ product_slug })`, () => {
-			const comp = shallow(
-				<GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } />
-			);
-			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
-				PLAN_PREMIUM_2_YEARS
-			);
-		} );
-	} );
-
-	[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ].forEach(
+	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL ] )(
+		`Business 1 year for (%s)`,
 		( product_slug ) => {
-			test( `Jetpack Security for (${ product_slug })`, () => {
-				const comp = shallow(
-					<GoogleAnalyticsJetpackForm { ...myProps } site={ { plan: { product_slug } } } />
-				);
-				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
-					PLAN_JETPACK_SECURITY_DAILY
-				);
-			} );
+			render( <GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } /> );
+			const nudge = screen.queryByTestId( 'UpsellNudge' );
+			expect( nudge ).toBeVisible();
+			expect( UpsellNudge ).toHaveBeenCalledWith(
+				expect.objectContaining( { plan: PLAN_PREMIUM } ),
+				expect.anything()
+			);
+		}
+	);
+
+	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS ] )(
+		`Business 2 year for (%s)`,
+		( product_slug ) => {
+			render( <GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } /> );
+			expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
+			expect( UpsellNudge ).toHaveBeenCalledWith(
+				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } ),
+				expect.anything()
+			);
+		}
+	);
+
+	test.each( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ] )(
+		`Jetpack Security for (%s)`,
+		( product_slug ) => {
+			render( <GoogleAnalyticsJetpackForm { ...myProps } site={ { plan: { product_slug } } } /> );
+			expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
+			expect( UpsellNudge ).toHaveBeenCalledWith(
+				expect.objectContaining( { plan: PLAN_JETPACK_SECURITY_DAILY } ),
+				expect.anything()
+			);
 		}
 	);
 } );

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -46,12 +46,12 @@ const props = {
 
 describe( 'GoogleAnalyticsForm basic tests', () => {
 	test( 'simple form should not blow up and have proper CSS class', () => {
-		const { container } = render( <GoogleAnalyticsSimpleForm { ...props } /> );
-		expect( container.querySelectorAll( '#analytics' ) ).toHaveLength( 1 );
+		render( <GoogleAnalyticsSimpleForm { ...props } /> );
+		expect( screen.queryByRole( 'form', { name: /analytics/i } ) ).toBeVisible();
 	} );
 	test( 'jetpack form should not blow up and have proper CSS class', () => {
-		const { container } = render( <GoogleAnalyticsJetpackForm { ...props } /> );
-		expect( container.querySelectorAll( '#analytics' ) ).toHaveLength( 1 );
+		render( <GoogleAnalyticsJetpackForm { ...props } /> );
+		expect( screen.queryByRole( 'form', { name: /analytics/i } ) ).toBeVisible();
 	} );
 	test( 'simple form should not show upgrade nudge if disabled', () => {
 		render( <GoogleAnalyticsSimpleForm { ...props } showUpgradeNudge={ false } /> );


### PR DESCRIPTION
#### Proposed Changes

* `GoogleAnalytics(Simple|Jetpack)Form`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409
