### PR TITLE
Update @wordpress/components

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -76,7 +76,7 @@
 		"@wordpress/base-styles": "^4.5.0",
 		"@wordpress/block-editor": "^9.1.0",
 		"@wordpress/blocks": "^11.8.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/data-controls": "^2.9.0",

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/base-styles": "^4.5.0",
 		"@wordpress/block-editor": "^9.1.0",
 		"@wordpress/blocks": "^11.8.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/editor": "^12.8.0",
 		"@wordpress/element": "^4.7.0",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/base-styles": "^4.5.0",
 		"@wordpress/block-editor": "^9.1.0",
 		"@wordpress/blocks": "^11.8.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/dom-ready": "^3.9.0",

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -2,7 +2,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
 import page from 'page';
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect, ComponentType } from 'react';
 
 /**
  * Module variables
@@ -79,15 +79,16 @@ export interface ProtectedFormProps {
 /*
  * HOC that passes markChanged/markSaved props to the wrapped component instance
  */
-export const protectForm = createHigherOrderComponent< ProtectedFormProps >( ( InnerComponent ) => {
-	return ( props ) => {
-		const { markChanged, markSaved } = useProtectForm();
-		const innerProps = { ...props, markChanged, markSaved } as React.ComponentProps<
-			typeof InnerComponent
-		>;
-		return <InnerComponent { ...innerProps } />;
-	};
-}, 'protectForm' );
+export const protectForm = createHigherOrderComponent(
+	< OuterProps, >( InnerComponent: ComponentType< OuterProps & ProtectedFormProps > ) => {
+		return ( props: OuterProps ) => {
+			const { markChanged, markSaved } = useProtectForm();
+			const innerProps = { ...props, markChanged, markSaved };
+			return <InnerComponent { ...innerProps } />;
+		};
+	},
+	'protectForm'
+);
 
 /*
  * Declarative variant that takes a 'isChanged' prop.

--- a/client/lib/route-modal/with-route-modal.tsx
+++ b/client/lib/route-modal/with-route-modal.tsx
@@ -1,15 +1,17 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import useRouteModal, { RouteModalData } from './use-route-modal';
+import type { ComponentType } from 'react';
 
 export default function withRouteModal( queryKey: string, defaultValue?: string ) {
-	return createHigherOrderComponent< { routeModalData: RouteModalData } >(
-		( InnerComponent ) => ( props ) => {
-			const routeModalData = useRouteModal( queryKey, defaultValue );
-			const innerProps = { ...props, routeModalData } as React.ComponentProps<
-				typeof InnerComponent
-			>;
-			return <InnerComponent { ...innerProps } />;
-		},
+	return createHigherOrderComponent(
+		< OuterProps, >(
+				InnerComponent: ComponentType< OuterProps & { routeModalData: RouteModalData } >
+			) =>
+			( props: OuterProps ) => {
+				const routeModalData = useRouteModal( queryKey, defaultValue );
+				const innerProps = { ...props, routeModalData };
+				return <InnerComponent { ...innerProps } />;
+			},
 		'WithRouteModal'
 	);
 }

--- a/client/package.json
+++ b/client/package.json
@@ -72,7 +72,7 @@
 		"@wordpress/base-styles": "^4.5.0",
 		"@wordpress/block-editor": "^9.1.0",
 		"@wordpress/blocks": "^11.8.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/data-controls": "^2.9.0",

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -77,10 +77,10 @@ yarn remove -w lodash
 Run
 
 ```
-yarn upgrade <package>
+yarn up <package>
 
 # Example
-# yarn upgrade react-query
+# yarn up react-query
 ```
 
 Note that this won't change the required range of `react-query` (i.e. it won't modify `package.json`). Instead, it will try to update `react-query` and any of its dependencies to the highest version that satisfies the specified range.
@@ -91,10 +91,10 @@ For example, if we declare a dependency on `react-query@^2.24.0` it may update r
 Run
 
 ```
-yarn upgrade <package>@^<semver-range>
+yarn up <package>@^<semver-range>
 
 # Example
-# yarn upgrade react-query@^3.0.0
+# yarn up react-query@^3.0.0
 ```
 
 As before, it will update `react-query` and all its dependencies. But in this case, it _will_ change the required range (i.e. it will modify `package.json`)

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
 		"@types/wordpress__data-controls": "^2.2.0",
 		"@types/wordpress__editor": "^10.0.1",
 		"@wordpress/base-styles": "^4.5.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/i18n": "^4.9.0",

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -33,7 +33,7 @@
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/react-i18n": "^3.7.0",
 		"@wordpress/url": "^3.10.0",
 		"classnames": "^2.3.1",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -36,7 +36,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/base-styles": "^4.5.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/react-i18n": "^3.7.0",

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -39,7 +39,7 @@
 		"@automattic/viewport-react": "workspace:^",
 		"@popperjs/core": "^2.10.2",
 		"@wordpress/base-styles": "^4.5.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/i18n": "^4.9.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/primitives": "^3.7.0",

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -93,13 +93,16 @@ export function useLocale(): string {
  * }
  * export default withLocale( MyComponent );
  */
