### PR TITLE
Onboarding: Fix issue with redirecting to Woo onboarding incorrectly

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -179,7 +179,7 @@ export const siteSetupFlow: Flow = {
 					}
 
 					// End of woo flow
-					if ( storeType === 'power' ) {
+					if ( intent === 'sell' && storeType === 'power' ) {
 						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
 
 						if (
@@ -296,7 +296,7 @@ export const siteSetupFlow: Flow = {
 					const [ checkoutUrl ] = params;
 
 					if ( checkoutUrl ) {
-						return exitFlow( checkoutUrl.toString() );
+						window.location.replace( checkoutUrl.toString() );
 					}
 
 					return navigate( 'wooTransfer' );


### PR DESCRIPTION
 This is a second attempt at #65205 which was reverted due to issues found in pre-releases tests. 

This PR removes the call to `resetOnboardStore` which broke flows due to wiping out pending actions. I'll follow up with suggested changes for that in a separate PR.

#### Proposed Changes

Not all of our store gets cleaned up properly between runs, so users that have previously gone through onboarding that also selected a power store (store with Woo installed), can get caught in a state where they land on an error page because Woo is not installed.

<img width="1009" alt="Screen Shot 2022-07-04 at 12 18 36 PM" src="https://user-images.githubusercontent.com/1126811/177197670-6ccde835-3cbf-42da-9428-dd8f851bd3bb.png">

After digging into this, it looks like there were a couple of things that needed to be fixed:

- Where we choose to redirect to the `wc-admin` page, we could've been more defensive by checking that the intent was sell in addition to the store type
- Along with ^, calling `exitFlow` as part of the e-commerce flow seems to have come with unintended consequences when others adding some cleanup in `exitFlow`

This PR addresses those points.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On WordPress.com
- Create a site and run through onboarding and select the `Sell` intent, select `More Power`, then pay for upgrade
- Create another site, select `Other` intent
- Select `Travel` category
- Select `Continue` on next page to go with theme
- Ensure that you land on an error page because Woo is not installed
- Checkout this PR locally and then follow the above instructions but in calypso.localhost:3000
- Verify you are not redirected to the Woo page and that you do not receive an error

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->