### PR TITLE
[E2E][GB 13.6.0] Fix E2E tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/types.ts
+++ b/packages/calypso-e2e/src/lib/components/types.ts
@@ -18,7 +18,7 @@ export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
  * The different foldable sections on the sidebar.
  */
 export type ArticleSections =
-	| 'Status & Visibility'
+	| 'Summary'
 	| 'Revisions'
 	| 'Permalink'
 	| 'Categories'

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -460,7 +460,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
 
-		await this.editorSettingsSidebarComponent.expandSection( 'Status & Visibility' );
+		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
 		await this.editorSettingsSidebarComponent.openVisibilityOptions();
 		await this.editorSettingsSidebarComponent.selectVisibility( visibility, {
 			password: password,
@@ -595,7 +595,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
 
-		await this.editorSettingsSidebarComponent.expandSection( 'Status & Visibility' );
+		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
 		await this.editorSettingsSidebarComponent.openSchedule();
 		await this.editorSettingsSidebarComponent.setScheduleDetails( date );
 		await this.editorSettingsSidebarComponent.closeSchedule();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix E2E test failures caused by the 13.6.0 WPCOM upgrade on simple sites.

#### Testing instructions

* The Gutenberg simple mobile build should pass from this branch (or only expected failures should show, if any).


Tracking issue: https://github.com/Automattic/wp-calypso/issues/64956
