### PR TITLE
Jetpack Agency Dashboard: fix an error that is thrown when setting a site as favorite. 

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -101,12 +101,11 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 
 				// Optimistically update the favorites count of the current query and the sibling query
 				const updateTotalFavorites = ( oldSites: any ) => {
-					const currentCount = oldSites?.total_favorites;
-					// Prevent value being set to negative
-					const decrementer = currentCount > 0 ? -1 : 0;
+					const currentCount = oldSites?.total_favorites || 0;
 					return {
 						...oldSites,
-						total_favorites: currentCount + ( isFavorite ? decrementer : 1 ),
+						// Prevent value being set to negative
+						total_favorites: Math.max( currentCount + ( isFavorite ? -1 : 1 ), 0 ),
 					};
 				};
 				queryClient.setQueryData( queryKey, updateTotalFavorites );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -101,9 +101,12 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 
 				// Optimistically update the favorites count of the current query and the sibling query
 				const updateTotalFavorites = ( oldSites: any ) => {
+					const currentCount = oldSites?.total_favorites;
+					// Prevent value being set to negative
+					const decrementer = currentCount > 0 ? -1 : 0;
 					return {
 						...oldSites,
-						total_favorites: oldSites.total_favorites + ( isFavorite ? -1 : 1 ),
+						total_favorites: currentCount + ( isFavorite ? decrementer : 1 ),
 					};
 				};
 				queryClient.setQueryData( queryKey, updateTotalFavorites );


### PR DESCRIPTION
#### Proposed Changes

This PR adds the following changes

- Fix an error which is thrown when setting a site as a favorite.
- Prevents setting the favorite count to a negative value.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/set-site-favorite-error` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/ in incognito mode so that the site's data is not cached, and you'll be redirected to the /dashboard.
3. Set a site as favorite, and verify that no error is being thrown and the site is set as favorite


Related to 1202076982646589-as-1202589515490329