### PR TITLE
Checkout: Change genericRedirectProcessor to use :orderId placeholder

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -46,7 +46,10 @@ export default async function genericRedirectProcessor(
 		search = '',
 	} = typeof window !== 'undefined' ? window.location : {};
 	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
-	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, siteSlug, undefined, 'absolute' );
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+		siteSlug,
+		urlType: 'absolute',
+	} );
 	const cancelUrl = `${ origin }${ pathname }${ search }`;
 
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId } ) );

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -1,4 +1,5 @@
 import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
+import { addUrlToPendingPageRedirect } from '../lib/pending-page';
 import prepareRedirectTransaction from '../lib/prepare-redirect-transaction';
 import { recordTransactionBeginAnalytics } from './analytics';
 import getDomainDetails from './get-domain-details';
@@ -45,12 +46,7 @@ export default async function genericRedirectProcessor(
 		search = '',
 	} = typeof window !== 'undefined' ? window.location : {};
 	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
-	const successUrlPath = `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`;
-	const successUrlBase = `${ origin }${ successUrlPath }`;
-
-	const successUrlObject = new URL( successUrlBase );
-	successUrlObject.searchParams.set( 'redirectTo', thankYouUrl );
-	const successUrl = successUrlObject.href;
+	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, siteSlug, undefined, 'absolute' );
 	const cancelUrl = `${ origin }${ pathname }${ search }`;
 
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId } ) );

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -1,0 +1,68 @@
+import page from 'page';
+
+/**
+ * Redirect to a checkout pending page and from there to a (relative or absolute) url.
+ */
+export function redirectThroughPending(
+	url: string,
+	siteSlug: string | undefined,
+	orderId: string | number | undefined
+): void {
+	if ( ! isRelativeUrl( url ) ) {
+		return absoluteRedirectThroughPending( url, siteSlug, orderId );
+	}
+	try {
+		relativeRedirectThroughPending( url, siteSlug, orderId );
+	} catch ( err ) {
+		absoluteRedirectThroughPending( url, siteSlug, orderId );
+	}
+}
+
+function isRelativeUrl( url: string ): boolean {
+	return url.startsWith( '/' ) && ! url.startsWith( '//' );
+}
+
+/**
+ * Redirect to a checkout pending page and from there to a relative url.
+ */
+export function relativeRedirectThroughPending(
+	url: string,
+	siteSlug: string | undefined,
+	orderId: string | number | undefined
+): void {
+	window.scrollTo( 0, 0 );
+	page( addUrlToPendingPageRedirect( url, siteSlug, orderId, 'relative' ) );
+}
+
+/**
+ * Redirect to a checkout pending page and from there to an absolute url.
+ */
+export function absoluteRedirectThroughPending(
+	url: string,
+	siteSlug: string | undefined,
+	orderId: string | number | undefined
+): void {
+	window.location.href = addUrlToPendingPageRedirect( url, siteSlug, orderId, 'absolute' );
+}
+
+/**
+ * Add a relative or absolute url to the checkout pending page url.
+ */
+export function addUrlToPendingPageRedirect(
+	url: string,
+	siteSlug: string | undefined,
+	orderId: string | number | undefined,
+	urlType: 'relative' | 'absolute'
+): string {
+	const { origin = 'https://wordpress.com' } = typeof window !== 'undefined' ? window.location : {};
+	const successUrlPath =
+		`/checkout/thank-you/${ siteSlug || 'no-site' }/pending/` +
+		( orderId ? `${ orderId }` : ':orderId' );
+	const successUrlBase = `${ origin }${ successUrlPath }`;
+	const successUrlObject = new URL( successUrlBase );
+	successUrlObject.searchParams.set( 'redirectTo', url );
+	if ( urlType === 'relative' ) {
+		return successUrlObject.pathname + successUrlObject.search + successUrlObject.hash;
+	}
+	return successUrlObject.href;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -33,6 +33,11 @@ export function redirectThroughPending(
 	try {
 		relativeRedirectThroughPending( url, options );
 	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`relative redirect to "${ url }" failed. Falling back to absolute redirect. Error was:`,
+			err
+		);
 		absoluteRedirectThroughPending( url, options );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -67,7 +67,9 @@ export function relativeRedirectThroughPending(
 	url: string,
 	options: Pick< PendingPageRedirectOptions, 'siteSlug' | 'orderId' >
 ): void {
-	window.scrollTo( 0, 0 );
+	if ( typeof window !== 'undefined' ) {
+		window.scrollTo( 0, 0 );
+	}
 	page(
 		addUrlToPendingPageRedirect( url, {
 			...options,

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -2,6 +2,20 @@ import page from 'page';
 
 /**
  * Redirect to a checkout pending page and from there to a (relative or absolute) url.
+ *
+ * The `url` parameter is the final destination. It will be appended to the
+ * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `/checkout/thank-you/:receiptId`, then this will look something like:
+ * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ *
+ * The pending page will redirect to the final destination when the order is complete.
+ *
+ * If `siteSlug` is not provided, it will use `no-site`.
+ *
+ * An order ID is required for the pending page to operate. If `orderId` is not
+ * provided, it will use the placeholder `:orderId` but please note that this
+ * must be replaced somewhere (typically in an endpoint) before the
+ * resulting URL will be valid!
  */
 export function redirectThroughPending(
 	url: string,
@@ -24,6 +38,20 @@ function isRelativeUrl( url: string ): boolean {
 
 /**
  * Redirect to a checkout pending page and from there to a relative url.
+ *
+ * The `url` parameter is the final destination. It will be appended to the
+ * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `/checkout/thank-you/:receiptId`, then this will look something like:
+ * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ *
+ * The pending page will redirect to the final destination when the order is complete.
+ *
+ * If `siteSlug` is not provided, it will use `no-site`.
+ *
+ * An order ID is required for the pending page to operate. If `orderId` is not
+ * provided, it will use the placeholder `:orderId` but please note that this
+ * must be replaced somewhere (typically in an endpoint) before the
+ * resulting URL will be valid!
  */
 export function relativeRedirectThroughPending(
 	url: string,
@@ -36,6 +64,20 @@ export function relativeRedirectThroughPending(
 
 /**
  * Redirect to a checkout pending page and from there to an absolute url.
+ *
+ * The `url` parameter is the final destination. It will be appended to the
+ * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `/checkout/thank-you/:receiptId`, then this will look something like:
+ * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ *
+ * The pending page will redirect to the final destination when the order is complete.
+ *
+ * If `siteSlug` is not provided, it will use `no-site`.
+ *
+ * An order ID is required for the pending page to operate. If `orderId` is not
+ * provided, it will use the placeholder `:orderId` but please note that this
+ * must be replaced somewhere (typically in an endpoint) before the
+ * resulting URL will be valid!
  */
 export function absoluteRedirectThroughPending(
 	url: string,
@@ -47,6 +89,20 @@ export function absoluteRedirectThroughPending(
 
 /**
  * Add a relative or absolute url to the checkout pending page url.
+ *
+ * The `url` parameter is the final destination. It will be appended to the
+ * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `/checkout/thank-you/:receiptId`, then this will look something like:
+ * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ *
+ * The pending page will redirect to the final destination when the order is complete.
+ *
+ * If `siteSlug` is not provided, it will use `no-site`.
+ *
+ * An order ID is required for the pending page to operate. If `orderId` is not
+ * provided, it will use the placeholder `:orderId` but please note that this
+ * must be replaced somewhere (typically in an endpoint) before the
+ * resulting URL will be valid!
  */
 export function addUrlToPendingPageRedirect(
 	url: string,

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -45,7 +45,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment_partner: 'IE',
 			postal_code: '10001',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending?redirectTo=%2Fthank-you',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
 			zip: '10001',
 		},
 		tos: {
@@ -152,7 +152,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=%2Fthank-you',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
 			},
 		} );
 	} );
@@ -189,7 +189,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=' +
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=' +
 					encodeURIComponent( thankYouUrl ),
 			},
 		} );
@@ -227,7 +227,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=' +
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=' +
 					encodeURIComponent( thankYouUrl ),
 			},
 		} );
@@ -274,7 +274,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=%2Fthank-you',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
 			},
 		} );
 	} );
