### PR TITLE
Update menu after purchasing a marketplace plugin

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -11,7 +11,7 @@ import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
-import { updateAdminMenuAfterMarketplaceInstallation } from 'calypso/state/admin-menu/actions';
+import { updateAdminMenuAfterPluginInstallation } from 'calypso/state/admin-menu/actions';
 import { requestLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 import { getLatestAtomicTransfer } from 'calypso/state/atomic/transfers/selectors';
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
@@ -108,7 +108,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Update the menu after the site been transferred to Atomic or after the plugin has
 	// been installed, since that might change some menu items
 	useEffect( () => {
-		dispatch( updateAdminMenuAfterMarketplaceInstallation( siteId, productSlug ) );
+		dispatch( updateAdminMenuAfterPluginInstallation( siteId, productSlug ) );
 
 		// Use an empty array of dependencies since we want to run this effect only once.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider, Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import successImage from 'calypso/assets/images/marketplace/check-circle.svg';
@@ -10,6 +11,7 @@ import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
+import { updateAdminMenuAfterMarketplaceInstallation } from 'calypso/state/admin-menu/actions';
 import { requestLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 import { getLatestAtomicTransfer } from 'calypso/state/atomic/transfers/selectors';
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
@@ -103,6 +105,15 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isRequestingPlugins, pluginOnSite, dispatch, siteId, transfer ] );
 
+	// Update the menu after the site been transferred to Atomic or after the plugin has
+	// been installed, since that might change some menu items
+	useEffect( () => {
+		dispatch( updateAdminMenuAfterMarketplaceInstallation( siteId, productSlug ) );
+
+		// Use an empty array of dependencies since we want to run this effect only once.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	const thankYouImage = {
 		alt: '',
 		src: pluginIcon,
@@ -165,12 +176,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 					'Take your site to the next level. We have all the solutions to help you grow and thrive.'
 				),
 				stepCta: (
-					<FullWidthButton
-						onClick={ () =>
-							// Force reload the page.
-							( document.location.href = `${ document.location.origin }/plugins/${ siteSlug }` )
-						}
-					>
+					<FullWidthButton href={ `/plugins/${ siteSlug }` }>
 						{ translate( 'Explore plugins' ) }
 					</FullWidthButton>
 				),
@@ -193,9 +199,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				` }
 			/>
 			<MasterbarStyled
-				onClick={ () =>
-					( document.location.href = `${ document.location.origin }/plugins/${ siteSlug }` )
-				}
+				onClick={ () => page( `/plugins/${ siteSlug }` ) }
 				backText={ translate( 'Back to plugins' ) }
 			/>
 			<ThankYouContainer>

--- a/client/state/admin-menu/actions/index.js
+++ b/client/state/admin-menu/actions/index.js
@@ -48,8 +48,5 @@ export const updateAdminMenuAfterPluginInstallation =
 			return;
 		}
 
-		// Wait for another 2s before updating the menu to allow the plugin to finish any potential setup.
-		setTimeout( () => {
-			dispatch( requestAdminMenu( siteId ) );
-		}, 2000 );
+		dispatch( requestAdminMenu( siteId ) );
 	};

--- a/client/state/admin-menu/actions/index.js
+++ b/client/state/admin-menu/actions/index.js
@@ -1,6 +1,10 @@
 import 'calypso/state/admin-menu/init';
 import 'calypso/state/data-layer/wpcom/sites/admin-menu';
 import { ADMIN_MENU_REQUEST, ADMIN_MENU_RECEIVE } from 'calypso/state/action-types';
+import { requestLatestAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
+import { getLatestAtomicTransfer } from 'calypso/state/atomic/transfers/selectors';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 
 export const requestAdminMenu = function requestAdminMenu( siteId ) {
 	return {
@@ -16,3 +20,36 @@ export const receiveAdminMenu = function receiveAdminMenu( siteId, menu ) {
 		menu,
 	};
 };
+
+export const updateAdminMenuAfterMarketplaceInstallation =
+	( siteId, productSlug ) => ( dispatch, getState ) => {
+		const { transfer } = getLatestAtomicTransfer( getState(), siteId );
+		const pluginOnSite = getPluginOnSite( getState(), siteId, productSlug );
+
+		// Wait for the Atomic transfer to be completed...
+		if ( transfer?.status !== 'completed' ) {
+			// Check again after 2s.
+			dispatch( requestLatestAtomicTransfer( siteId ) );
+			setTimeout(
+				() => dispatch( updateAdminMenuAfterMarketplaceInstallation( siteId, productSlug ) ),
+				2000
+			);
+			return;
+		}
+
+		// ...And for the plugin to be activated.
+		if ( ! pluginOnSite ) {
+			// Check again after 2s.
+			dispatch( fetchSitePlugins( siteId ) );
+			setTimeout(
+				() => dispatch( updateAdminMenuAfterMarketplaceInstallation( siteId, productSlug ) ),
+				2000
+			);
+			return;
+		}
+
+		// Wait for another 2s before updating the menu to allow the plugin to finish any potential setup.
+		setTimeout( () => {
+			dispatch( requestAdminMenu( siteId ) );
+		}, 2000 );
+	};

--- a/client/state/admin-menu/actions/index.js
+++ b/client/state/admin-menu/actions/index.js
@@ -21,7 +21,7 @@ export const receiveAdminMenu = function receiveAdminMenu( siteId, menu ) {
 	};
 };
 
-export const updateAdminMenuAfterMarketplaceInstallation =
+export const updateAdminMenuAfterPluginInstallation =
 	( siteId, productSlug ) => ( dispatch, getState ) => {
 		const { transfer } = getLatestAtomicTransfer( getState(), siteId );
 		const pluginOnSite = getPluginOnSite( getState(), siteId, productSlug );
@@ -31,18 +31,18 @@ export const updateAdminMenuAfterMarketplaceInstallation =
 			// Check again after 2s.
 			dispatch( requestLatestAtomicTransfer( siteId ) );
 			setTimeout(
-				() => dispatch( updateAdminMenuAfterMarketplaceInstallation( siteId, productSlug ) ),
+				() => dispatch( updateAdminMenuAfterPluginInstallation( siteId, productSlug ) ),
 				2000
 			);
 			return;
 		}
 
-		// ...And for the plugin to be activated.
+		// ...and for the plugin to be installed.
 		if ( ! pluginOnSite ) {
 			// Check again after 2s.
 			dispatch( fetchSitePlugins( siteId ) );
 			setTimeout(
-				() => dispatch( updateAdminMenuAfterMarketplaceInstallation( siteId, productSlug ) ),
+				() => dispatch( updateAdminMenuAfterPluginInstallation( siteId, productSlug ) ),
 				2000
 			);
 			return;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65264

#### Proposed Changes

Triggers a request to update the menu after purchasing a marketplace plugin, once the site has been transferred to Atomic and the plugin has been activated.

#### Testing Instructions

- Use the Calypso live link below.
- Switch to Simple site with a Free plan
- Go to Plugins
- Purchase a WooCommerce extension
- In the "Thank you" page, **while the "Manage plugin" button still has the loading animation**, click on either "Back to plugins" or "Explore plugins".
<img width="500" alt="Screen Shot 2022-07-06 at 12 47 38" src="https://user-images.githubusercontent.com/1233880/177562051-e9fe4439-82dd-46cf-9faa-ffae6dac83d2.png">

- Wait a few seconds for the Atomic transfer to be completed and for the plugin to be installed
- Make sure that the "WooCommerce" menu item that links to `woocommerce-installation` is not present.

