### PR TITLE
Support self-service account closures for Atomic sites

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -23,7 +23,6 @@ import getUserPurchasedPremiumThemes from 'calypso/state/selectors/get-user-purc
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import isAccountClosed from 'calypso/state/selectors/is-account-closed';
-import userHasAnyAtomicSites from 'calypso/state/selectors/user-has-any-atomic-sites';
 import AccountCloseConfirmDialog from './confirm-dialog';
 
 import './style.scss';
@@ -67,9 +66,8 @@ class AccountSettingsClose extends Component {
 	};
 
 	render() {
-		const { translate, hasAtomicSites, hasCancelablePurchases, isLoading, purchasedPremiumThemes } =
-			this.props;
-		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
+		const { translate, hasCancelablePurchases, isLoading, purchasedPremiumThemes } = this.props;
+		const isDeletePossible = ! isLoading && ! hasCancelablePurchases;
 		const containerClasses = classnames( 'account-close', 'main', 'is-wide-layout', {
 			'is-loading': isLoading,
 			'is-hiding-other-sites': this.state.showSiteDropdown,
@@ -135,28 +133,8 @@ class AccountSettingsClose extends Component {
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
-						{ ! isLoading && hasAtomicSites && (
-							<Fragment>
-								<p className="account-close__body-copy">
-									{ translate(
-										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
-									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate(
-										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
-									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
-										components: {
-											a: <ActionPanelLink href="/help/contact" />,
-										},
-									} ) }
-								</p>
-							</Fragment>
-						) }
-						{ ! isLoading && hasCancelablePurchases && ! hasAtomicSites && (
+
+						{ ! isLoading && hasCancelablePurchases && (
 							<Fragment>
 								<p className="account-close__body-copy">
 									{ translate( 'You still have active purchases on your account.' ) }
@@ -227,18 +205,17 @@ class AccountSettingsClose extends Component {
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ ( isLoading || isDeletePossible ) && (
-							<Button scary onClick={ this.handleDeleteClick }>
+							<Button
+								scary
+								onClick={ this.handleDeleteClick }
+								data-testid={ 'close-account-button' }
+							>
 								<Gridicon icon="trash" />
 								{ translate( 'Close account', { context: 'button label' } ) }
 							</Button>
 						) }
-						{ hasAtomicSites && (
-							<Button primary href="/help/contact">
-								{ translate( 'Contact support' ) }
-							</Button>
-						) }
-						{ hasCancelablePurchases && ! hasAtomicSites && (
-							<Button primary href="/me/purchases">
+						{ hasCancelablePurchases && (
+							<Button primary href="/me/purchases" data-testid={ 'manage-purchases-button' }>
 								{ translate( 'Manage purchases', { context: 'button label' } ) }
 							</Button>
 						) }
@@ -265,7 +242,6 @@ export default connect(
 			isLoading,
 			hasCancelablePurchases: hasCancelableUserPurchases( state ),
 			purchasedPremiumThemes,
-			hasAtomicSites: userHasAnyAtomicSites( state ),
 			isAccountClosed: isAccountClosed( state ),
 			sitesToBeDeleted: getAccountClosureSites( state ),
 		};

--- a/client/me/account-close/test/main.js
+++ b/client/me/account-close/test/main.js
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import AccountSettingsClose from '../main';
+
+describe( 'AccountSettingsClose', () => {
+	it( 'Shows Manage purchases button when refundable purchases exist', () => {
+		render(
+			<ReduxProvider store={ createTestStore( true ) }>
+				<AccountSettingsClose />
+			</ReduxProvider>
+		);
+		expect( screen.queryByTestId( 'manage-purchases-button' ) ).toBeInTheDocument();
+	} );
+
+	it( 'Allows user to close account if no refundable purchases', () => {
+		render(
+			<ReduxProvider store={ createTestStore( false ) }>
+				<AccountSettingsClose />
+			</ReduxProvider>
+		);
+		expect( screen.queryByTestId( 'close-account-button' ) ).toBeInTheDocument();
+	} );
+} );
+
+function createTestStore( is_refundable ) {
+	return createReduxStore(
+		{
+			currentUser: {
+				id: 1,
+			},
+			purchases: {
+				hasLoadedUserPurchasesFromServer: true,
+				data: [
+					{
+						is_refundable,
+						user_id: 1,
+						product_slug: 'premium_theme',
+					},
+				],
+			},
+			sites: {
+				items: [],
+			},
+		},
+		( state ) => {
+			return state;
+		}
+	);
+}


### PR DESCRIPTION
Fixes #57399

As per @mmtr's comment [here](https://github.com/Automattic/wp-calypso/issues/57399#issuecomment-1180249740), we should allow users with Atomic sites to close them (after removing purchases).

#### Proposed Changes

Remove the `isAtomic`-style logic from the Close Account page. This simplifies the logic so there are now only two scenarios:
1. The user has refundable purchases and is shown the "Manage purchases" button; or
2. The user doesn't have refundable purchases and is shown the "Close account" button.

#### Testing Instructions

I have manually tested this and it worked albeit after a manual refresh. I tried to setup a fresh user and ran into some issues where the user account had purchases disabled. 

#### Pre-merge Checklist

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

