### PR TITLE
Signup: enable add-on flow on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,7 +112,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/professional-email-step": false,
-		"signup/add-ons": false,
+		"signup/add-ons": true,
 		"signup/anchor-fm": true,
 		"signup/reskin": true,
 		"signup/social": true,


### PR DESCRIPTION
In order to help with internal testing, this enables the `signup/add-ons` flag for the wpcalypso environment.

See: p1657209706969079/1657195189.815009-slack-C031TFM2NKC

**To test:**
- a visual check should suffice
- after merging, the add-ons step will be appended to free flows at `wpcalypso.wordpress.com/start/`