### PR TITLE
Revert "Plugins: Remove upgrade banners"

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,12 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
+	FEATURE_INSTALL_PLUGINS,
+	findFirstSimilarPlanKey,
+	isBlogger,
+	isPersonal,
+	isPremium,
+	TYPE_BUSINESS,
+	TYPE_STARTER,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_UPLOAD_PLUGINS,
@@ -11,6 +19,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import announcementImage from 'calypso/assets/images/marketplace/diamond.svg';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -23,6 +32,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import NoResults from 'calypso/my-sites/no-results';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import EducationFooter from 'calypso/my-sites/plugins/education-footer';
@@ -308,6 +318,62 @@ const PluginSingleListView = ( {
 	);
 };
 
+const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSlug } ) => {
+	const translate = useTranslate();
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+
+	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic ) {
+		return null;
+	}
+	const isLegacyPlan = isBlogger( sitePlan ) || isPersonal( sitePlan ) || isPremium( sitePlan );
+	const checkoutPlan = eligibleForProPlan && ! isLegacyPlan ? 'pro' : 'business';
+	const bannerURL = `/checkout/${ siteSlug }/${ checkoutPlan }`;
+	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
+		type: TYPE_BUSINESS,
+	} );
+
+	const title =
+		eligibleForProPlan && ! isLegacyPlan
+			? translate( 'Upgrade to the Pro plan to install plugins.' )
+			: translate( 'Upgrade to the Business plan to install plugins.' );
+
+	return (
+		<UpsellNudge
+			event="calypso_plugins_browser_upgrade_nudge"
+			showIcon={ true }
+			href={ bannerURL }
+			feature={ FEATURE_INSTALL_PLUGINS }
+			plan={ plan }
+			title={ title }
+		/>
+	);
+};
+
+const UpgradeNudgePaid = ( props ) => {
+	const translate = useTranslate();
+
+	if ( ! props.sitePlan ) {
+		return null;
+	}
+
+	const plan = findFirstSimilarPlanKey( props.sitePlan.product_slug, {
+		type: TYPE_STARTER,
+	} );
+
+	return (
+		<UpsellNudge
+			event="calypso_plugins_browser_upgrade_nudge"
+			showIcon={ true }
+			href={ `/checkout/${ props.siteSlug }/starter` }
+			feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
+			plan={ plan }
+			title={ translate( 'Upgrade to the Starter plan to install paid plugins.' ) }
+		/>
+	);
+};
+
 const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -417,6 +483,14 @@ function isNotInstalled( plugin, installedPlugins ) {
 }
 
 const PluginBrowserContent = ( props ) => {
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, props.selectedSite?.ID )
+	);
+
+	const isLegacyPlan =
+		props.sitePlan &&
+		( isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan ) );
+
 	if ( props.search ) {
 		return <SearchListView { ...props } />;
 	}
@@ -426,7 +500,21 @@ const PluginBrowserContent = ( props ) => {
 
 	return (
 		<>
-			{ ! props.jetpackNonAtomic && <PluginSingleListView { ...props } category="paid" /> }
+			{ ! props.jetpackNonAtomic && (
+				<>
+					<div className="plugins-browser__upgrade-banner">
+						{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan ? (
+							<UpgradeNudgePaid { ...props } />
+						) : (
+							<UpgradeNudge { ...props } />
+						) }
+					</div>
+					<PluginSingleListView { ...props } category="paid" />
+				</>
+			) }
+			{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan && (
+				<UpgradeNudge { ...props } />
+			) }
 			<PluginSingleListView { ...props } category="featured" />
 			<PluginSingleListView { ...props } category="popular" />
 		</>

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -42,6 +42,17 @@ jest.mock( '@automattic/languages', () => [
 	},
 ] );
 
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_BLOGGER,
+	PLAN_BLOGGER_2_YEARS,
+} from '@automattic/calypso-products';
 import { mount } from 'enzyme';
 import { merge } from 'lodash';
 import { Provider } from 'react-redux';
@@ -67,7 +78,7 @@ const initialReduxState = {
 	},
 	ui: { selectedSiteId: 1 },
 	sites: {
-		items: { 1: { ID: 1, title: 'Test Site' } },
+		items: { 1: { ID: 1, title: 'Test Site', plan: { productSlug: PLAN_FREE } } },
 		connection: { items: { 1: true } },
 	},
 	currentUser: { capabilities: { 1: { manage_options: true } } },
@@ -114,10 +125,79 @@ describe( 'Search view', () => {
 	} );
 } );
 
+describe( 'Upsell Nudge should get appropriate plan constant', () => {
+	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( product_slug ) => {
+		test( `Business 1 year for (${ product_slug })`, () => {
+			const comp = mountWithRedux( <PluginsBrowser />, {
+				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+			} );
+			expect(
+				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+			).toBe( 1 );
+			expect(
+				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+			).toBe( PLAN_BUSINESS );
+		} );
+	} );
+
+	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach(
+		( product_slug ) => {
+			test( `Business 2 year for (${ product_slug })`, () => {
+				const comp = mountWithRedux( <PluginsBrowser />, {
+					sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+				} );
+				expect(
+					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+				).toBe( 1 );
+				expect(
+					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+				).toBe( PLAN_BUSINESS_2_YEARS );
+			} );
+		}
+	);
+} );
+
 describe( 'PluginsBrowser basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const comp = mountWithRedux( <PluginsBrowser /> );
 		expect( comp.find( 'main' ).length ).toBe( 1 );
+	} );
+	test( 'should show upsell nudge when appropriate', () => {
+		const comp = mountWithRedux( <PluginsBrowser /> );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 1 );
+	} );
+	test( 'should not show upsell nudge if no site is selected', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, { ui: { selectedSiteId: null } } );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
+	} );
+	test( 'should not show upsell nudge if no sitePlan', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			ui: { selectedSiteId: 10 },
+			sites: { items: { 10: { ID: 10, plan: null } } },
+		} );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
+	} );
+	test( 'should not show upsell nudge if non-atomic jetpack site', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			sites: { items: { 1: { jetpack: true } } },
+		} );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
+	} );
+	test( 'should not show upsell nudge has business plan', () => {
+		const comp = mountWithRedux( <PluginsBrowser />, {
+			sites: { items: { 1: { jetpack: true, plan: { productSlug: PLAN_PREMIUM } } } },
+		} );
+		expect(
+			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+		).toBe( 0 );
 	} );
 	test( 'should show notice if site is not connected to wpcom', () => {
 		const comp = mountWithRedux( <PluginsBrowser />, {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#65123

#### Proposed Changes

This PR brings back the upgrade banners to the Plugins page, since the lack of them could contribute to a substantial conversion loss (see p1657025199523499-slack-C029JEQRVRT).

Before | After
--- | ---
<img width="1646" alt="Screen Shot 2022-06-30 at 15 37 34" src="https://user-images.githubusercontent.com/1233880/176692724-79a8906c-e438-4b6f-b6fc-098af5c244b6.png"> | <img width="1646" alt="Screen Shot 2022-06-30 at 15 38 13" src="https://user-images.githubusercontent.com/1233880/176692698-4b9197b5-9c83-4dae-9782-c430015524f9.png">


#### Testing Instructions

- Use the Calypso live link below.
- Go to Plugins.
- Mare sure the upgrade banners are back.