### PR TITLE
HelpCenter: fix api endpoint permission 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -50,7 +50,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 	 * @return boolean
 	 */
 	public function permission_callback() {
-		return current_user_can( 'read' );
+		return is_user_logged_in();
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -59,7 +59,7 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 	 * @return boolean
 	 */
 	public function permission_callback() {
-		return current_user_can( 'read' );
+		return is_user_logged_in();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

Change the API endpoint permissions to use `is_user_logged_in()`. This is due to an error in Simple sites with calling the endpoint.

## Testing Instructions

Using a non-proxied user load the HelpCenter and verify all functionality works.