### PR TITLE
Onboarding: Clear out onboard store at exitFlow of stepper framework

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -96,7 +96,7 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction, setStepProgress, resetGoals, resetIntent, resetSelectedDesign } =
+		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
@@ -145,9 +145,7 @@ export const siteSetupFlow: Flow = {
 			navigate( 'processing' );
 
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-			resetGoals();
-			resetIntent();
-			resetSelectedDesign();
+			resetOnboardStoreWithSkipFlags( [ 'pendingAction' ] );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -145,7 +145,7 @@ export const siteSetupFlow: Flow = {
 			navigate( 'processing' );
 
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-			resetOnboardStoreWithSkipFlags( [ 'pendingAction' ] );
+			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction' ] );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -108,6 +108,12 @@ export const resetFonts = () => ( {
 
 export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
+	skipFlags: [] as string[],
+} );
+
+export const resetOnboardStoreWithSkipFlags = ( skipFlags: string[] ) => ( {
+	type: 'RESET_ONBOARD_STORE' as const,
+	skipFlags,
 } );
 
 export const setDomain = ( domain: DomainSuggestion | undefined ) => ( {
@@ -287,6 +293,7 @@ export type OnboardAction = ReturnType<
 	| typeof removeFeature
 	| typeof resetFonts
 	| typeof resetOnboardStore
+	| typeof resetOnboardStoreWithSkipFlags
 	| typeof setStoreType
 	| typeof setDomain
 	| typeof setDomainCategory

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -11,7 +11,7 @@ const domain: Reducer< DomainSuggestion | undefined, OnboardAction > = ( state, 
 	if ( action.type === 'SET_DOMAIN' ) {
 		return action.domain;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'domain' ) ) {
 		return undefined;
 	}
 	return state;
@@ -21,7 +21,7 @@ const domainSearch: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	if ( action.type === 'SET_DOMAIN_SEARCH_TERM' ) {
 		return action.domainSearch;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'domainSearch' ) ) {
 		return '';
 	}
 	return state;
@@ -31,7 +31,7 @@ const domainCategory: Reducer< string | undefined, OnboardAction > = ( state, ac
 	if ( action.type === 'SET_DOMAIN_CATEGORY' ) {
 		return action.domainCategory;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'domainCategory' ) ) {
 		return undefined;
 	}
 	return state;
@@ -41,7 +41,10 @@ const hasUsedDomainsStep: Reducer< boolean, OnboardAction > = ( state = false, a
 	if ( action.type === 'SET_HAS_USED_DOMAINS_STEP' ) {
 		return action.hasUsedDomainsStep;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'hasUsedDomainsStep' )
+	) {
 		return false;
 	}
 	return state;
@@ -51,7 +54,10 @@ const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, act
 	if ( action.type === 'SET_HAS_USED_PLANS_STEP' ) {
 		return action.hasUsedPlansStep;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'hasUsedPlansStep' )
+	) {
 		return false;
 	}
 	return state;
@@ -70,7 +76,7 @@ const planProductId: Reducer< number | undefined, OnboardAction > = ( state, act
 	if ( action.type === 'SET_PLAN_PRODUCT_ID' ) {
 		return action.planProductId;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'planProductId' ) ) {
 		return undefined;
 	}
 	return state;
@@ -83,7 +89,10 @@ const randomizedDesigns: Reducer< { featured: Design[] }, OnboardAction > = (
 	if ( action.type === 'SET_RANDOMIZED_DESIGNS' ) {
 		return action.randomizedDesigns;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'randomizedDesigns' )
+	) {
 		return { featured: [] };
 	}
 	return state;
@@ -96,7 +105,12 @@ const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 	if ( action.type === 'SET_FONTS' ) {
 		return action.fonts;
 	}
-	if ( action.type === 'RESET_FONTS' || action.type === 'RESET_ONBOARD_STORE' ) {
+
+	if ( action.type === 'RESET_FONTS' ) {
+		return undefined;
+	}
+
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'selectedFonts' ) ) {
 		return undefined;
 	}
 	return state;
@@ -106,7 +120,12 @@ const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, ac
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
 	}
-	if ( [ 'RESET_SELECTED_DESIGN', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+
+	if ( action.type === 'RESET_SELECTED_DESIGN' ) {
+		return undefined;
+	}
+
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'selectedDesign' ) ) {
 		return undefined;
 	}
 	return state;
