### PR TITLE
Fix: Regression when getting to checkout page with a siteId

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -458,7 +458,11 @@ export function siteSelection( context, next ) {
 	}
 
 	// If the path fragment does not resemble a site, set all sites to visible
-	if ( ! ( typeof siteFragment === 'string' && siteFragment.length ) ) {
+	const typeOfSiteFragment = typeof siteFragment;
+	if (
+		! ( typeOfSiteFragment === 'string' && siteFragment.length ) &&
+		typeOfSiteFragment !== 'number'
+	) {
 		dispatch( setAllSitesSelected() );
 		return next();
 	}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -457,14 +457,13 @@ export function siteSelection( context, next ) {
 		return;
 	}
 
-	const siteId = getSiteId( getState(), siteFragment );
-
-	// If we can't figure out the siteId, set all sites to visible.
-	if ( null === siteId ) {
+	// If the path fragment does not resemble a site, set all sites to visible
+	if ( ! ( typeof siteFragment === 'string' && siteFragment.length ) ) {
 		dispatch( setAllSitesSelected() );
 		return next();
 	}
 
+	const siteId = getSiteId( getState(), siteFragment );
 	if ( siteId ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -457,13 +457,14 @@ export function siteSelection( context, next ) {
 		return;
 	}
 
-	// If the path fragment does not resemble a site, set all sites to visible
-	if ( ! ( typeof siteFragment === 'string' && siteFragment.length ) ) {
+	const siteId = getSiteId( getState(), siteFragment );
+
+	// If we can't figure out the siteId, set all sites to visible.
+	if ( null === siteId ) {
 		dispatch( setAllSitesSelected() );
 		return next();
 	}
 
-	const siteId = getSiteId( getState(), siteFragment );
 	if ( siteId ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.


### PR DESCRIPTION
Fixes a regression introduced in [this PR](https://github.com/Automattic/wp-calypso/pull/63989).

### Testing
1. Apply this diff.
2. Go to the theme showcase on a free site.
3. Click on the banner prompting for upgrading to pro.
4. Verify you see the checkout page for the correct site (the current behaviour is showing the user site list).

Closes https://github.com/Automattic/wp-calypso/issues/65267
