### PR TITLE
Sites Dashboard: Refactor sites table

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,10 +1,11 @@
-import { Button, SitesTable, Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import getSites from 'calypso/state/selectors/get-sites';
 import { notNullish } from '../util';
+import { SitesTable } from './sites-table';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 const MAX_PAGE_WIDTH = '1184px';

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -72,7 +72,7 @@ export function SitesTable( { buildSiteUrl, className, sites }: SitesTableProps 
 					<Row key={ site.ID }>
 						<td>
 							<div style={ { display: 'flex' } }>
-								<SiteIcon site={ site } size={ 50 } />
+								<SiteIcon siteId={ site.ID } size={ 50 } />
 								<div style={ { marginLeft: '20px' } }>
 									<SiteName>
 										<a href={ buildSiteUrl ? buildSiteUrl( site ) : site.URL }>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -1,9 +1,8 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-// eslint-disable-next-line no-restricted-imports
 import SiteIcon from 'calypso/blocks/site-icon';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SitesTableProps {
 	buildSiteUrl?: ( site: SiteData ) => string;
@@ -62,9 +61,9 @@ export function SitesTable( { buildSiteUrl, className, sites }: SitesTableProps 
 		<Table className={ className }>
 			<thead className="sites-table__mobile-hidden">
 				<Row>
-					<th>{ __( 'Site', __i18n_text_domain__ ) }</th>
-					<th>{ __( 'Plan', __i18n_text_domain__ ) }</th>
-					<th>{ __( 'Last Publish', __i18n_text_domain__ ) }</th>
+					<th>{ __( 'Site' ) }</th>
+					<th>{ __( 'Plan' ) }</th>
+					<th>{ __( 'Last Publish' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>
 			</thead>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -76,7 +76,7 @@ export function SitesTable( { buildSiteUrl, className, sites }: SitesTableProps 
 								<div style={ { marginLeft: '20px' } }>
 									<SiteName>
 										<a href={ buildSiteUrl ? buildSiteUrl( site ) : site.URL }>
-											{ site.name ? site.name : __( '(No Site Title)', __i18n_text_domain__ ) }
+											{ site.name ? site.name : __( '(No Site Title)' ) }
 										</a>
 									</SiteName>
 									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer">

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,4 +17,3 @@ export { HappinessEngineersTray } from './happiness-engineers-tray';
 export { Spinner } from './spinner';
 export { SpinnerExample } from './spinner/example';
 export { default as WordPressLogo } from './wordpress-logo';
-export { SitesTable } from './sites-table';


### PR DESCRIPTION
@danielbachhuber  I think the issue came from using calypso blocks from the new package component `SiteTable`.
Eslint was throwing an error that we "_wisely_" decided to hide.
I've discovered that this pattern was introduced here https://github.com/Automattic/wp-calypso/blob/trunk/.eslintrc.js#L57 to avoid circular dependencies.
<img width="1072" alt="Screenshot 2022-07-05 at 19 07 36" src="https://user-images.githubusercontent.com/779993/177382837-dbc507e5-44b0-4f62-b36a-66c4b6071409.png">



I think moving the SitesTable to another folder will fix the issue. 🤞 