### PR TITLE
Sites Dashboard: First pass at Sites Table design

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,10 +1,11 @@
-import { Button, SitesTable, Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import getSites from 'calypso/state/selectors/get-sites';
 import { notNullish } from '../util';
+import { SitesTable } from './sites-table';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 const MAX_PAGE_WIDTH = '1184px';

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -1,9 +1,8 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-// eslint-disable-next-line no-restricted-imports
 import SiteIcon from 'calypso/blocks/site-icon';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SitesTableProps {
 	buildSiteUrl?: ( site: SiteData ) => string;
@@ -62,9 +61,9 @@ export function SitesTable( { buildSiteUrl, className, sites }: SitesTableProps 
 		<Table className={ className }>
 			<thead className="sites-table__mobile-hidden">
 				<Row>
-					<th>{ __( 'Site', __i18n_text_domain__ ) }</th>
-					<th>{ __( 'Plan', __i18n_text_domain__ ) }</th>
-					<th>{ __( 'Last Publish', __i18n_text_domain__ ) }</th>
+					<th>{ __( 'Site' ) }</th>
+					<th>{ __( 'Plan' ) }</th>
+					<th>{ __( 'Last Publish' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>
 			</thead>
@@ -73,11 +72,11 @@ export function SitesTable( { buildSiteUrl, className, sites }: SitesTableProps 
 					<Row key={ site.ID }>
 						<td>
 							<div style={ { display: 'flex' } }>
-								<SiteIcon site={ site } size={ 50 } />
+								<SiteIcon siteId={ site.ID } size={ 50 } />
 								<div style={ { marginLeft: '20px' } }>
 									<SiteName>
 										<a href={ buildSiteUrl ? buildSiteUrl( site ) : site.URL }>
-											{ site.name ? site.name : __( '(No Site Title)', __i18n_text_domain__ ) }
+											{ site.name ? site.name : __( '(No Site Title)' ) }
 										</a>
 									</SiteName>
 									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer">

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,4 +17,3 @@ export { HappinessEngineersTray } from './happiness-engineers-tray';
 export { Spinner } from './spinner';
 export { SpinnerExample } from './spinner/example';
 export { default as WordPressLogo } from './wordpress-logo';
-export { SitesTable } from './sites-table';

--- a/packages/components/src/sites-table/index.tsx
+++ b/packages/components/src/sites-table/index.tsx
@@ -1,5 +1,8 @@
+import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+// eslint-disable-next-line no-restricted-imports
+import SiteIcon from 'calypso/blocks/site-icon';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
 
 interface SitesTableProps {
@@ -11,31 +14,85 @@ interface SitesTableProps {
 const Table = styled.table`
 	border-collapse: collapse;
 	table-layout: fixed;
+	@media only screen and ( max-width: 781px ) {
+		.sites-table__mobile-hidden {
+			display: none;
+		}
+	}
 `;
 
 const Row = styled.tr`
 	line-height: 2em;
 	border-bottom: 1px solid #eee;
+	td {
+		padding-top: 5px;
+		padding-bottom: 5px;
+		vertical-align: middle;
+	}
 `;
+
+const SiteName = styled.h2`
+	font-weight: 500;
+	font-size: 16px;
+	letter-spacing: -0.4px;
+	color: var( --studio-gray-100 );
+	a {
+		color: inherit;
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+`;
+
+const SiteUrl = styled.a`
+	font-size: 14px;
+	line-height: 20px;
+	letter-spacing: -0.24px;
+	color: var( --studio-gray-60 );
+`;
+
+const displaySiteUrl = ( siteUrl: string ) => {
+	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
+};
 
 export function SitesTable( { buildSiteUrl, className, sites }: SitesTableProps ) {
 	const { __ } = useI18n();
 
 	return (
 		<Table className={ className }>
-			<thead>
+			<thead className="sites-table__mobile-hidden">
 				<Row>
 					<th>{ __( 'Site', __i18n_text_domain__ ) }</th>
 					<th>{ __( 'Plan', __i18n_text_domain__ ) }</th>
+					<th>{ __( 'Last Publish', __i18n_text_domain__ ) }</th>
+					<th style={ { width: '20px' } }></th>
 				</Row>
 			</thead>
 			<tbody>
 				{ sites.map( ( site ) => (
 					<Row key={ site.ID }>
 						<td>
-							<a href={ buildSiteUrl ? buildSiteUrl( site ) : site.URL }>{ site.name }</a>
+							<div style={ { display: 'flex' } }>
+								<SiteIcon site={ site } size={ 50 } />
+								<div style={ { marginLeft: '20px' } }>
+									<SiteName>
+										<a href={ buildSiteUrl ? buildSiteUrl( site ) : site.URL }>
+											{ site.name ? site.name : __( '(No Site Title)', __i18n_text_domain__ ) }
+										</a>
+									</SiteName>
+									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer">
+										{ displaySiteUrl( site.URL ) }
+									</SiteUrl>
+								</div>
+							</div>
 						</td>
-						<td>{ site.plan.product_name_short }</td>
+						<td className="sites-table__mobile-hidden">{ site.plan.product_name_short }</td>
+						<td className="sites-table__mobile-hidden"></td>
+						<td style={ { width: '20px' } }>
+							<button type="button">
+								<Gridicon icon="ellipsis" />
+							</button>
+						</td>
 					</Row>
 				) ) }
 			</tbody>


### PR DESCRIPTION
See #65166

## Proposed Changes

A first pass at design for the Sites Table:

* Adds the `SiteIcon` until we have a more robust site preview thumbnail.
* Displays and links to the `site.URL` below the site name.
* Adds `(No Site Title)` as a fallback when there is no site name.
* Adds a placeholder ellipsis icon for the eventual ellipsis menu.
* Hides the 'Plan' and 'Last Publish' columns on mobile.
* Hides the table header on mobile.

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/36432/177371282-32e983a6-6161-4edd-84be-24a48acafa8b.png">

**This pull request intentionally does not address all items on the linked issue.** To avoid blocking other team members, I'd like to iterate on the issue over 2-4 pull requests. Please limit feedback to the code submitted on the pull request.

## Testing Instructions

1. Check out the branch locally.
2. Navigate to `/sites-dashboard` and view the new Sites Dashboard.