### PR TITLE
Checkout: Allow string versions of receiptId etc in getThankYouPageUrl

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -111,10 +111,10 @@ export default function getThankYouPageUrl( {
 	siteSlug?: string;
 	adminUrl?: string;
 	redirectTo?: string;
-	receiptId?: number;
+	receiptId?: number | string;
 	noPurchaseMade?: boolean;
-	orderId?: number;
-	purchaseId?: number;
+	orderId?: number | string;
+	purchaseId?: number | string;
 	feature?: string;
 	cart?: ResponseCart;
 	isJetpackNotAtomic?: boolean;
@@ -298,7 +298,7 @@ export default function getThankYouPageUrl( {
 	if ( isReceiptIdOrPlaceholder( pendingOrReceiptId ) ) {
 		const redirectUrlForPostCheckoutUpsell = getRedirectUrlForPostCheckoutUpsell( {
 			receiptId: pendingOrReceiptId,
-			orderId,
+			orderId: orderId ? Number( orderId ) : undefined,
 			cart,
 			siteSlug,
 			hideUpsell: Boolean( hideNudge ),
@@ -339,18 +339,18 @@ export default function getThankYouPageUrl( {
 }
 
 function getPendingOrReceiptId(
-	receiptId: number | undefined,
-	orderId: number | undefined,
-	purchaseId: number | undefined
+	receiptId: string | number | undefined,
+	orderId: string | number | undefined,
+	purchaseId: string | number | undefined
 ): PendingOrReceiptId {
 	if ( receiptId ) {
-		return receiptId;
+		return Number( receiptId );
 	}
 	if ( orderId ) {
-		return `pending/${ orderId }`;
+		return `pending/${ Number( orderId ) }`;
 	}
 	if ( purchaseId ) {
-		return purchaseId;
+		return Number( purchaseId );
 	}
 	return ':receiptId';
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -57,6 +57,15 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
 
+	it( 'redirects to the thank-you page with a receipt id when a site and receiptId is set as a string', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			receiptId: String( samplePurchaseId ),
+		} );
+		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
+	} );
+
 	it( 'redirects to the thank-you page with a receipt id when a site and receiptId is set', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
@@ -1633,6 +1642,28 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				isJetpackCheckout: true,
 				receiptId: 80023,
+			} );
+			expect( url ).toBe(
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023'
+			);
+		} );
+
+		it( 'redirects with receiptId query param when a valid receipt ID is provided as a string', () => {
+			const cart = {
+				...getEmptyResponseCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						product_slug: 'jetpack_backup_daily',
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: undefined,
+				cart,
+				isJetpackCheckout: true,
+				receiptId: '80023',
 			} );
 			expect( url ).toBe(
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023'


### PR DESCRIPTION
#### Proposed Changes

This fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/65213 where the receipt ID passed through the `getThankYouPageUrl()` function is sometimes a number inside a string.

#### Testing Instructions

Automated test included.