### PR TITLE
Licensing Portal: Move the required payment method step to after selecting your license product for agencies

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -128,13 +128,33 @@ export default function IssueLicenseForm( {
 
 			switch ( error.code ) {
 				case 'missing_valid_payment_method':
-					page.redirect(
-						addQueryArgs(
-							{
-								return: addQueryArgs( { product }, partnerPortalBasePath( '/issue-license' ) ),
+					if ( paymentMethodRequired ) {
+						page.redirect(
+							addQueryArgs(
+								{
+									return: addQueryArgs( { product }, partnerPortalBasePath( '/issue-license' ) ),
+								},
+								partnerPortalBasePath( '/payment-methods/add' )
+							)
+						);
+						return;
+					}
+
+					errorMessage = translate(
+						'We could not find a valid payment method.{{br/}} ' +
+							'{{a}}Try adding a new payment method{{/a}} or contact support.',
+						{
+							components: {
+								a: (
+									<a
+										href={
+											'/partner-portal/payment-methods/add?return=/partner-portal/issue-license'
+										}
+									/>
+								),
+								br: <br />,
 							},
-							partnerPortalBasePath( '/payment-methods/add' )
-						)
+						}
 					);
 					break;
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import sortBy from 'lodash/sortBy';
 import page from 'page';
-import { ReactElement, useCallback, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
@@ -49,9 +49,10 @@ export default function IssueLicenseForm( {
 	} );
 
 	const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
+	const defaultProduct = ( getQueryArg( window.location.href, 'product' ) || '' ).toString();
 
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
-	const [ product, setProduct ] = useState( '' );
+	const [ product, setProduct ] = useState( defaultProduct );
 
 	const handleRedirectToDashboard = ( licenseKey: string ) => {
 		const selectedProduct = products?.data?.find( ( p ) => p.slug === product );
@@ -127,21 +128,13 @@ export default function IssueLicenseForm( {
 
 			switch ( error.code ) {
 				case 'missing_valid_payment_method':
-					errorMessage = translate(
-						'We could not find a valid payment method.{{br/}} ' +
-							'{{a}}Try adding a new payment method{{/a}} or contact support.',
-						{
-							components: {
-								a: (
-									<a
-										href={
-											'/partner-portal/payment-methods/add?return=/partner-portal/issue-license'
-										}
-									/>
-								),
-								br: <br />,
+					page.redirect(
+						addQueryArgs(
+							{
+								return: addQueryArgs( { product }, partnerPortalBasePath( '/issue-license' ) ),
 							},
-						}
+							partnerPortalBasePath( '/payment-methods/add' )
+						)
 					);
 					break;
 
@@ -151,6 +144,17 @@ export default function IssueLicenseForm( {
 			}
 
 			dispatch( errorNotice( errorMessage ) );
+		},
+		retry: ( errorCount, error ) => {
+			// If the user has just added their payment method it's likely that there's a slight delay before the API
+			// is made aware of this and allows the creation of the license.
+			// In order to make this a smoother experience for the user, we retry a couple of times silently if the
+			// error is missing_valid_payment_method but our local state shows that the user has a payment method.
+			if ( ! paymentMethodRequired && error?.code === 'missing_valid_payment_method' ) {
+				return errorCount < 3;
+			}
+
+			return false;
 		},
 	} );
 
@@ -185,6 +189,18 @@ export default function IssueLicenseForm( {
 	}, [ dispatch, product, issueLicense.mutate ] );
 
 	const selectedSiteDomian = selectedSite?.domain;
+
+	// If a product is passed down from the query we want to instantly try and create a license for it
+	// and we only want to try that once hence why we pass no dependencies to useEffect().
+	// This is a short-term solution as we shouldn't be executing such actions with a GET request without a nonce.
+	useEffect( () => {
+		if ( defaultProduct !== '' ) {
+			page.redirect(
+				removeQueryArgs( window.location.pathname + window.location.search, 'product' )
+			);
+			issueLicense.mutate( { product: defaultProduct } );
+		}
+	}, [] );
 
 	return (
 		<div className="issue-license-form">

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -171,7 +171,7 @@ export default function IssueLicenseForm( {
 			// In order to make this a smoother experience for the user, we retry a couple of times silently if the
 			// error is missing_valid_payment_method but our local state shows that the user has a payment method.
 			if ( ! paymentMethodRequired && error?.code === 'missing_valid_payment_method' ) {
-				return errorCount < 3;
+				return errorCount < 5;
 			}
 
 			return false;


### PR DESCRIPTION
Agencies are required to add a payment method before they issue a license but this disrupts the ideal flow of `Issue License -> Add Payment Method -> Assign License`.

Context: 1202074155672006-as-1202548879851664

#### Proposed Changes

* Licensing Portal: Allow agencies to select a license product before adding a payment method via a short-term solution.

#### Testing Instructions

* Make sure you don't have a payment method in the Licensing Portal.
* Make sure your partner account is set to an agency and your partner key's billable type is set to Stripe.
* Issue a license and follow the flow until your license is issued and assigned (Issue License -> Add Payment Method -> Assign License) and confirm the flow works as expected without issues.

Note 1: Due to current implementation details, after adding a payment method you will be redirected back to the "Issue License" screen but that screen will automatically issue your pre-selected license (the primary button will be showing a loading animation the moment you see the screen after adding your payment method). This is not ideal and we should have something better in place in the near future.
Note 2: This is a short-term solution added in the interest of opening up the Licensing Portal to agencies via the new self-serve signup flow.