### PR TITLE
Hook Sites Dashboard into All Sites selector

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Global } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { some, startsWith } from 'lodash';
@@ -48,6 +49,8 @@ import {
 import DIFMLiteInProgress from 'calypso/my-sites/marketing/do-it-for-me/difm-lite-in-progress';
 import NavigationComponent from 'calypso/my-sites/navigation';
 import SitesComponent from 'calypso/my-sites/sites';
+import { SitesDashboard } from 'calypso/sites-dashboard/components/sites-dashboard';
+import { globalStyles } from 'calypso/sites-dashboard/controller';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice, warningNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -67,9 +70,6 @@ import { isSupportSession } from 'calypso/state/support/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { globalStyles } from 'calypso/sites-dashboard/controller';
-import { Global } from '@emotion/react';
-import { SitesDashboard } from 'calypso/sites-dashboard/components/sites-dashboard';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -67,6 +67,9 @@ import { isSupportSession } from 'calypso/state/support/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { globalStyles } from 'calypso/sites-dashboard/controller';
+import { Global } from '@emotion/react';
+import { SitesDashboard } from 'calypso/sites-dashboard/components/sites-dashboard';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -346,6 +349,15 @@ function createSitesComponent( context ) {
 	const basePath = filteredPathName === '/sites' ? '/home' : filteredPathName;
 
 	recordPageView( contextPath, sitesPageTitleForAnalytics );
+
+	if ( config.isEnabled( 'build/sites-dashboard' ) ) {
+		return (
+			<>
+				<Global styles={ globalStyles } />
+				<SitesDashboard />
+			</>
+		);
+	}
 
 	return (
 		<SitesComponent

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -354,7 +354,7 @@ function createSitesComponent( context ) {
 		return (
 			<>
 				<Global styles={ globalStyles } />
-				<SitesDashboard />
+				<SitesDashboard siteBasePath={ basePath } />
 			</>
 		);
 	}

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -9,9 +9,10 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SearchableSitesTableProps {
 	sites: SiteData[];
+	siteBasePath: string;
 }
 
-export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
+export function SearchableSitesTable( { sites, siteBasePath }: SearchableSitesTableProps ) {
 	const { __ } = useI18n();
 
 	const [ term, setTerm ] = useState( '' );
@@ -46,7 +47,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 						/>
 					</div>
 					{ filteredSites.length > 0 ? (
-						<SitesTable sites={ filteredSites } />
+						<SitesTable sites={ filteredSites } siteBasePath={ siteBasePath } />
 					) : (
 						<h2>{ __( 'No sites match your search.' ) }</h2>
 					) }

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -22,12 +22,13 @@ const Title = styled.div`
 type SitesContainerProps = {
 	sites: SiteData[];
 	status: string;
+	siteBasePath: string;
 };
 
-export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
+export const SitesContainer = ( { sites, status, siteBasePath }: SitesContainerProps ) => {
 	const { __ } = useI18n();
 	if ( sites.length > 0 ) {
-		return <SearchableSitesTable sites={ sites } />;
+		return <SearchableSitesTable sites={ sites } siteBasePath={ siteBasePath } />;
 	}
 
 	if ( status === 'launched' ) {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -10,6 +10,7 @@ import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
 	launchStatus?: string;
+	siteBasePath: string;
 }
 
 const MAX_PAGE_WIDTH = '1184px';
@@ -58,7 +59,7 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
-export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
+export function SitesDashboard( { launchStatus, siteBasePath }: SitesDashboardProps ) {
 	const { __ } = useI18n();
 	const sites = useSelector( getSites );
 

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -87,7 +87,11 @@ export function SitesDashboard( { launchStatus, siteBasePath }: SitesDashboardPr
 							launchStatus={ launchStatus }
 						>
 							{ ( filteredSites, status ) => (
-								<SitesContainer sites={ filteredSites } status={ status } />
+								<SitesContainer
+									sites={ filteredSites }
+									status={ status }
+									siteBasePath={ siteBasePath }
+								/>
 							) }
 						</SitesTableFilterTabs>
 					) }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -59,7 +59,9 @@ const SiteUrl = styled.a`
 `;
 
 const getDashboardUrl = ( slug: string, siteBasePath: string ) => {
-	const path = siteBasePath;
+	let path = siteBasePath;
+
+	path = path.split( '?' )[ 0 ];
 
 	return path + '/' + slug;
 };

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -10,6 +10,12 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SiteTableRowProps {
 	site: SiteData;
+	siteBasePath: string;
+}
+
+interface VisitDashboardItemProps {
+	site: SiteData;
+	siteBasePath: string;
 }
 
 const Row = styled.tr`
@@ -52,24 +58,26 @@ const SiteUrl = styled.a`
 	}
 `;
 
-const getDashboardUrl = ( slug: string ) => {
-	return '/home/' + slug;
+const getDashboardUrl = ( slug: string, siteBasePath: string ) => {
+	const path = siteBasePath;
+
+	return path + '/' + slug;
 };
 
 const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
 };
 
-const VisitDashboardItem = ( { site }: { site: SiteData } ) => {
+const VisitDashboardItem = ( { site, siteBasePath }: VisitDashboardItemProps ) => {
 	const { __ } = useI18n();
 	return (
-		<PopoverMenuItem href={ getDashboardUrl( site.slug ) }>
+		<PopoverMenuItem href={ getDashboardUrl( site.slug, siteBasePath ) }>
 			{ __( 'Visit Dashboard' ) }
 		</PopoverMenuItem>
 	);
 };
 
-export default function SitesTableRow( { site }: SiteTableRowProps ) {
+export default function SitesTableRow( { site, siteBasePath }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 
 	const isComingSoon =
@@ -83,7 +91,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					leading={
 						<a
 							style={ { display: 'block' } }
-							href={ getDashboardUrl( site.slug ) }
+							href={ getDashboardUrl( site.slug, siteBasePath ) }
 							title={ __( 'Visit Dashboard' ) }
 						>
 							<SiteIcon siteId={ site.ID } size={ 50 } />
@@ -92,7 +100,10 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					title={
 						<div style={ { display: 'flex', alignItems: 'center', marginBottom: '8px' } }>
 							<SiteName style={ { marginRight: '8px' } }>
-								<a href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
+								<a
+									href={ getDashboardUrl( site.slug, siteBasePath ) }
+									title={ __( 'Visit Dashboard' ) }
+								>
 									{ site.name ? site.name : __( '(No Site Title)' ) }
 								</a>
 							</SiteName>
@@ -122,7 +133,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 			<td className="sites-table-row__mobile-hidden">July 16, 1969</td>
 			<td style={ { width: '20px' } }>
 				<EllipsisMenu>
-					<VisitDashboardItem site={ site } />
+					<VisitDashboardItem site={ site } siteBasePath={ siteBasePath } />
 				</EllipsisMenu>
 			</td>
 		</Row>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -6,6 +6,7 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 interface SitesTableProps {
 	className?: string;
 	sites: SiteData[];
+	siteBasePath: string;
 }
 
 const Table = styled.table`
@@ -32,7 +33,7 @@ const Row = styled.tr`
 	}
 `;
 
-export function SitesTable( { className, sites }: SitesTableProps ) {
+export function SitesTable( { className, sites, siteBasePath }: SitesTableProps ) {
 	const { __ } = useI18n();
 
 	return (
@@ -47,7 +48,7 @@ export function SitesTable( { className, sites }: SitesTableProps ) {
 			</thead>
 			<tbody>
 				{ sites.map( ( site ) => (
-					<SitesTableRow site={ site } key={ site.ID }></SitesTableRow>
+					<SitesTableRow site={ site } key={ site.ID } siteBasePath={ siteBasePath } />
 				) ) }
 			</tbody>
 		</Table>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -3,7 +3,7 @@ import { SitesDashboard } from './components/sites-dashboard';
 import type { Context as PageJSContext } from 'page';
 
 export const globalStyles = css`
-	body.is-group-sites-dashboard {
+	body.is-group-sites {
 		background: #fdfdfd;
 
 		.layout__content {

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -2,7 +2,7 @@ import { Global, css } from '@emotion/react';
 import { SitesDashboard } from './components/sites-dashboard';
 import type { Context as PageJSContext } from 'page';
 
-const globalStyles = css`
+export const globalStyles = css`
 	body.is-group-sites-dashboard {
 		background: #fdfdfd;
 

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -17,7 +17,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
-			<SitesDashboard launchStatus={ context.query.status } />
+			<SitesDashboard launchStatus={ context.query.status } siteBasePath="/home" />
 		</>
 	);
 	next();


### PR DESCRIPTION
#### Proposed Changes

This PR replaces the current Sites component accessible by the "All My Sites" link with the new Sites Dashboard. 

The feature is kept behind the `build/sites-dashboard` feature flag.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Pull branch, start the calypso
2. Click on "Switch Sites" in the sidebar
3. Click on "All My Sites" in the sidebar
4. Confirm that the new Sites Dashboard is displayed instead of the Sites component
5. Choose any site, confirm that the home for the selected site is loaded

![Screen Capture on 2022-07-12 at 08-36-05](https://user-images.githubusercontent.com/727413/178464305-33bdf9c3-0922-4f5a-9326-6ae11525d800.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65181
