### PR TITLE
Licensing Portal: Improve no primary payment method error clarity

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -141,7 +141,7 @@ export default function IssueLicenseForm( {
 					}
 
 					errorMessage = translate(
-						'We could not find a valid payment method.{{br/}} ' +
+						'A primary payment method is required.{{br/}} ' +
 							'{{a}}Try adding a new payment method{{/a}} or contact support.',
 						{
 							components: {

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -77,7 +77,7 @@ export default function LicensePreview( {
 				'/partner-portal/payment-methods/add'
 			);
 			const errorMessage = translate(
-				'We could not find a valid payment method.{{br/}} ' +
+				'A primary payment method is required.{{br/}} ' +
 					'{{a}}Try adding a new payment method{{/a}} or contact support.',
 				{
 					components: {


### PR DESCRIPTION
#### Proposed Changes

* Licensing Portal: Improve no primary payment method error clarity

#### Testing Instructions

* Switch your account to an agency and your testing key billing type to "Stripe".
* Make sure you don't have a payment method.
* Click on the "Assign" on any unassigned license and confirm the wording makes sense.
* Apply this diff so this edge case is easy to trigger:
```
diff --git a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
index 33c608f46c..b4c1abfc34 100644
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -128,7 +128,7 @@ export default function IssueLicenseForm( {
 
 			switch ( error.code ) {
 				case 'missing_valid_payment_method':
-					if ( paymentMethodRequired ) {
+					if ( false && paymentMethodRequired ) {
 						page.redirect(
 							addQueryArgs(
 								{
```
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license?product=jetpack-complete and confirm the same error shows up.
![Screen Shot 2022-07-06 at 15 33 30](https://user-images.githubusercontent.com/22746396/177550976-4e55232b-92d2-4c8b-986a-265de34f04c0.png)
