### PR TITLE
Jetpack Agency Dashboard: update empty state messages and hide/show search/filter

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -108,6 +108,19 @@ export default function SitesOverview(): ReactElement {
 	);
 
 	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
+	const hasAppliedFilter = !! search || filter?.issueTypes?.length > 0;
+	const showEmptyState = ! isLoading && ! isError && ! data?.sites?.length;
+
+	let emptyStateMessage = '';
+	if ( showEmptyState ) {
+		emptyStateMessage = translate( 'No active sites' );
+		if ( filter.showOnlyFavorites ) {
+			emptyStateMessage = translate( "You don't have any favorites yet." );
+		}
+		if ( hasAppliedFilter ) {
+			emptyStateMessage = translate( 'No results found. Please try refining your search.' );
+		}
+	}
 
 	return (
 		<div className="sites-overview">
@@ -139,7 +152,7 @@ export default function SitesOverview(): ReactElement {
 								isMobile &&
 									highlightTab &&
 									selectedItem.key === 'favorites' &&
-									'site-overview__highlight-tab'
+									'sites-overview__highlight-tab'
 							) }
 						>
 							<NavTabs selectedText={ selectedItem.label } selectedCount={ selectedItem.count }>
@@ -152,18 +165,19 @@ export default function SitesOverview(): ReactElement {
 				</div>
 				<div className="sites-overview__content">
 					<div className="sites-overview__content-wrapper">
-						<SiteSearchFilterContainer
-							searchQuery={ search }
-							currentPage={ currentPage }
-							filter={ filter }
-							isLoading={ isLoading }
-						/>
-						<SiteContent
-							data={ data }
-							isError={ isError }
-							isLoading={ isLoading }
-							currentPage={ currentPage }
-						/>
+						{ ( ! showEmptyState || hasAppliedFilter ) && (
+							<SiteSearchFilterContainer
+								searchQuery={ search }
+								currentPage={ currentPage }
+								filter={ filter }
+								isLoading={ isLoading }
+							/>
+						) }
+						{ showEmptyState ? (
+							<div className="sites-overview__no-sites">{ emptyStateMessage }</div>
+						) : (
+							<SiteContent data={ data } isLoading={ isLoading } currentPage={ currentPage } />
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import Pagination from 'calypso/components/pagination';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -19,25 +18,14 @@ const addPageArgs = ( pageNumber: number ) => {
 
 interface Props {
 	data: { sites: Array< any >; total: number; perPage: number } | undefined;
-	isError: boolean;
 	isLoading: boolean;
 	currentPage: number;
 }
 
-export default function SiteContent( {
-	data,
-	isError,
-	isLoading,
-	currentPage,
-}: Props ): ReactElement {
-	const translate = useTranslate();
+export default function SiteContent( { data, isLoading, currentPage }: Props ): ReactElement {
 	const isMobile = useMobileBreakpoint();
 
 	const sites = formatSites( data?.sites );
-
-	if ( ! isLoading && ! isError && ! sites.length ) {
-		return <div className="site-content__no-sites">{ translate( 'No active sites' ) }</div>;
-	}
 
 	const handlePageClick = ( pageNumber: number ) => {
 		addPageArgs( pageNumber );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -1,11 +1,6 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-.site-content__no-sites {
-	text-align: center;
-	font-size: 1.5rem;
-	margin-top: 16px;
-}
 .site-content__mobile-view {
 	@include break-large() {
 		display: none;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render } from '@testing-library/react';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -17,7 +18,6 @@ describe( '<SiteContent>', () => {
 	];
 	let props = {
 		data: { sites, total: 1, perPage: 10 },
-		isError: false,
 		isLoading: false,
 		currentPage: 1,
 	};
@@ -38,17 +38,6 @@ describe( '<SiteContent>', () => {
 		const { container } = render( <Wrapper props={ props } /> );
 		const [ tableContent ] = container.getElementsByClassName( 'site-table__table' );
 		expect( tableContent ).toBeInTheDocument();
-	} );
-	test( 'should render correctly and no sites', () => {
-		props = {
-			...props,
-			data: {
-				...props.data,
-				sites: [],
-			},
-		};
-		const { getByText } = render( <Wrapper props={ props } /> );
-		expect( getByText( 'No active sites' ) ).toBeInTheDocument();
 	} );
 	test( 'should render correctly and show loading indicator', () => {
 		props = {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -302,7 +302,7 @@
 		fill: unset;
 	}
 }
-.site-overview__highlight-tab.section-nav {
+.sites-overview__highlight-tab.section-nav {
 	animation: highlight-tab-animation 0.4s linear;
 	.section-nav__mobile-header-text {
 		animation: highlight-tab-animation-count 0.4s linear;
@@ -310,4 +310,9 @@
 	.section-nav__mobile-header .gridicon {
 		animation: highlight-tab-animation-icon 0.4s linear;
 	}
+}
+.sites-overview__no-sites {
+	text-align: center;
+	font-size: 1.5rem;
+	margin-top: 16px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import SitesOverviewContext from '../context';
+import SitesOverview from '../index';
+
+describe( '<SitesOverview>', () => {
+	const initialState = {
+		sites: {},
+		partnerPortal: { partner: {} },
+		agencyDashboard: {},
+		ui: {},
+		documentHead: {},
+		currentUser: {
+			capabilities: {},
+		},
+	};
+	const middlewares = [ thunk ];
+
+	const mockStore = configureStore( middlewares );
+	const store = mockStore( initialState );
+
+	const context = {
+		currentPage: 1,
+		search: '',
+		filter: { issueTypes: [], showOnlyFavorites: false },
+	};
+
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { context } ): JSX.Element => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<SitesOverviewContext.Provider value={ context }>
+					<SitesOverview />
+				</SitesOverviewContext.Provider>
+			</QueryClientProvider>
+		</Provider>
+	);
+
+	const setData = (): void => {
+		const data = {
+			sites: [],
+			total: 1,
+			perPage: 1,
+			totalFavorites: 1,
+		};
+		const queryKey = [ 'jetpack-agency-dashboard-sites', context.search, 1, context.filter ];
+		queryClient.setQueryData( queryKey, data );
+	};
+
+	test( 'Show the correct empty state message when there are no sites and no applied filters in All tab', async () => {
+		setData();
+
+		const { getAllByText } = render( <Wrapper context={ context } /> );
+		const [ dashboardHeading ] = getAllByText( 'Dashboard' );
+		expect( dashboardHeading ).toBeInTheDocument();
+
+		const [ dashboardSubHeading ] = getAllByText(
+			'Manage all your Jetpack sites from one location'
+		);
+		expect( dashboardSubHeading ).toBeInTheDocument();
+
+		const [ emptyStateMessage ] = getAllByText( 'No active sites' );
+		expect( emptyStateMessage ).toBeInTheDocument();
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	test( 'Show the correct empty state message when there are no sites and has applied filters in All tab', async () => {
+		context.search = 'test';
+		setData();
+
+		const { getAllByText } = render( <Wrapper context={ context } /> );
+
+		const [ emptyStateMessage ] = getAllByText(
+			'No results found. Please try refining your search.'
+		);
+		expect( emptyStateMessage ).toBeInTheDocument();
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	test( 'Show the correct empty state message when there are no sites and has applied filters in Favorites tab', async () => {
+		context.filter.showOnlyFavorites = true;
+		setData();
+
+		const { getAllByText } = render( <Wrapper context={ context } /> );
+
+		const [ emptyStateMessage ] = getAllByText(
+			'No results found. Please try refining your search.'
+		);
+		expect( emptyStateMessage ).toBeInTheDocument();
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	test( 'Show the correct empty state message when there are no sites and no applied filters in Favorites tab', async () => {
+		context.search = '';
+		context.filter.showOnlyFavorites = true;
+		setData();
+
+		const { getAllByText } = render( <Wrapper context={ context } /> );
+
+		const [ emptyStateMessage ] = getAllByText( "You don't have any favorites yet." );
+		expect( emptyStateMessage ).toBeInTheDocument();
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

This PR makes the following changes

- Hide the search and filter when there are no sites found and no filter/search is applied.
- Update the empty state messages for different states.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/empty-state-for-agency-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enter any text in the search box/apply a filter, verify the empty state messages are shown and filter/search is hidden when no sites are found and no search/filter is applied for the below scenarios

**Scenarios**

1. When no sites are found in the **All** tab and no filter/search is applied.

<img width="1728" alt="Screenshot 2022-07-14 at 1 11 33 PM" src="https://user-images.githubusercontent.com/10586875/178961029-f744c434-a752-40b3-9b80-d92897a21f80.png">

2. When no sites are found in the **All** tab and filter/search is applied.

<img width="1728" alt="Screenshot 2022-07-14 at 1 12 07 PM" src="https://user-images.githubusercontent.com/10586875/178961098-d82c3636-5d01-447b-b896-d435559a63bf.png">

<img width="1728" alt="Screenshot 2022-07-14 at 1 12 31 PM" src="https://user-images.githubusercontent.com/10586875/178961107-8067f3f2-5feb-4510-8642-6e7ed4e33b7d.png">

3. When no sites are found in the **Favorites** tab and no filter/search is applied.

<img width="1728" alt="Screenshot 2022-07-14 at 1 11 48 PM" src="https://user-images.githubusercontent.com/10586875/178961165-e55d5a4e-2e72-4343-b1b2-9da4b1a80e43.png">

4. When no sites are found in the **Favorites** tab and filter/search is applied.

<img width="1728" alt="Screenshot 2022-07-14 at 1 12 14 PM" src="https://user-images.githubusercontent.com/10586875/178961218-bee50bc0-eb7c-4696-9f82-8d1c1be325ce.png">

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202076982646589-as-1202537169533321 & 1202076982646589-as-1202578425954554