### PR TITLE
Do not initialize jetpack ga on wpcom env (#65529)

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -206,7 +206,7 @@ class GoogleLoginButton extends Component {
 			const { code: error_code } = getErrorFromHTTPError( httpError );
 
 			if ( error_code ) {
-				this.props.recordTracksEvent( 'calypso_login_auth_code_exchange_failure', {
+				this.props.recordTracksEvent( 'calypso_login_social_auth_code_exchange_failure', {
 					social_account_type: 'google',
 					error_code,
 				} );

--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -1,3 +1,4 @@
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { GaPurchase } from '../utils/jetpack-cart-to-ga-purchase';
 import { GaItem } from '../utils/jetpack-product-to-ga-item';
 import { TRACKING_IDS } from './constants';
@@ -6,7 +7,11 @@ import { TRACKING_IDS } from './constants';
 import './setup';
 
 export function setup( params: Gtag.ConfigParams ) {
-	window.gtag( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
+	// TODO: GA4 properties for WPCOM will be here
+
+	if ( isJetpackCloud() ) {
+		window.gtag( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
+	}
 }
 
 export function fireJetpackEcommercePurchase( purchase: GaPurchase ) {

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -12,7 +12,10 @@ export function setupGoogleAnalyticsGtag( params ) {
 	GA4.setup( params );
 
 	window.gtag( 'config', TRACKING_IDS.wpcomGoogleAnalyticsGtag, params );
-	window.gtag( 'config', TRACKING_IDS.jetpackGoogleAnalyticsGtag, params );
+
+	if ( isJetpackCloud() ) {
+		window.gtag( 'config', TRACKING_IDS.jetpackGoogleAnalyticsGtag, params );
+	}
 }
 
 /**

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -3,7 +3,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
 import { useHasSeenWhatsNewModalQuery } from '@automattic/data-stores';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import WhatsNewGuide from '@automattic/whats-new';
 import { Button, SVG, Circle } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
@@ -25,6 +25,7 @@ export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
 	const [ showWhatsNewDot, setShowWhatsNewDot ] = useState( false );
 	const sectionName = useSelector( getSectionName );
+	const locale = useLocale();
 
 	const { isBusinessOrEcomPlanUser, siteId, isSimpleSite } = useSelector( ( state ) => {
 		const purchases = getUserPurchases( state );
@@ -78,19 +79,21 @@ export const HelpCenterMoreResources = () => {
 
 	return (
 		<>
-			<h3 className="help-center__section-title">{ __( 'More Resources' ) }</h3>
+			<h3 className="help-center__section-title">
+				{ __( 'More Resources', __i18n_text_domain__ ) }
+			</h3>
 			<ul className="inline-help__more-resources" aria-labelledby="inline-help__more-resources">
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
+							href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/', locale ) }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__video"
 							onClick={ () => trackMoreResourcesButtonClick( 'video' ) }
 						>
 							<Icon icon={ video } size={ 24 } />
-							<span>{ __( 'Video tutorials' ) }</span>
+							<span>{ __( 'Video tutorials', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
@@ -98,14 +101,14 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://wordpress.com/webinars' ) }
+							href={ localizeUrl( 'https://wordpress.com/webinars', locale ) }
 							rel="noreferrer"
 							target="_blank"
 							onClick={ trackWebinairsButtonClick }
 							className="inline-help__capture-video"
 						>
 							<Icon icon={ captureVideo } size={ 24 } />
-							<span>{ __( 'Webinars' ) }</span>
+							<span>{ __( 'Webinars', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
@@ -113,14 +116,14 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://wpcourses.com/?ref=wpcom-help-more-resources' ) }
+							href={ localizeUrl( 'https://wpcourses.com/?ref=wpcom-help-more-resources', locale ) }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__desktop"
 							onClick={ () => trackMoreResourcesButtonClick( 'courses' ) }
 						>
 							<Icon icon={ desktop } size={ 24 } />
-							<span>{ __( 'Courses' ) }</span>
+							<span>{ __( 'Courses', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
@@ -128,14 +131,14 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://learn.wordpress.com' ) }
+							href={ localizeUrl( 'https://learn.wordpress.com', locale ) }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__format-list-numbered"
 							onClick={ () => trackMoreResourcesButtonClick( 'guides' ) }
 						>
 							<Icon icon={ formatListNumbered } size={ 24 } />
-							<span>{ __( 'Step-by-step guides' ) }</span>
+							<span>{ __( 'Step-by-step guides', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
@@ -149,7 +152,7 @@ export const HelpCenterMoreResources = () => {
 								className="inline-help__new-releases"
 							>
 								<Icon icon={ <NewReleases /> } size={ 24 } />
-								<span>{ __( "What's new" ) }</span>
+								<span>{ __( "What's new", __i18n_text_domain__ ) }</span>
 								{ showWhatsNewDot && (
 									<Icon className="inline-help__new-releases_dot" icon={ circle } size={ 16 } />
 								) }


### PR DESCRIPTION
#### Proposed Changes

* Add some missing text domains

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #Add 