### PR TITLE
Sites Dashboard: Use icons to indicate site launched status

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -15,9 +15,9 @@ interface Site {
 	slug: string;
 	URL: string;
 	plan: SitePlan;
-	launch_status: string;
-	is_coming_soon: boolean;
-	is_private: boolean;
+	launch_status?: string;
+	is_coming_soon?: boolean;
+	is_private?: boolean;
 }
 
 interface SitePlan {

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -121,7 +121,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							rel="noreferrer"
 							title={ __( 'Visit Site' ) }
 						>
-							<Icon size={ 16 } icon={ icon }></Icon>
+							<Icon size={ 16 } icon={ icon } />
 							<span>{ displaySiteUrl( site.URL ) }</span>
 						</SiteUrl>
 					</div>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,5 +1,5 @@
-import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
+import { Icon, globe, lock, tool } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -91,11 +91,11 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 
 	const isComingSoon =
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
-	let icon = 'globe';
+	let icon = globe;
 	if ( site.is_private && ! isComingSoon ) {
-		icon = 'lock';
+		icon = lock;
 	} else if ( isComingSoon ) {
-		icon = 'customize';
+		icon = tool;
 	}
 
 	return (
@@ -121,7 +121,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							rel="noreferrer"
 							title={ __( 'Visit Site' ) }
 						>
-							<Gridicon size={ 12 } icon={ icon }></Gridicon>
+							<Icon size={ 16 } icon={ icon }></Icon>
 							<span>{ displaySiteUrl( site.URL ) }</span>
 						</SiteUrl>
 					</div>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -14,6 +15,9 @@ interface Site {
 	slug: string;
 	URL: string;
 	plan: SitePlan;
+	launch_status: string;
+	is_coming_soon: boolean;
+	is_private: boolean;
 }
 
 interface SitePlan {
@@ -54,9 +58,14 @@ const SiteName = styled.h2`
 `;
 
 const SiteUrl = styled.a`
+	display: flex;
+	align-items: center;
 	color: var( --studio-gray-60 );
 	&:visited {
 		color: var( --studio-gray-60 );
+	}
+	span {
+		margin-left: 4px;
 	}
 `;
 
@@ -79,6 +88,16 @@ const VisitDashboardItem = ( site: Site ) => {
 
 export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
+
+	const isComingSoon =
+		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
+	let icon = 'globe';
+	if ( site.is_private && ! isComingSoon ) {
+		icon = 'lock';
+	} else if ( isComingSoon ) {
+		icon = 'customize';
+	}
+
 	return (
 		<Row>
 			<td>
@@ -102,7 +121,8 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							rel="noreferrer"
 							title={ __( 'Visit Site' ) }
 						>
-							{ displaySiteUrl( site.URL ) }
+							<Gridicon size={ 12 } icon={ icon }></Gridicon>
+							<span>{ displaySiteUrl( site.URL ) }</span>
 						</SiteUrl>
 					</div>
 				</div>


### PR DESCRIPTION
See #65166

## Proposed Changes

Introduces `@wordpress/icons` to indicate site launched status:

* Public: `globe`
* Private: `lock`
* Coming Soon: `tool`

<img width="644" alt="image" src="https://user-images.githubusercontent.com/36432/177641010-b34dcfdc-c8d0-4b23-926a-4b3179711bf3.png">

**This pull request intentionally does not address all items on the linked issue.** To avoid blocking other team members, I'd like to iterate on the issue over 2-4 pull requests. Please limit feedback to the code submitted on the pull request.

## Testing Instructions

1. Check out the branch locally.
2. Navigate to `/sites-dashboard` and view the new Sites Dashboard.