### PR TITLE
WPCOM Block Editor: Fix back to dashboard url destination in wp-admin

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -2,6 +2,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
+import './features/override-edit-site-back-button';
 import './features/tracking';
 import './features/use-classic-block-guide';
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';

--- a/apps/wpcom-block-editor/src/wpcom/features/override-edit-site-back-button.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/override-edit-site-back-button.js
@@ -15,9 +15,10 @@ const editSitePackage = require( '@wordpress/edit-site' );
  * both wp-admin and the calypso iframe.
  */
 function overrideBackToDashboardButton() {
-	if ( ! editSitePackage ) return;
+	if ( ! editSitePackage?.__experimentalMainDashboardButton ) return;
 
-	const SiteEditorDashboardFill = editSitePackage?.__experimentalMainDashboardButton;
+	const SiteEditorDashboardFill = editSitePackage.__experimentalMainDashboardButton;
+	const siteSlug = window.location.hostname;
 
 	registerPlugin( 'a8c-wpcom-block-editor-site-editor-back-to-dashboard-override', {
 		render: function SiteEditorCloseFill() {
@@ -25,7 +26,7 @@ function overrideBackToDashboardButton() {
 				createElement( NavigationBackButton, {
 					backButtonLabel: __( 'Dashboard' ),
 					className: 'edit-site-navigation-panel__back-to-dashboard',
-					href: 'helloworld.com', // TODO: Dynamically generate correct close url
+					href: `https://wordpress.com/home/${ siteSlug }`,
 				} ),
 			] );
 		},

--- a/apps/wpcom-block-editor/src/wpcom/features/override-edit-site-back-button.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/override-edit-site-back-button.js
@@ -1,0 +1,35 @@
+import { __experimentalNavigationBackButton as NavigationBackButton } from '@wordpress/components';
+import domReady from '@wordpress/dom-ready';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+/**
+ * Conditional dependency.  We cannot use the standard 'import' since this package is
+ * not available in the post editor and causes WSOD in that case.  Instead, we can
+ * define it from 'require' and conditionally check if it is available for use.
+ */
+const editSitePackage = require( '@wordpress/edit-site' );
+
+/**
+ * Ensures that the site editor's back to dashboard button always leads back to Calypso from
+ * both wp-admin and the calypso iframe.
+ */
+function overrideBackToDashboardButton() {
+	if ( ! editSitePackage ) return;
+
+	const SiteEditorDashboardFill = editSitePackage?.__experimentalMainDashboardButton;
+
+	registerPlugin( 'a8c-wpcom-block-editor-site-editor-back-to-dashboard-override', {
+		render: function SiteEditorCloseFill() {
+			return createElement( SiteEditorDashboardFill, null, [
+				createElement( NavigationBackButton, {
+					backButtonLabel: __( 'Dashboard' ),
+					className: 'edit-site-navigation-panel__back-to-dashboard',
+					href: 'helloworld.com', // TODO: Dynamically generate correct close url
+				} ),
+			] );
+		},
+	} );
+}
+
+domReady( overrideBackToDashboardButton );

--- a/apps/wpcom-block-editor/src/wpcom/features/override-edit-site-back-button.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/override-edit-site-back-button.js
@@ -1,6 +1,5 @@
 import { __experimentalNavigationBackButton as NavigationBackButton } from '@wordpress/components';
 import domReady from '@wordpress/dom-ready';
-import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 /**
@@ -22,13 +21,16 @@ function overrideBackToDashboardButton() {
 
 	registerPlugin( 'a8c-wpcom-block-editor-site-editor-back-to-dashboard-override', {
 		render: function SiteEditorCloseFill() {
-			return createElement( SiteEditorDashboardFill, null, [
-				createElement( NavigationBackButton, {
-					backButtonLabel: __( 'Dashboard' ),
-					className: 'edit-site-navigation-panel__back-to-dashboard',
-					href: `https://wordpress.com/home/${ siteSlug }`,
-				} ),
-			] );
+			return (
+				<SiteEditorDashboardFill>
+					<NavigationBackButton
+						backButtonLabel={ __( 'Dashboard' ) }
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="edit-site-navigation-panel__back-to-dashboard"
+						href={ `https://wordpress.com/home/${ siteSlug }` }
+					/>
+				</SiteEditorDashboardFill>
+			);
 		},
 	} );
 }


### PR DESCRIPTION
## Context

Currently, we are updating the < Dashboard button in the site editor in the calypso iframe.

This means that only editor instances accessed through calypso (wordpress.com/site-editor/{SiteURL}) will land at "My Home" after selecting to exit to the Dashboard. While sites that may get redirected to the wp-admin site editor instance will lead users back into wp-admin.

We want to update this so even the wp-admin editor's < Dashboard button leads users back to "My Home" in calypso.

<img width="1280" alt="Screen Shot 2022-07-07 at 5 34 57 PM" src="https://user-images.githubusercontent.com/5414230/179617917-8032bc57-5d75-4454-9406-2cefcd038cdf.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site and `widgets.wp.com` through your hosts file
* Checkout this branch in a terminal
* Navigate the `calypso/apps/wpcom-block-editor` in the terminal
* Run `yarn dev --sync`
* Have a full site editing theme activated ( Blockbase, Blank Canvas, Quadrat, etc. )
* Navigate to Appearance > Site Editor
* Open the nav sidebar by clicking on the site icon in the top left hand corner of the screen
* Verify that the < Dashboard button leads back to Calypso my home ( `wordpress.com/home/{SITE-SLUG-HERE}` ) instead of wp-admin.
* Ensure this for both simple and atomic sites

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64131
