### PR TITLE
Make Jetpack Cloud upsells redirect back to cloud after checkout.

### DIFF
--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -69,7 +69,10 @@ const BackupsUpsellBody: FunctionComponent = () => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createProductURL = getPurchaseURLCallback( selectedSiteSlug, {} );
+	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
+		// For the Backup upsell in Jetpack Cloud, we want to redirect back here to the Backup page after checkout.
+		redirect_to: window.location.href,
+	} );
 	const dispatch = useDispatch();
 
 	const onClick = useCallback(
@@ -87,7 +90,7 @@ const BackupsUpsellBody: FunctionComponent = () => {
 				productSlug={ PRODUCT_JETPACK_BACKUP_T1_YEARLY }
 				siteId={ siteId }
 				currencyCode={ currencyCode }
-				getButtonURL={ createProductURL }
+				getButtonURL={ createCheckoutURL }
 				onCtaButtonClick={ onClick }
 			/>
 		</>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -164,7 +164,7 @@ export default function getThankYouPageUrl( {
 			return sanitizedRedirectTo;
 		}
 
-		if ( hostname === 'cloud.jetpack.com' ) {
+		if ( hostname === 'cloud.jetpack.com' || hostname === 'jetpack.cloud.localhost' ) {
 			debug( 'returning Jetpack cloud redirectTo', redirectTo );
 			return redirectTo;
 		}

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -589,6 +589,20 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( redirectTo + '&action=edit&plan_upgraded=1' );
 	} );
 
+	it( 'redirects to external redirectTo url if the hostame is cloud.jetpack.com', () => {
+		const adminUrl = 'https://my.site/wp-admin/';
+		const redirectTo = 'https://cloud.jetpack.com/backup/foo.bar';
+		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', adminUrl, redirectTo } );
+		expect( url ).toBe( redirectTo );
+	} );
+
+	it( 'redirects to external redirectTo url if the hostame is jetpack.cloud.localhost', () => {
+		const adminUrl = 'https://my.site/wp-admin/';
+		const redirectTo = 'http://jetpack.cloud.localhost:3000/backup/foo.bar';
+		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', adminUrl, redirectTo } );
+		expect( url ).toBe( redirectTo );
+	} );
+
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
 			...getEmptyResponseCart(),

--- a/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
@@ -39,7 +39,10 @@ export default function JetpackSearchUpsell(): ReactElement {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createProductURL = getPurchaseURLCallback( selectedSiteSlug, {} );
+	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
+		// For the Search upsell in Jetpack Cloud, we want to redirect back here to the Search page after checkout.
+		redirect_to: window.location.href,
+	} );
 
 	const WPComUpgradeUrl =
 		'https://jetpack.com/upgrade/search/?utm_campaign=my-sites-jetpack-search&utm_source=calypso&site=' +
@@ -66,7 +69,7 @@ export default function JetpackSearchUpsell(): ReactElement {
 						productSlug={ PRODUCT_JETPACK_SEARCH }
 						siteId={ siteId }
 						currencyCode={ currencyCode }
-						getButtonURL={ createProductURL }
+						getButtonURL={ createCheckoutURL }
 						onCtaButtonClick={ onClick }
 					/>
 				</div>

--- a/client/my-sites/scan/scan-upsell/index.jsx
+++ b/client/my-sites/scan/scan-upsell/index.jsx
@@ -67,7 +67,10 @@ function ScanUpsellBody() {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createProductURL = getPurchaseURLCallback( selectedSiteSlug, {} );
+	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
+		// For the Scan upsell in Jetpack Cloud, we want to redirect back here to the Scan page after checkout.
+		redirect_to: window.location.href,
+	} );
 	const dispatch = useDispatch();
 
 	const onClick = useCallback(
@@ -85,7 +88,7 @@ function ScanUpsellBody() {
 				productSlug={ PRODUCT_JETPACK_SCAN }
 				siteId={ siteId }
 				currencyCode={ currencyCode }
-				getButtonURL={ createProductURL }
+				getButtonURL={ createCheckoutURL }
 				onCtaButtonClick={ onClick }
 			/>
 		</>


### PR DESCRIPTION
#### Proposed Changes

This PR makes the Jetpack Cloud upsells for Backup, Scan, and Search, redirect back to the respective page on Jetpack Cloud after completing checkout. (See video below) - instead of redirecting to the site's Jetpack Assistant.

Currently, when clicking the CTA in the Backup, Scan, or Search upsells in Jetpack Cloud, after checking out, the user is redirected to the Assistant in the sites wp-admin Jetpack dashboard.  This is undesired, and instead the user should be redirected back to the Jetpack Cloud product page after checkout.

Asana task: 1164141197617539-as-1202157991753738/f

**Screencast video showing the checkout flow in this PR and how it now redirects back to Jetpack cloud (with Scan).**:

https://user-images.githubusercontent.com/11078128/179270670-3e23d4bd-380b-437c-b93e-adc0a36afb19.mp4


#### Testing Instructions

- Checkout this PR and spin up Calypso blue and green concurrently (`yarn start` and `yarn start-jetpack-cloud-p`)
- Open http://jetpack.cloud.localhost:3001, select a Jetpack site with no products or plans purchased. (Or create a new Jurassic Ninja site and connect Jetpack with Jetpack Free.)
- Once your site is selected, navigate to Backup, you should see the Backup upsell.
- Click "Get Backup" in the upsell, you will be taken to wordpress.com checkout.
- In the url, replace `wordpress.com` with `calypso.localhost:3000`, and reload the checkout page.
- Click to purchase Backup with credits.
- Verify you are redirected back to the Jetpack Cloud _Backup_ page, instead of the sites wp-admin Jetpack Assistant. (see screencast video above showing example of testing this flow with Scan.)
- Perform the same steps for above for the **Scan** upsell and the **Search** upsell. Verify that purchasing Scan and Search both redirect back to the respective page (Scan or Search) on Jetpack Cloud and not back to the site assistant..

#### Unit tests
run `yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts`
Verify all tests pass.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **Yes**
- [X] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? **Yes**, only self-hosted Jetpack sites that are shown in Jetpack Cloud are affected by this new post-checkout redirect.
- [ ] Have you checked for TypeScript, React or other console errors? **Yes**
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) **N/A**
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? **N/A**

Related to #