### PR TITLE
Disable plugin activate toggle for sites without that feature

### DIFF
--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -1,3 +1,4 @@
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -17,6 +18,7 @@ import {
 	isPluginActionInProgress,
 } from 'calypso/state/plugins/installed/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 
 import './style.scss';
 
@@ -42,6 +44,9 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 				( variation ) => variation.product_slug === purchase.productSlug
 			)
 		);
+	const hasManagePluginsFeature = useSelector( ( state ) =>
+		siteHasFeature( state, site.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
+	);
 
 	useEffect( () => {
 		if ( isWithinBreakpoint( '<1040px' ) ) {
@@ -98,6 +103,7 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 						site={ site }
 						plugin={ pluginOnSite }
 						hideLabel={ ! isMobileLayout }
+						disabled={ plugin.isMarketplaceProduct && ! hasManagePluginsFeature }
 					/>
 				) }
 				{ canToggleAutoupdate && (


### PR DESCRIPTION
#### Proposed Changes

* Conditionally disables the activate toggle based on whether it's a marketplace plugin and the site has the manage_plugins feature.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a site with installed plugins.
* Navigate to the single plugin view of one of those plugins.
* Self-hosted Jetpack sites and sites on Pro plan and up should always have the activate toggle enabled. <img width="1092" alt="image" src="https://user-images.githubusercontent.com/1398304/177427153-e1ea8fbf-e834-4020-9da3-3acdcc348a6f.png">
* Starter plan sites with Marketplace plugins should have the toggle disabled. <img width="1074" alt="image" src="https://user-images.githubusercontent.com/1398304/177427216-863e9f22-58f3-4e1a-b98e-be8d74e228bf.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/65263
