### PR TITLE
Sites Dashboard: Indicate launch status with labels

### DIFF
--- a/client/sites-dashboard/components/sites-launch-status-badge.tsx
+++ b/client/sites-dashboard/components/sites-launch-status-badge.tsx
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+const SitesLaunchStatusBadge = styled.span`
+	font-size: 12px;
+	font-weight: 400;
+	color: var( --studio-gray-80 );
+	background-color: var( --studio-gray-5 );
+	padding: 0px 10px;
+	border-radius: 4px;
+	line-height: 20px;
+	display: inline-block;
+`;
+
+export default SitesLaunchStatusBadge;

--- a/client/sites-dashboard/components/sites-p2-badge.tsx
+++ b/client/sites-dashboard/components/sites-p2-badge.tsx
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+const SitesLaunchStatusBadge = styled.span`
+	font-size: 12px;
+	font-weight: 400;
+	color: #fff;
+	background-color: #2b65f6;
+	padding: 0px 10px;
+	border-radius: 4px;
+	line-height: 20px;
+	display: inline-block;
+`;
+
+export default SitesLaunchStatusBadge;

--- a/client/sites-dashboard/components/sites-p2-badge.tsx
+++ b/client/sites-dashboard/components/sites-p2-badge.tsx
@@ -1,14 +1,9 @@
 import styled from '@emotion/styled';
+import SitesLaunchStatusBadge from './sites-launch-status-badge';
 
-const SitesLaunchStatusBadge = styled.span`
-	font-size: 12px;
-	font-weight: 400;
+const SitesP2Badge = styled( SitesLaunchStatusBadge )`
 	color: #fff;
 	background-color: #2b65f6;
-	padding: 0px 10px;
-	border-radius: 4px;
-	line-height: 20px;
-	display: inline-block;
 `;
 
-export default SitesLaunchStatusBadge;
+export default SitesP2Badge;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -67,26 +67,12 @@ const VisitDashboardItem = ( { site }: { site: SiteData } ) => {
 	);
 };
 
-const P2Badge = ( { site }: { site: SiteData } ) => {
-	if ( site.options && site.options.is_wpforteams_site ) {
-		return <SitesP2Badge>P2</SitesP2Badge>;
-	}
-	return null;
-};
-
-const LaunchStatusBadge = ( { site }: { site: SiteData } ) => {
-	const isComingSoon =
-		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
-	if ( site.is_private && ! isComingSoon ) {
-		return <SitesLaunchStatusBadge>Private</SitesLaunchStatusBadge>;
-	} else if ( isComingSoon ) {
-		return <SitesLaunchStatusBadge>Coming soon</SitesLaunchStatusBadge>;
-	}
-	return null;
-};
-
 export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
+
+	const isComingSoon =
+		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
+	const isP2Site = site.options?.is_wpforteams_site;
 
 	return (
 		<Row>
@@ -106,7 +92,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 									{ site.name ? site.name : __( '(No Site Title)' ) }
 								</a>
 							</SiteName>
-							<P2Badge site={ site } />
+							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 						</div>
 						<div>
 							<SiteUrl
@@ -118,7 +104,10 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							>
 								{ displaySiteUrl( site.URL ) }
 							</SiteUrl>
-							<LaunchStatusBadge site={ site } />
+							{ site.is_private && ! isComingSoon && (
+								<SitesLaunchStatusBadge>Private</SitesLaunchStatusBadge>
+							) }
+							{ isComingSoon && <SitesLaunchStatusBadge>Coming soon</SitesLaunchStatusBadge> }
 						</div>
 					</div>
 				</div>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -3,21 +3,12 @@ import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SitesLaunchStatusBadge from './sites-launch-status-badge';
+import SitesP2Badge from './sites-p2-badge';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SiteTableRowProps {
-	site: Site;
-}
-
-interface Site {
-	ID: number;
-	name: string;
-	slug: string;
-	URL: string;
-	plan: SitePlan;
-}
-
-interface SitePlan {
-	product_name_short: string;
+	site: SiteData;
 }
 
 const Row = styled.tr`
