### PR TITLE
Checkout: use post-checkout pending page for non-redirect payment methods

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryOrderTransaction from 'calypso/components/data/query-order-transaction';
 import EmptyContent from 'calypso/components/empty-content';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { AUTO_RENEWAL } from 'calypso/lib/url/support';
@@ -118,7 +117,6 @@ function useRedirectOnTransactionSuccess( {
 	redirectTo?: string;
 } ): void {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const transaction: OrderTransaction | null = useSelector( ( state ) =>
 		orderId ? getOrderTransaction( state, orderId ) : null
 	);
@@ -186,12 +184,8 @@ function useRedirectOnTransactionSuccess( {
 		if ( isRenewal ) {
 			displayRenewalSuccessNotice( {
 				productName,
-				billPeriod,
 				willAutoRenew,
-				expiry,
-				userEmail,
 				translate,
-				moment,
 				reduxDispatch,
 			} );
 		}
@@ -206,7 +200,6 @@ function useRedirectOnTransactionSuccess( {
 		siteSlug,
 		transaction,
 		translate,
-		moment,
 		reloadCart,
 		orderId,
 		receiptId,
@@ -215,42 +208,27 @@ function useRedirectOnTransactionSuccess( {
 
 function displayRenewalSuccessNotice( {
 	productName,
-	billPeriod,
 	willAutoRenew,
-	expiry,
-	userEmail,
 	translate,
-	moment,
 	reduxDispatch,
 }: {
 	productName: string;
-	billPeriod: string;
 	willAutoRenew: boolean;
-	expiry: string;
-	userEmail: string;
 	translate: ReturnType< typeof useTranslate >;
-	moment: ReturnType< typeof useLocalizedMoment >;
 	reduxDispatch: CalypsoDispatch;
 } ): void {
 	if ( willAutoRenew ) {
 		// showing notice for product that will auto-renew
 		reduxDispatch(
 			successNotice(
-				translate(
-					'Success! You renewed %(productName)s for %(duration)s, and we sent your receipt to %(email)s. {{a}}Learn more about renewals{{/a}}',
-					{
-						args: {
-							productName,
-							duration: moment.duration( { days: parseInt( billPeriod, 10 ) } ).humanize(),
-							email: userEmail,
-						},
-						components: {
-							a: (
-								<a href={ localizeUrl( AUTO_RENEWAL ) } target="_blank" rel="noopener noreferrer" />
-							),
-						},
-					}
-				),
+				translate( 'Success! You renewed %(productName)s. {{a}}Learn more about renewals{{/a}}', {
+					args: {
+						productName,
+					},
+					components: {
+						a: <a href={ localizeUrl( AUTO_RENEWAL ) } target="_blank" rel="noopener noreferrer" />,
+					},
+				} ),
 				{ displayOnNextPage: true }
 			)
 		);
@@ -260,17 +238,11 @@ function displayRenewalSuccessNotice( {
 	// showing notice for product that will not auto-renew
 	reduxDispatch(
 		successNotice(
-			translate(
-				'Success! You renewed %(productName)s for %(duration)s, until %(date)s. We sent your receipt to %(email)s.',
-				{
-					args: {
-						productName,
-						duration: moment.duration( { days: parseInt( billPeriod, 10 ) } ).humanize(),
-						date: moment( expiry ).format( 'LL' ),
-						email: userEmail,
-					},
-				}
-			),
+			translate( 'Success! You renewed %(productName)s.', {
+				args: {
+					productName,
+				},
+			} ),
 			{ displayOnNextPage: true }
 		)
 	);

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -213,6 +213,9 @@ function useRedirectOnTransactionSuccess( {
 				reduxDispatch,
 			} );
 		}
+		if ( ! isRenewal ) {
+			reduxDispatch( successNotice( translate( 'Your purchase has been completed!' ) ) );
+		}
 		performRedirect( redirectInstructions.url );
 	}, [
 		error,

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -190,7 +190,7 @@ function useRedirectOnTransactionSuccess( {
 			);
 			reduxDispatch(
 				errorNotice( defaultFailErrorNotice, {
-					isPersistent: true,
+					displayOnNextPage: true,
 				} )
 			);
 		}
@@ -199,7 +199,7 @@ function useRedirectOnTransactionSuccess( {
 			const unknownNotice = translate( 'Oops! Something went wrong. Please try again later.' );
 			reduxDispatch(
 				errorNotice( unknownNotice, {
-					isPersistent: true,
+					displayOnNextPage: true,
 				} )
 			);
 		}
@@ -214,7 +214,11 @@ function useRedirectOnTransactionSuccess( {
 			} );
 		}
 		if ( ! isRenewal ) {
-			reduxDispatch( successNotice( translate( 'Your purchase has been completed!' ) ) );
+			reduxDispatch(
+				successNotice( translate( 'Your purchase has been completed!' ), {
+					displayOnNextPage: true,
+				} )
+			);
 		}
 		performRedirect( redirectInstructions.url );
 	}, [

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -1,21 +1,13 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector, useDispatch, useStore } from 'react-redux';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
-import {
-	hasRenewalItem,
-	getRenewalItems,
-	hasPlan,
-	hasEcommercePlan,
-} from 'calypso/lib/cart-values/cart-items';
+import { hasPlan, hasEcommercePlan } from 'calypso/lib/cart-values/cart-items';
 import { getDomainNameFromReceiptOrCart } from 'calypso/lib/domains/cart-utils';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
-import { AUTO_RENEWAL } from 'calypso/lib/url/support';
 import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
@@ -23,7 +15,7 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { infoNotice, successNotice } from 'calypso/state/notices/actions';
+import { infoNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -48,7 +40,7 @@ import type {
 	PaymentEventCallbackArguments,
 } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
-import type { WPCOMTransactionEndpointResponse, Purchase } from '@automattic/wpcom-checkout';
+import type { WPCOMTransactionEndpointResponse } from '@automattic/wpcom-checkout';
 import type { CalypsoDispatch } from 'calypso/state/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-on-payment-complete' );
@@ -89,7 +81,6 @@ export default function useCreatePaymentCompleteCallback( {
 	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const siteId = useSelector( getSelectedSiteId );
 	const isDomainOnly =
 		useSelector( ( state ) => siteId && isDomainOnlySite( state, siteId ) ) || false;
@@ -182,17 +173,6 @@ export default function useCreatePaymentCompleteCallback( {
 				clearSignupDestinationCookie();
 			}
 
-			if ( hasRenewalItem( responseCart ) && transactionResult?.purchases ) {
-				debug( 'purchase had a renewal' );
-				displayRenewalSuccessNotice(
-					responseCart,
-					transactionResult.purchases,
-					translate,
-					moment,
-					reduxDispatch
-				);
-			}
-
 			if ( receiptId && transactionResult?.purchases ) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
@@ -281,7 +261,6 @@ export default function useCreatePaymentCompleteCallback( {
 			isInModal,
 			reduxStore,
 			isDomainOnly,
-			moment,
 			reduxDispatch,
 			siteId,
 			translate,
@@ -293,77 +272,6 @@ export default function useCreatePaymentCompleteCallback( {
 			adminPageRedirect,
 			domains,
 		]
-	);
-}
-
-function displayRenewalSuccessNotice(
-	responseCart: ResponseCart,
-	purchases: Record< number, Purchase[] >,
-	translate: ReturnType< typeof useTranslate >,
-	moment: ReturnType< typeof useLocalizedMoment >,
-	reduxDispatch: CalypsoDispatch
-): void {
-	const renewalItem = getRenewalItems( responseCart )[ 0 ];
-	// group all purchases into an array
-	const purchasedProducts = Object.values( purchases ?? {} ).reduce(
-		( result: Purchase[], value: Purchase[] ) => [ ...result, ...value ],
-		[]
-	);
-	// and take the first product which matches the product id of the renewalItem
-	const product = purchasedProducts.find( ( item ) => {
-		return String( item.product_id ) === String( renewalItem.product_id );
-	} );
-
-	if ( ! product ) {
-		debug( 'no product found for renewal notice matching', renewalItem, 'in', purchasedProducts );
-		return;
-	}
-
-	if ( product.will_auto_renew ) {
-		debug( 'showing notice for product that will auto-renew' );
-		reduxDispatch(
-			successNotice(
-				translate(
-					'Success! You renewed %(productName)s for %(duration)s, and we sent your receipt to %(email)s. {{a}}Learn more about renewals{{/a}}',
-					{
-						args: {
-							productName: renewalItem.product_name,
-							duration: moment
-								.duration( { days: parseInt( renewalItem.bill_period, 10 ) } )
-								.humanize(),
-							email: product.user_email,
-						},
-						components: {
-							a: (
-								<a href={ localizeUrl( AUTO_RENEWAL ) } target="_blank" rel="noopener noreferrer" />
-							),
-						},
-					}
-				),
-				{ displayOnNextPage: true }
-			)
-		);
-		return;
-	}
-
-	debug( 'showing notice for product that will not auto-renew' );
-	reduxDispatch(
-		successNotice(
-			translate(
-				'Success! You renewed %(productName)s for %(duration)s, until %(date)s. We sent your receipt to %(email)s.',
-				{
-					args: {
-						productName: renewalItem.product_name,
-						duration: moment
-							.duration( { days: parseInt( renewalItem.bill_period, 10 ) } )
-							.humanize(),
-						date: moment( product.expiry ).format( 'LL' ),
-						email: product.user_email,
-					},
-				}
-			),
-			{ displayOnNextPage: true }
-		)
 	);
 }
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -5,16 +5,14 @@ import CustomerHome from './main';
 
 export default async function ( context, next ) {
 	const state = await context.store.getState();
-	const siteId = await getSelectedSiteId( state );
-
-	const noticeType = context.query.notice;
+	const siteId = getSelectedSiteId( state );
 
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome key={ siteId } noticeType={ noticeType } />;
+	context.primary = <CustomerHome key={ siteId } />;
 
 	next();
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -2,8 +2,8 @@ import { Button } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { connect, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
@@ -21,7 +21,6 @@ import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
-import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import {
@@ -38,31 +37,12 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
-	noticeType,
 	sitePlanSlug,
 	isNew7DUser,
 } ) => {
 	const translate = useTranslate();
-	const reduxDispatch = useDispatch();
 
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
-
-	const shouldShowNotice = Boolean( canUserUseCustomerHome && layout && noticeType );
-	const lastShownNotice = useRef( null );
-	useEffect( () => {
-		if ( ! shouldShowNotice || lastShownNotice.current === noticeType ) {
-			return;
-		}
-
-		if ( noticeType === 'purchase-success' ) {
-			lastShownNotice.current = noticeType;
-			const successMessage = translate( 'Your purchase has been completed!' );
-			reduxDispatch( successNotice( successMessage ) );
-			return;
-		}
-
-		return;
-	}, [ shouldShowNotice, translate, reduxDispatch, noticeType ] );
 
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	useEffect( () => {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -95,14 +95,10 @@ class Upload extends Component {
 	};
 
 	componentDidMount() {
-		const { siteId, inProgress, noticeType } = this.props;
+		const { siteId, inProgress } = this.props;
 		! inProgress && this.props.clearThemeUpload( siteId );
 		if ( this.props.isAtomic && this.props.canUploadThemesOrPlugins ) {
 			this.redirectToWpAdmin();
-		}
-
-		if ( 'purchase-success' === noticeType ) {
-			this.purchaseSuccessMessage();
 		}
 	}
 
@@ -148,11 +144,6 @@ class Upload extends Component {
 			} ),
 			{ duration: 5000 }
 		);
-	}
-
-	purchaseSuccessMessage() {
-		const { translate } = this.props;
-		this.props.successNotice( translate( 'Your purchase has been completed!' ) );
 	}
 
 	failureMessage() {
@@ -215,7 +206,7 @@ class Upload extends Component {
 
 	renderUpgradeBanner() {
 		const { siteId, eligibleForProPlan, translate } = this.props;
-		const redirectTo = encodeURIComponent( `/themes/upload/${ siteId }?notice=purchase-success` );
+		const redirectTo = encodeURIComponent( `/themes/upload/${ siteId }` );
 
 		const upsellPlan = eligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
 		const title = eligibleForProPlan

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -18,6 +18,8 @@ import { flatten } from 'lodash';
  * @property {string} [registrar_support_url]
  * @property {boolean} [is_email_verified]
  * @property {boolean} [is_root_domain_with_us]
+ * @property {boolean} [is_renewal]
+ * @property {boolean} [will_auto_renew]
  */
 
 /**
@@ -45,6 +47,8 @@ import { flatten } from 'lodash';
  * @property {string} registrarSupportUrl
  * @property {boolean} isEmailVerified
  * @property {boolean} isRootDomainWithUs
+ * @property {boolean} isRenewal
+ * @property {boolean} willAutoRenew
  */
 
 /**
@@ -62,6 +66,9 @@ import { flatten } from 'lodash';
  * @type {object}
  * @property {string} receipt_id
  * @property {string} display_price
+ * @property {number} price_float
+ * @property {number} price_integer
+ * @property {string} currency
  * @property {RawPurchases|string[]} purchases - will only be an array if it is empty
  * @property {RawFailedPurchases|string[]} failed_purchases - will only be an array if it is empty
  */
@@ -81,6 +88,9 @@ import { flatten } from 'lodash';
  * @type {object}
  * @property {string} receiptId
  * @property {string} displayPrice
+ * @property {string} currency
+ * @property {number} priceFloat
+ * @property {number} priceInteger
  * @property {Purchase[]} purchases
  * @property {FailedPurchase[]} failedPurchases
  */
@@ -95,6 +105,9 @@ export function createReceiptObject( data ) {
 	return {
 		receiptId: data.receipt_id,
 		displayPrice: data.display_price,
+		currency: data.currency,
+		priceInteger: data.price_integer,
+		priceFloat: data.price_float,
 		purchases: flattenPurchases( data.purchases || {} ).map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),
@@ -110,6 +123,8 @@ export function createReceiptObject( data ) {
 				registrarSupportUrl: purchase.registrar_support_url ?? '',
 				isEmailVerified: Boolean( purchase.is_email_verified ),
 				isRootDomainWithUs: Boolean( purchase.is_root_domain_with_us ),
+				isRenewal: Boolean( purchase.is_renewal ),
+				willAutoRenew: Boolean( purchase.will_auto_renew ),
 			};
 		} ),
 		failedPurchases: flattenFailedPurchases( data.failed_purchases || {} ).map( ( purchase ) => {

--- a/client/state/receipts/initial.js
+++ b/client/state/receipts/initial.js
@@ -1,3 +1,15 @@
+/**
+ * @typedef ReceiptState
+ * @type {object}
+ * @property {null|import('calypso/state/receipts/assembler').ReceiptData} data
+ * @property {null|string} error
+ * @property {boolean} hasLoadedFromServer
+ * @property {boolean} isRequesting
+ */
+
+/**
+ * @member {ReceiptState}
+ */
 export const initialReceiptState = {
 	data: null,
 	error: null,

--- a/client/state/receipts/selectors.js
+++ b/client/state/receipts/selectors.js
@@ -2,6 +2,11 @@ import { initialReceiptState } from 'calypso/state/receipts/initial';
 
 import 'calypso/state/receipts/init';
 
+/**
+ * @param {import('calypso/types').AppState} state
+ * @param {number|string|undefined} receiptId
+ * @returns {import('calypso/state/receipts/initial').ReceiptState}
+ */
 export function getReceiptById( state, receiptId ) {
 	return state.receipts.items[ receiptId ] || initialReceiptState;
 }


### PR DESCRIPTION
#### Background

In this PR we try to simplify and organize some of the post-checkout redirect behavior by making non-redirect payment methods (eg: credit cards, full credits purchases, free purchases, Apple Pay, Google Pay) redirect to the "pending" page after checkout completes like we do with redirect payment methods (eg: 3DS cards, Bancontact, iDeal). The "pending" page will then send the browser to the final redirect location. Previously these payment methods sent the user directly to the final location, but this is inconsistent and requires writing separate behavior for the two kinds of payment methods.

Currently many parts of the code assume (quite understandably) that the `onPaymentComplete` prop of the `CheckoutProvider` component will run when the payment is complete, but it does not run for redirect payment methods because the transaction hasn't been completed (nor even started) by the time we redirect to the payment partner. This causes confusion because all the code being run by that function – notices, analytics, etc. – will only run when the user pays with a non-3DS credit card or credits.

#### Proposed Changes

This change will make it so we have a single location inside calypso where we can run functions after a purchase is complete by changing non-redirect payment methods to visit the "pending" page before going to the post-checkout URL.

This PR also replaces several post-checkout notice hacks with a notice triggered on the pending page so it will work for all payment methods and will even work for redirects or 3DS cards.

Note that even though this adds an extra redirect for the post-checkout process, it should not be noticable to users because it will be an instantaneous SPA redirect.

#### References

This is part of implementing https://github.com/Automattic/wp-calypso/issues/53356

Fixes 553-gh-Automattic/payments-shilling

Requires D84365-code to add new properties to the receipt endpoint. (Merged now.)

(Previously this PR also updated the Stripe redirect payment processor to use `:orderId` as well, but that change has been moved to https://github.com/Automattic/wp-calypso/pull/65415.)

#### Screenshots

Here's an example of the "pending" page and final page for a Starter Plan:

<img width="652" alt="pending-page" src="https://user-images.githubusercontent.com/2036909/178382533-1776d748-bd80-4950-b334-a3289744fa1b.png">

<img width="706" alt="post-checkout" src="https://user-images.githubusercontent.com/2036909/178382611-03b5649c-ca69-4ef1-b460-eb76a1a86cdc.png">

The notice you should see for a renewal:

<img width="854" alt="Screen Shot 2022-07-22 at 4 12 20 PM" src="https://user-images.githubusercontent.com/2036909/180519927-f5855f85-9475-4cca-a661-4080b6f1c91a.png">

The notice you should see for a new purchase:

<img width="931" alt="Screen Shot 2022-07-22 at 4 12 08 PM" src="https://user-images.githubusercontent.com/2036909/180519962-e5b8a6de-2c7f-4829-a094-86198b3522af.png">

#### Testing Instructions

- Add a plan to your cart and visit checkout using this branch.
- Complete the checkout form and select "Credit or debit card" as the payment method. If the store and public-api are sandboxed, you can use a Stripe test card like `4242424242424242`.
- Submit the purchase.
- Verify that you briefly see the "Please wait…" pending page. You may not actually be able to see this page because the redirect is so fast and it won't even show up in the browser devtools since it is an SPA redirect. 
- Verify that you are then redirected to a final post-checkout page (this usually will be something like `/checkout/thank-you/:site/:receiptId` but it depends on a lot of factors) that is not the generic thank-you page (`/checkout/thank-you/:site/pending` or `/checkout/thank-you/:site/unknown`).

We should also repeat the above steps for the following payment methods, but it's ok if you just test some of them since  they use the same code to generate the post-checkout URL. Just mention in your review which one(s) you tested.

- Existing saved credit card.
- Full credits purchase (you'll need to add enough credits to cover the entire purchase price).
- Free purchase (try purchasing a domain after purchasing a plan).
- Apple Pay.
- Google Pay.