### PR TITLE
Recommend PHP 8.0 for WoA sites

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -34,7 +34,7 @@ const WebServerSettingsCard = ( {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 	const [ selectedStaticFile404, setSelectedStaticFile404 ] = useState( '' );
 
-	const recommendedValue = '7.4';
+	const recommendedValue = '8.0';
 
 	const changePhpVersion = ( event ) => {
 		const newVersion = event.target.value;
@@ -56,16 +56,16 @@ const WebServerSettingsCard = ( {
 				disabled: true, // EOL 6th December, 2021
 			},
 			{
-				label: translate( '7.4 (recommended)', {
+				label: translate( '7.4', {
+					comment: 'PHP Version for a version switcher',
+				} ),
+				value: '7.4',
+			},
+			{
+				label: translate( '8.0 (recommended)', {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: recommendedValue,
-			},
-			{
-				label: translate( '8.0', {
-					comment: 'PHP Version for a version switcher',
-				} ),
-				value: '8.0',
 			},
 			{
 				label: translate( '8.1', {


### PR DESCRIPTION
#### Proposed Changes

Security support for PHP 7.4 is going away toward the end of this year, so we will be removing PHP 7.4 from the Atomic platform after that. PHP 8.0 is now recommended, and this PR updates the Hosting PHP version drop-down to reflect that.

#### Testing Instructions

Pick a test site.

For each PHP version in the menu:
1. set the site to that version
1. double-check that the site is actually running that PHP version
1. reload the Hosting page
1. confirm that the selected version is the site's current PHP version.
