### PR TITLE
Fix All My Sites link in sites selector on backup details page

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -480,7 +480,16 @@ const navigateToSite =
 				const path = allSitesPath.replace( /^\/posts\b(\/my)?/, postsBase );
 
 				// There is currently no "all sites" version of the insights page
-				return path.replace( /^\/stats\/insights\/?$/, '/stats/day' );
+				if ( path.match( /^\/stats\/insights\// ) ) {
+					return '/stats/day';
+				}
+
+				// Jetpack Cloud: default to /backups/ when in the details of a particular backup
+				if ( path.match( /^\/backup\/.*\/(download|restore|detail)/ ) ) {
+					return '/backup';
+				}
+
+				return path;
 			} else if ( siteBasePath ) {
 				const base = getSiteBasePath();
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -480,7 +480,7 @@ const navigateToSite =
 				const path = allSitesPath.replace( /^\/posts\b(\/my)?/, postsBase );
 
 				// There is currently no "all sites" version of the insights page
-				if ( path.match( /^\/stats\/insights/ ) ) {
+				if ( path.match( /^\/stats\/insights\/?/ ) ) {
 					return '/stats/day';
 				}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -480,7 +480,7 @@ const navigateToSite =
 				const path = allSitesPath.replace( /^\/posts\b(\/my)?/, postsBase );
 
 				// There is currently no "all sites" version of the insights page
-				if ( path.match( /^\/stats\/insights\// ) ) {
+				if ( path.match( /^\/stats\/insights/ ) ) {
 					return '/stats/day';
 				}
 


### PR DESCRIPTION
#### Proposed Changes

* I add missing handling for `/backups` routes in the store switcher's All My Sites link.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Main test

1. Start at the site that has Jetpack backups support
2. Navigate to Jetpack -> Backup
3. Open the backup download page by clicking "Download backup".
4. Click on "Switch site".
5. Click on "All My Sites".
6. Confirm that the site selector shows under https://wordpress.com/backup and that it allows navigating to backups on any other site.

##### Regression test

1. Start at any site
2. Navigate to Stats -> Insights
3. Click on "Switch site".
4. Click on "All My Sites".
6. Confirm that the "all sites" version of `/stats/day` page is displayed

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [ ] ~~Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?~~

Related to https://github.com/Automattic/wp-calypso/issues/65587