### PR TITLE
Checkout: Allow getThankYouPageUrl to return upsells when an order is present

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -298,7 +298,6 @@ export default function getThankYouPageUrl( {
 	if ( isReceiptIdOrPlaceholder( pendingOrReceiptId ) ) {
 		const redirectUrlForPostCheckoutUpsell = getRedirectUrlForPostCheckoutUpsell( {
 			receiptId: pendingOrReceiptId,
-			orderId: orderId ? Number( orderId ) : undefined,
 			cart,
 			siteSlug,
 			hideUpsell: Boolean( hideNudge ),
@@ -496,17 +495,11 @@ function getPlanUpgradeUpsellUrl( {
 	receiptId,
 	cart,
 	siteSlug,
-	orderId,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
-	orderId: number | undefined;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 } ): string | undefined {
-	if ( orderId ) {
-		return;
-	}
-
 	if ( cart && hasPremiumPlan( cart ) ) {
 		const upgradeItem = getNextHigherPlanSlug( cart );
 
@@ -520,14 +513,12 @@ function getPlanUpgradeUpsellUrl( {
 
 function getRedirectUrlForPostCheckoutUpsell( {
 	receiptId,
-	orderId,
 	cart,
 	siteSlug,
 	hideUpsell,
 	domains,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
-	orderId: number | undefined;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	hideUpsell: boolean;
@@ -539,7 +530,6 @@ function getRedirectUrlForPostCheckoutUpsell( {
 	const professionalEmailUpsellUrl = getProfessionalEmailUpsellUrl( {
 		receiptId,
 		cart,
-		orderId,
 		siteSlug,
 		domains,
 	} );
@@ -562,7 +552,6 @@ function getRedirectUrlForPostCheckoutUpsell( {
 		const planUpgradeUpsellUrl = getPlanUpgradeUpsellUrl( {
 			receiptId,
 			cart,
-			orderId,
 			siteSlug,
 		} );
 
@@ -576,16 +565,14 @@ function getProfessionalEmailUpsellUrl( {
 	receiptId,
 	cart,
 	siteSlug,
-	orderId,
 	domains,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
-	orderId: number | undefined;
 	domains: ResponseDomain[] | undefined;
 } ): string | undefined {
-	if ( orderId || ! cart ) {
+	if ( ! cart ) {
 		return;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -27,6 +27,7 @@ jest.mock( '@automattic/calypso-products', () => ( {
 } ) );
 
 const samplePurchaseId = 12342424241;
+const sampleOrderId = 5423525543;
 
 const defaultArgs = {
 	getUrlFromCookie: jest.fn( () => null ),
@@ -79,9 +80,9 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			orderId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/pending/${ samplePurchaseId }` );
+		expect( url ).toBe( `/checkout/thank-you/foo.bar/pending/${ sampleOrderId }` );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receipt id when a site but no orderId is set and the cart contains the personal plan', () => {
@@ -163,7 +164,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
-			orderId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/features/all-free-features/foo.bar` );
 	} );
@@ -812,10 +813,10 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			orderId: samplePurchaseId,
+			orderId: sampleOrderId,
 			getUrlFromCookie,
 		} );
-		expect( url ).toBe( `/cookie/pending/${ samplePurchaseId }` );
+		expect( url ).toBe( `/cookie/pending/${ sampleOrderId }` );
 	} );
 
 	it( 'redirects to url from cookie followed by placeholder receiptId if create_new_blog is set and there is no receipt', () => {
@@ -1021,10 +1022,10 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			orderId: samplePurchaseId,
+			orderId: sampleOrderId,
 			cart,
 		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/pending/${ samplePurchaseId }` );
+		expect( url ).toBe( `/checkout/thank-you/foo.bar/pending/${ sampleOrderId }` );
 	} );
 
 	it( 'redirects to the thank you page if jetpack is not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -63,6 +63,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			receiptId: String( samplePurchaseId ),
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -72,6 +73,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -153,6 +155,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe(
 			`/checkout/thank-you/features/all-free-features/foo.bar/${ samplePurchaseId }`
@@ -769,6 +772,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 			getUrlFromCookie,
 		} );
 		expect( url ).toBe( `/cookie/${ samplePurchaseId }` );
@@ -792,6 +796,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 			getUrlFromCookie,
 		} );
 		expect( url ).toBe( `/cookie/${ samplePurchaseId }` );
@@ -893,6 +898,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -915,6 +921,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -941,6 +948,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }?d=concierge` );
 	} );
@@ -963,6 +971,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -983,6 +992,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/${ samplePurchaseId }` );
 	} );
@@ -1003,6 +1013,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe(
 			`/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
@@ -1043,6 +1054,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -1062,6 +1074,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -1081,6 +1094,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }?d=concierge` );
 	} );
@@ -1152,6 +1166,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1176,6 +1191,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1200,6 +1216,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1224,6 +1241,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1253,6 +1271,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1266,6 +1285,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1288,6 +1308,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1310,6 +1331,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1333,6 +1355,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1359,6 +1382,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				domains,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1382,6 +1406,7 @@ describe( 'getThankYouPageUrl', () => {
 				domains,
 				hideNudge: true,
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				siteSlug: 'foo.bar',
 			} );
 
@@ -1404,6 +1429,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
@@ -1423,6 +1449,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 			hideNudge: true,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
@@ -1443,6 +1470,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }?d=traffic-guide` );
 	} );
@@ -1462,6 +1490,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: samplePurchaseId,
+			orderId: sampleOrderId,
 			isJetpackNotAtomic: true,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }?d=traffic-guide` );
@@ -1531,6 +1560,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: 'foo.bar',
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				cart,
 			} );
 			expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/${ samplePurchaseId }` );
@@ -1551,6 +1581,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: 'foo.bar',
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				cart,
 			} );
 			expect( url ).toBe(
@@ -1573,6 +1604,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: 'foo.bar',
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				cart,
 			} );
 			expect( url ).toBe(
@@ -1599,6 +1631,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: 'foo.bar',
 				receiptId: samplePurchaseId,
+				orderId: sampleOrderId,
 				cart,
 			} );
 			expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
@@ -1643,6 +1676,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				isJetpackCheckout: true,
 				receiptId: 80023,
+				orderId: sampleOrderId,
 			} );
 			expect( url ).toBe(
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023'
@@ -1665,6 +1699,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				isJetpackCheckout: true,
 				receiptId: '80023',
+				orderId: sampleOrderId,
 			} );
 			expect( url ).toBe(
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023'
@@ -1711,6 +1746,7 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 				isJetpackCheckout: true,
 				receiptId: 80023,
+				orderId: sampleOrderId,
 				jetpackTemporarySiteId: '123456789',
 			} );
 			expect( url ).toBe(


### PR DESCRIPTION
#### Proposed Changes

Prior to D83797-code, transactions only returned an `order_id` argument for redirect payment methods (payment methods that take you away from calypso to complete their payment), but after that change, `order_id` was returned for any transaction that creates an order (all non-free transactions).

`getThankYouPageUrl()` is used to generate the post-checkout URL. This URL is either visited directly after a successful purchase (for non-redirect payment methods) or is provided to the calypso "pending" page which will send the browser to the URL after it verifies that the transaction is successful (currently just for redirect payment methods but note that after https://github.com/Automattic/wp-calypso/pull/65273 this will be used for non-redirect payment methods as well).

There are conditions in `getThankYouPageUrl()` which prevent returning an upsell URL (`getPlanUpgradeUpsellUrl()` and `getProfessionalEmailUpsellUrl()`) if an `orderId` (derived from `transaction.order_id`) is set, but since D83797-code, those conditions are being triggered for non-redirect payment methods as well.

I do not know why those conditions existed in the first place since forking the post-checkout URL based on the type of payment method seems strange to me; they may have been put in place for a different reason or possibly just by accident. In this diff, we remove those conditions so that the upsell URLs will be returned for redirect and non-redirect payment methods alike.

This fixes regressions caused by D83797-code. First reported by https://github.com/Automattic/wp-calypso/pull/65630#issuecomment-1185636543

https://github.com/Automattic/wp-calypso/pull/46433 / https://github.com/Automattic/wp-calypso/pull/44623 added the condition for `getPlanUpgradeUpsellUrl()` to protect against a bug which displayed an invalid URL when paying with 3DS cards. I'm pretty certain that bug is no longer relevant since quickstart sessions and concierge sessions are AFAIK no longer used and because of other bug fixes that have been applied to `getThankYouPageUrl()` in the meantime to prevent invalid URLs. 

https://github.com/Automattic/wp-calypso/pull/56794 added the condition for `getProfessionalEmailUpsellUrl()` and I'm not sure why it was added. My guess is that it was the same reason as `getPlanUpgradeUpsellUrl()`.

#### Testing instructions

Automated tests are included. The main thing to verify is if there was a reason these conditions existed in the first place and if this would break any flows.