### PR TITLE
Shopping Cart: Make the cartKey arg to useShoppingCart required

### DIFF
--- a/packages/shopping-cart/src/use-shopping-cart.ts
+++ b/packages/shopping-cart/src/use-shopping-cart.ts
@@ -5,7 +5,7 @@ import useManagerClient from './use-manager-client';
 import useRefetchOnFocus from './use-refetch-on-focus';
 import type { UseShoppingCart, CartKey } from './types';
 
-export default function useShoppingCart( cartKey?: CartKey ): UseShoppingCart {
+export default function useShoppingCart( cartKey: CartKey ): UseShoppingCart {
 	const managerClient = useManagerClient( 'useShoppingCart' );
 
 	const { defaultCartKey } = useContext( ShoppingCartOptionsContext );

--- a/packages/shopping-cart/src/use-shopping-cart.ts
+++ b/packages/shopping-cart/src/use-shopping-cart.ts
@@ -5,7 +5,7 @@ import useManagerClient from './use-manager-client';
 import useRefetchOnFocus from './use-refetch-on-focus';
 import type { UseShoppingCart, CartKey } from './types';
 
-export default function useShoppingCart( cartKey: CartKey ): UseShoppingCart {
+export default function useShoppingCart( cartKey: CartKey | undefined ): UseShoppingCart {
 	const managerClient = useManagerClient( 'useShoppingCart' );
 
 	const { defaultCartKey } = useContext( ShoppingCartOptionsContext );

--- a/packages/shopping-cart/test/use-shopping-cart.tsx
+++ b/packages/shopping-cart/test/use-shopping-cart.tsx
@@ -29,7 +29,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'addProductsToCart', () => {
 		const TestComponent = ( { products = undefined } ) => {
-			const { addProductsToCart } = useShoppingCart();
+			const { addProductsToCart } = useShoppingCart( undefined );
 			const onClick = () => {
 				addProductsToCart( products )
 					.then( () => markUpdateComplete() )
@@ -194,7 +194,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'removeProductFromCart', () => {
 		const TestComponent = () => {
-			const { removeProductFromCart, responseCart } = useShoppingCart();
+			const { removeProductFromCart, responseCart } = useShoppingCart( undefined );
 			const onClick = () => {
 				const uuid = responseCart.products.length ? responseCart.products[ 0 ].uuid : null;
 				removeProductFromCart( uuid )
@@ -262,7 +262,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'replaceProductsInCart', () => {
 		const TestComponent = ( { products } ) => {
-			const { replaceProductsInCart } = useShoppingCart();
+			const { replaceProductsInCart } = useShoppingCart( undefined );
 			const onClick = () => {
 				replaceProductsInCart( products )
 					.then( () => markUpdateComplete() )
@@ -349,7 +349,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'replaceProductInCart', () => {
 		const TestComponent = () => {
-			const { replaceProductInCart, responseCart } = useShoppingCart();
+			const { replaceProductInCart, responseCart } = useShoppingCart( undefined );
 			const onClick = () => {
 				const uuid = responseCart.products.length ? responseCart.products[ 0 ].uuid : null;
 				replaceProductInCart( uuid, { product_id: planTwo.product_id } )
@@ -418,7 +418,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'applyCoupon', () => {
 		const TestComponent = () => {
-			const { applyCoupon } = useShoppingCart();
+			const { applyCoupon } = useShoppingCart( undefined );
 			const onClick = () => {
 				applyCoupon( 'ABCD' )
 					.then( () => markUpdateComplete() )
@@ -486,7 +486,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'removeCoupon', () => {
 		const TestComponent = () => {
-			const { removeCoupon } = useShoppingCart();
+			const { removeCoupon } = useShoppingCart( undefined );
 			const onClick = () => {
 				removeCoupon()
 					.then( () => markUpdateComplete() )
@@ -556,7 +556,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'updateLocation', () => {
 		const TestComponent = () => {
-			const { updateLocation } = useShoppingCart();
+			const { updateLocation } = useShoppingCart( undefined );
 			const onClick = () => {
 				updateLocation( {
 					countryCode: 'US',
@@ -630,7 +630,7 @@ describe( 'useShoppingCart', () => {
 
 	describe( 'reloadFromServer', () => {
 		const TestComponent = () => {
-			const { reloadFromServer } = useShoppingCart();
+			const { reloadFromServer } = useShoppingCart( undefined );
 			const onClick = () => {
 				reloadFromServer()
 					.then( () => markUpdateComplete() )


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/54667 the `useShoppingCart` React hook was modified so that it requires a cart key (even if that key is undefined) as an argument. However, the argument was made optional to make it easier to migrate from the previous definition.

As of https://github.com/Automattic/wp-calypso/pull/56244 all uses of the function have been migrated. This PR makes the argument non-optional. This should also prevent bugs like the one fixed by https://github.com/Automattic/wp-calypso/pull/65618

#### Testing Instructions

Make sure there are no cases of `useShoppingCart()` called without an argument.