### PR TITLE
[TeamCity] Fix: pass the right GB version to the --url-prefix param for the GB source-maps build

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -216,7 +216,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					cd gutenberg
 
 					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
-					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files wpcom-test-01 upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/v13.1.0/"
+					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files wpcom-test-01 upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
 				"""
 			}
 		}


### PR DESCRIPTION
Follow up to: https://github.com/Automattic/wp-calypso/pull/63260.

#### Proposed Changes

* Pass the right GB version that's set in the TC build params instead of the fixed one that was left there.

#### Testing Instructions

* The build should pass and the output for it should show the right version in the arg passed to the `--url-prefix` param of the `sentry-cli` call.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
