### PR TITLE
Sites Management Dashboard: Add design for empty states

### DIFF
--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -48,7 +48,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 					{ filteredSites.length > 0 ? (
 						<SitesTable sites={ filteredSites } />
 					) : (
-						<h2>No sites match your search.</h2>
+						<h2>{ __( 'No sites match your search.' ) }</h2>
 					) }
 				</>
 			) }

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -45,7 +45,11 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 							placeholder={ __( 'Search by name or domain…' ) }
 						/>
 					</div>
-					<SitesTable sites={ filteredSites } />
+					{ filteredSites.length > 0 ? (
+						<SitesTable sites={ filteredSites } />
+					) : (
+						<h2>No sites match your search.</h2>
+					) }
 				</>
 			) }
 		</ClassNames>

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -19,10 +19,10 @@ const EmptyContainer = styled.div`
 
 type SitesContainerProps = {
 	sites: SiteData[];
-	filter: string;
+	status: string;
 };
 
-export const SitesContainer = ( { sites, filter }: SitesContainerProps ) => {
+export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 	const { __ } = useI18n();
 	if ( sites.length > 0 ) {
 		return (
@@ -39,7 +39,7 @@ export const SitesContainer = ( { sites, filter }: SitesContainerProps ) => {
 		);
 	}
 
-	switch ( filter ) {
+	switch ( status ) {
 		case 'launched':
 			return (
 				<EmptyContainer>

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -20,7 +20,6 @@ const EmptyContainer = styled.div`
 type SitesContainerProps = {
 	sites: SiteData[];
 	filter: string;
-	className?: string;
 };
 
 export const SitesContainer = ( { sites, filter }: SitesContainerProps ) => {

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -1,0 +1,140 @@
+import { ClassNames } from '@emotion/react';
+import styled from '@emotion/styled';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import EmptyContent from 'calypso/components/empty-content';
+import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import { SitesTable } from './sites-table';
+
+const EmptyContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 600px;
+
+	.empty-content__line {
+		max-width: 650px;
+	}
+`;
+
+type SitesContainerProps = {
+	sites: SiteData[];
+	filter: string;
+	className?: string;
+};
+
+export const SitesContainer = ( { sites, filter }: SitesContainerProps ) => {
+	const { __ } = useI18n();
+	if ( sites.length > 0 ) {
+		return (
+			<ClassNames>
+				{ ( { css } ) => (
+					<SitesTable
+						className={ css`
+							margin-top: 32px;
+						` }
+						sites={ sites }
+					/>
+				) }
+			</ClassNames>
+		);
+	}
+
+	switch ( filter ) {
+		case 'launched':
+			return (
+				<EmptyContainer>
+					<EmptyContent
+						title={ __( "You haven't launched a site" ) }
+						line={
+							<p>
+								{ createInterpolateElement(
+									__(
+										'Our <a>support center</a> and team are here to help you as you work your way towards launch.'
+									),
+									{
+										a: (
+											<a
+												href={ 'https://wordpress.com/support/' }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									}
+								) }
+							</p>
+						}
+						illustration={ '' }
+					/>
+				</EmptyContainer>
+			);
+		case 'private':
+			return (
+				<EmptyContainer>
+					<EmptyContent
+						title={ __( 'You have no private sites' ) }
+						line={
+							<p>
+								{ createInterpolateElement(
+									__(
+										"Private sites aren't accessible to the world. Read more about them <a>here</a>."
+									),
+									{
+										a: (
+											<a
+												href={ 'https://wordpress.com/support/settings/privacy-settings/' }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									}
+								) }
+							</p>
+						}
+						illustration={ '' }
+					/>
+				</EmptyContainer>
+			);
+		case 'coming-soon':
+			return (
+				<EmptyContainer>
+					<EmptyContent
+						title={ __( 'You have no coming soon sites' ) }
+						line={
+							<p>
+								{ createInterpolateElement(
+									__(
+										'Coming soon sites will display a landing page letting people know that a site is being built. Read more about them <a>here</a>.'
+									),
+									{
+										a: (
+											<a
+												href={ 'https://wordpress.com/support/settings/privacy-settings/' }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									}
+								) }
+							</p>
+						}
+						illustration={ '' }
+					/>
+				</EmptyContainer>
+			);
+		default:
+			return (
+				<EmptyContainer>
+					<EmptyContent
+						title={ __( 'Create your first site' ) }
+						line={ __(
+							"It's time to get your ideas online. We'll guide you through the process of creating a site that best suits your needs."
+						) }
+						action={ __( 'Create your first site' ) }
+						actionURL={ '/start?ref=sites-dashboard' }
+						illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
+					/>
+				</EmptyContainer>
+			);
+	}
+};

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -6,17 +6,20 @@ import EmptyContent from 'calypso/components/empty-content';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 import { SitesTable } from './sites-table';
 
-const EmptyContainer = styled.div`
+const EmptySites = styled( EmptyContent )`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	height: 600px;
-
-	.empty-content__line {
-		max-width: 650px;
-	}
+	align-items: center;
 `;
 
+const SecondaryText = styled.p`
+	max-width: 650px;
+`;
+
+const Title = styled.div`
+	margin-top: 50%;
+`;
 type SitesContainerProps = {
 	sites: SiteData[];
 	status: string;
@@ -24,6 +27,7 @@ type SitesContainerProps = {
 
 export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 	const { __ } = useI18n();
+	sites = [];
 	if ( sites.length > 0 ) {
 		return (
 			<ClassNames>
@@ -39,101 +43,96 @@ export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 		);
 	}
 
-	switch ( status ) {
-		case 'launched':
-			return (
-				<EmptyContainer>
-					<EmptyContent
-						title={ __( "You haven't launched a site" ) }
-						line={
-							<p>
-								{ createInterpolateElement(
-									__(
-										'Our <a>support center</a> and team are here to help you as you work your way towards launch.'
-									),
-									{
-										a: (
-											<a
-												href={ 'https://wordpress.com/support/' }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									}
-								) }
-							</p>
-						}
-						illustration={ '' }
-					/>
-				</EmptyContainer>
-			);
-		case 'private':
-			return (
-				<EmptyContainer>
-					<EmptyContent
-						title={ __( 'You have no private sites' ) }
-						line={
-							<p>
-								{ createInterpolateElement(
-									__(
-										"Private sites aren't accessible to the world. Read more about them <a>here</a>."
-									),
-									{
-										a: (
-											<a
-												href={ 'https://wordpress.com/support/settings/privacy-settings/' }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									}
-								) }
-							</p>
-						}
-						illustration={ '' }
-					/>
-				</EmptyContainer>
-			);
-		case 'coming-soon':
-			return (
-				<EmptyContainer>
-					<EmptyContent
-						title={ __( 'You have no coming soon sites' ) }
-						line={
-							<p>
-								{ createInterpolateElement(
-									__(
-										'Coming soon sites will display a landing page letting people know that a site is being built. Read more about them <a>here</a>.'
-									),
-									{
-										a: (
-											<a
-												href={ 'https://wordpress.com/support/settings/privacy-settings/' }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									}
-								) }
-							</p>
-						}
-						illustration={ '' }
-					/>
-				</EmptyContainer>
-			);
-		default:
-			return (
-				<EmptyContainer>
-					<EmptyContent
-						title={ __( 'Create your first site' ) }
-						line={ __(
-							"It's time to get your ideas online. We'll guide you through the process of creating a site that best suits your needs."
+	if ( status === 'launched' ) {
+		return (
+			<EmptySites
+				title={ <Title> { __( "You haven't launched a site" ) } </Title> }
+				line={
+					<SecondaryText>
+						{ createInterpolateElement(
+							__(
+								'Our <a>support center</a> and team are here to help you as you work your way towards launch.'
+							),
+							{
+								a: (
+									<a
+										href={ 'https://wordpress.com/support/' }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
 						) }
-						action={ __( 'Create your first site' ) }
-						actionURL={ '/start?ref=sites-dashboard' }
-						illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
-					/>
-				</EmptyContainer>
-			);
+					</SecondaryText>
+				}
+				illustration={ '' }
+			/>
+		);
 	}
+
+	if ( status === 'private' ) {
+		return (
+			<EmptySites
+				title={ <Title> { __( 'You have no private sites' ) } </Title> }
+				line={
+					<SecondaryText>
+						{ createInterpolateElement(
+							__(
+								"Private sites aren't accessible to the world. Read more about them <a>here</a>."
+							),
+							{
+								a: (
+									<a
+										href={ 'https://wordpress.com/support/settings/privacy-settings/' }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
+						) }
+					</SecondaryText>
+				}
+				illustration={ '' }
+			/>
+		);
+	}
+
+	if ( status === 'coming-soon' ) {
+		return (
+			<EmptySites
+				title={ <Title> { __( 'You have no coming soon sites' ) } </Title> }
+				line={
+					<SecondaryText>
+						{ createInterpolateElement(
+							__(
+								'Coming soon sites will display a landing page letting people know that a site is being built. Read more about them <a>here</a>.'
+							),
+							{
+								a: (
+									<a
+										href={ 'https://wordpress.com/support/settings/privacy-settings/' }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
+						) }
+					</SecondaryText>
+				}
+				illustration={ '' }
+			/>
+		);
+	}
+
+	return (
+		<EmptySites
+			title={ __( 'Create your first site' ) }
+			line={ __(
+				"It's time to get your ideas online. We'll guide you through the process of creating a site that best suits your needs."
+			) }
+			action={ __( 'Create your first site' ) }
+			actionURL={ '/start?ref=sites-dashboard' }
+			illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
+		/>
+	);
 };

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -1,10 +1,9 @@
-import { ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import EmptyContent from 'calypso/components/empty-content';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
-import { SitesTable } from './sites-table';
+import { SearchableSitesTable } from './searchable-sites-table';
 
 const EmptySites = styled( EmptyContent )`
 	display: flex;
@@ -28,18 +27,7 @@ type SitesContainerProps = {
 export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 	const { __ } = useI18n();
 	if ( sites.length > 0 ) {
-		return (
-			<ClassNames>
-				{ ( { css } ) => (
-					<SitesTable
-						className={ css`
-							margin-top: 32px;
-						` }
-						sites={ sites }
-					/>
-				) }
-			</ClassNames>
-		);
+		return <SearchableSitesTable sites={ sites } />;
 	}
 
 	if ( status === 'launched' ) {

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -27,7 +27,6 @@ type SitesContainerProps = {
 
 export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 	const { __ } = useI18n();
-	sites = [];
 	if ( sites.length > 0 ) {
 		return (
 			<ClassNames>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -5,7 +5,11 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import getSites from 'calypso/state/selectors/get-sites';
 import { notNullish } from '../util';
+<<<<<<< HEAD
 import { SearchableSitesTable } from './searchable-sites-table';
+=======
+import { SitesContainer } from './sites-container';
+>>>>>>> f9907e6090 (update filtered sites functionality to also return the filter key)
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
@@ -85,7 +89,13 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 							` }
 							launchStatus={ launchStatus }
 						>
+<<<<<<< HEAD
 							{ ( filteredSites ) => <SearchableSitesTable sites={ filteredSites } /> }
+=======
+							{ ( filteredSites, filter ) => (
+								<SitesContainer sites={ filteredSites } filter={ filter } />
+							) }
+>>>>>>> f9907e6090 (update filtered sites functionality to also return the filter key)
 						</SitesTableFilterTabs>
 					) }
 				</ClassNames>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -90,10 +90,15 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 							launchStatus={ launchStatus }
 						>
 <<<<<<< HEAD
+<<<<<<< HEAD
 							{ ( filteredSites ) => <SearchableSitesTable sites={ filteredSites } /> }
 =======
 							{ ( filteredSites, filter ) => (
 								<SitesContainer sites={ filteredSites } filter={ filter } />
+=======
+							{ ( filteredSites, status ) => (
+								<SitesContainer sites={ filteredSites } status={ status } />
+>>>>>>> 97c346dfca (refactor site filter to be site status instead)
 							) }
 >>>>>>> f9907e6090 (update filtered sites functionality to also return the filter key)
 						</SitesTableFilterTabs>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -5,11 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import getSites from 'calypso/state/selectors/get-sites';
 import { notNullish } from '../util';
-<<<<<<< HEAD
-import { SearchableSitesTable } from './searchable-sites-table';
-=======
 import { SitesContainer } from './sites-container';
->>>>>>> f9907e6090 (update filtered sites functionality to also return the filter key)
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
@@ -89,18 +85,9 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 							` }
 							launchStatus={ launchStatus }
 						>
-<<<<<<< HEAD
-<<<<<<< HEAD
-							{ ( filteredSites ) => <SearchableSitesTable sites={ filteredSites } /> }
-=======
-							{ ( filteredSites, filter ) => (
-								<SitesContainer sites={ filteredSites } filter={ filter } />
-=======
 							{ ( filteredSites, status ) => (
 								<SitesContainer sites={ filteredSites } status={ status } />
->>>>>>> 97c346dfca (refactor site filter to be site status instead)
 							) }
->>>>>>> f9907e6090 (update filtered sites functionality to also return the filter key)
 						</SitesTableFilterTabs>
 					) }
 				</ClassNames>

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -9,7 +9,7 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-
 
 interface SitesTableFilterTabsProps {
 	allSites: SiteData[];
-	children( filteredSites: SiteData[] ): JSX.Element;
+	children( filteredSites: SiteData[], filter: string ): JSX.Element;
 	className?: string;
 	launchStatus?: string;
 }
@@ -91,7 +91,7 @@ export function SitesTableFilterTabs( {
 				);
 			} }
 		>
-			{ ( tab ) => renderContents( filteredSites[ tab.name ] ) }
+			{ ( tab ) => renderContents( filteredSites[ tab.name ], tab.name ) }
 		</SitesTabPanel>
 	);
 }

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -9,7 +9,7 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-
 
 interface SitesTableFilterTabsProps {
 	allSites: SiteData[];
-	children( filteredSites: SiteData[], filter: string ): JSX.Element;
+	children( filteredSites: SiteData[], status: string ): JSX.Element;
 	className?: string;
 	launchStatus?: string;
 }


### PR DESCRIPTION
#### Proposed Changes

* Add ability to show a specific empty state design for each site filter.

#### Testing Instructions

1. Check out the branch locally.
2. Set `sites = []` in `client/sites-dashboard/components/sites-container.tsx`
3. Navigate to /sites-dashboard and view the new Sites Dashboard.
4. Observe the different empty states
5. Test empty search state by entering a site that does not exist. It should show `No sites match your search.`


**Note:**  The illustration for create site state is not yet added and it's using the default illustration
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* 
![image](https://user-images.githubusercontent.com/47489215/178327978-3d97bd73-e045-4703-9448-369a62a90879.png)

![image](https://user-images.githubusercontent.com/47489215/178328052-96e46293-a961-43b9-b075-c59059a41a91.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#65173](https://github.com/Automattic/wp-calypso/issues/65173)
