### PR TITLE
Site Switcher: Track "Switch Site" and "All My Sites" click

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -15,6 +15,7 @@ import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
 import searchSites from 'calypso/components/search-sites';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
@@ -211,6 +212,7 @@ export class SiteSelector extends Component {
 	};
 
 	onAllSitesSelect = ( event ) => {
+		this.props.recordTracksEvent( 'calypso_all_my_sites_click' );
 		this.onSiteSelect( event, ALL_SITES );
 	};
 
@@ -562,5 +564,5 @@ const mapState = ( state ) => {
 export default flow(
 	localize,
 	searchSites,
-	connect( mapState, { navigateToSite } )
+	connect( mapState, { navigateToSite, recordTracksEvent } )
 )( SiteSelector );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -8,7 +8,7 @@ import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
@@ -33,6 +33,7 @@ class CurrentSite extends Component {
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.setLayoutFocus( 'sites' );
+		this.props.recordTracksEvent( 'calypso_switch_site_click' );
 		this.props.recordGoogleEvent( 'Sidebar', 'Clicked Switch Site' );
 	};
 
@@ -118,6 +119,7 @@ export default connect(
 	} ),
 	{
 		recordGoogleEvent,
+		recordTracksEvent,
 		setLayoutFocus,
 		savePreference,
 	}


### PR DESCRIPTION
#### Proposed Changes

Add track events so we can understand the impact of the changes shipped with the Sites Management Dashboard.

#### Testing Instructions

- checkout this branch and start local Calypso;
- run `localStorage.setItem( 'debug', 'calypso:analytics' );` in the dev console so you can see the tracks events being dispatched;
- select a site in Calypso;
- click the `Switch Site` button and check that a Tracks event called `calypso_switch_site_click` was dispatched:

![image](https://user-images.githubusercontent.com/26530524/177876023-24c101cb-fb7b-435b-b8c5-cefe9c1e3168.png)

- click the `All My Sites` button and check that a tracks event called `calypso_all_my_sites_click` was dispatched:

![image](https://user-images.githubusercontent.com/26530524/177876104-09964d76-4628-4e61-942a-add08c06a469.png)

You should be able to find both events in Tracks. The events should also fire on Jetpack Cloud.

Fixes #65353.