### PR TITLE
Change Wix input title

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -243,7 +243,7 @@ function getConfig( args: ImporterConfigArgs = { siteTitle: '' } ): {
 				},
 			}
 		),
-		uploadDescription: translate( 'Enter the URL of your existing site. ' + '{{supportLink/}}', {
+		uploadDescription: translate( 'Enter the URL of your Wix site. ' + '{{supportLink/}}', {
 			components: {
 				supportLink: (
 					<InlineSupportLink supportContext="importers-wix" showIcon={ false }>


### PR DESCRIPTION
#### Proposed Changes

See 717-gh-Automattic/dotcom-manage and p1657609485105849/1657608824.705629-slack-C01A60HCGUA

#### Testing Instructions

* Go to `http://calypso.localhost:3000/import/YOUR-SITE`
* The input name must be "Enter the URL of your Wix site. Need help?"