### PR TITLE
Jetpack Pricing page: update SVG icon and markup on recommended plan

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -116,6 +116,8 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 		: null;
 
 	const starIcon = (
+		// Safari has problems rendering SVGs in retina screens when used inside an img tag, so we should use inline SVG instead.
+		// See details on this PR: https://github.com/Automattic/wp-calypso/pull/65304
 		<SVG className="jetpack-product-card__header-icon" width="16" height="16" viewBox="0 0 16 16">
 			<Path
 				d="M8 11.513 12.12 14l-1.093-4.687 3.64-3.153-4.793-.407-1.873-4.42-1.874 4.42-4.793.407 3.64 3.153L3.881 14 8 11.513Z"

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
+import { SVG, Path } from '@wordpress/components';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { createElement, ReactNode, useEffect, useRef } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
-import starIcon from './assets/star.svg';
 import DisplayPrice from './display-price';
 import JetpackProductCardFeatures from './features';
 import type {
@@ -115,6 +115,15 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 		  } )
 		: null;
 
+	const starIcon = (
+		<SVG className="jetpack-product-card__header-icon" width="16" height="16" viewBox="0 0 16 16">
+			<Path
+				d="M8 11.513 12.12 14l-1.093-4.687 3.64-3.153-4.793-.407-1.873-4.42-1.874 4.42-4.793.407 3.64 3.153L3.881 14 8 11.513Z"
+				fill="currentColor"
+			/>
+		</SVG>
+	);
+
 	useEffect( () => {
 		// The <DisplayPrice /> appearance changes the layout of the page and breaks the scroll into view behavior. Therefore, we will only scroll the element into view once the price is fully loaded.
 		if ( anchorRef && anchorRef.current && originalPrice ) {
@@ -136,7 +145,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 			<div className="jetpack-product-card__scroll-anchor" ref={ anchorRef }></div>
 			{ isFeatured && (
 				<div className="jetpack-product-card__header">
-					<img className="jetpack-product-card__header-icon" src={ starIcon } alt="" />
+					{ starIcon }
 					<span>{ featuredLabel || translate( 'Recommended' ) }</span>
 				</div>
 			) }

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -36,6 +36,7 @@
 
 .jetpack-product-card__header {
 	display: flex;
+	align-items: center;
 
 	box-sizing: border-box;
 	width: 100%;


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue where Safari would show a blurred version of an SVG icon. Apparently Safari has problems rendering SVGs in retina screens when used inside an `img` tag ([reference here](https://stackoverflow.com/a/63189810)), or maybe it was a combination of factors in this specific scenario. 

The changes in this PR update the SVG code and markup for the star icon that appears on the recommended plan in Jetpack's pricing pages. This applies to both Jetpack.com and WordPress.com.

* Cleaned up SVG icon's code.
* Updated pricing card markup and embedded the SVG inside.
* Removed `img` tag in favor of using inline markup.
* Updated CSS styles.

Reported here: p1657119576765489-slack-C0D96691V

#### Testing Instructions

* Fire up this PR.
* Go to http://jetpack.cloud.localhost:3000/pricing or https://localhost:3000/plans/JETPACK_SITE_URL.
* Check that the star icon in the recommended plan looks great.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/177594762-363d5ffe-538a-46a7-8ea8-9cab815c66c7.png) | ![image](https://user-images.githubusercontent.com/390760/177594754-d44e9376-c708-4f25-be23-bb07ba8d4a2b.png)