### PR TITLE
Checkout: Prevent adding product with domain as product_slug

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -41,7 +41,7 @@ import UpsellNudge, {
 	CONCIERGE_QUICKSTART_SESSION,
 	PROFESSIONAL_EMAIL_UPSELL,
 } from './upsell-nudge';
-import { getDomainOrProductFromContext } from './utils';
+import { getProductSlugFromContext } from './utils';
 
 const debug = debugFactory( 'calypso:checkout-controller' );
 
@@ -118,7 +118,7 @@ export function checkout( context, next ) {
 
 	const product = isJetpackCheckout
 		? context.params.productSlug
-		: getDomainOrProductFromContext( context );
+		: getProductSlugFromContext( context );
 
 	if ( 'thank-you' === product ) {
 		return;
@@ -182,7 +182,7 @@ export function checkout( context, next ) {
 }
 
 export function redirectJetpackLegacyPlans( context, next ) {
-	const product = getDomainOrProductFromContext( context );
+	const product = getProductSlugFromContext( context );
 
 	if ( isJetpackLegacyItem( product ) ) {
 		const state = context.store.getState();

--- a/client/my-sites/checkout/test/controller.js
+++ b/client/my-sites/checkout/test/controller.js
@@ -48,7 +48,7 @@ describe( 'redirectJetpackLegacyPlans', () => {
 	} );
 
 	it( 'should not redirect if the plan is not a Jetpack legacy plan', () => {
-		utils.getDomainOrProductFromContext.mockReturnValue( PRODUCT_JETPACK_BACKUP_DAILY );
+		utils.getProductSlugFromContext.mockReturnValue( PRODUCT_JETPACK_BACKUP_DAILY );
 
 		redirectJetpackLegacyPlans( {}, next );
 
@@ -57,7 +57,7 @@ describe( 'redirectJetpackLegacyPlans', () => {
 	} );
 
 	it( 'should redirect if the plan is a Jetpack legacy plan', () => {
-		utils.getDomainOrProductFromContext.mockReturnValue( PLAN_JETPACK_PERSONAL );
+		utils.getProductSlugFromContext.mockReturnValue( PLAN_JETPACK_PERSONAL );
 
 		redirectJetpackLegacyPlans( { store }, next );
 

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -1,70 +1,163 @@
 import configureStore from 'redux-mock-store';
-import { getDomainOrProductFromContext } from '../utils';
+import { getProductSlugFromContext } from '../utils';
 
 const mockStore = configureStore();
 
-describe( 'getDomainOrProductFromContext', () => {
-	const siteId = 1;
-	const siteSlug = 'example.com';
-	const newDomain = 'mydomain.com';
+describe( 'getProductSlugFromContext', () => {
+	const domainSiteId = 1;
+	const wpcomSiteId = 2;
+	const subdomainSiteId = 3;
+	const domainSiteSlug = 'example.com';
+	const wpcomSiteSlug = 'example.wordpress.com';
+	const subdomainSiteSlug = 'example.com::blog';
+	const wpcomStagingSiteSlug = 'example.wpcomstaging.com';
 	const newProduct = 'jetpack-product';
-	const store = mockStore( {
-		ui: {
-			selectedSiteId: siteId,
+	const newProductWithDomain = 'domain-mapping:example.com';
+	// Note that `%25` decodes to a slash for product slugs because of how
+	// calypso routing predecodes urls. See `decodeProductFromUrl()`.
+	const newProductWithDot = 'no-adverts%25no-adverts.php';
+	const sites = {
+		items: {
+			[ domainSiteId ]: {
+				id: domainSiteId,
+				slug: domainSiteSlug,
+			},
+			[ wpcomSiteId ]: {
+				id: wpcomSiteId,
+				slug: wpcomStagingSiteSlug,
+			},
+			[ subdomainSiteId ]: {
+				id: subdomainSiteId,
+				slug: subdomainSiteSlug,
+			},
 		},
-		sites: {
-			items: {
-				[ siteId ]: {
-					slug: siteSlug,
+	};
+	function getSiteIdFromDomain( domain ) {
+		return Object.values( sites.items ).find( ( item ) => item.slug === domain )?.id;
+	}
+
+	it.each( [
+		{
+			product: newProduct,
+			domainOrProduct: wpcomSiteSlug,
+			selectedSite: wpcomStagingSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: undefined,
+			domainOrProduct: wpcomSiteSlug,
+			selectedSite: wpcomStagingSiteSlug,
+			expected: '',
+		},
+		{
+			product: newProduct,
+			domainOrProduct: domainSiteSlug,
+			selectedSite: domainSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: domainSiteSlug,
+			domainOrProduct: newProduct,
+			selectedSite: domainSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: newProductWithDomain,
+			domainOrProduct: undefined,
+			selectedSite: domainSiteSlug,
+			expected: newProductWithDomain,
+		},
+		{
+			product: undefined,
+			domainOrProduct: newProductWithDomain,
+			selectedSite: domainSiteSlug,
+			expected: newProductWithDomain,
+		},
+		{
+			product: newProductWithDot,
+			domainOrProduct: undefined,
+			selectedSite: domainSiteSlug,
+			expected: newProductWithDot,
+		},
+		{
+			product: undefined,
+			domainOrProduct: newProductWithDot,
+			selectedSite: domainSiteSlug,
+			expected: newProductWithDot,
+		},
+		{
+			product: newProduct,
+			domainOrProduct: undefined,
+			selectedSite: undefined,
+			expected: '',
+		},
+		{
+			product: undefined,
+			domainOrProduct: newProduct,
+			selectedSite: undefined,
+			expected: newProduct,
+		},
+		{
+			product: undefined,
+			domainOrProduct: domainSiteSlug,
+			selectedSite: domainSiteSlug,
+			expected: '',
+		},
+		{
+			product: domainSiteSlug,
+			domainOrProduct: undefined,
+			selectedSite: domainSiteSlug,
+			expected: '',
+		},
+		{
+			product: newProduct,
+			domainOrProduct: undefined,
+			selectedSite: domainSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: undefined,
+			domainOrProduct: newProduct,
+			selectedSite: domainSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: subdomainSiteSlug,
+			domainOrProduct: newProduct,
+			selectedSite: subdomainSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: newProduct,
+			domainOrProduct: subdomainSiteSlug,
+			selectedSite: subdomainSiteSlug,
+			expected: newProduct,
+		},
+		{
+			product: undefined,
+			domainOrProduct: undefined,
+			selectedSite: domainSiteSlug,
+			expected: '',
+		},
+	] )(
+		`returns '$expected' when :product is '$product' and :domainOrProduct is '$domainOrProduct' and selected site is '$selectedSite'`,
+		( { product, domainOrProduct, selectedSite, expected } ) => {
+			const store = mockStore( {
+				ui: {
+					selectedSiteId: getSiteIdFromDomain( selectedSite ),
 				},
-			},
-		},
-	} );
+				sites,
+			} );
 
-	it( "should return the `domainOrProduct` parameter if it's not the selected site slug", () => {
-		const product = getDomainOrProductFromContext( {
-			store,
-			params: {
-				domainOrProduct: newDomain,
-			},
-		} );
+			const actual = getProductSlugFromContext( {
+				store,
+				params: {
+					domainOrProduct,
+					product,
+				},
+			} );
 
-		expect( product ).toEqual( newDomain );
-	} );
-
-	it( 'should return the `product` parameter if `domainOrProduct` is the selected site slug', () => {
-		const product = getDomainOrProductFromContext( {
-			store,
-			params: {
-				domainOrProduct: siteSlug,
-				product: newProduct,
-			},
-		} );
-
-		expect( product ).toEqual( newProduct );
-	} );
-
-	it( "should return the `product` parameter if there's no selected site", () => {
-		const product = getDomainOrProductFromContext( {
-			store: mockStore( {
-				ui: {},
-			} ),
-			params: {
-				product: newProduct,
-			},
-		} );
-
-		expect( product ).toEqual( newProduct );
-	} );
-
-	it( "should return the `product` parameter if there's no `domainOrProduct` parameter", () => {
-		const product = getDomainOrProductFromContext( {
-			store,
-			params: {
-				product: newProduct,
-			},
-		} );
-
-		expect( product ).toEqual( newProduct );
-	} );
+			expect( actual ).toEqual( expected );
+		}
+	);
 } );

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -1,20 +1,92 @@
 import { untrailingslashit } from 'calypso/lib/route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-export function getDomainOrProductFromContext( { params, store }: PageJS.Context ): string {
-	const { domainOrProduct, product } = params;
+/**
+ * Return the product slug or product alias from a checkout route.
+ *
+ * Checkout routes support including a product slug (eg: `value_bundle`) or
+ * alias (eg: `premium`) in the URL. The most common checkout route uses the
+ * format `/checkout/:site/:product`, but it also supports the path
+ * `/checkout/:product/:site`.
+ *
+ * Checkout also supports routes that only include one or the other, using the
+ * formats `/checkout/:product` and `/checkout/:site`.
+ *
+ * This function tries to determine which part of the path is the product, if
+ * any, and return it. It will return an empty string if no product is found.
+ *
+ * Some examples of valid paths:
+ *
+ * 1. `/checkout/example.com` (path contains a domain)
+ * 2. `/checkout/no-adverts%25no-adverts.php` (path contains a product)
+ * 3. `/checkout/domain-mapping:example.com` (path contains a product)
+ * 4. `/checkout/example.com::blog` (path contains a domain)
+ * 5. `/checkout/example.com::blog/pro` (path contains a domain followed by a product)
+ * 6. `/checkout/pro/example.com::blog` (path contains a product followed by a domain)
+ */
+export function getProductSlugFromContext( { params, store }: PageJS.Context ): string {
+	const {
+		domainOrProduct,
+		product,
+	}: { domainOrProduct: string | undefined; product: string | undefined } = params;
 	const state = store.getState();
 	const selectedSite = getSelectedSite( state );
 
-	let result;
-
-	if ( selectedSite?.slug !== domainOrProduct && domainOrProduct ) {
-		result = domainOrProduct;
-	} else {
-		result = product;
+	if ( ! domainOrProduct && ! product ) {
+		return '';
 	}
 
-	return result || '';
+	// If one matches the selected site, return the other.
+	if ( domainOrProduct && selectedSite?.slug && selectedSite.slug === domainOrProduct ) {
+		return product || '';
+	}
+
+	if ( product && selectedSite?.slug && selectedSite.slug === product ) {
+		return domainOrProduct || '';
+	}
+
+	// If there is no selected site, there will never be a `product`, and the
+	// `domainOrProduct` must be a product slug because a domain would have
+	// selected a site.
+	if ( ! selectedSite?.slug ) {
+		return domainOrProduct || '';
+	}
+
+	// If one string is a valid URL, and there is another, use the other one.
+	if ( domainOrProduct ) {
+		const isDomain = doesStringResembleDomain( domainOrProduct );
+		if ( isDomain && product ) {
+			return product;
+		}
+		if ( ! isDomain ) {
+			return domainOrProduct;
+		}
+	}
+
+	if ( product ) {
+		const isDomain = doesStringResembleDomain( product );
+		if ( isDomain && domainOrProduct ) {
+			return domainOrProduct;
+		}
+		if ( ! isDomain ) {
+			return product;
+		}
+	}
+
+	return '';
+}
+
+function doesStringResembleDomain( domainOrProduct: string ): boolean {
+	try {
+		const hasDot = domainOrProduct.includes( '.' );
+		if ( ! hasDot ) {
+			return false;
+		}
+		// eslint-disable-next-line no-new
+		new URL( 'http://' + domainOrProduct );
+		return true;
+	} catch {}
+	return false;
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

Checkout supports routes that are very similar to one another:

1. `/checkout/:site/:product`
2. `/checkout/:product/:site`

Also:

1. `/checkout/:site`
2. `/checkout/:product`

It's difficult for the router to know which string is a site and which is a product. One way the code makes its guess is by looking to see if either string matches the currently selected site slug. However, for sites with more than one slug (eg: mapped domains or wpcomstaging sites), this is often wrong.

Here are some valid paths:

1. `/checkout/example.com` (path contains a domain)
2. `/checkout/no-adverts%25no-adverts.php` (path contains a product)
3. `/checkout/domain-mapping:example.com` (path contains a product)
4. `/checkout/example.com::blog` (path contains a domain)
5. `/checkout/example.com::blog/pro` (path contains a domain followed by a product)
6. `/checkout/pro/example.com::blog` (path contains a product followed by a domain)

In this PR we refactor the decision-making process for product slugs to never return a string if it is a valid domain.

Fixes https://github.com/Automattic/wp-calypso/issues/65650

#### Testing Instructions

To reproduce:

1. Open your browser's devtools to watch network requests to the `/me/shopping-cart` endpoint.
1. Use a site that has a `<your site here>.wpcomstaging.com` site slug.
1. Visit `/checkout/<your site here>.wordpress.com` (the same site slug but using `wordpress.com` in place of `wpcomstaging.com`).
1. Verify that checkout loads an empty cart view with no errors.
1. Using your browser's devtools, make sure there were no `POST` requests to the `/me/shopping-cart` endpoint.
