### PR TITLE
Design Picker: Remove the header line

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -191,8 +191,6 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	 * Design Preview
 	 */
 	.design-setup__preview {
-		border-top: 1px solid #eee;
-		
 		.step-container__header {
 			margin-top: 40px;
 


### PR DESCRIPTION
#### Proposed Changes

* Removes the header line for the theme preview page.

#### Testing Instructions

* Go to `/setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`
* Select a theme, you should no longer the see the line below the header.


