### PR TITLE
Goals Capture: Update `goalsToIntent` logic for Goals Capture i2 screen

### DIFF
--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -9,7 +9,7 @@ describe( 'Test onboard utils', () => {
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Import, SiteGoal.DIFM ],
-			expectedIntent: SiteIntent.Import,
+			expectedIntent: SiteIntent.DIFM,
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote ],

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -10,14 +10,13 @@ const GOAL_TO_INTENT_MAP: { [ key in IntentDecidingGoal ]: SiteIntent } = {
 };
 
 export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
-	// For Plan B, clicking on Import link supercedes everything.
-	if ( goals.includes( SiteGoal.Import ) ) {
-		return SiteIntent.Import;
-	}
-
-	// Including DIFM goal overwrites any other goal selection made
+	// When DIFM and Import goals are selected together, DIFM Intent will have the priority and will be set.
 	if ( goals.includes( SiteGoal.DIFM ) ) {
 		return SiteIntent.DIFM;
+	}
+
+	if ( goals.includes( SiteGoal.Import ) ) {
+		return SiteIntent.Import;
 	}
 
 	const intentDecidingGoal = ( goals as IntentDecidingGoal[] ).find( ( goal ) =>


### PR DESCRIPTION
#### Proposed Changes

The proposed change adjusts the logic used to map selected Site Goals into Intent.

Currently, when the Import and DIFM goals are selected together, the Import has the priority. As a result, Import Intent is used and the user navigates to the Import flow.

After the proposed changes are applied, the DIFM will have the priority. Therefore, when both Import and DIFM goals are selected together, DIFM Intent will be used and the user will be directed to the DIFM flow.

We paired for this together with @phcp. 👨🏽‍💻👨🏼‍💻

#### Testing Instructions

1. Navigate to the Goals step screen with the `signup/goals-step-2` feature flag enabled, e.g. `http://calypso.localhost:3000/setup/goals?siteSlug=testsite.wordpress.com&flags=signup/goals-step-2`.
2. Try to select various goal combinations that will include Import + DIFM goals.
3. If your selection includes:
  a) Import without DIFM, the setup flow should get you to the Import flow
  b) DIFM without Import, the setup flow should get you to the DIFM flow
  c) Import && DIFM, the setup flow should get you to the DIFM flow
4. You can navigate to the Goals step screen with the `signup/goals-step-2` feature flag deactivated (e.g. `http://calypso.localhost:3000/setup/goals?siteSlug=testsite.wordpress.com&flags=-signup/goals-step-2`) and test the flow with the code changes applied. There should be no regression to the flow with the current Goals screen.

Related to #65281
