### PR TITLE
Add fuzzy search hook to `@automattic/search`

### DIFF
--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -40,7 +40,9 @@ There are 2 search modes that can be used through the `searchMode` prop:
 
 A hook that exposes fuzzy searching functionality.
 
-It can be beneficial especially as the size of the dataset grows because this mechanism does not walk through the whole list. Also, some users might want to find an object that they do not remember the exact name, so entering a partial string, or even one with typos, would still return results ranked by proximity.
+It can be beneficial especially as the size of the dataset grows because this mechanism maintains an index instead of simply walking through the whole array looking for matches.
+
+Also, some users might want to find an object that they do not remember the exact name, so entering a partial string, or even one with typos, would still return results ranked by proximity.
 
 Example: imagine you're querying for `example.wordpress.com`. While "normal", substring search, would fail if you've searched for `exmple`, fuzzy search would still return the result.
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -40,7 +40,7 @@ There are 2 search modes that can be used through the `searchMode` prop:
 
 A hook that exposes fuzzy searching functionality.
 
-It can be beneficial especially as the size of the dataset grows because this mechanism maintains an index instead of simply walking through the whole array looking for matches.
+`useFuzzySearch` can be beneficial especially as the size of the dataset grows because this mechanism maintains an index instead of simply walking through the whole array looking for matches.
 
 Also, some users might want to find an object that they do not remember the exact name, so entering a partial string, or even one with typos, would still return results ranked by proximity.
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -23,9 +23,9 @@ in the root of the repository to get the required `devDependencies`.
 
 `yarn workspace @automattic/search run storybook`
 
-## What's included?
+## What's Included?
 
-### Search input
+### Search Input
 
 A search input component.
 
@@ -64,7 +64,7 @@ The hook returns an object with a few properties:
 - `setQuery`, so you can change the term after an event (i.e. input change).
 
 
-##### Searching an array of objects
+##### Searching an Array of Objects
 
 You can also pass an array of objects as the `data`. That way you can search inside objects:
 
