### PR TITLE
Allow to manage all plugins in all sites

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -115,10 +115,10 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	renderCurrentActionButtons() {
-		const { hasManagePluginsFeature, isWpComAtomic, translate } = this.props;
+		const { hasManagePluginsFeature, isWpComAtomic, translate, siteId } = this.props;
 		const buttons = [];
 
-		if ( isWpComAtomic && ! hasManagePluginsFeature ) {
+		if ( siteId && isWpComAtomic && ! hasManagePluginsFeature ) {
 			return buttons;
 		}
 
@@ -381,6 +381,7 @@ export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
+		siteId,
 		allSites: getSites( state ),
 		hasManagePluginsFeature: siteHasFeature( state, siteId, WPCOM_FEATURES_MANAGE_PLUGINS ),
 		isWpComAtomic: isSiteWpcomAtomic( state, siteId ),

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -522,11 +522,11 @@ export class PluginsList extends Component {
 	}
 
 	getAllowedPluginActions( plugin ) {
-		const { hasManagePlugins, siteIsAtomic, siteIsJetpack } = this.props;
+		const { hasManagePlugins, siteIsAtomic, siteIsJetpack, selectedSite } = this.props;
 		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
 		const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
 		const canManagePlugins =
-			( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
+			! selectedSite || ( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
 
 		return {
 			autoupdate: ! isManagedPlugin && canManagePlugins,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65380

#### Proposed Changes

Excludes the "all sites" view from the changes introduced by #65065 so we no longer display the "Auto-managed on this site" on all plugins while also allowing to perform actions on all of them.

Before | After
--- | ---
<img width="1277" alt="Screen Shot 2022-07-15 at 16 46 53" src="https://user-images.githubusercontent.com/1233880/179247657-af219d6a-2a97-414d-86b0-e841b25155b3.png"> | <img width="1275" alt="Screen Shot 2022-07-15 at 16 46 34" src="https://user-images.githubusercontent.com/1233880/179247681-495b93cd-654c-4ce5-8096-83fd7f48929a.png">


#### Testing Instructions

- Use the Calypso live link below
- Go to `/plugins/manage`
- Make sure that none of the plugins display a "Auto-managed on this site" text.
- Click on the "Edit all" button
- Make sure you can perform action in all of them (note that actions performed on plugins installed on Atomic sites with a lower-tier plan will fail, since those sites doesn't allow to manage plugins).
- Switch to an Atomic site with a lower-tier plan
- Make sure you don't see any toggles to manage the plugins
- Make sure you don't see the "Edit all" button either

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?