### PR TITLE
SCSS mixins: `long-content-fade` to apply gradient from `transparent` to color

### DIFF
--- a/client/assets/stylesheets/shared/functions/_overflow-gradient.scss
+++ b/client/assets/stylesheets/shared/functions/_overflow-gradient.scss
@@ -16,7 +16,7 @@
 @function overflow-gradient( $color, $stop: 90%, $direction: to right ) {
 	@return linear-gradient(
 		$direction,
-		#{'rgba('} $color #{', 0 )'},
-		#{'rgba('} $color #{', 1 )'} $stop
+		transparent,
+		$color $stop
 	);
 }

--- a/client/package.json
+++ b/client/package.json
@@ -70,7 +70,7 @@
 		"@stripe/stripe-js": "^1.17.1",
 		"@wordpress/a11y": "^3.9.0",
 		"@wordpress/api-fetch": "^6.6.0",
-		"@wordpress/base-styles": "^4.5.0",
+		"@wordpress/base-styles": "^4.7.0",
 		"@wordpress/block-editor": "^9.1.0",
 		"@wordpress/blocks": "^11.8.0",
 		"@wordpress/components": "^19.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8275,10 +8275,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/base-styles@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "@wordpress/base-styles@npm:4.5.0"
-  checksum: 3553d08575c4b4bb116363610403bb1b3f3335e50fbb857c3d0c47eb47ff64d84be5c8edcc295c59b0f2fcfb9ed6414289ee97a22cc017fa8b8ae75f30edc427
+"@wordpress/base-styles@npm:^4.5.0, @wordpress/base-styles@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@wordpress/base-styles@npm:4.7.0"
+  checksum: c6e35d60a373875f4e9059547fcbe6292a951e6a270de9afe8d355714efa08cc2a941a092d45da53eadc1028d240df071875b10b53f47210f3f0896584df88a5
   languageName: node
   linkType: hard
 
@@ -12450,7 +12450,7 @@ __metadata:
     "@types/jest": ^27.4.0
     "@wordpress/a11y": ^3.9.0
     "@wordpress/api-fetch": ^6.6.0
-    "@wordpress/base-styles": ^4.5.0
+    "@wordpress/base-styles": ^4.7.0
     "@wordpress/block-editor": ^9.1.0
     "@wordpress/blocks": ^11.8.0
     "@wordpress/components": ^19.15.0


### PR DESCRIPTION
### Proposed Changes

Sync our version of `long-content-fade` with [Gutenberg's](https://github.com/WordPress/gutenberg/pull/42401).

This PR will be good to go once the next version of `@wordpress/base-styles` is merged. This PR will also bump the package's version.

### Testing Instructions

Open Calypso, click `Switch Sites` and you should see the gradient working on the edge for long site URLs. Amazingly, this does not work on `trunk`:

| This PR | `trunk` |
| ------- | -------- |
| ![image](https://user-images.githubusercontent.com/26530524/179005848-2debc22b-595d-429c-8a9a-6b2b5eb8c404.png) | ![image](https://user-images.githubusercontent.com/26530524/179005992-450c8191-2081-4804-a955-00090b5ab849.png) |

Related to https://github.com/Automattic/wp-calypso/pull/65505#discussion_r919294316.