@@ -44,7 +35,6 @@ const SiteName = styled.h2`
 	font-size: 16px;
 	letter-spacing: -0.4px;
 	color: var( --studio-gray-100 );
-	margin-bottom: 8px;
 	a {
 		color: inherit;
 		&:hover {
@@ -68,7 +58,7 @@ const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
 };
 
-const VisitDashboardItem = ( site: Site ) => {
+const VisitDashboardItem = ( site: SiteData ) => {
 	const { __ } = useI18n();
 	return (
 		<PopoverMenuItem href={ getDashboardUrl( site.slug ) }>
@@ -77,8 +67,27 @@ const VisitDashboardItem = ( site: Site ) => {
 	);
 };
 
+const P2Badge = ( site: SiteData ) => {
+	if ( site.options && site.options.is_wpforteams_site ) {
+		return <SitesP2Badge>P2</SitesP2Badge>;
+	}
+	return null;
+};
+
+const LaunchStatusBadge = ( site: SiteData ) => {
+	const isComingSoon =
+		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
+	if ( site.is_private && ! isComingSoon ) {
+		return <SitesLaunchStatusBadge>Private</SitesLaunchStatusBadge>;
+	} else if ( isComingSoon ) {
+		return <SitesLaunchStatusBadge>Coming soon</SitesLaunchStatusBadge>;
+	}
+	return null;
+};
+
 export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
+
 	return (
 		<Row>
 			<td>
@@ -91,19 +100,26 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 						<SiteIcon siteId={ site.ID } size={ 50 } />
 					</a>
 					<div style={ { marginLeft: '20px' } }>
-						<SiteName>
-							<a href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
-								{ site.name ? site.name : __( '(No Site Title)' ) }
-							</a>
-						</SiteName>
-						<SiteUrl
-							href={ site.URL }
-							target="_blank"
-							rel="noreferrer"
-							title={ __( 'Visit Site' ) }
-						>
-							{ displaySiteUrl( site.URL ) }
-						</SiteUrl>
+						<div style={ { display: 'flex', alignItems: 'center', marginBottom: '8px' } }>
+							<SiteName style={ { marginRight: '8px' } }>
+								<a href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
+									{ site.name ? site.name : __( '(No Site Title)' ) }
+								</a>
+							</SiteName>
+							{ P2Badge( site ) }
+						</div>
+						<div>
+							<SiteUrl
+								href={ site.URL }
+								target="_blank"
+								rel="noreferrer"
+								title={ __( 'Visit Site' ) }
+								style={ { marginRight: '8px' } }
+							>
+								{ displaySiteUrl( site.URL ) }
+							</SiteUrl>
+							{ LaunchStatusBadge( site ) }
+						</div>
 					</div>
 				</div>
 			</td>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -58,7 +58,7 @@ const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
 };
 
-const VisitDashboardItem = ( site: SiteData ) => {
+const VisitDashboardItem = ( { site }: { site: SiteData } ) => {
 	const { __ } = useI18n();
 	return (
 		<PopoverMenuItem href={ getDashboardUrl( site.slug ) }>
@@ -67,14 +67,14 @@ const VisitDashboardItem = ( site: SiteData ) => {
 	);
 };
 
-const P2Badge = ( site: SiteData ) => {
+const P2Badge = ( { site }: { site: SiteData } ) => {
 	if ( site.options && site.options.is_wpforteams_site ) {
 		return <SitesP2Badge>P2</SitesP2Badge>;
 	}
 	return null;
 };
 
-const LaunchStatusBadge = ( site: SiteData ) => {
+const LaunchStatusBadge = ( { site }: { site: SiteData } ) => {
 	const isComingSoon =
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 	if ( site.is_private && ! isComingSoon ) {
@@ -106,7 +106,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 									{ site.name ? site.name : __( '(No Site Title)' ) }
 								</a>
 							</SiteName>
-							{ P2Badge( site ) }
+							<P2Badge site={ site } />
 						</div>
 						<div>
 							<SiteUrl
@@ -118,7 +118,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							>
 								{ displaySiteUrl( site.URL ) }
 							</SiteUrl>
-							{ LaunchStatusBadge( site ) }
+							<LaunchStatusBadge site={ site } />
 						</div>
 					</div>
 				</div>
@@ -126,7 +126,9 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 			<td className="sites-table-row__mobile-hidden">{ site.plan.product_name_short }</td>
 			<td className="sites-table-row__mobile-hidden"></td>
 			<td style={ { width: '20px' } }>
-				<EllipsisMenu>{ VisitDashboardItem( site ) }</EllipsisMenu>
+				<EllipsisMenu>
+					<VisitDashboardItem site={ site } />
+				</EllipsisMenu>
 			</td>
 		</Row>
 	);


### PR DESCRIPTION
See #65166

## Proposed Changes

Uses labels to indicate launch status (and P2 sites):

<img width="654" alt="image" src="https://user-images.githubusercontent.com/36432/177786510-e028c045-1f2c-4dd0-a8d6-6b9989103f9b.png">

**This pull request intentionally does not address all items on the linked issue.** To avoid blocking other team members, I'd like to iterate on the issue over 2-4 pull requests. Please limit feedback to the code submitted on the pull request.

## Testing Instructions

1. Check out the branch locally.
2. Navigate to `/sites-dashboard` and view the new Sites Dashboard.