### PR TITLE
Include Marketplace plugins on the Free plan

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -27,10 +27,6 @@ function getHoldMessages(
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
-				if ( ! isLegacyPlan && isMarketplace ) {
-					return translate( 'Upgrade to a Starter plan' );
-				}
-
 				if ( ! isLegacyPlan && eligibleForProPlan ) {
 					return translate( 'Upgrade to a Pro plan' );
 				}
@@ -42,10 +38,6 @@ function getHoldMessages(
 					return translate(
 						"You'll also get to install custom plugins, have more storage, and access live support."
 					);
-				}
-
-				if ( isMarketplace ) {
-					return translate( "You'll also get to collect payments and have more storage." );
 				}
 
 				if ( billingPeriod === IntervalLength.MONTHLY ) {

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -21,7 +21,6 @@ function getHoldMessages(
 	translate: LocalizeProps[ 'translate' ],
 	eligibleForProPlan: boolean,
 	billingPeriod?: string,
-	isMarketplace?: boolean,
 	isLegacyPlan?: boolean
 ) {
 	return {
@@ -167,7 +166,6 @@ export function getBlockingMessages(
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
-	isMarketplace?: boolean;
 	isPlaceholder: boolean;
 }
 
@@ -211,7 +209,7 @@ export const HardBlockingNotice = ( {
 	);
 };
 
-export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const plan = selectedSite?.plan;
@@ -229,7 +227,6 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 		translate,
 		eligibleForProPlan,
 		billingPeriod,
-		isMarketplace,
 		isLegacyPlan
 	);
 	const blockingMessages = getBlockingMessages( translate );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -58,7 +58,6 @@ export const EligibilityWarnings = ( {
 	feature,
 	eligibilityData,
 	isEligible,
-	isMarketplace,
 	isPlaceholder,
 	onProceed,
 	standaloneProceed,
@@ -126,12 +125,7 @@ export const EligibilityWarnings = ( {
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<CompactCard>
-					<HoldList
-						context={ context }
-						holds={ listHolds }
-						isMarketplace={ isMarketplace }
-						isPlaceholder={ isPlaceholder }
-					/>
+					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 				</CompactCard>
 			) }
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -9,7 +9,6 @@ import {
 	PLAN_BLOGGER_2_YEARS,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_STARTER,
 } from '@automattic/calypso-products';
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
@@ -348,15 +347,9 @@ export function getPluginAuthorProfileKeyword( plugin ) {
  * @param currentPlan
  * @param pluginBillingPeriod
  * @param eligibleForProPlan
- * @param isMarketplace
  * @returns the correct business plan slug depending on current plan and pluginBillingPeriod
  */
-export function businessPlanToAdd(
-	currentPlan,
-	pluginBillingPeriod,
-	eligibleForProPlan,
-	isMarketplace = false
-) {
+export function businessPlanToAdd( currentPlan, pluginBillingPeriod, eligibleForProPlan ) {
 	// Legacy plans always upgrade to business.
 	switch ( currentPlan.product_slug ) {
 		case PLAN_PERSONAL_2_YEARS:
@@ -368,10 +361,6 @@ export function businessPlanToAdd(
 		case PLAN_BLOGGER:
 			return PLAN_BUSINESS;
 		default:
-			// Not on a legacy plan: Can upgrade to Starter, Pro, or Business depending on settings.
-			if ( isMarketplace ) {
-				return PLAN_WPCOM_STARTER;
-			}
 			if ( eligibleForProPlan ) {
 				return PLAN_WPCOM_PRO;
 			}

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -217,8 +217,7 @@ function onClickInstallPlugin( {
 				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
 					billingPeriod,
-					eligibleForProPlan,
-					true
+					eligibleForProPlan
 				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
 				}`

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -2,7 +2,6 @@ import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
 	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_STARTER,
 	isBlogger,
 	isPersonal,
 	isPremium,
@@ -71,10 +70,6 @@ const USPS: React.FC< Props > = ( {
 			isLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
 		}
 
-		if ( ! isLegacyPlan && isMarketplaceProduct ) {
-			return PLAN_WPCOM_STARTER;
-		}
-
 		if ( ! isLegacyPlan && isEligibleForProPlan( state, selectedSite?.ID ) ) {
 			return PLAN_WPCOM_PRO;
 		}
@@ -87,11 +82,6 @@ const USPS: React.FC< Props > = ( {
 	} );
 	let planText;
 	switch ( requiredPlan ) {
-		case PLAN_WPCOM_STARTER:
-			planText = translate( 'Included in the Starter plan (%s):', {
-				args: [ planDisplayCost ],
-			} );
-			break;
 		case PLAN_WPCOM_PRO:
 			planText = translate( 'Included in the Pro plan (%s):', {
 				args: [ planDisplayCost ],
@@ -140,7 +130,7 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( isFreePlan
+		...( isFreePlan && ! isMarketplaceProduct
 			? [
 					{
 						id: 'domain',
@@ -150,27 +140,7 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( shouldUpgrade && requiredPlan === PLAN_WPCOM_STARTER
-			? [
-					{
-						id: 'collect-payments',
-						image: <Gridicon icon="money" size={ 16 } />,
-						text: translate( 'Payments collection' ),
-						eligibilities: [ 'needs-upgrade' ],
-					},
-			  ]
-			: [] ),
-		...( shouldUpgrade && requiredPlan === PLAN_WPCOM_STARTER
-			? [
-					{
-						id: 'storage',
-						image: <Gridicon icon="product" size={ 16 } />,
-						text: translate( '6GB of storage' ),
-						eligibilities: [ 'needs-upgrade' ],
-					},
-			  ]
-			: [] ),
-		...( shouldUpgrade && requiredPlan !== PLAN_WPCOM_STARTER
+		...( shouldUpgrade
 			? [
 					{
 						id: 'hosting',
@@ -180,7 +150,7 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( shouldUpgrade && requiredPlan !== PLAN_WPCOM_STARTER
+		...( shouldUpgrade
 			? [
 					{
 						id: 'support',

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -5,7 +5,6 @@ import {
 	isPersonal,
 	isPremium,
 	TYPE_BUSINESS,
-	TYPE_STARTER,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_UPLOAD_PLUGINS,
@@ -350,29 +349,6 @@ const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSl
 	);
 };
 
-const UpgradeNudgePaid = ( props ) => {
-	const translate = useTranslate();
-
-	if ( ! props.sitePlan ) {
-		return null;
-	}
-
-	const plan = findFirstSimilarPlanKey( props.sitePlan.product_slug, {
-		type: TYPE_STARTER,
-	} );
-
-	return (
-		<UpsellNudge
-			event="calypso_plugins_browser_upgrade_nudge"
-			showIcon={ true }
-			href={ `/checkout/${ props.siteSlug }/starter` }
-			feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
-			plan={ plan }
-			title={ translate( 'Upgrade to the Starter plan to install paid plugins.' ) }
-		/>
-	);
-};
-
 const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -501,13 +477,6 @@ const PluginBrowserContent = ( props ) => {
 		<>
 			{ ! props.jetpackNonAtomic && (
 				<>
-					<div className="plugins-browser__upgrade-banner">
-						{ eligibleForProPlan && ! isLegacyPlan ? (
-							<UpgradeNudgePaid { ...props } />
-						) : (
-							<UpgradeNudge { ...props } />
-						) }
-					</div>
 					<PluginSingleListView { ...props } category="paid" />
 				</>
 			) }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -458,14 +458,6 @@ function isNotInstalled( plugin, installedPlugins ) {
 }
 
 const PluginBrowserContent = ( props ) => {
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, props.selectedSite?.ID )
-	);
-
-	const isLegacyPlan =
-		props.sitePlan &&
-		( isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan ) );
-
 	if ( props.search ) {
 		return <SearchListView { ...props } />;
 	}
@@ -475,12 +467,8 @@ const PluginBrowserContent = ( props ) => {
 
 	return (
 		<>
-			{ ! props.jetpackNonAtomic && (
-				<>
-					<PluginSingleListView { ...props } category="paid" />
-				</>
-			) }
-			{ eligibleForProPlan && ! isLegacyPlan && <UpgradeNudge { ...props } /> }
+			{ ! props.jetpackNonAtomic && <PluginSingleListView { ...props } category="paid" /> }
+			<UpgradeNudge { ...props } />
 			<PluginSingleListView { ...props } category="featured" />
 			<PluginSingleListView { ...props } category="popular" />
 		</>


### PR DESCRIPTION
#### Proposed Changes

D83834-code will add the `INSTALL_PURCHASED_PLUGINS` feature to all WP.com sites, effectively allowing Marketplace plugins to be purchased on any site, including Free plan sites.

This PR adapts the Calypso codebase to handle that new scenario.

#### Testing Instructions

- Apply D83834-code to your sandbox.
- Sandbox the API.
- Use the Calypso live link below.
- Switch to a Free plan site.
- Go to Plugins.
- Make sure there isn't any upgrade banner offering you to upgrade to the Starter plan to install paid plugins.
<img width="500" alt="Screen Shot 2022-07-08 at 12 26 35" src="https://user-images.githubusercontent.com/1233880/177975891-3f1668e2-897b-4c62-bc3b-b5792c4626ee.png">

- Select any paid plugin.
- Make sure it doesn't display anything indicating that a plan upgrade is required.
- Make sure it doesn't display anything indicating that free domain for one year is included.
<img width="200" alt="Screen Shot 2022-07-08 at 12 27 30" src="https://user-images.githubusercontent.com/1233880/177976044-8c2136b4-7678-47f9-bec9-c43c50727a97.png">

- Click on the "Purchase and activate" button.
- Make sure the Atomic warning modal doesn't display anything indicating that a plan upgrade is required.
<img width="400" alt="Screen Shot 2022-07-08 at 12 28 51" src="https://user-images.githubusercontent.com/1233880/177976259-961c6570-6456-4df6-91f2-200e438e54a9.png">

- Click on Continue.
- Make sure no plan has been added to the cart.
<img width="300" alt="Screen Shot 2022-07-08 at 12 29 05" src="https://user-images.githubusercontent.com/1233880/177976395-a321cee3-02a9-4004-91ad-c19c6e18cf29.png">

- Complete the purchase.
- Make sure your site is transferred to Atomic.
- At this point, you'll be stuck in the "Thank you" page because the Atomic site doesn't allow the plugin installation. That will be solved with these wpcomsh changes: 1029-gh-Automattic/wpcomsh.