### PR TITLE
Prevent Media Library Item from appearing in wrong day

### DIFF
--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -145,10 +145,7 @@ export class MediaLibraryList extends Component {
 	};
 
 	getItemGroup = ( item ) => {
-		const minDate = Math.min(
-			new Date( item.date.slice( 0, 10 ) ).getTime(),
-			new Date().getTime()
-		);
+		const minDate = Math.min( new Date( item.date ).getTime(), new Date().getTime() );
 		return this.props.moment( minDate ).format( 'YYYY-MM-DD' );
 	};
 


### PR DESCRIPTION
Fixes #54610

#### Proposed Changes

* No longer truncate the time portion of the item's date, it was causing it to move backwards a day for users in timezones west of GMT. This should be fine for users east of GMT since the time is stored with timezone information and moment should take care of displaying the correct formatted date string.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start`
* Visit the media library
* Upload an image or video
* Once upload is complete, the media item shouldn't move to the previous day

