### PR TITLE
Checkout: Add ":receiptId" placeholder replacement to CheckoutPending

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -91,6 +91,11 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 
 				didRedirect.current = true;
 
+				if ( redirectTo?.includes( ':receiptId' ) ) {
+					performRedirect( redirectTo.replace( ':receiptId', `${ receiptId }` ) );
+					return;
+				}
+
 				// Only treat `/pending` as a placeholder if it's the end of the URL
 				// pathname, but preserve query strings or hashes.
 				const receiptPlaceholderRegexp = /\/pending([?#]|$)/;


### PR DESCRIPTION
#### Proposed Changes

When a calypso purchase completes using a redirect payment method, the browser is sent through a series of redirects before ending up on a "pending" page which renders the `CheckoutPending` component. That component polls the orders endpoint until the transaction is complete. If successful, the component then redirects the user to the URL in the `redirectTo` query param passed back from the server (and originally generated by the `getThankYouPageUrl()` function in calypso). If the transaction was already complete when the browser was returning from the payment partner, that URL may have been modified by the server to include the receipt ID. However, if the transaction was still pending, the URL will not include the receipt ID and may include a `:receiptId` placeholder instead (in some cases this is stripped out but often it is not). Because the placeholder isn't a valid receipt ID, the final post-checkout URL may be invalid. In the case of the most common post-checkout page, this displays a very generic thank-you.

In this diff, we modify the `CheckoutPending` component to replace the `:receiptId` placeholder in the `redirectTo` query string URL, if such a placeholder exists, with the actual receipt ID retrieved from the orders endpoint, leading to the correct post-checkout page.

Does not require anything but this cannot be tested without D83814-code

#### Testing Instructions

First, since it's common for transactions to complete instantly, we need to modify the transaction flow to simulate what happens when the order is not complete. Apply D83759-code (this also includes D83814-code) to your sandbox and sandbox public-api.wordpress.com. This patch will also force the Bancontact redirect payment method to be available.

In order to use the Bancontact payment method, your user's currency will need to be EUR, so change that, if necessary, to continue.

Next, use calypso on this branch to purchase a wpcom plan that will redirect to a known thank-you page. The legacy business plan works well for this. To add it to your cart, visit the URL path `/checkout/business` (and select a site if necessary). During checkout, select Bancontact as the payment method and submit the purchase. You'll then need to confirm the purchase on the Stripe test page.

When you are returned to calypso, you should briefly see the "Please wait" pending page before being redirected to the post-checkout thank-you page. Verify that this page mentions the specific plan you purchased and doesn't look generic. Verify that the URL contains the numeric receipt ID.