### PR TITLE
Marketing Connections: Display tips for WPCOM Simple

### DIFF
--- a/client/my-sites/marketing/connections/service-examples.jsx
+++ b/client/my-sites/marketing/connections/service-examples.jsx
@@ -40,13 +40,13 @@ class SharingServiceExamples extends Component {
 	static propTypes = {
 		service: PropTypes.object.isRequired,
 		site: PropTypes.object,
-		isJetpack: PropTypes.bool,
+		hasJetpack: PropTypes.bool,
 		translate: PropTypes.func,
 	};
 
 	static defaultProps = {
 		site: Object.freeze( {} ),
-		isJetpack: false,
+		hasJetpack: false,
 	};
 
 	getSharingButtonsLink() {
@@ -119,7 +119,7 @@ class SharingServiceExamples extends Component {
 				textOnly: true,
 			} ),
 		};
-		return this.props.isJetpack
+		return this.props.hasJetpack
 			? [
 					{
 						image,
@@ -210,7 +210,7 @@ class SharingServiceExamples extends Component {
 				textOnly: true,
 			} ),
 		};
-		return this.props.isJetpack
+		return this.props.hasJetpack
 			? [
 					{
 						image,
@@ -254,7 +254,7 @@ class SharingServiceExamples extends Component {
 			src: '/calypso/images/sharing/connections-tumblr.png',
 			alt: this.props.translate( 'Share posts to your Tumblr blog', { textOnly: true } ),
 		};
-		return this.props.isJetpack
+		return this.props.hasJetpack
 			? [
 					{
 						image,
@@ -298,7 +298,7 @@ class SharingServiceExamples extends Component {
 			src: '/calypso/images/sharing/connections-twitter2.png',
 			alt: this.props.translate( 'Share posts to your Twitter followers', { textOnly: true } ),
 		};
-		return this.props.isJetpack
+		return this.props.hasJetpack
 			? [
 					{
 						image,
@@ -447,5 +447,5 @@ class SharingServiceExamples extends Component {
 
 export default connect( ( state ) => ( {
 	site: getSelectedSite( state ),
-	isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+	hasJetpack: ! isJetpackCloud() || isJetpackSite( state, getSelectedSiteId( state ) ),
 } ) )( localize( SharingServiceExamples ) );

--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -32,17 +32,15 @@ class SharingServiceTip extends Component {
 	static propTypes = {
 		service: PropTypes.object.isRequired,
 		translate: PropTypes.func,
-		isJetpack: PropTypes.bool,
+		hasJetpack: PropTypes.bool,
 		site: PropTypes.object,
 	};
 
 	getSharingButtonsLink() {
 		if ( this.props.site ) {
 			return isJetpackCloud()
-				? localizeUrl(
-						'https://jetpack.com/redirect/?source=calypso-marketing-sharing-buttons&site=' +
-							this.props.site.slug
-				  )
+				? 'https://jetpack.com/redirect/?source=calypso-marketing-sharing-buttons&site=' +
+						this.props.site.slug
 				: '/sharing/buttons/' + this.props.site.slug;
 		}
 		return localizeUrl( 'https://wordpress.com/support/sharing/' );
@@ -116,7 +114,7 @@ class SharingServiceTip extends Component {
 		const { service } = this.props;
 		if (
 			! includes(
-				this.props.isJetpack ? JETPACK_SERVICES_WITH_TIPS : SERVICES_WITH_TIPS,
+				this.props.hasJetpack ? JETPACK_SERVICES_WITH_TIPS : SERVICES_WITH_TIPS,
 				service.ID
 			) ||
 			'google_plus' === service.ID
@@ -135,5 +133,5 @@ class SharingServiceTip extends Component {
 
 export default connect( ( state ) => ( {
 	site: getSelectedSite( state ),
-	isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+	hasJetpack: ! isJetpackCloud() || isJetpackSite( state, getSelectedSiteId( state ) ),
 } ) )( localize( SharingServiceTip ) );


### PR DESCRIPTION

#### Proposed Changes

In #65284, we hid the tips and examples that weren't relevant to Jetpack
Social sites, but inadvertently hid them for WordPress.com Simple sites
too.

This change fixes that!

#### Testing Instructions

Goto marketing->connections with a WPCOM simple site

You should see the full example and links to related features.

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/96462/177997880-1e286f73-d0cc-4750-9a71-b3a5852b9a38.png">

