### PR TITLE
Marketplace: Read and populate Icon from search results

### DIFF
--- a/client/data/marketplace/constants.ts
+++ b/client/data/marketplace/constants.ts
@@ -11,27 +11,16 @@ export const WPORG_CACHE_KEY = 'wporg-plugins';
 // TODO: Only include the required fields here
 export const RETURNABLE_FIELDS = [
 	'blog_icon_url',
-	'category.name.default',
 	'comment_count',
-	'content..*.word_count',
 	'excerpt.default',
 	'excerpt_html',
-	'gravatar_url',
-	'has..*',
-	'image.url.raw',
-	'image.alt_text',
 	'like_count',
 	'modified',
 	'modified_gmt',
-	'shortcode_types',
-	'tag.name.default',
 	'title.default',
-
-	// Marketplace fields
 	'author',
 	'author_login',
 	'blog_id',
-	'blog_name',
 	'date',
 	'date_gmt',
 	'permalink.url.raw',
@@ -39,65 +28,21 @@ export const RETURNABLE_FIELDS = [
 	'post_type',
 	'slug',
 
-	// WooCommerce product fields
-	'wc.rating.count_1',
-	'wc.rating.count_2',
-	'wc.rating.count_3',
-	'wc.rating.count_4',
-	'wc.rating.count_5',
-	'meta._wc_average_rating.double',
-	'meta._wc_review_count.long',
-
-	// Plugin fields
-	'plugin.upgrade_notice',
-
-	// Authors
-	'plugin.contributors',
-
 	// Versions
-	'plugin.plugin_modified',
-	'plugin.update_age_in_months',
 	'plugin.tested',
-	'plugin.requires',
 	'plugin.stable_tag',
-	'plugin.tagged_versions',
-	'plugin.number_of_versions',
-	'plugin.number_of_translations',
-	'plugin.num_months_updated',
-	'plugin.disabled',
 
 	// Install Info
-	'plugin.percent_on_stable',
 	'plugin.active_installs',
-	'plugin.contributors_active_installs',
 
 	// Support Info
-	'plugin.support_resolution_yes',
-	'plugin.support_resolution_no',
-	'plugin.support_resolution_mu',
-	'plugin.support_resolution_percentage',
 	'plugin.support_threads',
 	'plugin.support_threads_resolved',
-	'plugin.support_threads_percentage',
-	'plugin.support_threads_percentage_p1',
 
 	// Ratings
 	'plugin.rating',
 	'plugin.num_ratings',
-	'plugin.rating_1',
-	'plugin.rating_2',
-	'plugin.rating_3',
-	'plugin.rating_4',
-	'plugin.rating_5',
-	'plugin.boost',
 
-	// Translated fields
-	'plugin.title',
-	'plugin.excerpt',
-	'plugin.content',
-	'plugin.all_content',
-	'plugin.description',
-	'plugin.installation',
-	'plugin.faq',
-	'plugin.changelog',
+	// Images
+	'plugin.icons',
 ] as const;

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -23,7 +23,7 @@ export type Plugin = {
 	last_updated?: string;
 	short_description?: string;
 	download_link?: string;
-	icons?: Record< string, string >;
+	icon?: string;
 };
 
 export type ESIndexResult = {
@@ -52,6 +52,14 @@ export type ESIndexResult = {
 	'plugin.support_threads'?: number;
 	'plugin.support_threads_resolved'?: number;
 	'plugin.active_installs'?: number;
+	'plugin.icons'?: string;
+};
+
+export type Icon = {
+	filename: string;
+	revision: string;
+	resolution: string;
+	location: string;
 };
 
 export type ESHits = Array< { fields: ESIndexResult } >;

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -7,21 +7,23 @@ import { search } from './search-api';
 import { getPluginsListKey } from './utils';
 import type { ESHits, ESResponse, Plugin, PluginQueryOptions, Icon } from './types';
 
-// /**
-//  *
-//  * @param pluginSlug
-//  * @param iconsObject
-//  * @returns A string containing an icon url
-// 		or undefined if icons is empty or it is not JSON or it does not contain a valid resolution
-//  */
+/**
+ *
+ * @param pluginSlug
+ * @param icons
+ * @returns A string containing an icon url or
+ * 	undefined if the icons param is falsy or
+ * 	a default generated url Icon if icons param is not JSON or it does not contain a valid resolution
+ */
 const createIconUrl = ( pluginSlug: string, icons?: string ): string | undefined => {
-	if ( ! icons ) return;
+	const defaultIconUrl = buildDefaultIconUrl( pluginSlug );
+	if ( ! icons ) return defaultIconUrl;
 
 	let iconsObject: Record< string, Icon > = {};
 	try {
 		iconsObject = JSON.parse( icons );
 	} catch ( error ) {
-		return;
+		return defaultIconUrl;
 	}
 
 	// Transform Icon response for easier handling
@@ -40,7 +42,7 @@ const createIconUrl = ( pluginSlug: string, icons?: string ): string | undefined
 		iconByResolution.svg ||
 		iconByResolution.default;
 
-	if ( ! icon ) return;
+	if ( ! icon ) return defaultIconUrl;
 
 	return buildIconUrl( pluginSlug, icon.location, icon.filename, icon.revision );
 };
@@ -49,8 +51,9 @@ function buildIconUrl( pluginSlug: string, location: string, filename: string, r
 	return `https://ps.w.org/${ pluginSlug }/${ location }/${ filename }?rev=${ revision }`;
 }
 
-// const createAuthorUrl = ( headerAuthor: string, headerAuthorUri: string ) =>
-// 	`<a href="${ headerAuthorUri }">${ headerAuthor }</a>`;
+function buildDefaultIconUrl( pluginSlug: string ) {
+	return `https://s.w.org/plugins/geopattern-icon/${ pluginSlug }.svg`;
+}
 
 const mapStarRatingToPercent = ( starRating?: number ) => ( starRating ?? 0 / 5 ) * 100;
 

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -26,12 +26,14 @@ const createIconUrl = ( pluginSlug: string, icons?: string ): string => {
 	}
 
 	// Transform Icon response for easier handling
-	const iconByResolution = Object.entries( iconsObject ).reduce( ( icon, iconByResolution ) => {
-		const [ , currentIcon ] = iconByResolution;
-		const newKey = currentIcon.resolution;
-		icon[ newKey ] = currentIcon;
-		return icon;
-	}, {} as Record< string, Icon > );
+	const iconByResolution = Object.values( iconsObject ).reduce(
+		( iconByResolution, currentIcon ) => {
+			const newKey = currentIcon.resolution;
+			iconByResolution[ newKey ] = currentIcon;
+			return iconByResolution;
+		},
+		{} as Record< string, Icon >
+	);
 
 	const icon =
 		iconByResolution[ '256x256' ] ||

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -12,10 +12,9 @@ import type { ESHits, ESResponse, Plugin, PluginQueryOptions, Icon } from './typ
  * @param pluginSlug
  * @param icons
  * @returns A string containing an icon url or
- * 	undefined if the icons param is falsy or
- * 	a default generated url Icon if icons param is not JSON or it does not contain a valid resolution
+ * 	a default generated url Icon if icons param is falsy, it is not JSON or it does not contain a valid resolution
  */
-const createIconUrl = ( pluginSlug: string, icons?: string ): string | undefined => {
+const createIconUrl = ( pluginSlug: string, icons?: string ): string => {
 	const defaultIconUrl = buildDefaultIconUrl( pluginSlug );
 	if ( ! icons ) return defaultIconUrl;
 

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -4,33 +4,50 @@ import { extractSearchInformation } from 'calypso/lib/plugins/utils';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { DEFAULT_PAGE_SIZE } from './constants';
 import { search } from './search-api';
-import { ESHits, ESResponse, Plugin, PluginQueryOptions } from './types';
 import { getPluginsListKey } from './utils';
+import type { ESHits, ESResponse, Plugin, PluginQueryOptions, Icon } from './types';
 
 // /**
 //  *
 //  * @param pluginSlug
-//  * @param iconsArray
-//  * @returns An object containing a resolution -> icon url map
+//  * @param iconsObject
+//  * @returns A string containing an icon url
+// 		or undefined if icons is empty or it is not JSON or it does not contain a valid resolution
 //  */
-// const createIconsObject = ( pluginSlug: string, iconsArray: string ) => {
-// 	type Icon = {
-// 		resolution: string;
-// 		filename: string;
-// 		location: string;
-// 		revision: string;
-// 	};
-// 	const icons: Record< string, Icon > = phpUnserialize( iconsArray );
-// 	return Object.values( icons ).reduce(
-// 		( prev: Record< string, string >, { resolution, filename, location, revision } ) => {
-// 			prev[
-// 				resolution
-// 			] = `https://ps.w.org/${ pluginSlug }/${ location }/${ filename }?rev=${ revision }`;
-// 			return prev;
-// 		},
-// 		{}
-// 	);
-// };
+const createIconUrl = ( pluginSlug: string, icons?: string ): string | undefined => {
+	if ( ! icons ) return;
+
+	let iconsObject: Record< string, Icon > = {};
+	try {
+		iconsObject = JSON.parse( icons );
+	} catch ( error ) {
+		return;
+	}
+
+	// Transform Icon response for easier handling
+	const iconByResolution = Object.entries( iconsObject ).reduce( ( icon, iconByResolution ) => {
+		const [ , currentIcon ] = iconByResolution;
+		const newKey = currentIcon.resolution;
+		icon[ newKey ] = currentIcon;
+		return icon;
+	}, {} as Record< string, Icon > );
+
+	const icon =
+		iconByResolution[ '256x256' ] ||
+		iconByResolution[ '128x128' ] ||
+		iconByResolution[ '2x' ] ||
+		iconByResolution[ '1x' ] ||
+		iconByResolution.svg ||
+		iconByResolution.default;
+
+	if ( ! icon ) return;
+
+	return buildIconUrl( pluginSlug, icon.location, icon.filename, icon.revision );
+};
+
+function buildIconUrl( pluginSlug: string, location: string, filename: string, revision: string ) {
+	return `https://ps.w.org/${ pluginSlug }/${ location }/${ filename }?rev=${ revision }`;
+}
 
 // const createAuthorUrl = ( headerAuthor: string, headerAuthorUri: string ) =>
 // 	`<a href="${ headerAuthorUri }">${ headerAuthor }</a>`;
@@ -55,7 +72,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			active_installs: hit[ 'plugin.active_installs' ],
 			last_updated: hit.modified,
 			short_description: hit[ 'excerpt.default' ], // TODO: add localization
-			// icons: createIconsObject( slug, hit.blog_icon_url ),
+			icon: createIconUrl( hit.slug, hit[ 'plugin.icons' ] ),
 		};
 		return plugin;
 	} );


### PR DESCRIPTION
#### Proposed Changes

* This PR will read the `plugin.icons` field from the `/marketplace/search` response and it will use it to build the URL used to populate the Icons in the plugin list when searching for a plugin.
* Additionally, only the fields used by the plugin list will be returned. The non-used fields have been removed.


#### Testing Instructions

* Enable the feature flag `marketplace-jetpack-plugin-search`[^1]
* Go to the Plugins screen `/plugins/{site}`
* Search for a plugin in the Search input and press `Enter`. E.g. try searching by `ecommerce`
* Make sure the plugin detail list contains Icons.
> **Note**
> There are some plugin that do not return Icons and are automatically generated. That has been done part of commit [aebf63e](https://github.com/Automattic/wp-calypso/commit/aebf63eb8d3f411ff55c0b6cf983d89e0d2d612d). It relates to the task [#63169](https://github.com/Automattic/wp-calypso/issues/63169)


|Screenshot | 
|-------|
|![CleanShot 2022-07-05 at 17 36 54@2x](https://user-images.githubusercontent.com/3519124/177365286-823a1e13-e28d-4386-b69f-9b447a081815.png)|

Related to #64885, #63169

[^1]: To enable this feature flag add `?flags=marketplace-jetpack-plugin-search` to the end of your URL or past the following code on the developer tools console `document.cookie = 'flags=+marketplace-jetpack-plugin-search;max-age=1209600;path=/'`