### PR TITLE
Licensing Portal: Add a link to a support article when the user has no active licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -35,9 +35,31 @@ export default function LicenseListEmpty( { filter }: Props ): ReactElement {
 	return (
 		<div className="license-list__empty-list">
 			<h2>{ licenseFilterStatusTitle }</h2>
+
+			{ filter === LicenseFilter.NotRevoked && (
+				<p>
+					{ translate(
+						'Learn more about {{a}}adding licenses and billing {{icon}}{{/icon}}{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/"
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+								icon: <Gridicon icon="external" size={ 16 } />,
+							},
+						}
+					) }
+				</p>
+			) }
+
 			{ filter === LicenseFilter.Detached && hasAssignedLicenses && (
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
 			) }
+
 			<Button href="/partner-portal/issue-license" onClick={ onIssueNewLicense }>
 				{ translate( 'Issue New License' ) }
 			</Button>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/style.scss
@@ -22,9 +22,15 @@
 			margin-bottom: 1rem;
 			font-size: $font-title-medium;
 		}
+
 		p {
 			margin-bottom: 1rem;
 			font-size: $font-body;
+
+			a {
+				color: var( --studio-gray-80 );
+				text-decoration: underline;
+			}
 		}
 
 		.button {


### PR DESCRIPTION
Context: 1201801459945917-as-1202546764922247

#### Proposed Changes

* Licensing Portal: Add a link to a support article when the user has no active licenses

#### Testing Instructions

* Apply patch and run Jetpack Cloud
* Make sure you have no active licenses (assigned and unassigned)
* Open up http://jetpack.cloud.localhost:3000/partner-portal/licenses and confirm the new support article is linked as in the screenshot below.

![Screen Shot 2022-07-12 at 17 17 44](https://user-images.githubusercontent.com/22746396/178511886-20746ef5-2cf1-4a91-b68e-adeeb26b3310.png)