### PR TITLE
Sites Management Dashboard: Add a sample 'Published At' date

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -17,6 +17,7 @@ const Row = styled.tr`
 	td {
 		padding-top: 12px;
 		padding-bottom: 12px;
+		padding-right: 24px;
 		vertical-align: middle;
 		font-size: 14px;
 		line-height: 20px;
@@ -113,7 +114,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 				</div>
 			</td>
 			<td className="sites-table-row__mobile-hidden">{ site.plan.product_name_short }</td>
-			<td className="sites-table-row__mobile-hidden"></td>
+			<td className="sites-table-row__mobile-hidden">July 16, 1969</td>
 			<td style={ { width: '20px' } }>
 				<EllipsisMenu>
 					<VisitDashboardItem site={ site } />


### PR DESCRIPTION
See #65166

## Proposed Changes

Adds a sample 'Published At' date:

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/36432/178015175-3a4ca396-4cf4-4606-ab49-47dd730df0f5.png">

## Testing Instructions

1. Check out the branch locally.
2. Navigate to `/sites-dashboard` and view the new Sites Dashboard.