### PR TITLE
Add a progressbar to /marketplace/thank-you/<product-slug>

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -250,7 +250,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				<div className="marketplace-plugin-install__root">
 					<MarketplaceProgressBar
 						steps={ steps }
-						currentStep={ currentStep }
+						currentStep={ currentStep - 1 }
 						additionalSteps={ additionalSteps }
 					/>
 				</div>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -160,10 +160,6 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		alt: '',
 		src: pluginIcon,
 	};
-	const blankImage = {
-		alt: '',
-		src: '',
-	};
 
 	// Cast pluginOnSite's type because the return type of getPluginOnSite is
 	// wrong and I don't know how to fix it. Remove this cast if the return type
@@ -259,16 +255,18 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				</div>
 			) }
 			<ThankYouContainer>
-				<ThankYou
-					containerClassName="marketplace-thank-you"
-					sections={ [ setupSection ] }
-					showSupportSection={ true }
-					thankYouImage={ transfer ? thankYouImage : blankImage }
-					thankYouTitle={ transfer && translate( 'All ready to go!' ) }
-					thankYouSubtitle={ pluginOnSite && thankYouSubtitle }
-					headerBackgroundColor="#fff"
-					headerTextColor="#000"
-				/>
+				{ transfer && (
+					<ThankYou
+						containerClassName="marketplace-thank-you"
+						sections={ [ setupSection ] }
+						showSupportSection={ true }
+						thankYouImage={ thankYouImage }
+						thankYouTitle={ translate( 'All ready to go!' ) }
+						thankYouSubtitle={ pluginOnSite && thankYouSubtitle }
+						headerBackgroundColor="#fff"
+						headerTextColor="#000"
+					/>
+				) }
 			</ThankYouContainer>
 		</ThemeProvider>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -121,7 +121,9 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite
 	useEffect( () => {
-		if ( transfer?.status === AtomicTransferComplete && pluginOnSite ) {
+		if ( ! transfer ) {
+			setCurrentStep( 0 );
+		} else if ( transfer?.status === AtomicTransferComplete && pluginOnSite ) {
 			// Everything done: Step 0
 			setCurrentStep( 0 );
 		} else if ( transfer?.status === AtomicTransferComplete ) {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -43,6 +43,8 @@ const ThankYouContainer = styled.div`
 	}
 `;
 
+const AtomicTransferProvisioned = 'provisioned';
+const AtomicTransferRelocating = 'relocating_switcheroo';
 const AtomicTransferComplete = 'completed';
 
 const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
@@ -124,17 +126,23 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			setCurrentStep( 0 );
 		} else if ( transfer?.status === AtomicTransferComplete ) {
 			// Transfer is complete, but need to install plugin
+			setCurrentStep( 4 );
+		} else if ( transfer?.status === AtomicTransferRelocating ) {
+			setCurrentStep( 3 );
+		} else if ( transfer?.status === AtomicTransferProvisioned ) {
 			setCurrentStep( 2 );
 		} else {
-			// Need to transfer and install plugin
+			// Need to do entire atomic transfer and install plugin
 			setCurrentStep( 1 );
 		}
 	}, [ transfer, pluginOnSite ] );
 
 	const steps = useMemo(
 		() => [
+			translate( 'Activating the plugin feature' ), // Transferring to Atomic
 			translate( 'Setting up plugin installation' ), // Transferring to Atomic
-			translate( 'Installing plugin' ),
+			translate( 'Installing plugin' ), // Transferring to Atomic
+			translate( 'Activating plugin' ),
 		],
 		[ translate ]
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -122,20 +122,26 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite
 	useEffect( () => {
-		if ( transfer && transfer.status === AtomicTransferComplete && ! pluginOnSite ) {
+		if ( ! transfer || ( isRequestingPlugins && ! pluginOnSite ) ) {
+			// Status unknown
+			setCurrentStep( 0 );
+		} else if ( transfer?.status === AtomicTransferComplete && pluginOnSite ) {
+			// Everything done: Step 0
+			setCurrentStep( 0 );
+		} else if ( transfer?.status === AtomicTransferComplete ) {
 			// Transfer is complete, but need to install plugin
 			setCurrentStep( 4 );
-		} else if ( transfer && transfer.status === AtomicTransferRelocating ) {
+		} else if ( transfer?.status === AtomicTransferRelocating ) {
 			setCurrentStep( 3 );
-		} else if ( transfer && transfer.status === AtomicTransferProvisioned ) {
+		} else if ( transfer?.status === AtomicTransferProvisioned ) {
 			setCurrentStep( 2 );
-		} else if ( transfer && transfer.status === AtomicTransferActive ) {
+		} else if ( transfer?.status === AtomicTransferActive ) {
+			// Need to do entire atomic transfer and install plugin
 			setCurrentStep( 1 );
 		} else {
-			// Everything is complete or status unknown
 			setCurrentStep( 0 );
 		}
-	}, [ transfer, pluginOnSite ] );
+	}, [ transfer, pluginOnSite, isRequestingPlugins ] );
 
 	const steps = useMemo(
 		() => [

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -125,9 +125,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Step 0 hides the progress bar. It means "complete" or "still loading transfer status".
 	// Steps 1-4 advance through the bar.
 	useEffect( () => {
-		if ( ! transfer ) {
-			setCurrentStep( 0 );
-		} else if ( transfer?.status === AtomicTransferActive ) {
+		if ( transfer?.status === AtomicTransferActive ) {
 			setCurrentStep( 1 );
 		} else if ( transfer?.status === AtomicTransferProvisioned ) {
 			setCurrentStep( 2 );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -160,6 +160,10 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		alt: '',
 		src: pluginIcon,
 	};
+	const blankImage = {
+		alt: '',
+		src: '',
+	};
 
 	// Cast pluginOnSite's type because the return type of getPluginOnSite is
 	// wrong and I don't know how to fix it. Remove this cast if the return type
@@ -255,18 +259,16 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				</div>
 			) }
 			<ThankYouContainer>
-				{ transfer && (
-					<ThankYou
-						containerClassName="marketplace-thank-you"
-						sections={ [ setupSection ] }
-						showSupportSection={ true }
-						thankYouImage={ thankYouImage }
-						thankYouTitle={ translate( 'All ready to go!' ) }
-						thankYouSubtitle={ pluginOnSite && thankYouSubtitle }
-						headerBackgroundColor="#fff"
-						headerTextColor="#000"
-					/>
-				) }
+				<ThankYou
+					containerClassName="marketplace-thank-you"
+					sections={ [ setupSection ] }
+					showSupportSection={ true }
+					thankYouImage={ transfer ? thankYouImage : blankImage }
+					thankYouTitle={ transfer && translate( 'All ready to go!' ) }
+					thankYouSubtitle={ pluginOnSite && thankYouSubtitle }
+					headerBackgroundColor="#fff"
+					headerTextColor="#000"
+				/>
 			</ThankYouContainer>
 		</ThemeProvider>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -10,6 +10,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
+import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { updateAdminMenuAfterPluginInstallation } from 'calypso/state/admin-menu/actions';
@@ -137,25 +138,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		],
 		[ translate ]
 	);
-
-	// Duplicate of marketplace-plugin-install/index.tsx, extract if this works
-	const additionalSteps = useMemo(
-		() => [
-			translate( 'Connecting the dots' ),
-			translate( 'Still working' ),
-			translate( 'Wheels are in motion' ),
-			translate( 'Working magic' ),
-			translate( 'Putting the pieces together' ),
-			translate( 'Assembling the parts' ),
-			translate( 'Stacking the building blocks' ),
-			translate( 'Getting our ducks in a row' ),
-			translate( 'Initiating countdown' ),
-			translate( 'Flipping the switches' ),
-			translate( 'Unlocking potential' ),
-			translate( 'Gears are turning' ),
-		],
-		[ translate ]
-	);
+	const additionalSteps = useMarketplaceAdditionalSteps();
 
 	const thankYouImage = {
 		alt: '',

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -43,6 +43,7 @@ const ThankYouContainer = styled.div`
 	}
 `;
 
+const AtomicTransferActive = 'active';
 const AtomicTransferProvisioned = 'provisioned';
 const AtomicTransferRelocating = 'relocating_switcheroo';
 const AtomicTransferComplete = 'completed';
@@ -121,21 +122,18 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite
 	useEffect( () => {
-		if ( ! transfer ) {
-			setCurrentStep( 0 );
-		} else if ( transfer?.status === AtomicTransferComplete && pluginOnSite ) {
-			// Everything done: Step 0
-			setCurrentStep( 0 );
-		} else if ( transfer?.status === AtomicTransferComplete ) {
+		if ( transfer && transfer.status === AtomicTransferComplete && ! pluginOnSite ) {
 			// Transfer is complete, but need to install plugin
 			setCurrentStep( 4 );
-		} else if ( transfer?.status === AtomicTransferRelocating ) {
+		} else if ( transfer && transfer.status === AtomicTransferRelocating ) {
 			setCurrentStep( 3 );
-		} else if ( transfer?.status === AtomicTransferProvisioned ) {
+		} else if ( transfer && transfer.status === AtomicTransferProvisioned ) {
 			setCurrentStep( 2 );
-		} else {
-			// Need to do entire atomic transfer and install plugin
+		} else if ( transfer && transfer.status === AtomicTransferActive ) {
 			setCurrentStep( 1 );
+		} else {
+			// Everything is complete or status unknown
+			setCurrentStep( 0 );
 		}
 	}, [ transfer, pluginOnSite ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -122,13 +122,17 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite
 	useEffect( () => {
-		if ( ! transfer || ( isRequestingPlugins && ! pluginOnSite ) ) {
+		if (
+			typeof transfer === 'undefined' &&
+			typeof pluginOnSite === 'undefined' &&
+			isRequestingPlugins === false
+		) {
 			// Status unknown
-			setCurrentStep( 0 );
+			setCurrentStep( 1 );
 		} else if ( transfer?.status === AtomicTransferComplete && pluginOnSite ) {
 			// Everything done: Step 0
 			setCurrentStep( 0 );
-		} else if ( transfer?.status === AtomicTransferComplete ) {
+		} else if ( transfer?.status === AtomicTransferComplete && ! pluginOnSite ) {
 			// Transfer is complete, but need to install plugin
 			setCurrentStep( 4 );
 		} else if ( transfer?.status === AtomicTransferRelocating ) {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -121,7 +121,9 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite
+	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite.
+	// Step 0 hides the progress bar. It means "complete" or "still loading transfer status".
+	// Steps 1-4 advance through the bar.
 	useEffect( () => {
 		if ( ! transfer ) {
 			setCurrentStep( 0 );
@@ -132,6 +134,13 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		} else if ( transfer?.status === AtomicTransferRelocating ) {
 			setCurrentStep( 3 );
 		} else if ( transfer?.status === AtomicTransferComplete ) {
+			/*
+			 * When we're done transferring, we want to see pluginOnSite to advance
+			 * to step 0 (complete).
+			 * Even after pluginOnSite exists, subsequent requests temporarily set
+			 * pluginOnSite = undefined when there are outstanding network requests.
+			 * Workaround: After seeing pluginOnSite once, we cannot go back to step 4.
+			 */
 			if ( ! pluginOnSite && ! sawPluginOnce ) {
 				setCurrentStep( 4 );
 			} else if ( pluginOnSite && ! sawPluginOnce ) {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -125,6 +125,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Step 0 hides the progress bar. It means "complete" or "still loading transfer status".
 	// Steps 1-4 advance through the bar.
 	const transferStatus = transfer?.status;
+	const isPluginOnSite = !! pluginOnSite;
 	useEffect( () => {
 		if ( transferStatus === AtomicTransferActive ) {
 			setCurrentStep( 1 );
@@ -134,15 +135,15 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			setCurrentStep( 3 );
 		} else if ( transferStatus === AtomicTransferComplete ) {
 			/*
-			 * When we're done transferring, we want to see pluginOnSite to advance
+			 * When we're done transferring, we want to see isPluginOnSite to advance
 			 * to step 0 (complete).
 			 * Even after pluginOnSite exists, subsequent requests temporarily set
 			 * pluginOnSite = undefined when there are outstanding network requests.
-			 * Workaround: After seeing pluginOnSite once, we cannot go back to step 4.
+			 * Workaround: After seeing isPluginOnSite once, we cannot go back to step 4.
 			 */
-			if ( ! pluginOnSite && ! sawPluginOnce ) {
+			if ( ! isPluginOnSite && ! sawPluginOnce ) {
 				setCurrentStep( 4 );
-			} else if ( pluginOnSite && ! sawPluginOnce ) {
+			} else if ( isPluginOnSite && ! sawPluginOnce ) {
 				setCurrentStep( 0 );
 				setSawPluginOnce( true );
 			} else {
@@ -151,7 +152,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		} else {
 			setCurrentStep( 0 );
 		}
-	}, [ transferStatus, pluginOnSite, sawPluginOnce ] );
+	}, [ transferStatus, isPluginOnSite, sawPluginOnce ] );
 
 	const steps = useMemo(
 		() => [

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -108,8 +108,6 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		if ( transfer?.status === AtomicTransferComplete && ! pluginOnSite && ! isRequestingPlugins ) {
 			waitFor( 1 ).then( () => dispatch( fetchSitePlugins( siteId ) ) );
 		}
-		// Do not add retries in dependencies to avoid infinite loop.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isRequestingPlugins, pluginOnSite, dispatch, siteId, transfer ] );
 
 	// Update the menu after the site been transferred to Atomic or after the plugin has

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -63,8 +63,12 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ sawPluginOnce, setSawPluginOnce ] = useState( false );
 
+	const isPluginOnSite = !! pluginOnSite;
+	const transferStatus = transfer?.status;
+
 	// Site is transferring to Atomic.
 	// Poll the transfer status.
+	// The dependencies intentionally use transfer over transferStatus.
 	useEffect( () => {
 		if ( ! siteId || transfer?.status === AtomicTransferComplete ) {
 			return;
@@ -105,10 +109,10 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.
 	useEffect( () => {
-		if ( transfer?.status === AtomicTransferComplete && ! pluginOnSite && ! isRequestingPlugins ) {
+		if ( transferStatus === AtomicTransferComplete && ! pluginOnSite && ! isRequestingPlugins ) {
 			waitFor( 1 ).then( () => dispatch( fetchSitePlugins( siteId ) ) );
 		}
-	}, [ isRequestingPlugins, pluginOnSite, dispatch, siteId, transfer ] );
+	}, [ isRequestingPlugins, pluginOnSite, dispatch, siteId, transferStatus ] );
 
 	// Update the menu after the site been transferred to Atomic or after the plugin has
 	// been installed, since that might change some menu items
@@ -122,8 +126,6 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite.
 	// Step 0 hides the progress bar. It means "complete" or "still loading transfer status".
 	// Steps 1-4 advance through the bar.
-	const transferStatus = transfer?.status;
-	const isPluginOnSite = !! pluginOnSite;
 	useEffect( () => {
 		if ( transferStatus === AtomicTransferActive ) {
 			setCurrentStep( 1 );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -124,14 +124,15 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Set progressbar (currentStep) depending on transfer.status and pluginOnSite.
 	// Step 0 hides the progress bar. It means "complete" or "still loading transfer status".
 	// Steps 1-4 advance through the bar.
+	const transferStatus = transfer?.status;
 	useEffect( () => {
-		if ( transfer?.status === AtomicTransferActive ) {
+		if ( transferStatus === AtomicTransferActive ) {
 			setCurrentStep( 1 );
-		} else if ( transfer?.status === AtomicTransferProvisioned ) {
+		} else if ( transferStatus === AtomicTransferProvisioned ) {
 			setCurrentStep( 2 );
-		} else if ( transfer?.status === AtomicTransferRelocating ) {
+		} else if ( transferStatus === AtomicTransferRelocating ) {
 			setCurrentStep( 3 );
-		} else if ( transfer?.status === AtomicTransferComplete ) {
+		} else if ( transferStatus === AtomicTransferComplete ) {
 			/*
 			 * When we're done transferring, we want to see pluginOnSite to advance
 			 * to step 0 (complete).
@@ -150,7 +151,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		} else {
 			setCurrentStep( 0 );
 		}
-	}, [ transfer, pluginOnSite, sawPluginOnce ] );
+	}, [ transferStatus, pluginOnSite, sawPluginOnce ] );
 
 	const steps = useMemo(
 		() => [

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -14,6 +14,7 @@ import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
+import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps';
 import theme from 'calypso/my-sites/marketplace/theme';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -263,24 +264,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 		],
 		[ isUploadFlow, translate ]
 	);
-
-	const additionalSteps = useMemo(
-		() => [
-			translate( 'Connecting the dots' ),
-			translate( 'Still working' ),
-			translate( 'Wheels are in motion' ),
-			translate( 'Working magic' ),
-			translate( 'Putting the pieces together' ),
-			translate( 'Assembling the parts' ),
-			translate( 'Stacking the building blocks' ),
-			translate( 'Getting our ducks in a row' ),
-			translate( 'Initiating countdown' ),
-			translate( 'Flipping the switches' ),
-			translate( 'Unlocking potential' ),
-			translate( 'Gears are turning' ),
-		],
-		[ translate ]
-	);
+	const additionalSteps = useMarketplaceAdditionalSteps();
 
 	const renderError = () => {
 		// Evaluate error causes in priority order

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+
+function useMarketplaceAdditionalSteps() {
+	const translate = useTranslate();
+	const additionalSteps = useMemo(
+		() => [
+			translate( 'Connecting the dots' ),
+			translate( 'Still working' ),
+			translate( 'Wheels are in motion' ),
+			translate( 'Working magic' ),
+			translate( 'Putting the pieces together' ),
+			translate( 'Assembling the parts' ),
+			translate( 'Stacking the building blocks' ),
+			translate( 'Getting our ducks in a row' ),
+			translate( 'Initiating countdown' ),
+			translate( 'Flipping the switches' ),
+			translate( 'Unlocking potential' ),
+			translate( 'Gears are turning' ),
+		],
+		[ translate ]
+	);
+	return additionalSteps;
+}
+export default useMarketplaceAdditionalSteps;


### PR DESCRIPTION
#### Proposed Changes

* When buying a marketplace plugin on a simple starter site, have the checkout "thank you" page render a progressbar to indicate the atomic transfer

**New String (step 1):**
![2022-07-07_14-40](https://user-images.githubusercontent.com/937354/177858414-c3d9b3fe-edcd-49f4-8f55-914836cdf443.png)

**Step 2:**
![2022-07-07_14-40_1](https://user-images.githubusercontent.com/937354/177858432-0bfe2721-e2bd-4178-9bb7-ec6f6005b2ea.png)

**Step 3:**
![2022-07-07_14-40_2](https://user-images.githubusercontent.com/937354/177858442-9283ac2d-7acc-4628-9fe4-cc9b2a42e3c0.png)


What I have now looks like it needs some work:

https://user-images.githubusercontent.com/937354/177633691-7eab9ee8-6ba1-4dae-ad31-fcba9e89236e.mp4



#### Testing Instructions

* Have a simple site with starter plan
* Buy Xero
* Watch the thank you page

* Also try the page in other contexts (like sites that are already atomic)


Fixes https://github.com/Automattic/wp-calypso/issues/65314
