### PR TITLE
Sidebar: Hide external link icon when collapsed

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Count from 'calypso/components/count';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -9,6 +10,7 @@ import TranslatableString from 'calypso/components/translatable/proptype';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { isExternal } from 'calypso/lib/url';
 import { preload } from 'calypso/sections-helper';
+import { getSidebarIsCollapsed } from 'calypso/state/ui/selectors';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
@@ -17,6 +19,7 @@ export default function SidebarItem( props ) {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
 	} );
+	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
 	const { materialIcon, materialIconStyle, icon, customIcon, count, badge } = props;
 
 	let _preloaded = false;
@@ -76,7 +79,7 @@ export default function SidebarItem( props ) {
 						</Badge>
 					) }
 				</span>
-				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
+				{ showAsExternal && ! sidebarIsCollapsed && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }
 			</a>
 		</li>


### PR DESCRIPTION
Fixes #64633

## Proposed Changes

Hides a sidebar item's external link icon when a sidebar is collapsed

### Before

<img width="423" alt="image" src="https://user-images.githubusercontent.com/36432/178356204-3ce6ca33-2bf4-49bc-aa3e-e693aebe5233.png">

### After

<img width="585" alt="image" src="https://user-images.githubusercontent.com/36432/178356132-b58f158b-5f2f-41c2-83af-da83848a8273.png">

## Testing Instructions

1. Navigate to a Calypso page for a Jetpack-connected site.
2. Observe the external link icon for "WP Admin".
3. Collapse the sidebar.
4. Observe the external link icon no longer displays for "WP Admin".
5. Expand the sidebar.
6. Observe the external link icon for "WP Admin".