### PR TITLE
Help Center: Improved percentage and simple sites management

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,12 +386,12 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  * At the moment we're showing only to 10% of the users. And to all proxied requests.
  */
 function load_help_center() {
-	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-		return;
-	}
-
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && ! $is_proxied ) {
+		return;
+	}
 
 	// only shipping to en locale for now.
 	$current_locale = get_locale();

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
@@ -32,7 +33,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, isSimpleSite as getIsSimpleSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
@@ -369,20 +370,18 @@ export default withCurrentRoute(
 		const sidebarIsHidden = ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
-		const userId = getCurrentUserId( state );
-		const currentSegment = 10; //percentage of users that will not see the FAB, but the Help Center
-		const userSegment = userId % 100;
-		const locale = getCurrentLocaleSlug( state );
 		const isEditor = getSectionName( state ) === 'gutenberg-editor';
-		const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
-		const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
+		const isSimpleSite = getIsSimpleSite( state );
+		const userAllowedToHelpCenter = shouldShowHelpCenterToUser(
+			getCurrentUserId( state ),
+			getCurrentLocaleSlug( state )
+		);
 
 		const disableFAB =
 			isSimpleSite &&
-			isHelpCenterEnabled &&
-			locale === 'en' &&
 			isEditor &&
-			userSegment < currentSegment;
+			config.isEnabled( 'editor/help-center' ) &&
+			userAllowedToHelpCenter;
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Popover, Button } from '@automattic/components';
+import { shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -31,7 +32,11 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	getSiteSlug,
+	isJetpackSite,
+	isSimpleSite as getIsSimpleSite,
+} from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -491,23 +496,17 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	render() {
-		const { isCheckout, isCheckoutPending } = this.props;
+		const { isInEditor, isCheckout, isCheckoutPending, isSimpleSite, user, locale } = this.props;
 		const { isMobile } = this.state;
 
 		if ( isCheckout || isCheckoutPending ) {
 			return this.renderCheckout();
 		}
 		if ( isMobile ) {
-			const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
-			const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
-			const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
-			const userSegment = this.props.user.ID % 100;
-
 			if (
-				this.props.isInEditor &&
-				isHelpCenterEnabled &&
-				userSegment < currentSegment &&
-				this.props.locale === 'en' &&
+				config.isEnabled( 'editor/help-center' ) &&
+				shouldShowHelpCenterToUser( user.ID, locale ) &&
+				isInEditor &&
 				isSimpleSite
 			) {
 				return (
@@ -600,6 +599,7 @@ export default connect(
 			isUserNewerThanNewNavigation:
 				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
 			locale: getCurrentLocaleSlug( state ),
+			isSimpleSite: getIsSimpleSite( state ),
 		};
 	},
 	{

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -67,3 +67,4 @@ export { default as getSiteWooCommerceWizardUrl } from './get-site-woocommerce-w
 export { default as getJetpackSearchCustomizeUrl } from './get-jetpack-search-customize-url';
 export { default as getJetpackSearchDashboardUrl } from './get-jetpack-search-dashboard-url';
 export { default as getJetpackVersion } from './get-jetpack-version';
+export { default as isSimpleSite } from './is-simple-site';

--- a/client/state/sites/selectors/is-simple-site.ts
+++ b/client/state/sites/selectors/is-simple-site.ts
@@ -1,0 +1,15 @@
+import { createSelector } from '@automattic/state-utils';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
+
+/**
+ * Returns true if the current site is a simple site
+ *
+ * @param  {object}   state         Global state tree
+ * @returns {?boolean}               Whether the current site is a simple site or not
+ */
+export default createSelector(
+	( state: AppState, siteId = getSelectedSiteId( state ) ) => ! isJetpackSite( state, siteId ),
+	( state: AppState, siteId = getSelectedSiteId( state ) ) => [ isJetpackSite( state, siteId ) ]
+);

--- a/config/development.json
+++ b/config/development.json
@@ -51,7 +51,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"editor/help-center": true,
-		"checkout/help-center": true,
+		"checkout/help-center": false,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,7 +29,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"editor/help-center": true,
-		"checkout/help-center": true,
+		"checkout/help-center": false,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -35,7 +35,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"editor/help-center": true,
-		"checkout/help-center": true,
+		"checkout/help-center": false,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -7,9 +7,9 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 	: OtherSupportAvailability;
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
-	supportType: SUPPORT_TYPE
+	supportType: SUPPORT_TYPE,
+	enabled = true
 ) {
-	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
@@ -18,7 +18,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 				apiVersion: '1.1',
 			} ),
 		{
-			enabled: isSimpleSite,
+			enabled,
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,
 		}

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -4,11 +4,10 @@ import useHappychatAuth from './use-happychat-auth';
 
 export function useHappychatAvailable() {
 	const [ available, setIsAvailable ] = useState< boolean | undefined >( undefined );
-	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth();
 
 	useEffect( () => {
-		if ( isSimpleSite && ! isLoadingAuth && dataAuth ) {
+		if ( ! isLoadingAuth && dataAuth ) {
 			const connection = buildConnectionForCheckingAvailability( {
 				receiveAccept: ( receivedAvailability ) => {
 					setIsAvailable( receivedAvailability );
@@ -19,7 +18,7 @@ export function useHappychatAvailable() {
 			} );
 			connection.init( ( value: unknown ) => value, Promise.resolve( dataAuth ) );
 		}
-	}, [ dataAuth, isLoadingAuth, isSimpleSite ] );
+	}, [ dataAuth, isLoadingAuth ] );
 
 	return { available: Boolean( available ), isLoading: available === undefined };
 }

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -7,6 +7,7 @@ import { useSupportAvailability } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
+import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -23,15 +24,22 @@ import '../styles.scss';
 const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 
-	const siteId = useSelector( getSelectedSiteId );
-	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
+	const { siteId, isSimpleSite } = useSelector( ( state ) => {
+		return {
+			siteId: getSelectedSiteId( state ),
+			isSimpleSite: getIsSimpleSite( state ),
+		};
+	} );
 
 	// prefetch the current site and user
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
 	const user = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { setDirectlyData } = useDispatch( HELP_CENTER_STORE );
-	const { isLoading: isLoadingChat } = useSupportAvailability( 'CHAT' );
-	const { data: supportData, isLoading: isSupportDataLoading } = useSupportAvailability( 'OTHER' );
+	const { isLoading: isLoadingChat } = useSupportAvailability( 'CHAT', isSimpleSite );
+	const { data: supportData, isLoading: isSupportDataLoading } = useSupportAvailability(
+		'OTHER',
+		isSimpleSite
+	);
 	useStillNeedHelpURL();
 
 	useEffect( () => {

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -32,6 +32,17 @@ declare module 'calypso/state/ui/selectors' {
 
 declare module 'calypso/state/sites/selectors' {
 	export const getSite: ( state: unknown, siteId: number ) => { is_wpcom_atomic: boolean };
+	export const getIsSimpleSite: ( state: unknown ) => boolean;
+}
+
+declare module 'calypso/state/sites/selectors/is-simple-site' {
+	const getIsSimpleSite: ( state: unknown, siteId?: number ) => boolean;
+	export default getIsSimpleSite;
+}
+
+declare module 'calypso/state/sites/selectors/is-jetpack-site' {
+	const isJetpackSite: ( state: unknown, siteId?: number ) => boolean;
+	export default isJetpackSite;
 }
 
 declare module 'calypso/state/sites/hooks' {
@@ -46,4 +57,8 @@ declare module 'calypso/state/selectors/has-cancelable-user-purchases' {
 declare module 'calypso/state/inline-help/selectors/get-admin-help-results' {
 	const getAdminHelpResults: ( state: unknown ) => unknown[];
 	export default getAdminHelpResults;
+}
+
+declare module '@automattic/state-utils' {
+	export const createSelector = unknown;
 }

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -1,9 +1,12 @@
+/* eslint-disable no-restricted-imports */
 import { useHas3PC, useSupportAvailability } from '@automattic/data-stores';
+import { useSelector } from 'react-redux';
+import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 
 export function useStillNeedHelpURL() {
-	const { data: supportAvailability } = useSupportAvailability( 'OTHER' );
 	const { hasCookies } = useHas3PC();
-	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
+	const isSimpleSite: boolean = useSelector( ( state ) => getIsSimpleSite( state ) );
+	const { data: supportAvailability } = useSupportAvailability( 'OTHER', isSimpleSite );
 
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -9,3 +9,4 @@ export { execute, checkAPIThenInitializeDirectly, askDirectlyQuestion } from './
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
 export * from './support-variations';
+export { shouldShowHelpCenterToUser } from './utils';

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,0 +1,7 @@
+// function that tells us if we want to show the Help Center to the user, given that we're showing it to
+// only a certain percentage of users.
+export function shouldShowHelpCenterToUser( userId: number, locale: string ) {
+	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
+	const userSegment = userId % 100;
+	return userSegment < currentSegment && locale === 'en';
+}


### PR DESCRIPTION
#### Proposed Changes

This PR extracts from https://github.com/Automattic/wp-calypso/pull/64866 the machinery to check for simple sites and to check if a user should see the Help Center.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch.
* `yarn dev --sync` from `apps/editing-toolkit`
* Check that all works correctly

