### PR TITLE
Remove AMP: Record AMP upsell tracks when site can install plugins

### DIFF
--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_SFTP, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_INSTALL_PLUGINS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -50,10 +50,10 @@ class AmpWpcom extends Component {
 	};
 
 	renderUpgradeNotice() {
-		const { hasSftpFeature, siteSlug, translate } = this.props;
+		const { canInstallPlugins, siteSlug, translate } = this.props;
 		let tracksProps;
 
-		if ( ! hasSftpFeature ) {
+		if ( ! canInstallPlugins ) {
 			tracksProps = {
 				tracksImpressionName: 'calypso_settings_amp_upsell_impression',
 				tracksClickName: 'calypso_settings_amp_upsell_click',
@@ -152,11 +152,11 @@ class AmpWpcom extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
+		const canInstallPlugins = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PLUGINS );
 
 		return {
 			siteSlug: getSelectedSiteSlug( state ),
-			hasSftpFeature,
+			canInstallPlugins,
 		};
 	},
 	{ recordTracksEvent }


### PR DESCRIPTION
Inspired by this post about "feature checking" p58i-cDG-p2

Previously the AMP message was determining whether the user would need to upgrade before installing AMP (and consequently whether we should record upsell specific tracks events) by checking whether the site had the FTP feature. _Hypothetically there could be a plan in the future that offers FTP access, but not the ability to install plugins_. So it's more semantically correct to gate the tracks events based on the feature that's actually needed to install AMP: in this case `WPCOM_FEATURES_INSTALL_PLUGINS`

See PCYsg-IbE-p2#feature-checks-calypso for more documentation.

The upsell message still needs to recommend a specific plan, so it is still recommending the Pro plan. Perhaps in an ideal world we would iterate over all of the available plans and recommend the lowest plan that offers the `WPCOM_FEATURES_INSTALL_PLUGINS` feature. But I think recommending Pro is ok for now.

#### Proposed Changes

* Use the absence of the `WPCOM_FEATURES_INSTALL_PLUGINS` feature to determine whether to record upsell tracks events

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using site(s) where AMP has been deprecated
* Using a site whose plan **does not** allow plugins, visit the performance settings
  * Click the AMP banner
  * Confirm that the `calypso_settings_amp_upsell_click` event **is** sent
* Using a site whose plan **allows** plugins, visit the performance settings
  * Click the AMP banner
  * Confirm that the `calypso_settings_amp_upsell_click` event **is not** sent

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64889