### PR TITLE
Vertical step: Disable synonym search for non-Engligh locale

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -28,7 +28,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
-	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' ) || ! isEnglishLocale;
+	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' ) ?? ! isEnglishLocale;
 	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
 	const handleSiteVerticalSelect = ( vertical: Vertical ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -26,9 +26,9 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const translate = useTranslate();
 	const headerText = translate( 'What’s your website about?' );
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
-	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
+	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' ) || ! isEnglishLocale;
 	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
 	const handleSiteVerticalSelect = ( vertical: Vertical ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR disables synonyms in vertical suggestions. For instances, when a non-English locale user types "car", the vertical suggestion shouldn't show terms that are synonyms to car. For the sake of context, the vertical API only supports English synonyms.      

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-English locale.
* Head to vertical question screen `/setup/vertical?siteSlug=${site_slug}`
* Ensure that the suggested verticals partially match with the user input text.
* Ensure that terms like "art" or "car" won't trigger synonyms.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

