### PR TITLE
Improve "Installed plugins" navigation

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -75,7 +75,10 @@ export class PluginsMain extends Component {
 			}
 		} );
 
-		if ( prevProps.isRequestingSites && ! this.props.isRequestingSites ) {
+		if (
+			( prevProps.isRequestingSites && ! this.props.isRequestingSites ) ||
+			prevProps.selectedSiteSlug !== selectedSiteSlug
+		) {
 			// Selected site is not a Jetpack site
 			if (
 				selectedSiteSlug &&

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -400,7 +400,13 @@ const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
 	);
 };
 
-const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpackNonAtomic } ) => {
+const ManageButton = ( {
+	shouldShowManageButton,
+	siteAdminUrl,
+	siteSlug,
+	jetpackNonAtomic,
+	hasManagePlugins,
+} ) => {
 	const translate = useTranslate();
 
 	if ( ! shouldShowManageButton ) {
@@ -410,10 +416,11 @@ const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpack
 	const site = siteSlug ? '/' + siteSlug : '';
 
 	// When no site is selected eg `/plugins` or when Jetpack is self hosted
-	// show the Calypso Plugins Manage page.
+	// or if the site does not have the manage plugins feature show the
+	// Calypso Plugins Manage page.
 	// In any other case, redirect to current site WP Admin.
 	const managePluginsDestination =
-		! siteAdminUrl || jetpackNonAtomic
+		! siteAdminUrl || jetpackNonAtomic || ! hasManagePlugins
 			? `/plugins/manage${ site }`
 			: `${ siteAdminUrl }plugins.php`;
 
@@ -691,6 +698,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 							siteAdminUrl={ siteAdminUrl }
 							siteSlug={ siteSlug }
 							jetpackNonAtomic={ jetpackNonAtomic }
+							hasManagePlugins={ hasManagePlugins }
 						/>
 
 						<UploadPluginButton


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65101

#### Proposed Changes

- Redirect from `/plugins/manage` to `/plugins` for Simple sites
- "Installed plugins" now links to `/plugins/manage` on Limited Atomic sites


#### Testing Instructions

- Use the Calypso live link below
- Switch to a Limited Atomic site
- Click on "Installed plugins"
- Make sure you land on `/plugins/manage` directly (without passing through `wp-admin/plugins.php`)
- Switch to a Simple site
- Make sure you are redirected to `/plugins`