### PR TITLE
Enable all FTM flows for all languages

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -55,6 +55,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const isEnglishLocale = useIsEnglishLocale();
+	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -97,7 +98,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		[ staticDesigns ]
 	);
 
-	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale;
+	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 
 	const enabledGeneratedDesigns =
 		verticalsStepEnabled &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -21,6 +21,7 @@ import './style.scss';
 const IntentStep: Step = function IntentStep( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
 	const isEnglishLocale = useIsEnglishLocale();
+	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const translate = useTranslate();
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
@@ -53,7 +54,7 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 			goNext={ goNext }
 			skipLabelText={ translate( 'Skip to dashboard' ) }
 			skipButtonAlign={ 'top' }
-			hideBack={ ! ( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale ) }
+			hideBack={ ! ( isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM ) }
 			isHorizontalLayout={ true }
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -28,7 +28,8 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
 	const isEnglishLocale = useIsEnglishLocale();
-	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
+	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
+	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
 	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
 		setVertical( vertical );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -31,10 +31,11 @@ export const siteSetupFlow: Flow = {
 
 	useSteps() {
 		const isEnglishLocale = useIsEnglishLocale();
+		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 
 		return [
-			...( isEnabled( 'signup/goals-step' ) && isEnglishLocale ? [ 'goals' ] : [] ),
-			...( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale ? [ 'vertical' ] : [] ),
+			...( isEnabled( 'signup/goals-step' ) && isEnabledFTM ? [ 'goals' ] : [] ),
+			...( isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM ? [ 'vertical' ] : [] ),
 			'intent',
 			'options',
 			'designSetup',
@@ -78,6 +79,7 @@ export const siteSetupFlow: Flow = {
 		const site = useSite();
 		const currentUser = useSelector( getCurrentUser );
 		const isEnglishLocale = useIsEnglishLocale();
+		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 		const urlQueryParams = useQuery();
 
 		let siteSlug: string | null = null;
@@ -98,8 +100,8 @@ export const siteSetupFlow: Flow = {
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
-		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale;
-		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
+		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
+		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
 		// Set up Step progress for Woo flow - "Step 2 of 4"
 		if ( intent === 'sell' && storeType === 'power' ) {

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -46,7 +46,8 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 	const displayCost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_DIFM_LITE ) );
 	const isLoading = useSelector( isProductsListFetching );
 	const isEnglishLocale = useIsEnglishLocale();
-	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
+	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
+	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
 	const getBackUrl = ( siteSlug?: string ) => {
 		const step = goalsCaptureStepEnabled ? 'goals' : 'intent';

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": false,
+		"signup/ftm-flow-non-en": true,
 		"signup/hero-flow-non-en": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,6 +100,7 @@
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": false,
+		"signup/ftm-flow-non-en": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/production.json
+++ b/config/production.json
@@ -113,6 +113,7 @@
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": false,
+		"signup/ftm-flow-non-en": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -113,6 +113,7 @@
 		"signup/goals-step": true,
 		"signup/goals-step-2": false,
 		"signup/inline-help": false,
+		"signup/ftm-flow-non-en": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,6 +123,7 @@
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": false,
+		"signup/ftm-flow-non-en": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/seller-upgrade-modal": false,


### PR DESCRIPTION
#### Proposed Changes

Currently, the FTM flows are available to English-locale users. This PR adds the flag `signup/ftm-flow-non-en` which enables the FTM flows for all languages in the development and horizon environments for testing purposes.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `me/account` and change your WordPress locale to a non-English locale.
* Once saved, head to `/setup?siteSlug=${site_slug}`
* Expect to see the FTM flows (goals screen, vertical question screen, generated design picker, etc.) working as intended.

Note: We'll be addressing translation issues in a CfT, and it's out of scope for this task.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #[64978](https://github.com/Automattic/wp-calypso/issues/64978)
