### PR TITLE
Update sites and analyzer data stores

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -70,7 +70,7 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
-		"onboarding/import-light": true,
+		"onboarding/import-light": false,
 		"help": true,
 		"home/layout-dev": true,
 		"importers/substack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,7 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
-		"onboarding/import-light": true,
+		"onboarding/import-light": false,
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,

--- a/packages/data-stores/src/analyzer/index.ts
+++ b/packages/data-stores/src/analyzer/index.ts
@@ -4,9 +4,8 @@ import { createActions } from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducers';
 import * as selectors from './selectors';
+export * from './types';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
-
-export type { ColorsData } from './types';
 export type { State };
 
 let isRegistered = false;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -7,6 +7,7 @@ import {
 	LatestAtomicTransferError,
 	AtomicSoftwareStatusError,
 	AtomicSoftwareInstallError,
+	GlobalStyles,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type {
@@ -187,6 +188,23 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			body: cartData,
 		} );
 		return success;
+	}
+
+	const receiveSiteGlobalStyles = ( siteId: number, globalStyles: GlobalStyles ) => ( {
+		type: 'RECEIVE_SITE_GLOBAL_STYLES' as const,
+		siteId,
+		globalStyles,
+	} );
+
+	function* getGlobalStyles( siteId: number, stylesheet: string ) {
+		const globalStyles: GlobalStyles = yield wpcomRequest( {
+			path: `/sites/${ siteId }/global-styles/themes/${ stylesheet }`,
+			apiNamespace: 'wp/v2',
+		} );
+
+		yield receiveSiteGlobalStyles( siteId, globalStyles );
+
+		return globalStyles;
 	}
 
 	function* saveSiteSettings(
@@ -493,6 +511,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		launchSiteFailure,
 		getCart,
 		setCart,
+		getGlobalStyles,
+		receiveSiteGlobalStyles,
 		setSiteSetupError,
 		clearSiteSetupError,
 		initiateAtomicTransfer,
@@ -530,6 +550,7 @@ export type Action =
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'updateSiteSettings' ]
+			| ActionCreators[ 'receiveSiteGlobalStyles' ]
 			| ActionCreators[ 'reset' ]
 			| ActionCreators[ 'resetNewSiteFailed' ]
 			| ActionCreators[ 'launchSiteStart' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -10,6 +10,7 @@ import {
 	SiteSettings,
 	AtomicTransferStatus,
 	LatestAtomicTransferStatus,
+	GlobalStyles,
 } from './types';
 import {
 	AtomicTransferState,
@@ -161,6 +162,23 @@ export const sitesSettings: Reducer< { [ key: number ]: SiteSettings }, Action >
 			},
 		};
 	}
+	return state;
+};
+
+export const sitesGlobalStyles: Reducer< { [ key: number ]: GlobalStyles }, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'RECEIVE_SITE_GLOBAL_STYLES' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				...state?.[ action.siteId ],
+				...action.globalStyles,
+			},
+		};
+	}
+
 	return state;
 };
 
@@ -387,6 +405,7 @@ const reducer = combineReducers( {
 	launchStatus,
 	sitesDomains,
 	sitesSettings,
+	sitesGlobalStyles,
 	siteSetupErrors,
 	atomicTransferStatus,
 	latestAtomicTransferStatus,

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -62,6 +62,10 @@ export const getSiteSettings = ( state: State, siteId: number ) => {
 	return state.sitesSettings[ siteId ];
 };
 
+export const getSiteGlobalStyles = ( state: State, siteId: number ) => {
+	return state.sitesGlobalStyles[ siteId ];
+};
+
 export const getSiteSetupError = ( state: State ) => {
 	return state.siteSetupErrors;
 };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -398,3 +398,21 @@ export interface AtomicSoftwareInstallError {
 	message: string;
 	code: string;
 }
+
+interface PaletteColor {
+	slug: string;
+	color: string;
+	name: string;
+	default: string;
+}
+
+export interface GlobalStyles {
+	settings: {
+		color: {
+			palette: {
+				default: PaletteColor[];
+				theme: PaletteColor[];
+			};
+		};
+	};
+}


### PR DESCRIPTION
#### Proposed Changes

* Added **getGlobalStyles** action to the **sites** data store
* Export all types from the **analyzer** data store

#### Testing Instructions
* No need for testing
* It is not in use so far, it can be used for the future consumption of global styles

Related to #64774