@@ -132,7 +151,10 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 		return state.filter( ( id ) => id !== action.featureId );
 	}
 
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'selectedFeatures' )
+	) {
 		return [];
 	}
 
@@ -146,7 +168,7 @@ const selectedSite: Reducer< number | undefined, OnboardAction > = (
 	if ( action.type === 'SET_SELECTED_SITE' ) {
 		return action.selectedSite;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'selectedSite' ) ) {
 		return undefined;
 	}
 	return state;
@@ -156,7 +178,10 @@ const showSignupDialog: Reducer< boolean, OnboardAction > = ( state = false, act
 	if ( action.type === 'SET_SHOW_SIGNUP_DIALOG' ) {
 		return action.showSignup;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'showSignupDialog' )
+	) {
 		return false;
 	}
 	return state;
@@ -166,7 +191,7 @@ const siteTitle: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_SITE_TITLE' ) {
 		return action.siteTitle;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'siteTitle' ) ) {
 		return '';
 	}
 	return state;
@@ -176,7 +201,7 @@ const anchorPodcastId: Reducer< string | null, OnboardAction > = ( state = '', a
 	if ( action.type === 'SET_ANCHOR_PODCAST_ID' ) {
 		return action.anchorPodcastId;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'anchorPodcastId' ) ) {
 		return '';
 	}
 	return state;
@@ -186,7 +211,7 @@ const anchorEpisodeId: Reducer< string | null, OnboardAction > = ( state = '', a
 	if ( action.type === 'SET_ANCHOR_PODCAST_EPISODE_ID' ) {
 		return action.anchorEpisodeId;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'anchorEpisodeId' ) ) {
 		return '';
 	}
 	return state;
@@ -196,7 +221,10 @@ const anchorSpotifyUrl: Reducer< string | null, OnboardAction > = ( state = '', 
 	if ( action.type === 'SET_ANCHOR_PODCAST_SPOTIFY_URL' ) {
 		return action.anchorSpotifyUrl;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'anchorSpotifyUrl' )
+	) {
 		return '';
 	}
 	return state;
@@ -206,7 +234,10 @@ const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false,
 	if ( action.type === 'ONBOARDING_START' ) {
 		return true;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'hasOnboardingStarted' )
+	) {
 		return false;
 	}
 	return state;
@@ -216,7 +247,7 @@ const lastLocation: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	if ( action.type === 'SET_LAST_LOCATION' ) {
 		return action.path;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'lastLocation' ) ) {
 		return '';
 	}
 	return state;
@@ -226,7 +257,12 @@ const intent: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_INTENT' ) {
 		return action.intent;
 	}
-	if ( [ 'RESET_INTENT', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+
+	if ( action.type === 'RESET_INTENT' ) {
+		return '';
+	}
+
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'intent' ) ) {
 		return '';
 	}
 	return state;
@@ -236,7 +272,7 @@ const startingPoint: Reducer< string, OnboardAction > = ( state = '', action ) =
 	if ( action.type === 'SET_STARTING_POINT' ) {
 		return action.startingPoint;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'startingPoint' ) ) {
 		return '';
 	}
 	return state;
@@ -246,7 +282,7 @@ const storeType: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_STORE_TYPE' ) {
 		return action.storeType;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'storeType' ) ) {
 		return '';
 	}
 	return state;
@@ -259,7 +295,7 @@ const pendingAction: Reducer< undefined | ( () => Promise< any > ), OnboardActio
 	if ( action.type === 'SET_PENDING_ACTION' ) {
 		return action.pendingAction;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'pendingAction' ) ) {
 		return undefined;
 	}
 	return state;
@@ -269,7 +305,7 @@ const progress: Reducer< number, OnboardAction > = ( state = -1, action ) => {
 	if ( action.type === 'SET_PROGRESS' ) {
 		return action.progress;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'progress' ) ) {
 		return -1;
 	}
 	return state;
@@ -279,7 +315,7 @@ const progressTitle: Reducer< string | undefined, OnboardAction > = ( state, act
 	if ( action.type === 'SET_PROGRESS_TITLE' ) {
 		return action.progressTitle;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'progressTitle' ) ) {
 		return undefined;
 	}
 	return state;
