### PR TITLE
Enable include_weighted_roots in query get_verticals

### DIFF
--- a/client/data/site-verticals/use-site-verticals-query.ts
+++ b/client/data/site-verticals/use-site-verticals-query.ts
@@ -6,6 +6,7 @@ const defaults = {
 	term: '',
 	limit: 10,
 	skip_synonyms: false,
+	include_weighted_roots: true,
 };
 
 const useSiteVerticalsQuery = (


### PR DESCRIPTION
#### Proposed Changes
* Use the API param `include_weighted_roots` to get the level 1 category of the matches added to the suggestions list.

Please share your thoughts about how these features should work and how to implement them.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
It is required to use the API sandboxed from D83269-code
1. Navigate to /setup/vertical?siteSlug=<your_site>
2. Type "car" or other text to search for a vertical
3. Check that the level 1 category is shown Autos & Vehicles in the suggestions list or the correspondent to your search term

| Before | after |
| :-: | :-: |
| <img width="529" alt="Screen Shot 2565-06-27 at 13 28 55" src="https://user-images.githubusercontent.com/1881481/175931594-b5261f5d-4941-4808-882c-5290c4517f56.png"> |  <img width="535" alt="Screen Shot 2565-06-28 at 06 50 18" src="https://user-images.githubusercontent.com/1881481/176095520-b7e15595-5cf3-4ec7-8f79-b57b5a9a6b4b.png"> |
| <img width="544" alt="Screen Shot 2565-06-27 at 13 29 04" src="https://user-images.githubusercontent.com/1881481/175931587-e9fb7328-6f2f-4619-b2ad-5b62814a8a95.png">  |  <img width="540" alt="Screen Shot 2565-06-27 at 13 13 28" src="https://user-images.githubusercontent.com/1881481/175931598-f0b26b50-10aa-4dce-ae08-5abc998006cc.png"> |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 71-gh-Automattic/ganon-issues