### PR TITLE
Theme Showcase: Update forum support card description for Premium and WordPress.org themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -53,6 +53,7 @@ import {
 	isThemePremium,
 	isPremiumThemeAvailable,
 	isWpcomTheme as isThemeWpcom,
+	isWporgTheme,
 	getCanonicalTheme,
 	getPremiumThemePrice,
 	getThemeDetailsUrl,
@@ -443,8 +444,8 @@ class ThemeSheet extends Component {
 			return null;
 		}
 
-		const description = this.props.isPremium
-			? this.props.translate( 'Get in touch with the theme author' )
+		const description = this.props.isWporg
+			? this.props.translate( 'Get help from the theme author and WordPress.org community' )
 			: this.props.translate( 'Get help from volunteers and staff' );
 
 		return (
@@ -890,6 +891,7 @@ export default connect(
 			backPath,
 			isCurrentUserPaid,
 			isWpcomTheme,
+			isWporg: isWporgTheme( state, id ),
 			isLoggedIn: isUserLoggedIn( state ),
 			isActive: isThemeActive( state, id, siteId ),
 			isJetpack,


### PR DESCRIPTION
#### Proposed Changes

* Changes description copy for Premium and WordPress.org themes on the forums support card on the individual theme support page in the theme showcase

#### Premium themes

When viewing the "Support" page for a premium WordPress.com theme, currently the card description reads:

`Get in touch with the theme author`

![Videomaker_Theme_‹_kokkiestrialtestsite_—_WordPress_com](https://user-images.githubusercontent.com/11873759/177783829-5b9ac375-72b3-49af-aad8-01835a5f7744.png)

This is a leftover from when we had separate forums for each premium theme on WordPress.com, staffed by the theme authors for third party themes. However, those forums were all retired when we retired legacy premium themes, and support for our new in-house premium themes are provided via regular support channels. The Forums card on the theme support page directs to the general Themes subforum (which is being retired - once #64987 is merged it will go to the forums homepage), so the description on that card is misleading.

This PR changes the description copy to be the same as for free WordPress.com themes:

`Get help from volunteers and staff`

![Videomaker_Theme_‹_kokkiestrialtestsite_—_WordPress_com](https://user-images.githubusercontent.com/11873759/177784379-f3daffa5-50db-459b-8e89-543c5fd4ff74.png)

#### WordPress.org themes

If you view a non-Automattic theme in the theme showcase, and the theme has a WordPress.org forum, we display a forums support card in the theme showcase, linking to that WordPress.org forums. Currently the description on that card reads:

`Get help from volunteers and staff`

![Storefront_Theme_‹_kokkiestrialtestsite_—_WordPress_com](https://user-images.githubusercontent.com/11873759/177784096-83227721-fbde-4951-b08a-e5f43da0cf28.png)

This is misleading as there aren't any "staff" in the WordPress.org forums. This is especially problematic for Atomic site owners who could interpret that to mean WordPress.com staff.

This PR changes the description copy to the following:

`Get help from the theme author and WordPress.org community`

![Storefront_Theme_‹_kokkiestrialtestsite_—_WordPress_com](https://user-images.githubusercontent.com/11873759/177784251-bfadd232-03b6-4c6d-97a9-a7ec285d8dfd.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to /themes/[site] on a Simple, Atomic and Jetpack-connected site in turn
* Select a WordPress.com premium theme (e.g. Videomaker), from the showcase
* On the theme description page, click on the Support tab
* The copy on the Forums support card should read `Get help from volunteers and staff`
* Edit the URL to view the Support tab for a WordPress.org theme instead, e.g. theme/storefront/support/[site]
* The copy on the Forums support card should read `Get help from the theme author and WordPress.org community`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64969 and Fixes #64988 - this simply replaces the `isPremium` check to show unique copy for Premium themes, with a `isWporg` check instead, to show unique copy for WordPress.org themes.
