### PR TITLE
Stepper: Allow data to be passed from navigate() to the next step component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,8 +1,10 @@
+import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect } from 'react';
 import Modal from 'react-modal';
 import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from 'react-router-dom';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import SignupHeader from 'calypso/signup/signup-header';
 import recordStepStart from './analytics/record-step-start';
 import * as Steps from './steps-repository';
@@ -32,13 +34,21 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentRoute = location.pathname.substring( 1 ).replace( /\/+$/, '' ) as StepPath;
 	const history = useHistory();
 	const { search } = useLocation();
-	const stepNavigation = flow.useStepNavigation( currentRoute, ( path ) => {
+	const { setStepData } = useDispatch( STEPPER_INTERNAL_STORE );
+	const stepNavigation = flow.useStepNavigation( currentRoute, async ( path, extraData = null ) => {
+		// If any extra data is passed to the navigate() function, store it to the stepper-internal store.
+		if ( extraData ) {
+			setStepData( extraData );
+		}
+
 		const _path = path.includes( '?' ) // does path contain search params
 			? generatePath( '/' + path )
 			: generatePath( '/' + path + search );
 
 		history.push( _path, stepPaths );
 	} );
+	// Retrieve any extra step data from the stepper-internal store. This will be passed as a prop to the current step.
+	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() );
 
 	flow.useSideEffect?.();
 
@@ -63,7 +73,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 
 		const StepComponent = Steps[ path ];
-		return <StepComponent navigation={ stepNavigation } flow={ flow.name } />;
+		return <StepComponent navigation={ stepNavigation } flow={ flow.name } data={ stepData } />;
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -33,7 +33,7 @@ export type UseStepHook = () => StepPath[];
 
 export type UseStepNavigationHook = (
 	currentStep: StepPath,
-	navigate: ( stepName: StepPath | `${ StepPath }?${ string }` ) => void,
+	navigate: ( stepName: StepPath | `${ StepPath }?${ string }`, extraData?: any ) => void,
 	steps?: StepPath[]
 ) => NavigationControls;
 
@@ -54,6 +54,7 @@ export type Flow = {
 export type StepProps = {
 	navigation: NavigationControls;
 	flow: string | null;
+	data?: Record< string, unknown >;
 };
 
 export type Step = React.FC< StepProps >;


### PR DESCRIPTION
#### Proposed Changes

We use the new stepper-internal data store. Data is passed to `navigate()` and then pushed to the stepData reducer of stepper-internal.

When the next step is rendered, any existing stepData is passed as a prop to the step component.

#### Testing Instructions

See #65378 for a proof-of-concept showing this new functionality.

Closes #64781
