### PR TITLE
Sites Management Dashboard: Restore input fade on search

### DIFF
--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -6,9 +6,4 @@ export const SitesSearch = styled( Search )`
 	border-radius: 4px;
 	overflow: hidden;
 	height: 44px;
-
-	// TODO: make the fade optional in the component
-	.search-component__input-fade::before {
-		display: none !important;
-	}
 `;


### PR DESCRIPTION
#### Proposed Changes

Blocked by https://github.com/Automattic/wp-calypso/pull/65598.

On https://github.com/Automattic/wp-calypso/pull/65505, we disabled the gradient because it didn't account for the search input background, but as https://github.com/Automattic/wp-calypso/pull/65598 fixed the problem, we can revert the change and enable it again.

#### Testing Instructions

| This PR | `trunk` |
| -------- | ------- |
| ![image](https://user-images.githubusercontent.com/26530524/179008510-1e525469-b965-461f-ab38-f83a8d940b71.png) | ![image](https://user-images.githubusercontent.com/26530524/179008654-7b9408ea-aa07-44e2-8c27-d5d8f88d3e02.png) |

Open the Sites Management Dashboard and check that the input fades when there are a lot of characters.

Related to https://github.com/Automattic/wp-calypso/pull/65505.