### PR TITLE
Do not initialize jetpack ga on wpcom env

### DIFF
--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -1,3 +1,4 @@
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { GaPurchase } from '../utils/jetpack-cart-to-ga-purchase';
 import { GaItem } from '../utils/jetpack-product-to-ga-item';
 import { TRACKING_IDS } from './constants';
@@ -6,7 +7,11 @@ import { TRACKING_IDS } from './constants';
 import './setup';
 
 export function setup( params: Gtag.ConfigParams ) {
-	window.gtag( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
+	// TODO: GA4 properties for WPCOM will be here
+
+	if ( isJetpackCloud() ) {
+		window.gtag( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
+	}
 }
 
 export function fireJetpackEcommercePurchase( purchase: GaPurchase ) {

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -12,7 +12,10 @@ export function setupGoogleAnalyticsGtag( params ) {
 	GA4.setup( params );
 
 	window.gtag( 'config', TRACKING_IDS.wpcomGoogleAnalyticsGtag, params );
-	window.gtag( 'config', TRACKING_IDS.jetpackGoogleAnalyticsGtag, params );
+
+	if ( isJetpackCloud() ) {
+		window.gtag( 'config', TRACKING_IDS.jetpackGoogleAnalyticsGtag, params );
+	}
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

By mistake, Jetpack GA properties started to be initialized on WPCOM (Calypso) environment since July 7th. This PR fixes the issue ensuring that the GA property for Jetpack is only initialized on Jetpack Cloud.

#### Testing Instructions

* Install and enable [GA Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) in your Chrome
* Run `yarn start`
* Enable ad tracking on your local instance (PCYsg-dGP-p2#calypso)
* Open `localhost:3000`
* Ensure that there are no mentions of `UA-52447-43` and `G-YELRMVV4YG` in the code and console logs

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/64993