@@ -79,10 +79,10 @@ const Component = () => {
 
 Note that you must pass the `keys` argument so the hook indexes those keys. Those are the keys that will be accounted when searching. That argument is **required** when you're working with an array of objects.
 
-##### Setting custom options
+##### Setting Custom Options
 
 Beyond passing `keys` (and [its variations](https://fusejs.io/examples.html)), you can extend the hook by providing the `options` argument, which will extend the fuzzy search mechanism following [the options described by Fuse.js](https://fusejs.io/api/options.html).
 
-##### Setting an initial query
+##### Setting an Initial Query
 
 It's also possible to set an initial query through the `initialQuery` argument. That'll be the the initial state for the returned `query` property and will be used as the initial search filter.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -40,9 +40,9 @@ There are 2 search modes that can be used through the `searchMode` prop:
 
 A hook that exposes fuzzy searching functionality.
 
-It can be beneficial especially as the sites of the list of sites grow. Some users might want to find a site that they do not remember the exact name, so they can enter a partial string, or even one with typos, and the result would still be returned.
+It can be beneficial especially as the size of the dataset grows because this mechanism does not walk through the whole list. Also, some users might want to find an object that they do not remember the exact name, so entering a partial string, or even one with typos, would still return results ranked by proximity.
 
-Example: imagine you're querying for `example.wordpress.com`. While "normal", substring search, would fail if you've searched for `exmple`, fuzzy search would still return the site.
+Example: imagine you're querying for `example.wordpress.com`. While "normal", substring search, would fail if you've searched for `exmple`, fuzzy search would still return the result.
 
 #### Usage
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,31 +1,82 @@
 # Search
 
-A search input component.
+The search module.
 
-## Installation
+### Installation
 
-Install the component.
+Install the package.
 
 ```bash
 yarn add @automattic/search
 ```
 
-## Internationalization
+### Internationalization
 
-This package depends directly on `@wordpress/i18n` for translations. This means consumers must provide locale data prior to using the component.
+This package depends directly on `@wordpress/i18n` for translations. This means consumers must provide locale data prior to using it.
 
-## Development Workflow
+### Development Workflow
 
 This package is developed as part of the Calypso monorepo. Run `yarn`
 in the root of the repository to get the required `devDependencies`.
 
 ### Using [Storybook](https://storybook.js.org/)
 
-`yarn workspace @automattic/components run storybook`
+`yarn workspace @automattic/search run storybook`
 
-### Search Modes
+## What's included?
+
+### Search input
+
+A search input component.
+
+#### Search Modes
 
 There are 2 search modes that can be used through the `searchMode` prop:
 
 - `when-typing` (default): The search component calls the `onSearch` prop while the user is typing.
 - `on-enter`: The search component only triggers the `onSearch` prop when the user hits the `Enter` key.
+
+### `useFuzzySearch`
+
+A hook that exposes fuzzy searching functionality.
+
+It can be beneficial especially as the sites of the list of sites grow. Some users might want to find a site that they do not remember the exact name, so they can enter a partial string, or even one with typos, and the result would still be returned.
+
+Example: imagine you're querying for `example.wordpress.com`. While "normal", substring search, would fail if you've searched for `exmple`, fuzzy search would still return the site.
+
+#### Usage
+
+The simplest form of usage is to pass an array of strings as the `data` argument, which is your collection:
+
+```js
+useFuzzySearch( {
+	data: [ 'site.wordpress.com', 'another.wordpress.com' ]
+} );
+```
+
+The hook returns an object with a few properties:
+- `results`, which is your data;
+- `query`, that is the searched term;
+- `setQuery`, so you can change the term after an event (i.e. input change).
+
+
+##### Searching an array of objects
+
+You can also pass an array of objects as the `data`. That way you can search inside objects:
+
+```js
+useFuzzySearch( {
+	data: [ { siteURL: 'site.wordpress.com', ... }, ... ],
+	keys: [ 'siteURL', 'nested.key' ],
+} );
+```
+
+Note that you must pass the `keys` argument so the hook indexes those keys. Those are the keys that will be accounted when searching. That argument is **required** when you're working with an array of objects.
+
+##### Setting custom options
+
+Beyond passing `keys` (and [its variations](https://fusejs.io/examples.html)), you can extend the hook by providing the `options` argument, which will extend the fuzzy search mechanism following [the options described by Fuse.js](https://fusejs.io/api/options.html).
+
+##### Setting an initial query
+
+It's also possible to set an initial query through the `initialQuery` argument. That'll be the the initial state for the returned `query` property and will be used as the initial search filter.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -2,7 +2,7 @@
 
 The search module.
 
-### Installation
+## Installation
 
 Install the package.
 
@@ -10,16 +10,16 @@ Install the package.
 yarn add @automattic/search
 ```
 
-### Internationalization
+## Internationalization
 
 This package depends directly on `@wordpress/i18n` for translations. This means consumers must provide locale data prior to using it.
 
-### Development Workflow
+## Development Workflow
 
 This package is developed as part of the Calypso monorepo. Run `yarn`
 in the root of the repository to get the required `devDependencies`.
 
-### Using [Storybook](https://storybook.js.org/)
+## Using [Storybook](https://storybook.js.org/)
 
 `yarn workspace @automattic/search run storybook`
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -49,9 +49,11 @@ Example: imagine you're querying for `example.wordpress.com`. While "normal", su
 The simplest form of usage is to pass an array of strings as the `data` argument, which is your collection:
 
 ```js
-useFuzzySearch( {
-	data: [ 'site.wordpress.com', 'another.wordpress.com' ]
-} );
+const Component = () => {
+	const { results, query, setQuery } = useFuzzySearch( {
+		data: [ 'site.wordpress.com', 'another.wordpress.com' ],
+	} );
+};
 ```
 
 The hook returns an object with a few properties:
@@ -65,10 +67,12 @@ The hook returns an object with a few properties:
 You can also pass an array of objects as the `data`. That way you can search inside objects:
 
 ```js
-useFuzzySearch( {
-	data: [ { siteURL: 'site.wordpress.com', ... }, ... ],
-	keys: [ 'siteURL', 'nested.key' ],
-} );
+const Component = () => {
+	useFuzzySearch( {
+		data: [ { siteURL: 'site.wordpress.com', nested: { key: 'value' } } ],
+		keys: [ 'siteURL', 'nested.key' ],
+	} );
+};
 ```
 
 Note that you must pass the `keys` argument so the hook indexes those keys. Those are the keys that will be accounted when searching. That argument is **required** when you're working with an array of objects.

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -52,7 +52,7 @@
 		"@storybook/react": "^6.4.18",
 		"@testing-library/dom": "^8.11.3",
 		"@testing-library/react": "^12.1.3",
-		"@testing-library/user-event": "^13.5.0",
+		"@testing-library/user-event": "^14.2.5",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/is-shallow-equal": "^4.9.0",
 		"react": "^17.0.2",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -51,6 +51,7 @@
 		"@storybook/addon-actions": "^6.4.21",
 		"@storybook/react": "^6.4.18",
 		"@testing-library/dom": "^8.11.3",
+		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^12.1.3",
 		"@testing-library/user-event": "^14.2.5",
 		"@wordpress/data": "^6.9.0",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/react-i18n": "^3.7.0",
 		"classnames": "^2.3.1",
+		"fuse.js": "^6.6.2",
 		"lodash": "^4.17.21",
 		"redux": "^4.1.2",
 		"tslib": "^2.3.0"

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './search';
+export { useFuzzySearch } from './use-fuzzy-search';

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -39,9 +39,10 @@ describe( 'search', () => {
 			expect( document.activeElement ).not.toBe( searchbox );
 		} );
 
-		it( 'should return a ref with clear', () => {
+		it( 'should return a ref with clear', async () => {
 			const searchbox = screen.getByRole( 'searchbox' );
-			userEvent.type( searchbox, 'This is a test search' );
+			const user = userEvent.setup();
+			await user.type( searchbox, 'This is a test search' );
 			expect( searchbox.value ).toBe( 'This is a test search' );
 			act( () => {
 				ref.current.clear();
@@ -52,7 +53,7 @@ describe( 'search', () => {
 	} );
 
 	describe( '"on-enter" search mode', () => {
-		it( "shouldn't call onSearch and onSearchChange when search changes", () => {
+		it( "shouldn't call onSearch and onSearchChange when search changes", async () => {
 			const searchString = '12345';
 			const onSearch = jest.fn();
 			const onSearchChange = jest.fn();
@@ -60,12 +61,13 @@ describe( 'search', () => {
 				<Search onSearch={ onSearch } searchMode="on-enter" onSearchChange={ onSearchChange } />
 			);
 			const searchbox = screen.getByRole( 'searchbox' );
-			userEvent.type( searchbox, searchString );
+			const user = userEvent.setup();
+			await user.type( searchbox, searchString );
 			expect( onSearch ).toHaveBeenCalledTimes( 0 ); // once per character
 			expect( onSearchChange ).toHaveBeenCalledTimes( 0 );
 		} );
 
-		it( 'should call onSearch and onSearchChange when user hits enter', () => {
+		it( 'should call onSearch and onSearchChange when user hits enter', async () => {
 			const searchString = '12345{enter}';
 			const onSearch = jest.fn();
 			const onSearchChange = jest.fn();
@@ -73,7 +75,8 @@ describe( 'search', () => {
 				<Search onSearch={ onSearch } searchMode="on-enter" onSearchChange={ onSearchChange } />
 			);
 			const searchbox = screen.getByRole( 'searchbox' );
-			userEvent.type( searchbox, searchString );
+			const user = userEvent.setup();
+			await user.type( searchbox, searchString );
 			expect( onSearch ).toHaveBeenCalledTimes( 1 ); // once per character
 			expect( onSearch ).toHaveBeenCalledWith( '12345' );
 			expect( onSearchChange ).toHaveBeenCalledTimes( 1 );
@@ -81,13 +84,14 @@ describe( 'search', () => {
 		} );
 	} );
 
-	it( 'should call onSearch and onSearchChange when search changes', () => {
+	it( 'should call onSearch and onSearchChange when search changes', async () => {
 		const searchString = '12345';
 		const onSearch = jest.fn();
 		const onSearchChange = jest.fn();
 		render( <Search onSearch={ onSearch } onSearchChange={ onSearchChange } /> );
 		const searchbox = screen.getByRole( 'searchbox' );
-		userEvent.type( searchbox, searchString );
+		const user = userEvent.setup();
+		await user.type( searchbox, searchString );
 		expect( onSearch ).toHaveBeenCalledTimes( 5 ); // once per character
 		expect( onSearch ).toHaveBeenCalledWith( '1' );
 		expect( onSearch ).toHaveBeenCalledWith( '12' );
@@ -102,12 +106,13 @@ describe( 'search', () => {
 		expect( onSearchChange ).toHaveBeenCalledWith( '12345' );
 	} );
 
-	it( 'should call onKeyDown when typing into search', () => {
+	it( 'should call onKeyDown when typing into search', async () => {
 		const searchString = '12345';
 		const onKeyDown = jest.fn();
 		render( <Search onKeyDown={ onKeyDown } /> );
 		const searchbox = screen.getByRole( 'searchbox' );
-		userEvent.type( searchbox, searchString );
+		const user = userEvent.setup();
+		await user.type( searchbox, searchString );
 		expect( onKeyDown ).toHaveBeenCalledTimes( 5 ); // once per character
 		// it gets called with the raw event, so it's not really possible to assert what it was called with
 	} );
@@ -126,11 +131,12 @@ describe( 'search', () => {
 		expect( uniqueIds ).toHaveLength( 3 );
 	} );
 
-	it( 'should call onSearchOpen when search is focused', () => {
+	it( 'should call onSearchOpen when search is focused', async () => {
 		const onSearchOpen = jest.fn();
 		render( <Search onSearchOpen={ onSearchOpen } /> );
 		const searchbox = screen.getByRole( 'searchbox' );
-		userEvent.click( searchbox );
+		const user = userEvent.setup();
+		await user.click( searchbox );
 		expect( onSearchOpen ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -138,14 +144,15 @@ describe( 'search', () => {
 		const onSearchOpen = jest.fn();
 		render( <Search pinned defaultIsOpen={ false } onSearchOpen={ onSearchOpen } /> );
 		const openButton = screen.getByLabelText( 'Open Search' );
-		userEvent.click( openButton );
+		const user = userEvent.setup();
+		await user.click( openButton );
 		await focusResolve();
 		const searchbox = screen.getByRole( 'searchbox' );
 		expect( onSearchOpen ).toHaveBeenCalledTimes( 1 );
 		expect( document.activeElement ).toBe( searchbox );
 	} );
 
-	it( 'should close search and call onSearchClose when clicking the close button', () => {
+	it( 'should close search and call onSearchClose when clicking the close button', async () => {
 		const onSearchClose = jest.fn();
 		render(
 			<Search
@@ -158,7 +165,8 @@ describe( 'search', () => {
 
 		const closeButton = screen.getByLabelText( 'Close Search' );
 
-		userEvent.click( closeButton );
+		const user = userEvent.setup();
+		await user.click( closeButton );
 		const searchbox = screen.queryByRole( 'searchbox' );
 		expect( searchbox ).toBeNull();
 		expect( onSearchClose ).toHaveBeenCalledTimes( 1 );
@@ -182,7 +190,7 @@ describe( 'search', () => {
 		expect( onSearchChange ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call onSearch without debouncing when reverting to empty keyword', () => {
+	it( 'should call onSearch without debouncing when reverting to empty keyword', async () => {
 		const onSearch = jest.fn();
 		render( <Search onSearch={ onSearch } defaultValue="a" delaySearch delayTimeout={ 1000 } /> );
 
@@ -190,13 +198,14 @@ describe( 'search', () => {
 		expect( onSearch ).toHaveBeenCalledWith( 'a' );
 
 		// type backspace into the search box, making its value empty
-		userEvent.type( screen.getByRole( 'searchbox' ), '{backspace}' );
+		const user = userEvent.setup();
+		await user.type( screen.getByRole( 'searchbox' ), '{backspace}' );
 
 		// check that `onSearch` has been called immediately, without debouncing
 		expect( onSearch ).toHaveBeenCalledWith( '' );
 	} );
 
-	it( 'should not call onSearch with current value when the prop changes', () => {
+	it( 'should not call onSearch with current value when the prop changes', async () => {
 		function SearchWithHistory() {
 			const [ history, push ] = useReducer( ( list, item ) => [ ...list, item ], [] );
 			return (
@@ -217,7 +226,8 @@ describe( 'search', () => {
 		expect( document.querySelectorAll( 'li' ) ).toHaveLength( 1 );
 
 		// type one letter into the search box
-		userEvent.type( screen.getByRole( 'searchbox' ), 's' );
+		const user = userEvent.setup();
+		await user.type( screen.getByRole( 'searchbox' ), 's' );
 
 		// check that a second item was added to history
 		expect( document.querySelectorAll( 'li' ) ).toHaveLength( 2 );

--- a/packages/search/src/test/use-fuzzy-search.tsx
+++ b/packages/search/src/test/use-fuzzy-search.tsx
@@ -15,37 +15,43 @@ const TestComponent = < T, >( props: UseFuzzySearchOptions< T > ) => {
 };
 
 describe( 'useFuzzySearch', () => {
-	it( 'allows fuzzy searching a simple string array', () => {
+	it( 'allows fuzzy searching a simple string array', async () => {
+		const user = userEvent.setup();
+
 		const data = [ 'ok', 'hello' ];
 
 		render( <TestComponent data={ data } /> );
 
 		const searchbox = screen.getByRole( 'searchbox' );
-		userEvent.type( searchbox, 'k' );
+		await user.type( searchbox, 'k' );
 
 		expect( screen.queryByText( /ok/ ) ).toBeTruthy();
 		expect( screen.queryByText( /hello/ ) ).not.toBeTruthy();
 	} );
 
-	it( 'allows fuzzy searching an array of objects', () => {
+	it( 'allows fuzzy searching an array of objects', async () => {
+		const user = userEvent.setup();
+
 		const data = [ { prop: 'value' }, { prop: 'another' } ];
 
 		render( <TestComponent data={ data } fields={ [ 'prop' ] } /> );
 
 		const searchbox = screen.getByRole( 'searchbox' );
-		userEvent.type( searchbox, 'v' );
+		await user.type( searchbox, 'v' );
 
 		expect( screen.queryByText( /value/ ) ).toBeTruthy();
 		expect( screen.queryByText( /another/ ) ).not.toBeTruthy();
 	} );
 
-	it( 'allows fuzzy searching on nested keys', () => {
+	it( 'allows fuzzy searching on nested keys', async () => {
+		const user = userEvent.setup();
+
 		const data = [ { deep: { prop: 'value' } }, { deep: { prop: 'another' } } ];
 
 		render( <TestComponent data={ data } fields={ [ 'deep.prop' ] } /> );
 
 		const searchbox = screen.getByRole( 'searchbox' );
-		userEvent.type( searchbox, 'an' );
+		await user.type( searchbox, 'an' );
 
 		expect( screen.queryByText( /another/ ) ).toBeTruthy();
 		expect( screen.queryByText( /value/ ) ).not.toBeTruthy();

--- a/packages/search/src/test/use-fuzzy-search.tsx
+++ b/packages/search/src/test/use-fuzzy-search.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Search, { useFuzzySearch } from '..';
+import type { UseFuzzySearchOptions } from '../use-fuzzy-search';
+
+const TestComponent = < T, >( props: UseFuzzySearchOptions< T > ) => {
+	const { results, setQuery } = useFuzzySearch( props );
+
+	return (
+		<>
+			<Search onSearch={ setQuery } />
+			{ results.map( ( result ) => JSON.stringify( result ) ) }
+		</>
+	);
+};
+
+describe( 'useFuzzySearch', () => {
+	it( 'allows fuzzy searching a simple string array', () => {
+		const data = [ 'ok', 'hello' ];
+
+		render( <TestComponent data={ data } /> );
+
+		const searchbox = screen.getByRole( 'searchbox' );
+		userEvent.type( searchbox, 'k' );
+
+		expect( screen.queryByText( /ok/ ) ).toBeTruthy();
+		expect( screen.queryByText( /hello/ ) ).not.toBeTruthy();
+	} );
+
+	it( 'allows fuzzy searching an array of objects', () => {
+		const data = [ { prop: 'value' }, { prop: 'another' } ];
+
+		render( <TestComponent data={ data } fields={ [ 'prop' ] } /> );
+
+		const searchbox = screen.getByRole( 'searchbox' );
+		userEvent.type( searchbox, 'v' );
+
+		expect( screen.queryByText( /value/ ) ).toBeTruthy();
+		expect( screen.queryByText( /another/ ) ).not.toBeTruthy();
+	} );
+
+	it( 'allows fuzzy searching on nested keys', () => {
+		const data = [ { deep: { prop: 'value' } }, { deep: { prop: 'another' } } ];
+
+		render( <TestComponent data={ data } fields={ [ 'deep.prop' ] } /> );
+
+		const searchbox = screen.getByRole( 'searchbox' );
+		userEvent.type( searchbox, 'an' );
+
+		expect( screen.queryByText( /another/ ) ).toBeTruthy();
+		expect( screen.queryByText( /value/ ) ).not.toBeTruthy();
+	} );
+
+	it( 'allows setting an initial query', () => {
+		const data = [ { prop: 'value' }, { prop: 'another' } ];
+
+		render( <TestComponent data={ data } fields={ [ 'prop' ] } initialQuery="ano" /> );
+
+		expect( screen.queryByText( /another/ ) ).toBeTruthy();
+		expect( screen.queryByText( /value/ ) ).not.toBeTruthy();
+	} );
+} );

--- a/packages/search/src/test/use-fuzzy-search.tsx
+++ b/packages/search/src/test/use-fuzzy-search.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Search, { useFuzzySearch } from '..';
 import type { UseFuzzySearchOptions } from '../use-fuzzy-search';
+import '@testing-library/jest-dom';
 
 const TestComponent = < T, >( props: UseFuzzySearchOptions< T > ) => {
 	const { results, setQuery } = useFuzzySearch( props );
@@ -25,8 +26,8 @@ describe( 'useFuzzySearch', () => {
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'k' );
 
-		expect( screen.queryByText( /ok/ ) ).toBeTruthy();
-		expect( screen.queryByText( /hello/ ) ).not.toBeTruthy();
+		expect( screen.queryByText( /ok/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /hello/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'allows fuzzy searching an array of objects', async () => {
@@ -39,8 +40,8 @@ describe( 'useFuzzySearch', () => {
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'v' );
 
-		expect( screen.queryByText( /value/ ) ).toBeTruthy();
-		expect( screen.queryByText( /another/ ) ).not.toBeTruthy();
+		expect( screen.queryByText( /value/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /another/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'allows fuzzy searching on nested keys', async () => {
@@ -53,8 +54,8 @@ describe( 'useFuzzySearch', () => {
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'an' );
 
-		expect( screen.queryByText( /another/ ) ).toBeTruthy();
-		expect( screen.queryByText( /value/ ) ).not.toBeTruthy();
+		expect( screen.queryByText( /another/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /value/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'allows setting an initial query', () => {
@@ -62,7 +63,7 @@ describe( 'useFuzzySearch', () => {
 
 		render( <TestComponent data={ data } fields={ [ 'prop' ] } initialQuery="ano" /> );
 
-		expect( screen.queryByText( /another/ ) ).toBeTruthy();
-		expect( screen.queryByText( /value/ ) ).not.toBeTruthy();
+		expect( screen.queryByText( /another/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /value/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/search/src/test/use-fuzzy-search.tsx
+++ b/packages/search/src/test/use-fuzzy-search.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import Search, { useFuzzySearch } from '..';
 import type { UseFuzzySearchOptions } from '../use-fuzzy-search';
 

--- a/packages/search/src/test/use-fuzzy-search.tsx
+++ b/packages/search/src/test/use-fuzzy-search.tsx
@@ -35,7 +35,7 @@ describe( 'useFuzzySearch', () => {
 
 		const data = [ { prop: 'value' }, { prop: 'another' } ];
 
-		render( <TestComponent data={ data } fields={ [ 'prop' ] } /> );
+		render( <TestComponent data={ data } keys={ [ 'prop' ] } /> );
 
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'v' );
@@ -49,7 +49,7 @@ describe( 'useFuzzySearch', () => {
 
 		const data = [ { deep: { prop: 'value' } }, { deep: { prop: 'another' } } ];
 
-		render( <TestComponent data={ data } fields={ [ 'deep.prop' ] } /> );
+		render( <TestComponent data={ data } keys={ [ 'deep.prop' ] } /> );
 
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'an' );
@@ -61,7 +61,7 @@ describe( 'useFuzzySearch', () => {
 	it( 'allows setting an initial query', () => {
 		const data = [ { prop: 'value' }, { prop: 'another' } ];
 
-		render( <TestComponent data={ data } fields={ [ 'prop' ] } initialQuery="ano" /> );
+		render( <TestComponent data={ data } keys={ [ 'prop' ] } initialQuery="ano" /> );
 
 		expect( screen.queryByText( /another/ ) ).toBeInTheDocument();
 		expect( screen.queryByText( /value/ ) ).not.toBeInTheDocument();

--- a/packages/search/src/test/use-fuzzy-search.tsx
+++ b/packages/search/src/test/use-fuzzy-search.tsx
@@ -26,7 +26,7 @@ describe( 'useFuzzySearch', () => {
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'k' );
 
-		expect( screen.queryByText( /ok/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /ok/ ) ).toBeVisible();
 		expect( screen.queryByText( /hello/ ) ).not.toBeInTheDocument();
 	} );
 
@@ -40,7 +40,7 @@ describe( 'useFuzzySearch', () => {
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'v' );
 
-		expect( screen.queryByText( /value/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /value/ ) ).toBeVisible();
 		expect( screen.queryByText( /another/ ) ).not.toBeInTheDocument();
 	} );
 
@@ -54,7 +54,7 @@ describe( 'useFuzzySearch', () => {
 		const searchbox = screen.getByRole( 'searchbox' );
 		await user.type( searchbox, 'an' );
 
-		expect( screen.queryByText( /another/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /another/ ) ).toBeVisible();
 		expect( screen.queryByText( /value/ ) ).not.toBeInTheDocument();
 	} );
 
@@ -63,7 +63,7 @@ describe( 'useFuzzySearch', () => {
 
 		render( <TestComponent data={ data } keys={ [ 'prop' ] } initialQuery="ano" /> );
 
-		expect( screen.queryByText( /another/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /another/ ) ).toBeVisible();
 		expect( screen.queryByText( /value/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -1,0 +1,46 @@
+import Fuse from 'fuse.js';
+import { useState, useMemo } from 'react';
+
+const defaultOptions = {
+	threshold: 0.4,
+	distance: 20,
+};
+
+type UseFuzzySearchOptions< T > = {
+	data: T[];
+	fields: Fuse.IFuseOptions< T >[ 'keys' ];
+	options?: Partial< Fuse.IFuseOptions< T > >;
+	initialQuery?: string;
+};
+
+export const useFuzzySearch = < T >( {
+	data,
+	fields,
+	initialQuery = '',
+	options = defaultOptions,
+}: UseFuzzySearchOptions< T > ) => {
+	const [ query, setQuery ] = useState( initialQuery );
+
+	const fuseInstance = useMemo( () => {
+		return new Fuse( data, {
+			keys: fields,
+			includeScore: false,
+			includeMatches: false,
+			...options,
+		} );
+	}, [ data, fields, options ] );
+
+	const results = useMemo( () => {
+		if ( ! query ) {
+			return data;
+		}
+
+		return fuseInstance.search( query ).map( ( { item } ) => item );
+	}, [ fuseInstance, query, data ] );
+
+	return {
+		results,
+		query,
+		setQuery,
+	};
+};

--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -6,16 +6,23 @@ const defaultOptions = {
 	distance: 20,
 };
 
-type UseFuzzySearchOptions< T > = {
+type FieldsProp< T > = T extends string
+	? {
+			fields?: never;
+	  }
+	: {
+			fields: Fuse.IFuseOptions< T >[ 'keys' ];
+	  };
+
+export type UseFuzzySearchOptions< T > = {
 	data: T[];
-	fields: Fuse.IFuseOptions< T >[ 'keys' ];
 	options?: Partial< Fuse.IFuseOptions< T > >;
 	initialQuery?: string;
-};
+} & FieldsProp< T >;
 
 export const useFuzzySearch = < T >( {
 	data,
-	fields,
+	fields = [],
 	initialQuery = '',
 	options = defaultOptions,
 }: UseFuzzySearchOptions< T > ) => {

--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -40,8 +40,8 @@ export const useFuzzySearch = < T >( {
 	 * the `fuseInstance` variable to the dependency array.
 	 *
 	 */
-	const [ fuseInstance ] = useState< Fuse< T > >( () => {
-		return new Fuse< T >( data, {
+	const [ fuseInstance ] = useState( () => {
+		return new Fuse( data, {
 			keys: fields,
 			includeScore: false,
 			includeMatches: false,

--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -6,23 +6,23 @@ const defaultOptions = {
 	distance: 20,
 };
 
-type FieldsProp< T > = T extends string
+type KeysProp< T > = T extends string
 	? {
-			fields?: never;
+			keys?: never;
 	  }
 	: {
-			fields: Fuse.IFuseOptions< T >[ 'keys' ];
+			keys: Fuse.IFuseOptions< T >[ 'keys' ];
 	  };
 
 export type UseFuzzySearchOptions< T > = {
 	data: T[];
 	options?: Partial< Fuse.IFuseOptions< T > >;
 	initialQuery?: string;
-} & FieldsProp< T >;
+} & KeysProp< T >;
 
 export const useFuzzySearch = < T >( {
 	data,
-	fields = [],
+	keys = [],
 	initialQuery = '',
 	options = defaultOptions,
 }: UseFuzzySearchOptions< T > ) => {
@@ -42,7 +42,7 @@ export const useFuzzySearch = < T >( {
 	 */
 	const [ fuseInstance ] = useState( () => {
 		return new Fuse( data, {
-			keys: fields,
+			keys,
 			includeScore: false,
 			includeMatches: false,
 			...options,

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -5,5 +5,6 @@
 		"outDir": "dist/esm",
 		"rootDir": "src"
 	},
-	"include": [ "src" ]
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
 }

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -3,8 +3,8 @@
 	"compilerOptions": {
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",
-		"rootDir": "src"
+		"rootDir": "src",
+		"types": [ "jest" ]
 	},
-	"include": [ "src" ],
-	"exclude": [ "**/test/*" ]
+	"include": [ "src" ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,7 @@ __metadata:
     "@wordpress/is-shallow-equal": ^4.9.0
     "@wordpress/react-i18n": ^3.7.0
     classnames: ^2.3.1
+    fuse.js: ^6.6.2
     lodash: ^4.17.21
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -18415,6 +18416,13 @@ __metadata:
   version: 3.6.1
   resolution: "fuse.js@npm:3.6.1"
   checksum: bd9d5bc4d82781de7bb46057e96775f9efc497eb8b334b61cfea589db730c1fe7789bf5ff61b1146c15e18ffe5b27715807e5d436f333662b47917b530ced5e9
+  languageName: node
+  linkType: hard
+
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: c2fe4f234f516e9ea83b06f06f8f3c8b7117f51aa75bbccd052eed0c0423364bf1e360ffbf29cadae8ef6aa39476b7961eaf9d07bed779cea5c83d62b34e2df9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,6 +1161,7 @@ __metadata:
     "@storybook/addon-actions": ^6.4.21
     "@storybook/react": ^6.4.18
     "@testing-library/dom": ^8.11.3
+    "@testing-library/jest-dom": ^5.16.4
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^14.2.5
     "@wordpress/base-styles": ^4.5.0
@@ -6356,9 +6357,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^5.16.2":
-  version: 5.16.2
-  resolution: "@testing-library/jest-dom@npm:5.16.2"
+"@testing-library/jest-dom@npm:^5.16.2, @testing-library/jest-dom@npm:^5.16.4":
+  version: 5.16.4
+  resolution: "@testing-library/jest-dom@npm:5.16.4"
   dependencies:
     "@babel/runtime": ^7.9.2
     "@types/testing-library__jest-dom": ^5.9.1
@@ -6369,7 +6370,7 @@ __metadata:
     dom-accessibility-api: ^0.5.6
     lodash: ^4.17.15
     redent: ^3.0.0
-  checksum: f57ee673318f97ace6d7aac94a466f39264060afa5857c41f2fa39c40c6a9dfd29373f624a329286912eb078d95e7afdd2c728f02dae8cf0e82ad628263200d8
+  checksum: c34016bbc4865f8f9912d62ac63b409b87e785ff281a50f6eae8c1bc2364963c0831541da8a185bbd8b5964a6e3371fb623c339e8128d84706eb06f93f145801
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,7 +1162,7 @@ __metadata:
     "@storybook/react": ^6.4.18
     "@testing-library/dom": ^8.11.3
     "@testing-library/react": ^12.1.3
-    "@testing-library/user-event": ^13.5.0
+    "@testing-library/user-event": ^14.2.5
     "@wordpress/base-styles": ^4.5.0
     "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
@@ -6409,23 +6409,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^13.5.0":
-  version: 13.5.0
-  resolution: "@testing-library/user-event@npm:13.5.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
+"@testing-library/user-event@npm:^14.2.0, @testing-library/user-event@npm:^14.2.5":
+  version: 14.2.5
+  resolution: "@testing-library/user-event@npm:14.2.5"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: ff57edaeab31322c80c3f01d55404b4cebb907b9ec7672b96a1a14d053f172046b01c5f27b45677927ebee8ed91bce695a7d09edec9a48875cfacabe39d0426a
-  languageName: node
-  linkType: hard
-
-"@testing-library/user-event@npm:^14.2.0":
-  version: 14.2.0
-  resolution: "@testing-library/user-event@npm:14.2.0"
-  peerDependencies:
-    "@testing-library/dom": ">=7.21.4"
-  checksum: 1011c63521685bfb758d6c8d4fed5f16de6ebc28f5817d017364302d7b69f00acacb9dea1a1bf4a5efdf6e166f66541a42b6c6e8e08914310cd23a1b1af98e98
+  checksum: b585e1e137e4c2a1d6b11e7eb59fc8c8e49b4d7be41e24fbbdff1f01aef65096e3793fe16198f525fcbeafc5ec3605333abf518b02cac50c9a188ec06acc7009
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

Right now, our client-side searches are pretty limited: we have the `searchSites` HOC that exposes basic search functionality that's not very customizable and the results have to match the term exactly, bringing a subpar user experience.

This PR adds a `useFuzzySearch` hook that relies on the `fuse.js` package. That hook can be used anywhere search is needed. You can pass fields that are indexed and the search state is also handled.

#### Testing Instructions

Check out this branch, run `yarn install` then `yarn build-packages` so the `@automattic/search` package gets updated.

Once done, apply this diff to Calypso:

```diff
diff --git a/client/components/search-sites/index.js b/client/components/search-sites/index.js
index e17a05af82..f1fa99da83 100644
--- a/client/components/search-sites/index.js
+++ b/client/components/search-sites/index.js
@@ -1,3 +1,4 @@
+import { useFuzzySearch } from '@automattic/search';
 import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -16,27 +17,20 @@ const mapState = ( state ) => ( {
 export default function searchSites( WrappedComponent ) {
 	const componentName = WrappedComponent.displayName || WrappedComponent.name || '';
 
-	class Searcher extends Component {
-		state = { term: null };
-
-		setSearchTerm = ( term ) => this.setState( { term } );
-
-		getSearchResults() {
-			return this.state.term
-				? searchCollection( this.props.sites, this.state.term.toLowerCase(), [ 'name', 'URL' ] )
-				: null;
-		}
-
-		render() {
-			return (
-				<WrappedComponent
-					{ ...this.props }
-					searchSites={ this.setSearchTerm }
-					sitesFound={ this.getSearchResults() }
-				/>
-			);
-		}
-	}
+	const Searcher = ( props ) => {
+		const { query, setQuery, results } = useFuzzySearch( {
+			data: props.sites,
+			fields: [ 'name', 'URL' ],
+		} );
+
+		return (
+			<WrappedComponent
+				{ ...props }
+				searchSites={ setQuery }
+				sitesFound={ query ? results : null }
+			/>
+		);
+	};
 
 	const Connected = connect( mapState )( Searcher );
 	Connected.displayName = `SearchSites(${ componentName })`;
```

Open any site in Calypso, click `Switch Site` and start typing in the search bar. It no longer requires an exact match to return queried results.

This is an optional change to the `searchSites` HOC just to exemplify the usage. It does not necessarily need to be used there. I first implemented this hook in #65454 but I moved it here so I don't have a PR breaking the single-subject rule.

Related to #65169, first implemented in #65454.
