### PR TITLE
Help Center: Add undefined check before referencing featureFlags global

### DIFF
--- a/packages/help-center/src/contexts/FeatureFlagContext.tsx
+++ b/packages/help-center/src/contexts/FeatureFlagContext.tsx
@@ -10,10 +10,16 @@ const FeatureFlagContext = React.createContext< FeatureFlags | undefined >( unde
 export const FeatureFlagProvider: React.FC< { children: JSX.Element } > = function ( {
 	children,
 } ) {
+	let featureFlags;
+
+	// If the Editing Toolkit Plugin is not loaded
+	if ( typeof helpCenterFeatureFlags === 'undefined' ) {
+		featureFlags = undefined;
+	} else {
+		featureFlags = helpCenterFeatureFlags;
+	}
 	return (
-		<FeatureFlagContext.Provider value={ helpCenterFeatureFlags }>
-			{ children }
-		</FeatureFlagContext.Provider>
+		<FeatureFlagContext.Provider value={ featureFlags }>{ children }</FeatureFlagContext.Provider>
 	);
 };
 


### PR DESCRIPTION
#### Context

The helpCenterFeatureFlags global is loaded by an inline script enqueued through the Editing Toolkit Plugin (ETK). There are environments where ETK is not loaded, which causes a runtime error when we try to access a nonexistent global. This PR adds an undefined check to avoid any errors being thrown.

#### Proposed Changes

* Add undefined check before referencing helpCenterFeatureFlags global

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load this PR
- Sandbox a site
- Run yarn dev --sync in apps/editing-toolkit
- Disable the editing toolkit plugin on the site
- Verify that opening the help center no longer throws an in-editor error
- Ensure that the feature flags still inject values as expected into the client ( import useFeatureFlags and log out its value to the console )
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->