### PR TITLE
Google Sign-In Migration: namespace auth code exchange failure event correctly

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -206,7 +206,7 @@ class GoogleLoginButton extends Component {
 			const { code: error_code } = getErrorFromHTTPError( httpError );
 
 			if ( error_code ) {
-				this.props.recordTracksEvent( 'calypso_login_auth_code_exchange_failure', {
+				this.props.recordTracksEvent( 'calypso_login_social_auth_code_exchange_failure', {
 					social_account_type: 'google',
 					error_code,
 				} );


### PR DESCRIPTION
#### Proposed Changes

After https://github.com/Automattic/wp-calypso/pull/64957#discussion_r918896012, we found that the event name is potentially misleading and decided to namespace it according to other `calypso_login_social_*` events.

#### Testing Instructions

Check out this branch locally, run Calypso, and navigate to `/start/user`.

Once there, open the dev tools and input `localStorage.setItem( 'debug', 'calypso:analytics' );` into the console so you can see the events being dispatched to Tracks. Remember to set the log level to `Verbose`.

Keep the dev tools open and add `?code=somerandomcode` to the URL and press `Enter`.  In the console, you should see that the `calypso_login_social_auth_code_exchange_failure` was dispatched:

![image](https://user-images.githubusercontent.com/26530524/178746052-9f74beea-ce97-446e-9ba6-735b0ab73adf.png)

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/pull/64957#discussion_r918896012.