### PR TITLE
WP Toolbar location changed from settings/writing to settings/general section (#16631).

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -51,6 +51,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import SiteIconSetting from './site-icon-setting';
 import wrapSettingsForm from './wrap-settings-form';
+import Masterbar from './masterbar';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentDidMount() {
@@ -165,6 +166,23 @@ export class SiteSettingsFormGeneral extends Component {
 							</Button>
 						</div>
 					</div>
+				) }
+			</>
+		);
+	}
+
+	toolbarOption() {
+		const { isRequestingSettings, isSavingSettings, siteIsJetpack, siteIsAtomic } = this.props;
+
+		const isNonAtomicJetpackSite = siteIsJetpack && ! siteIsAtomic;
+
+		return (
+			<>
+				{ isNonAtomicJetpackSite && (
+					<Masterbar
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+					/>
 				) }
 			</>
 		);
@@ -640,6 +658,8 @@ export class SiteSettingsFormGeneral extends Component {
 				</Card>
 
 				{ this.props.isUnlaunchedSite ? this.renderLaunchSite() : this.privacySettings() }
+
+				{ this.toolbarOption() }
 
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -179,6 +179,7 @@ export class SiteSettingsFormGeneral extends Component {
 		return (
 			<>
 				{ isNonAtomicJetpackSite && (
+					// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
 					<Masterbar
 						isSavingSettings={ isSavingSettings }
 						isRequestingSettings={ isRequestingSettings }
@@ -659,8 +660,6 @@ export class SiteSettingsFormGeneral extends Component {
 
 				{ this.props.isUnlaunchedSite ? this.renderLaunchSite() : this.privacySettings() }
 
-				{ this.toolbarOption() }
-
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">
 						<SettingsSectionHeader
@@ -695,6 +694,8 @@ export class SiteSettingsFormGeneral extends Component {
 						) }
 					</div>
 				) }
+
+				{ this.toolbarOption() }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -49,9 +49,9 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import Masterbar from './masterbar';
 import SiteIconSetting from './site-icon-setting';
 import wrapSettingsForm from './wrap-settings-form';
-import Masterbar from './masterbar';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentDidMount() {

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -12,7 +12,6 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
-import Masterbar from './masterbar';
 import MediaSettingsWriting from './media-settings-writing';
 import PressThis from './press-this';
 import PublishingTools from './publishing-tools';

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -35,7 +35,6 @@ class SiteSettingsFormWriting extends Component {
 			handleAutosavingRadio,
 			handleSubmitForm,
 			isPodcastingSupported,
-			isMasterbarSectionVisible,
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
@@ -141,13 +140,6 @@ class SiteSettingsFormWriting extends Component {
 						<PressThis />
 					</div>
 				) }
-
-				{ isMasterbarSectionVisible && (
-					<Masterbar
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-					/>
-				) }
 			</form>
 		);
 	}
@@ -163,10 +155,6 @@ const connectComponent = connect(
 		return {
 			siteIsJetpack,
 			siteId,
-			isMasterbarSectionVisible:
-				siteIsJetpack &&
-				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
-				! isAtomic,
 			isPodcastingSupported,
 			isAtomic,
 		};

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -25,6 +25,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import editorReducer from 'calypso/state/editor/reducer';
+import jetpackReducer from 'calypso/state/jetpack/reducer';
 import mediaReducer from 'calypso/state/media/reducer';
 import siteSettingsReducer from 'calypso/state/site-settings/reducer';
 import timezonesReducer from 'calypso/state/timezones/reducer';
@@ -55,6 +56,7 @@ const initialState = {
 		byContinents: {},
 	},
 	ui: {},
+	jetpack: {},
 };
 
 function renderWithRedux( ui ) {
@@ -66,6 +68,7 @@ function renderWithRedux( ui ) {
 			siteSettings: siteSettingsReducer,
 			timezones: timezonesReducer,
 			ui: uiReducer,
+			jetpack: jetpackReducer,
 		},
 	} );
 }


### PR DESCRIPTION
#### Proposed Changes

WP Toolbar location changed from settings/writing to settings/general section.

*

#### Testing Instructions

Notice that "WordPress.com Toolbar" card is shifted from settings/writing to settings/general section.

Before: (It is in Writing section) - Screenshot:
<img width="1254" alt="Screenshot 2022-07-07 at 11 38 50 AM" src="https://user-images.githubusercontent.com/3984908/177705486-94df3c1c-0bc2-4c24-b459-0cc588a5f753.png">


After: (It is removed from Writing section & put in General section.) - Screenshot:
<img width="1247" alt="Screenshot 2022-07-07 at 11 39 10 AM" src="https://user-images.githubusercontent.com/3984908/177705503-a93ac583-e82d-46f7-9269-7d52bf069f41.png">


*

Fixes: https://github.com/Automattic/wp-calypso/issues/16631


Related to #16631 
