### PR TITLE
Design Picker: Verticalize standard themes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -45,7 +45,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			showDeviceSwitcher={ false }
 			previewUrl={ getDesignPreviewUrl( design, {
 				language: locale,
-				verticalId,
+				vertical_id: verticalId,
 				viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -363,7 +363,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
 			siteTitle: intent === 'write' ? siteTitle : undefined,
-			verticalId: siteVerticalId,
+			verticalId: isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined,
 		} );
 
 		const stepContent = (
@@ -531,7 +531,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			previewOnly={ newDesignEnabled }
 			hasDesignOptionHeader={ ! newDesignEnabled }
-			verticalId={ siteVerticalId }
+			verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -362,8 +362,8 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {
 			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
-			siteTitle: intent === 'write' ? siteTitle : undefined,
-			verticalId: isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined,
+			site_title: intent === 'write' ? siteTitle : undefined,
+			vertical_id: isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined,
 		} );
 
 		const stepContent = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -363,6 +363,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
 			siteTitle: intent === 'write' ? siteTitle : undefined,
+			verticalId: siteVerticalId,
 		} );
 
 		const stepContent = (
@@ -530,6 +531,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			previewOnly={ newDesignEnabled }
 			hasDesignOptionHeader={ ! newDesignEnabled }
+			verticalId={ siteVerticalId }
 		/>
 	);
 

--- a/config/development.json
+++ b/config/development.json
@@ -158,6 +158,7 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
+		"signup/standard-theme-v13n": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,6 +106,7 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
+		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -119,6 +119,7 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
+		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,6 +119,7 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
+		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,6 +130,7 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
+		"signup/standard-theme-v13n": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -31,6 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/calypso-config": "workspace:^",
 		"@automattic/domain-utils": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/happychat-connection": "workspace:^",

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Design } from '@automattic/design-picker/src/types';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -288,12 +289,15 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		 */
 		const anchorDesigns = [ 'hannah', 'gilbert', 'riley' ];
 		if ( anchorDesigns.indexOf( selectedDesign.template ) < 0 ) {
+			// Send vertical_id only if the current design is generated design or we enabled the v13n of standard themes
+			const vertical_id =
+				!! recipe || isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined;
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',
 				body: {
 					trim_content: true,
-					vertical_id: siteVerticalId || undefined,
+					vertical_id: vertical_id || undefined,
 					pattern_ids: recipe?.pattern_ids,
 					header_pattern_ids: recipe?.header_pattern_ids || [],
 					footer_pattern_ids: recipe?.footer_pattern_ids || [],

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -11,6 +11,10 @@ import {
 	AtomicSoftwareStatus,
 } from '../types';
 
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+} ) );
+
 const client_id = 'magic_client_id';
 const client_secret = 'magic_client_secret';
 const mockedClientCredentials = { client_id, client_secret };

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -16,6 +16,10 @@ import {
 	SiteError,
 } from '../types';
 
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+} ) );
+
 describe( 'Site', () => {
 	const siteDetailsResponse: SiteDetails = {
 		ID: 12345,

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -18,6 +18,10 @@ import {
 import { SiteDetails } from '../types';
 import type { State } from '../reducer';
 
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+} ) );
+
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	default: jest.fn(),

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -128,7 +128,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								key={ design.slug }
 								thumbnailUrl={ getDesignPreviewUrl( design, {
 									language: locale,
-									verticalId,
+									vertical_id: verticalId,
 									viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 									viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 									use_screenshot_overrides: true,

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -47,7 +47,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		<MShotsImage
 			url={ getDesignPreviewUrl( design, {
 				language: locale,
-				verticalId,
+				vertical_id: verticalId,
 				use_screenshot_overrides: true,
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -31,15 +31,25 @@ interface DesignPreviewImageProps {
 	design: Design;
 	locale: string;
 	highRes: boolean;
+	verticalId?: string;
 }
 
-const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale, highRes } ) => {
+const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
+	design,
+	locale,
+	highRes,
+	verticalId,
+} ) => {
 	const scrollable = design.preview !== 'static';
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	return (
 		<MShotsImage
-			url={ getDesignPreviewUrl( design, { language: locale, use_screenshot_overrides: true } ) }
+			url={ getDesignPreviewUrl( design, {
+				language: locale,
+				verticalId,
+				use_screenshot_overrides: true,
+			} ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""
 			options={ getMShotOptions( { scrollable, highRes, isMobile } ) }
@@ -62,6 +72,7 @@ interface DesignButtonProps {
 	hasDesignOptionHeader?: boolean;
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
+	verticalId?: string;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -77,6 +88,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable = false,
 	onCheckout = undefined,
+	verticalId,
 } ) => {
 	const { __ } = useI18n();
 
@@ -165,7 +177,12 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					</div>
 				) : (
 					<div className="design-picker__image-frame-inside">
-						<DesignPreviewImage design={ design } locale={ locale } highRes={ highRes } />
+						<DesignPreviewImage
+							design={ design }
+							locale={ locale }
+							highRes={ highRes }
+							verticalId={ verticalId }
+						/>
 					</div>
 				) }
 			</span>
@@ -310,6 +327,7 @@ export interface DesignPickerProps {
 	previewOnly?: boolean;
 	hasDesignOptionHeader?: boolean;
 	onCheckout?: any;
+	verticalId?: string;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -338,6 +356,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	previewOnly = false,
 	hasDesignOptionHeader = true,
 	onCheckout = undefined,
+	verticalId,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -385,6 +404,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						previewOnly={ previewOnly }
 						hasDesignOptionHeader={ hasDesignOptionHeader }
 						onCheckout={ onCheckout }
+						verticalId={ verticalId }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -64,8 +64,8 @@ export interface Design {
 
 export interface DesignPreviewOptions {
 	language?: string;
-	verticalId?: string;
-	siteTitle?: string;
+	vertical_id?: string;
+	site_title?: string;
 	viewport_width?: number;
 	viewport_height?: number;
 	use_screenshot_overrides?: boolean;

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -50,8 +50,8 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should append the preview options to the query params', () => {
 			const options: DesignPreviewOptions = {
 				language: 'id',
-				verticalId: '3',
-				siteTitle: 'Design Title',
+				vertical_id: '3',
+				site_title: 'Design Title',
 				viewport_width: 1280,
 				viewport_height: 700,
 			};
@@ -65,7 +65,7 @@ describe( 'Design Picker designs utils', () => {
 		// in a `background-url: url( ... )` CSS rule the parentheses will break it.
 		it( 'should escape parentheses within the site title', () => {
 			const options: DesignPreviewOptions = {
-				siteTitle: 'Mock(Design)(Title)',
+				site_title: 'Mock(Design)(Title)',
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -22,7 +22,7 @@ export const getDesignPreviewUrl = (
 		footer_pattern_ids: recipe?.footer_pattern_ids
 			? recipe?.footer_pattern_ids.join( ',' )
 			: undefined,
-		vertical_id: options.verticalId,
+		vertical_id: options.vertical_id,
 		language: options.language,
 		...( options.viewport_width && { viewport_width: options.viewport_width } ),
 		viewport_height: options.viewport_height || DEFAULT_VIEWPORT_HEIGHT,
@@ -30,7 +30,7 @@ export const getDesignPreviewUrl = (
 		use_screenshot_overrides: options.use_screenshot_overrides,
 	} );
 
-	const siteTitle = options.siteTitle || design.title;
+	const siteTitle = options.site_title || design.title;
 	if ( siteTitle ) {
 		// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped
 		// parentheses in the URL break it. `addQueryArgs` and `encodeURIComponent` don't escape

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,6 +445,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/data-stores@workspace:packages/data-stores"
   dependencies:
+    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/domain-utils": "workspace:^"
     "@automattic/format-currency": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

* Add `signup/standard-theme-v13n` config to control the v13n of standard themes
* Pass `siteVerticalId` to `getDesignPreviewUrl` function for both `MShotsImage` and the large preview
* When requesting `theme-setup` endpoint, send the `vertical_id` only when the selected design is generated design or the config is enabled.

https://user-images.githubusercontent.com/13596067/178727654-04e28a6f-010f-4f6b-962a-a5d7877f2cda.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?siteSlug=<your_site>`
* Check the mShots of the standard themes are verticalized
* Preview any design and see the large preview is also verticalized

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 77-gh-Automattic/ganon-issues