### PR TITLE
Mailbox forms: Switch to using individual useState() hooks for <MailboxesForm/>

### DIFF
--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -221,7 +221,8 @@ const MailboxesForm = ( {
 	emailProduct: ProductListItem | null;
 	goToEmail: () => void;
 } ): JSX.Element => {
-	const [ state, setState ] = useState( { isValidating: false, isAddingToCart: false } );
+	const [ isAddingToCart, setIsAddingToCart ] = useState( false );
+	const [ isValidating, setIsValidating ] = useState( false );
 
 	const cartKey = useCartKey();
 	const cartManager = useShoppingCart( cartKey );
@@ -261,24 +262,25 @@ const MailboxesForm = ( {
 			} );
 		};
 
-		setState( { ...state, isValidating: true } );
+		setIsValidating( true );
 		if (
 			! ( await mailboxOperations.validateAndCheck( mailProperties.isAdditionalMailboxesPurchase ) )
 		) {
 			recordContinueEvent( { canContinue: false } );
-			setState( { ...state, isValidating: false } );
+			setIsValidating( false );
 			return;
 		}
 
+		setIsValidating( false );
 		recordContinueEvent( { canContinue: true } );
-		setState( { ...state, isAddingToCart: true } );
+		setIsAddingToCart( true );
 
 		cartManager
 			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )
 			.then( () => {
 				page( '/checkout/' + selectedSite.slug );
 			} )
-			.finally( () => setState( { ...state, isAddingToCart: false } ) );
+			.finally( () => setIsAddingToCart( false ) );
 	};
 
 	return (
@@ -287,7 +289,7 @@ const MailboxesForm = ( {
 
 			<Card>
 				<NewMailBoxList
-					areButtonsBusy={ state.isAddingToCart || state.isValidating }
+					areButtonsBusy={ isAddingToCart || isValidating }
 					onSubmit={ onSubmit }
 					onCancel={ onCancel }
 					provider={ provider }


### PR DESCRIPTION
We recently discovered we are not correctly updating the state based on previous values. 

From the React [documentation](https://reactjs.org/docs/react-component.html#setstate): `setState()` does not always immediately update the component. It may batch or defer the update until later. This makes reading this.state right after calling `setState()` a potential pitfall.

#### Proposed Changes

* Switch to using individual hooks per state variable so that we do not need to read a previous value, nor update value based on a previous state.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a site/domain with an existing email subscription
* Visit the Email plan page and attempt to add new mailboxes i.e. [ **Updates** ] -> [ **Emails** ] -> [ :**domain** ] -> [ **Add new mailboxes** ]
* Confirm that you can add a new mailbox to checkout
* Confirm that the validation works as before

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
