### PR TITLE
Sites Management Dashboard: Create resuseable ListTile component

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -236,6 +236,7 @@ export default class DesignAssets extends Component {
 					<LineChart readmeFilePath="line-chart" />
 					<LinkCard readmeFilePath="link-card" />
 					<ListEnd readmeFilePath="list-end" />
+					<ListTile readmeFilePath="/packages/components/src/list-tile" />
 					<MarkedLinesExample readmeFilePath="marked-lines" />
 					<MultipleChoiceQuestionExample readmeFilePath="multiple-choice-question" />
 					<Notices readmeFilePath="notice" />
@@ -285,7 +286,6 @@ export default class DesignAssets extends Component {
 					<Wizard readmeFilePath="wizard" />
 					<WizardProgressBar readmeFilePath="wizard-progress-bar" />
 					<WpcomColophon readmeFilePath="wpcom-colophon" />
-					<ListTile readmeFilePath="list-tile" />
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -7,6 +7,7 @@ import {
 import Buttons from '@automattic/components/src/button/docs/example';
 import Cards from '@automattic/components/src/card/docs/example';
 import Gridicon from '@automattic/components/src/gridicon/docs/example';
+import ListTile from '@automattic/components/src/list-tile/docs/example';
 import ProductIcon from '@automattic/components/src/product-icon/docs/example';
 import ProgressBar from '@automattic/components/src/progress-bar/docs/example';
 import Ribbon from '@automattic/components/src/ribbon/docs/example';
@@ -284,6 +285,7 @@ export default class DesignAssets extends Component {
 					<Wizard readmeFilePath="wizard" />
 					<WizardProgressBar readmeFilePath="wizard-progress-bar" />
 					<WpcomColophon readmeFilePath="wpcom-colophon" />
+					<ListTile readmeFilePath="list-tile" />
 				</Collection>
 			</Main>
 		);

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,3 +1,4 @@
+import { ListTile } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -79,15 +79,17 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	return (
 		<Row>
 			<td>
-				<div style={ { display: 'flex', alignItems: 'center' } }>
-					<a
-						style={ { display: 'block' } }
-						href={ getDashboardUrl( site.slug ) }
-						title={ __( 'Visit Dashboard' ) }
-					>
-						<SiteIcon siteId={ site.ID } size={ 50 } />
-					</a>
-					<div style={ { marginLeft: '20px' } }>
+				<ListTile
+					leading={
+						<a
+							style={ { display: 'block' } }
+							href={ getDashboardUrl( site.slug ) }
+							title={ __( 'Visit Dashboard' ) }
+						>
+							<SiteIcon siteId={ site.ID } size={ 50 } />
+						</a>
+					}
+					title={
 						<div style={ { display: 'flex', alignItems: 'center', marginBottom: '8px' } }>
 							<SiteName style={ { marginRight: '8px' } }>
 								<a href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
@@ -96,6 +98,8 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 						</div>
+					}
+					subtitle={
 						<div>
 							<SiteUrl
 								href={ site.URL }
@@ -111,8 +115,8 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							) }
 							{ isComingSoon && <SitesLaunchStatusBadge>Coming soon</SitesLaunchStatusBadge> }
 						</div>
-					</div>
-				</div>
+					}
+				/>
 			</td>
 			<td className="sites-table-row__mobile-hidden">{ site.plan.product_name_short }</td>
 			<td className="sites-table-row__mobile-hidden">July 16, 1969</td>

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,3 +17,4 @@ export { HappinessEngineersTray } from './happiness-engineers-tray';
 export { Spinner } from './spinner';
 export { SpinnerExample } from './spinner/example';
 export { default as WordPressLogo } from './wordpress-logo';
+export { ListTile } from './list-tile';

--- a/packages/components/src/list-tile/README.md
+++ b/packages/components/src/list-tile/README.md
@@ -1,0 +1,20 @@
+# ListTile
+
+Renders a ListTile component.
+
+## How to use
+
+```jsx
+import LisTile from '@automattic/components';
+
+function render() {
+	return <ListTile title={'Title'}/>;
+}
+```
+
+## Props
+
+- `title`: a string or react node representing the title of the list tile.
+- `subtitle`: an optional string or react node.
+- `leading`: an optional leading component to be displayed in the list tile.
+- `trailing`: an optional trailing component to be displayed in the list tile. eg icon.

--- a/packages/components/src/list-tile/README.md
+++ b/packages/components/src/list-tile/README.md
@@ -8,7 +8,7 @@ Renders a ListTile component.
 import ListTile from '@automattic/components';
 
 function render() {
-	return <ListTile title={'Title'}/>;
+	return <ListTile title="Title" />;
 }
 ```
 

--- a/packages/components/src/list-tile/README.md
+++ b/packages/components/src/list-tile/README.md
@@ -5,7 +5,7 @@ Renders a ListTile component.
 ## How to use
 
 ```jsx
-import LisTile from '@automattic/components';
+import ListTile from '@automattic/components';
 
 function render() {
 	return <ListTile title={'Title'}/>;

--- a/packages/components/src/list-tile/docs/example.jsx
+++ b/packages/components/src/list-tile/docs/example.jsx
@@ -1,0 +1,29 @@
+import { useHappinessEngineersQuery } from '@automattic/data-stores';
+import { Gravatar } from '../../gravatar';
+import Gridicon from '../../gridicon';
+import { ListTile } from '../index';
+
+export default function ListTileExample() {
+	const { data } = useHappinessEngineersQuery();
+	return (
+		<div
+			style={ {
+				backgroundColor: 'white',
+				width: '300px',
+				border: '1px solid lightgray',
+				padding: '16px',
+			} }
+		>
+			<ListTile
+				title={ 'This is a title' }
+				subtitle={ 'This is a subtitle' }
+				leading={ <Gravatar user={ data } size={ 42 } /> }
+				trailing={
+					<div style={ { marginTop: '-20px', marginRight: '-20px' } }>
+						<Gridicon icon={ 'info' } size={ 24 } />{ ' ' }
+					</div>
+				}
+			/>
+		</div>
+	);
+}

--- a/packages/components/src/list-tile/index.tsx
+++ b/packages/components/src/list-tile/index.tsx
@@ -1,0 +1,28 @@
+import './style.scss';
+
+type Props = {
+	title: string | React.ReactElement;
+	subtitle: string | React.ReactElement;
+	leading?: React.ReactNode | React.ReactElement;
+	trailing?: React.ReactNode | React.ReactElement;
+};
+
+export const ListTile = ( { title, subtitle, leading, trailing }: Props ) => {
+	if ( typeof title === 'string' ) {
+		title = <h2 className="list-tile__title"> { title } </h2>;
+	}
+	if ( typeof subtitle === 'string' ) {
+		subtitle = <span className="list-tile__subtitle"> { subtitle } </span>;
+	}
+
+	return (
+		<div className="list-tile">
+			{ leading && <div className="list-tile__leading">{ leading }</div> }
+			<div style={ { width: '100%' } }>
+				{ title }
+				{ subtitle }
+			</div>
+			{ trailing && <div>{ trailing }</div> }
+		</div>
+	);
+};

--- a/packages/components/src/list-tile/style.scss
+++ b/packages/components/src/list-tile/style.scss
@@ -1,0 +1,29 @@
+.list-tile {
+	display: flex;
+    align-items: center;
+    line-height: 1.2;
+    margin-right: 20px;
+
+	.list-tile__leading {
+		margin-right: 20px;
+	}
+
+    .list-tile__title {
+        font-weight: 500;
+	    font-size: 16;
+	    letter-spacing: -0.4px;
+	    color: var( --studio-gray-100 );
+    }
+
+    .list-tile__subtitle {
+        font-size: 14;
+	    line-height: 20px;
+	    letter-spacing: -0.24px;
+	    color: var( --studio-gray-60 );
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-rendering: auto;
+        max-height: 40px;
+        white-space: normal;
+    }
+}

--- a/packages/components/src/list-tile/style.scss
+++ b/packages/components/src/list-tile/style.scss
@@ -1,7 +1,7 @@
 .list-tile {
 	display: flex;
     align-items: center;
-    line-height: 1.2;
+    line-height: 1;
     margin-right: 20px;
 
 	.list-tile__leading {

--- a/packages/components/src/list-tile/style.scss
+++ b/packages/components/src/list-tile/style.scss
@@ -10,13 +10,13 @@
 
     .list-tile__title {
         font-weight: 500;
-	    font-size: 16;
+	    font-size: 1rem;
 	    letter-spacing: -0.4px;
 	    color: var( --studio-gray-100 );
     }
 
     .list-tile__subtitle {
-        font-size: 14;
+        font-size: 0.875rem;
 	    line-height: 20px;
 	    letter-spacing: -0.24px;
 	    color: var( --studio-gray-60 );


### PR DESCRIPTION
#### Proposed Changes

* Extract parts of the dashboard row content into a ListTile component as the way it's structured on the UI is representative of a ListTile.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch locally.
2. Navigate to `/sites-dashboard` and view the new Sites Dashboard.
3. Observe the highlighted UI is rendered as a ListTile
4. Navigate to http://calypso.localhost:3000/devdocs/design search for list tile component
<img width="833" alt="ui" src="https://user-images.githubusercontent.com/47489215/177613977-0054c0f8-159f-4eca-9082-842011b1c02c.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65166
