### PR TITLE
All Sites selector navigates to the multisite dashboard

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -96,7 +96,9 @@ export function createNavigation( context ) {
 		basePath = sectionify( context.pathname );
 	}
 
-	const allSitesPath = config.isEnabled( 'build/sites-dashboard' ) ? '/sites-dashboard' : basePath;
+	const allSitesPath = config.isEnabled( 'build/sites-dashboard' )
+		? addQueryArgs( { return: basePath === '/home' ? undefined : basePath }, '/sites-dashboard' )
+		: basePath;
 
 	return (
 		<NavigationComponent

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -96,10 +96,12 @@ export function createNavigation( context ) {
 		basePath = sectionify( context.pathname );
 	}
 
+	const allSitesPath = config.isEnabled( 'build/sites-dashboard' ) ? '/sites-dashboard' : basePath;
+
 	return (
 		<NavigationComponent
 			path={ context.path }
-			allSitesPath={ basePath }
+			allSitesPath={ allSitesPath }
 			siteBasePath={ basePath }
 		/>
 	);

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -9,9 +9,10 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SearchableSitesTableProps {
 	sites: SiteData[];
+	siteBasePath: string;
 }
 
-export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
+export function SearchableSitesTable( { sites, siteBasePath }: SearchableSitesTableProps ) {
 	const { __ } = useI18n();
 
 	const [ term, setTerm ] = useState( '' );
@@ -46,7 +47,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 						/>
 					</div>
 					{ filteredSites.length > 0 ? (
-						<SitesTable sites={ filteredSites } />
+						<SitesTable sites={ filteredSites } siteBasePath={ siteBasePath } />
 					) : (
 						<h2>{ __( 'No sites match your search.' ) }</h2>
 					) }

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -22,12 +22,13 @@ const Title = styled.div`
 type SitesContainerProps = {
 	sites: SiteData[];
 	status: string;
+	siteBasePath?: string;
 };
 
-export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
+export const SitesContainer = ( { sites, status, siteBasePath }: SitesContainerProps ) => {
 	const { __ } = useI18n();
 	if ( sites.length > 0 ) {
-		return <SearchableSitesTable sites={ sites } />;
+		return <SearchableSitesTable sites={ sites } siteBasePath={ siteBasePath || '/home' } />;
 	}
 
 	if ( status === 'launched' ) {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -10,6 +10,7 @@ import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
 	launchStatus?: string;
+	siteBasePath?: string;
 }
 
 const MAX_PAGE_WIDTH = '1184px';
@@ -58,7 +59,7 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
-export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
+export function SitesDashboard( { launchStatus, siteBasePath }: SitesDashboardProps ) {
 	const { __ } = useI18n();
 	const sites = useSelector( getSites );
 
@@ -86,7 +87,11 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 							launchStatus={ launchStatus }
 						>
 							{ ( filteredSites, status ) => (
-								<SitesContainer sites={ filteredSites } status={ status } />
+								<SitesContainer
+									sites={ filteredSites }
+									status={ status }
+									siteBasePath={ siteBasePath }
+								/>
 							) }
 						</SitesTableFilterTabs>
 					) }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -10,6 +10,7 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 interface SiteTableRowProps {
 	site: SiteData;
+	siteBasePath: string;
 }
 
 const Row = styled.tr`
@@ -52,8 +53,8 @@ const SiteUrl = styled.a`
 	}
 `;
 
-const getDashboardUrl = ( slug: string ) => {
-	return '/home/' + slug;
+const getDashboardUrl = ( slug: string, siteBasePath: string ) => {
+	return siteBasePath + '/' + slug;
 };
 
 const displaySiteUrl = ( siteUrl: string ) => {
@@ -63,13 +64,13 @@ const displaySiteUrl = ( siteUrl: string ) => {
 const VisitDashboardItem = ( { site }: { site: SiteData } ) => {
 	const { __ } = useI18n();
 	return (
-		<PopoverMenuItem href={ getDashboardUrl( site.slug ) }>
+		<PopoverMenuItem href={ getDashboardUrl( site.slug, '/home' ) }>
 			{ __( 'Visit Dashboard' ) }
 		</PopoverMenuItem>
 	);
 };
 
-export default function SitesTableRow( { site }: SiteTableRowProps ) {
+export default function SitesTableRow( { site, siteBasePath }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 
 	const isComingSoon =
@@ -83,7 +84,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					leading={
 						<a
 							style={ { display: 'block' } }
-							href={ getDashboardUrl( site.slug ) }
+							href={ getDashboardUrl( site.slug, siteBasePath ) }
 							title={ __( 'Visit Dashboard' ) }
 						>
 							<SiteIcon siteId={ site.ID } size={ 50 } />
@@ -92,7 +93,10 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					title={
 						<div style={ { display: 'flex', alignItems: 'center', marginBottom: '8px' } }>
 							<SiteName style={ { marginRight: '8px' } }>
-								<a href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
+								<a
+									href={ getDashboardUrl( site.slug, siteBasePath ) }
+									title={ __( 'Visit Dashboard' ) }
+								>
 									{ site.name ? site.name : __( '(No Site Title)' ) }
 								</a>
 							</SiteName>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -6,6 +6,7 @@ import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 interface SitesTableProps {
 	className?: string;
 	sites: SiteData[];
+	siteBasePath: string;
 }
 
 const Table = styled.table`
@@ -32,7 +33,7 @@ const Row = styled.tr`
 	}
 `;
 
-export function SitesTable( { className, sites }: SitesTableProps ) {
+export function SitesTable( { className, sites, siteBasePath }: SitesTableProps ) {
 	const { __ } = useI18n();
 
 	return (
@@ -47,7 +48,11 @@ export function SitesTable( { className, sites }: SitesTableProps ) {
 			</thead>
 			<tbody>
 				{ sites.map( ( site ) => (
-					<SitesTableRow site={ site } key={ site.ID }></SitesTableRow>
+					<SitesTableRow
+						site={ site }
+						key={ site.ID }
+						siteBasePath={ siteBasePath }
+					></SitesTableRow>
 				) ) }
 			</tbody>
 		</Table>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -17,7 +17,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
-			<SitesDashboard launchStatus={ context.query.status } />
+			<SitesDashboard launchStatus={ context.query.status } siteBasePath={ context.query.return } />
 		</>
 	);
 	next();


### PR DESCRIPTION
#### Proposed Changes

Another way to hook the new sites management dashboard into the "All My Sites" button. Other options are #65524 and #65524

This PR is a bit like #65524 in that it customises the link in the sidebar rather than customising the sites controller (which increases the bundle sizes a lot). Except this PR doesn't attempt to take over the `/sites` route.

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #