### PR TITLE
WoA: Stop recommending default static file 404

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -136,7 +136,7 @@ const WebServerSettingsCard = ( {
 
 	const getStaticFile404Settings = () => [
 		{
-			label: translate( 'Default (recommended)', {
+			label: translate( 'Default', {
 				comment: 'The default way to handle requests for nonexistent static files.',
 			} ),
 			value: 'default',


### PR DESCRIPTION
#### Proposed Changes

Stop recommending the default for static file 404s. The default is to delegate to WordPress, and since we going to start explicitly selecting lightweight static file 404s for new WoA sites, we don't want users to return to default because it is recommended.

##### Before

![web-server-settings-before](https://user-images.githubusercontent.com/530877/177820500-884bc12a-24f2-419e-b34c-bfe50692c37c.png)

##### After

![web-server-settings-after](https://user-images.githubusercontent.com/530877/177820516-1c19eb45-a358-4297-a984-3884f190b493.png)

