### PR TITLE
POC: Passing data through navigate() to a step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,8 +1,10 @@
+import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect } from 'react';
 import Modal from 'react-modal';
 import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from 'react-router-dom';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import SignupHeader from 'calypso/signup/signup-header';
 import recordStepStart from './analytics/record-step-start';
 import * as Steps from './steps-repository';
@@ -32,13 +34,21 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentRoute = location.pathname.substring( 1 ).replace( /\/+$/, '' ) as StepPath;
 	const history = useHistory();
 	const { search } = useLocation();
-	const stepNavigation = flow.useStepNavigation( currentRoute, ( path ) => {
+	const { setStepData } = useDispatch( STEPPER_INTERNAL_STORE );
+	const stepNavigation = flow.useStepNavigation( currentRoute, async ( path, extraData = null ) => {
+		// If any extra data is passed to the navigate() function, store it to the stepper-internal store.
+		if ( extraData ) {
+			setStepData( extraData );
+		}
+
 		const _path = path.includes( '?' ) // does path contain search params
 			? generatePath( '/' + path )
 			: generatePath( '/' + path + search );
 
 		history.push( _path, stepPaths );
 	} );
+	// Retrieve any extra step data from the stepper-internal store. This will be passed as a prop to the current step.
+	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() );
 
 	flow.useSideEffect?.();
 
@@ -63,7 +73,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 
 		const StepComponent = Steps[ path ];
-		return <StepComponent navigation={ stepNavigation } flow={ flow.name } />;
+		return <StepComponent navigation={ stepNavigation } flow={ flow.name } data={ stepData } />;
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -14,7 +14,7 @@ const WarningsOrHoldsSection = styled.div`
 	margin-top: 40px;
 `;
 
-const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
+const ErrorStep: Step = function ErrorStep( { navigation, flow, data } ) {
 	const { goBack, goNext } = navigation;
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
@@ -26,16 +26,30 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
-	const defaultBodyText =
-		flow !== 'anchor-fm'
-			? __(
-					'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
-			  )
-			: __(
-					'It looks like something went wrong while setting up your site. Return to Anchor or continue with site creation.'
-			  );
+	let headerText = __( "We've hit a snag" );
+	let defaultBodyText = __(
+		'It looks like something went wrong while setting up your site. Return to Anchor or continue with site creation.'
+	);
 
-	const headerText = siteSetupError?.error || __( "We've hit a snag" );
+	// Default body text for the Anchor flow.
+	if ( flow === 'anchor-fm' ) {
+		defaultBodyText = __(
+			'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+		);
+	}
+
+	// Override the default body text with data passed from navigate().
+	if ( data?.message ) {
+		defaultBodyText = data.message as string;
+	}
+
+	// Override the header text with data passed from navigate().
+	if ( data?.error ) {
+		headerText = data.error as string;
+	}
+
+	// Setup error text from the SITE_STORE take precendece over everything.
+	headerText = siteSetupError?.error || headerText;
 	const bodyText = siteSetupError?.message || defaultBodyText;
 
 	const getContent = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { isEnabled } from '@automattic/calypso-config';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { IntentScreen, StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -18,9 +16,8 @@ import './style.scss';
 /**
  * The intent capture step
  */
-const IntentStep: Step = function IntentStep( { navigation } ) {
+const IntentStep: Step = function IntentStep( { navigation, data } ) {
 	const { goBack, goNext, submit } = navigation;
-	const isEnglishLocale = useIsEnglishLocale();
 	const translate = useTranslate();
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
@@ -45,34 +42,38 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 		submit?.( providedDependencies, intent );
 	};
 
+	const extraData = data as Record< string, any >;
+
 	return (
-		<StepContainer
-			stepName={ 'intent-step' }
-			headerImageUrl={ intentImageUrl }
-			goBack={ goBack }
-			goNext={ goNext }
-			skipLabelText={ translate( 'Skip to dashboard' ) }
-			skipButtonAlign={ 'top' }
-			hideBack={ ! ( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale ) }
-			isHorizontalLayout={ true }
-			formattedHeader={
-				<FormattedHeader
-					id={ 'intent-header' }
-					headerText={ headerText }
-					subHeaderText={ subHeaderText }
-					align={ 'left' }
-				/>
-			}
-			stepContent={
-				<IntentScreen
-					intents={ intents }
-					intentsAlt={ intentsAlt }
-					onSelect={ submitIntent }
-					preventWidows={ preventWidows }
-				/>
-			}
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			{ extraData?.message && <h1>{ extraData.message }</h1> }
+			<StepContainer
+				stepName={ 'intent-step' }
+				headerImageUrl={ intentImageUrl }
+				goBack={ goBack }
+				goNext={ goNext }
+				skipLabelText={ translate( 'Skip to dashboard' ) }
+				skipButtonAlign={ 'top' }
+				isHorizontalLayout={ true }
+				formattedHeader={
+					<FormattedHeader
+						id={ 'intent-header' }
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+						align={ 'left' }
+					/>
+				}
+				stepContent={
+					<IntentScreen
+						intents={ intents }
+						intentsAlt={ intentsAlt }
+						onSelect={ submitIntent }
+						preventWidows={ preventWidows }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -15,7 +13,7 @@ import type { Step } from '../../types';
 import type { Vertical } from 'calypso/components/select-vertical/types';
 
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
-	const { goBack, goNext, submit } = navigation;
+	const { goNext, submit } = navigation;
 	const [ vertical, setVertical ] = React.useState< Vertical | null >();
 	const [ isBusy, setIsBusy ] = React.useState( false );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
@@ -27,8 +25,6 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const headerText = translate( 'What’s your website about?' );
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
-	const isEnglishLocale = useIsEnglishLocale();
-	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
 
 	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
 		setVertical( vertical );
@@ -60,34 +56,67 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	}
 
 	return (
-		<StepContainer
-			stepName={ 'site-vertical' }
-			goBack={ goalsCaptureStepEnabled ? goBack : undefined }
-			goNext={ goNext }
-			headerImageUrl={ siteVerticalImage }
-			skipLabelText={ translate( 'Skip to dashboard' ) }
-			skipButtonAlign={ 'top' }
-			isHorizontalLayout={ true }
-			hideBack={ ! goalsCaptureStepEnabled }
-			formattedHeader={
-				<FormattedHeader
-					id={ 'site-vertical-header' }
-					headerText={ headerText }
-					subHeaderText={ subHeaderText }
-					align={ 'left' }
-				/>
-			}
-			stepContent={
-				<SiteVerticalForm
-					defaultVertical={ siteVertical }
-					isSkipSynonyms={ Boolean( isSkipSynonyms ) }
-					isBusy={ isBusy }
-					onSelect={ handleSiteVerticalSelect }
-					onSubmit={ handleSubmit }
-				/>
-			}
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			<StepContainer
+				stepName={ 'site-vertical' }
+				goNext={ goNext }
+				headerImageUrl={ siteVerticalImage }
+				skipLabelText={ translate( 'Skip to dashboard' ) }
+				skipButtonAlign={ 'top' }
+				isHorizontalLayout={ true }
+				hideBack={ true }
+				formattedHeader={
+					<FormattedHeader
+						id={ 'site-vertical-header' }
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+						align={ 'left' }
+					/>
+				}
+				stepContent={
+					<>
+						<button
+							onClick={ ( e ) => {
+								e.preventDefault();
+								submit?.( { data: { error: 'OH NO! 🙀', message: 'This is an error message!' } } );
+							} }
+							className="button site-vertical__submit-button is-primary"
+							style={ {
+								position: 'absolute',
+								bottom: '249px',
+								right: '280px',
+							} }
+						>
+							Error 1
+						</button>
+						<button
+							onClick={ ( e ) => {
+								e.preventDefault();
+								submit?.( {
+									data: { error: '😱😱😱😱😱', message: 'Something else bad happened!' },
+								} );
+							} }
+							className="button site-vertical__submit-button is-primary"
+							style={ {
+								position: 'absolute',
+								bottom: '249px',
+								right: '130px',
+							} }
+						>
+							Error 2
+						</button>
+						<SiteVerticalForm
+							defaultVertical={ siteVertical }
+							isSkipSynonyms={ Boolean( isSkipSynonyms ) }
+							isBusy={ isBusy }
+							onSelect={ handleSiteVerticalSelect }
+							onSubmit={ handleSubmit }
+						/>
+					</>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -33,7 +33,7 @@ export type UseStepHook = () => StepPath[];
 
 export type UseStepNavigationHook = (
 	currentStep: StepPath,
-	navigate: ( stepName: StepPath | `${ StepPath }?${ string }` ) => void,
+	navigate: ( stepName: StepPath | `${ StepPath }?${ string }`, extraData?: any ) => void,
 	steps?: StepPath[]
 ) => NavigationControls;
 
@@ -54,6 +54,7 @@ export type Flow = {
 export type StepProps = {
 	navigation: NavigationControls;
 	flow: string | null;
+	data?: Record< string, unknown >;
 };
 
 export type Step = React.FC< StepProps >;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -324,6 +324,12 @@ export const siteSetupFlow: Flow = {
 				}
 
 				case 'vertical': {
+					const data = providedDependencies.data as Record< string, any >;
+
+					if ( data?.error ) {
+						return navigate( 'error', data );
+					}
+
 					if ( goalsStepEnabled ) {
 						if ( goals.includes( SiteGoal.Import ) ) {
 							return navigate( 'import' );


### PR DESCRIPTION
#### Proposed Changes

This is a a proof-of-concept PR for testing the functionality in #65377 and is not intended to be merged.

#### Testing Instructions

- Apply this branch
- Go to http://calypso.localhost:3000/setup/vertical?siteSlug=[slug]
- You should see the following screen
![image](https://user-images.githubusercontent.com/917632/177835531-ccbc06b6-19b7-4d32-bc56-0c7a0d7ff96f.png)

- Clicking "Error 1" should take you to the error step with the message "This is an error message!".
- Clicking "Error 2" should take you to the error step with the message "Something else bad happened!"


Related to #64781
