### PR TITLE
Fix - Issue 65324 - JITM modal style is broken on mobile

### DIFF
--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -25,6 +25,8 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 			min-width: 90vw;
 			left: 5vw;
 			right: 5vw;
+			height: auto;
+			min-height: unset;
 		}
 
 		@media ( min-width: $wpcom-modal-breakpoint ) {
@@ -55,6 +57,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 
 	.components-guide__container {
 		margin-top: 0;
+		min-height: unset;
 	}
 
 	.components-guide__footer {
@@ -62,11 +65,9 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	}
 
 	.components-guide__page {
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		justify-content: start;
-		flex-direction: row;
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			flex-direction: row;
+		}
 	}
 
 	.components-guide__page-control {
@@ -106,9 +107,8 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	flex-direction: column;
 	justify-content: space-between;
 	background: var( --studio-white );
-	width: 100%;
 	height: 100%;
-	padding-left: 7%;
+	padding: 0 7%;
 
 	:last-child {
 		margin-bottom: 5%;
@@ -121,9 +121,9 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		flex-direction: column;
 		justify-content: flex-end;
-		max-width: 60%;
 		min-height: $wpcom-modal-content-min-height;
 		bottom: 0;
+		padding: 0 2% 0 7%;
 	}
 }
 
@@ -131,19 +131,24 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 .modal__visual {
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		flex: 1 auto;
-		min-width: 290px;
 	}
 }
 
 .modal__text {
-	padding: 1em 2em 1em 0;
+	padding: 1em 0;
 	margin: 0;
 	font-family: $sans;
 	font-size: $font-body-small;
+	display: flex;
+	flex-direction: column;
 
 	button,a {
 		margin-top: 13%;
 		padding: 10px 24px;
+	}
+
+	.components-button {
+		align-self: flex-start;
 	}
 }
 
@@ -186,7 +191,6 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 
 	font-size: $font-title-medium;
 	line-height: 1;
-	margin: 0 5% 0 0;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		font-size: $font-headline-small;
@@ -208,8 +212,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		display: block;
 		background-color: var( --studio-blue-5 );
-		height: 100%;
-		width: 90%;
+		min-width: 45%;
 		position: relative;
 		overflow: hidden;
 	}


### PR DESCRIPTION
#### Proposed Changes

* Fixes the reported issue: https://github.com/Automattic/wp-calypso/issues/65324

#### Testing Instructions

* Have a Professional Email subscription
* Visit home page `/home/:site`
* **Expected result:** The Professional Email Embedded Inbox modal should show up, rendering in proper style.

**Desktop** - The modal should close when user clicks on the "x" button (at the top right corner) or anywhere outside the modal.
 
<img width="766" alt="Screen Shot 2022-07-06 at 7 23 29 PM" src="https://user-images.githubusercontent.com/104910361/177659066-20aab412-11e5-4325-9e84-fc244a531dcd.png">

**Mobile** - The modal should close when user clicks on anywhere outside the modal. 

<img width="394" alt="Screen Shot 2022-07-06 at 7 23 54 PM" src="https://user-images.githubusercontent.com/104910361/177659104-8dcdddba-698f-4528-9799-caa8e79987d4.png">

Related to #65324