@@ -305,9 +341,13 @@ const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'CLEAR_DIFM_GOAL' ) {
 		return state.filter( ( goal ) => goal !== SiteGoal.DIFM );
 	}
-	if ( [ 'RESET_GOALS', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+	if ( action.type === 'RESET_GOALS' ) {
 		return [];
 	}
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'goals' ) ) {
+		return [];
+	}
+
 	return state;
 };
 
@@ -315,7 +355,7 @@ const editEmail: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_EDIT_EMAIL' ) {
 		return action.email;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'editEmail' ) ) {
 		return '';
 	}
 	return state;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -11,7 +11,7 @@ const domain: Reducer< DomainSuggestion | undefined, OnboardAction > = ( state, 
 	if ( action.type === 'SET_DOMAIN' ) {
 		return action.domain;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'domain' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;
@@ -21,7 +21,7 @@ const domainSearch: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	if ( action.type === 'SET_DOMAIN_SEARCH_TERM' ) {
 		return action.domainSearch;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'domainSearch' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -31,7 +31,7 @@ const domainCategory: Reducer< string | undefined, OnboardAction > = ( state, ac
 	if ( action.type === 'SET_DOMAIN_CATEGORY' ) {
 		return action.domainCategory;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'domainCategory' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;
@@ -41,10 +41,7 @@ const hasUsedDomainsStep: Reducer< boolean, OnboardAction > = ( state = false, a
 	if ( action.type === 'SET_HAS_USED_DOMAINS_STEP' ) {
 		return action.hasUsedDomainsStep;
 	}
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'hasUsedDomainsStep' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return false;
 	}
 	return state;
@@ -54,10 +51,7 @@ const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, act
 	if ( action.type === 'SET_HAS_USED_PLANS_STEP' ) {
 		return action.hasUsedPlansStep;
 	}
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'hasUsedPlansStep' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return false;
 	}
 	return state;
@@ -76,7 +70,7 @@ const planProductId: Reducer< number | undefined, OnboardAction > = ( state, act
 	if ( action.type === 'SET_PLAN_PRODUCT_ID' ) {
 		return action.planProductId;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'planProductId' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;
@@ -89,10 +83,7 @@ const randomizedDesigns: Reducer< { featured: Design[] }, OnboardAction > = (
 	if ( action.type === 'SET_RANDOMIZED_DESIGNS' ) {
 		return action.randomizedDesigns;
 	}
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'randomizedDesigns' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return { featured: [] };
 	}
 	return state;
@@ -105,12 +96,7 @@ const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 	if ( action.type === 'SET_FONTS' ) {
 		return action.fonts;
 	}
-
-	if ( action.type === 'RESET_FONTS' ) {
-		return undefined;
-	}
-
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'selectedFonts' ) ) {
+	if ( action.type === 'RESET_FONTS' || action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;
@@ -120,12 +106,7 @@ const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, ac
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
 	}
-
-	if ( action.type === 'RESET_SELECTED_DESIGN' ) {
-		return undefined;
-	}
-
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'selectedDesign' ) ) {
+	if ( [ 'RESET_SELECTED_DESIGN', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return undefined;
 	}
 	return state;
@@ -151,10 +132,7 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 		return state.filter( ( id ) => id !== action.featureId );
 	}
 
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'selectedFeatures' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return [];
 	}
 
@@ -168,7 +146,7 @@ const selectedSite: Reducer< number | undefined, OnboardAction > = (
 	if ( action.type === 'SET_SELECTED_SITE' ) {
 		return action.selectedSite;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'selectedSite' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;
@@ -178,10 +156,7 @@ const showSignupDialog: Reducer< boolean, OnboardAction > = ( state = false, act
 	if ( action.type === 'SET_SHOW_SIGNUP_DIALOG' ) {
 		return action.showSignup;
 	}
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'showSignupDialog' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return false;
 	}
 	return state;
@@ -191,7 +166,7 @@ const siteTitle: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_SITE_TITLE' ) {
 		return action.siteTitle;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'siteTitle' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -201,7 +176,7 @@ const anchorPodcastId: Reducer< string | null, OnboardAction > = ( state = '', a
 	if ( action.type === 'SET_ANCHOR_PODCAST_ID' ) {
 		return action.anchorPodcastId;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'anchorPodcastId' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -211,7 +186,7 @@ const anchorEpisodeId: Reducer< string | null, OnboardAction > = ( state = '', a
 	if ( action.type === 'SET_ANCHOR_PODCAST_EPISODE_ID' ) {
 		return action.anchorEpisodeId;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'anchorEpisodeId' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -221,10 +196,7 @@ const anchorSpotifyUrl: Reducer< string | null, OnboardAction > = ( state = '', 
 	if ( action.type === 'SET_ANCHOR_PODCAST_SPOTIFY_URL' ) {
 		return action.anchorSpotifyUrl;
 	}
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'anchorSpotifyUrl' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -234,10 +206,7 @@ const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false,
 	if ( action.type === 'ONBOARDING_START' ) {
 		return true;
 	}
-	if (
-		action.type === 'RESET_ONBOARD_STORE' &&
-		! action.skipFlags.includes( 'hasOnboardingStarted' )
-	) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return false;
 	}
 	return state;
@@ -247,7 +216,7 @@ const lastLocation: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	if ( action.type === 'SET_LAST_LOCATION' ) {
 		return action.path;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'lastLocation' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -257,12 +226,7 @@ const intent: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_INTENT' ) {
 		return action.intent;
 	}
-
-	if ( action.type === 'RESET_INTENT' ) {
-		return '';
-	}
-
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'intent' ) ) {
+	if ( [ 'RESET_INTENT', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return '';
 	}
 	return state;
@@ -272,7 +236,7 @@ const startingPoint: Reducer< string, OnboardAction > = ( state = '', action ) =
 	if ( action.type === 'SET_STARTING_POINT' ) {
 		return action.startingPoint;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'startingPoint' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -282,7 +246,7 @@ const storeType: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_STORE_TYPE' ) {
 		return action.storeType;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'storeType' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;
@@ -295,7 +259,10 @@ const pendingAction: Reducer< undefined | ( () => Promise< any > ), OnboardActio
 	if ( action.type === 'SET_PENDING_ACTION' ) {
 		return action.pendingAction;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'pendingAction' ) ) {
+	if (
+		action.type === 'RESET_ONBOARD_STORE' &&
+		! action.skipFlags.includes( 'skipPendingAction' )
+	) {
 		return undefined;
 	}
 	return state;
@@ -305,7 +272,7 @@ const progress: Reducer< number, OnboardAction > = ( state = -1, action ) => {
 	if ( action.type === 'SET_PROGRESS' ) {
 		return action.progress;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'progress' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return -1;
 	}
 	return state;
@@ -315,7 +282,7 @@ const progressTitle: Reducer< string | undefined, OnboardAction > = ( state, act
 	if ( action.type === 'SET_PROGRESS_TITLE' ) {
 		return action.progressTitle;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'progressTitle' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;
@@ -341,13 +308,9 @@ const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'CLEAR_DIFM_GOAL' ) {
 		return state.filter( ( goal ) => goal !== SiteGoal.DIFM );
 	}
-	if ( action.type === 'RESET_GOALS' ) {
+	if ( [ 'RESET_GOALS', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return [];
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'goals' ) ) {
-		return [];
-	}
-
 	return state;
 };
 
@@ -355,7 +318,7 @@ const editEmail: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_EDIT_EMAIL' ) {
 		return action.email;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' && ! action.skipFlags.includes( 'editEmail' ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}
 	return state;


### PR DESCRIPTION
#### Proposed Changes

While reviewing code for #65205, I noticed an issue where the root was that we didn't clear out the data store in between runs. But, also that we had twice added code to clear out the store in the past month.

It seems like the best solution here is to clear out as much data as possible in between runs to minimize issues with subsequent runs. But, in `exitFlow` in Stepper, we can't just call `resetOnboardStore` because that also clears out pending actions. This seems to be the root cause for why pre-release tests failed in #65205 and I had to subsequently revert.

As we move into tailored use cases, or very focused websites, we may see that the same user going through onboarding multiple times will increase.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Generally, we need to test all of the flows
* I've also run pre-release tests locally and then verified that only the creating a new user and sms test fails, which seems the same for `trunk`: `CALYPSO_BASE_URL='http://calypso.localhost:3000' yarn jest --group=calypso-release`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
