### PR TITLE
Sites Management Dashboard: add search mechanism

### DIFF
--- a/client/components/search-sites/index.js
+++ b/client/components/search-sites/index.js
@@ -1,13 +1,7 @@
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import getSites from 'calypso/state/selectors/get-sites';
-
-const matches = ( item, term, keys ) =>
-	keys.some( ( key ) => get( item, key, '' ).toLowerCase().indexOf( term ) > -1 );
-
-const searchCollection = ( collection, term, keys ) =>
-	collection.filter( ( item ) => matches( item, term, keys ) );
+import { searchCollection } from './utils';
 
 const mapState = ( state ) => ( {
 	sites: getSites( state ),

--- a/client/components/search-sites/utils.ts
+++ b/client/components/search-sites/utils.ts
@@ -1,0 +1,7 @@
+import { get } from 'lodash';
+
+const matches = < T >( item: T, term: string, keys: ( keyof T )[] ) =>
+	keys.some( ( key ) => get( item, key, '' ).toLowerCase().indexOf( term ) > -1 );
+
+export const searchCollection = < T >( collection: T[], term: string, keys: ( keyof T )[] ) =>
+	collection.filter( ( item ) => matches( item, term, keys ) );

--- a/client/components/search-sites/utils.ts
+++ b/client/components/search-sites/utils.ts
@@ -1,7 +1,13 @@
-import { get } from 'lodash';
-
 const matches = < T >( item: T, term: string, keys: ( keyof T )[] ) =>
-	keys.some( ( key ) => get( item, key, '' ).toLowerCase().indexOf( term ) > -1 );
+	keys.some( ( key ) => {
+		const value = item[ key ];
+
+		if ( ! value || typeof value !== 'string' ) {
+			return false;
+		}
+
+		return value.toLowerCase().indexOf( term ) > -1;
+	} );
 
 export const searchCollection = < T >( collection: T[], term: string, keys: ( keyof T )[] ) =>
-	collection.filter( ( item ) => matches( item, term, keys ) );
+	collection.filter( ( item ) => item && matches( item, term, keys ) );

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,4 +1,5 @@
 import { ClassNames } from '@emotion/react';
+import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
 import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesSearch } from './sites-search';
@@ -10,6 +11,8 @@ interface SearchableSitesTableProps {
 }
 
 export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
+	const { __ } = useI18n();
+
 	const [ term, setTerm ] = useState( '' );
 
 	const filteredSites = useMemo( () => {
@@ -31,7 +34,12 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 							max-width: 100%;
 						` }
 					>
-						<SitesSearch onSearch={ setTerm } delaySearch isReskinned />
+						<SitesSearch
+							onSearch={ setTerm }
+							delaySearch
+							isReskinned
+							placeholder={ __( 'Search by name or domain' ) + '...' }
+						/>
 					</div>
 					<SitesTable sites={ filteredSites } />
 				</>

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,0 +1,24 @@
+import { ClassNames } from '@emotion/react';
+import { useState } from 'react';
+import Search from 'calypso/components/search';
+import { SitesTable } from './sites-table';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+
+export function SearchableSitesTable( { sites }: { className?: string; sites: SiteData[] } ) {
+	const [ search, setSearch ] = useState( '' );
+
+	return (
+		<ClassNames>
+			{ ( { css } ) => (
+				<div
+					className={ css`
+						margin-top: 32px;
+					` }
+				>
+					<Search onSearch={ setSearch } value={ search } />
+					<SitesTable sites={ sites } />
+				</div>
+			) }
+		</ClassNames>
+	);
+}

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,7 +1,7 @@
-import Search from '@automattic/search';
 import { ClassNames } from '@emotion/react';
 import { useMemo, useState } from 'react';
 import { searchCollection } from 'calypso/components/search-sites/utils';
+import { SitesSearch } from './sites-search';
 import { SitesTable } from './sites-table';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
@@ -31,7 +31,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 							max-width: 100%;
 						` }
 					>
-						<Search onSearch={ setTerm } delaySearch />
+						<SitesSearch onSearch={ setTerm } delaySearch isReskinned />
 					</div>
 					<SitesTable sites={ filteredSites } />
 				</>

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -23,14 +23,18 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 	return (
 		<ClassNames>
 			{ ( { css } ) => (
-				<div
-					className={ css`
-						margin-top: 32px;
-					` }
-				>
-					<Search onSearch={ setTerm } delaySearch />
+				<>
+					<div
+						className={ css`
+							margin: 32px 0;
+							width: 286px;
+							max-width: 100%;
+						` }
+					>
+						<Search onSearch={ setTerm } delaySearch />
+					</div>
 					<SitesTable sites={ filteredSites } />
-				</div>
+				</>
 			) }
 		</ClassNames>
 	);

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,11 +1,24 @@
+import Search from '@automattic/search';
 import { ClassNames } from '@emotion/react';
-import { useState } from 'react';
-import Search from 'calypso/components/search';
+import { useMemo, useState } from 'react';
+import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesTable } from './sites-table';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
-export function SearchableSitesTable( { sites }: { className?: string; sites: SiteData[] } ) {
-	const [ search, setSearch ] = useState( '' );
+interface SearchableSitesTableProps {
+	sites: SiteData[];
+}
+
+export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
+	const [ term, setTerm ] = useState( '' );
+
+	const filteredSites = useMemo( () => {
+		if ( ! term ) {
+			return sites;
+		}
+
+		return searchCollection( sites, term.toLowerCase(), [ 'URL', 'domain', 'name', 'slug' ] );
+	}, [ term, sites ] );
 
 	return (
 		<ClassNames>
@@ -15,8 +28,8 @@ export function SearchableSitesTable( { sites }: { className?: string; sites: Si
 						margin-top: 32px;
 					` }
 				>
-					<Search onSearch={ setSearch } value={ search } />
-					<SitesTable sites={ sites } />
+					<Search onSearch={ setTerm } delaySearch />
+					<SitesTable sites={ filteredSites } />
 				</div>
 			) }
 		</ClassNames>

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -40,7 +40,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 							onSearch={ handleSearch }
 							delaySearch
 							isReskinned
-							placeholder={ __( 'Search by name or domain' ) + '...' }
+							placeholder={ __( 'Search by name or domain…' ) }
 						/>
 					</div>
 					<SitesTable sites={ filteredSites } />

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -23,6 +23,8 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 		return searchCollection( sites, term.toLowerCase(), [ 'URL', 'domain', 'name', 'slug' ] );
 	}, [ term, sites ] );
 
+	const handleSearch = ( rawTerm: string ) => setTerm( rawTerm.trim() );
+
 	return (
 		<ClassNames>
 			{ ( { css } ) => (
@@ -35,7 +37,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 						` }
 					>
 						<SitesSearch
-							onSearch={ setTerm }
+							onSearch={ handleSearch }
 							delaySearch
 							isReskinned
 							placeholder={ __( 'Search by name or domain' ) + '...' }

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
 import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesSearch } from './sites-search';
+import { SitesSearchIcon } from './sites-search-icon';
 import { SitesTable } from './sites-table';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
@@ -37,6 +38,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 						` }
 					>
 						<SitesSearch
+							searchIcon={ <SitesSearchIcon /> }
 							onSearch={ handleSearch }
 							delaySearch
 							isReskinned

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import getSites from 'calypso/state/selectors/get-sites';
 import { notNullish } from '../util';
-import { SitesTable } from './sites-table';
+import { SearchableSitesTable } from './searchable-sites-table';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
@@ -85,18 +85,7 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 							` }
 							launchStatus={ launchStatus }
 						>
-							{ ( filteredSites ) => (
-								<ClassNames>
-									{ ( { css } ) => (
-										<SitesTable
-											className={ css`
-												margin-top: 32px;
-											` }
-											sites={ filteredSites }
-										/>
-									) }
-								</ClassNames>
-							) }
+							{ ( filteredSites ) => <SearchableSitesTable sites={ filteredSites } /> }
 						</SitesTableFilterTabs>
 					) }
 				</ClassNames>

