### PR TITLE
HelpCenter: add back to top button for articles

### DIFF
--- a/packages/help-center/src/components/back-to-top-button.scss
+++ b/packages/help-center/src/components/back-to-top-button.scss
@@ -1,6 +1,6 @@
 $animation-timing: 300ms;
 
-.help-center__container-content {
+.help-center__container {
 
 	.back-to-top-button__help-center {
 		position: sticky;
@@ -11,7 +11,6 @@ $animation-timing: 300ms;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		padding: 6px 0;
 
 		background-color: var( --studio-white );
 		color: var( --studio-black );
@@ -34,6 +33,12 @@ $animation-timing: 300ms;
 			background-color: var( --studio-white );
 			color: var( --studio-black );
 			border-color: rgba( 0, 0, 0, 0.1 );
+		}
+	}
+
+	&:not( .is-mobile ) {
+		.back-to-top-button__help-center {
+			padding: 6px 0;
 		}
 	}
 }

--- a/packages/help-center/src/components/back-to-top-button.scss
+++ b/packages/help-center/src/components/back-to-top-button.scss
@@ -1,0 +1,39 @@
+$animation-timing: 300ms;
+
+.help-center__container-content {
+
+	.back-to-top-button__help-center {
+		position: sticky;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 6px 0;
+
+		background-color: var( --studio-white );
+		color: var( --studio-black );
+		border-color: rgba( 0, 0, 0, 0.1 );
+
+		border-radius: 0;
+		border-width: 1px 0 0;
+
+		visibility: hidden;
+		opacity: 0;
+		transition: visibility 0s linear $animation-timing, opacity $animation-timing;
+
+		&.is-visible {
+			visibility: visible;
+			opacity: 1;
+			transition: visibility 0s linear 0s, opacity $animation-timing;
+		}
+
+		&:hover {
+			background-color: var( --studio-white );
+			color: var( --studio-black );
+			border-color: rgba( 0, 0, 0, 0.1 );
+		}
+	}
+}

--- a/packages/help-center/src/components/back-to-top-button.tsx
+++ b/packages/help-center/src/components/back-to-top-button.tsx
@@ -33,9 +33,7 @@ export const BackToTopButton: FC< Props > = ( { container } ) => {
 			containerNode.addEventListener( 'scroll', scrollCallback );
 
 			return () => {
-				if ( containerNode ) {
-					containerNode.removeEventListener( 'scroll', scrollCallback );
-				}
+				containerNode.removeEventListener( 'scroll', scrollCallback );
 			};
 		}
 	}, [ container, scrollCallback ] );

--- a/packages/help-center/src/components/back-to-top-button.tsx
+++ b/packages/help-center/src/components/back-to-top-button.tsx
@@ -1,0 +1,58 @@
+import { Button } from '@automattic/components';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { Icon, arrowUp } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import type { FC, RefObject } from 'react';
+import './back-to-top-button.scss';
+
+type Props = { container: RefObject< HTMLDivElement > };
+
+export const BackToTopButton: FC< Props > = ( { container } ) => {
+	const { __ } = useI18n();
+	const [ visible, setVisible ] = useState( false );
+
+	const SCROLL_THRESHOLD = 400;
+
+	const scrollCallback = useCallback( () => {
+		const containerNode = container.current;
+
+		if ( containerNode ) {
+			if ( containerNode.scrollTop > SCROLL_THRESHOLD ) {
+				setVisible( true );
+			} else {
+				setVisible( false );
+			}
+		}
+	}, [ container ] );
+
+	useEffect( () => {
+		const containerNode = container?.current;
+
+		if ( containerNode ) {
+			containerNode.addEventListener( 'scroll', scrollCallback );
+
+			return () => {
+				if ( containerNode ) {
+					containerNode.removeEventListener( 'scroll', scrollCallback );
+				}
+			};
+		}
+	}, [ container, scrollCallback ] );
+
+	const goToTop = () => {
+		if ( container.current ) {
+			container.current.scrollTop = 0;
+		}
+	};
+
+	return (
+		<Button
+			className={ classnames( 'back-to-top-button__help-center', { 'is-visible': visible } ) }
+			onClick={ goToTop }
+		>
+			<Icon icon={ arrowUp } size={ 16 } />
+			{ __( 'Back to top', __i18n_text_domain__ ) }
+		</Button>
+	);
+};

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -4,7 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CardBody } from '@wordpress/components';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { Route, useLocation } from 'react-router-dom';
@@ -24,7 +24,6 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 	const location = useLocation();
 	const className = classnames( 'help-center__container-content' );
 	const section = useSelector( getSectionName );
-	const containerRef = useRef( null );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
@@ -36,7 +35,7 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 	}, [ location, section ] );
 
 	return (
-		<CardBody hidden={ isMinimized } className={ className } ref={ containerRef }>
+		<CardBody hidden={ isMinimized } className={ className }>
 			<Route exact path="/">
 				<HelpCenterSearch />
 			</Route>

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -4,7 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CardBody } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { Route, useLocation } from 'react-router-dom';
@@ -13,6 +13,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
  * Internal Dependencies
  */
 import { Content } from '../types';
+import { BackToTopButton } from './back-to-top-button';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
 import { HelpCenterEmbedResult } from './help-center-embed-result';
@@ -24,6 +25,7 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 	const location = useLocation();
 	const className = classnames( 'help-center__container-content' );
 	const section = useSelector( getSectionName );
+	const containerRef = useRef( null );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
@@ -35,12 +37,13 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 	}, [ location, section ] );
 
 	return (
-		<CardBody hidden={ isMinimized } className={ className }>
+		<CardBody hidden={ isMinimized } className={ className } ref={ containerRef }>
 			<Route exact path="/">
 				<HelpCenterSearch />
 			</Route>
 			<Route path="/post">
 				<HelpCenterEmbedResult />
+				<BackToTopButton container={ containerRef } />
 			</Route>
 			<Route path="/contact-options">
 				<HelpCenterContactPage />

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -13,7 +13,6 @@ import { getSectionName } from 'calypso/state/ui/selectors';
  * Internal Dependencies
  */
 import { Content } from '../types';
-import { BackToTopButton } from './back-to-top-button';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
 import { HelpCenterEmbedResult } from './help-center-embed-result';
@@ -43,7 +42,6 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 			</Route>
 			<Route path="/post">
 				<HelpCenterEmbedResult />
-				<BackToTopButton container={ containerRef } />
 			</Route>
 			<Route path="/contact-options">
 				<HelpCenterContactPage />

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -10,6 +10,7 @@ import { useLocation, useHistory } from 'react-router-dom';
 import ArticleContent from 'calypso/blocks/support-article-dialog/dialog-content';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { BackButton } from './back-button';
+import { BackToTopButton } from './back-to-top-button';
 
 export const HelpCenterEmbedResult: React.FC = () => {
 	const { search } = useLocation();
@@ -44,23 +45,26 @@ export const HelpCenterEmbedResult: React.FC = () => {
 	};
 
 	return (
-		<div className="help-center-embed-result">
-			<Flex justify="space-between">
-				<FlexItem>
-					<BackButton onClick={ redirectToSearchOrHome } />
-				</FlexItem>
-				<FlexItem>
-					<Button
-						borderless={ true }
-						href={ link ?? '' }
-						target="_blank"
-						className="help-center-embed-result__external-button"
-					>
-						<Icon icon={ external } size={ 20 } />
-					</Button>
-				</FlexItem>
-			</Flex>
-			<ArticleContent postId={ postId } blogId={ blogId } articleUrl={ null } />
-		</div>
+		<>
+			<div className="help-center-embed-result">
+				<Flex justify="space-between">
+					<FlexItem>
+						<BackButton onClick={ redirectToSearchOrHome } />
+					</FlexItem>
+					<FlexItem>
+						<Button
+							borderless={ true }
+							href={ link ?? '' }
+							target="_blank"
+							className="help-center-embed-result__external-button"
+						>
+							<Icon icon={ external } size={ 20 } />
+						</Button>
+					</FlexItem>
+				</Flex>
+				<ArticleContent postId={ postId } blogId={ blogId } articleUrl={ null } />
+			</div>
+			<BackToTopButton />
+		</>
 	);
 };

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -15,6 +15,8 @@
 }
 
 .help-center .help-center__container-content {
+	scroll-behavior: smooth;
+
 	/**
  	 * SEARCH
  	 */


### PR DESCRIPTION
#### Proposed Changes

Most articles are quite long. For support articles we need to add a "Back to top" button
This will allow easier navigation.

| Before  | After |
| ------------- | ------------- |
| <img width="414" alt="Screenshot 2022-07-11 at 11 36 42" src="https://user-images.githubusercontent.com/7000684/178235374-8eee6a58-b982-49d5-bf75-bdb1f9e0b5c9.png">  | <img width="412" alt="Screenshot 2022-07-11 at 11 36 07" src="https://user-images.githubusercontent.com/7000684/178235467-c53b4ce9-6bf2-40fa-b1f3-3d8ae416ec88.png"> |


#### Testing Instructions
- Checkout this branch
- In `apps/editing-toolkit` run `$yarn dev --sync`
- In a sandboxed simple site open the new help center
- Open an article
- Scroll through the article
Test "back to top" button action and how it appears/disappears

Related to #64894
