### PR TITLE
Help Center - Fix support availbility permission check

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -62,7 +62,7 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	 * @return boolean
 	 */
 	public function permission_callback() {
-		return current_user_can( 'read' );
+		return is_user_logged_in();
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

* Check only if the user is logged in to give support availability options. We don't need the `read` privilege because this permission requires knowing the site for no reason. 