--- a/client/sites-dashboard/components/sites-search-icon.tsx
+++ b/client/sites-dashboard/components/sites-search-icon.tsx
@@ -1,0 +1,32 @@
+export const SitesSearchIcon = () => {
+	return (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 20 20"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			style={ {
+				paddingLeft: '16px',
+				paddingRight: '10px',
+				height: '100%',
+				backgroundColor: 'var( --color-surface )',
+			} }
+		>
+			<path
+				d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z"
+				stroke="#8C8F94"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+			<path
+				d="M17.5 17.5L13.875 13.875"
+				stroke="#8C8F94"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	);
+};

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -1,0 +1,27 @@
+import Search from '@automattic/search';
+import styled from '@emotion/styled';
+
+export const SitesSearch = styled( Search )`
+	--color-surface: #f6f7f7;
+	border-radius: 4px;
+	overflow: hidden;
+	height: 44px;
+
+	.search-component__icon-search {
+		background: var( --color-surface );
+		height: 100%;
+		fill: currentColor;
+		height: 100%;
+
+		// Flip horizontally
+		transform: scale( -1, 1 );
+
+		padding-right: 8px;
+		padding-left: 5px;
+	}
+
+	// TODO: make the fade optional in the component
+	.search-component__input-fade::before {
+		display: none !important;
+	}
+`;

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -7,19 +7,6 @@ export const SitesSearch = styled( Search )`
 	overflow: hidden;
 	height: 44px;
 
-	.search-component__icon-search {
-		background: var( --color-surface );
-		height: 100%;
-		fill: currentColor;
-		height: 100%;
-
-		// Flip horizontally
-		transform: scale( -1, 1 );
-
-		padding-right: 8px;
-		padding-left: 5px;
-	}
-
 	// TODO: make the fade optional in the component
 	.search-component__input-fade::before {
 		display: none !important;

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -25,7 +25,6 @@ interface SiteTab extends Omit< TabPanel.Tab, 'title' > {
 const SitesTabPanel = styled( TabPanel )`
 	.components-tab-panel__tabs {
 		overflow-x: auto;
-		padding-bottom: 10px;
 	}
 
 	.components-tab-panel__tabs-item {


### PR DESCRIPTION
#### Proposed Changes

This PR adds the basic search mechanism used throughout Calypso on the SMD.

It's a starting point for searching sites and will be iterated upon by follow-up PRs, most likely https://github.com/Automattic/wp-calypso/pull/65501, and a future PR that allows customizing the search icon and removing the input fade (described in the comments).

#### Testing Instructions

Check out this branch, open SMD, and try inputting substring values for the URL, domain, name, or slug.

| No search | With result | No result |
| ---------- | ----------- | --------- |
| ![image](https://user-images.githubusercontent.com/26530524/178569239-c6c8e63b-86d1-41da-a87b-9a5b6bb9e10a.png) | ![image](https://user-images.githubusercontent.com/26530524/178569295-6454e2b4-29fa-43cc-a8aa-427d9347510b.png) | ![image](https://user-images.githubusercontent.com/26530524/178569330-693db342-ad25-412a-8760-4458ec104897.png) |

The "no result" state will be fixed in a follow-up issue.

Related to #65169.