### PR TITLE
Site Editor: Back to dashboard button in Calypso never redirects back to themes showcase

### DIFF
--- a/client/state/route/last-non-editor-route/reducer.js
+++ b/client/state/route/last-non-editor-route/reducer.js
@@ -6,7 +6,7 @@ import { ROUTE_CLEAR_LAST_NON_EDITOR, ROUTE_SET } from 'calypso/state/action-typ
  * page, you go to `/page`, which then redirects to `/block-editor/page`.
  * Matching page or post handles that case.
  */
-const editorPattern = /^\/(block-editor|page[^s]|post[^s])/;
+const editorPattern = /^\/(block-editor|site-editor|page[^s]|post[^s])/;
 
 export const lastNonEditorRouteReducer = ( state = '', action ) => {
 	const { path, type } = action;


### PR DESCRIPTION
## Context
[There is logic in place](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/selectors/get-editor-close-config.js) to ensure that if a page or post editor is visited from the themes showcase, the back to dashboard button in the editor leads the user back to the themes view ( as opposed to my home ). 

The site editor, however, isn't doing this, and it appears to be an oversight.

The culprit was the lastNonEditorRoute reducer, which handles state for the most recently visited calypso url path that didn't load the gutenberg block editor (Ex. /home, /themes, etc.).

Unfortunately, the logic didn't consider the /site-editor route to be a valid editor. As a result, it was returning /site-editor as a "lastNonEditorRoute", when in reality, it shouldn't have been. This /site-editor route would override /themes as the "lastNonEditorRoute", which would prevent downstream logic from having the back to dashboard url navigate the user back to the themes showcase.
https://github.com/Automattic/wp-calypso/blob/737180c02a201663713f8d330930d539fe382ad1/client/state/selectors/get-editor-close-config.js#L24-L30

We amend that issue by including /site-editor as a recognized editor route in the regex pattern matcher.

## Proposed Changes

* Update regex pattern matching to nclude site-editor as a recognized editor route

## Gifs
### Before
![2022-07-13 19 39 06](https://user-images.githubusercontent.com/5414230/178886352-bdeda403-e271-43de-a688-e3f56c06fcd4.gif)

### After
![2022-07-13 19 28 44](https://user-images.githubusercontent.com/5414230/178885157-2c2ab3e5-10cd-45d0-a492-1b787e8355cd.gif)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Spin up a dev environment for Calypso ( navigate to Calypso repo in a terminal and run `yarn start` )
* Navigate to the themes showcase
* Activate a full site editing theme
* In the current theme card in the themes showcase, click the "Edit" button
* When taken to the site editor, click on the back to dashboard button
* Verify that you are redirected to the themes showcase instead of my home

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64131