### PR TITLE
Help Center: Scaffold testing environment for help center components

### DIFF
--- a/packages/help-center/jest.config.js
+++ b/packages/help-center/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
 	setupFiles: [ '<rootDir>/jestSetup.ts' ],
 	testEnvironment: 'jsdom',
 	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'jsx', 'json', 'node' ],
-	transformIgnorePatterns: [ 'node_modules/(?!react-native|react-navigation)/' ],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/help-center/jest.config.js
+++ b/packages/help-center/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	setupFiles: [ '<rootDir>/jestSetup.ts' ],
 	testEnvironment: 'jsdom',
-	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'jsx', 'json', 'node' ],
+	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'json' ],
 	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/help-center/jest.config.js
+++ b/packages/help-center/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
+	setupFiles: [ '<rootDir>/jestSetup.ts' ],
 	testEnvironment: 'jsdom',
+	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'jsx', 'json', 'node' ],
+	transformIgnorePatterns: [ 'node_modules/(?!react-native|react-navigation)/' ],
 };

--- a/packages/help-center/jestSetup.ts
+++ b/packages/help-center/jestSetup.ts
@@ -1,0 +1,7 @@
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+	__esModule: true,
+	default: function config( key: string ) {
+		return key;
+	},
+} ) );

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router-dom';
 import type { FC } from 'react';
 import '../styles.scss';
 
-type Props = { onClick?: () => void; backToRoot?: boolean };
+export type Props = { onClick?: () => void; backToRoot?: boolean };
 
 export const BackButton: FC< Props > = ( { onClick, backToRoot = false } ) => {
 	const { __ } = useI18n();

--- a/packages/help-center/src/components/test/back-button.js
+++ b/packages/help-center/src/components/test/back-button.js
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+import { shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { BackButton } from '../back-button.tsx';
+
+const mockHistoryPush = jest.fn();
+const mockHistoryGoBack = jest.fn();
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useHistory: () => ( {
+		push: mockHistoryPush,
+		goBack: mockHistoryGoBack,
+	} ),
+} ) );
+
+function renderWrapper( props ) {
+	return shallow(
+		<MemoryRouter>
+			<BackButton { ...props } />
+		</MemoryRouter>
+	);
+}
+
+describe( 'BackButton', () => {
+	describe( 'when the user clicks the back button', () => {
+		describe( 'and the system decides to navigate back home', () => {
+			it( 'navigates back home', () => {
+				const wrapper = renderWrapper( { backToRoot: true } );
+				const button = wrapper.find( BackButton ).dive();
+				button.simulate( 'click' );
+				expect( mockHistoryPush.mock.calls.length ).toBe( 1 );
+			} );
+		} );
+
+		describe( 'and the system decides to navigate to the previous page', () => {
+			it( 'navigates to the previous page', () => {
+				const wrapper = renderWrapper( { backToRoot: false } );
+				const button = wrapper.find( BackButton ).dive();
+				button.simulate( 'click' );
+				expect( mockHistoryGoBack.mock.calls.length ).toBe( 1 );
+			} );
+		} );
+
+		describe( 'and the system decides to navigate to a custom page', () => {
+			it( 'navigates to the custom page', () => {
+				const onClickSpy = jest.fn();
+				const wrapper = renderWrapper( { onClick: onClickSpy } );
+
+				const button = wrapper.find( BackButton ).dive();
+				button.simulate( 'click' );
+
+				expect( onClickSpy.mock.calls.length ).toBe( 1 );
+			} );
+		} );
+	} );
+} );

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -2,9 +2,9 @@
  * @jest-environment jsdom
  */
 /* eslint-disable import/no-extraneous-dependencies */
+import { Button } from '@automattic/components';
 import { shallow } from 'enzyme';
-import { MemoryRouter } from 'react-router-dom';
-import { BackButton } from '../back-button.tsx';
+import { BackButton, Props } from '../back-button';
 
 const mockHistoryPush = jest.fn();
 const mockHistoryGoBack = jest.fn();
@@ -16,12 +16,8 @@ jest.mock( 'react-router-dom', () => ( {
 	} ),
 } ) );
 
-function renderWrapper( props ) {
-	return shallow(
-		<MemoryRouter>
-			<BackButton { ...props } />
-		</MemoryRouter>
-	);
+function renderWrapper( props: Props ) {
+	return shallow( <BackButton { ...props } /> );
 }
 
 describe( 'BackButton', () => {
@@ -29,7 +25,7 @@ describe( 'BackButton', () => {
 		describe( 'and the system decides to navigate back home', () => {
 			it( 'navigates back home', () => {
 				const wrapper = renderWrapper( { backToRoot: true } );
-				const button = wrapper.find( BackButton ).dive();
+				const button = wrapper.find( Button );
 				button.simulate( 'click' );
 				expect( mockHistoryPush.mock.calls.length ).toBe( 1 );
 			} );
@@ -38,7 +34,7 @@ describe( 'BackButton', () => {
 		describe( 'and the system decides to navigate to the previous page', () => {
 			it( 'navigates to the previous page', () => {
 				const wrapper = renderWrapper( { backToRoot: false } );
-				const button = wrapper.find( BackButton ).dive();
+				const button = wrapper.find( Button );
 				button.simulate( 'click' );
 				expect( mockHistoryGoBack.mock.calls.length ).toBe( 1 );
 			} );
@@ -49,7 +45,7 @@ describe( 'BackButton', () => {
 				const onClickSpy = jest.fn();
 				const wrapper = renderWrapper( { onClick: onClickSpy } );
 
-				const button = wrapper.find( BackButton ).dive();
+				const button = wrapper.find( Button );
 				button.simulate( 'click' );
 
 				expect( onClickSpy.mock.calls.length ).toBe( 1 );


### PR DESCRIPTION
#### Proposed Changes

* Set up unit testing environment for help center components
* Mock calypso config global
* Create new help center back button unit tests

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the calypso repo in a terminal
* Run `yarn test-packages help-center`
* Verify that the specs are passing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64336
