### PR TITLE
Add view and click tracking to email-no-domain page

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -24,6 +24,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
@@ -88,9 +89,9 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		selectedIntervalLength,
 		sectionHeaderLabel,
 		source,
-	} = props;
+	}: EmailManagementHomeProps = props;
 
-	const selectedSite = useSelector( getSelectedSite );
+	const selectedSite: SiteData | null = useSelector( getSelectedSite );
 
 	const canManageSite = useSelector( ( state ) => {
 		if ( ! selectedSite ) {

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -24,7 +24,6 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
@@ -89,9 +88,9 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		selectedIntervalLength,
 		sectionHeaderLabel,
 		source,
-	}: EmailManagementHomeProps = props;
+	} = props;
 
-	const selectedSite: SiteData | null = useSelector( getSelectedSite );
+	const selectedSite = useSelector( getSelectedSite );
 
 	const canManageSite = useSelector( ( state ) => {
 		if ( ! selectedSite ) {

--- a/client/my-sites/email/email-management/home/email-no-domain.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.tsx
@@ -1,6 +1,5 @@
 import { isFreePlan } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
 import EmptyContent from 'calypso/components/empty-content';
@@ -13,15 +12,14 @@ import type { AppState } from 'calypso/types';
 const EmailNoDomain = ( {
 	selectedSite,
 	translate,
-	source
-} : {
-	selectedSite: SiteData,
-	translate: Function,
-	source: string
+	source,
+}: {
+	selectedSite: SiteData;
+	translate: ( input: string ) => string;
+	source: string;
 } ) => {
-	const hasAvailableDomainCredit = useSelector( ( state: AppState ) => {
-		hasDomainCredit( state, selectedSite.ID );
-	}
+	const hasAvailableDomainCredit = useSelector( ( state: AppState ) =>
+		hasDomainCredit( state, selectedSite.ID )
 	);
 
 	const isFreePlanProduct = isFreePlan( selectedSite?.plan?.product_slug ?? null );
@@ -96,15 +94,6 @@ const EmailNoDomain = ( {
 			{ trackImpression( 'domain' ) }
 		</EmptyContent>
 	);
-};
-
-EmailNoDomain.propTypes = {
-	// Props passed to this component
-	selectedSite: PropTypes.object.isRequired,
-	source: PropTypes.string,
-
-	// Props injected via localize()
-	translate: PropTypes.func.isRequired,
 };
 
 export default localize( EmailNoDomain );

--- a/client/my-sites/email/email-management/home/email-no-domain.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.tsx
@@ -1,5 +1,5 @@
 import { isFreePlan } from '@automattic/calypso-products';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
 import EmptyContent from 'calypso/components/empty-content';
@@ -9,15 +9,9 @@ import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { AppState } from 'calypso/types';
 
-const EmailNoDomain = ( {
-	selectedSite,
-	translate,
-	source,
-}: {
-	selectedSite: SiteData;
-	translate: ( input: string ) => string;
-	source: string;
-} ) => {
+const EmailNoDomain = ( { selectedSite, source }: { selectedSite: SiteData; source: string } ) => {
+	const translate = useTranslate();
+
 	const hasAvailableDomainCredit = useSelector( ( state: AppState ) =>
 		hasDomainCredit( state, selectedSite.ID )
 	);
@@ -96,4 +90,4 @@ const EmailNoDomain = ( {
 	);
 };
 
-export default localize( EmailNoDomain );
+export default EmailNoDomain;

--- a/client/my-sites/email/email-management/home/email-no-domain.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.tsx
@@ -23,6 +23,9 @@ const EmailNoDomain = ( { selectedSite, source }: { selectedSite: SiteData; sour
 	};
 
 	const trackImpression = ( noDomainContext: string ) => {
+		// This is executed multiple times by different conditionals as the site states get set.
+		// Particularly, `hasAvailableDomainCredit` takes some time to be returned.
+		// To ensure we are tracking the proper values, only make a tracking request when all states are set.
 		if ( isFreePlanProduct === null || hasAvailableDomainCredit === null ) {
 			return '';
 		}

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -219,12 +219,21 @@ export function recordInboxNewMailboxUpsellClickEvent() {
 }
 
 /**
- * Tracks an event for the key 'calypso_inbox_upsell'.
+ * Tracks an event for the key 'calypso_{source}_upsell', where {source} defaults to "email".
+ * For upsell triggered from the inbox, the event 'calypso_inbox_upsell' will be tracked.
  *
+ * @param source - source generating the event.
  * @param context context, where this event was logged.
  */
-export function recordInboxUpsellTracksEvent( context: string | null = null ) {
-	recordTracksEvent( 'calypso_inbox_upsell', {
+export function recordEmailUpsellTracksEvent(
+	source: string | null = null,
+	context: string | null = null
+) {
+	if ( ! source ) {
+		source = 'email';
+	}
+
+	recordTracksEvent( 'calypso_' + source + '_upsell', {
 		context,
 	} );
 }

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -227,14 +227,10 @@ export function recordInboxNewMailboxUpsellClickEvent() {
  * @param context context, where this event was logged.
  */
 export function recordEmailUpsellTracksEvent(
-	source: string | null = null,
+	source: string | null = 'email',
 	context: string | null = null
 ) {
-	if ( ! source ) {
-		source = 'email';
-	}
-
-	recordTracksEvent( 'calypso_' + source + '_upsell', {
+	recordTracksEvent( `calypso_${ source }_upsell`, {
 		context,
 	} );
 }

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -24,6 +24,7 @@ import {
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import type { EmailAccount } from 'calypso/data/emails/types';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { AppState } from 'calypso/types';
 
 export function getNumberOfMailboxesText( domain: ResponseDomain ) {
 	if ( hasGSuiteWithUs( domain ) ) {
@@ -69,7 +70,7 @@ export function getNumberOfMailboxesText( domain: ResponseDomain ) {
  * @param domain - domain object
  * @returns the corresponding email purchase, or null if not found
  */
-export function getEmailPurchaseByDomain( state: any, domain: ResponseDomain ) {
+export function getEmailPurchaseByDomain( state: AppState, domain: ResponseDomain ) {
 	const subscriptionId = getEmailSubscriptionIdByDomain( domain );
 
 	return subscriptionId ? getByPurchaseId( state, subscriptionId ) : null;

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -221,7 +221,10 @@ export function recordInboxNewMailboxUpsellClickEvent() {
 
 /**
  * Tracks an event for the key 'calypso_{source}_upsell', where {source} defaults to "email".
- * For upsell triggered from the inbox, the event 'calypso_inbox_upsell' will be tracked.
+ *
+ * Events tracked:
+ * `calypso_inbox_upsell`, when upsell triggered by a CTA click from the Inbox.
+ * `calypso_email_upsell`, when upsell triggered by a CTA click from Upgrades > Emails.
  *
  * @param source - source generating the event.
  * @param context context, where this event was logged.


### PR DESCRIPTION
#### Proposed Changes

Add view and click tracking to understand upsell engagement of the "no domains" screen as users without a custom domain navigates to the **Upgrades > Emails** or **Inbox** page.

"No domain" screen for users on a free plan:

<img width="848" alt="no-domain-plan" src="https://user-images.githubusercontent.com/104910361/178350488-8494f5fa-5406-4a45-b97d-f970b0f720bc.png">

"No domain" screen for users with a paid plan:

<img width="843" alt="no-domain-domain" src="https://user-images.githubusercontent.com/104910361/178350611-22c75ce9-c9cc-4c9d-bc57-ca320e56e147.png">

**1) View Tracking**
* Event Name: `calypso_email_management_no_domain` 
* Triggered on **page load**, sending the following properties:
  * `source`
    * `email` if "no domain" screen is shown on the **Upgrades > Emails** page `/email/:site`
    * `inbox` if "no domain" screen is shown on the **Inbox** page `/inbox/:site`
  * `context`
    * `plan` if user is on a free plan
    * `domain` if user has a paid plan

**2) CTA Click Tracking** 
* Event Name: `calypso_email_upsell` 
* Triggered when users **click** on the CTA on the "no domain" screen, sending the following properties:
  * `context`
    * `plan` if user is on a free plan
    * `domain` if user has a paid plan

Note that the original `recordInboxUpsellTracksEvent()` function for tracking CTA clicks in the "no domains" screen for the **Inbox** `/inbox/:site` had been modified to support click tracking on both `/inbox:site` and `/email/:site`. When the CTA is clicked on `/inbox:site`, the event tracked should remain as-is, which is `claypso_inbox_upsell`.

---

#### Testing Instructions

**1) View Tracking**
* Open the web console's network tab, filter network calls by `calypso_email_management_no_domain`
* Visit **Upgrades > Email**, verify the properties `context` and `source` are reporting appropriate values
* Visit **Inbox**, verify the properties `context` and `source` are reporting appropriate values

|  | Upgrades > Email  | Inbox |
| ------------- | ------------- | ------------- |
| User on free plan  | `context: plan`, `source: email` | `context: plan`, `source: inbox`  | 
| User on paid plan  | `context: domain`, `source: email` | `context: domain`, `source: inbox` | 

<img width="753" alt="view-tracking" src="https://user-images.githubusercontent.com/104910361/178349905-10fb506b-1315-4446-a0dc-1c6030f6bd31.png">

**2) CTA Click Tracking**
* Open the web console's network tab, filter network calls by `_upsell`
* Visit **Upgrades > Email**, click on CTA, verify the properties `context` and `source` are reporting appropriate values

|  | Upgrades > Email  | Inbox |
| ------------- | ------------- | ------------- |
| User on free plan | `context: plan`, `_en: calypso_email_upsell` | `context: plan`, `_en: calypso_inbox_upsell` | 
| User on paid plan  | `context: domain`, `_en: calypso_email_upsell` | `context: domain`, `_en: calypso_inbox_upsell` | 

<img width="587" alt="click-tracking" src="https://user-images.githubusercontent.com/104910361/178350019-d5efca2f-c98f-4073-9d80-f3cd5da61b15.png">

Related to [#52815](https://github.com/Automattic/wp-calypso/pull/52815#discussion_r631821363)
