### PR TITLE
Theme Picker: Theme info dropdown not immediately clickable

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -79,6 +79,9 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	// Setup a click handler to close the info popup when the user clicks anywhere outside the popup.
 	useEffect( () => {
 		const closeInfoPopup = ( e: any ) => {
+			if ( ! e.isTrusted ) {
+				return;
+			}
 			const infoPopup = document.querySelector( '.site-setup.design-setup .theme-info-popup' );
 			const isInfoPopupButton = e.target.classList.contains( 'design-setup__info-popover' );
 			const isInfoPopupButtonParent = e.target.parentNode.classList.contains(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -287,6 +287,9 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		border-radius: 2px;
 		margin-right: 10px;
 		cursor: pointer;
+		svg {
+			pointer-events: none;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.scss
@@ -109,4 +109,10 @@
 			line-height: 20px;
 		}
 	}
+
+	&.loading{
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
@@ -43,7 +43,11 @@ const ThemeInfoPopup = ( { slug }: ThemeInfoPopupProps ) => {
 	};
 
 	if ( ! theme ) {
-		return <LoadingEllipsis />;
+		return (
+			<div className="theme-info-popup loading">
+				<LoadingEllipsis />
+			</div>
+		);
 	}
 
 	const { author, author_uri, description } = theme;


### PR DESCRIPTION
#### Proposed Changes

* If we opened the dropdown before the theme was loaded, it would close when the theme was loaded.
* The svg icon was sometimes preventing the click event to work properly.
* Improved the loading ellipses in the case the theme is not loaded when you try to open it.

<img width="820" alt="Screen Shot 2022-07-05 at 15 49 07" src="https://user-images.githubusercontent.com/1234758/177395415-7dd8b54d-93ef-4081-891e-a436aee79728.png">

#### Testing Instructions

* Go to `/setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`.
* Select a theme and then click on the `i` button before the theme loads and wait for the theme to load. The dropdown should no longer close.
* You should encounter no problem when clicking the `i` button to toggle the dropdown state.

Closes #65136
