### PR TITLE
Add-ons: Signup - fix bug with missing cart items in step submission

### DIFF
--- a/client/signup/steps/add-ons/index.tsx
+++ b/client/signup/steps/add-ons/index.tsx
@@ -137,11 +137,13 @@ export default function AddOnsStep( props: Props ): React.ReactElement {
 			cartItem: addOnProducts,
 		};
 
-		dispatch(
-			submitSignupStep( step, {
-				cartItem: addOnProducts,
-			} )
-		);
+		setTimeout( () => {
+			dispatch(
+				submitSignupStep( step, {
+					cartItem: addOnProducts,
+				} )
+			);
+		}, 10 );
 	}, [ dispatch, props.stepName, props.stepSectionName, selectedAddOns ] );
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

Addresses https://github.com/Automattic/wp-calypso/issues/65341

Queues up the dispatch call to submit cart items with the step vi `setTimeout`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/add-ons` and pick "Premium Themes"
* Go to checkout but don't complete purchase
* Go back and select another add-on, "No Ads"
* Proceed to checkout and confirm both add-ons are there

We tested in Chrome, Firefox, Safari

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/65341

Props to @DavidRothstein for finding the cause