### PR TITLE
Marketplace: Update Preinstalled Premium Plugins Browser Item

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -14,6 +14,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { PluginPrice } from '../plugin-price';
+import PreinstalledPremiumPluginPriceDisplay from '../plugin-price/preinstalled-premium-plugin-price-display';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 import CTAButton from './CTA-button';
 
@@ -53,12 +54,12 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 						isFetching ? (
 							<div className="plugin-details-CTA__price-placeholder">...</div>
 						) : (
-							translate( '{{span}}From{{/span}} %(price)s {{span}}%(period)s{{/span}}', {
-								args: { price, period },
-								components: { span: <span className="plugin-details-CTA__period" /> },
-								comment:
-									'`price` already includes the currency symbol; `period` can be monthly or yearly. Example: "From $100 monthly"',
-							} )
+							<PreinstalledPremiumPluginPriceDisplay
+								className="plugin-details-CTA__period"
+								period={ period }
+								pluginSlug={ plugin.slug }
+								price={ price }
+							/>
 						)
 					}
 				</PluginPrice>

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -53,10 +53,12 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 						isFetching ? (
 							<div className="plugin-details-CTA__price-placeholder">...</div>
 						) : (
-							<>
-								{ price + ' ' }
-								<span className="plugin-details-CTA__period">{ period }</span>
-							</>
+							translate( '{{span}}From{{/span}} %(price)s {{span}}%(period)s{{/span}}', {
+								args: { price, period },
+								components: { span: <span className="plugin-details-CTA__period" /> },
+								comment:
+									'`price` already includes the currency symbol; `period` can be monthly or yearly. Example: "From $100 monthly"',
+							} )
 						)
 					}
 				</PluginPrice>

--- a/client/my-sites/plugins/plugin-price/preinstalled-premium-plugin-price-display.jsx
+++ b/client/my-sites/plugins/plugin-price/preinstalled-premium-plugin-price-display.jsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function PreinstalledPremiumPluginPriceDisplay( {
+	className,
+	period,
+	pluginSlug,
+	price,
+} ) {
+	const translate = useTranslate();
+
+	if ( 'jetpack-search' === pluginSlug ) {
+		return translate( '{{span}}From{{/span}} %(price)s {{span}}%(period)s{{/span}}', {
+			args: { price, period },
+			components: { span: <span className={ className } /> },
+			comment:
+				'`price` already includes the currency symbol; `period` can be monthly or yearly. Example: "From $100 monthly"',
+		} );
+	}
+	return translate( '%(price)s {{span}}%(period)s{{/span}}', {
+		args: { price, period },
+		components: { span: <span className={ className } /> },
+		comment:
+			'`price` already includes the currency symbol; `period` can be monthly or yearly. Example: "$100 monthly"',
+	} );
+}

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -26,6 +26,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { PREINSTALLED_PLUGINS } from '../constants';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
+import PreinstalledPremiumPluginBrowserItemPricing from './preinstalled-premium-plugin-browser-item-pricing';
 import { PluginsBrowserElementVariant } from './types';
 
 import './style.scss';
