### PR TITLE
CI: add Authentication E2E build.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -33,6 +33,7 @@ object WebApp : Project({
 	buildType(playwrightPrBuildType("desktop", "23cc069f-59e5-4a63-a131-539fb55264e7"))
 	buildType(playwrightPrBuildType("mobile", "90fbd6b7-fddb-4668-9ed0-b32598143616"))
 	buildType(PreReleaseE2ETests)
+	buildType(AuthenticationE2ETests)
 	buildType(QuarantinedE2ETests)
 })
 
@@ -784,6 +785,44 @@ object PreReleaseE2ETests : E2EBuildType(
 			buildFailed = true
 			buildFinishedSuccessfully = true
 			buildProbablyHanging = true
+		}
+	}
+)
+
+object AuthenticationE2ETests : E2EBuildType(
+	buildId = "Calypso_E2E_Authentication",
+	buildUuid = "f5036e29-f400-49ea-b5c5-4aba9307c5e8",
+	buildName = "Authentication E2E Tests",
+	buildDescription = "Runs a suite of Authentication E2E tests.",
+	concurrentBuilds = 1,
+	testGroup = "authentication",
+	buildParams = {
+		param("env.VIEWPORT_NAME", "desktop")
+	},
+	buildFeatures = {
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#e2eflowtesting-notif"
+				messageFormat = verboseMessageFormat {
+					addStatusText = true
+				}
+			}
+			branchFilter = "+:<default>"
+			buildFailedToStart = true
+			buildFailed = true
+			buildFinishedSuccessfully = false
+			buildProbablyHanging = true
+		}
+	},
+	buildTriggers = {
+		schedule {
+			schedulingPolicy = cron {
+				hours = "*/2"
+			}
+			branchFilter = "+:<default>"
+			triggerBuild = always()
+			withPendingChangesOnly = false
 		}
 	}
 )

--- a/test/e2e/specs/authentication/authentication__magic-link.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-release
+ * @group authentication
  */
 
 import { DataHelper, EmailClient, LoginPage, SecretsManager } from '@automattic/calypso-e2e';

--- a/test/e2e/specs/authentication/authentication__sms.ts
+++ b/test/e2e/specs/authentication/authentication__sms.ts
@@ -2,7 +2,7 @@
  * @group authentication
  *
  * One real problem with this spec is that SMS OTP can only be requested once every 5 minutes as per the backend code.
- * What this means is that in rare cases where Pre-Release Tests are lined up one after another in the queue, it may result in an unexpected failure of this spec, which would appear to be a flaky test failure to the developer.
+ * This is why the spec is isolated in its own build, to bypass the situation where Pre-Release Tests are lined up one after another (eg. when two PRs are merged together).
  *
  * It may be necessary to keep a close eye on this test and immediately pull the test from rotation if we find the flakiness exceeds an acceptable level.
  */

--- a/test/e2e/specs/authentication/authentication__sms.ts
+++ b/test/e2e/specs/authentication/authentication__sms.ts
@@ -1,8 +1,7 @@
 /**
- * @group calypso-release
+ * @group authentication
  *
- * One possible problem with this spec is that SMS OTP can only be requested once per minute.
- * In addition, anecdotally it appears that any login attempt during this one-minute blackout period resets the timer, though this isn't confirmed.
+ * One real problem with this spec is that SMS OTP can only be requested once every 5 minutes as per the backend code.
  * What this means is that in rare cases where Pre-Release Tests are lined up one after another in the queue, it may result in an unexpected failure of this spec, which would appear to be a flaky test failure to the developer.
  *
  * It may be necessary to keep a close eye on this test and immediately pull the test from rotation if we find the flakiness exceeds an acceptable level.

--- a/test/e2e/specs/authentication/authentication__totp.ts
+++ b/test/e2e/specs/authentication/authentication__totp.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-release
+ * @group authentication
  */
 
 import { DataHelper, TestAccount } from '@automattic/calypso-e2e';


### PR DESCRIPTION
#### Proposed Changes

This PR creates a new Authentication E2E build configuration and moves all tests under `test/e2e/authentication` into this group.

This new build is set to trigger at 00 every two hours, every day of the week. This is to stay within the Mailosaur limits for Business Plan, which includes 500 SMS per month.

#### Testing Instructions

Ensure the following:
  - [x] Unit Tests
  - [x] Code Style

Related to #
