### PR TITLE
Goals Capture: Enable `signup/goals-step-2` and `onboarding/import-light-url-screen` feature flags in production and stage

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -113,7 +113,7 @@
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
-		"signup/goals-step-2": false,
+		"signup/goals-step-2": true,
 		"signup/ftm-flow-non-en": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,6 +46,7 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
+		"onboarding/import-light-url-screen": true,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -112,7 +112,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/goals-step": true,
-		"signup/goals-step-2": false,
+		"signup/goals-step-2": true,
 		"signup/inline-help": false,
 		"signup/ftm-flow-non-en": true,
 		"signup/hero-flow-non-en": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
+		"onboarding/import-light-url-screen": true,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,


### PR DESCRIPTION
⚠️ Please do not merge this PR until the prerequisites are merged first More details in: pdDOJh-vD-p2. ⚠️

---

#### Proposed Changes

The proposed changes launch the new design (i2) of the Goals Capture screen and new Import screen by enabling the `signup/goals-step-2` and `onboarding/import-light-url-screen` feature flags in `production.json` and `stage.json`.

| Before | After |
| ------------- | ------------- |
| ![Markup on 2022-07-08 at 11:23:38](https://user-images.githubusercontent.com/25105483/177961773-9d069b27-d76f-4df7-bb7c-9915932d6924.png) | ![Markup on 2022-07-08 at 11:24:22](https://user-images.githubusercontent.com/25105483/177961781-4162826b-1bcc-4517-b2b2-4bc52403a4cd.png) |

#### Testing Instructions

The new Goals Capture and Import screens should be tested in the previous PRs (pdDOJh-vD-p2) and on Horizon by following the [steps described here](pdDOJh-vD-p2#comment-415). This PR only enables the new screens in production and staging environments.

Related to #65283