### PR TITLE
Checkout: Update PayPal processor to use "pending" page on success

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -49,7 +49,10 @@ export default async function payPalProcessor(
 		currentUrl.searchParams.set( 'cart', 'no-user' );
 	}
 	const cancelUrl = currentUrl.toString();
-	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, siteSlug, undefined, 'absolute' );
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+		siteSlug,
+		urlType: 'absolute',
+	} );
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -6,6 +6,7 @@ import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
+import { addUrlToPendingPageRedirect } from '../lib/pending-page';
 import { createTransactionEndpointCartFromResponseCart } from '../lib/translate-cart';
 import { createWpcomAccountBeforeTransaction } from './create-wpcom-account-before-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
@@ -43,16 +44,12 @@ export default async function payPalProcessor(
 	// endpoints. Otherwise we may end up with an incorrect URL like
 	// 'http://wordpress.com/checkout?cart=no-user#step2?paypal=ABCDEFG'.
 	currentUrl.hash = '';
-	// The successUrl must always be absolute but getThankYouUrl can return
-	// relative paths, so we must check.
-	const successUrl = thankYouUrl.startsWith( 'http' )
-		? thankYouUrl
-		: currentUrl.origin + thankYouUrl;
 	if ( createUserAndSiteBeforeTransaction ) {
 		// It's not clear if this is still required but it may be.
 		currentUrl.searchParams.set( 'cart', 'no-user' );
 	}
 	const cancelUrl = currentUrl.toString();
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, siteSlug, undefined, 'absolute' );
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -49,7 +49,8 @@ describe( 'payPalExpressProcessor', () => {
 		country: '',
 		domain_details: null,
 		postal_code: '',
-		success_url: 'https://example.com/thank-you',
+		success_url:
+			'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
 		tos: {
 			locale: 'en',
 			path: '/',
@@ -112,6 +113,8 @@ describe( 'payPalExpressProcessor', () => {
 		).resolves.toStrictEqual( expected );
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
+			success_url:
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',
@@ -148,6 +151,8 @@ describe( 'payPalExpressProcessor', () => {
 		).resolves.toStrictEqual( expected );
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
+			success_url:
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',
@@ -176,6 +181,8 @@ describe( 'payPalExpressProcessor', () => {
 		).resolves.toStrictEqual( expected );
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
+			success_url:
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',
@@ -265,7 +272,8 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
-			success_url: 'https://wordpress.com/thank-you',
+			success_url:
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '0',
@@ -298,7 +306,8 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
-			success_url: 'https://wordpress.com/thank-you',
+			success_url:
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '0',

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -50,7 +50,7 @@ describe( 'payPalExpressProcessor', () => {
 		domain_details: null,
 		postal_code: '',
 		success_url:
-			'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
+			'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 		tos: {
 			locale: 'en',
 			path: '/',
@@ -114,7 +114,7 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			success_url:
-				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',
@@ -152,7 +152,7 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			success_url:
-				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',
@@ -182,7 +182,7 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			success_url:
-				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '1234567',
@@ -273,7 +273,7 @@ describe( 'payPalExpressProcessor', () => {
 			...basicExpectedRequest,
 			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '0',
@@ -307,7 +307,7 @@ describe( 'payPalExpressProcessor', () => {
 			...basicExpectedRequest,
 			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: '0',


### PR DESCRIPTION
#### Proposed Changes

In this PR we try to organize some of the post-checkout redirect behavior by making the PayPal payment method redirect to the "pending" page after checkout completes like we do with Stripe redirect payment methods (eg: 3DS, Bancontact, iDeal). The "pending" page will then send the browser to the final redirect location. Previously the user's browser was redirected immediately after returning from PayPal to the final destination, but this is inconsistent with the other payment methods and means that post-checkout code has to be implemented in two or even three locations.

Along with https://github.com/Automattic/wp-calypso/pull/65273, this will make it so we have a single location inside calypso where we can run functions after a purchase is complete. Currently many parts of the code assume (quite understandably) that the `onPaymentComplete` prop of the `CheckoutProvider` component will run when the payment is complete, but it does not run for redirect payment methods because the transaction hasn't been completed (nor even started) by the time we redirect to the payment partner.

This is part of implementing https://github.com/Automattic/wp-calypso/issues/53356

Requires D83820-code

#### Screenshots

Here's an example of the "pending" page and final page for a Starter Plan:

<img width="652" alt="pending-page" src="https://user-images.githubusercontent.com/2036909/178382533-1776d748-bd80-4950-b334-a3289744fa1b.png">

<img width="706" alt="post-checkout" src="https://user-images.githubusercontent.com/2036909/178382611-03b5649c-ca69-4ef1-b460-eb76a1a86cdc.png">

#### Testing Instructions

- Add a plan to your cart and visit checkout using this branch.
- Complete the checkout form and select PayPal as the payment method. 
- Complete the purchase and confirm it at PayPal.
- Verify that you briefly see the "Please wait…" pending page in calypso.
- Verify that you are then redirected to a final post-checkout page (this usually will be something like `/checkout/thank-you/:site/:receiptId` but it depends on a lot of factors) that is not the generic thank-you page (`/checkout/thank-you/:site/pending` or `/checkout/thank-you/:site/unknown`).
