### PR TITLE
Show post-checkout Professional Email upsell to domain only users

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -31,6 +31,7 @@ import {
 	isRenewable,
 	isSiteRedirect,
 	isSpaceUpgrade,
+	isStarter,
 	isTitanMail,
 	isTrafficGuide,
 	isUnlimitedSpace,
@@ -115,6 +116,10 @@ export function hasProPlan( cart: ResponseCart ): boolean {
 
 export function hasBusinessPlan( cart: ResponseCart ): boolean {
 	return getAllCartItems( cart ).some( isBusiness );
+}
+
+export function hasStarterPlan( cart: ResponseCart ): boolean {
+	return getAllCartItems( cart ).some( isStarter );
 }
 
 export function hasDomainCredit( cart: ResponseCart ): boolean {

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -55,7 +55,7 @@ import type {
 	MinimalRequestCartProduct,
 } from '@automattic/shopping-cart';
 
-export function getAllCartItems( cart: ResponseCart ): ResponseCartProduct[] {
+export function getAllCartItems( cart?: ResponseCart ): ResponseCartProduct[] {
 	return ( cart && cart.products ) || [];
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -372,7 +372,7 @@ export class CheckoutThankYou extends Component {
 	};
 
 	render() {
-		const { translate, isHappychatEligible, email } = this.props;
+		const { translate, isHappychatEligible, email, selectedSite } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -384,6 +384,7 @@ export class CheckoutThankYou extends Component {
 		let wasGSuiteOrGoogleWorkspace = false;
 		let wasTitanEmailOnlyProduct = false;
 		let wasTitanEmailProduct = false;
+		let wasDomainOnly = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props ).filter( ( purchase ) => ! isCredits( purchase ) );
@@ -403,6 +404,11 @@ export class CheckoutThankYou extends Component {
 			);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
 			wasTitanEmailOnlyProduct = purchases.length === 1 && purchases.some( isTitanMail );
+			wasDomainOnly =
+				selectedSite?.options?.is_domain_only &&
+				purchases.every(
+					( purchase ) => isDomainMapping( purchase ) || isDomainRegistration( purchase )
+				);
 		} else if ( isStarterPlanEnabled() ) {
 			// Don't show the Happiness support until we figure out the user doesn't have a starter plan
 			showHappinessSupport = false;
@@ -483,7 +489,7 @@ export class CheckoutThankYou extends Component {
 					domain={ domainName }
 					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
-					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace }
+					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace || wasDomainOnly }
 					selectedSiteSlug={ this.props.selectedSiteSlug }
 					type={ purchaseType }
 				/>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -372,7 +372,7 @@ export class CheckoutThankYou extends Component {
 	};
 
 	render() {
-		const { translate, isHappychatEligible, email, selectedSite } = this.props;
+		const { translate, isHappychatEligible, email } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -384,7 +384,6 @@ export class CheckoutThankYou extends Component {
 		let wasGSuiteOrGoogleWorkspace = false;
 		let wasTitanEmailOnlyProduct = false;
 		let wasTitanEmailProduct = false;
-		let wasDomainOnly = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props ).filter( ( purchase ) => ! isCredits( purchase ) );
@@ -404,11 +403,6 @@ export class CheckoutThankYou extends Component {
 			);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
 			wasTitanEmailOnlyProduct = purchases.length === 1 && purchases.some( isTitanMail );
-			wasDomainOnly =
-				selectedSite?.options?.is_domain_only &&
-				purchases.every(
-					( purchase ) => isDomainMapping( purchase ) || isDomainRegistration( purchase )
-				);
 		} else if ( isStarterPlanEnabled() ) {
 			// Don't show the Happiness support until we figure out the user doesn't have a starter plan
 			showHappinessSupport = false;
@@ -489,7 +483,7 @@ export class CheckoutThankYou extends Component {
 					domain={ domainName }
 					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
-					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace || wasDomainOnly }
+					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace }
 					selectedSiteSlug={ this.props.selectedSiteSlug }
 					type={ purchaseType }
 				/>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -499,6 +499,7 @@ export class CheckoutThankYou extends Component {
 				<TitanSetUpThankYou
 					domainName={ purchases[ 0 ].meta }
 					emailAddress={ email }
+					isDomainOnlySite={ this.props.domainOnlySiteFlow }
 					subtitle={ translate( 'You will receive an email confirmation shortly.' ) }
 					title={ translate( 'Congratulations on your purchase!' ) }
 				/>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -9,6 +9,7 @@ import {
 	isPlan,
 	isWpComPremiumPlan,
 	isTitanMail,
+	isDomainRegistration,
 } from '@automattic/calypso-products';
 import {
 	URL_TYPE,
@@ -35,6 +36,7 @@ import {
 	hasTrafficGuide,
 	hasDIFMProduct,
 	hasProPlan,
+	hasStarterPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
@@ -281,9 +283,10 @@ export default function getThankYouPageUrl( {
 	}
 
 	const signupFlowName = getSignupCompleteFlowName();
+	const isDomainOnly = siteSlug === 'no-site' && cart?.products.every( isDomainRegistration );
 
 	// Domain only flow
-	if ( cart?.create_new_blog || signupFlowName === 'domain' ) {
+	if ( ( cart?.create_new_blog || signupFlowName === 'domain' ) && ! isDomainOnly ) {
 		clearSignupCompleteFlowName();
 		const newBlogReceiptUrl = urlFromCookie
 			? `${ urlFromCookie }/${ pendingOrReceiptId }`
@@ -302,6 +305,7 @@ export default function getThankYouPageUrl( {
 			siteSlug,
 			hideUpsell: Boolean( hideNudge ),
 			domains,
+			isDomainOnly,
 		} );
 
 		if ( redirectUrlForPostCheckoutUpsell ) {
@@ -517,12 +521,14 @@ function getRedirectUrlForPostCheckoutUpsell( {
 	siteSlug,
 	hideUpsell,
 	domains,
+	isDomainOnly,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	hideUpsell: boolean;
 	domains: ResponseDomain[] | undefined;
+	isDomainOnly?: boolean;
 } ): string | undefined {
 	if ( hideUpsell ) {
 		return;
@@ -532,6 +538,7 @@ function getRedirectUrlForPostCheckoutUpsell( {
 		cart,
 		siteSlug,
 		domains,
+		isDomainOnly,
 	} );
 
 	if ( professionalEmailUpsellUrl ) {
@@ -566,11 +573,13 @@ function getProfessionalEmailUpsellUrl( {
 	cart,
 	siteSlug,
 	domains,
+	isDomainOnly,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	domains: ResponseDomain[] | undefined;
+	isDomainOnly?: boolean;
 } ): string | undefined {
 	if ( ! cart ) {
 		return;
@@ -585,11 +594,13 @@ function getProfessionalEmailUpsellUrl( {
 	}
 
 	if (
+		! isDomainOnly &&
 		! hasBloggerPlan( cart ) &&
 		! hasPersonalPlan( cart ) &&
 		! hasBusinessPlan( cart ) &&
 		! hasEcommercePlan( cart ) &&
-		! hasProPlan( cart )
+		! hasProPlan( cart ) &&
+		! hasStarterPlan( cart )
 	) {
 		return;
 	}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -283,7 +283,8 @@ export default function getThankYouPageUrl( {
 	}
 
 	const signupFlowName = getSignupCompleteFlowName();
-	const isDomainOnly = siteSlug === 'no-site' && cart?.products.every( isDomainRegistration );
+	const isDomainOnly =
+		siteSlug === 'no-site' && getAllCartItems( cart ).every( isDomainRegistration );
 
 	// Domain only flow
 	if ( ( cart?.create_new_blog || signupFlowName === 'domain' ) && ! isDomainOnly ) {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -1294,6 +1294,30 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
+		it( 'Is displayed if user is buying a domain only registration', () => {
+			const cart = {
+				...getEmptyResponseCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						is_domain_registration: true,
+						meta: 'foo.bar',
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: 'no-site',
+				cart,
+				receiptId: samplePurchaseId,
+			} );
+
+			expect( url ).toBe(
+				`/checkout/offer-professional-email/foo.bar/${ samplePurchaseId }/no-site`
+			);
+		} );
+
 		it( 'Is not displayed if cart is missing', () => {
 			const url = getThankYouPageUrl( {
 				...defaultArgs,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -199,7 +199,7 @@ export default function () {
 	}
 
 	page(
-		'/checkout/offer-professional-email/:domain/:receiptId/:site',
+		'/checkout/offer-professional-email/:domain/:receiptId/:site?',
 		redirectLoggedOut,
 		siteSelection,
 		upsellNudge,

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -155,7 +155,7 @@ const ProfessionalEmailUpsell = ( {
 		<div>
 			<header className="professional-email-upsell__header">
 				<h3 className="professional-email-upsell__small-title">
-					{ translate( "Hold tight, we're getting your site ready." ) }
+					{ translate( "Hold tight, we're getting things ready." ) }
 				</h3>
 				<h1 className="professional-email-upsell__title wp-brand-font">
 					{ translate( 'Add Professional Email @%(domain)s', {

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -24,6 +24,7 @@ import {
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductCost } from 'calypso/state/products-list/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -85,6 +86,9 @@ const ProfessionalEmailUpsell = ( {
 
 		return getProductCost( state, TITAN_MAIL_MONTHLY_SLUG );
 	} );
+
+	const selectedSite = useSelector( getSelectedSite );
+	const isDomainOnlySite = selectedSite?.options?.is_domain_only ?? false;
 
 	const isMobileView = useBreakpoint( MOBILE_BREAKPOINT );
 
@@ -155,7 +159,9 @@ const ProfessionalEmailUpsell = ( {
 		<div>
 			<header className="professional-email-upsell__header">
 				<h3 className="professional-email-upsell__small-title">
-					{ translate( "Hold tight, we're getting things ready." ) }
+					{ isDomainOnlySite
+						? translate( "Hold tight, we're getting your domain ready." )
+						: translate( "Hold tight, we're getting your site ready." ) }
 				</h3>
 				<h1 className="professional-email-upsell__title wp-brand-font">
 					{ translate( 'Add Professional Email @%(domain)s', {

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -42,7 +42,9 @@ const TitanSetUpThankYou = ( {
 	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 	const translate = useTranslate();
 
-	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
+	const emailManagementPath = selectedSiteSlug
+		? emailManagement( selectedSiteSlug, domainName, currentRoute )
+		: '/email';
 	const inboxPath = emailManagementInbox( selectedSiteSlug );
 
 	const thankYouImage = {

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -25,6 +25,7 @@ type TitanSetUpThankYouProps = {
 	containerClassName?: string;
 	domainName: string;
 	emailAddress?: string;
+	isDomainOnlySite?: boolean;
 	title?: string;
 	subtitle?: string;
 };
@@ -33,18 +34,17 @@ const TitanSetUpThankYou = ( {
 	containerClassName,
 	domainName,
 	emailAddress,
+	isDomainOnlySite = false,
 	subtitle,
 	title,
 }: TitanSetUpThankYouProps ) => {
 	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSite = useSelector( getSelectedSite );
-	const selectedSiteSlug = selectedSite?.slug ?? null;
+	const selectedSiteSlug = selectedSite?.slug ?? ( isDomainOnlySite ? domainName : null );
 	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 	const translate = useTranslate();
 
-	const emailManagementPath = selectedSiteSlug
-		? emailManagement( selectedSiteSlug, domainName, currentRoute )
-		: '/email';
+	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
 	const inboxPath = emailManagementInbox( selectedSiteSlug );
 
 	const thankYouImage = {


### PR DESCRIPTION
#### Proposed Changes

We recently discussed the possibility of displaying the post-checkout Professional Email upsell after domain only checkouts (i.e. domain purchases that start at wordpress.com/domains/). This change adds that functionality. For more context, see: pbLl1t-1cg-p2#comment-993 

Before this is merged, we should consider if this should be launched as an A/B test.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch, start Calypso locally
2. Navigate to `http://calypso.localhost:3000/domains`
3. Add a domain to your cart and complete checkout (without any additional products in your cart)
4. Ensure that the thank you page displayed after checkout is `http://calypso.localhost:3000/checkout/offer-professional-email/:domain/:receiptId/:site` and that it shows the appropriate content (see screenshot below)

<img width="1498" alt="Screen Shot 2022-07-15 at 10 40 30" src="https://user-images.githubusercontent.com/1101677/179187520-48e3663b-ca44-4709-b870-47665409c63d.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #
