### PR TITLE
Plugin Details: Update the sidebar design

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -36,7 +36,6 @@ const PluginAnnualSavingLabelDesktop = styled.span`
 
 const BillingIntervalSwitcherContainer = styled.div`
 	display: flex;
-	justify-content: space-between;
 	margin-top: -4px;
 	margin-bottom: 16px;
 `;
@@ -49,6 +48,10 @@ const RadioButton = styled( FormRadio )`
 
 const RadioButtonLabel = styled( FormLabel )`
 	color: var( --studio-gray-60 );
+
+	&:first-child {
+		margin-right: 15px;
+	}
 `;
 
 type Props = {

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -28,6 +28,7 @@ export default function CTAButton( {
 	billingPeriod,
 	isJetpackSelfHosted,
 	isSiteConnected,
+	disabled,
 } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -139,7 +140,9 @@ export default function CTAButton( {
 						preinstalledPremiumPluginProduct,
 					} );
 				} }
-				disabled={ ( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false }
+				disabled={
+					( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false || disabled
+				}
 			>
 				{
 					// eslint-disable-next-line no-nested-ternary

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -184,7 +184,7 @@ const PluginDetailsCTA = ( {
 					}
 				</PluginPrice>
 			</div>
-			{ ! legacyVersion && (
+			{ ! legacyVersion && isMarketplaceProduct && (
 				<BillingIntervalSwitcher
 					billingPeriod={ billingPeriod }
 					onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
@@ -238,7 +238,7 @@ const PluginDetailsCTA = ( {
 				</div>
 			) }
 
-			{ ! isJetpackSelfHosted && (
+			{ legacyVersion && ! isJetpackSelfHosted && (
 				<USPS
 					shouldUpgrade={ shouldUpgrade }
 					isFreePlan={ isFreePlan }

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -4,6 +4,7 @@ import {
 	FEATURE_INSTALL_PLUGINS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import { userCan } from 'calypso/lib/site/utils';
@@ -173,7 +174,7 @@ const PluginDetailsCTA = ( {
 								) : (
 									translate( 'Free' )
 								) }
-								{ shouldUpgrade && (
+								{ legacyVersion && shouldUpgrade && (
 									<span className="plugin-details-CTA__uprade-required">
 										{ translate( 'Plan upgrade required' ) }
 									</span>
@@ -203,6 +204,18 @@ const PluginDetailsCTA = ( {
 					isSiteConnected={ isSiteConnected }
 				/>
 			</div>
+			{ ! legacyVersion && shouldUpgrade && (
+				<div className="plugin-details-CTA__upgrade-required">
+					<span className="plugin-details-CTA__upgrade-required-icon">
+						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+						<Gridicon icon="notice-outline" size={ 20 } />
+						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+					</span>
+					<span className="plugin-details-CTA__upgrade-required-text">
+						{ translate( 'You need to upgrade your plan to install plugins.' ) }
+					</span>
+				</div>
+			) }
 			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 				<div className="plugin-details-CTA__t-and-c">
 					{ translate(

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -226,20 +226,7 @@ const PluginDetailsCTA = ( props ) => {
 					disabled={ requestingPluginsForSites || incompatiblePlugin || userCantManageTheSite }
 				/>
 			</div>
-			{ shouldUpgrade && (
-				<div className="plugin-details-CTA__upgrade-required">
-					<span className="plugin-details-CTA__upgrade-required-icon">
-						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						<Gridicon icon="notice-outline" size={ 20 } />
-						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-					</span>
-					<span className="plugin-details-CTA__upgrade-required-text">
-						{ translate( 'You need to upgrade your plan to install plugins.' ) }
-					</span>
-				</div>
-			) }
-			{ /* Awaiting confirmation for adding this section */ }
-			{ /* { ! isJetpackSelfHosted && ! isMarketplaceProduct && (
+			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 				<div className="plugin-details-CTA__t-and-c">
 					{ translate(
 						'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
@@ -259,7 +246,19 @@ const PluginDetailsCTA = ( props ) => {
 						}
 					) }
 				</div>
-			) } */ }
+			) }
+			{ shouldUpgrade && (
+				<div className="plugin-details-CTA__upgrade-required">
+					<span className="plugin-details-CTA__upgrade-required-icon">
+						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+						<Gridicon icon="notice-outline" size={ 20 } />
+						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+					</span>
+					<span className="plugin-details-CTA__upgrade-required-text">
+						{ translate( 'You need to upgrade your plan to install plugins.' ) }
+					</span>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -86,6 +86,20 @@
 	}
 }
 
+.plugin-details-CTA__upgrade-required {
+	display: flex;
+
+	.plugin-details-CTA__upgrade-required-icon {
+		color: var( --studio-orange-40 );
+	}
+
+	.plugin-details-CTA__upgrade-required-text {
+		color: var( --studio-gray-80 );
+		font-size: $font-body-small;
+		margin-left: 16px;
+	}
+}
+
 .is-placeholder {
 	.plugin-details-CTA__price,
 	.plugin-details-CTA__install,

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -100,6 +100,24 @@
 	}
 }
 
+.plugin-details-CTA__installed-text {
+	color: var( --studio-gray-100 );
+	font-size: $font-body;
+	height: 40px;
+
+	.plugin-details-CTA__installed-text-quantity {
+		color: var( --studio-green-50 );
+	}
+
+	.plugin-details-CTA__installed-text-active {
+		color: var( --studio-green-60 );
+	}
+
+	.plugin-details-CTA__installed-text-inactive {
+		color: var( --studio-red-60 );
+	}
+}
+
 .is-placeholder {
 	.plugin-details-CTA__price,
 	.plugin-details-CTA__install,

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -72,6 +72,7 @@
 .plugin-details-CTA__t-and-c {
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
+	margin-bottom: 16px;
 }
 
 .plugin-details-CTA__not-available {
@@ -115,6 +116,12 @@
 
 	.plugin-details-CTA__installed-text-inactive {
 		color: var( --studio-red-60 );
+	}
+}
+
+.legacy {
+	.plugin-details-CTA__t-and-c {
+		margin-bottom: 0;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -47,6 +47,7 @@
 	font-family: $sans;
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
+	padding-left: 3px;
 }
 
 .plugin-details-CTA__uprade-required {
@@ -92,6 +93,7 @@
 
 	.plugin-details-CTA__upgrade-required-icon {
 		color: var( --studio-orange-40 );
+		padding-top: 3px;
 	}
 
 	.plugin-details-CTA__upgrade-required-text {
@@ -122,6 +124,10 @@
 .legacy {
 	.plugin-details-CTA__t-and-c {
 		margin-bottom: 0;
+	}
+
+	.plugin-details-CTA__period {
+		padding-left: 0;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,10 +1,20 @@
-import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
+import config from '@automattic/calypso-config';
+import {
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_BUSINESS,
+	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_STARTER,
+	isBlogger,
+	isPersonal,
+	isPremium,
+} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
 import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -16,7 +26,7 @@ const StyledUl = styled.ul`
 `;
 
 const StyledLi = styled.li`
-	color: var( --studio-gray-50 );
+	color: var( --studio-gray-80 );
 	font-size: 12px;
 	display: flex;
 	align-items: center;
@@ -32,6 +42,14 @@ const StyledLi = styled.li`
 	svg {
 		margin-right: 8px;
 	}
+
+	&.legacy {
+		color: var( --studio-gray-50 );
+	}
+`;
+
+const GreenGridicon = styled( Gridicon )`
+	color: var( --studio-green-50 );
 `;
 
 interface Props {
@@ -41,32 +59,70 @@ interface Props {
 	billingPeriod: IntervalLength;
 }
 
-const USPS: React.FC< Props > = ( {
+export const USPS: React.FC< Props > = ( {
 	shouldUpgrade,
 	isFreePlan,
 	isMarketplaceProduct,
 	billingPeriod,
 } ) => {
 	const translate = useTranslate();
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
+
+	if ( legacyVersion ) {
+		return (
+			<LegacyUSPS
+				shouldUpgrade={ shouldUpgrade }
+				isFreePlan={ isFreePlan }
+				isMarketplaceProduct={ isMarketplaceProduct }
+				billingPeriod={ billingPeriod }
+			/>
+		);
+	}
+
+	if ( ! isMarketplaceProduct ) {
+		return null;
+	}
+
+	const filteredUSPS = [
+		translate( 'Plugin updates' ),
+		translate( '%(days)d-day money-back guarantee', {
+			args: { days: billingPeriod === IntervalLength.ANNUALLY ? 14 : 7 },
+		} ),
+	];
+
+	return (
+		<PluginDetailsSidebarUSP
+			id="marketplace-product"
+			title={ translate( 'Included with your purchase' ) }
+			description={
+				<StyledUl>
+					{ filteredUSPS.map( ( usp, i ) => (
+						<StyledLi key={ `usp-${ i }` }>
+							<GreenGridicon icon="checkmark" size={ 16 } />
+							<span>{ usp }</span>
+						</StyledLi>
+					) ) }
+				</StyledUl>
+			}
+			first
+		/>
+	);
+};
+
+export const PlanUSPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, billingPeriod } ) => {
+	const translate = useTranslate();
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
-
-	const selectedSite = useSelector( getSelectedSite );
-	const requiredPlan = useSelector( ( state ) => {
-		if ( ! shouldUpgrade ) {
-			return '';
-		}
-
-		if ( isEligibleForProPlan( state, selectedSite?.ID ) ) {
-			return PLAN_WPCOM_PRO;
-		}
-
-		return isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
-	} );
-
+	const supportText = usePluginsSupportText();
+	const requiredPlan = useRequiredPlan( shouldUpgrade, isAnnualPeriod );
 	const planDisplayCost = useSelector( ( state ) => {
-		return getProductDisplayCost( state, requiredPlan );
+		return getProductDisplayCost( state, requiredPlan || '' );
 	} );
+
+	if ( ! shouldUpgrade ) {
+		return null;
+	}
+
 	let planText;
 	switch ( requiredPlan ) {
 		case PLAN_WPCOM_PRO:
@@ -82,7 +138,55 @@ const USPS: React.FC< Props > = ( {
 			break;
 	}
 
+	const filteredUSPS = [
+		...( isFreePlan ? [ translate( 'Free domain for one year' ) ] : [] ),
+		translate( 'Best-in-class hosting' ),
+		supportText,
+	];
+
+	return (
+		<PluginDetailsSidebarUSP
+			id="marketplace-plan"
+			title={ planText }
+			description={
+				<StyledUl>
+					{ filteredUSPS.map( ( usp, i ) => (
+						<StyledLi key={ `usps__-${ i }` }>
+							<GreenGridicon icon="checkmark" size={ 16 } />
+							<span>{ usp }</span>
+						</StyledLi>
+					) ) }
+				</StyledUl>
+			}
+			first
+		/>
+	);
+};
+
+function LegacyUSPS( { shouldUpgrade, isFreePlan, isMarketplaceProduct, billingPeriod }: Props ) {
+	const translate = useTranslate();
+
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+	const requiredPlan = useRequiredPlan( shouldUpgrade, isAnnualPeriod );
+	const planDisplayCost = useSelector( ( state ) => {
+		return getProductDisplayCost( state, requiredPlan || '' );
+	} );
 	const supportText = usePluginsSupportText();
+
+	let planText;
+	switch ( requiredPlan ) {
+		case PLAN_WPCOM_PRO:
+			planText = translate( 'Included in the Pro plan (%s):', {
+				args: [ planDisplayCost ],
+			} );
+			break;
+		case PLAN_BUSINESS:
+		case PLAN_BUSINESS_MONTHLY:
+			planText = translate( 'Included in the Business plan (%s):', {
+				args: [ planDisplayCost ],
+			} );
+			break;
+	}
 
 	const filteredUSPS = [
 		...( isMarketplaceProduct
@@ -152,13 +256,29 @@ const USPS: React.FC< Props > = ( {
 	return (
 		<StyledUl>
 			{ filteredUSPS.map( ( usp ) => (
-				<StyledLi key={ usp.id }>
+				<StyledLi key={ usp.id } className="usps__li legacy">
 					{ usp?.image }
 					<span className={ usp.className }>{ usp.text }</span>
 				</StyledLi>
 			) ) }
 		</StyledUl>
 	);
-};
+}
+
+function useRequiredPlan( shouldUpgrade: boolean, isAnnualPeriod: boolean ) {
+	const selectedSite = useSelector( getSelectedSite );
+
+	return useSelector( ( state ) => {
+		if ( ! shouldUpgrade ) {
+			return '';
+		}
+
+		if ( isEligibleForProPlan( state, selectedSite?.ID ) ) {
+			return PLAN_WPCOM_PRO;
+		}
+
+		return isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
+	} );
+}
 
 export default USPS;

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,13 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	PLAN_BUSINESS_MONTHLY,
-	PLAN_BUSINESS,
-	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_STARTER,
-	isBlogger,
-	isPersonal,
-	isPremium,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -27,7 +19,7 @@ const StyledUl = styled.ul`
 
 const StyledLi = styled.li`
 	color: var( --studio-gray-80 );
-	font-size: 12px;
+	font-size: $font-body-small;
 	display: flex;
 	align-items: center;
 	margin: 5px 0;
@@ -45,6 +37,7 @@ const StyledLi = styled.li`
 
 	&.legacy {
 		color: var( --studio-gray-50 );
+		font-size: 12px;
 	}
 `;
 

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -55,6 +55,7 @@ $mobile-icon-height: 175px;
 .plugin-details-header__name {
 	font-family: $brand-serif;
 	font-size: $font-title-large;
+	overflow-wrap: anywhere;
 	line-height: 40px;
 	color: var( --studio-gray-100 );
 }

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -48,7 +48,14 @@ const Description = styled.div`
 	margin-bottom: 12px;
 `;
 
-const PluginDetailsSidebarUSP = ( { id, icon, title, description, links, first } ) => {
+const PluginDetailsSidebarUSP = ( {
+	id,
+	title,
+	description,
+	icon = undefined,
+	links = undefined,
+	first = false,
+} ) => {
 	const isNarrow = useBreakpoint( '<1040px' );
 	const Header = () => {
 		return (

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -53,8 +53,13 @@ const PluginDetailsSidebarUSP = ( { id, icon, title, description, links, first }
 	const Header = () => {
 		return (
 			<>
-				<Icon src={ icon.src } showAsAccordion={ isNarrow } />
-				&nbsp;
+				{ icon && (
+					<>
+						<Icon src={ icon.src } showAsAccordion={ isNarrow } />
+						&nbsp;
+					</>
+				) }
+
 				<Title showAsAccordion={ isNarrow }>{ title }</Title>
 			</>
 		);

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
@@ -41,7 +42,8 @@ const Title = styled.div`
 	color: var( --studio-gray-100 );
 	font-size: 16px;
 	${ ( props ) => ! props.showAsAccordion && 'font-weight: 600' };
-	${ ( props ) => ! props.showAsAccordion && 'margin-bottom: 12px;' };
+	${ ( props ) => ! props.showAsAccordion && ! props.legacy && 'margin-bottom: 4px;' };
+	${ ( props ) => ! props.showAsAccordion && props.legacy && 'margin-bottom: 12px;' };
 `;
 const Description = styled.div`
 	color: var( --studio-gray-60 );
@@ -56,6 +58,8 @@ const PluginDetailsSidebarUSP = ( {
 	links = undefined,
 	first = false,
 } ) => {
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
+
 	const isNarrow = useBreakpoint( '<1040px' );
 	const Header = () => {
 		return (
@@ -67,7 +71,9 @@ const PluginDetailsSidebarUSP = ( {
 					</>
 				) }
 
-				<Title showAsAccordion={ isNarrow }>{ title }</Title>
+				<Title showAsAccordion={ isNarrow } legacy={ legacyVersion }>
+					{ title }
+				</Title>
 			</>
 		);
 	};

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -12,6 +12,7 @@ const Container = styled( FoldableCard )`
 	width: 100%;
 	margin-bottom: 0;
 	box-shadow: none;
+	${ ( props ) => props.showAsAccordion && ! props.legacy && 'border-bottom: 1px solid #eeeeee' };
 	${ ( props ) => props.showAsAccordion && 'border-top: 1px solid var( --studio-gray-5)' };
 	${ ( props ) => props.showAsAccordion && props.first && 'border-top: 0' };
 	.foldable-card__content {

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -39,7 +39,7 @@ const PluginDetailsSidebar = ( {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const billingPeriod = useSelector( getBillingInterval );
-	const isFreePlan = isFreePlanProduct( selectedSite?.plan );
+	const isFreePlan = selectedSite && isFreePlanProduct( selectedSite.plan );
 	const pluginFeature = isMarketplaceProduct
 		? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 		: FEATURE_INSTALL_PLUGINS;
@@ -115,7 +115,7 @@ const PluginDetailsSidebar = ( {
 				/>
 			) }
 
-			{ ! legacyVersion && (
+			{ ! legacyVersion && selectedSite && (
 				<USPS
 					shouldUpgrade={ shouldUpgrade }
 					isFreePlan={ isFreePlan }
@@ -124,7 +124,7 @@ const PluginDetailsSidebar = ( {
 				/>
 			) }
 
-			{ ! legacyVersion && (
+			{ ! legacyVersion && selectedSite && (
 				<PlanUSPS
 					shouldUpgrade={ shouldUpgrade }
 					isFreePlan={ isFreePlan }

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 import eye from 'calypso/assets/images/marketplace/eye.svg';
@@ -19,11 +20,26 @@ const PluginDetailsSidebar = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
+
 	const isWooCommercePluginRequired = requirements.plugins?.some(
 		( pluginName ) => pluginName === 'plugins/woocommerce'
 	);
 
 	const supportText = usePluginsSupportText();
+
+	const supportLinks = [
+		{
+			href: 'https://wordpress.com/support/help-support-options/#live-chat-support',
+			label: translate( 'How to get help!' ),
+		},
+		{ href: 'https://automattic.com/privacy/', label: translate( 'See privacy policy' ) },
+	];
+	documentation_url &&
+		supportLinks.unshift( {
+			href: documentation_url,
+			label: translate( 'View documentation' ),
+		} );
 
 	if ( ! isMarketplaceProduct ) {
 		return (
@@ -54,25 +70,13 @@ const PluginDetailsSidebar = ( {
 			</>
 		);
 	}
-	const supportLinks = [
-		{
-			href: 'https://wordpress.com/support/help-support-options/#live-chat-support',
-			label: translate( 'How to get help!' ),
-		},
-		{ href: 'https://automattic.com/privacy/', label: translate( 'See privacy policy' ) },
-	];
-	documentation_url &&
-		supportLinks.unshift( {
-			href: documentation_url,
-			label: translate( 'View documentation' ),
-		} );
 
 	return (
 		<div className="plugin-details-sidebar__plugin-details-content">
 			{ isWooCommercePluginRequired && (
 				<PluginDetailsSidebarUSP
 					id="woo"
-					icon={ { src: wooLogo } }
+					icon={ legacyVersion && { src: wooLogo } }
 					title={ translate( 'Your store foundations' ) }
 					description={ translate(
 						'This plugin requires the WooCommerce plugin to work.{{br/}}If you do not have it installed, it will be installed automatically for free.',
@@ -88,23 +92,23 @@ const PluginDetailsSidebar = ( {
 			{ demo_url && (
 				<PluginDetailsSidebarUSP
 					id="demo"
-					icon={ { src: eye } }
+					icon={ legacyVersion && { src: eye } }
 					title={ translate( 'Try it before you buy it' ) }
 					description={ translate(
 						'Take a look at the posibilities of this plugin before your commit.'
 					) }
 					links={ [ { href: { demo_url }, label: translate( 'View live demo' ) } ] }
-					first={ ! isWooCommercePluginRequired }
+					first={ ! isWooCommercePluginRequired || ! legacyVersion }
 				/>
 			) }
 
 			<PluginDetailsSidebarUSP
 				id="support"
-				icon={ { src: support } }
+				icon={ legacyVersion && { src: support } }
 				title={ translate( 'Support' ) }
 				description={ supportText }
 				links={ supportLinks }
-				first={ ! isWooCommercePluginRequired && ! demo_url }
+				first={ ( ! isWooCommercePluginRequired && ! demo_url ) || ! legacyVersion }
 			/>
 		</div>
 	);

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -25,6 +25,10 @@
 		}
 	}
 
+	.card {
+		background: transparent;
+	}
+
 	@media screen and ( max-width: 1040px ) {
 		display: flex;
 		justify-content: space-between;

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -10,6 +10,12 @@
 }
 
 .plugin-details-sidebar__plugin-details-content {
+	margin: 32px 0;
+	padding: 32px 0;
+	border-style: solid none;
+	border-width: 1px;
+	border-color: #eeeeee;
+
 	.title {
 		color: var( --studio-gray-60 );
 		font-size: $font-body-extra-small;
@@ -33,5 +39,13 @@
 		display: flex;
 		justify-content: space-between;
 		flex-wrap: wrap; // Needed for paid plugin USPs.
+	}
+}
+
+.legacy {
+	.plugin-details-sidebar__plugin-details-content {
+		margin: 0;
+		padding: 0;
+		border-style: none;
 	}
 }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -363,7 +363,6 @@ function PluginDetails( props ) {
 							isSiteConnected={ isSiteConnected }
 						/>
 
-						<br />
 						{ ! showPlaceholder && <PluginDetailsSidebar plugin={ fullPlugin } /> }
 					</div>
 				</div>

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -125,7 +125,8 @@ body.is-section-plugins.theme-default.color-scheme {
 	}
 
 	@include display-grid;
-	@include grid-template-columns( 3, 80px, 1fr );
+	grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) minmax( 300px, 1fr );
+	grid-column-gap: 60px;
 	grid-template-areas: 'header header actions'
 						'content content actions';
 
@@ -301,6 +302,8 @@ body.is-section-plugins header .select-dropdown__item {
 	}
 
 	.plugin-details__layout {
+		@include grid-template-columns( 3, 80px, 1fr );
+
 		padding-top: 0;
 		grid-template-areas: none;
 		grid-template-columns: initial;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -125,7 +125,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	}
 
 	@include display-grid;
-	grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) minmax( 300px, 1fr );
+	grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) 350px;
 	grid-column-gap: 60px;
 	grid-template-areas: 'header header actions'
 						'content content actions';
@@ -148,7 +148,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	.plugin-details__actions {
 		grid-area: actions;
 		background-color: var( --studio-gray-0 );
-		padding: 20px;
+		padding: 40px;
 
 		@include breakpoint-deprecated( '<960px' ) {
 			margin-top: 40px;


### PR DESCRIPTION
#### Proposed Changes

* Update the sidebar min-width to `300px`
* Add the needs plan upgrade message
* Update the USPS styles
* Handle the edge-cases for the CTA

#### Out of scope 
- Manage sites - #63888
- Activate/Deactivate, etc. - #65611

#### Testing Instructions
* Enable the feature flag `plugins/plugin-details-layout`*

---

* Go to a plugin page without a selected site. Ex: `plugins/wordpress-seo`
* You should see the `Manage sites` button

---

* Go to a plugin installed on the selected site. Ex: `plugins/wordpress-seo/{site}`
* You should see the install and active (or inactive) text and the activate/deactivate button.


---

* Go to a free plugin not installed on your business/ecommerce/starter/pro site. Ex: `/plugins/google-site-kit/:site:`
* You should see the `Install and activate` button.

---

* Go to a free plugin not installed on your free site. Ex: `/plugins/google-site-kit/:site:`
*  You should see the `Install and activate` button and the `Upgrade needed` message.

---

* Go to a WooCommerce paid plugin from your business/ecommerce/starter/pro site. Ex: `/plugins/woocommerce-subscriptions/{site}`
* You should see the purchase buttons along with all the available USPS (store foundation, support, etc)

---

* Go to a WooCommerce paid plugin from your free site. Ex: `/plugins/woocommerce-subscriptions/{site}`
* You should the purchase and plans USPS along with the other USPS

---

* Disable the `plugins/plugin-details-layout` feature flag and go to plugins pages.
* The result should be the same as available on WordPress.com

---

\* To enable this feature flag add `?flags=plugins/plugin-details-layout` to the end of your URL or past the following code on the developer tools console `document.cookie = 'flags=plugins/plugin-details-layout;max-age=1209600;path=/'`

---

Fixes #63714