### PR TITLE
Sites Management Dashboard: Add SitesBadge and style the tabs for desktop and mobile

### DIFF
--- a/client/sites-dashboard/components/sites-badge.tsx
+++ b/client/sites-dashboard/components/sites-badge.tsx
@@ -12,11 +12,11 @@ const Wrapper = styled.span`
 	line-height: 20px;
 `;
 
-interface SitesBadgePrpos {
+interface SitesBadgeProps {
 	children: ReactNode;
 }
 
-function SitesBadge( { children }: SitesBadgePrpos ) {
+function SitesBadge( { children }: SitesBadgeProps ) {
 	return <Wrapper>{ children }</Wrapper>;
 }
 

--- a/client/sites-dashboard/components/sites-badge.tsx
+++ b/client/sites-dashboard/components/sites-badge.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+const Wrapper = styled.span`
+	font-size: 12px;
+	font-weight: 500;
+	color: var( --studio-gray-80 );
+	background-color: var( --studio-gray-5 );
+	padding: 0px 10px;
+	margin-left: 10px;
+	border-radius: 4px;
+	line-height: 20px;
+`;
+
+interface SitesBadgePrpos {
+	children: ReactNode;
+}
+
+function SitesBadge( { children }: SitesBadgePrpos ) {
+	return <Wrapper>{ children }</Wrapper>;
+}
+
+export default SitesBadge;

--- a/client/sites-dashboard/components/sites-badge.tsx
+++ b/client/sites-dashboard/components/sites-badge.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
-import { ReactNode } from 'react';
 
-const Wrapper = styled.span`
+const SitesBadge = styled.span`
 	font-size: 12px;
 	font-weight: 500;
 	color: var( --studio-gray-80 );
@@ -11,13 +10,5 @@ const Wrapper = styled.span`
 	border-radius: 4px;
 	line-height: 20px;
 `;
-
-interface SitesBadgeProps {
-	children: ReactNode;
-}
-
-function SitesBadge( { children }: SitesBadgeProps ) {
-	return <Wrapper>{ children }</Wrapper>;
-}
 
 export default SitesBadge;

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -41,7 +41,7 @@ function filterSites( sites: SiteData[], filterType: string ): SiteData[] {
 			case 'private':
 				return site.is_private && ! isComingSoon;
 			case 'coming-soon':
-				return site.is_private && isComingSoon;
+				return isComingSoon;
 			default:
 				// Treat unknown filters the same as 'all'
 				return site;

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -1,5 +1,7 @@
+import styled from '@emotion/styled';
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import SitesBadge from './sites-badge';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
 
 interface SitesTableFilterTabsProps {
@@ -8,6 +10,37 @@ interface SitesTableFilterTabsProps {
 	className?: string;
 }
 
+interface FilteredSites {
+	[ name: string ]: SiteData[];
+}
+
+interface SiteTab extends Omit< TabPanel.Tab, 'title' > {
+	title: React.ReactChild;
+}
+
+const SitesTabPanel = styled( TabPanel )`
+	.components-tab-panel__tabs {
+		overflow-x: auto;
+		padding-bottom: 10px;
+	}
+
+	.components-tab-panel__tabs-item {
+		--wp-admin-theme-color: var( --studio-gray-100 );
+		color: var( --studio-gray-60 );
+		padding: 0;
+		margin-right: 24px;
+		font-size: 16px;
+		flex-shrink: 0;
+	}
+	.components-tab-panel__tabs-item:hover,
+	.components-tab-panel__tabs-item.is-active,
+	.components-tab-panel__tabs-item.is-active:focus,
+	.components-tab-panel__tabs-item:focus:not( :disabled ) {
+		box-shadow: inset 0 -2px 0 0 var( --wp-admin-theme-color );
+		color: var( --studio-gray-100 );
+	}
+`;
+
 export function SitesTableFilterTabs( {
 	allSites,
 	children: renderContents,
@@ -15,18 +48,32 @@ export function SitesTableFilterTabs( {
 }: SitesTableFilterTabsProps ) {
 	const { __ } = useI18n();
 
+	let tabs: SiteTab[] = [
+		{ name: 'all', title: __( 'All' ) },
+		{ name: 'launched', title: __( 'Launched' ) },
+		{ name: 'private', title: __( 'Private' ) },
+		{ name: 'coming-soon', title: __( 'Coming soon' ) },
+	];
+
+	const filteredSites: FilteredSites = tabs.reduce(
+		( acc, { name } ) => ( { ...acc, [ name ]: filterSites( allSites, name ) } ),
+		{}
+	);
+
+	tabs = tabs.map( ( { name, title } ) => ( {
+		name,
+		title: (
+			<>
+				{ title }
+				<SitesBadge>{ filteredSites[ name ].length }</SitesBadge>
+			</>
+		),
+	} ) );
+
 	return (
-		<TabPanel
-			className={ className }
-			tabs={ [
-				{ name: 'all', title: __( 'All' ) },
-				{ name: 'launched', title: __( 'Launched' ) },
-				{ name: 'private', title: __( 'Private' ) },
-				{ name: 'coming-soon', title: __( 'Coming soon' ) },
-			] }
-		>
-			{ ( tab ) => renderContents( filterSites( allSites, tab.name ) ) }
-		</TabPanel>
+		<SitesTabPanel className={ className } tabs={ tabs as TabPanel.Tab[] }>
+			{ ( tab ) => renderContents( filteredSites[ tab.name ] ) }
+		</SitesTabPanel>
 	);
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Fix coming soon filtering
* Style Tabs and add scroll for small screens.
* Add new `SitesBadge` component


#### Screenshots

**Desktop**
<img width="952" alt="Screenshot 2022-07-04 at 19 45 05" src="https://user-images.githubusercontent.com/779993/177200146-4e83e031-993a-4cda-b67c-7c69b8572f93.png">

https://user-images.githubusercontent.com/779993/177200898-77e63925-5bd9-4417-be52-29494e6068de.mp4

**Mobile**
<img width="402" alt="Screenshot 2022-07-06 at 15 51 40" src="https://user-images.githubusercontent.com/779993/177566162-8f1a1f2a-d9ea-4a35-997d-11cfe049b77a.png">


https://user-images.githubusercontent.com/779993/177566298-49917009-a3ed-4a57-ba20-b72a38ae2caf.mp4





#### Testing Instructions

* Access to : /sites-dashboard (https://container-youthful-khayyam.calypso.live/sites-dashboard)
* Observe the tabs match the style and functionality.

- Solves #65165
