### PR TITLE
DIFM Landing Page: Fix animation intervals

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/site-build-showcase.tsx
+++ b/client/my-sites/marketing/do-it-for-me/site-build-showcase.tsx
@@ -11,13 +11,13 @@ const Container = styled.div`
 	position: relative;
 
 	@keyframes fadeAnimation {
-		7% {
+		6% {
 			opacity: 1;
 		}
-		23% {
+		20% {
 			opacity: 1;
 		}
-		30% {
+		26% {
 			opacity: 0;
 		}
 	}
@@ -27,7 +27,7 @@ const Container = styled.div`
 		height: 100%;
 		position: absolute;
 		top: 0;
-		animation: fadeAnimation 36s infinite;
+		animation: fadeAnimation 40s infinite;
 		background-size: contain;
 		background-repeat: no-repeat;
 		opacity: 0;


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to #64780. Bug Report: p1657545532487679/1657539093.720089-slack-C02KVCAL7GX

Since there are 5 images and the delay between images is fixed at 8 seconds, the complete slideshow takes requires 40 seconds to complete. However, in #64780, it was incorrectly set as 36s causing the first slide to begin its transition early. 

The keyframes do two transitions:
1. 0 - 2.4seconds: Opacity from 0 -> 1.
2. 8 - 2.4seconds: Opacity from 1 -> 0

Each consecutive image has an animation-delay of 8 seconds, so each image starts fading in exactly when the previous image starts fading out.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/difmStartingPoint?siteSlug=<site slug>`
* Confirm that the animation is stable after the first cycle and each image is shown for ~8 seconds.

https://user-images.githubusercontent.com/5436027/178280632-f7cae3e0-5f6c-4121-b539-f8bce1f31318.mp4


