### PR TITLE
Fix incorrect design_type in calypso_signup_design_type_submit event

### DIFF
--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -72,6 +72,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet, price }: any ): D
 		is_featured_picks: isFeaturedPicks,
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+		design_type: is_premium ? 'premium' : 'standard',
 		price,
 
 		// Deprecated; used for /start flow


### PR DESCRIPTION
#### Proposed Changes

* The `design_type` was deleted by https://github.com/Automattic/wp-calypso/pull/65052 and it leads the `calypso_signup_design_type_submit` event looks weird. This PR adds `design_type` back so that we can get the correct `design_type`

  ![image](https://user-images.githubusercontent.com/13596067/177307480-24c9c08b-d2ad-43fe-ad60-701066b41975.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to setup flow: `/setup?siteSlug=<your_site>`
* Select "Promote myself or business" goal
* Select any vertical
* Click "View more options" in the Design Picker
* Select a free design
* Make sure the `design_type` of `calypso_signup_design_type_submit` event is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1656945325711169/1656942068.387019-slack-CRWCHQGUB