### PR TITLE
Fix the display of the new Custom CSS and Premium Themes add-ons in checkout

### DIFF
--- a/packages/calypso-products/src/is-add-on.ts
+++ b/packages/calypso-products/src/is-add-on.ts
@@ -1,7 +1,9 @@
+import { isCustomDesign } from './is-custom-design';
 import { isNoAds } from './is-no-ads';
+import { isUnlimitedThemes } from './is-unlimited-themes';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isAddOn( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
 	// Right now the definition of an "add-on" just comes from a hardcoded list.
-	return isNoAds( product );
+	return isCustomDesign( product ) || isNoAds( product ) || isUnlimitedThemes( product );
 }


### PR DESCRIPTION
#### Proposed Changes

The new Custom CSS and Premium Themes add-ons aren't being identified as add-ons in checkout, so they just get displayed with a "Billed annually" label in checkout rather than the custom label that the No Ads add-on has.

This pull request fixes them to display the same as No Ads.

**Before:**

![before](https://user-images.githubusercontent.com/235183/177623363-8bb20975-0eb8-40ba-ad2b-689b809b78d5.png)

**After:**

![after](https://user-images.githubusercontent.com/235183/177623358-034c45ee-3ec2-4dbc-9b4f-3b1275e677bc.png)

#### Testing Instructions

Put all three add-ons in your shopping cart and go to checkout to see how they are displayed.  (`https://wordpress.com/checkout/[slug]` will get a product into your shopping cart, where `[slug]` is the relevant product slug.)