### PR TITLE
Launch Marketplace plugins on Starter plan

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -65,6 +65,7 @@
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-jetpack-plugin-search": false,
+		"marketplace-starter-plan": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration/sign-in-with-google": false,

--- a/config/production.json
+++ b/config/production.json
@@ -74,6 +74,7 @@
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-jetpack-plugin-search": false,
+		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -72,6 +72,7 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
+		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,


### PR DESCRIPTION
#### Proposed Changes

Enables the `marketplace-starter-plan` feature flag in all environments, effectively launching the support of Marketplace plugins by the Starter plan.

More info: pdtkmj-dL-p2