### PR TITLE
Jetpack Agency Dashboard: fix UI issues with the site table and card 

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -5,7 +5,7 @@
 }
 .site-card__header {
 	position: relative;
-	padding: 16px;
+	padding: 16px 16px 16px 8px;
 	height: 50px;
 	box-sizing: border-box;
 	display: flex;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
@@ -25,6 +25,12 @@
 	}
 	.search.is-open {
 		box-shadow: none;
+		.search__open-icon {
+			width: 40px;
+			@include break-large() {
+				width: 60px;
+			}
+		}
 	}
 }
 
@@ -43,6 +49,9 @@
 	.filterbar__wrap.card {
 		overflow-x: auto;
 		box-shadow: none;
+		.filterbar__label {
+			margin-left: 12px;
+		}
 		.filterbar__control-list {
 			li {
 				display: inline-flex;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
@@ -27,7 +27,7 @@
 		box-shadow: none;
 		.search__open-icon {
 			width: 40px;
-			@include break-large() {
+			@include break-wide() {
 				width: 60px;
 			}
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
@@ -6,6 +6,7 @@
 	top: 6px;
 	color: var( --studio-gray-20 ) !important;
 	@include break-large() {
+		position: static;
 		visibility: hidden;
 		color: var( --color-primary ) !important;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
@@ -6,7 +6,6 @@
 	top: 6px;
 	color: var( --studio-gray-20 ) !important;
 	@include break-large() {
-		position: static;
 		visibility: hidden;
 		color: var( --color-primary ) !important;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -87,5 +87,5 @@ td.site-table__td-with-error {
 	vertical-align: middle;
 }
 .site-table-site-title {
-	margin-inline-start: 8px;
+	margin-inline-start: 32px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -123,6 +123,9 @@
 		width: calc( 100% - 55px );
 		margin-inline-start: 32px;
 		font-size: 0.875rem;
+		position: absolute;
+		top: 50%;
+		transform: translateY( -50% );
 	}
 }
 .sites-overview__overlay {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -114,7 +114,7 @@
 	vertical-align: middle;
 	color: var( --studio-gray-100 );
 	@include break-zoomed-in {
-		width: calc( 100% - 90px );
+		width: calc( 100% - 120px );
 		margin-inline-start: 8px;
 		margin-inline-end: 5px;
 		font-size: 1rem;
@@ -139,7 +139,7 @@
 		rgba( 255, 255, 255, 1 ) 100%
 	);
 	top: 0;
-	right: 48px;
+	right: 75px;
 	@include break-large() {
 		right: 0;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -121,11 +121,8 @@
 	}
 	@include break-large() {
 		width: calc( 100% - 55px );
-		margin-inline-start: 32px;
+		margin-inline-start: 55px;
 		font-size: 0.875rem;
-		position: absolute;
-		top: 50%;
-		transform: translateY( -50% );
 	}
 }
 .sites-overview__overlay {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -135,10 +135,10 @@
 		rgba( 255, 255, 255, 0.8 ) 30%,
 		rgba( 255, 255, 255, 1 ) 100%
 	);
-	top: 0;
-	right: 75px;
+	inset-block-start: 0;
+	inset-inline-end: 75px;
 	@include break-large() {
-		right: 0;
+		inset-inline-end: 0;
 	}
 }
 .sites-overview__vertical-align-middle {
@@ -189,7 +189,7 @@
 	color: #bbbbbb !important;
 	padding: 6px;
 	position: absolute;
-	right: 16px;
+	inset-inline-end: 16px;
 }
 .sites-overview__badge {
 	font-size: 0.75rem !important;
@@ -208,7 +208,7 @@
 	.popover__arrow {
 		&::before {
 			border-bottom-color: var( --studio-gray-60 ) !important;
-			top: 1px !important;
+			inset-block-start: 1px !important;
 		}
 	}
 	.popover__inner {
@@ -221,8 +221,8 @@
 .sites-overview__status-critical {
 	color: var( --studio-red-50 );
 	position: absolute;
-	right: 42px;
-	top: 50%;
+	inset-inline-end: 42px;
+	inset-block-start: 50%;
 	transform: translateY( -50% );
 	display: inline-flex;
 	@include break-large() {
@@ -231,8 +231,8 @@
 }
 .sites-overview__status-count {
 	position: absolute;
-	right: 42px;
-	top: 50%;
+	inset-inline-end: 42px;
+	inset-block-start: 50%;
 	transform: translateY( -50% );
 	border-radius: 50%; /* stylelint-disable-line */
 	border-width: 2px;


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the following issues in the agency dashboard

- Issue mentioned here - https://github.com/Automattic/wp-calypso/pull/65484#issuecomment-1182301221 which is having a proper spacing between the star and the site titles (and header that reads "site")
- Overlapping issue between error circle and site domain 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/agency-dashboard-ui-fixes` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the site column heading and sites are aligned as shown below

Before

<img width="375" alt="Screenshot 2022-07-12 at 4 10 30 PM" src="https://user-images.githubusercontent.com/10586875/178677286-dc88898c-ca2d-420f-954f-e855bbe288c6.png">

After

<img width="1424" alt="Screenshot 2022-07-14 at 12 33 25 PM" src="https://user-images.githubusercontent.com/10586875/178922175-232ecefd-da05-49b2-83e6-fd3561cbf68f.png">


4. Switch to mobile view using the dev tool and verify the error circles on cards are not overlapping with the site title

Before

![image (2)](https://user-images.githubusercontent.com/10586875/178677616-bb9f6bc9-0c24-4a83-9063-3ab8c77eebf3.png)

After

<img width="387" alt="Screenshot 2022-07-14 at 12 13 18 PM" src="https://user-images.githubusercontent.com/10586875/178922280-5be63b33-e04c-4646-9512-11f3d373324f.png">


Related to 1164141197617539-as-1202571997347410