### PR TITLE
[etk/error-reporting] Setup action hook callback to capture React Error Boundary exceptions

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import apiFetch from '@wordpress/api-fetch';
+import { addAction } from '@wordpress/hooks';
 
 const shouldActivateSentry = window.A8C_ETK_ErrorReporting_Config?.shouldActivateSentry === 'true';
 /**
@@ -16,6 +17,12 @@ function activateSentry() {
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production
 		release: 'wpcom-test-01',
+	} );
+
+	// Capture exceptions from Gutenberg React Error Boundaries
+	addAction( 'editor.ErrorBoundary.errorLogged', 'etk/error-reporting', ( error ) => {
+		// error is the exception's error object
+		Sentry.captureException( error );
 	} );
 
 	// We still need to report the head errors, if any.


### PR DESCRIPTION
Follow up to: https://github.com/WordPress/gutenberg/pull/42024.

#### Proposed Changes

Register a callback to `editor.ErrorBoundary.errorLogged` WP action hook that will forward the error to Sentry every time the action is called.

The action has been added to all active React Error Boundaries in Gutenberg in the following changeset: https://github.com/WordPress/gutenberg/pull/42024 .


#### Testing Instructions

1. Sync this ETK build to your sandbox (or use `install-plugin.sh` to install from this branch);
2. Get GB from trunk (or get the 13.7+, if available) 
3. Follow the instructions in [this PR](https://github.com/WordPress/gutenberg/pull/42024) to simulate an error that will be captured by one of the Error Boundaries
4. Build and sync the GB build to your sandbox (use `a8c-wp-env` to easily sync)
5. Wait for the error to be triggered
6. It should appear in Sentry after a while (in the `wpcom-gutenberg-wp-admin` project)

WARNING: Even if the testing plan passes, this should only be merged when GB 13.7 is shipped to WPCOM simple.
