### PR TITLE
Backup: Add realtime backups info banner

### DIFF
--- a/client/my-sites/backup/backups-made-realtime-banner.tsx
+++ b/client/my-sites/backup/backups-made-realtime-banner.tsx
@@ -1,0 +1,37 @@
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+import Banner from 'calypso/components/banner';
+// import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const BackupsMadeRealtimeBanner: FunctionComponent = () => {
+	const translate = useTranslate();
+
+	const siteId = useSelector( getSelectedSiteId );
+
+	return (
+		<Banner
+			callToAction={ translate( 'Learn more' ) }
+			className="backups-made-realtime-banner"
+			description={ translate(
+				'Your site is backed up as you make edits, and automatically once a day.'
+			) }
+			horizontal="true"
+			disableCircle={ true }
+			event="calypso_backups_made_realtime_banner"
+			dismissPreferenceName={ `backups-made-realtime-${ siteId }` }
+			href="https://jetpack.com/blog/real-time-backups-become-a-reality-with-jetpack/"
+			target="_blank"
+			icon={ 'history' }
+			title={ translate( 'Every change you make will be backed up' ) }
+			tracksClickName="calypso_backups_made_realtime_banner_click"
+			tracksDismissName="calypso_backups_made_realtime_banner_dismiss"
+			tracksImpressionName="ccalypso_backups_made_realtime_banner_view"
+		/>
+	);
+};
+
+export default BackupsMadeRealtimeBanner;

--- a/client/my-sites/backup/backups-made-realtime-banner.tsx
+++ b/client/my-sites/backup/backups-made-realtime-banner.tsx
@@ -18,17 +18,17 @@ const BackupsMadeRealtimeBanner: FunctionComponent = () => {
 			description={ translate(
 				'Your site is backed up as you make edits, and automatically once a day.'
 			) }
-			horizontal="true"
-			disableCircle={ true }
 			event="calypso_backups_made_realtime_banner"
 			dismissPreferenceName={ `backups-made-realtime-${ siteId }` }
 			href="https://jetpack.com/blog/real-time-backups-become-a-reality-with-jetpack/"
 			target="_blank"
-			icon={ 'history' }
+			icon="history"
 			title={ translate( 'Every change you make will be backed up' ) }
 			tracksClickName="calypso_backups_made_realtime_banner_click"
 			tracksDismissName="calypso_backups_made_realtime_banner_dismiss"
 			tracksImpressionName="ccalypso_backups_made_realtime_banner_view"
+			horizontal
+			disableCircle
 		/>
 	);
 };

--- a/client/my-sites/backup/backups-made-realtime-banner.tsx
+++ b/client/my-sites/backup/backups-made-realtime-banner.tsx
@@ -2,7 +2,6 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import Banner from 'calypso/components/banner';
-// import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -32,6 +32,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BackupDatePicker from './backup-date-picker';
+import BackupsMadeRealtimeBanner from './backups-made-realtime-banner';
 import EnableRestoresBanner from './enable-restores-banner';
 import { backupMainPath } from './paths';
 import SearchResults from './search-results';
@@ -175,6 +176,7 @@ const BackupStatus = ( { selectedDate, needCredentials, onDateChange } ) => {
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
 				{ needCredentials && <EnableRestoresBanner /> }
+				{ ! needCredentials && hasRealtimeBackups && <BackupsMadeRealtimeBanner /> }
 
 				<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
 				<BackupStorageSpace />

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -117,7 +117,7 @@ const isFilterEmpty = ( filter ) => {
 	return true;
 };
 
-const AdminContent = ( { selectedDate } ) => {
+function AdminContent( { selectedDate } ) {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -157,9 +157,9 @@ const AdminContent = ( { selectedDate } ) => {
 			) }
 		</>
 	);
-};
+}
 
-const BackupStatus = ( { selectedDate, needCredentials, onDateChange } ) => {
+function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 
@@ -188,6 +188,6 @@ const BackupStatus = ( { selectedDate, needCredentials, onDateChange } ) => {
 			</div>
 		</div>
 	);
-};
+}
 
 export default BackupPage;

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -155,6 +155,10 @@
 	}
 }
 
+.backups-made-realtime-banner .banner__icons .banner__icon {
+	display: block;
+}
+
 /* Jetpack.com-only changes */
 .is_jetpackcom {
 	.backup__restore-banner {


### PR DESCRIPTION
#### Proposed Changes

This PR adds an informational banner at the top of the /backup page, (if the user has a Backup realtime subscription and server credentials have been entered).

Project thread & design: p1HpG7-gb4-p2#comment-55084
Asana card: 1164141197617539-as-1202580352248673

#### Screenshots:

Jetpack Cloud:
![Markup 2022-07-11 at 09 04 34](https://user-images.githubusercontent.com/11078128/178272347-009d47e2-b2b0-4ceb-b777-1be41124d0da.png)

WordPress.com:
![Markup 2022-07-11 at 09 13 03](https://user-images.githubusercontent.com/11078128/178272386-9f7603ce-a108-48c8-94fa-58ed6100173d.png)

#### Testing Instructions

- Checkout this PR and spin up Calypso blue and green concurrently (`yarn start` and `yarn start-jetpack-cloud-p`). Or use the Calypso.Live links below.
- Select a Jetpack site that has a Backup realtime subscription. (or create a site with Jurassic Ninja and purchase Backup with credits (or add backup using Store Admin) ).
- Make sure server credentials have been entered and saved. (When server credentials **have not** been entered yet, a different Banner is displayed, reminding user to enter credentials to enable restores.)
- Once credentials have been entered, visit `/backup/:site` (replace `:site` with your site name/slug.) in both Calypso green and Calypso blue.
- Verify you can see the new Banner at the top of the /backup page UI, (See screenshots above).
- Verify it looks all good visually. Copy, spelling, appearance, etc.
**Bonus:**
- Using Store Admin, remove the Backup realtime subscription, and then add a Backup **daily** subscription.
- Visit the /backup page and verify the new Backup realtime banner **does not** get displayed.


---

- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202580352248673