### PR TITLE
calypso-e2e: wait for response from `plans` endpoint to complete in mobile viewport.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -154,9 +154,12 @@ export class PlansPage {
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
 		if ( this.version === 'legacy' && envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.page.waitForResponse( ( response ) =>
-				response.url().includes( '/images/wpcom-ecommerce' )
-			);
+			await Promise.all( [
+				this.page.waitForResponse( /plans\?/ ),
+				this.page.waitForResponse( ( response ) =>
+					response.url().includes( '/images/wpcom-ecommerce' )
+				),
+			] );
 		}
 
 		await clickNavTab( this.page, targetTab );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -54,7 +54,6 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 
 	describe( 'Renew Plan', function () {
 		it( `Details of purchased plan ${ planTier } are shown`, async function () {
-			const plansPage = new PlansPage( page, 'legacy' );
 			await plansPage.clickManagePlan();
 
 			individualPurchasesPage = new IndividualPurchasePage( page );


### PR DESCRIPTION
#### Proposed Changes

This PR addresses flakiness seen in https://github.com/Automattic/wp-calypso/issues/65393.

Key changes:
- wait for the request to `plans` endpoint to complete if the test is run using mobile viewport with legacy plans grid.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

Fixes https://github.com/Automattic/wp-calypso/issues/65393.
