### PR TITLE
Double-check the RTL state before updating the CSS files

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -521,10 +521,14 @@ export function switchWebpackCSS( isRTL ) {
 		}
 
 		const newLink = await loadCSS( newHref, currentLink );
-		newLink.setAttribute( 'data-webpack', true );
-
-		if ( currentLink.parentElement ) {
-			currentLink.parentElement.removeChild( currentLink );
+		// After the CSS loads the RTL status might have changed
+		// This is a double-check to ensure the value of isRTL
+		// before the CSS link is removed from the DOM
+		if ( i18n.isRtl() === isRTL ) {
+			newLink.setAttribute( 'data-webpack', true );
+			currentLink.parentElement?.removeChild( currentLink );
+		} else {
+			currentLink.parentElement?.removeChild( newLink );
 		}
 	} );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -521,10 +521,9 @@ export function switchWebpackCSS( isRTL ) {
 		}
 
 		const newLink = await loadCSS( newHref, currentLink );
-		// After the CSS loads the RTL status might have changed
+		// After the CSS files load the RTL state might have changed
 		// This is a double-check to ensure the value of isRTL
-		// before the CSS link is removed from the DOM
-		if ( i18n.isRtl() === isRTL ) {
+		if ( i18n.isRtl() === isRTL && newLink ) {
 			newLink.setAttribute( 'data-webpack', true );
 			currentLink.parentElement?.removeChild( currentLink );
 		} else {
@@ -542,6 +541,15 @@ export function switchWebpackCSS( isRTL ) {
  */
 function loadCSS( cssUrl, currentLink ) {
 	return new Promise( ( resolve ) => {
+		// While looping the current links the RTL state might have changed
+		// This is a double-check to ensure the value of isRTL
+		const isRTL = i18n.isRtl();
+		const isRTLHref = currentLink.getAttribute( 'href' ).endsWith( '.rtl.css' );
+
+		if ( isRTL === isRTLHref ) {
+			return resolve( null );
+		}
+
 		const link = document.createElement( 'link' );
 		link.rel = 'stylesheet';
 		link.type = 'text/css';

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -516,18 +516,17 @@ export function switchWebpackCSS( isRTL ) {
 	forEach( currentLinks, async ( currentLink ) => {
 		const currentHref = currentLink.getAttribute( 'href' );
 		const newHref = setRTLFlagOnCSSLink( currentHref, isRTL );
-		if ( currentHref === newHref ) {
+		const isNewHrefAdded = currentLink.parentElement?.querySelector( `[href = '${ newHref }']` );
+
+		if ( currentHref === newHref || isNewHrefAdded ) {
 			return;
 		}
 
 		const newLink = await loadCSS( newHref, currentLink );
-		// After the CSS files load the RTL state might have changed
-		// This is a double-check to ensure the value of isRTL
-		if ( i18n.isRtl() === isRTL && newLink ) {
+
+		if ( newLink ) {
 			newLink.setAttribute( 'data-webpack', true );
 			currentLink.parentElement?.removeChild( currentLink );
-		} else {
-			currentLink.parentElement?.removeChild( newLink );
 		}
 	} );
 }


### PR DESCRIPTION
#### Proposed Changes

Because the CSS files are loaded asynchronously the RTL state might have changed while the files are being loaded. This PR adds a double-check to ensure that the value of `isRTL` matches the CSS files before the CSS links are removed from the DOM to update the RTL styles. 

#### Testing Instructions

1. Set language to Arabic or Hebrew
2. Create new site at /start
3. Select domain and free plan
4. Check that the CSS filenames end with `.rtl.css` after the page is loaded with the onboarding steps

Related to #65582
