### PR TITLE
Plans Overhaul: AB test add-ons step in signup

### DIFF
--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -22,7 +22,7 @@ import type { ReactElement } from 'react';
 const globalOverrides = css`
 	.is-section-add-ons {
 		#content.layout__content {
-			background: red;
+			background: #fdfdfd;
 		}
 	}
 `;

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -22,7 +22,7 @@ import type { ReactElement } from 'react';
 const globalOverrides = css`
 	.is-section-add-ons {
 		#content.layout__content {
-			background: #fdfdfd;
+			background: red;
 		}
 	}
 `;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -112,6 +112,17 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'with-add-ons',
+			steps: isEnabled( 'signup/professional-email-step' )
+				? [ 'user', 'domains', 'emails', 'plans', 'add-ons' ]
+				: [ 'user', 'domains', 'plans', 'add-ons' ],
+			destination: getSignupDestination,
+			description:
+				'Copy of the onboarding flow that includes an add-ons step; the flow is used for AB testing (ExPlat) add-ons in signup',
+			lastModified: '2022-07-07',
+			showRecaptcha: true,
+		},
+		{
 			name: 'onboarding-with-email',
 			steps: getAddOnsStep( [ 'user', 'domains', 'emails', 'plans' ] ),
 			destination: getSignupDestination,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -180,6 +180,7 @@
 		"launch-site",
 		"onboarding",
 		"onboarding-with-email",
+		"with-add-ons",
 		"setup-site",
 		"account",
 		"do-it-for-me",


### PR DESCRIPTION
#### Proposed Changes

Experiment code for the add-ons steps in Signup (`onboarding` flow). 
Addresses 834-gh-Automattic/martech

* D82535-code should ship along to enable the menu item in Calypso admin

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For debugging, run in console: `localStorage.setItem( 'debug', 'calypso:signup' );`

- [ ] when navigating to `/start` while assigned to treatment of `wpcom_calypso_signup_addons` experiment, you should get the `with-add-ons` flow
    - [ ] when advancing from `/start/domains` you should land on `/start/with-add-ons/plans`
- [ ] after picking a Free domain (or "Skip Purchase") in `/start/with-add-ons/domains`
    - [ ] the option to select a Free plan should show in `/start/with-add-ons/plans`
    - [ ] selecting a Free plan should land on `/start/with-add-ons/add-ons` step
- [ ] navigating back should work as expected
- [ ] all the above should work also when starting as a logged-out user

#### TODO

- [ ] Update experiment name once decided. Currently defined as `wpcom_calypso_signup_addons`
- [ ] are we ok with the `with-add-ons` flow injected in the URL? do we prefer a different name?
- [ ] D82535-code should ship along to enable the menu item in Calypso admin

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#834