### PR TITLE
Jetpack Agency Dashboard: fix site column heading misalignment

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -87,5 +87,5 @@ td.site-table__td-with-error {
 	vertical-align: middle;
 }
 .site-table-site-title {
-	margin-inline-start: 32px;
+	margin-inline-start: 8px;
 }


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the alignment issue of the `Site` column heading

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/set-site-favorite-error` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify the Site column heading is aligned with the list of sites

**Screenshots**

Before

<img width="398" alt="Screenshot 2022-07-12 at 4 24 01 PM" src="https://user-images.githubusercontent.com/10586875/178474960-74e2e8cd-5b67-479b-ad2b-f0eae46feeef.png">

After

<img width="375" alt="Screenshot 2022-07-12 at 4 10 30 PM" src="https://user-images.githubusercontent.com/10586875/178474950-de24d5c0-dc46-4197-8cdc-55e5259cc142.png">

Related to 1202076982646589-as-1202589515490312