### PR TITLE
CDN Upsell Nudge: Take the user directly to the Pro checkout

### DIFF
--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -23,7 +23,7 @@ const Cloudflare = () => {
 	const hasJetpackCDN = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_CDN )
 	);
-	const upgradeLink = `/plans/${ siteSlug }?customerType=business`;
+	const upgradeLink = `/checkout/${ siteSlug }/pro`;
 
 	const recordClick = () => {
 		dispatch(


### PR DESCRIPTION
Fixes #64975

## Proposed Changes

Takes the user directly to the Pro plan checkout when they click on the CDN Upsell Nudge:

https://user-images.githubusercontent.com/36432/177626809-0d447d12-b8bb-4dfb-9ad0-32e4460685a5.mp4

Prior to this change, they would end up on the plan selector page:

https://user-images.githubusercontent.com/36432/177627080-e50daa36-e320-472d-b2b1-a216733f8d92.mp4

The `UpsellNudge` card with `const upgradeLink = '?customerType=business';` was originally added in #49263

"Available on the Pro plan" was added 3 months ago with #61595 but it seems `upgradeLink` was missed in the process.

## Testing Instructions

1. Create a simple blog
2. Navigate to WP Admin -> Settings -> Performance
3. Click "Available on the Pro plan" action either in CDN or Cloudflare CDN block
