### PR TITLE
Checkout: Add immediate redirect on pre-filled receipt ID to pending page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -295,7 +295,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		this.props.recordTracksEvent( 'calypso_thank_you_no_site_receipt_error' );
 
-		page( `/home/${ selectedSite.slug }` );
+		page( selectedSite?.slug ? `/home/${ selectedSite.slug }` : '/' );
 	};
 
 	visitDomain = ( event ) => {

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -112,28 +112,7 @@ function CheckoutPending( {
 
 				didRedirect.current = true;
 
-				if ( redirectTo?.includes( ':receiptId' ) ) {
-					performRedirect( redirectTo.replace( ':receiptId', `${ receiptId }` ) );
-					return;
-				}
-
-				// Only treat `/pending` as a placeholder if it's the end of the URL
-				// pathname, but preserve query strings or hashes.
-				const receiptPlaceholderRegexp = /\/pending([?#]|$)/;
-				if ( redirectTo && receiptPlaceholderRegexp.test( redirectTo ) ) {
-					performRedirect( redirectTo.replace( receiptPlaceholderRegexp, `/${ receiptId }$1` ) );
-					return;
-				}
-
-				if ( redirectTo ) {
-					performRedirect( redirectTo );
-					return;
-				}
-
-				const defaultSuccessUrl = siteSlug
-					? `/checkout/thank-you/${ siteSlug }/${ receiptId }`
-					: '/checkout/thank-you/no-site';
-				performRedirect( defaultSuccessUrl );
+				redirectWithInterpolatedReceipt( redirectTo, siteSlug, receiptId );
 				return;
 			}
 
@@ -198,6 +177,35 @@ function CheckoutPending( {
 
 function isValidOrderId( orderId: number | ':orderId' ): orderId is number {
 	return Number.isInteger( orderId );
+}
+
+function redirectWithInterpolatedReceipt(
+	url: string | undefined,
+	siteSlug: string | undefined,
+	receiptId: number
+): void {
+	if ( url?.includes( ':receiptId' ) ) {
+		performRedirect( url.replace( ':receiptId', `${ receiptId }` ) );
+		return;
+	}
+
+	// Only treat `/pending` as a placeholder if it's the end of the URL
+	// pathname, but preserve query strings or hashes.
+	const receiptPlaceholderRegexp = /\/pending([?#]|$)/;
+	if ( url && receiptPlaceholderRegexp.test( url ) ) {
+		performRedirect( url.replace( receiptPlaceholderRegexp, `/${ receiptId }$1` ) );
+		return;
+	}
+
+	if ( url ) {
+		performRedirect( url );
+		return;
+	}
+
+	const defaultSuccessUrl = siteSlug
+		? `/checkout/thank-you/${ siteSlug }/${ receiptId }`
+		: '/checkout/thank-you/no-site';
+	performRedirect( defaultSuccessUrl );
 }
 
 function performRedirect( url: string ): void {

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -155,6 +155,15 @@ function useRedirectOnTransactionSuccess( {
 			);
 		}
 
+		if ( redirectInstructions.isUnknown ) {
+			const unknownNotice = translate( 'Oops! Something went wrong. Please try again later.' );
+			reduxDispatch(
+				errorNotice( unknownNotice, {
+					isPersistent: true,
+				} )
+			);
+		}
+
 		didRedirect.current = true;
 		performRedirect( redirectInstructions.url );
 	}, [

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -203,7 +203,7 @@ function redirectWithInterpolatedReceipt(
 	receiptId: number
 ): void {
 	if ( url?.includes( ':receiptId' ) ) {
-		performRedirect( url.replaceAll( ':receiptId', `${ receiptId }` ) );
+		performRedirect( url.replaceAll( ':receiptId', `${ receiptId }` ), siteSlug );
 		return;
 	}
 
@@ -211,27 +211,69 @@ function redirectWithInterpolatedReceipt(
 	// pathname, but preserve query strings or hashes.
 	const receiptPlaceholderRegexp = /\/pending([?#]|$)/;
 	if ( url && receiptPlaceholderRegexp.test( url ) ) {
-		performRedirect( url.replace( receiptPlaceholderRegexp, `/${ receiptId }$1` ) );
+		performRedirect( url.replace( receiptPlaceholderRegexp, `/${ receiptId }$1` ), siteSlug );
 		return;
 	}
 
 	if ( url ) {
-		performRedirect( url );
+		performRedirect( url, siteSlug );
 		return;
 	}
 
 	const defaultSuccessUrl = siteSlug
 		? `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		: '/checkout/thank-you/no-site';
-	performRedirect( defaultSuccessUrl );
+	performRedirect( defaultSuccessUrl, siteSlug );
 }
 
-function performRedirect( url: string ): void {
+function performRedirect( url: string, siteSlug: string | undefined ): void {
 	if ( url.startsWith( '/' ) ) {
 		page( url );
 		return;
 	}
-	window.location.href = url;
+
+	const allowedHostsForRedirect = [
+		'wordpress.com',
+		'calypso.localhost',
+		'jetpack.cloud.localhost',
+		'cloud.jetpack.com',
+		siteSlug,
+	];
+
+	try {
+		const parsedUrl = new URL( url );
+		const { hostname, pathname } = parsedUrl;
+		if ( ! hostname ) {
+			throw new Error( `No hostname found for redirect '${ url }'` );
+		}
+
+		// For subdirectory site, check that both hostname and subdirectory matches
+		// the siteSlug (host.name::subdirectory).
+		if ( siteSlug?.includes( '::' ) ) {
+			const [ hostnameFromSlug, ...subdirectoryParts ] = siteSlug.split( '::' );
+			const subdirectoryPathFromSlug = subdirectoryParts.join( '/' );
+			if (
+				hostname !== hostnameFromSlug &&
+				! pathname?.startsWith( `/${ subdirectoryPathFromSlug }` )
+			) {
+				throw new Error( `Redirect '${ url }' is not valid for subdirectory site '${ siteSlug }'` );
+			}
+			window.location.href = url;
+			return;
+		}
+
+		if ( ! allowedHostsForRedirect.includes( hostname ) ) {
+			throw new Error( `Invalid hostname '${ hostname }' for redirect '${ url }'` );
+		}
+
+		window.location.href = url;
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( `Redirecting to absolute url '${ url }' failed:`, err );
+	}
+
+	const fallbackUrl = '/checkout/thank-you/no-site';
+	page( fallbackUrl );
 }
 
 export default function CheckoutPendingWrapper( props: CheckoutPendingProps ) {

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -203,7 +203,7 @@ function redirectWithInterpolatedReceipt(
 	receiptId: number
 ): void {
 	if ( url?.includes( ':receiptId' ) ) {
-		performRedirect( url.replace( ':receiptId', `${ receiptId }` ) );
+		performRedirect( url.replaceAll( ':receiptId', `${ receiptId }` ) );
 		return;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -90,54 +90,12 @@ function isValidOrderId( orderId: number | ':orderId' ): orderId is number {
 	return Number.isInteger( orderId );
 }
 
-function performRedirect( url: string, siteSlug: string | undefined ): void {
+function performRedirect( url: string ): void {
 	if ( url.startsWith( '/' ) ) {
 		page( url );
 		return;
 	}
-
-	const allowedHostsForRedirect = [
-		'wordpress.com',
-		'calypso.localhost',
-		'jetpack.cloud.localhost',
-		'cloud.jetpack.com',
-		siteSlug,
-	];
-
-	try {
-		const parsedUrl = new URL( url );
-		const { hostname, pathname } = parsedUrl;
-		if ( ! hostname ) {
-			throw new Error( `No hostname found for redirect '${ url }'` );
-		}
-
-		// For subdirectory site, check that both hostname and subdirectory matches
-		// the siteSlug (host.name::subdirectory).
-		if ( siteSlug?.includes( '::' ) ) {
-			const [ hostnameFromSlug, ...subdirectoryParts ] = siteSlug.split( '::' );
-			const subdirectoryPathFromSlug = subdirectoryParts.join( '/' );
-			if (
-				hostname !== hostnameFromSlug &&
-				! pathname?.startsWith( `/${ subdirectoryPathFromSlug }` )
-			) {
-				throw new Error( `Redirect '${ url }' is not valid for subdirectory site '${ siteSlug }'` );
-			}
-			window.location.href = url;
-			return;
-		}
-
-		if ( ! allowedHostsForRedirect.includes( hostname ) ) {
-			throw new Error( `Invalid hostname '${ hostname }' for redirect '${ url }'` );
-		}
-
-		window.location.href = url;
-	} catch ( err ) {
-		// eslint-disable-next-line no-console
-		console.error( `Redirecting to absolute url '${ url }' failed:`, err );
-	}
-
-	const fallbackUrl = '/checkout/thank-you/no-site';
-	page( fallbackUrl );
+	window.location.href = url;
 }
 
 function useRedirectOnTransactionSuccess( {
@@ -196,7 +154,7 @@ function useRedirectOnTransactionSuccess( {
 		}
 
 		didRedirect.current = true;
-		performRedirect( redirectInstructions.url, siteSlug );
+		performRedirect( redirectInstructions.url );
 	}, [
 		error,
 		redirectTo,

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -93,7 +93,7 @@ function CheckoutPending( {
 			page( failRedirectUrl );
 		};
 
-		if ( receiptId && ! redirectTo?.includes( ':receiptId' ) ) {
+		if ( receiptId ) {
 			didRedirect.current = true;
 			redirectWithInterpolatedReceipt( redirectTo, siteSlug, receiptId );
 			return;

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -138,16 +138,18 @@ function useRedirectOnTransactionSuccess( {
 			receiptId,
 			redirectTo,
 			siteSlug,
-			translate,
 		} );
 
 		if ( ! redirectInstructions ) {
 			return;
 		}
 
-		if ( redirectInstructions.errorNotice ) {
+		if ( redirectInstructions.isError ) {
+			const defaultFailErrorNotice = translate(
+				"Sorry, we couldn't process your payment. Please try again later."
+			);
 			reduxDispatch(
-				errorNotice( redirectInstructions.errorNotice, {
+				errorNotice( defaultFailErrorNotice, {
 					isPersistent: true,
 				} )
 			);

--- a/client/my-sites/checkout/checkout-thank-you/pending.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.tsx
@@ -10,13 +10,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { errorNotice } from 'calypso/state/notices/actions';
-import {
-	SUCCESS,
-	ERROR,
-	FAILURE,
-	UNKNOWN,
-	ASYNC_PENDING,
-} from 'calypso/state/order-transactions/constants';
+import { SUCCESS, ERROR, FAILURE, UNKNOWN } from 'calypso/state/order-transactions/constants';
 import getOrderTransaction from 'calypso/state/selectors/get-order-transaction';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
@@ -245,12 +239,6 @@ function useRedirectOnTransactionSuccess( {
 
 				didRedirect.current = true;
 				redirectWithInterpolatedReceipt( redirectTo, siteSlug, transactionReceiptId );
-				return;
-			}
-
-			if ( ASYNC_PENDING === transaction.processingStatus ) {
-				didRedirect.current = true;
-				page( '/me/purchases/pending' );
 				return;
 			}
 

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -3,6 +3,7 @@ import page from 'page';
 export interface PendingPageRedirectOptions {
 	siteSlug?: string | undefined;
 	orderId?: string | number | undefined;
+	receiptId?: string | number | undefined;
 	urlType?: 'relative' | 'absolute';
 }
 
@@ -18,6 +19,9 @@ export interface PendingPageRedirectOptions {
  *
  * If `siteSlug` is not provided, it will use `no-site`.
  *
+ * If `receiptId` is provided, it means the transaction is already complete and
+ * may cause the pending page to redirect immediately to the `url`.
+ *
  * An order ID is required for the pending page to operate. If `orderId` is not
  * provided, it will use the placeholder `:orderId` but please note that this
  * must be replaced somewhere (typically in an endpoint) before the
@@ -25,7 +29,7 @@ export interface PendingPageRedirectOptions {
  */
 export function redirectThroughPending(
 	url: string,
-	options: Pick< PendingPageRedirectOptions, 'siteSlug' | 'orderId' >
+	options: Omit< PendingPageRedirectOptions, 'urlType' >
 ): void {
 	if ( ! isRelativeUrl( url ) ) {
 		return absoluteRedirectThroughPending( url, options );
@@ -58,6 +62,9 @@ function isRelativeUrl( url: string ): boolean {
  *
  * If `siteSlug` is not provided, it will use `no-site`.
  *
+ * If `receiptId` is provided, it means the transaction is already complete and
+ * may cause the pending page to redirect immediately to the `url`.
+ *
  * An order ID is required for the pending page to operate. If `orderId` is not
  * provided, it will use the placeholder `:orderId` but please note that this
  * must be replaced somewhere (typically in an endpoint) before the
@@ -65,7 +72,7 @@ function isRelativeUrl( url: string ): boolean {
  */
 export function relativeRedirectThroughPending(
 	url: string,
-	options: Pick< PendingPageRedirectOptions, 'siteSlug' | 'orderId' >
+	options: Omit< PendingPageRedirectOptions, 'urlType' >
 ): void {
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
@@ -90,6 +97,9 @@ export function relativeRedirectThroughPending(
  *
  * If `siteSlug` is not provided, it will use `no-site`.
  *
+ * If `receiptId` is provided, it means the transaction is already complete and
+ * may cause the pending page to redirect immediately to the `url`.
+ *
  * An order ID is required for the pending page to operate. If `orderId` is not
  * provided, it will use the placeholder `:orderId` but please note that this
  * must be replaced somewhere (typically in an endpoint) before the
@@ -97,7 +107,7 @@ export function relativeRedirectThroughPending(
  */
 export function absoluteRedirectThroughPending(
 	url: string,
-	options: Pick< PendingPageRedirectOptions, 'siteSlug' | 'orderId' >
+	options: Omit< PendingPageRedirectOptions, 'urlType' >
 ): void {
 	window.location.href = addUrlToPendingPageRedirect( url, {
 		...options,
@@ -122,6 +132,9 @@ export function absoluteRedirectThroughPending(
  * must be replaced somewhere (typically in an endpoint) before the
  * resulting URL will be valid!
  *
+ * If `receiptId` is provided, it means the transaction is already complete and
+ * may cause the pending page to redirect immediately to the `url`.
+ *
  * You should always specify `urlType` as either 'absolute' or 'relative' but
  * it will default to 'absolute'.
  */
@@ -129,7 +142,7 @@ export function addUrlToPendingPageRedirect(
 	url: string,
 	options: PendingPageRedirectOptions
 ): string {
-	const { siteSlug, orderId, urlType = 'absolute' } = options;
+	const { siteSlug, orderId, urlType = 'absolute', receiptId = ':receiptId' } = options;
 
 	const { origin = 'https://wordpress.com' } = typeof window !== 'undefined' ? window.location : {};
 	const successUrlPath =
@@ -138,6 +151,7 @@ export function addUrlToPendingPageRedirect(
 	const successUrlBase = `${ origin }${ successUrlPath }`;
 	const successUrlObject = new URL( successUrlBase );
 	successUrlObject.searchParams.set( 'redirectTo', url );
+	successUrlObject.searchParams.set( 'receiptId', String( receiptId ) );
 	if ( urlType === 'relative' ) {
 		return successUrlObject.pathname + successUrlObject.search + successUrlObject.hash;
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -303,7 +303,7 @@ export function getRedirectFromPendingPage( {
 	// existing behavior and send the user to a generic thank-you page,
 	// assuming that the purchase was successful. This goes to the URL path
 	// `/checkout/thank-you/:site/:receiptId` but without a real receiptId.
-	if ( ! orderId ) {
+	if ( ! orderId && ! transaction ) {
 		return {
 			url: getDefaultSuccessUrl( siteSlug, undefined ),
 		};

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -235,11 +235,14 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 	return false;
 }
 
-function filterAllowedRedirect( url: string, siteSlug: string | undefined ): string {
+function filterAllowedRedirect(
+	url: string,
+	siteSlug: string | undefined,
+	fallbackUrl: string
+): string {
 	if ( isRedirectAllowed( url, siteSlug ) ) {
 		return url;
 	}
-	const fallbackUrl = '/checkout/thank-you/no-site';
 	return fallbackUrl;
 }
 
@@ -294,7 +297,8 @@ export function getRedirectFromPendingPage( {
 					redirectTo ?? getDefaultSuccessUrl( siteSlug, receiptId ),
 					receiptId
 				),
-				siteSlug
+				siteSlug,
+				getDefaultSuccessUrl( siteSlug, receiptId )
 			),
 		};
 	}
@@ -324,7 +328,8 @@ export function getRedirectFromPendingPage( {
 						redirectTo ?? getDefaultSuccessUrl( siteSlug, transactionReceiptId ),
 						transactionReceiptId
 					),
-					siteSlug
+					siteSlug,
+					getDefaultSuccessUrl( siteSlug, receiptId )
 				),
 			};
 		}

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -12,6 +12,7 @@ export interface PendingPageRedirectOptions {
 export interface RedirectInstructions {
 	url: string;
 	isError?: boolean;
+	isUnknown?: boolean;
 }
 
 export interface RedirectForTransactionStatusArgs {
@@ -344,7 +345,7 @@ export function getRedirectFromPendingPage( {
 		if ( UNKNOWN === processingStatus ) {
 			return {
 				url: planRoute,
-				isError: true,
+				isUnknown: true,
 			};
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -311,7 +311,7 @@ export function getRedirectFromPendingPage( {
 	// `/checkout/thank-you/:site/:receiptId` but without a real receiptId.
 	if ( ! orderId ) {
 		return {
-			url: getDefaultSuccessUrl( siteSlug, receiptId ),
+			url: getDefaultSuccessUrl( siteSlug, undefined ),
 		};
 	}
 
@@ -329,7 +329,7 @@ export function getRedirectFromPendingPage( {
 						transactionReceiptId
 					),
 					siteSlug,
-					getDefaultSuccessUrl( siteSlug, receiptId )
+					getDefaultSuccessUrl( siteSlug, transactionReceiptId )
 				),
 			};
 		}

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -250,13 +250,7 @@ function getDefaultSuccessUrl(
 	siteSlug: string | undefined,
 	receiptId: number | undefined
 ): string {
-	if ( receiptId ) {
-		return `/checkout/thank-you/${ siteSlug ?? 'no-site' }/${ receiptId }`;
-	}
-	if ( siteSlug ) {
-		return `/checkout/thank-you/${ siteSlug }/unknown-receipt`;
-	}
-	return '/checkout/thank-you/no-site';
+	return `/checkout/thank-you/${ siteSlug ?? 'no-site' }/${ receiptId ?? 'unknown-receipt' }`;
 }
 
 /**

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -45,7 +45,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment_partner: 'IE',
 			postal_code: '10001',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			zip: '10001',
 		},
 		tos: {
@@ -152,7 +152,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -190,7 +190,8 @@ describe( 'genericRedirectProcessor', () => {
 				...basicExpectedStripeRequest.payment,
 				success_url:
 					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=' +
-					encodeURIComponent( thankYouUrl ),
+					encodeURIComponent( thankYouUrl ) +
+					'&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -228,7 +229,8 @@ describe( 'genericRedirectProcessor', () => {
 				...basicExpectedStripeRequest.payment,
 				success_url:
 					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=' +
-					encodeURIComponent( thankYouUrl ),
+					encodeURIComponent( thankYouUrl ) +
+					'&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -274,7 +276,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -310,7 +312,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/test/pending-page.ts
@@ -9,6 +9,8 @@ jest.mock( 'page' );
 // This seems to be the default origin for jsdom + Jest.
 const currentWindowOrigin = 'https://example.com';
 
+const encodedReceiptPlaceholder = encodeURIComponent( ':receiptId' );
+
 describe( 'addUrlToPendingPageRedirect', () => {
 	beforeAll( () => {
 		jest.spyOn( window, 'scrollTo' ).mockImplementation();
@@ -26,7 +28,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		expect( actual ).toEqual(
 			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 	} );
 
@@ -42,7 +44,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		expect( actual ).toEqual(
 			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 	} );
 
@@ -57,7 +59,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		expect( actual ).toEqual(
 			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 	} );
 
@@ -70,7 +72,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		expect( actual ).toEqual(
 			`${ currentWindowOrigin }/checkout/thank-you/no-site/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 	} );
 
@@ -83,7 +85,22 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		expect( actual ).toEqual(
 			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/:orderId?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
+		);
+	} );
+
+	it( 'returns a receipt ID as `receiptId` if provided', () => {
+		const finalUrl = '/foo/bar/baz';
+		const siteSlug = 'example2.com';
+		const receiptId = 1234;
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			siteSlug,
+			receiptId,
+		} );
+		expect( actual ).toEqual(
+			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/:orderId?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }&receiptId=${ receiptId }`
 		);
 	} );
 } );
@@ -102,7 +119,7 @@ describe( 'redirectThroughPending', () => {
 		expect( redirectSpy ).toHaveBeenCalledWith(
 			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 	} );
 
@@ -123,7 +140,7 @@ describe( 'redirectThroughPending', () => {
 		expect( global.window.location.href ).toEqual(
 			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
 				finalUrl
-			) }`
+			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 		delete global.window.location;
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/test/pending-page.ts
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 import page from 'page';
-import { addUrlToPendingPageRedirect, redirectThroughPending } from '../lib/pending-page';
+import {
+	addUrlToPendingPageRedirect,
+	redirectThroughPending,
+	getRedirectFromPendingPage,
+} from '../lib/pending-page';
 
 jest.mock( 'page' );
 
@@ -143,5 +147,62 @@ describe( 'redirectThroughPending', () => {
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
 		delete global.window.location;
+	} );
+} );
+
+describe( 'getRedirectFromPendingPage', () => {
+	it( 'returns a simple relative url if there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( { redirectTo: '/home', receiptId: 12345 } );
+		expect( actual ).toEqual( { url: '/home' } );
+	} );
+
+	it( 'returns a receipt interpolated relative url if there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: '/home/:receiptId',
+			receiptId: 12345,
+		} );
+		expect( actual ).toEqual( { url: '/home/12345' } );
+	} );
+
+	it( 'returns a simple absolute url if it is allowed and there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: 'https://wordpress.com/home',
+			receiptId: 12345,
+		} );
+		expect( actual ).toEqual( { url: 'https://wordpress.com/home' } );
+	} );
+
+	it( 'returns a simple absolute url if it matches the siteSlug and there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: 'https://example.com/home',
+			receiptId: 12345,
+			siteSlug: 'example.com',
+		} );
+		expect( actual ).toEqual( { url: 'https://example.com/home' } );
+	} );
+
+	it( 'returns a receipt interpolated absolute url if it is allowed and there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: 'https://wordpress.com/home/:receiptId',
+			receiptId: 12345,
+		} );
+		expect( actual ).toEqual( { url: 'https://wordpress.com/home/12345' } );
+	} );
+
+	it( 'returns a generic siteless url for an absolute url if it is not allowed and there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: 'https://example.com/home',
+			receiptId: 12345,
+		} );
+		expect( actual ).toEqual( { url: '/checkout/thank-you/no-site/12345' } );
+	} );
+
+	it( 'returns a generic url with a site for an absolute url if it is not allowed and there is also a receipt and a site', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: 'https://example.com/home',
+			receiptId: 12345,
+			siteSlug: 'foo.bar',
+		} );
+		expect( actual ).toEqual( { url: '/checkout/thank-you/foo.bar/12345' } );
 	} );
 } );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -216,10 +216,19 @@ export function checkoutPending( context, next ) {
 	 */
 	const redirectTo = context.query.redirectTo;
 
+	const receiptId = Number.isInteger( Number( context.query.receiptId ) )
+		? Number( context.query.receiptId )
+		: undefined;
+
 	setSectionMiddleware( { name: 'checkout-pending' } )( context );
 
 	context.primary = (
-		<CheckoutPending orderId={ orderId } siteSlug={ siteSlug } redirectTo={ redirectTo } />
+		<CheckoutPending
+			orderId={ orderId }
+			siteSlug={ siteSlug }
+			redirectTo={ redirectTo }
+			receiptId={ receiptId }
+		/>
 	);
 
 	next();


### PR DESCRIPTION
#### Proposed Changes

The post-checkout "pending" page is visited by most payment methods ([and more](https://github.com/Automattic/wp-calypso/pull/65273) [soon](https://github.com/Automattic/wp-calypso/pull/65327)). It gets an order ID and then polls for the status of that order until the order is complete (or failed). Once complete, it redirects the user to the URL in the `redirectTo` query parameter.

For most transactions, the order ID is added to the "pending" page URL by either an API endpoint (eg: for redirect payment methods) or directly when the "pending" page URL is created. If the transaction is already complete by the time the URL loads, it will redirect almost instantly since the order endpoint will confirm the success. However, there are some transactions that do not produce an order: free purchases.

Fortunately, by the time a free purchase transaction endpoint request completes, it is always successful (a failure would not complete). So if such purchases use the "pending" page, they really only need to have it go directly to the `redirectTo` query parameter, but this won't work because without an order ID, the "pending" page has no way to confirm that the order was successful.

In this PR, we modify the "pending" page URL to add a new query param, `receiptId`. If set to a number, the "pending" page will know that the transaction has completed and can ignore the order ID (or lack of one).

Because it's relatively easy to provide a receipt ID in the URL, we make it easy to trigger the open redirect already present in the "pending" page (on success, it redirects to whatever is in the `redirectTo` query string). Therefore, this PR also changes the pending page so that it will only redirect to known hosts, similar to https://github.com/Automattic/wp-calypso/pull/54414.

This is needed by https://github.com/Automattic/wp-calypso/pull/65273 and is part of implementing https://github.com/Automattic/wp-calypso/issues/53356.

#### Testing Instructions

Nothing uses this functionality currently. To test it, try a free purchase (eg: buying a domain using a domain credit) using https://github.com/Automattic/wp-calypso/issues/65273 and verify that you end up on a thank-you page with the receipt ID in the URL rather than a generic thank-you page that has `unknown` in the URL.

To that end, this PR adds unit tests for all the possible redirect cases.