@@ -262,39 +263,19 @@ const InstalledInOrPricing = ( {
 	const isPluginActive = useSelector( ( state ) =>
 		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
 	)?.active;
-	const {
-		isPreinstalledPremiumPlugin,
-		isPreinstalledPremiumPluginActive,
-		isPreinstalledPremiumPluginUpgraded,
-	} = usePreinstalledPremiumPlugin( plugin.slug );
-	const active = isWpcomPreinstalled || isPluginActive || isPreinstalledPremiumPluginActive;
+	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
+	const active = isWpcomPreinstalled || isPluginActive;
+	let checkmarkColorClass = 'checkmark--active';
 
-	const checkmarkColorClass =
-		! selectedSiteId || active ? 'checkmark--active' : 'checkmark--inactive';
-
-	if ( isPreinstalledPremiumPluginUpgraded ) {
-		/* eslint-disable wpcalypso/jsx-gridicon-size */
-		return (
-			<div className="plugins-browser-item__installed-and-active-container">
-				<div className="plugins-browser-item__installed ">
-					<Gridicon icon="checkmark" className={ checkmarkColorClass } size={ 14 } />
-					{ translate( 'Installed' ) }
-				</div>
-				<div className="plugins-browser-item__active">
-					<Badge type={ active ? 'success' : 'info' }>
-						{ active ? translate( 'Active' ) : translate( 'Inactive' ) }
-					</Badge>
-				</div>
-			</div>
-		);
-		/* eslint-enable wpcalypso/jsx-gridicon-size */
+	if ( isPreinstalledPremiumPlugin ) {
+		return <PreinstalledPremiumPluginBrowserItemPricing plugin={ plugin } />;
 	}
 
-	if (
-		( ! isPreinstalledPremiumPlugin && sitesWithPlugin && sitesWithPlugin.length > 0 ) ||
-		isWpcomPreinstalled
-	) {
+	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
+		if ( selectedSiteId ) {
+			checkmarkColorClass = active ? 'checkmark--active' : 'checkmark--inactive';
+		}
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
 				<div className="plugins-browser-item__installed ">
@@ -330,7 +311,7 @@ const InstalledInOrPricing = ( {
 								<>
 									{ price + ' ' }
 									<span className="plugins-browser-item__period">{ period }</span>
-									{ shouldUpgrade && ! isPreinstalledPremiumPlugin && (
+									{ shouldUpgrade && (
 										<div className="plugins-browser-item__period">
 											{ translate( 'Requires a plan upgrade' ) }
 										</div>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -262,11 +262,15 @@ const InstalledInOrPricing = ( {
 	const isPluginActive = useSelector( ( state ) =>
 		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
 	)?.active;
-	const { isPreinstalledPremiumPlugin, isPreinstalledPremiumPluginUpgraded } =
-		usePreinstalledPremiumPlugin( plugin.slug );
-	const active = isWpcomPreinstalled || isPluginActive;
+	const {
+		isPreinstalledPremiumPlugin,
+		isPreinstalledPremiumPluginActive,
+		isPreinstalledPremiumPluginUpgraded,
+	} = usePreinstalledPremiumPlugin( plugin.slug );
+	const active = isWpcomPreinstalled || isPluginActive || isPreinstalledPremiumPluginActive;
 
-	let checkmarkColorClass = 'checkmark--active';
+	const checkmarkColorClass =
+		selectedSiteId && active ? 'checkmark--active' : 'checkmark--inactive';
 
 	if ( isPreinstalledPremiumPluginUpgraded ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
@@ -291,9 +295,6 @@ const InstalledInOrPricing = ( {
 		isWpcomPreinstalled
 	) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
-		if ( selectedSiteId ) {
-			checkmarkColorClass = active ? 'checkmark--active' : 'checkmark--inactive';
-		}
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
 				<div className="plugins-browser-item__installed ">

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -330,7 +330,7 @@ const InstalledInOrPricing = ( {
 								<>
 									{ price + ' ' }
 									<span className="plugins-browser-item__period">{ period }</span>
-									{ shouldUpgrade && (
+									{ shouldUpgrade && ! isPreinstalledPremiumPlugin && (
 										<div className="plugins-browser-item__period">
 											{ translate( 'Requires a plan upgrade' ) }
 										</div>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -270,7 +270,7 @@ const InstalledInOrPricing = ( {
 	const active = isWpcomPreinstalled || isPluginActive || isPreinstalledPremiumPluginActive;
 
 	const checkmarkColorClass =
-		selectedSiteId && active ? 'checkmark--active' : 'checkmark--inactive';
+		! selectedSiteId || active ? 'checkmark--active' : 'checkmark--inactive';
 
 	if ( isPreinstalledPremiumPluginUpgraded ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
@@ -6,6 +6,7 @@ import Badge from 'calypso/components/badge';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PreinstalledPremiumPluginPriceDisplay from '../plugin-price/preinstalled-premium-plugin-price-display';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 
 export default function PreinstalledPremiumPluginBrowserItemPricing( { plugin } ) {
@@ -59,12 +60,12 @@ export default function PreinstalledPremiumPluginBrowserItemPricing( { plugin } 
 					isFetching ? (
 						<div className="plugins-browser-item__pricing-placeholder">...</div>
 					) : (
-						translate( '{{span}}From{{/span}} %(price)s {{span}}%(period)s{{/span}}', {
-							args: { price, period },
-							components: { span: <span className="plugins-browser-item__period" /> },
-							comment:
-								'`price` already includes the currency symbol; `period` can be monthly or yearly. Example: "From $100 monthly"',
-						} )
+						<PreinstalledPremiumPluginPriceDisplay
+							className="plugins-browser-item__period"
+							period={ period }
+							pluginSlug={ plugin.slug }
+							price={ price }
+						/>
 					)
 				}
 			</PluginPrice>

--- a/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
@@ -1,21 +1,42 @@
+/* eslint-disable wpcalypso/jsx-gridicon-size */
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 
 export default function PreinstalledPremiumPluginBrowserItemPricing( { plugin } ) {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const {
+		isPreinstalledPremiumPluginActive,
+		isPreinstalledPremiumPluginUpgraded,
+		sitesWithPreinstalledPremiumPlugin,
+	} = usePreinstalledPremiumPlugin( plugin.slug );
 	const translate = useTranslate();
 
-	const { isPreinstalledPremiumPluginActive, isPreinstalledPremiumPluginUpgraded } =
-		usePreinstalledPremiumPlugin( plugin.slug );
-
-	if ( isPreinstalledPremiumPluginUpgraded ) {
-		const checkmarkColorClass = isPreinstalledPremiumPluginActive
+	const checkmarkColorClass =
+		! selectedSiteId || isPreinstalledPremiumPluginActive
 			? 'checkmark--active'
 			: 'checkmark--inactive';
-		/* eslint-disable wpcalypso/jsx-gridicon-size */
+
+	if ( ! selectedSiteId && sitesWithPreinstalledPremiumPlugin > 0 ) {
+		return (
+			<div className="plugins-browser-item__installed-and-active-container">
+				<div className="plugins-browser-item__installed ">
+					<Gridicon icon="checkmark" className={ checkmarkColorClass } size={ 14 } />
+					{ translate( 'Installed on %d site', 'Installed on %d sites', {
+						args: [ sitesWithPreinstalledPremiumPlugin ],
+						count: sitesWithPreinstalledPremiumPlugin,
+					} ) }
+				</div>
+			</div>
+		);
+	}
+
+	if ( isPreinstalledPremiumPluginUpgraded ) {
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
 				<div className="plugins-browser-item__installed ">
@@ -29,7 +50,6 @@ export default function PreinstalledPremiumPluginBrowserItemPricing( { plugin } 
 				</div>
 			</div>
 		);
-		/* eslint-enable wpcalypso/jsx-gridicon-size */
 	}
 
 	return (

--- a/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
@@ -1,0 +1,53 @@
+import { Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import Badge from 'calypso/components/badge';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
+import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
+
+export default function PreinstalledPremiumPluginBrowserItemPricing( { plugin } ) {
+	const translate = useTranslate();
+
+	const { isPreinstalledPremiumPluginActive, isPreinstalledPremiumPluginUpgraded } =
+		usePreinstalledPremiumPlugin( plugin.slug );
+
+	if ( isPreinstalledPremiumPluginUpgraded ) {
+		const checkmarkColorClass = isPreinstalledPremiumPluginActive
+			? 'checkmark--active'
+			: 'checkmark--inactive';
+		/* eslint-disable wpcalypso/jsx-gridicon-size */
+		return (
+			<div className="plugins-browser-item__installed-and-active-container">
+				<div className="plugins-browser-item__installed ">
+					<Gridicon icon="checkmark" className={ checkmarkColorClass } size={ 14 } />
+					{ translate( 'Installed' ) }
+				</div>
+				<div className="plugins-browser-item__active">
+					<Badge type={ isPreinstalledPremiumPluginActive ? 'success' : 'info' }>
+						{ isPreinstalledPremiumPluginActive ? translate( 'Active' ) : translate( 'Inactive' ) }
+					</Badge>
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-gridicon-size */
+	}
+
+	return (
+		<div className="plugins-browser-item__pricing">
+			<PluginPrice plugin={ plugin } billingPeriod={ IntervalLength.MONTHLY }>
+				{ ( { isFetching, price, period } ) =>
+					isFetching ? (
+						<div className="plugins-browser-item__pricing-placeholder">...</div>
+					) : (
+						translate( '{{span}}From{{/span}} %(price)s {{span}}%(period)s{{/span}}', {
+							args: { price, period },
+							components: { span: <span className="plugins-browser-item__period" /> },
+							comment:
+								'`price` already includes the currency symbol; `period` can be monthly or yearly. Example: "From $100 monthly"',
+						} )
+					)
+				}
+			</PluginPrice>
+		</div>
+	);
+}

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -1,6 +1,9 @@
 import { useSelector } from 'react-redux';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import isPluginActive from 'calypso/state/selectors/is-plugin-active';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { PREINSTALLED_PREMIUM_PLUGINS } from '../constants';
 import { getPeriodVariationValue } from '../plugin-price';
@@ -17,6 +20,20 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 			siteHasFeature( state, selectedSiteId, preinstalledPremiumPlugin.feature )
 	);
 
+	const isPreinstalledPremiumPluginActive = useSelector( ( state ) => {
+		if ( ! preinstalledPremiumPlugin ) {
+			return false;
+		}
+		// Always active on simple sites
+		if (
+			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
+			! isJetpackSite( state, selectedSiteId )
+		) {
+			return true;
+		}
+		return isPluginActive( state, selectedSiteId, pluginSlug );
+	} );
+
 	const preinstalledPremiumPluginFeature = preinstalledPremiumPlugin?.feature;
 
 	const preinstalledPremiumPluginProduct =
@@ -24,6 +41,7 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 
 	return {
 		isPreinstalledPremiumPlugin: !! preinstalledPremiumPlugin,
+		isPreinstalledPremiumPluginActive,
 		isPreinstalledPremiumPluginUpgraded,
 		preinstalledPremiumPluginFeature,
 		preinstalledPremiumPluginProduct,

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
-import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
+import { getPluginOnSite, getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
@@ -21,11 +21,12 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 	const isPreinstalledPremiumPluginUpgraded = useSelector(
 		( state ) =>
 			!! preinstalledPremiumPlugin &&
+			!! selectedSiteId &&
 			siteHasFeature( state, selectedSiteId, preinstalledPremiumPlugin.feature )
 	);
 
 	const isPreinstalledPremiumPluginActive = useSelector( ( state ) => {
-		if ( ! preinstalledPremiumPlugin ) {
+		if ( ! preinstalledPremiumPlugin || ! selectedSiteId ) {
 			return false;
 		}
 		// Always active on simple sites
@@ -33,6 +34,11 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
 			! isJetpackSite( state, selectedSiteId )
 		) {
+			return true;
+		}
+		// Always active on atomic sites that don't have the plugin installed
+		const pluginOnSite = getPluginOnSite( state, selectedSiteId, pluginSlug );
+		if ( isSiteAutomatedTransfer( state, selectedSiteId ) && ! pluginOnSite ) {
 			return true;
 		}
 		return isPluginActive( state, selectedSiteId, pluginSlug );

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -2,8 +2,7 @@ import { useSelector } from 'react-redux';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getPluginOnSite, getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
+import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -54,23 +53,17 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 			return 0;
 		}
 		if ( selectedSiteId ) {
-			return isPreinstalledPremiumPluginUpgraded;
+			return Number( isPreinstalledPremiumPluginUpgraded );
 		}
 
-		const allSites = getSelectedOrAllSites( state );
-		const allSimpleSites = allSites.filter(
-			( site ) =>
-				canCurrentUser( state, site.ID, 'manage_options' ) &&
-				! isSiteAutomatedTransfer( state, site.ID ) &&
-				! isJetpackSite( state, site.ID )
-		);
+		const allSites = getSelectedOrAllSitesJetpackCanManage( state );
 		const sitesWithPlugin = getSitesWithPlugin(
 			state,
 			siteObjectsToSiteIds( allSites ),
 			pluginSlug
 		);
 
-		return allSimpleSites.length + sitesWithPlugin.length;
+		return sitesWithPlugin.length;
 	} );
 
 	return {


### PR DESCRIPTION
#### Proposed Changes

* Fix preinstalled premium plugins labelled as inactive on simple sites.
* Show the installed count in the All Sites view.
* Fix price label to clarify the final cost might be higher.

##### Fix preinstalled premium plugins labelled as inactive on simple sites

Preinstalled premium plugins such as Jetpack Search are both available on WPORG and preinstalled on WPCOM sites, and fully managed on Simple sites.

In the previous change (#65125), Jetpack Search was showing up as "inactive" in the Marketplace list on simple sites, where it should be always active instead.
The bug required a bit of a rethinking about how to determine the active status of this very specific type of plugins.

##### Show the installed count in the All Sites view

In the "All Sites" view, other plugins show the number of sites they are installed on.
I've updated the Preinstalled Premium Plugin to show that as well.

Beware a12s: all our test and internal sites count! 😄 

##### Fix price label to clarify the final cost might be higher

JP Search pricing [depends on the number of indexed records](https://jetpack.com/upgrade/search/).
While testing this PR I realized that one of my sites was on a higher tier, and the checkout price was double what I saw in the Marketplace.

For now, I've added a "From" label to the price. A follow-up could be to use the _actual_ price for each site.

#### Testing Instructions

| Not Purchased | Active | Inactive | All Sites |
| - | - | - | - |
| <img width="530" alt="Screenshot 2022-07-22 at 16 20 51" src="https://user-images.githubusercontent.com/2070010/180471466-b14de9ba-8ea7-482a-a085-23e2a5cf857e.png"> | <img width="531" alt="Screenshot 2022-07-05 at 16 58 51" src="https://user-images.githubusercontent.com/2070010/177370950-1fdefd50-b20a-409e-bff1-dd31ae608f68.png"> | <img width="531" alt="Screenshot 2022-07-05 at 16 58 44" src="https://user-images.githubusercontent.com/2070010/177370915-bca15b22-967a-4e9b-993e-0362742bad32.png"> | <img width="527" alt="Screenshot 2022-07-22 at 16 19 26" src="https://user-images.githubusercontent.com/2070010/180471069-e178f757-f9c1-4ed3-93ab-1427c0bd931d.png"> |

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all the test sites have Jetpack Search upgraded.
  Its free version will always display the price instead of the installed/active status.
  * ⚠️ Check on a non-upgraded site that the price shows a "From" label to indicate that the final price might be higher.
* On a Simple site:
  * Navigate to Plugins and search for `jetpack search`.
  * ⚠️ Check that the Jetpack Search card shows "Active".
* On an Atomic or Jetpack site:
  * Navigate to Plugins and search for `jetpack search`.
  * ⚠️ Check that the Jetpack Search card shows the appropriate active state (e.g. "Active").
  * Open the installed plugins page (e.g. `/wp-admin/plugins.php`) and toggle the Jetpack Search's state.
  * Navigate back to Plugins and search for `jetpack search` again.
  * ⚠️ Check that the Jetpack Search card shows the appropriate active state (e.g. "Inactive").
* On the All Sites view:
  * Navigate to Plugins and search for `jetpack search`.
  * ⚠️ Check that it shows the "Installed on" line (a12s will see a very large number there).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to #65125
Fixes #65904