### PR TITLE
Onboarding: change default theme to Livro for write intent

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -272,6 +272,15 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield saveSiteSettings( siteId, { blogdescription } );
 	}
 
+	function* setThemeOnSite( siteSlug: string, theme: string ) {
+		yield wpcomRequest( {
+			path: `/sites/${ siteSlug }/themes/mine`,
+			apiVersion: '1.1',
+			body: { theme: theme, dont_change_homepage: true },
+			method: 'POST',
+		} );
+	}
+
 	function* setDesignOnSite( siteSlug: string, selectedDesign: Design, siteVerticalId: string ) {
 		const { theme, recipe } = selectedDesign;
 
@@ -496,6 +505,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveNewSite,
 		receiveNewSiteFailed,
 		resetNewSiteFailed,
+		setThemeOnSite,
 		setDesignOnSite,
 		createSite,
 		receiveSite,


### PR DESCRIPTION
#### Proposed Changes

Once `site-setup-flow`'s exit flow is initiated, check whether the user's intent is `write` and whether they have not selected a design via design picker themselves. If that is the case then apply default theme of `livro`. Otherwise do nothing.

I used `POST /sites/${ siteSlug }/themes/mine` api to change the current theme for a site.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the patch
2. Go to `http://calypso.localhost:3000/setup/goals?siteSlug=<yours site>`
3. Select `Write & Publish` goal and press `Continue` button
4. Select any vertical if you wish and `Continue` to the next step
5. Fill out site options (`Blog name` and `Tagline`) if you wish and press `Continue`
6. Select `Start writing` option and the `livro` theme should be applied
![Screenshot 2022-07-13 at 13 09 03](https://user-images.githubusercontent.com/2019970/178720980-2449099e-6afd-4b6c-93e0-cd3093e669f3.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65035 