-export const withLocale = createHigherOrderComponent< { locale: string } >( ( InnerComponent ) => {
-	return ( props ) => {
-		const locale = useLocale();
-		const innerProps = { ...props, locale } as React.ComponentProps< typeof InnerComponent >;
-		return <InnerComponent { ...innerProps } />;
-	};
-}, 'withLocale' );
+export const withLocale = createHigherOrderComponent(
+	< OuterProps, >( InnerComponent: React.ComponentType< OuterProps & { locale: string } > ) => {
+		return ( props: OuterProps ) => {
+			const locale = useLocale();
+			const innerProps = { ...props, locale };
+			return <InnerComponent { ...innerProps } />;
+		};
+	},
+	'withLocale'
+);
 
 /**
  * React hook providing whether the current locale slug belongs to English or not

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -1,6 +1,6 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { getLocaleSlug } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, ComponentType } from 'react';
 import { useLocale } from './locale-context';
 import {
 	localesWithBlog,
@@ -217,12 +217,17 @@ export function useLocalizeUrl() {
 	);
 }
 
-export const withLocalizeUrl = createHigherOrderComponent< {
-	localizeUrl: ReturnType< typeof useLocalizeUrl >;
-} >( ( InnerComponent ) => {
-	return ( props ) => {
-		const localizeUrl = useLocalizeUrl();
-		const innerProps = { ...props, localizeUrl } as React.ComponentProps< typeof InnerComponent >;
-		return <InnerComponent { ...innerProps } />;
-	};
-}, 'withLocalizeUrl' );
+export const withLocalizeUrl = createHigherOrderComponent(
+	< OuterProps, >(
+		InnerComponent: ComponentType<
+			OuterProps & { localizeUrl: ReturnType< typeof useLocalizeUrl > }
+		>
+	) => {
+		return ( props: OuterProps ) => {
+			const localizeUrl = useLocalizeUrl();
+			const innerProps = { ...props, localizeUrl };
+			return <InnerComponent { ...innerProps } />;
+		};
+	},
+	'withLocalizeUrl'
+);

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -31,7 +31,7 @@
 		"@automattic/search": "workspace:^",
 		"@babel/runtime": "^7.17.2",
 		"@wordpress/base-styles": "^4.5.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/i18n": "^4.9.0",
 		"@wordpress/react-i18n": "^3.7.0"
 	},

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -36,7 +36,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/plans-grid": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/react-i18n": "^3.7.0",
 		"@wordpress/url": "^3.10.0",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/react-i18n": "^3.7.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -30,7 +30,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/blocks": "^11.8.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/i18n": "^4.9.0",

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -18,7 +18,7 @@ interface PagePatternModalProps {
 	areTipsEnabled?: boolean;
 	hideWelcomeGuide: () => void;
 	insertPattern: ( title: string | null, blocks: unknown[] ) => void;
-	instanceId: number;
+	instanceId: string | number;
 	isOpen: boolean;
 	isWelcomeGuideActive?: boolean;
 	locale?: string;

--- a/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
@@ -8,7 +8,7 @@ import type { PatternDefinition } from '../pattern-definition';
 const noop = () => undefined;
 
 interface PatternSelectorControlProps {
-	instanceId: number;
+	instanceId: string | number;
 	label: string;
 	legendLabel?: string;
 	locale?: string;

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -32,7 +32,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/primitives": "^3.7.0",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -30,7 +30,7 @@
 		"@automattic/typography": "workspace:^",
 		"@babel/runtime": "^7.17.2",
 		"@wordpress/base-styles": "^4.5.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/compose": "^5.7.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/react-i18n": "^3.7.0",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -38,7 +38,7 @@
 	},
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/i18n": "^4.9.0",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -35,7 +35,7 @@
 		"@automattic/viewport-react": "workspace:^",
 		"@popperjs/core": "^2.10.2",
 		"@wordpress/base-styles": "^4.5.0",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/dom": "^3.9.0",
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/i18n": "^4.9.0",

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -40,7 +40,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/typography": "workspace:^",
-		"@wordpress/components": "^19.11.0",
+		"@wordpress/components": "^19.15.0",
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/i18n": "^4.10.0",
 		"@wordpress/keycodes": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/react-i18n": ^3.7.0
     "@wordpress/url": ^3.10.0
     classnames: ^2.3.1
@@ -527,7 +527,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/icons": ^9.0.0
     "@wordpress/react-i18n": ^3.7.0
@@ -693,7 +693,7 @@ __metadata:
     "@storybook/addon-backgrounds": ^6.4.19
     "@storybook/react": ^6.4.19
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/i18n": ^4.9.0
     "@wordpress/icons": ^9.0.0
     "@wordpress/primitives": ^3.7.0
@@ -797,7 +797,7 @@ __metadata:
     "@automattic/search": "workspace:^"
     "@babel/runtime": ^7.17.2
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/i18n": ^4.9.0
     "@wordpress/react-i18n": ^3.7.0
     typescript: ^4.5.5
@@ -854,7 +854,7 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/react": ^12.1.3
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/icons": ^9.0.0
     "@wordpress/react-i18n": ^3.7.0
     "@wordpress/url": ^3.10.0
@@ -997,7 +997,7 @@ __metadata:
     "@wordpress/base-styles": ^4.5.0
     "@wordpress/block-editor": ^9.1.0
     "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/data": ^6.9.0
     "@wordpress/editor": ^12.8.0
     "@wordpress/element": ^4.7.0
@@ -1030,7 +1030,7 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/react": ^12.1.3
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/data": ^6.9.0
     "@wordpress/icons": ^9.0.0
     "@wordpress/react-i18n": ^3.7.0
@@ -1063,7 +1063,7 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/react": ^12.1.3
     "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/element": ^4.7.0
     "@wordpress/i18n": ^4.9.0
@@ -1092,7 +1092,7 @@ __metadata:
     "@automattic/onboarding": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/icons": ^9.0.0
     "@wordpress/primitives": ^3.7.0
@@ -1163,7 +1163,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^13.5.0
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/data": ^6.9.0
     "@wordpress/icons": ^9.0.0
@@ -1227,7 +1227,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@emotion/react": ^11.4.1
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/i18n": ^4.9.0
     classnames: ^2.3.1
     enzyme: ^3.11.0
@@ -1274,7 +1274,7 @@ __metadata:
     "@popperjs/core": ^2.10.2
     "@storybook/react": ^6.4.18
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/dom": ^3.9.0
     "@wordpress/element": ^4.7.0
     "@wordpress/i18n": ^4.9.0
@@ -1393,7 +1393,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/typography": "workspace:^"
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/element": ^4.7.0
     "@wordpress/i18n": ^4.10.0
     "@wordpress/keycodes": ^3.10.0
@@ -1448,7 +1448,7 @@ __metadata:
     "@wordpress/base-styles": ^4.5.0
     "@wordpress/block-editor": ^9.1.0
     "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/data": ^6.9.0
     "@wordpress/dependency-extraction-webpack-plugin": ^3.5.0
@@ -1547,7 +1547,7 @@ __metadata:
     "@wordpress/base-styles": ^4.5.0
     "@wordpress/block-editor": ^9.1.0
     "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/data": ^6.9.0
     "@wordpress/data-controls": ^2.9.0
@@ -8180,14 +8180,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/a11y@npm:^3.10.0, @wordpress/a11y@npm:^3.2.1, @wordpress/a11y@npm:^3.2.4, @wordpress/a11y@npm:^3.7.0, @wordpress/a11y@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/a11y@npm:3.10.0"
+"@wordpress/a11y@npm:^3.10.0, @wordpress/a11y@npm:^3.13.0, @wordpress/a11y@npm:^3.2.1, @wordpress/a11y@npm:^3.2.4, @wordpress/a11y@npm:^3.7.0, @wordpress/a11y@npm:^3.9.0":
+  version: 3.13.0
+  resolution: "@wordpress/a11y@npm:3.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/dom-ready": ^3.10.0
-    "@wordpress/i18n": ^4.10.0
-  checksum: d1ff5a404754ba4632fea9bf9766e98dbe5cd848839227e88f0e93da7229516a7d2e7ba6bafbcb49e93264063bf89ec8a0e4e2dc24308089da4fdd1464d6db13
+    "@wordpress/dom-ready": ^3.13.0
+    "@wordpress/i18n": ^4.13.0
+  checksum: 506496a689fd5052e356a764dca6dcc17403b91531b94ea9ddc0844d29914f15a2ba2c4f69c71a64fe6e566ba70cd522ff2ad3807d6ff18761307d5d8b23b0f0
   languageName: node
   linkType: hard
 
@@ -8559,9 +8559,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/components@npm:^19.11.0, @wordpress/components@npm:^19.2.0, @wordpress/components@npm:^19.9.0":
-  version: 19.11.0
-  resolution: "@wordpress/components@npm:19.11.0"
+"@wordpress/components@npm:^19.11.0, @wordpress/components@npm:^19.15.0, @wordpress/components@npm:^19.2.0, @wordpress/components@npm:^19.9.0":
+  version: 19.15.0
+  resolution: "@wordpress/components@npm:19.15.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     "@emotion/cache": ^11.7.1
@@ -8572,21 +8572,21 @@ __metadata:
     "@emotion/utils": 1.0.0
     "@floating-ui/react-dom": 0.6.3
     "@use-gesture/react": ^10.2.6
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/date": ^4.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/dom": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/escape-html": ^2.9.0
-    "@wordpress/hooks": ^3.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
-    "@wordpress/is-shallow-equal": ^4.9.0
-    "@wordpress/keycodes": ^3.9.0
-    "@wordpress/primitives": ^3.7.0
-    "@wordpress/rich-text": ^5.7.0
-    "@wordpress/warning": ^2.9.0
+    "@wordpress/a11y": ^3.13.0
+    "@wordpress/compose": ^5.11.0
+    "@wordpress/date": ^4.13.0
+    "@wordpress/deprecated": ^3.13.0
+    "@wordpress/dom": ^3.13.0
+    "@wordpress/element": ^4.11.0
+    "@wordpress/escape-html": ^2.13.0
+    "@wordpress/hooks": ^3.13.0
+    "@wordpress/i18n": ^4.13.0
+    "@wordpress/icons": ^9.4.0
+    "@wordpress/is-shallow-equal": ^4.13.0
+    "@wordpress/keycodes": ^3.13.0
+    "@wordpress/primitives": ^3.11.0
+    "@wordpress/rich-text": ^5.11.0
+    "@wordpress/warning": ^2.13.0
     classnames: ^2.3.1
     colord: ^2.7.0
     dom-scroll-into-view: ^1.2.1
@@ -8596,16 +8596,17 @@ __metadata:
     highlight-words-core: ^1.2.2
     lodash: ^4.17.21
     memize: ^1.1.0
-    moment: ^2.22.1
+    moment: ^2.26.0
     re-resizable: ^6.4.0
     react-colorful: ^5.3.1
     react-dates: ^21.8.0
     reakit: ^1.3.8
+    remove-accents: ^0.4.2
     uuid: ^8.3.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 35661863f7461a42182e4d5dce81d93b714c3106f4ea3b41733dffb454d17b8c40512e429211dd9e927b2fd3b473b868abc068d90aab805c8d8f98f2184479b6
+  checksum: ac3fc949141b0a45b49e56f04cc694d18c542044a2dcbf61b4f8259a679144a1260a4ff40d33f63243e67043fa7e3c4779406eaf0aa6b5e8520d184e9a7f419b
   languageName: node
   linkType: hard
 
@@ -8630,26 +8631,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/compose@npm:^5.0.1, @wordpress/compose@npm:^5.0.7, @wordpress/compose@npm:^5.5.0, @wordpress/compose@npm:^5.7.0, @wordpress/compose@npm:^5.8.0":
-  version: 5.8.0
-  resolution: "@wordpress/compose@npm:5.8.0"
+"@wordpress/compose@npm:^5.0.1, @wordpress/compose@npm:^5.0.7, @wordpress/compose@npm:^5.11.0, @wordpress/compose@npm:^5.5.0, @wordpress/compose@npm:^5.7.0":
+  version: 5.11.0
+  resolution: "@wordpress/compose@npm:5.11.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     "@types/lodash": ^4.14.172
     "@types/mousetrap": ^1.6.8
-    "@wordpress/deprecated": ^3.10.0
-    "@wordpress/dom": ^3.10.0
-    "@wordpress/element": ^4.8.0
-    "@wordpress/is-shallow-equal": ^4.10.0
-    "@wordpress/keycodes": ^3.10.0
-    "@wordpress/priority-queue": ^2.10.0
+    "@wordpress/deprecated": ^3.13.0
+    "@wordpress/dom": ^3.13.0
+    "@wordpress/element": ^4.11.0
+    "@wordpress/is-shallow-equal": ^4.13.0
+    "@wordpress/keycodes": ^3.13.0
+    "@wordpress/priority-queue": ^2.13.0
     clipboard: ^2.0.8
     lodash: ^4.17.21
     mousetrap: ^1.6.5
     use-memo-one: ^1.1.1
   peerDependencies:
     react: ^17.0.0
-  checksum: 24d882e9566333cbf36258c420bf3f8ee589848f03919768f5a56bc5c253509fc2822c7bcb7c7562eaeda0a32a9576b44ea87862ffac93411046685fe7ab6d1f
+  checksum: 561bbbed104d9f51c88c4ba50375d6a4b58a9fdb96a3668df3181e7d22b091f92ed8e245c6105b8c1aa38c059aab969e66a0c768bb6d8c37bb465e586418996c
   languageName: node
   linkType: hard
 
@@ -8714,17 +8715,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/data@npm:^6.0.1, @wordpress/data@npm:^6.1.5, @wordpress/data@npm:^6.10.0, @wordpress/data@npm:^6.7.0, @wordpress/data@npm:^6.9.0":
-  version: 6.10.0
-  resolution: "@wordpress/data@npm:6.10.0"
+"@wordpress/data@npm:^6.0.1, @wordpress/data@npm:^6.1.5, @wordpress/data@npm:^6.10.0, @wordpress/data@npm:^6.13.0, @wordpress/data@npm:^6.7.0, @wordpress/data@npm:^6.9.0":
+  version: 6.13.0
+  resolution: "@wordpress/data@npm:6.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/compose": ^5.8.0
-    "@wordpress/deprecated": ^3.10.0
-    "@wordpress/element": ^4.8.0
-    "@wordpress/is-shallow-equal": ^4.10.0
-    "@wordpress/priority-queue": ^2.10.0
-    "@wordpress/redux-routine": ^4.10.0
+    "@wordpress/compose": ^5.11.0
+    "@wordpress/deprecated": ^3.13.0
+    "@wordpress/element": ^4.11.0
+    "@wordpress/is-shallow-equal": ^4.13.0
+    "@wordpress/priority-queue": ^2.13.0
+    "@wordpress/redux-routine": ^4.13.0
     equivalent-key-map: ^0.2.2
     is-promise: ^4.0.0
     lodash: ^4.17.21
@@ -8733,7 +8734,7 @@ __metadata:
     use-memo-one: ^1.1.1
   peerDependencies:
     react: ^17.0.0
-  checksum: 7435e0cf07685ddf4405ad7c8c8955168d8357bbf50753f2a38f9f357f6da1605d3a2c68b1de4d44bb0ddac2b18da3822852262f3ae1a69d16485035efe7eb3c
+  checksum: 506b4cd10e5f9361494b2fb30463481f96e7b40355323343f71a54691ff602018a318018a8c9b480155ab38300046f421210f339d085020f2d95de9777cd1d6f
   languageName: node
   linkType: hard
 
@@ -8748,14 +8749,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/date@npm:^4.2.1, @wordpress/date@npm:^4.2.3, @wordpress/date@npm:^4.7.0, @wordpress/date@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "@wordpress/date@npm:4.9.0"
+"@wordpress/date@npm:^4.13.0, @wordpress/date@npm:^4.2.1, @wordpress/date@npm:^4.2.3, @wordpress/date@npm:^4.7.0, @wordpress/date@npm:^4.9.0":
+  version: 4.13.0
+  resolution: "@wordpress/date@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     moment: ^2.22.1
     moment-timezone: ^0.5.31
-  checksum: 65bb8a5085c01fb7aaa22ff62554484bd2f2e07ccdda7f6506c616ce7250fc41aea503d6bb4af7c7ab5fef51a01992be00a8121574da65126d5f29d43ecc1820
+  checksum: 2e245bece4efda7b783c800a55004dda5199f7c10b42892f8f14bf2885e747003bf3e5c96a5c575a37631107656a49780fae02900975a0683ba19ab187ae1a91
   languageName: node
   linkType: hard
 
@@ -8781,13 +8782,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/deprecated@npm:^3.10.0, @wordpress/deprecated@npm:^3.2.3, @wordpress/deprecated@npm:^3.7.0, @wordpress/deprecated@npm:^3.8.0, @wordpress/deprecated@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/deprecated@npm:3.10.0"
+"@wordpress/deprecated@npm:^3.13.0, @wordpress/deprecated@npm:^3.2.3, @wordpress/deprecated@npm:^3.7.0, @wordpress/deprecated@npm:^3.8.0, @wordpress/deprecated@npm:^3.9.0":
+  version: 3.13.0
+  resolution: "@wordpress/deprecated@npm:3.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/hooks": ^3.10.0
-  checksum: 94034ea2eff867af2fb144690d8c58fee0c51ff5c21429b3ef12df0a0640a9a367374f07a441761b49a2a5efa8dc25b0ad0df96177aaf69cc20aca5ec80310c0
+    "@wordpress/hooks": ^3.13.0
+  checksum: 9a62783134dabac4210e8001c34d6b9237a9657552cb8a482501133080fb7f885273580abcfe69cd05bfe27110292b2c49192408e8c7f56d0ec6c346da3ab68f
   languageName: node
   linkType: hard
 
@@ -8800,12 +8801,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dom-ready@npm:^3.10.0, @wordpress/dom-ready@npm:^3.2.1, @wordpress/dom-ready@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/dom-ready@npm:3.10.0"
+"@wordpress/dom-ready@npm:^3.13.0, @wordpress/dom-ready@npm:^3.2.1, @wordpress/dom-ready@npm:^3.9.0":
+  version: 3.13.0
+  resolution: "@wordpress/dom-ready@npm:3.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 62ede5215e5ce11e70443291080ba14dee109cd459b6aa90c83e4d54ba9c69a087af86df991ec7a85f65cb4a44cf1664e5e39fb5981cf13ebba19b6fd6629222
+  checksum: 03b4b7db1b67115c3aef6c0f9bc3bca0a1e3d8445c449dd77d6703114ce132071b3ec87a0810cbe385947ebf4edbb043730d01f56e1937d0fda70075315b332c
   languageName: node
   linkType: hard
 
@@ -8819,14 +8820,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dom@npm:^3.10.0, @wordpress/dom@npm:^3.2.7, @wordpress/dom@npm:^3.7.0, @wordpress/dom@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/dom@npm:3.10.0"
+"@wordpress/dom@npm:^3.13.0, @wordpress/dom@npm:^3.2.7, @wordpress/dom@npm:^3.7.0, @wordpress/dom@npm:^3.9.0":
+  version: 3.13.0
+  resolution: "@wordpress/dom@npm:3.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     "@wordpress/deprecated": ^3.8.0
     lodash: ^4.17.21
-  checksum: 8e9b3696cc92a1172b233f1926b13cdd8f7f3145747020701db70c0726e7ba4276075c0d13ab109f6acc28a935d7402b06185761a2ae4ed295a231cc291350c2
+  checksum: a5a00c12e9064916862e08c741f5ae9feca14a1a44f64634e61852542f2c0f71457214f124bbc3d93f66dcb7f27df8c8710fd3b501f4b2ed7bb287431d902ade
   languageName: node
   linkType: hard
 
@@ -9028,18 +9029,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/element@npm:^4.0.1, @wordpress/element@npm:^4.0.4, @wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0, @wordpress/element@npm:^4.8.0":
-  version: 4.8.0
-  resolution: "@wordpress/element@npm:4.8.0"
+"@wordpress/element@npm:^4.0.1, @wordpress/element@npm:^4.0.4, @wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
+  version: 4.11.0
+  resolution: "@wordpress/element@npm:4.11.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     "@types/react": ^17.0.37
     "@types/react-dom": ^17.0.11
-    "@wordpress/escape-html": ^2.10.0
+    "@wordpress/escape-html": ^2.13.0
     lodash: ^4.17.21
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 8eb8cace49582d80df2f7391db4d408375545392ca6c2677a44249940d0347720335052f7042373a9c22de92f6d5e9e4b599c3076ca78520b56212772a18b76d
+  checksum: 0ebd6c488bc425313cc92c047fb59be2df586dbf487f28d31d223c03c4b556ab95ea6c76ff4e80c98664cc665a72a1bc7393fbb87911c6a9edad0001946afe29
   languageName: node
   linkType: hard
 
@@ -9074,12 +9075,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/escape-html@npm:^2.10.0, @wordpress/escape-html@npm:^2.2.0, @wordpress/escape-html@npm:^2.2.1, @wordpress/escape-html@npm:^2.2.3, @wordpress/escape-html@npm:^2.9.0":
-  version: 2.10.0
-  resolution: "@wordpress/escape-html@npm:2.10.0"
+"@wordpress/escape-html@npm:^2.13.0, @wordpress/escape-html@npm:^2.2.0, @wordpress/escape-html@npm:^2.2.1, @wordpress/escape-html@npm:^2.2.3, @wordpress/escape-html@npm:^2.9.0":
+  version: 2.13.0
+  resolution: "@wordpress/escape-html@npm:2.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: b5953e90e3e57f5f2626e2ba49810757a59eb4c17fef3fcee7c976980ac47e7ee59d14b954c30e63e77e45666e3e1f46b890d6dca42146844318bedee0d881b1
+  checksum: 06518d4530db95441f18ba0457b4ee8ce71e82a788c75ba666c9b2ef2a8d7280654635d9f19b2f1a9c5dd21d5b0b977a95f0a93a7a2a1668f7fa1e97f1c824e7
   languageName: node
   linkType: hard
 
@@ -9150,12 +9151,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/hooks@npm:^3.10.0, @wordpress/hooks@npm:^3.2.0, @wordpress/hooks@npm:^3.2.2, @wordpress/hooks@npm:^3.7.0, @wordpress/hooks@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/hooks@npm:3.10.0"
+"@wordpress/hooks@npm:^3.13.0, @wordpress/hooks@npm:^3.2.0, @wordpress/hooks@npm:^3.2.2, @wordpress/hooks@npm:^3.7.0, @wordpress/hooks@npm:^3.9.0":
+  version: 3.13.0
+  resolution: "@wordpress/hooks@npm:3.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 9bb09e7ccd3c1eb8123acc989aafc777bba034fc485f606ca938a5ec261743b8009cdd0b1338db05b5bc2d1278880198749ffe2daad918af4c31c4f97bcad5eb
+  checksum: 3594d5fe9ed39254ba2b58b7596062fe6fda73e2b8a07098069c899eb4c6b0e7b618db7775c6a129988631fb2fd6fbcfa543afc649f9ec1daab3997c2a900b23
   languageName: node
   linkType: hard
 
@@ -9185,12 +9186,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/i18n@npm:^4.10.0, @wordpress/i18n@npm:^4.2.1, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.7.0, @wordpress/i18n@npm:^4.9.0":
-  version: 4.10.0
-  resolution: "@wordpress/i18n@npm:4.10.0"
+"@wordpress/i18n@npm:^4.10.0, @wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.1, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.7.0, @wordpress/i18n@npm:^4.9.0":
+  version: 4.13.0
+  resolution: "@wordpress/i18n@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/hooks": ^3.10.0
+    "@wordpress/hooks": ^3.13.0
     gettext-parser: ^1.3.1
     lodash: ^4.17.21
     memize: ^1.1.0
@@ -9198,7 +9199,7 @@ __metadata:
     tannin: ^1.2.0
   bin:
     pot-to-php: tools/pot-to-php.js
-  checksum: 6b50aa19eaae354f751d7cf5e907a8fa19cdd2f8387d50c7fbedaef3ab6242d47937092a6da5658f5c4e2a729cdf30425b3c612de2d8e8b30483df2ff29e4bea
+  checksum: 29e9cfa003358d262f23019fb26dea0ad1f2bf41ab2c13b146bb617725616cd40b0eaea163f95678bdda983994592e5ef17af01de26371add8e59a5b3673a9a5
   languageName: node
   linkType: hard
 
@@ -9257,14 +9258,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/icons@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@wordpress/icons@npm:9.0.0"
+"@wordpress/icons@npm:^9.0.0, @wordpress/icons@npm:^9.4.0":
+  version: 9.4.0
+  resolution: "@wordpress/icons@npm:9.4.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/primitives": ^3.7.0
-  checksum: 0539af297c3b1b21b67e50a186d784a5a742fe825156e119ae6ec9f446c87646397416a6173c51537a1d13110cd78447626cad6eb77e689865f8cdadf98263e7
+    "@wordpress/element": ^4.11.0
+    "@wordpress/primitives": ^3.11.0
+  checksum: e8461abfe83963cf62c4c17bed84eb5bc6107602a52501bfe7a6d1c972424d43188a9660b26a365e8f238c31a8bfe39bcd07e0996331fe86d4ac0ddb947b705a
   languageName: node
   linkType: hard
 
@@ -9302,12 +9303,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/is-shallow-equal@npm:^4.10.0, @wordpress/is-shallow-equal@npm:^4.2.1, @wordpress/is-shallow-equal@npm:^4.7.0, @wordpress/is-shallow-equal@npm:^4.9.0":
-  version: 4.10.0
-  resolution: "@wordpress/is-shallow-equal@npm:4.10.0"
+"@wordpress/is-shallow-equal@npm:^4.13.0, @wordpress/is-shallow-equal@npm:^4.2.1, @wordpress/is-shallow-equal@npm:^4.7.0, @wordpress/is-shallow-equal@npm:^4.9.0":
+  version: 4.13.0
+  resolution: "@wordpress/is-shallow-equal@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 2a9967c85891e186f1403483e6f8f0cf60d7ff44e9c4821787b0ca5ca94f86316a1871857716748befad86aaa9bad33d3f3117519008409f3f8393fe21877967
+  checksum: 021285643f7d9c148ef21a819a849f21081622d90835271b8ea74ece6a52bcb852efc11b30304955cd9caefd1dbb5c2e78a4c2807e978a76ccfdea3a4780a371
   languageName: node
   linkType: hard
 
@@ -9369,14 +9370,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/keycodes@npm:^3.10.0, @wordpress/keycodes@npm:^3.2.1, @wordpress/keycodes@npm:^3.2.4, @wordpress/keycodes@npm:^3.7.0, @wordpress/keycodes@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/keycodes@npm:3.10.0"
+"@wordpress/keycodes@npm:^3.10.0, @wordpress/keycodes@npm:^3.13.0, @wordpress/keycodes@npm:^3.2.1, @wordpress/keycodes@npm:^3.2.4, @wordpress/keycodes@npm:^3.7.0, @wordpress/keycodes@npm:^3.9.0":
+  version: 3.13.0
+  resolution: "@wordpress/keycodes@npm:3.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/i18n": ^4.10.0
+    "@wordpress/i18n": ^4.13.0
     lodash: ^4.17.21
-  checksum: 18b7511ed2f15589436da3476cf155016a4f0e991580f9e21c4bf8e0f04fe8aa89ea0061b06c46f3baf6ac5e0ab31baa837f366ed5c0dfb65d7d4ff848d9f2a6
+  checksum: b57e796bc1f35a3457e78119799f4009c80d36f7ab902ccfb85ffb306ee6cdc157069fd5f39e4f3a7ee74507e2cb65daf3f76f11c5efe9dc44e053f04652600a
   languageName: node
   linkType: hard
 
@@ -9530,14 +9531,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/primitives@npm:^3.0.1, @wordpress/primitives@npm:^3.0.4, @wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.5.0, @wordpress/primitives@npm:^3.7.0, @wordpress/primitives@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@wordpress/primitives@npm:3.8.0"
+"@wordpress/primitives@npm:^3.0.1, @wordpress/primitives@npm:^3.0.4, @wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.5.0, @wordpress/primitives@npm:^3.7.0, @wordpress/primitives@npm:^3.8.0":
+  version: 3.11.0
+  resolution: "@wordpress/primitives@npm:3.11.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^4.8.0
+    "@wordpress/element": ^4.11.0
     classnames: ^2.3.1
-  checksum: c58ff7999acb9519afd4d1edb0c48f30fd97dcbd45d4e742bb6741ea8e493343c54e7a1b295a579d0a0c1e7b3d104e530ebcbda5e25bfd19a8d650317dd51c8f
+  checksum: e8cc74ac246b8ae031eba239a2424ca0166169023b829838a306a3393374dd8e1c9294df8e16c5a5dae769e4e176bf21a523a257298be64ecce1fc976e0b52e8
   languageName: node
   linkType: hard
 
@@ -9550,12 +9551,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/priority-queue@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@wordpress/priority-queue@npm:2.10.0"
+"@wordpress/priority-queue@npm:^2.13.0":
+  version: 2.13.0
+  resolution: "@wordpress/priority-queue@npm:2.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 046c89ed0374219b3b259e14c8ed4eeb377a2b146dcc8c4678692b261917bec09694395a85b3fcbc628f1162d545fa4497b9adb1ecdb34376eeb185a3e4be513
+  checksum: 39909befa2c8f66684c82fbe436bafd1d6db018a5c8e803f14ed142500b9ea18dadfcc9f1cb659b1ab10f0bcaf7ba4dd62e8d9d731e094907a1eb272d2997bf1
   languageName: node
   linkType: hard
 
@@ -9592,9 +9593,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/redux-routine@npm:^4.10.0":
-  version: 4.10.0
-  resolution: "@wordpress/redux-routine@npm:4.10.0"
+"@wordpress/redux-routine@npm:^4.13.0":
+  version: 4.13.0
+  resolution: "@wordpress/redux-routine@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     is-promise: ^4.0.0
@@ -9602,7 +9603,7 @@ __metadata:
     rungen: ^0.3.2
   peerDependencies:
     redux: ">=4"
-  checksum: 1e2412a5a3441407e630906e577512087ad5d02bdfec83c79c40aa65bcbaeb8cf80f8220b289a4f4e9758bdd9750baee026e89f77c9aae452a269884fc98c4f0
+  checksum: 5490599778378df687fdb94dea8fe6731c172f2811e17a4b6a811f3721f5598824e040e10da10e8d2345abe6cecbd3f590cabd88567386d0f9f78dbb2d50f6fb
   languageName: node
   linkType: hard
 
@@ -9648,24 +9649,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/rich-text@npm:^5.0.7, @wordpress/rich-text@npm:^5.5.0, @wordpress/rich-text@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@wordpress/rich-text@npm:5.7.0"
+"@wordpress/rich-text@npm:^5.0.7, @wordpress/rich-text@npm:^5.11.0, @wordpress/rich-text@npm:^5.5.0, @wordpress/rich-text@npm:^5.7.0":
+  version: 5.11.0
+  resolution: "@wordpress/rich-text@npm:5.11.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/escape-html": ^2.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/keycodes": ^3.9.0
+    "@wordpress/a11y": ^3.13.0
+    "@wordpress/compose": ^5.11.0
+    "@wordpress/data": ^6.13.0
+    "@wordpress/element": ^4.11.0
+    "@wordpress/escape-html": ^2.13.0
+    "@wordpress/i18n": ^4.13.0
+    "@wordpress/keycodes": ^3.13.0
     lodash: ^4.17.21
     memize: ^1.1.0
-    rememo: ^3.0.0
+    rememo: ^4.0.0
   peerDependencies:
     react: ^17.0.0
-  checksum: e0781ec66bb1f3fe3c7f1c383f9965c577454ff197116449867515dc3b51c6c6881c70bf32f806aa16921909363a6e214ef30acd8a131610c8882b10e61774c9
+  checksum: 132e79666c8e53498a3b687095f469122408b39a64e206b48eb2fc441a8067ce728d3b50dabbe4e125fc28cce29bcd1d7ccd6fcdcc86710dadca6625f54b52d4
   languageName: node
   linkType: hard
 
@@ -9843,10 +9844,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/warning@npm:^2.2.2, @wordpress/warning@npm:^2.7.0, @wordpress/warning@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "@wordpress/warning@npm:2.9.0"
-  checksum: e151c64c4162da64c49430e8d8161e00c4e616c4498aead8d598d81fa15a58eda603f9b09a2c3681d85bccb7ec44f1c624b3169ae5e8a88bba13e19151a8d473
+"@wordpress/warning@npm:^2.13.0, @wordpress/warning@npm:^2.2.2, @wordpress/warning@npm:^2.7.0, @wordpress/warning@npm:^2.9.0":
+  version: 2.13.0
+  resolution: "@wordpress/warning@npm:2.13.0"
+  checksum: f7f1fd837d157309889b1c8b3c91ff64d3f802e7492546af9aa39db2399ab69d25b3bc59f53e56fbaafc37d215b383440cd8ce419cbc96579dffdc68d778e16a
   languageName: node
   linkType: hard
 
@@ -12434,7 +12435,7 @@ __metadata:
     "@wordpress/base-styles": ^4.5.0
     "@wordpress/block-editor": ^9.1.0
     "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/compose": ^5.7.0
     "@wordpress/data": ^6.9.0
     "@wordpress/data-controls": ^2.9.0
@@ -30376,7 +30377,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remove-accents@npm:0.4.2":
+"rememo@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "rememo@npm:4.0.1"
+  checksum: e83f367396aafe840131fb4aec83fc08a9cc73e3a16f8f87d0980d923f5cca5e676bd29986ca61b7a776e2b856b90d2c68cb944a30d5225186b2778c7d3db2bd
+  languageName: node
+  linkType: hard
+
+"remove-accents@npm:0.4.2, remove-accents@npm:^0.4.2":
   version: 0.4.2
   resolution: "remove-accents@npm:0.4.2"
   checksum: 5cbc00efa52df29ce947a0c572ff975b011f5f197ebe7b4f6e527de26aba534cba12d502e3040b72e46ad01de3d4f2d5ef57a6593c964965e43ddb60438da0f8
@@ -35679,7 +35687,7 @@ swiper@4.5.1:
     "@typescript-eslint/eslint-plugin": ^5.7.0
     "@typescript-eslint/parser": ^5.7.0
     "@wordpress/base-styles": ^4.5.0
-    "@wordpress/components": ^19.11.0
+    "@wordpress/components": ^19.15.0
     "@wordpress/data": ^6.9.0
     "@wordpress/element": ^4.7.0
     "@wordpress/eslint-plugin": ^12.3.0


### PR DESCRIPTION
Currently we can't import `@wordpress/components` in some places, because if it's ever imported into a file that's used during unit tests, then it will break the tests. This is a bug in the package which was addressed in WordPress/gutenberg#42248. This PR updates the version of the package used by Calypso so it can

[Changelog for the component package](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CHANGELOG.md), the relevant notes are for versions `19.12.0` through `19.15.0`. There have been enhancements to the components we use, but bigger changes (like the updated design for the `DateTimePicker`) only impact our custom blocks, and those blocks will be using the shared `wp.components` version of the package anyway.

#### Proposed Changes

- Updated components package
- Used `yarn dedupe` to ensure only a single version in the mono repo
- Fix usage of `withInstanceId()` and `createHigherOrderComponent()` which have had their type definitions change

It doesn't update the 3rd-party types package (i.e. `@types/wordpress__components`) because doing so creates yarn errors and it's not needed to address the issue we're facing.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test
   * Calypso (especially places that use GB components)
   * ETK
   * Jetpack
   * Atomic
   * Simple sites

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [ ] ~~Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?~~
