### PR TITLE
HelpCenter: add max-height animation

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -74,7 +74,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 							</div>
 						) : (
 							<>
-								<HelpCenterContent isMinimized={ isMinimized } />
+								<HelpCenterContent />
 								{ ! isMinimized && <HelpCenterFooter /> }
 							</>
 						) }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -12,7 +12,6 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import { Content } from '../types';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
 import { HelpCenterEmbedResult } from './help-center-embed-result';
@@ -20,7 +19,7 @@ import InlineChat from './help-center-inline-chat';
 import { HelpCenterSearch } from './help-center-search';
 import { SuccessScreen } from './ticket-success-screen';
 
-const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
+const HelpCenterContent: React.FC = () => {
 	const location = useLocation();
 	const className = classnames( 'help-center__container-content' );
 	const section = useSelector( getSectionName );
@@ -35,7 +34,7 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 	}, [ location, section ] );
 
 	return (
-		<CardBody hidden={ isMinimized } className={ className }>
+		<CardBody className={ className }>
 			<Route exact path="/">
 				<HelpCenterSearch />
 			</Route>

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -11,6 +11,7 @@ $head-foot-height: 50px;
 	color: #000;
 	z-index: 9999;
 	cursor: default;
+	transition: max-height 0.5s;
 
 	button.button-primary,
 	button.button-secondary {
@@ -78,7 +79,7 @@ $head-foot-height: 50px;
 	}
 
 	&.is-desktop {
-		top: calc( $header-height + 16px );
+		top: calc( #{$header-height} + 16px );
 		right: 16px;
 		width: 410px;
 		height: 80vh;
@@ -92,7 +93,7 @@ $head-foot-height: 50px;
 
 		.help-center__container-content {
 			flex-grow: 1;
-			height: calc( 80vh - $head-foot-height * 2 );
+			height: calc( 80vh - #{$head-foot-height} * 2 );
 			position: relative;
 		}
 
@@ -118,7 +119,7 @@ $head-foot-height: 50px;
 
 		&.is-minimized {
 			min-height: $head-foot-height;
-			top: calc( 100vh - $head-foot-height );
+			top: calc( 100vh - #{$head-foot-height} );
 		}
 	}
 

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -7,10 +7,6 @@ export interface Container {
 	isLoading?: boolean;
 }
 
-export interface Content {
-	isMinimized: boolean;
-}
-
 export interface Header {
 	isMinimized?: boolean;
 	onMinimize?: () => void;


### PR DESCRIPTION
#### Proposed Changes

* This PR adds animation when minimizing or maximizing the Help Center
* The CardBody managing of minimized/maximized state has been removed to simplify the code and remove a glitch when minimizing where the whole content disappears while the max-height animation is going.

#### Testing Instructions
- Checkout this branch
- In `apps/editing-toolkit` run `yarn dev --sync`
- In a sandboxed simple site open the new help center
- Test the minimize/maximize and the animations


Related to #64895
