### PR TITLE
Enable generated design picker when intent = write

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -130,7 +130,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const enabledGeneratedDesigns =
 		verticalsStepEnabled &&
 		isEnabled( 'signup/design-picker-generated-designs' ) &&
-		intent === 'build';
+		( intent === 'build' || intent === 'write' );
 
 	const { data: generatedDesigns = [], isLoading: isLoadingGeneratedDesigns } =
 		useStarterDesignsGeneratedQuery(
@@ -370,7 +370,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		window.scrollTo( { top: 0 } );
 	}, [ isForceStaticDesigns, isPreviewingDesign ] );
 
-	// When the intent is build, we can potentially show the generated design picker.
+	// When the intent is build or write, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
 	if ( ! site || isLoadingGeneratedDesigns ) {
 		return null;


### PR DESCRIPTION
#### Proposed Changes

For the purpose of parity of the design picking experience in the Build and Write flow, this PR updates the generated design picker so that it can also be accessed from the Write flow (if the site vertical is eligible).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Goals screen `/setup/goals?siteSlug=${site_slug}`.
* Select the option "Write & Publish" and click the "Continue" button.
* Once in the Vertical Question screen, select the vertical "Food" or "News" and click the "Continue" button.
* In the next screen, click the "Continue" button.
* In the next screen, click the "View designs" button.
* Expect to see the generated design picker. Test that it works as before.
* Ensure that selected a design takes you to the post editor page.
* After exiting the post editor, make sure that the site design is as selected from the design picker.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65279