### PR TITLE
Design Picker: Enable the flag to release the design updates

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -158,7 +158,7 @@
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
-		"signup/theme-preview-screen": false,
+		"signup/theme-preview-screen": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,7 +106,7 @@
 		"signup/site-vertical-step": true,
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
-		"signup/theme-preview-screen": false,
+		"signup/theme-preview-screen": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -119,7 +119,7 @@
 		"signup/site-vertical-step": true,
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
-		"signup/theme-preview-screen": false,
+		"signup/theme-preview-screen": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,7 +119,7 @@
 		"signup/site-vertical-step": true,
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
-		"signup/theme-preview-screen": false,
+		"signup/theme-preview-screen": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,7 @@
 		"signup/site-vertical-step": true,
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
-		"signup/theme-preview-screen": false,
+		"signup/theme-preview-screen": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,


### PR DESCRIPTION
#### Proposed Changes

* Enables the `signup/theme-preview-screen` flag.

<img width="758" alt="Screen Shot 2022-07-06 at 17 16 49" src="https://user-images.githubusercontent.com/1234758/177635478-d5e445ba-9d23-40c1-b76a-460ab7d71ddc.png">
<img width="1512" alt="Screen Shot 2022-07-06 at 17 20 19" src="https://user-images.githubusercontent.com/1234758/177636008-a87c126f-b636-4732-b223-864ed98ee5a8.png">

#### Testing Instructions

* Go to `/setup/designSetup?siteSlug=<SITE-SLUG>`.
* You should see the new features.

Closes #65137
