### PR TITLE
Checkout: Get correct shopping cart for creating Google/Apple Pay payment request

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -296,6 +296,7 @@ function useCreateApplePay( {
 	stripe,
 	isApplePayAvailable,
 	isWebPayLoading,
+	cartKey,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
@@ -303,16 +304,17 @@ function useCreateApplePay( {
 	stripe: Stripe | null;
 	isApplePayAvailable: boolean;
 	isWebPayLoading: boolean;
+	cartKey: CartKey | undefined;
 } ): PaymentMethod | null {
 	const isStripeReady = ! isStripeLoading && ! stripeLoadingError && stripe && stripeConfiguration;
 
 	const shouldCreateApplePayMethod = isStripeReady && ! isWebPayLoading && isApplePayAvailable;
 
 	const applePayMethod = useMemo( () => {
-		return shouldCreateApplePayMethod && stripe && stripeConfiguration
-			? createApplePayMethod( stripe, stripeConfiguration )
+		return shouldCreateApplePayMethod && stripe && stripeConfiguration && cartKey
+			? createApplePayMethod( stripe, stripeConfiguration, cartKey )
 			: null;
-	}, [ shouldCreateApplePayMethod, stripe, stripeConfiguration ] );
+	}, [ shouldCreateApplePayMethod, stripe, stripeConfiguration, cartKey ] );
 
 	return applePayMethod;
 }
