### PR TITLE
Plugin Details: Update banner position.

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -17,7 +17,6 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
 	const selectedSite = useSelector( getSelectedSite );
-	const banner = plugin.banners?.high || plugin.banners?.low;
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsHeaderPlaceholder />;
@@ -29,11 +28,6 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 
 	return (
 		<div className="plugin-details-header__container">
-			{ Boolean( banner ) && (
-				<div className="plugin-details-header__banner">
-					<img className="plugin-details-header__banner-image" alt={ plugin.name } src={ banner } />
-				</div>
-			) }
 			<div className="plugin-details-header__main-info">
 				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
 				<div className="plugin-details-header__title-container">
@@ -98,7 +92,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	);
 };
 
-const LegacyPluginDetailsHeader = ( { plugin } ) => {
+function LegacyPluginDetailsHeader( { plugin } ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
@@ -154,10 +148,10 @@ const LegacyPluginDetailsHeader = ( { plugin } ) => {
 			</div>
 		</div>
 	);
-};
+}
 
 const LIMIT_OF_TAGS = 3;
-const Tags = ( { plugin } ) => {
+function Tags( { plugin } ) {
 	const selectedSite = useSelector( getSelectedSite );
 
 	if ( ! plugin?.tags ) {
@@ -179,9 +173,9 @@ const Tags = ( { plugin } ) => {
 			) ) }
 		</span>
 	);
-};
+}
 
-const PluginDetailsHeaderPlaceholder = () => {
+function PluginDetailsHeaderPlaceholder() {
 	return (
 		<div className="plugin-details-header__wrapper is-placeholder">
 			<div className="plugin-details-header__tags">...</div>
@@ -192,6 +186,6 @@ const PluginDetailsHeaderPlaceholder = () => {
 			</div>
 		</div>
 	);
-};
+}
 
 export default PluginDetailsHeader;

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -231,7 +230,6 @@ class PluginSections extends Component {
 		} );
 		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
 		const videoUrl = this.props.plugin?.banner_video_src;
-		const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
 		/*eslint-disable react/no-danger*/
 		if (
@@ -273,15 +271,14 @@ class PluginSections extends Component {
 
 		return (
 			<div ref={ this.descriptionContent } className={ contentClasses }>
-				{ legacyVersion && (
-					<div className="plugin-sections__banner">
-						<img
-							className="plugin-sections__banner-image"
-							alt={ this.props.plugin.name }
-							src={ banner }
-						/>
-					</div>
-				) }
+				<div className="plugin-sections__banner">
+					<img
+						className="plugin-sections__banner-image"
+						alt={ this.props.plugin.name }
+						src={ banner }
+					/>
+				</div>
+
 				<div
 					// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
 					dangerouslySetInnerHTML={ {


### PR DESCRIPTION
#### Proposed Changes

Before this change, the banner was shown on the top of the page.
After this change, the banner is shown after the header and within the content.

#### Testing Instructions

* Enable the feature flag `plugins/plugin-details-layout`*
* Go to a plugins page with a banner. Ex: `/plugins/woocommerce-subscriptions`
* Check if it looks like the layout below:

| Before  | After |
| ------------- | ------------- |
|<img width="662" alt="Screen Shot 2022-07-07 at 14 32 05" src="https://user-images.githubusercontent.com/5039531/177846406-4c1b16b6-e11a-4e0b-82fe-0868afabb258.png">|<img width="662" alt="Screen Shot 2022-07-07 at 14 31 48" src="https://user-images.githubusercontent.com/5039531/177846468-cbea29f9-6293-4acb-b430-cdd71c784c49.png">|



\* To enable this feature flag add `?flags=plugins/plugin-details-layout` to the end of your URL or past the following code on the developer tools console `document.cookie = 'flags=plugins/plugin-details-layout;max-age=1209600;path=/'`

---
