### PR TITLE
Allow plugin slugs and store slugs to diverge

### DIFF
--- a/packages/calypso-products/src/has-marketplace-product.ts
+++ b/packages/calypso-products/src/has-marketplace-product.ts
@@ -1,17 +1,20 @@
 /**
- * Returns true if a list of products contains a marketplace product with a matching product or store product slug.
+ * Returns true if a list of products includes a product with a matching product or store product slug.
  *
  * @param {object} productsList - List of products
- * @param {string} productSlug - internal product slug e.g. woocommerce-product-csv-import-suite or store product slug, e.g wc_product_csv_import_suite_yearly
+ * @param {string} searchSlug - Either a product slug e.g. woocommerce-product-csv-import-suite or store product slug, e.g wc_product_csv_import_suite_yearly
  * @returns {boolean}
  */
 export const hasMarketplaceProduct = (
 	productsList: Record< string, { product_type: string; billing_product_slug: string } >,
-	productSlug: string
+	searchSlug: string
 ): boolean =>
+	// storeProductSlug is from the legacy store_products system, billing_product_slug is from
+	// the non-legacy billing system and for marketplace plugins will match the slug of the plugin
+	// by convention.
 	Object.entries( productsList ).some(
-		( [ subscriptionSlug, { product_type, billing_product_slug } ] ) =>
-			( productSlug === subscriptionSlug || productSlug === billing_product_slug ) &&
+		( [ storeProductSlug, { product_type, billing_product_slug } ] ) =>
+			( searchSlug === storeProductSlug || searchSlug === billing_product_slug ) &&
 			// additional type check needed when called from JS context
 			typeof product_type === 'string' &&
 			product_type.startsWith( 'marketplace' )

--- a/packages/calypso-products/src/has-marketplace-product.ts
+++ b/packages/calypso-products/src/has-marketplace-product.ts
@@ -1,20 +1,17 @@
-const cleanSlug = ( slug: string ) =>
-	slug && slug.replace( /_/g, '-' ).split( /-(monthly|yearly|2y)/ )[ 0 ];
-
 /**
- * Returns true if a list of products contains a marketplace product with the specified product slug.
+ * Returns true if a list of products contains a marketplace product with a matching product or store product slug.
  *
  * @param {object} productsList - List of products
- * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @param {string} productSlug - internal product slug e.g. woocommerce-product-csv-import-suite or store product slug, e.g wc_product_csv_import_suite_yearly
  * @returns {boolean}
  */
 export const hasMarketplaceProduct = (
-	productsList: Record< string, { product_type: string; product_slug: string } >,
+	productsList: Record< string, { product_type: string; billing_product_slug: string } >,
 	productSlug: string
 ): boolean =>
 	Object.entries( productsList ).some(
-		( [ subscriptionSlug, { product_type } ] ) =>
-			cleanSlug( productSlug ) === cleanSlug( subscriptionSlug ) &&
+		( [ subscriptionSlug, { product_type, billing_product_slug } ] ) =>
+			( productSlug === subscriptionSlug || productSlug === billing_product_slug ) &&
 			// additional type check needed when called from JS context
 			typeof product_type === 'string' &&
 			product_type.startsWith( 'marketplace' )

--- a/packages/calypso-products/test/has-marketplace-product.js
+++ b/packages/calypso-products/test/has-marketplace-product.js
@@ -5,14 +5,42 @@ describe( 'hasMarketplaceProduct', () => {
 		empty_product: {},
 		product_with_wrong_types: { product_type: 1, slug: 1 },
 		jetpack: { product_type: 'jetpack' },
-		woocommerce_bookings_monthly: { product_type: 'marketplace_plugin' },
-		woocommerce_bookings_yearly: { product_type: 'marketplace_plugin' },
-		woocommerce_bookings_2y: { product_type: 'marketplace_plugin' },
-		'woocommerce-subscriptions-monthly': { product_type: 'marketplace_plugin' },
-		'woocommerce-subscriptions-yearly': { product_type: 'marketplace_plugin' },
-		'woocommerce-subscriptions-2y': { product_type: 'marketplace_plugin' },
-		'woocommerce-test-plugin': { product_type: 'plugin' },
-		'woocommerce-test-plugin-advanced': { product_type: 'marketplace_plugin' },
+		woocommerce_bookings_monthly: {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-bookings',
+		},
+		woocommerce_bookings_yearly: {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-bookings',
+		},
+		woocommerce_bookings_2y: {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-bookings',
+		},
+		'woocommerce-subscriptions-monthly': {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-subscriptions',
+		},
+		'woocommerce-subscriptions-yearly': {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-subscriptions',
+		},
+		'woocommerce-subscriptions-2y': {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-subscriptions',
+		},
+		'woocommerce-test-plugin': {
+			product_type: 'plugin',
+			billing_product_slug: 'woocommerce-test-plugin',
+		},
+		'woocommerce-test-plugin-advanced': {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'woocommerce-test-plugin-advanced',
+		},
+		wc_store_products_usually_underscored: {
+			product_type: 'marketplace_plugin',
+			billing_product_slug: 'wc-billing-product-slug-can-differ',
+		},
 	};
 
 	test( "should return false when the product isn't in the products list", () => {
@@ -35,11 +63,13 @@ describe( 'hasMarketplaceProduct', () => {
 		expect( hasMarketplaceProduct( productsList, 'woocommerce-test-plugin' ) ).toBe( false );
 	} );
 
-	describe( 'product is a marketplace product', () => {
-		test( 'should return true when the product slug contains underscores', () => {
-			expect( hasMarketplaceProduct( productsList, 'woocommerce_bookings' ) ).toBe( true );
-		} );
+	test( "should return true when the billing_product_slug matches even when key doesn't match", () => {
+		expect( hasMarketplaceProduct( productsList, 'wc-billing-product-slug-can-differ' ) ).toBe(
+			true
+		);
+	} );
 
+	describe( 'product is a marketplace product', () => {
 		test( 'should return true when the product slug contains dashes', () => {
 			expect( hasMarketplaceProduct( productsList, 'woocommerce-subscriptions' ) ).toBe( true );
 		} );


### PR DESCRIPTION
hasMarketplaceProduct is sometimes called with product slugs and
sometimes called with store product slugs. In both cases they are
compared to the keys in the productList in the redux state, which are
store product slugs.

A product slug looks like: woocommerce-product-csv-import-suite

A store product slug looks like: wc_product_csv_import_suite_yearly

This change follows the approach proposed in pdh6GB-Pq-p2#comment-1538.
Specifically, it always compares against the billing_product_slug and
against the store product slug, removing the need to normalise slugs
before comparing.

A unit test has been added to support this, and one unit test removed.
The removed test wasn't a valid test case - it was supplying an
artificial slug which would never be supplied in normal circumstances,
not matching either kind of slug.

This fixes part of 634-gh-Automattic/dotcom-manage

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Apply patch / use the calypso live links
 2. Search for paid plugins, click through to their details page and install them, they should all work.

Suggested plugins to try: WooCommerce Conditional Shipping & Payments, WooCommerce bookings, WooCommerce product csv import suite (see D83766-code)