@@ -441,6 +443,7 @@ export default function useCreatePaymentMethods( {
 		stripe,
 		isApplePayAvailable,
 		isWebPayLoading,
+		cartKey,
 	} );
 
 	const googlePayMethod = useCreateGooglePay( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -38,6 +38,7 @@ import useCreateExistingCards from './use-create-existing-cards';
 import type { StoredCard } from '../../types/stored-cards';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { CartKey } from '@automattic/shopping-cart';
 import type { Stripe } from '@stripe/stripe-js';
 
 export { useCreateExistingCards };
@@ -323,6 +324,7 @@ function useCreateGooglePay( {
 	stripe,
 	isGooglePayAvailable,
 	isWebPayLoading,
+	cartKey,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
@@ -330,6 +332,7 @@ function useCreateGooglePay( {
 	stripe: Stripe | null;
 	isGooglePayAvailable: boolean;
 	isWebPayLoading: boolean;
+	cartKey: CartKey | undefined;
 } ): PaymentMethod | null {
 	const isStripeReady =
 		! isStripeLoading &&
@@ -341,10 +344,10 @@ function useCreateGooglePay( {
 		isEnabled( 'checkout/google-pay' );
 
 	return useMemo( () => {
-		return isStripeReady && stripe && stripeConfiguration
-			? createGooglePayMethod( stripe, stripeConfiguration )
+		return isStripeReady && stripe && stripeConfiguration && cartKey
+			? createGooglePayMethod( stripe, stripeConfiguration, cartKey )
 			: null;
-	}, [ stripe, stripeConfiguration, isStripeReady ] );
+	}, [ stripe, stripeConfiguration, isStripeReady, cartKey ] );
 }
 
 export default function useCreatePaymentMethods( {
@@ -447,6 +450,7 @@ export default function useCreatePaymentMethods( {
 		stripe,
 		isGooglePayAvailable,
 		isWebPayLoading,
+		cartKey,
 	} );
 
 	const existingCardMethods = useCreateExistingCards( {

--- a/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
@@ -7,20 +7,26 @@ import PaymentRequestButton from '../payment-request-button';
 import { usePaymentRequestOptions, useStripePaymentRequest } from './web-pay-utils';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { CartKey } from '@automattic/shopping-cart';
 import type { Stripe } from '@stripe/stripe-js';
 
 const debug = debugFactory( 'composite-checkout:apple-pay-payment-method' );
 
 export function createApplePayMethod(
 	stripe: Stripe,
-	stripeConfiguration: StripeConfiguration
+	stripeConfiguration: StripeConfiguration,
+	cartKey: CartKey
 ): PaymentMethod {
 	return {
 		id: 'apple-pay',
 		paymentProcessorId: 'apple-pay',
 		label: <ApplePayLabel />,
 		submitButton: (
-			<ApplePaySubmitButton stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
+			<ApplePaySubmitButton
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+				cartKey={ cartKey }
+			/>
 		),
 		inactiveContent: <ApplePaySummary />,
 		getAriaLabel: ( __ ) => __( 'Apple Pay' ),
@@ -45,13 +51,15 @@ export function ApplePaySubmitButton( {
 	onClick,
 	stripe,
 	stripeConfiguration,
+	cartKey,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	stripe: Stripe;
 	stripeConfiguration: StripeConfiguration;
+	cartKey: CartKey;
 } ) {
-	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration );
+	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration, cartKey );
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
 			debug( 'submitting stripe payment with key', paymentMethodToken );

--- a/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
@@ -7,20 +7,26 @@ import PaymentRequestButton from '../payment-request-button';
 import { usePaymentRequestOptions, useStripePaymentRequest } from './web-pay-utils';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { CartKey } from '@automattic/shopping-cart';
 import type { Stripe } from '@stripe/stripe-js';
 
 const debug = debugFactory( 'wpcom-checkout:google-pay-payment-method' );
 
 export function createGooglePayMethod(
 	stripe: Stripe,
-	stripeConfiguration: StripeConfiguration
+	stripeConfiguration: StripeConfiguration,
+	cartKey: CartKey
 ): PaymentMethod {
 	return {
 		id: 'google-pay',
 		paymentProcessorId: 'google-pay',
 		label: <GooglePayLabel />,
 		submitButton: (
-			<GooglePaySubmitButton stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
+			<GooglePaySubmitButton
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+				cartKey={ cartKey }
+			/>
 		),
 		inactiveContent: <GooglePaySummary />,
 		getAriaLabel: () => 'Google Pay',
@@ -43,13 +49,15 @@ export function GooglePaySubmitButton( {
 	onClick,
 	stripe,
 	stripeConfiguration,
+	cartKey,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	stripe: Stripe;
 	stripeConfiguration: StripeConfiguration;
+	cartKey: CartKey;
 } ) {
-	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration );
+	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration, cartKey );
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
 			debug( 'submitting stripe payment with key', paymentMethodToken );

--- a/packages/wpcom-checkout/src/payment-methods/web-pay-utils.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/web-pay-utils.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import { getLabel } from '../checkout-labels';
 import type { StripeConfiguration, PaymentRequestOptions } from '@automattic/calypso-stripe';
 import type { LineItem } from '@automattic/composite-checkout';
-import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import type { CartKey, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { PaymentRequest, Stripe } from '@stripe/stripe-js';
 
 const debug = debugFactory( 'wpcom-checkout:web-pay-utils' );
@@ -26,10 +26,11 @@ const PAYMENT_REQUEST_OPTIONS = {
 };
 
 export function usePaymentRequestOptions(
-	stripeConfiguration: StripeConfiguration
+	stripeConfiguration: StripeConfiguration,
+	cartKey: CartKey
 ): PaymentRequestOptions | null {
 	const total = useTotal();
-	const { responseCart } = useShoppingCart();
+	const { responseCart } = useShoppingCart( cartKey );
 	const country = getProcessorCountryFromStripeConfiguration( stripeConfiguration );
 	const currency = responseCart.currency;
 	const paymentRequestOptions = useMemo( () => {
@@ -45,6 +46,7 @@ export function usePaymentRequestOptions(
 			...PAYMENT_REQUEST_OPTIONS,
 		};
 	}, [ country, currency, total, responseCart.products ] );
+	debug( 'returning stripe payment request options', paymentRequestOptions );
 	return paymentRequestOptions;
 }
 


### PR DESCRIPTION
#### Proposed Changes

When preparing a web payment request (eg: Google Pay or Apple Pay), we have to collect certain data from the shopping cart and [pass it to Stripe](https://stripe.com/docs/js/payment_request/create). To get the arguments for that, we use a custom React hook called `usePaymentRequestOptions()` which in turn calls `useShoppingCart()` to collect its cart data.

However, `useShoppingCart()` requires a cart key (typically the site ID) to operate properly. `usePaymentRequestOptions()` was not providing the cart key and therefore was getting incorrect cart data. The main effect of this is that the currency of the cart may have been returned as `USD` even if there was another currency set for the user. When this currency was passed to the web payment request, it caused the Google or Apple Pay purchase to always be in USD. So if the cart total was EUR 42.50, the user would be charged USD 42.50, a very different price.

In this PR, we modify `usePaymentRequestOptions()` to require a cart key and use it when fetching the cart data. This corrects the currency for the payment method.

I think this regression was added in https://github.com/Automattic/wp-calypso/pull/63720

Fixes pNPgK-60i-p2 and pNPgK-60p-p2

#### Screenshots

The cart total:

<img width="574" alt="Screen Shot 2022-07-14 at 6 37 52 PM" src="https://user-images.githubusercontent.com/2036909/179100010-23d0bdd9-0da3-4790-bfb5-1cb9fd46e30e.png">

Google Pay before this PR:

<img width="265" alt="broken" src="https://user-images.githubusercontent.com/2036909/179100122-28c89ed1-5851-4888-b791-560e21ef4f99.png">

Google Pay after this PR:

<img width="390" alt="fixed" src="https://user-images.githubusercontent.com/2036909/179100142-2de63310-4281-4887-905e-ce284a16ad5a.png">

#### Testing Instructions

In order to test Google Pay you must access calypso through https. This can be done using various local tunnels, or by using the calypso.live links in this PR.

A user testing Google Pay must have at least one saved card in their Google wallet.

- First set the currency of your user to something other than USD.
- Add a product to your cart and visit checkout.
- Select "Google Pay" as the payment method.
- Click to submit the checkout form.
- Verify that the Google Pay dialog shows the correct price in the correct currency.