### PR TITLE
Reload the CSS files every time the RTL state changes

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -516,9 +516,6 @@ export function switchWebpackCSS( isRTL ) {
 	forEach( currentLinks, async ( currentLink ) => {
 		const currentHref = currentLink.getAttribute( 'href' );
 		const newHref = setRTLFlagOnCSSLink( currentHref, isRTL );
-		if ( currentHref === newHref ) {
-			return;
-		}
 
 		const newLink = await loadCSS( newHref, currentLink );
 		newLink.setAttribute( 'data-webpack', true );


### PR DESCRIPTION
#### Proposed Changes

Because the CSS files are loaded asynchronously the RTL state might have changed while the files are being loaded. 

This PR removes a check to ensure that the CSS files are reloaded every time the RTL state changes to force the update to the last RTL state.

#### Testing Instructions

1. Set language to Arabic or Hebrew
2. Create new site at /start
3. Select domain and free plan
4. Check that the CSS filenames end with `.rtl.css` after the page is loaded with the onboarding steps

Related to #65582 #65588
