### PR TITLE
Checkout: Only pass receiptId to CheckoutThankYouComponent if it is a number

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -226,7 +226,19 @@ export function checkoutPending( context, next ) {
 }
 
 export function checkoutThankYou( context, next ) {
-	const receiptId = Number( context.params.receiptId );
+	// This route requires a numeric receipt ID like
+	// `/checkout/thank-you/example.com/1234` but it also operates as a fallback
+	// if something goes wrong with the "pending" page and will respond to a URL
+	// like `/checkout/thank-you/example.com/pending`. In that case, the word
+	// `pending` is a placeholder for the receipt ID that never got properly
+	// replaced (perhaps it could not find the receipt ID, for example).
+	//
+	// In that case, we still want to display a generic thank-you page (because
+	// the transaction was probably still successful), so we set `receiptId` to
+	// `undefined`.
+	const receiptId = Number.isInteger( Number( context.params.receiptId ) )
+		? Number( context.params.receiptId )
+		: undefined;
 	const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
 
 	const state = context.store.getState();


### PR DESCRIPTION
#### Proposed Changes

The `checkoutThankYou` route controller requires a numeric receipt ID in the URL, like `/checkout/thank-you/example.com/1234`, but the route also operates as a fallback if something goes wrong with the "pending" page and will respond to a URL like `/checkout/thank-you/example.com/pending` or `/checkout/thank-you/example.com/unknown` after https://github.com/Automattic/wp-calypso/pull/65390. In that case, the word `pending` or `unknown` is a placeholder for the receipt ID that never got properly replaced (perhaps it could not find the receipt ID, for example). In that case, we still want to display a generic "thank-you" page (because the transaction was probably still successful).

In this PR, if the receipt ID is not a number, we set it to `undefined`. This actually doesn't change any behavior for the page, which already displayed a generic "thank-you" page for the non-numeric route, but in that case the `receiptId` prop for `CheckoutThankYouComponent` will be `NaN` and if that component is ever cleaned up I want to make sure they don't accidentally drop support for this feature. This makes it more explicit.

#### Testing Instructions

Visit `/checkout/thank-you/no-site/pending` and verify that you see a generic "thank-you" page.