### PR TITLE
Sites Dashboard: Persist launch status state in URLs

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -8,6 +8,10 @@ import { notNullish } from '../util';
 import { SitesTable } from './sites-table';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
+interface SitesDashboardProps {
+	launchStatus?: string;
+}
+
 const MAX_PAGE_WIDTH = '1184px';
 
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
@@ -54,7 +58,7 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
-export function SitesDashboard() {
+export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 	const { __ } = useI18n();
 	const sites = useSelector( getSites );
 
@@ -79,6 +83,7 @@ export function SitesDashboard() {
 								position: relative;
 								top: -48px;
 							` }
+							launchStatus={ launchStatus }
 						>
 							{ ( filteredSites ) => (
 								<ClassNames>

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { removeQueryArgs } from '@wordpress/url';
 import page from 'page';
+import { addQueryArgs } from 'calypso/lib/url';
 import SitesBadge from './sites-badge';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
 
@@ -83,7 +85,11 @@ export function SitesTableFilterTabs( {
 			initialTabName={ initialTabName }
 			tabs={ tabs as TabPanel.Tab[] }
 			onSelect={ ( tabName ) => {
-				page( 'all' === tabName ? '/sites-dashboard' : '/sites-dashboard/' + tabName );
+				page(
+					'all' === tabName
+						? removeQueryArgs( window.location.pathname + window.location.search, 'status' )
+						: addQueryArgs( { status: tabName }, window.location.pathname + window.location.search )
+				);
 			} }
 		>
 			{ ( tab ) => renderContents( filteredSites[ tab.name ] ) }

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import page from 'page';
 import SitesBadge from './sites-badge';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
 
@@ -8,6 +9,7 @@ interface SitesTableFilterTabsProps {
 	allSites: SiteData[];
 	children( filteredSites: SiteData[] ): JSX.Element;
 	className?: string;
+	launchStatus?: string;
 }
 
 interface FilteredSites {
@@ -45,6 +47,7 @@ export function SitesTableFilterTabs( {
 	allSites,
 	children: renderContents,
 	className,
+	launchStatus,
 }: SitesTableFilterTabsProps ) {
 	const { __ } = useI18n();
 
@@ -54,6 +57,10 @@ export function SitesTableFilterTabs( {
 		{ name: 'private', title: __( 'Private' ) },
 		{ name: 'coming-soon', title: __( 'Coming soon' ) },
 	];
+
+	const initialTabName = tabs.find( ( tab ) => tab.name === launchStatus )
+		? launchStatus
+		: undefined;
 
 	const filteredSites: FilteredSites = tabs.reduce(
 		( acc, { name } ) => ( { ...acc, [ name ]: filterSites( allSites, name ) } ),
@@ -71,7 +78,14 @@ export function SitesTableFilterTabs( {
 	} ) );
 
 	return (
-		<SitesTabPanel className={ className } tabs={ tabs as TabPanel.Tab[] }>
+		<SitesTabPanel
+			className={ className }
+			initialTabName={ initialTabName }
+			tabs={ tabs as TabPanel.Tab[] }
+			onSelect={ ( tabName ) => {
+				page( 'all' === tabName ? '/sites-dashboard' : '/sites-dashboard/' + tabName );
+			} }
+		>
 			{ ( tab ) => renderContents( filteredSites[ tab.name ] ) }
 		</SitesTabPanel>
 	);

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -17,7 +17,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
-			<SitesDashboard />
+			<SitesDashboard launchStatus={ context.params.launchStatus } />
 		</>
 	);
 	next();

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -17,7 +17,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
-			<SitesDashboard launchStatus={ context.params.launchStatus } />
+			<SitesDashboard launchStatus={ context.query.status } />
 		</>
 	);
 	next();

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -9,5 +9,5 @@ export default function () {
 		return;
 	}
 
-	page( '/sites-dashboard', sitesDashboard, makeLayout, clientRender );
+	page( '/sites-dashboard/:launchStatus?', sitesDashboard, makeLayout, clientRender );
 }

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -9,5 +9,5 @@ export default function () {
 		return;
 	}
 
-	page( '/sites-dashboard/:launchStatus?', sitesDashboard, makeLayout, clientRender );
+	page( '/sites-dashboard', sitesDashboard, makeLayout, clientRender );
 }


### PR DESCRIPTION
Fixes #65323

## Proposed Changes

Persists the launch status tab filter state in URLs (e.g. `/sites-dashboard?status=launched` and `/sites-dashboard?status=private`):

<img width="702" alt="image" src="https://user-images.githubusercontent.com/36432/178274281-6d85659e-441e-4091-b89a-5cde74f7cd25.png">

'All' sites remains as `/sites-dashboard`.

One thing worth noting: `TabPanel` renders `<button>`, so we have to call `page()` to update the URL when a tab item is selected. I _think_ this is a horrible hack that's bad for accessibility, but I'm not 100% confident. I don't think it should be a PR blocker, though.

## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Click on the 'Launched' tab.
3. Observe the URL as `/sites-dashboard?status=launched`, and only Launched sites listed.
4. Click on the 'Private' tab.
5. Observe the URL as `/sites-dashboard?status=private`, and only Private sites listed.
6. Click on the 'Coming soon' tab.
7. Observe the URL as `/sites-dashboard?status=coming-soon`, and only Coming soon sites listed.
8. Refresh the page.
9. Observe the URL as `/sites-dashboard?status=coming-soon`, and only Coming soon sites listed.
10. Manually navigate to `/sites-dashboard?status=foobar`.
11. Observe the 'All' tab selected with all sites visible.
