### PR TITLE
Update refactor backup page queries

### DIFF
--- a/client/components/jetpack/backup-badge/index.jsx
+++ b/client/components/jetpack/backup-badge/index.jsx
@@ -1,12 +1,16 @@
 import { ScreenReaderText } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import Badge from 'calypso/components/badge';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
-import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
+import { useLatestBackupAttempt } from 'calypso/my-sites/backup/status/hooks';
 
 const BackupBadge = ( { siteId } ) => {
 	const translate = useTranslate();
-	const backupStatus = useDailyBackupStatus( siteId, 'today' );
+	const lastAttemptOnDate = useLatestBackupAttempt( siteId, {
+		after: moment( 'today' ).startOf( 'day' ),
+		before: moment( 'today' ).endOf( 'day' ),
+	} );
 
 	let numWarningCache = null;
 
@@ -32,7 +36,7 @@ const BackupBadge = ( { siteId } ) => {
 		return numWarnings;
 	};
 
-	if ( backupStatus.isLoading || numBackupWarnings( backupStatus.lastBackupAttemptOnDate ) === 0 ) {
+	if ( lastAttemptOnDate.isLoading || numBackupWarnings( lastAttemptOnDate.backupAttempt ) === 0 ) {
 		return <></>;
 	}
 
@@ -43,9 +47,9 @@ const BackupBadge = ( { siteId } ) => {
 					'%(number)d {{span}}warning{{/span}}',
 					'%(number)d {{span}}warnings{{/span}}',
 					{
-						count: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+						count: numBackupWarnings( lastAttemptOnDate.backupAttempt ),
 						args: {
-							number: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+							number: numBackupWarnings( lastAttemptOnDate.backupAttempt ),
 						},
 						components: {
 							span: <span className="backup-badge__words" />,
@@ -55,9 +59,9 @@ const BackupBadge = ( { siteId } ) => {
 			</span>
 			<ScreenReaderText>
 				{ translate( '%(number)d warning', '%(number)d warnings', {
-					count: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+					count: numBackupWarnings( lastAttemptOnDate.backupAttempt ),
 					args: {
-						number: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+						number: numBackupWarnings( lastAttemptOnDate.backupAttempt ),
 					},
 				} ) }
 			</ScreenReaderText>

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -7,7 +7,6 @@ import BackupWarningHeader from 'calypso/components/jetpack/backup-warnings/back
 import BackupWarningListHeader from 'calypso/components/jetpack/backup-warnings/backup-warning-list-header';
 import LogItem from 'calypso/components/jetpack/log-item';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
-import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 
 import './style.scss';
 
@@ -131,14 +130,12 @@ const getWarningInfo = ( code, category ) => {
 	return warningInfo;
 };
 
-const BackupWarnings = ( { siteId, selectedDate } ) => {
-	const backupStatus = useDailyBackupStatus( siteId, selectedDate );
-
-	if ( ! backupStatus.lastBackupAttemptOnDate ) {
+const BackupWarnings = ( { lastBackupAttemptOnDate } ) => {
+	if ( ! lastBackupAttemptOnDate ) {
 		return <></>;
 	}
 
-	const backup = backupStatus.lastBackupAttemptOnDate;
+	const backup = lastBackupAttemptOnDate;
 
 	const warnings = getBackupWarnings( backup );
 	const hasWarnings = Object.keys( warnings ).length !== 0;

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -33,6 +33,7 @@ import './style.scss';
 const DailyBackupStatus = ( {
 	selectedDate,
 	lastBackupAttempt,
+	lastBackupAttemptOnDate,
 	lastBackupDate,
 	backup,
 	deltas,
@@ -114,9 +115,13 @@ const DailyBackupStatus = ( {
 
 	if ( backup ) {
 		const isSuccessful = hasRealtimeBackups ? isSuccessfulRealtimeBackup : isSuccessfulDailyBackup;
-
 		return isSuccessful( backup ) ? (
-			<BackupSuccessful backup={ backup } deltas={ deltas } selectedDate={ selectedDate } />
+			<BackupSuccessful
+				backup={ backup }
+				deltas={ deltas }
+				selectedDate={ selectedDate }
+				lastBackupAttemptOnDate={ lastBackupAttemptOnDate }
+			/>
 		) : (
 			<BackupFailed backup={ backup } />
 		);
@@ -141,6 +146,7 @@ const DailyBackupStatus = ( {
 DailyBackupStatus.propTypes = {
 	selectedDate: PropTypes.object.isRequired, // Moment object
 	lastBackupDate: PropTypes.object, // Moment object
+	lastBackupAttemptOnDate: PropTypes.object, // Moment object
 	backup: PropTypes.object,
 	deltas: PropTypes.object,
 };
@@ -157,7 +163,7 @@ const Wrapper = ( props ) => {
 				<QueryRewindBackups siteId={ siteId } />
 				<DailyBackupStatus { ...props } />
 			</Card>
-			<BackupWarnings selectedDate={ props.selectedDate } siteId={ siteId } />
+			<BackupWarnings lastBackupAttemptOnDate={ props.lastBackupAttemptOnDate } />
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -9,7 +9,6 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
-import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -23,16 +22,14 @@ import cloudWarningIcon from './icons/cloud-warning.svg';
 
 import './style.scss';
 
-const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
+const BackupSuccessful = ( { backup, deltas, selectedDate, lastBackupAttemptOnDate } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
 	const hasRealtimeBackups = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_REAL_TIME_BACKUPS )
 	);
-
-	const backupStatus = useDailyBackupStatus( siteId, selectedDate );
-	const warnings = getBackupWarnings( backupStatus.lastBackupAttemptOnDate );
+	const warnings = getBackupWarnings( lastBackupAttemptOnDate );
 	const hasWarnings = Object.keys( warnings ).length !== 0;
 
 	const moment = useLocalizedMoment();

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -13,7 +13,7 @@ import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { useFirstMatchingBackupAttempt, useMatchingBackupAttemptsInRange } from '../hooks';
 
-const useLatestBackupAttempt = ( siteId, { before, after, successOnly = false } = {} ) => {
+export const useLatestBackupAttempt = ( siteId, { before, after, successOnly = false } = {} ) => {
 	return useFirstMatchingBackupAttempt( siteId, {
 		before,
 		after,

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -32,6 +32,7 @@ export const DailyStatus = ( { selectedDate } ) => {
 				lastBackupDate,
 				backup: lastBackupAttemptOnDate,
 				deltas,
+				lastBackupAttemptOnDate,
 			} }
 		/>
 	);
@@ -73,6 +74,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 					lastBackupDate,
 					backup: lastSuccessfulBackupOnDate || lastBackupAttemptOnDate,
 					lastBackupAttempt,
+					lastBackupAttemptOnDate,
 				} }
 			/>
 


### PR DESCRIPTION
#### Proposed Changes

This PR continues refactoring of Backup page on Both, wordpress.com and cloud.jetpack.com in order to reduce the number of API calls to Activity Log endpoint. There are 2 points updated in this PR:
- We pass `latestBackupAttempt` to the `BackupSuccessful` and `BackupWarnings` instead of using query inside these. This way we won't do unnecessary calls as we already have an information needed on a higher level (this removes 2 API calls) on wordpress.com
- Inside `BackupBadge` component we use more precise query to do only 1 API call instead of 4. (this removes 3 API calls) on cloud.jetpack.com

#### Testing Instructions
Update the branch locally or use the builds of this branch.

##### Note
On calypso.localhost and cloud.jetpack.lolhost set up Timezone properly for your JN website, which will allow to observe more stable results.

##### Realtime backups
-  Create a JN site (or use one) and purchase [backup](https://wordpress.com/checkout/jetpack/jetpack_backup_t1_yearly) plan.
- Make several actions on the site (install/activate plugins, add users).
- Run build locally `yarn start`
- Navigate to `http://calypso.localhost:3000/backup/--Your JN site--` and check that it displays correctly. You can compare to `http://wordpress.com/backup/--Your JN site--`. 
- Observe that number of calls is lower. You can check the network tab in dev tools and search for `activity?`.
- Run `yarn start-jetpack-cloud-p` and check the same for `http://jetpack.cloud.localhost:3001/backup/--Your JN site--` and `https://cloud.jetpack.com/backup/--Your JN site--`

##### Daily backups
-  Create a JN site (or use one) and purchase `https://wordpress.com/checkout/jetpack_backup_daily/--Your JN site--` plan.
- Make several actions on the site (install/activate plugins, add users).
- Run build locally `yarn start`
- Navigate to `http://calypso.localhost:3000/backup/--Your JN site--` and check that it displays correctly. You can compare to `http://wordpress.com/backup/--Your JN site--`. 
- Observe that number of calls is lower. You can check the network tab in dev tools and search for `activity?`.
- Run `yarn start-jetpack-cloud-p` and check the same for `http://jetpack.cloud.localhost:3001/backup/--Your JN site--` and `https://cloud.jetpack.com/backup/--Your JN site--` 

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? (There are no tests for this PR as we don't basically added any logic here, rather optimized and reused parameters)
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #
1164141197617539-as-1201763904638117/f