### PR TITLE
Sites Dashboard: Fix warnings for `SitesSearchIcon`

### DIFF
--- a/client/sites-dashboard/components/sites-search-icon.tsx
+++ b/client/sites-dashboard/components/sites-search-icon.tsx
@@ -16,16 +16,16 @@ export const SitesSearchIcon = () => {
 			<path
 				d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z"
 				stroke="#8C8F94"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
 			/>
 			<path
 				d="M17.5 17.5L13.875 13.875"
 				stroke="#8C8F94"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
 			/>
 		</svg>
 	);


### PR DESCRIPTION
## Proposed Changes

Fixes the following warning:

```
react_devtools_backend.js:4026 Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?
    at path
    at svg
    at SitesSearchIcon
    at div
```

See conversation in p1657904042892329-slack-C0347E545HR

## Testing Instructions

1. Open `/sites-dashboard`.
2. See the console clear of warnings.

## Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?
