### PR TITLE
Site Settings: fix site clone form JS error

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -634,7 +634,9 @@ export class SiteSettingsFormGeneral extends Component {
 		} );
 
 		// We currently don't have a monthly or a biennial pro plan, hence keeping the business plan upsell for those cases.
-		const upsellPlan = isWpComAnnualPlan( site.plan.product_slug ) ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
+		const upsellPlan = isWpComAnnualPlan( site?.plan.product_slug )
+			? PLAN_WPCOM_PRO
+			: PLAN_BUSINESS;
 
 		return (
 			<div className={ classNames( classes ) }>


### PR DESCRIPTION
#### Proposed Changes

Fix null property access error introduced [here](https://github.com/Automattic/wp-calypso/commit/d224e8dde4e005c710e42bbba3e035523cb565da#diff-bc79a829db32a21a70056887cf8a6bd4ebce6890c1a8fd3091258dba0610b680R616) in #63462 

#### Testing Instructions

To reproduce:

* With a self-hosted Jetpack-connected site added to your WPcom account, go to: https://wordpress.com/settings/general/__SITE__
* Scroll down to `Site Tools > Clone`
* When clicking on Clone, you should see a blank white page, and there will be a JS error in the console:

```
TypeError: Cannot read properties of null (reading 'plan')
    at at.render (settings.7aa5717fa92d4e805c32.min.js:1:89681)
```

After patching, this clone form should load without error.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #63462 via user report 5360503-zd-woothemes