### PR TITLE
Checkout: Remove pending URL from getThankYouPageUrl

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -194,7 +194,7 @@ export default function getThankYouPageUrl( {
 	// endpoint (`/me/transactions/order/:orderId`) for the transaction data,
 	// then replaces the `:receiptId` placeholder itself and redirects to the
 	// receipt page.
-	const receiptIdOrPlaceholder = getPendingOrReceiptId( receiptId, purchaseId );
+	const receiptIdOrPlaceholder = getReceiptIdOrPlaceholder( receiptId, purchaseId );
 	debug( 'receiptIdOrPlaceholder is', receiptIdOrPlaceholder );
 
 	// jetpack userless & siteless checkout uses a special thank you page
@@ -346,7 +346,7 @@ function getNewBlogReceiptUrl(
 		: fallbackUrl;
 }
 
-function getPendingOrReceiptId(
+function getReceiptIdOrPlaceholder(
 	receiptId: string | number | undefined,
 	purchaseId: string | number | undefined
 ): ReceiptIdOrPlaceholder | undefined {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -83,6 +83,7 @@ export default function getThankYouPageUrl( {
 	redirectTo,
 	receiptId,
 	noPurchaseMade,
+	orderId,
 	purchaseId,
 	feature,
 	cart,
@@ -221,6 +222,7 @@ export default function getThankYouPageUrl( {
 
 	const fallbackUrl = getFallbackDestination( {
 		receiptIdOrPlaceholder,
+		orderId,
 		noPurchaseMade,
 		siteSlug,
 		adminUrl,
@@ -277,9 +279,11 @@ export default function getThankYouPageUrl( {
 	// Domain only flow
 	if ( ( cart?.create_new_blog || signupFlowName === 'domain' ) && ! isDomainOnly ) {
 		clearSignupCompleteFlowName();
-		const newBlogReceiptUrl = urlFromCookie
-			? `${ urlFromCookie }/${ receiptIdOrPlaceholder }`
-			: fallbackUrl;
+		const newBlogReceiptUrl = getNewBlogReceiptUrl(
+			urlFromCookie,
+			receiptIdOrPlaceholder,
+			fallbackUrl
+		);
 		debug( 'new blog created, so returning', newBlogReceiptUrl );
 		// Skip composed url if we have to redirect to intent flow
 		if ( ! newBlogReceiptUrl.includes( '/start/setup-site' ) ) {
@@ -287,14 +291,16 @@ export default function getThankYouPageUrl( {
 		}
 	}
 
-	const redirectUrlForPostCheckoutUpsell = getRedirectUrlForPostCheckoutUpsell( {
-		receiptId: receiptIdOrPlaceholder,
-		cart,
-		siteSlug,
-		hideUpsell: Boolean( hideNudge ),
-		domains,
-		isDomainOnly,
-	} );
+	const redirectUrlForPostCheckoutUpsell = receiptIdOrPlaceholder
+		? getRedirectUrlForPostCheckoutUpsell( {
+				receiptId: receiptIdOrPlaceholder,
+				cart,
+				siteSlug,
+				hideUpsell: Boolean( hideNudge ),
+				domains,
+				isDomainOnly,
+		  } )
+		: undefined;
 
 	if ( redirectUrlForPostCheckoutUpsell ) {
 		debug(
@@ -309,11 +315,13 @@ export default function getThankYouPageUrl( {
 	// when purchasing a concierge session or when purchasing the Ultimate Traffic Guide
 	const displayModeParam = getDisplayModeParamFromCart( cart );
 
-	const thankYouPageUrlForTrafficGuide = getThankYouPageUrlForTrafficGuide( {
-		cart,
-		siteSlug,
-		receiptIdOrPlaceholder,
-	} );
+	const thankYouPageUrlForTrafficGuide = receiptIdOrPlaceholder
+		? getThankYouPageUrlForTrafficGuide( {
+				cart,
+				siteSlug,
+				receiptIdOrPlaceholder,
+		  } )
+		: undefined;
 	if ( thankYouPageUrlForTrafficGuide ) {
 		return getUrlWithQueryParam( thankYouPageUrlForTrafficGuide, displayModeParam );
 	}
@@ -328,21 +336,38 @@ export default function getThankYouPageUrl( {
 	return getUrlWithQueryParam( fallbackUrl, displayModeParam );
 }
 
+function getNewBlogReceiptUrl(
+	urlFromCookie: string | undefined,
+	receiptIdOrPlaceholder: ReceiptIdOrPlaceholder | undefined,
+	fallbackUrl: string
+): string {
+	return urlFromCookie && receiptIdOrPlaceholder
+		? `${ urlFromCookie }/${ receiptIdOrPlaceholder }`
+		: fallbackUrl;
+}
+
 function getPendingOrReceiptId(
 	receiptId: string | number | undefined,
 	purchaseId: string | number | undefined
-): ReceiptIdOrPlaceholder {
-	if ( receiptId ) {
+): ReceiptIdOrPlaceholder | undefined {
+	if ( receiptId && Number.isInteger( Number( receiptId ) ) ) {
 		return Number( receiptId );
 	}
-	if ( purchaseId ) {
+	if ( receiptId && ! Number.isInteger( Number( receiptId ) ) ) {
+		return undefined;
+	}
+	if ( purchaseId && Number.isInteger( Number( purchaseId ) ) ) {
 		return Number( purchaseId );
+	}
+	if ( purchaseId && ! Number.isInteger( Number( purchaseId ) ) ) {
+		return undefined;
 	}
 	return ':receiptId';
 }
 
 function getFallbackDestination( {
 	receiptIdOrPlaceholder,
+	orderId,
 	noPurchaseMade,
 	siteSlug,
 	adminUrl,
@@ -353,7 +378,8 @@ function getFallbackDestination( {
 	adminPageRedirect,
 	redirectTo,
 }: {
-	receiptIdOrPlaceholder: ReceiptIdOrPlaceholder;
+	receiptIdOrPlaceholder: ReceiptIdOrPlaceholder | undefined;
+	orderId?: string | number;
 	noPurchaseMade?: boolean;
 	siteSlug: string | undefined;
 	adminUrl: string | undefined;
@@ -365,7 +391,8 @@ function getFallbackDestination( {
 	redirectTo?: string;
 } ): string {
 	const isCartEmpty = cart ? getAllCartItems( cart ).length === 0 : true;
-	const isReceiptEmpty = ':receiptId' === receiptIdOrPlaceholder;
+	const isReceiptEmpty =
+		':receiptId' === receiptIdOrPlaceholder || receiptIdOrPlaceholder === undefined;
 
 	if ( noPurchaseMade ) {
 		debug( 'fallback is just root' );
@@ -373,9 +400,10 @@ function getFallbackDestination( {
 	}
 
 	// We will show the Thank You page if there's a site slug and either one of the following is true:
-	// - has a receipt number (or a pending order)
-	// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
-	if ( siteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
+	// - has a receipt number (or a pending order).
+	// - does not have a receipt number but has an item in cart (as in the case of paying with a redirect payment method).
+	// - has an orderId (as in the case of paying with a redirect payment method).
+	if ( siteSlug && ( ! isReceiptEmpty || ! isCartEmpty || orderId ) ) {
 		// If we just purchased a Jetpack product or a Jetpack plan (either Jetpack Security or Jetpack Complete),
 		// redirect to the my plans page. The product being purchased can come from the `product` prop or from the
 		// cart so we need to check both places.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -5,7 +5,6 @@ import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getThankYouPageUrl from './get-thank-you-page-url';
 import type { ResponseCart } from '@automattic/shopping-cart';
-import type { WPCOMTransactionEndpointResponse } from '@automattic/wpcom-checkout';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-get-thank-you-url' );
@@ -27,7 +26,6 @@ export type GetThankYouUrl = () => string;
  */
 export default function useGetThankYouUrl( {
 	siteSlug,
-	transactionResult,
 	redirectTo,
 	purchaseId,
 	feature,
@@ -45,15 +43,9 @@ export default function useGetThankYouUrl( {
 	const isEligibleForSignupDestinationResult = isEligibleForSignupDestination( cart );
 
 	const getThankYouUrl = useCallback( () => {
-		debug( 'for getThankYouUrl, transactionResult is', transactionResult );
-		const receiptId = transactionResult?.receipt_id;
-		const orderId = transactionResult?.order_id;
-
 		const getThankYouPageUrlArguments = {
 			siteSlug,
 			adminUrl,
-			receiptId,
-			orderId,
 			redirectTo,
 			purchaseId,
 			feature,
@@ -74,7 +66,6 @@ export default function useGetThankYouUrl( {
 		return url;
 	}, [
 		isInModal,
-		transactionResult,
 		isEligibleForSignupDestinationResult,
 		siteSlug,
 		adminUrl,
@@ -93,7 +84,6 @@ export default function useGetThankYouUrl( {
 
 export interface GetThankYouUrlProps {
 	siteSlug: string | undefined;
-	transactionResult?: WPCOMTransactionEndpointResponse | undefined;
 	redirectTo?: string | undefined;
 	purchaseId?: number | undefined;
 	feature?: string | undefined;

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -1034,7 +1034,7 @@ describe( 'getThankYouPageUrl', () => {
 		);
 	} );
 
-	it( 'redirects to the receipt page with when the business upgrade nudge would normally be included', () => {
+	it( 'redirects to the business upgrade nudge with a placeholder when jetpack is not in the cart and premium is in the cart but there is no receipt', () => {
 		const cart = {
 			...getEmptyResponseCart(),
 			products: [
@@ -1050,7 +1050,7 @@ describe( 'getThankYouPageUrl', () => {
 			orderId: sampleOrderId,
 			cart,
 		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/:receiptId` );
+		expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/:receiptId` );
 	} );
 
 	it( 'redirects to the thank you page if jetpack is not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -78,13 +78,13 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to the thank-you pending page with a order id when a site and orderId is set', () => {
+	it( 'redirects to the receipt page with a placeholder id when a site and orderId is set', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			orderId: sampleOrderId,
 		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/pending/${ sampleOrderId }` );
+		expect( url ).toBe( `/checkout/thank-you/foo.bar/:receiptId` );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receipt id when a site but no orderId is set and the cart contains the personal plan', () => {
@@ -169,7 +169,7 @@ describe( 'getThankYouPageUrl', () => {
 			feature: 'all-free-features',
 			orderId: sampleOrderId,
 		} );
-		expect( url ).toBe( `/checkout/thank-you/features/all-free-features/foo.bar` );
+		expect( url ).toBe( `/checkout/thank-you/features/all-free-features/foo.bar/:receiptId` );
 	} );
 
 	it( 'redirects to the thank-you page with a feature when a site and a valid feature is set with no receipt but the cart is not empty', () => {
@@ -816,7 +816,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/cookie/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to url from cookie followed by pending order id if create_new_blog is set', () => {
+	it( 'redirects to url from cookie followed by receipt id placeholder if create_new_blog is set', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
 			...getEmptyResponseCart(),
@@ -835,7 +835,7 @@ describe( 'getThankYouPageUrl', () => {
 			orderId: sampleOrderId,
 			getUrlFromCookie,
 		} );
-		expect( url ).toBe( `/cookie/pending/${ sampleOrderId }` );
+		expect( url ).toBe( `/cookie/:receiptId` );
 	} );
 
 	it( 'redirects to url from cookie followed by placeholder receiptId if create_new_blog is set and there is no receipt', () => {
@@ -1034,7 +1034,7 @@ describe( 'getThankYouPageUrl', () => {
 		);
 	} );
 
-	it( 'redirects to the thank-you pending page with an order id when the business upgrade nudge would normally be included', () => {
+	it( 'redirects to the receipt page with when the business upgrade nudge would normally be included', () => {
 		const cart = {
 			...getEmptyResponseCart(),
 			products: [
@@ -1050,7 +1050,7 @@ describe( 'getThankYouPageUrl', () => {
 			orderId: sampleOrderId,
 			cart,
 		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/pending/${ sampleOrderId }` );
+		expect( url ).toBe( `/checkout/thank-you/foo.bar/:receiptId` );
 	} );
 
 	it( 'redirects to the thank you page if jetpack is not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {


### PR DESCRIPTION
#### Proposed Changes

When generating the post-checkout URL, the function `getThankYouPageUrl()` sometimes returns a link to the post-checkout "pending" page with a final post-checkout URL in the query string; that page waits for the order to be complete before itself redirecting to the final URL. However, after https://github.com/Automattic/wp-calypso/pull/65273 and https://github.com/Automattic/wp-calypso/pull/65327, all post-checkout URLs will pass through the "pending" page, rendering it unnecessary to have that as a possible return value of `getThankYouPageUrl()`.

This PR simplifies `getThankYouPageUrl()` so that it will never return a URL to the "pending" page. As this function is already quite complex, this will serve to help make its logic easier to understand and may make it easier to further simplify in the future (see https://github.com/Automattic/wp-calypso/pull/65947).

This is part of implementing https://github.com/Automattic/wp-calypso/issues/53356

#### Testing Instructions

Automated tests are included, and there are no longer any routes which do not use the "pending" page, so no testing should be necessary.