### PR TITLE
Remove unnecessary translation check in Gravatar settings

### DIFF
--- a/client/me/profile/updated-gravatar-string.js
+++ b/client/me/profile/updated-gravatar-string.js
@@ -1,10 +1,9 @@
-import { englishLocales } from '@automattic/i18n-utils';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 
 class UpdatedGravatarString extends Component {
 	render() {
-		const { translate, locale, gravatarProfileLink } = this.props;
+		const { translate, gravatarProfileLink } = this.props;
 		const stringParts = {
 			components: {
 				spanLead: <strong className="profile__link-destination-label-lead" />,
@@ -15,18 +14,10 @@ class UpdatedGravatarString extends Component {
 				),
 			},
 		};
-		return englishLocales.includes( locale ) ||
-			i18n.hasTranslation(
-				'{{spanLead}}Hide my photo and Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your photo and {{profileLink}}Gravatar profile{{/profileLink}} from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles can be deleted at {{deleteLink}}Gravatar.com{{/deleteLink}}.{{/spanExtra}}'
-			)
-			? translate(
-					'{{spanLead}}Hide my photo and Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your photo and {{profileLink}}Gravatar profile{{/profileLink}} from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles can be deleted at {{deleteLink}}Gravatar.com{{/deleteLink}}.{{/spanExtra}}',
-					stringParts
-			  )
-			: translate(
-					'{{spanLead}}Hide my Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your {{profileLink}}Gravatar profile{{/profileLink}} and photo from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles can be deleted at {{deleteLink}}Gravatar.com{{/deleteLink}}.{{/spanExtra}}',
-					stringParts
-			  );
+		return translate(
+			'{{spanLead}}Hide my photo and Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your photo and {{profileLink}}Gravatar profile{{/profileLink}} from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles can be deleted at {{deleteLink}}Gravatar.com{{/deleteLink}}.{{/spanExtra}}',
+			stringParts
+		);
 	}
 }
 export default localize( UpdatedGravatarString );


### PR DESCRIPTION
#### Proposed Changes

Tidy the `hasTranslation` check that was added in #65122. [The translations are now complete](https://translate.wordpress.com/deliverables/overview/7419597).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Take a look at the `/me` UI to make sure the copy still works as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [ ] ~~Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?~~

Related to #65122