### PR TITLE
Fix/help center warnings

### DIFF
--- a/packages/help-center/src/icons/mail.tsx
+++ b/packages/help-center/src/icons/mail.tsx
@@ -4,10 +4,10 @@ const Mail = () => {
 			<path
 				d="M18 6.75H6C5.30964 6.75 4.75 7.30964 4.75 8V16C4.75 16.6904 5.30964 17.25 6 17.25H18C18.6904 17.25 19.25 16.6904 19.25 16V8C19.25 7.30964 18.6904 6.75 18 6.75Z"
 				stroke="#fff"
-				stroke-width="1.5"
+				strokeWidth="1.5"
 				fill="transparent"
 			/>
-			<path d="M5 7L12 13L19 7" stroke="#fff" fill="transparent" stroke-width="1.5" />
+			<path d="M5 7L12 13L19 7" stroke="#fff" fill="transparent" strokeWidth="1.5" />
 		</svg>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* No task for this but wanted to remove some console warnings that are really annoying
* The first one is regarding the `Mail` icons and how we are setting the stroke-width attribute:
<img width="490" alt="Screenshot 2022-07-13 at 12 55 53" src="https://user-images.githubusercontent.com/7000684/178717768-7fd37fec-bdea-4ab8-928c-eb6f44e8a0bf.png">

* The second one is related to `react-draggable`. And according to the docs https://github.com/react-grid-layout/react-draggable to remove the warning we need to pass a `nodeRef`.
<img width="478" alt="Screenshot 2022-07-13 at 12 54 26" src="https://user-images.githubusercontent.com/7000684/178717820-b962fdc1-7252-4706-ad1b-1e7b3dcdc3fe.png">


#### Testing Instructions
- Checkout this branch
- Run `yarn dev --sync
- Open the console and open the help center
- Check if the draggable warning is gone
- Click on "Still need help"
- Check if the warnings about the mail icon is gone
- Check if draggable works properly
