### PR TITLE
Redirect global styles doc link to WP.com

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -22,6 +22,8 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 			return 'https://wordpress.com/support/widgets/';
 		case 'https://wordpress.org/plugins/classic-widgets/':
 			return 'https://wordpress.com/plugins/classic-widgets';
+		case 'https://wordpress.org/support/article/styles-overview/':
+			return 'https://wordpress.com/support/using-styles/';
 	}
 
 	return translation;


### PR DESCRIPTION
### Context

See issue #59526 for additional details. 

In the Site Editor, when you open Global Styles, Gutenberg provides a Welcome Guide tutorial. On the last page of the tutorial, there is a link to Global Styles documentation on WordPress.org. For WordPress.com users (when Editor Toolkit is active) we want to link to an alternative Global Styles documentation link on WordPress.com. 

Doc on WP.org: https://wordpress.org/support/article/styles-overview/
Alternative doc on WP.com:  https://wordpress.com/support/using-styles/

**Opening Global Styles and the Welcome Guide:**

![147231835-c8ce6329-310c-47bc-9c05-7960facaa657](https://user-images.githubusercontent.com/21228350/179022571-132cfca8-6867-4c1c-bbe9-f8496e28c9d1.png)

**The location of the link that is being changed:**

![147232633-651c6d5b-c092-49b2-b1f4-524823d2649b](https://user-images.githubusercontent.com/21228350/179022609-3b212d41-847b-47aa-997f-de6fa1dd1a08.png)


### Proposed Changes

There is already a module in the Editor Toolkit that handles redirects for documentation links. The module leverages i18n filters to update documentation URLs in specific cases. I've added lines to include the redirect above. 


### Testing Instructions

See the above screenshots for additional clarity on this process.

1) Go to Appearance > Editor. Click the button to open Global Styles. Click the Welcome Guide button to launch the tutorial. Advance through the tutorial to the last page. On the last page, find the link named 'Here’s a detailed guide to learn how to make the most of it.' 

2) In a WordPress.com or Editor Toolkit-enabled environment, the above link should go to: 
https://wordpress.org/support/article/styles-overview/

3) In any WordPress.org environment with out the Editor Toolkit, the above link should go to: 
https://wordpress.com/support/using-styles/
