### PR TITLE
DIFM: Allow WoA sites in site picker based on flag

### DIFF
--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config/';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -51,7 +52,7 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 	const filterSites = ( site: SiteData ) => {
 		return !! (
 			site.capabilities?.manage_options &&
-			! site.jetpack &&
+			( isEnabled( 'difm/allow-woa-sites' ) || ! site.jetpack ) &&
 			! site.options?.is_wpforteams_site &&
 			! site.options?.is_difm_lite_in_progress
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"dev/auth-helper": true,
 		"dev/features-helper": true,
 		"dev/preferences-helper": true,
+		"difm/allow-woa-sites": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/dashes-filter": false,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,6 +22,7 @@
 		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"devdocs": false,
+		"difm/allow-woa-sites": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,

--- a/config/production.json
+++ b/config/production.json
@@ -24,6 +24,7 @@
 		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"desktop-promo": true,
+		"difm/allow-woa-sites": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
+		"difm/allow-woa-sites": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,

--- a/config/test.json
+++ b/config/test.json
@@ -35,6 +35,7 @@
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"difm/allow-woa-sites": false,
 		"fullstory": true,
 		"gdpr-banner": false,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -29,6 +29,7 @@
 		"devdocs/color-scheme-picker": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
+		"difm/allow-woa-sites": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,


### PR DESCRIPTION
#### Proposed Changes

Context: pdh1Xd-15m-p2

This PR adds a new feature flag `difm/allow-woa-sites`. Enabling this flag will show WoA sites in the site picker step of the DIFM flow. This is the first step to adding support for WoA sites, but does not ensure full support. This feature flag should be used for testing only.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and choose Existing Site.
* Confirm that WoA sites are NOT shown in the list.
* Go to `/start/do-it-for-me?flags=difm/allow-woa-sites` and choose Existing Site.
* Confirm that WoA sites are shown in the list.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