@@ -310,7 +310,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=%2Fthank-you',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/test/pending-page.ts
@@ -1,0 +1,51 @@
+import { addUrlToPendingPageRedirect } from '../lib/pending-page';
+
+describe( 'addUrlToPendingPageRedirect', () => {
+	it( 'returns a relative URL when in relative mode', () => {
+		const finalUrl = '/foo/bar/baz';
+		const siteSlug = 'example.com';
+		const orderId = '12345';
+		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'relative' );
+		expect( actual ).toEqual(
+			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }`
+		);
+	} );
+
+	it( 'returns an absolute URL when in absolute mode', () => {
+		const finalUrl = '/foo/bar/baz';
+		const siteSlug = 'example.com';
+		const orderId = '12345';
+		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'absolute' );
+		expect( actual ).toEqual(
+			`https://wordpress.com/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }`
+		);
+	} );
+
+	it( 'returns a no-site URL if no siteSlug is provided', () => {
+		const finalUrl = '/foo/bar/baz';
+		const siteSlug = undefined;
+		const orderId = '12345';
+		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'absolute' );
+		expect( actual ).toEqual(
+			`https://wordpress.com/checkout/thank-you/no-site/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }`
+		);
+	} );
+
+	it( 'returns a order ID placeholder when no order ID is provided', () => {
+		const finalUrl = '/foo/bar/baz';
+		const siteSlug = 'example.com';
+		const orderId = undefined;
+		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'absolute' );
+		expect( actual ).toEqual(
+			`https://wordpress.com/checkout/thank-you/${ siteSlug }/pending/:orderId?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }`
+		);
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/test/pending-page.ts
@@ -5,7 +5,11 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		const finalUrl = '/foo/bar/baz';
 		const siteSlug = 'example.com';
 		const orderId = '12345';
-		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'relative' );
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			siteSlug,
+			orderId,
+			urlType: 'relative',
+		} );
 		expect( actual ).toEqual(
 			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
@@ -17,7 +21,26 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		const finalUrl = '/foo/bar/baz';
 		const siteSlug = 'example.com';
 		const orderId = '12345';
-		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'absolute' );
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			siteSlug,
+			orderId,
+			urlType: 'absolute',
+		} );
+		expect( actual ).toEqual(
+			`https://wordpress.com/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }`
+		);
+	} );
+
+	it( 'returns an absolute URL in default mode', () => {
+		const finalUrl = '/foo/bar/baz';
+		const siteSlug = 'example.com';
+		const orderId = '12345';
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			siteSlug,
+			orderId,
+		} );
 		expect( actual ).toEqual(
 			`https://wordpress.com/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
@@ -27,9 +50,10 @@ describe( 'addUrlToPendingPageRedirect', () => {
 
 	it( 'returns a no-site URL if no siteSlug is provided', () => {
 		const finalUrl = '/foo/bar/baz';
-		const siteSlug = undefined;
 		const orderId = '12345';
-		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'absolute' );
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			orderId,
+		} );
 		expect( actual ).toEqual(
 			`https://wordpress.com/checkout/thank-you/no-site/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
@@ -40,8 +64,9 @@ describe( 'addUrlToPendingPageRedirect', () => {
 	it( 'returns a order ID placeholder when no order ID is provided', () => {
 		const finalUrl = '/foo/bar/baz';
 		const siteSlug = 'example.com';
-		const orderId = undefined;
-		const actual = addUrlToPendingPageRedirect( finalUrl, siteSlug, orderId, 'absolute' );
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			siteSlug,
+		} );
 		expect( actual ).toEqual(
 			`https://wordpress.com/checkout/thank-you/${ siteSlug }/pending/:orderId?redirectTo=${ encodeURIComponent(
 				finalUrl


### PR DESCRIPTION
#### Proposed Changes

When submitting a Stripe redirect payment method transaction, the payment method adds the final post-checkout URL (as generated by the `getThankYouPageUrl()` function) to the `redirectTo` query param of the URL of a "pending" page. The pending page will wait for the transaction to be complete before sending the user to their final destination. 

However, the pending page requires an order ID to function and this is provided by the redirect machinery between the transaction submission and the return to the "pending" page. Prior to D83802-code, that machinery simply appended the order ID to the end of the URL. This is risky since it relies on an implicit agreement between the server and the client about where the order ID will be added. In that diff, the server was modified to instead replace the new `:orderId` placeholder (if it exists; otherwise it will use the old behavior to prevent regressions with old clients).

In this diff, we change `genericRedirectProcessor()`, which is the payment processor function for all Stripe redirect payment methods (eg: Bancontact, iDEAL), to add the `:orderId` placeholder to the pending page URL sent to the server when a transaction is submitted.

This is part of implementing https://github.com/Automattic/wp-calypso/issues/53356

#### Testing Instructions

- Apply D45443-code to your sandbox to force Bancontact to be available. Then sandbox public-api.
- Make sure your test user's currency is set to EUR.
- Add a plan to your cart and visit checkout using this branch.
- Complete the checkout form and select Bancontact as the payment method.
- Submit the purchase.
- Verify that you briefly see the "Please wait…" pending page.
- Verify that you are then redirected to a final post-checkout page (this usually will be something like `/checkout/thank-you/YOUR-SITE-HERE/12345` but it depends on a lot of factors) that is _not_ the generic thank-you page (`/checkout/thank-you/YOUR-SITE-HERE/pending` or `/checkout/thank-you/YOUR-SITE-HERE/unknown`).