### PR TITLE
Support header_pattern_ids and footer_pattern_ids from the recipe

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -194,6 +194,12 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		is_premium: design?.is_premium,
 		is_generated: showGeneratedDesigns,
 		...( design?.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
+		...( design?.recipe?.header_pattern_ids && {
+			header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
+		} ),
+		...( design?.recipe?.footer_pattern_ids && {
+			footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
+		} ),
 	} );
 
 	const categorizationOptions = getCategorizationOptions(

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -293,8 +293,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				apiNamespace: 'wpcom/v2',
 				body: {
 					trim_content: true,
-					pattern_ids: recipe?.pattern_ids,
 					vertical_id: siteVerticalId || undefined,
+					pattern_ids: recipe?.pattern_ids,
+					header_pattern_ids: recipe?.header_pattern_ids || [],
+					footer_pattern_ids: recipe?.footer_pattern_ids || [],
 				},
 				method: 'POST',
 			} );

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -17,6 +17,8 @@ export interface Category {
 export interface DesignRecipe {
 	stylesheet?: string;
 	pattern_ids?: number[];
+	header_pattern_ids?: number[];
+	footer_pattern_ids?: number[];
 }
 
 export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -2,6 +2,15 @@ import { DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
 import { Design, DesignPreviewOptions } from '../../types';
 import { getDesignPreviewUrl } from '../designs';
 
+const mergeDesign = ( currentDesign, newDesign ) => ( {
+	...currentDesign,
+	...newDesign,
+	recipe: {
+		...currentDesign.recipe,
+		...newDesign.recipe,
+	},
+} );
+
 describe( 'Design Picker designs utils', () => {
 	describe( 'getDesignPreviewUrl', () => {
 		const design = {
@@ -15,6 +24,26 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
 			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
 				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+			);
+		} );
+
+		it( 'should append the header_pattern_ids to the query params', () => {
+			const customizedDesign = mergeDesign( design, {
+				recipe: { header_pattern_ids: [ 56, 78 ] },
+			} );
+
+			expect( getDesignPreviewUrl( customizedDesign, {} ) ).toEqual(
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&header_pattern_ids=56%2C78&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+			);
+		} );
+
+		it( 'should append the footer_pattern_ids to the query params', () => {
+			const customizedDesign = mergeDesign( design, {
+				recipe: { footer_pattern_ids: [ 56, 78 ] },
+			} );
+
+			expect( getDesignPreviewUrl( customizedDesign, {} ) ).toEqual(
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&footer_pattern_ids=56%2C78&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
 			);
 		} );
 

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -16,6 +16,12 @@ export const getDesignPreviewUrl = (
 	let url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/block-previews/site', {
 		stylesheet: recipe?.stylesheet,
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
+		header_pattern_ids: recipe?.header_pattern_ids
+			? recipe?.header_pattern_ids.join( ',' )
+			: undefined,
+		footer_pattern_ids: recipe?.footer_pattern_ids
+			? recipe?.footer_pattern_ids.join( ',' )
+			: undefined,
 		vertical_id: options.verticalId,
 		language: options.language,
 		...( options.viewport_width && { viewport_width: options.viewport_width } ),


### PR DESCRIPTION
#### Proposed Changes

* Get `header_pattern_ids` and `footer_pattern_ids` from the recipe and use them as below
  * apply these values when calling the `theme-setup` endpoint
  * apply these values when getting the preview URL
  * apply these values when tracking the selected recipe 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?siteSlug=<your_site>`
* Check the `header_pattern_ids` and `footer_pattern_ids` are shown in the preview url
* Select the generated desgin and check `theme-setup` endpoint is requested with `header_pattern_ids` and `footer_pattern_ids`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 58-gh-Automattic/ganon-issues