### PR TITLE
Search: match edge fade color with `--color-surface` variable

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -29,7 +29,7 @@
 	"dependencies": {
 		"@automattic/typography": "workspace:^",
 		"@babel/runtime": "^7.17.2",
-		"@wordpress/base-styles": "^4.5.0",
+		"@wordpress/base-styles": "^4.7.0",
 		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/icons": "^9.0.0",

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -1,3 +1,4 @@
+import './search.stories.scss';
 import { action } from '@storybook/addon-actions';
 import { Icon } from '@wordpress/components';
 import Search from './search';
@@ -96,3 +97,8 @@ export const WithCustomSearchIcon = () => {
 
 	return <BoxedSearch searchIcon={ <Icon icon={ customIcon } /> } />;
 };
+
+export const WithDifferentColor = () => (
+	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+	<BoxedSearch className="stories__search--with-different-color" />
+);

--- a/packages/search/src/search.stories.scss
+++ b/packages/search/src/search.stories.scss
@@ -1,0 +1,3 @@
+.stories__search--with-different-color {
+    --color-surface: red;
+}

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -208,7 +208,7 @@ $input-z-index: 20;
 			font-size: $font-body;
 
 			&::before {
-				@include long-content-fade( $size: 32px, $z-index: $input-z-index + 2 );
+				@include long-content-fade( $direction: right, $size: 32px, $z-index: $input-z-index + 2, $color: var( --color-surface ) );
 				border-radius: inherit;
 			}
 
@@ -218,7 +218,8 @@ $input-z-index: 20;
 					@include long-content-fade(
 						$direction: right,
 						$size: 32px,
-						$z-index: $input-z-index + 2
+						$z-index: $input-z-index + 2,
+						$color: var( --color-surface )
 					);
 					border-radius: inherit;
 				}

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -208,7 +208,7 @@ $input-z-index: 20;
 			font-size: $font-body;
 
 			&::before {
-				@include long-content-fade( $direction: right, $size: 32px, $z-index: $input-z-index + 2, $color: var( --color-surface ) );
+				@include long-content-fade( $size: 32px, $z-index: $input-z-index + 2, $color: var( --color-surface ) );
 				border-radius: inherit;
 			}
 

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -177,7 +177,7 @@ $input-z-index: 20;
 	}
 
 	&.is-open {
-		background-color: $white;
+		background-color: var( --color-surface, $white );
 		width: 100%;
 
 		.search-component__open-icon {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,7 +1168,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.16.4
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^14.2.5
-    "@wordpress/base-styles": ^4.5.0
+    "@wordpress/base-styles": ^4.7.0
     "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/data": ^6.9.0
@@ -8275,10 +8275,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/base-styles@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "@wordpress/base-styles@npm:4.5.0"
-  checksum: 3553d08575c4b4bb116363610403bb1b3f3335e50fbb857c3d0c47eb47ff64d84be5c8edcc295c59b0f2fcfb9ed6414289ee97a22cc017fa8b8ae75f30edc427
+"@wordpress/base-styles@npm:^4.5.0, @wordpress/base-styles@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@wordpress/base-styles@npm:4.7.0"
+  checksum: c6e35d60a373875f4e9059547fcbe6292a951e6a270de9afe8d355714efa08cc2a941a092d45da53eadc1028d240df071875b10b53f47210f3f0896584df88a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

Setting the `--color-surface` variable in the `<Search />` component styling doesn't change the color used in the edge fading gradient at the end of the input:

![image](https://user-images.githubusercontent.com/26530524/178798854-a463fee0-c94e-427e-bb46-4e2f20df987a.png)

This PR fixes that by matching the color of the `--color-surface` variable in the `long-content-fade` mixin call:

![image](https://user-images.githubusercontent.com/26530524/178796267-7baf60fd-b65d-4ab0-a631-96a4dc3c9182.png)

#### Testing Instructions

Install dependencies and run `yarn workspace @automattic/search run storybook`. Check the "With Different Color" story and type a few characters so it overflows the container. The content should fade to the red background instead of white.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/pull/65505#discussion_r919294316.