### PR TITLE
Design Picker: Add header border to match design proposed

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -191,6 +191,8 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	 * Design Preview
 	 */
 	.design-setup__preview {
+		border-top: 1px solid #eee;
+		
 		.step-container__header {
 			margin-top: 40px;
 


### PR DESCRIPTION
#### Proposed Changes

* Add a line to the header to match de design proposed.

![Screen Shot 2022-07-07 at 14 45 33](https://user-images.githubusercontent.com/1234758/177836897-230acd32-82c0-49e3-8ffc-cbd92e61b49d.png)

#### Testing Instructions

* Go to `/setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`
* Select a theme, you should see the line below the header.

Closes #65357
