### PR TITLE
Forms: Hide Microsoft Edge password reveal toggle

### DIFF
--- a/client/components/forms/form-password-input/style.scss
+++ b/client/components/forms/form-password-input/style.scss
@@ -4,6 +4,10 @@
 	.form-text-input {
 		/*!rtl:ignore*/
 		padding-right: 32px;
+
+		&::-ms-reveal {
+			display: none;
+		}
 	}
 
 	.form-password-input__toggle {


### PR DESCRIPTION
#### Proposed Changes

* Hides Microsoft Edge's password reveal toggle for the `FormPasswordInput` in favor of the Calypso password reveal implementation.

I went ahead and tester other browsers in our commit checklist and noticed one issue with some overlap with Safari's password manager. But, no other issues.

<img width="469" alt="Screen Shot 2022-07-05 at 9 15 55 PM" src="https://user-images.githubusercontent.com/1126811/177453857-5dbe8d2c-08d4-4fad-b625-4a7cca71c4c1.png">

I went ahead and marked this questions as design input requested to get input on whether we'd like to try to address issues with overlapping icons or just remove our password reveal icon.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install Microsoft Edge if not already installed
* Checkout PR and load https://calypso.localhost:3000/log-in
* Enter email address to a known WordPress.com user
* Begin typing any value into the password field
* Ensure that you only see one password reveal toggle

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
