### PR TITLE
Search: allow customized icon

### DIFF
--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions';
+import { Icon } from '@wordpress/components';
 import Search from './search';
 
 export default { title: 'Search', component: Search };
@@ -65,3 +66,33 @@ export const WithOverlayStyling = () => {
 };
 
 export const WithDefaultValue = () => <BoxedSearch defaultValue="a default search value" />;
+
+export const WithCustomSearchIcon = () => {
+	const customIcon = (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 20 20"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			style={ { paddingLeft: '16px', paddingRight: '10px' } }
+		>
+			<path
+				d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z"
+				stroke="#8C8F94"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+			<path
+				d="M17.5 17.5L13.875 13.875"
+				stroke="#8C8F94"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	);
+
+	return <BoxedSearch searchIcon={ <Icon icon={ customIcon } /> } />;
+};

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -76,6 +76,7 @@ type Props = {
 	searching?: boolean;
 	value?: string;
 	searchMode?: 'when-typing' | 'on-enter';
+	searchIcon?: ReactNode;
 };
 
 //This is fix for IE11. Does not work on Edge.
@@ -143,6 +144,7 @@ const InnerSearch = (
 		hideClose = false,
 		isReskinned = false,
 		searchMode = 'when-typing',
+		searchIcon,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
@@ -408,6 +410,10 @@ const InnerSearch = (
 
 	const renderOpenIcon = () => {
 		const enableOpenIcon = pinned && ! isOpen;
+
+		if ( searchIcon ) {
+			return searchIcon;
+		}
 
 		if ( isReskinned ) {
 			return renderReskinSearchIcon();

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -222,4 +222,10 @@ describe( 'search', () => {
 		// check that a second item was added to history
 		expect( document.querySelectorAll( 'li' ) ).toHaveLength( 2 );
 	} );
+
+	it( 'should allow a custom search icon', () => {
+		render( <Search searchIcon="CUSTOMICON" /> );
+
+		expect( screen.getByText( 'CUSTOMICON' ) ).toBeTruthy();
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

Add a `searchIcon` prop to the `<Search />` component so it's possible to override the icon on the left with a custom one.

#### Testing Instructions

- Check out this branch;
- Run `yarn workspace @automattic/search run storybook`;
- Open the `With Custom Search Icon` story and check that the icon on that input is different from the others;
- Play around with the SVG in `WithCustomSearchIcon` if you want, the changes must be reflected immediately.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/pull/65505/files#r920372130.