### PR TITLE
Design Picker: Hide description & badge in DIFM flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -746,6 +746,8 @@ export function generateSteps( {
 				showLetUsChoose: true,
 				hideFullScreenPreview: true,
 				hideDesignTitle: true,
+				hideDescription: true,
+				hideBadge: true,
 			},
 		},
 		'difm-options': {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -42,6 +42,8 @@ export default function DesignPickerStep( props ) {
 		showLetUsChoose,
 		hideFullScreenPreview,
 		hideDesignTitle,
+		hideDescription,
+		hideBadge,
 		signupDependencies: dependencies,
 	} = props;
 
@@ -242,6 +244,8 @@ export default function DesignPickerStep( props ) {
 					categoriesFooter={ renderCategoriesFooter() }
 					hideFullScreenPreview={ hideFullScreenPreview }
 					hideDesignTitle={ hideDesignTitle }
+					hideDescription={ hideDescription }
+					hideBadge={ hideBadge }
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				/>
 				{ renderCheckoutModal() }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -57,6 +57,8 @@ interface DesignButtonProps {
 	disabled?: boolean;
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
+	hideDescription?: boolean;
+	hideBadge?: boolean;
 	hasDesignOptionHeader?: boolean;
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
@@ -70,6 +72,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	highRes,
 	disabled,
 	hideDesignTitle,
+	hideDescription,
+	hideBadge,
 	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable = false,
 	onCheckout = undefined,
@@ -94,6 +98,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 	function getPricingDescription() {
 		if ( ! isEnabled( 'signup/theme-preview-screen' ) ) {
+			return null;
+		}
+
+		if ( hideDescription ) {
 			return null;
 		}
 
@@ -166,7 +174,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					{ ! hideDesignTitle && (
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
-					{ badgeContainer }
+					{ ! hideBadge && badgeContainer }
 				</span>
 				{ getPricingDescription() }
 			</span>
@@ -296,6 +304,8 @@ export interface DesignPickerProps {
 	recommendedCategorySlug: string | null;
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
+	hideDescription?: boolean;
+	hideBadge?: boolean;
 	isPremiumThemeAvailable?: boolean;
 	previewOnly?: boolean;
 	hasDesignOptionHeader?: boolean;
@@ -321,6 +331,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	categorization,
 	hideFullScreenPreview,
 	hideDesignTitle,
+	hideDescription,
+	hideBadge,
 	recommendedCategorySlug,
 	isPremiumThemeAvailable,
 	previewOnly = false,
@@ -367,6 +379,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						highRes={ highResThumbnails }
 						hideFullScreenPreview={ hideFullScreenPreview }
 						hideDesignTitle={ hideDesignTitle }
+						hideDescription={ hideDescription }
+						hideBadge={ hideBadge }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
 						previewOnly={ previewOnly }
 						hasDesignOptionHeader={ hasDesignOptionHeader }


### PR DESCRIPTION
#### Proposed Changes

* This change hides the description and badge added in #65052 for the DIFM flow. In the DIFM flow, the Design Picker step needs to display only the scrollable thumbnail for each theme.

|Before|After|
|----|----|
|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/178729763-b1112744-f753-40f0-af9e-13835518037b.png">|<img width="1919" alt="image" src="https://user-images.githubusercontent.com/5436027/178729819-dea05226-5d98-4ff7-bf30-37e6500fd7ee.png">|


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`. 
* Go through the flow steps till you reach the Design Picker step. Confirm that the description and badge are hidden.

**Testing for regressions**:
* Go to `setup/designSetup?siteSlug=<SITE-SLUG>`.
* Confirm that the description and badge are visible.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - **NA**
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? - **NA**
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) - **NA**
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? - **NA**

Closes Automattic/martech#946