### PR TITLE
Seller Experience: Removes info button until further notice

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useStarterDesignsGeneratedQuery } from '@automattic/data-stores';
 import DesignPicker, {
 	GeneratedDesignPicker,
@@ -32,7 +32,6 @@ import { STEP_NAME } from './constants';
 import GeneratedDesignPickerWebPreview from './generated-design-picker-web-preview';
 import PreviewToolbar from './preview-toolbar';
 import StickyPositioner from './sticky-positioner';
-import ThemeInfoPopup from './theme-info-popup';
 import UpgradeModal from './upgrade-modal';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
@@ -74,36 +73,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const isEligibleForProPlan = useSelect(
 		( select ) => site && select( SITE_STORE ).isEligibleForProPlan( site.ID )
 	);
-	const [ showInfoPopup, setShowInfoPopup ] = useState( false );
-
-	// Setup a click handler to close the info popup when the user clicks anywhere outside the popup.
-	useEffect( () => {
-		const closeInfoPopup = ( e: any ) => {
-			if ( ! e.isTrusted ) {
-				return;
-			}
-			const infoPopup = document.querySelector( '.site-setup.design-setup .theme-info-popup' );
-			const isInfoPopupButton = e.target.classList.contains( 'design-setup__info-popover' );
-			const isInfoPopupButtonParent = e.target.parentNode.classList.contains(
-				'design-setup__info-popover'
-			);
-			const isInfoPopup = e.target === infoPopup;
-			const isChildOfInfoPopup = infoPopup?.contains( e.target );
-
-			// Don't use this close handler if the info button or popup or anything inside the popup is clicked.
-			if ( isInfoPopupButton || isInfoPopupButtonParent || isInfoPopup || isChildOfInfoPopup ) {
-				return;
-			}
-
-			setShowInfoPopup( false );
-		};
-
-		document.body.addEventListener( 'click', closeInfoPopup );
-
-		return function cleanup() {
-			window.removeEventListener( 'click', closeInfoPopup );
-		};
-	}, [] );
 
 	const siteVerticalId = useSelect(
 		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || ''
@@ -433,18 +402,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		if ( newDesignEnabled ) {
 			actionButtons = (
 				<div>
-					<button
-						type="button"
-						className={ 'design-setup__info-popover' }
-						onClick={ ( e ) => {
-							e.preventDefault();
-
-							setShowInfoPopup( ! showInfoPopup );
-						} }
-					>
-						<Gridicon fill={ 'white' } icon={ 'info-outline' } size={ 24 } />
-					</button>
-
 					{ shouldUpgrade ? (
 						<Button primary borderless={ false } onClick={ upgradePlan }>
 							{ translate( 'Unlock theme' ) }
@@ -460,7 +417,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 
 		return (
 			<>
-				{ showInfoPopup && selectedDesign && <ThemeInfoPopup slug={ selectedDesign.slug } /> }
 				<StepContainer
 					stepName={ STEP_NAME }
 					stepContent={ stepContent }


### PR DESCRIPTION
See related issue for context.

#### Testing
1. Apply this diff.
2. Go to `/setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`.
3. Select a theme.
4. Verify you don't see the info button.

Closes https://github.com/Automattic/wp-calypso/issues/65360
