### PR TITLE
Marketplace: preventWidows on educational section title.

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import FeatureItem from 'calypso/components/feature-item';
 import LinkCard from 'calypso/components/link-card';
 import Section from 'calypso/components/section';
+import { preventWidows } from 'calypso/lib/formatting';
 
 const ThreeColumnContainer = styled.div`
 	@media ( max-width: 960px ) {
@@ -64,7 +65,12 @@ const EducationFooter = () => {
 					/>
 				</ThreeColumnContainer>
 			</Section>
-			<Section header={ __( 'Add additional features to your WordPress site. Risk free.' ) } dark>
+			<Section
+				header={ preventWidows(
+					__( 'Add additional features to your WordPress site. Risk free.' )
+				) }
+				dark
+			>
 				<ThreeColumnContainer>
 					<FeatureItem header={ __( 'Fully Managed' ) }>
 						{ __(


### PR DESCRIPTION
#### Proposed Changes

* Prevents widow words in /plugins educational section title.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins 
* Scroll to the bottom
* Inspect that the section title `Add additional features to your WordPress site. Risk free.` doesn't leave a single word in the last sentence

![CleanShot 2022-07-15 at 09 41 26@2x](https://user-images.githubusercontent.com/12430020/179166424-deef0a60-3966-422c-b416-d8f9b060220f.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Fixes #65460