### PR TITLE
Remove `marketplace-starter-plan` feature flag

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { isBlogger, isPersonal, isPremium } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -28,7 +27,7 @@ function getHoldMessages(
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
-				if ( ! isLegacyPlan && isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
+				if ( ! isLegacyPlan && isMarketplace ) {
 					return translate( 'Upgrade to a Starter plan' );
 				}
 
@@ -45,7 +44,7 @@ function getHoldMessages(
 					);
 				}
 
-				if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
+				if ( isMarketplace ) {
 					return translate( "You'll also get to collect payments and have more storage." );
 				}
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -370,7 +369,7 @@ export function businessPlanToAdd(
 			return PLAN_BUSINESS;
 		default:
 			// Not on a legacy plan: Can upgrade to Starter, Pro, or Business depending on settings.
-			if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
+			if ( isMarketplace ) {
 				return PLAN_WPCOM_STARTER;
 			}
 			if ( eligibleForProPlan ) {

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -72,7 +71,7 @@ const USPS: React.FC< Props > = ( {
 			isLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
 		}
 
-		if ( ! isLegacyPlan && isMarketplaceProduct && isEnabled( 'marketplace-starter-plan' ) ) {
+		if ( ! isLegacyPlan && isMarketplaceProduct ) {
 			return PLAN_WPCOM_STARTER;
 		}
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
 	findFirstSimilarPlanKey,
@@ -503,7 +502,7 @@ const PluginBrowserContent = ( props ) => {
 			{ ! props.jetpackNonAtomic && (
 				<>
 					<div className="plugins-browser__upgrade-banner">
-						{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan ? (
+						{ eligibleForProPlan && ! isLegacyPlan ? (
 							<UpgradeNudgePaid { ...props } />
 						) : (
 							<UpgradeNudge { ...props } />
@@ -512,9 +511,7 @@ const PluginBrowserContent = ( props ) => {
 					<PluginSingleListView { ...props } category="paid" />
 				</>
 			) }
-			{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan && (
-				<UpgradeNudge { ...props } />
-			) }
+			{ eligibleForProPlan && ! isLegacyPlan && <UpgradeNudge { ...props } /> }
 			<PluginSingleListView { ...props } category="featured" />
 			<PluginSingleListView { ...props } category="popular" />
 		</>

--- a/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
+++ b/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -39,7 +38,7 @@ export const willAtomicSiteRevertAfterPurchaseDeactivation = (
 	}
 
 	const isAtomicSupportedProduct = ( productSlug ) => {
-		if ( isEnabled( 'marketplace-starter-plan' ) && isMarketplaceProduct( state, productSlug ) ) {
+		if ( isMarketplaceProduct( state, productSlug ) ) {
 			return true;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -106,7 +106,6 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -65,7 +65,6 @@
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-starter-plan": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration/sign-in-with-google": false,

--- a/config/production.json
+++ b/config/production.json
@@ -74,7 +74,6 @@
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -72,7 +72,6 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/test.json
+++ b/config/test.json
@@ -57,7 +57,6 @@
 		"legal-updates-banner": true,
 		"mailchimp": true,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/vat-details": true,
 		"migration/sign-in-with-google": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,7 +83,6 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,


### PR DESCRIPTION
#### Proposed Changes

Removes the `marketplace-starter-plan` feature flag since the marketplace plugins have been successfully launched to the Starter plan (https://github.com/Automattic/wp-calypso/pull/65297) and everything looks stable after a few days.

This will also make easier to add the marketplace plugins to more plans.

#### Testing Instructions

- Use the Calypso live link below
- Switch to a Free site
- Go to Plugins
- Make sure you see two upgrade nudges, one for paid plugins (Starter plan) and another one for free plugins (Pro plan)
- Select any paid plugins
- Make sure it says that a plan upgrade is required
- Proceed with the purchase
- Make sure your site is upgraded to the Starter plan, transferred to Atomic, and the paid plugin is successfully installed
