### PR TITLE
plugins-list: Change lodash includes to ES7 includes

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -2,7 +2,7 @@ import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, isEqual, range, reduce, sortBy } from 'lodash';
+import { isEmpty, isEqual, range, reduce, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -524,7 +524,7 @@ export class PluginsList extends Component {
 	getAllowedPluginActions( plugin ) {
 		const { hasManagePlugins, siteIsAtomic, siteIsJetpack } = this.props;
 		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
-		const isManagedPlugin = siteIsAtomic && includes( autoManagedPlugins, plugin.slug );
+		const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
 		const canManagePlugins =
 			( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
 


### PR DESCRIPTION
#### Proposed Changes

* Remove one usage of lodash `includes` with javascript `.includes()`

#### Testing Instructions

* Visit `/plugins/manage/<site>` on an atomic business or ecommerce site
* Akismet and jetpack should still appear as auto-managed
![2022-07-05_17-51](https://user-images.githubusercontent.com/937354/177429943-5e437890-251c-4cff-b045-cf6cf410470a.png)

