### PR TITLE
Checkout: Redirect from the pending page to generic thank-you if no order ID

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -19,9 +19,10 @@ import {
 } from 'calypso/state/order-transactions/constants';
 import getOrderTransaction from 'calypso/state/selectors/get-order-transaction';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
+import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
 
 interface CheckoutPendingProps {
-	orderId: number;
+	orderId: number | ':orderId';
 	siteSlug?: string;
 	redirectTo?: string;
 }
@@ -44,10 +45,19 @@ interface CheckoutPendingProps {
  * case, that string will be replaced by the receipt ID when the transaction
  * completes.
  */
-function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProps ) {
+function CheckoutPending( {
+	orderId: orderIdOrPlaceholder,
+	siteSlug,
+	redirectTo,
+}: CheckoutPendingProps ) {
+	const orderId = isValidOrderId( orderIdOrPlaceholder ) ? orderIdOrPlaceholder : undefined;
 	const translate = useTranslate();
-	const transaction = useSelector( ( state ) => getOrderTransaction( state, orderId ) );
-	const error = useSelector( ( state ) => getOrderTransactionError( state, orderId ) );
+	const transaction: OrderTransaction | null = useSelector( ( state ) =>
+		orderId ? getOrderTransaction( state, orderId ) : null
+	);
+	const error = useSelector( ( state ) =>
+		orderId ? getOrderTransactionError( state, orderId ) : undefined
+	);
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
 	const { reloadFromServer: reloadCart } = useShoppingCart( cartKey );
@@ -80,6 +90,17 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 
 			page( failRedirectUrl );
 		};
+
+		if ( ! orderId ) {
+			// If the order ID is missing, we don't know what to do because there's no
+			// way to know the status of the transaction. If this happens it's
+			// definitely a bug, but let's keep the existing behavior and send the user
+			// to a generic thank-you page, assuming that the purchase was successful.
+			// This goes to the URL path `/checkout/thank-you/:site/:receiptId`.
+			didRedirect.current = true;
+			page( `/checkout/thank-you/${ siteSlug ?? 'no-site' }/unknown` );
+			return;
+		}
 
 		const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
 
@@ -151,11 +172,11 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 		if ( error ) {
 			retryOnError();
 		}
-	}, [ error, redirectTo, reduxDispatch, siteSlug, transaction, translate, reloadCart ] );
+	}, [ error, redirectTo, reduxDispatch, siteSlug, transaction, translate, reloadCart, orderId ] );
 
 	return (
 		<Main className="checkout-thank-you__pending">
-			<QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } />
+			{ orderId && <QueryOrderTransaction orderId={ orderId } pollIntervalMs={ 5000 } /> }
 			<PageViewTracker
 				path={
 					siteSlug
@@ -173,6 +194,10 @@ function CheckoutPending( { orderId, siteSlug, redirectTo }: CheckoutPendingProp
 			/>
 		</Main>
 	);
+}
+
+function isValidOrderId( orderId: number | ':orderId' ): orderId is number {
+	return Number.isInteger( orderId );
 }
 
 function performRedirect( url: string ): void {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -202,17 +202,24 @@ export function redirectJetpackLegacyPlans( context, next ) {
 }
 
 export function checkoutPending( context, next ) {
-	const orderId = Number( context.params.orderId );
+	const orderId = Number.isInteger( Number( context.params.orderId ) )
+		? Number( context.params.orderId )
+		: ':orderId';
+
+	/**
+	 * @type {string|undefined}
+	 */
 	const siteSlug = context.params.site;
+
+	/**
+	 * @type {string|undefined}
+	 */
+	const redirectTo = context.query.redirectTo;
 
 	setSectionMiddleware( { name: 'checkout-pending' } )( context );
 
 	context.primary = (
-		<CheckoutPending
-			orderId={ orderId }
-			siteSlug={ siteSlug }
-			redirectTo={ context.query.redirectTo }
-		/>
+		<CheckoutPending orderId={ orderId } siteSlug={ siteSlug } redirectTo={ redirectTo } />
 	);
 
 	next();


### PR DESCRIPTION
#### Proposed Changes

When checkout completes, it sometimes redirects to a "pending" page which polls the orders endpoint until the transaction is successful or fails, at which point it redirects to the final post-checkout page (as defined by the `redirectTo` query param) or back to checkout, respectively.

The URL that brings the browser to the "pending" page must include an order ID so that the page can determine the status of the transaction. This is usually provided by the transaction endpoints (eg: `/me/transactions/source-payment`) as part of the payment processing flow. In https://github.com/Automattic/wp-calypso/pull/65273 and D83802-code we create an explicit placeholder for that order ID (previously the order ID was just appended directly but this behavior will be removed).

Because bugs happen, it's possible that a user may somehow end up back at calypso with the placeholder still present in the URL instead of a real order ID. If this happens, the user might be stuck on the "pending" page forever with no clarity about what has happened. 

In this PR we modify the pending page to handle that failure case by sending the user to a generic "thank-you" page. (This is not an ideal flow, but it matches the current behavior before we add the explicit order ID placeholder. See D83802-code for an explanation of why the explicit placeholder should be an improvement.)

This is part of implementing https://github.com/Automattic/wp-calypso/issues/53356

#### Testing Instructions

Manually visit `/checkout/thank-you/no-site/pending/:orderId` on this branch and verify that you are redirected to a generic thank-you page.