### PR TITLE
Showing new plans to legacy Personal and Premium

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -6,6 +6,8 @@ import {
 	PLAN_FREE,
 	PLAN_WPCOM_FLEXIBLE,
 	PLAN_WPCOM_STARTER,
+	TYPE_STARTER,
+	TYPE_PRO,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
@@ -94,6 +96,14 @@ export const PlansComparisonAction: React.FunctionComponent< Props > = ( {
 	if ( ! isInSignup ) {
 		if ( isCurrentPlan ) {
 			return <Button disabled>{ translate( 'This is your plan' ) }</Button>;
+		}
+
+		if (
+			( currentSitePlanSlug === 'value_bundle' && [ TYPE_STARTER ].includes( plan.type ) ) ||
+			( currentSitePlanSlug === 'business-bundle' &&
+				[ TYPE_STARTER, TYPE_PRO ].includes( plan.type ) )
+		) {
+			return <Button disabled>{ translate( 'Unavailable' ) }</Button>;
 		}
 
 		if ( [ TYPE_FLEXIBLE, TYPE_FREE ].includes( plan.type ) ) {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -30,7 +30,6 @@ import { useExperiment } from 'calypso/lib/explat';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
-import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -3,6 +3,8 @@ import {
 	getPlan,
 	getIntervalTypeForTerm,
 	PLAN_FREE,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
 	PLAN_WPCOM_STARTER,
@@ -171,9 +173,14 @@ class Plans extends Component {
 
 		if (
 			eligibleForProPlan &&
-			[ PLAN_FREE, PLAN_WPCOM_FLEXIBLE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO ].includes(
-				currentPlan?.productSlug
-			)
+			[
+				PLAN_FREE,
+				PLAN_WPCOM_FLEXIBLE,
+				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO,
+				PLAN_PERSONAL,
+				PLAN_PREMIUM,
+			].includes( currentPlan?.productSlug )
 		) {
 			return (
 				<PlansComparison

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -246,7 +246,6 @@ class Plans extends Component {
 							/>
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />
-								{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
 								{ this.renderPlansMain() }
 								<PerformanceTrackerStop />
 							</div>

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -9,7 +9,6 @@ import {
 	IndividualPurchasePage,
 	CartCheckoutPage,
 	TestAccount,
-	NoticeComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -43,12 +42,6 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 
 		it( `${ planName } is the active plan`, async function () {
 			await plansPage.validateActivePlan( planTier );
-		} );
-
-		it( 'Legacy plan notice is shown', async function () {
-			const noticeComponent = new NoticeComponent( page );
-			const message = `You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.`;
-			await noticeComponent.noticeShown( message );
 		} );
 	} );
 

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -9,6 +9,7 @@ import {
 	IndividualPurchasePage,
 	CartCheckoutPage,
 	TestAccount,
+	NoticeComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -27,7 +28,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
-		plansPage = new PlansPage( page, 'legacy' );
+		plansPage = new PlansPage( page, 'current' );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {
@@ -42,6 +43,12 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 
 		it( `${ planName } is the active plan`, async function () {
 			await plansPage.validateActivePlan( planTier );
+		} );
+
+		it( 'Legacy plan notice is shown', async function () {
+			const noticeComponent = new NoticeComponent( page );
+			const message = `You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.`;
+			await noticeComponent.noticeShown( message );
 		} );
 	} );
 


### PR DESCRIPTION
#### Proposed Changes
The PR updates the Plans page in Calypso admin to show the new plans to customers on the legacy Personal and Premium plans, and allows the users to select a higher plan.

For example, legacy Personal plan customers can choose either Starter or Pro. Legacy Premium plan customers can choose only Pro. 

I've left the current experience as-is for Business and Ecommerce plan customers because it seems like a bad experience to display two plans they are not able to switch to (by now, all legacy plan customers are outside of the refund window).

Here are screens showing various scenarios:

**Legacy Premium customer:**

<img width="1263" alt="CleanShot 2022-07-07 at 17 34 05@2x" src="https://user-images.githubusercontent.com/35781181/177877829-bc9eafa3-9a3b-4063-bb9b-3ffa00fae6f6.png">

--

**Legacy Business customer:**

<img width="1262" alt="CleanShot 2022-07-07 at 17 34 25@2x" src="https://user-images.githubusercontent.com/35781181/177877844-640d8d65-073a-46d5-8c30-efd4c0776265.png">

--

**Legacy Personal customer:**

<img width="1267" alt="CleanShot 2022-07-07 at 17 35 54@2x" src="https://user-images.githubusercontent.com/35781181/177877861-0b8d40e9-3911-4f47-9d42-35d6f489f244.png">

--

**Here's a shot of checkout page with credits applied:**

<img width="944" alt="CleanShot 2022-07-07 at 17 41 18@2x" src="https://user-images.githubusercontent.com/35781181/177878037-4c4a32b2-7030-49b4-8142-a6df66c8ab5b.png">

--


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso locally
* Navigate to Calypso using accounts on legacy plans
* Confirm that:
  * Personal plan customers are able to select either Starter or Pro.
  * Premium plan customers are only able to select Pro.
  * Business and Ecom customers still see the legacy plans grid.
  * Free users see the new plan options.
  * Starter and Pro users see the new plan options.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #63875
