### PR TITLE
Repo gardening: add new task to gather all ticket references

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -4,7 +4,9 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
+  issue_comment: # To gather support references in issue comments.
+    types: [created]
 concurrency:
   # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
   # Don't cancel any for other events, accomplished by grouping on the unique run_id.
@@ -40,4 +42,4 @@ jobs:
          slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
          slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues'
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues,gatherSupportReferences'


### PR DESCRIPTION
#### Proposed Changes

This will create a new comment on each issue, gathering all ticket and chat links into a single comment that can be used when reaching out to customers once an issue has been fixed.

This was implemented in https://github.com/Automattic/jetpack/pull/25066/

#### Testing Instructions

This can only be tested once it's merged and running on `trunk`. You can, however, see how things will look like in this issue:
https://github.com/jeherve/jetpack/issues/43

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?

Internal references:
- pciE2j-18N-p2
- pcLjiI-QJ-p2#comment-806
