### PR TITLE
Marketplace: Add back 2fa branding

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -42,7 +42,6 @@ import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-fr
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-
 import './style.scss';
 
 class Login extends Component {
@@ -70,6 +69,7 @@ class Login extends Component {
 		onSocialConnectStart: PropTypes.func,
 		onTwoFactorRequested: PropTypes.func,
 		signupUrl: PropTypes.string,
+		redirectTo: PropTypes.string,
 	};
 
 	state = {
@@ -137,6 +137,9 @@ class Login extends Component {
 		if ( this.props.onTwoFactorRequested ) {
 			this.props.onTwoFactorRequested( authType );
 		} else {
+			const currentURLQueryParameters = Object.fromEntries(
+				new URL( this.props.redirectTo ).searchParams.entries()
+			);
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,
@@ -144,6 +147,7 @@ class Login extends Component {
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: authType,
 					locale: this.props.locale,
+					isPartnerSignup: isPartnerSignupQuery( currentURLQueryParameters ),
 				} )
 			);
 		}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -137,9 +137,9 @@ class Login extends Component {
 		if ( this.props.onTwoFactorRequested ) {
 			this.props.onTwoFactorRequested( authType );
 		} else {
-			const currentURLQueryParameters = Object.fromEntries(
-				new URL( this.props.redirectTo ).searchParams.entries()
-			);
+			const currentURLQueryParameters = this.props?.redirectTo
+				? Object.fromEntries( new URL( this.props.redirectTo ).searchParams.entries() )
+				: '';
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -137,9 +137,6 @@ class Login extends Component {
 		if ( this.props.onTwoFactorRequested ) {
 			this.props.onTwoFactorRequested( authType );
 		} else {
-			const currentURLQueryParameters = this.props?.redirectTo
-				? Object.fromEntries( new URL( this.props.redirectTo ).searchParams.entries() )
-				: '';
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,
@@ -147,7 +144,7 @@ class Login extends Component {
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: authType,
 					locale: this.props.locale,
-					isPartnerSignup: isPartnerSignupQuery( currentURLQueryParameters ),
+					isPartnerSignup: this.props.isPartnerSignup,
 				} )
 			);
 		}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -70,6 +70,7 @@ class Login extends Component {
 		onTwoFactorRequested: PropTypes.func,
 		signupUrl: PropTypes.string,
 		redirectTo: PropTypes.string,
+		isPartnerSignup: PropTypes.bool,
 	};
 
 	state = {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -40,6 +40,7 @@ export function login( {
 	allowSiteConnection = undefined,
 	signupUrl = undefined,
 	useQRCode = undefined,
+	isPartnerSignup = undefined,
 } = {} ) {
 	let url = '/log-in';
 
@@ -99,6 +100,10 @@ export function login( {
 
 	if ( allowSiteConnection ) {
 		url = addQueryArgs( { allow_site_connection: '1' }, url );
+	}
+
+	if ( isPartnerSignup ) {
+		url = addQueryArgs( { is_partner_signup: true }, url );
 	}
 
 	return url;

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -181,11 +181,17 @@ export async function postLoginRequest( action, bodyObj ) {
  * https://woocommerce.com/partner-signup uses a wp.com branded login and signup flow
  * while using woocommerces's oauth client id.
  *
- * This function detects this situation by checking for a redirect back to that page.
+ * This function check for is_partner_signup query or detects this situation by checking
+ * for a redirect back to that page.
  */
 export function isPartnerSignupQuery( currentQuery ) {
 	if ( ! currentQuery ) {
 		return false;
+	}
+
+	// Check for is_partner_signup query
+	if ( currentQuery?.is_partner_signup ) {
+		return true;
 	}
 
 	// Handles login through /log-in/?redirect_to=...


### PR DESCRIPTION
When Logged in coming from partner signup and has 2FA validation, it loses the rebranding.
This undo this revert #64839, add some fixes, and can be tested using the new e2e tests added [here](https://github.com/Automattic/wp-calypso/pull/65068)

#### Proposed changes
We need to pass the `redirect_to` query param to the 2FA URL in order to know where it came

#### Testing Instructions
- Go to http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dsnip%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dpartner-signup%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26redirect_to%3Dhttps%3A%2F%2Fwoocommerce.com%2Fpartner-signup%2F
- Log in using an account with 2FA authentication
- When asked for 2FA, the URL should contain the `redirect_to` query param and should see it as the screenshot

#### E2E testing instructions
With new tests added [here](https://github.com/Automattic/wp-calypso/pull/65068) you can test SMS or TOTP 2FA methods
`yarn jest test/e2e/specs/authentication/authentication__sms.ts`
`yarn jest test/e2e/specs/authentication/authentication__totp.ts`

#### Screenshot
<img width="284" alt="image" src="https://user-images.githubusercontent.com/402286/174169703-8666acf0-0d6c-41e9-8a19-b72004ec38cb.png">

Fixes #64992 
