### PR TITLE
Show upgrade banner when installing a theme on a Limited Atomic site

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -265,13 +265,14 @@ class Upload extends Component {
 			failed,
 			inProgress,
 			isJetpack,
+			isStandaloneJetpack,
 			isAtomic,
 			selectedSite,
 			uploadedTheme,
 		} = this.props;
 
 		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer;
-		const isDisabled = ! canUploadThemesOrPlugins && ! isJetpack;
+		const isDisabled = ! isStandaloneJetpack && ( ! canUploadThemesOrPlugins || ! isAtomic );
 
 		const WrapperComponent = isDisabled ? FeatureExample : Fragment;
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -271,8 +271,11 @@ class Upload extends Component {
 			uploadedTheme,
 		} = this.props;
 
+		const { showEligibility } = this.state;
+
 		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer;
-		const isDisabled = ! isStandaloneJetpack && ( ! canUploadThemesOrPlugins || ! isAtomic );
+		const isDisabled =
+			! isStandaloneJetpack && ( ! canUploadThemesOrPlugins || ( ! isAtomic && showEligibility ) );
 
 		const WrapperComponent = isDisabled ? FeatureExample : Fragment;
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -42,7 +42,6 @@ import {
 	isFetchingSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
@@ -98,7 +97,7 @@ class Upload extends Component {
 	componentDidMount() {
 		const { siteId, inProgress, noticeType } = this.props;
 		! inProgress && this.props.clearThemeUpload( siteId );
-		if ( this.props.isAutomatedTransfer && this.props.canUploadThemesOrPlugins ) {
+		if ( this.props.isAtomic && this.props.canUploadThemesOrPlugins ) {
 			this.redirectToWpAdmin();
 		}
 
@@ -124,7 +123,7 @@ class Upload extends Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.isAutomatedTransfer && this.props.canUploadThemesOrPlugins ) {
+		if ( this.props.isAtomic && this.props.canUploadThemesOrPlugins ) {
 			this.redirectToWpAdmin();
 		}
 		if ( this.props.complete && ! prevProps.complete ) {
@@ -266,15 +265,13 @@ class Upload extends Component {
 			failed,
 			inProgress,
 			isJetpack,
-			isAutomatedTransfer,
+			isAtomic,
 			selectedSite,
 			uploadedTheme,
 		} = this.props;
 
-		const { showEligibility } = this.state;
-
 		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer;
-		const isDisabled = showEligibility || ( ! canUploadThemesOrPlugins && ! isJetpack );
+		const isDisabled = ! canUploadThemesOrPlugins && ! isJetpack;
 
 		const WrapperComponent = isDisabled ? FeatureExample : Fragment;
 
@@ -286,7 +283,7 @@ class Upload extends Component {
 					) }
 					{ inProgress && this.renderProgressBar() }
 					{ complete && ! failed && uploadedTheme && this.renderTheme() }
-					{ complete && isAutomatedTransfer && <WpAdminAutoLogin site={ selectedSite } /> }
+					{ complete && isAtomic && <WpAdminAutoLogin site={ selectedSite } /> }
 				</Card>
 			</WrapperComponent>
 		);
@@ -310,14 +307,15 @@ class Upload extends Component {
 			canUploadThemesOrPlugins,
 			complete,
 			isFetchingPurchases,
-			isJetpack,
+			isStandaloneJetpack,
 			isMultisite,
 			siteId,
 			themeId,
 			translate,
 		} = this.props;
 
-		const showUpgradeBanner = ! isFetchingPurchases && ! canUploadThemesOrPlugins && ! isJetpack;
+		const showUpgradeBanner =
+			! isFetchingPurchases && ! canUploadThemesOrPlugins && ! isStandaloneJetpack;
 		const { showEligibility } = this.state;
 
 		if ( isMultisite ) {
@@ -376,6 +374,9 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const themeId = getUploadedThemeId( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
+	const isAtomic = isSiteWpcomAtomic( state, siteId );
+	const isStandaloneJetpack = isJetpack && ! isAtomic;
+
 	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
@@ -389,17 +390,16 @@ const mapStateToProps = ( state ) => {
 		siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ) ||
 		siteHasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS );
 
-	const isAtomic = isSiteWpcomAtomic( state, siteId );
-
 	const showEligibility =
-		( isAtomic || ( canUploadThemesOrPlugins && ! isJetpack ) ) &&
-		( hasEligibilityMessages || ! isEligible );
+		canUploadThemesOrPlugins && ! isAtomic && ( hasEligibilityMessages || ! isEligible );
 
 	return {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		selectedSite: getSelectedSite( state ),
+		isAtomic,
 		isJetpack,
+		isStandaloneJetpack,
 		inProgress: isUploadInProgress( state, siteId ),
 		complete: isUploadComplete( state, siteId ),
 		failed: hasUploadFailed( state, siteId ),
@@ -412,7 +412,6 @@ const mapStateToProps = ( state ) => {
 		installing: isInstallInProgress( state, siteId ),
 		backPath: getBackPath( state ),
 		showEligibility,
-		isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		canUploadThemesOrPlugins,
 		isFetchingPurchases:


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65295

#### Proposed Changes

Ensures that an upgrade banner shows up in the Install Theme page on Atomic sites with a lower-tier plan. It also hides the Atomic eligibility component

Before | After
--- | ---
<img width="500" alt="Screen Shot 2022-07-06 at 15 42 56" src="https://user-images.githubusercontent.com/1233880/177565346-865b7e65-ee48-45fd-a51e-8df6c22abf83.png"> | <img width="500" alt="Screen Shot 2022-07-06 at 17 39 30" src="https://user-images.githubusercontent.com/1233880/177591020-3963b4bc-db9a-4cee-a2e2-a7d9dbfd99e4.png">


#### Testing Instructions

- Use the Calypso live link below
- Go to `/themes/upload`
- Switch to an Atomic site with a lower-tier plan (e.g. Starter plan)
- Make sure you see an upgrade banner and there is no Atomic eligibility messages
- Make sure there are no regressions in other sites
  - Simple sites on Free/Starter should show an upgrade banner
  - Simple sites on Pro should show the Atomic eligibility warning
  - Jetpack sites on any plan should allow theme uploads
