### PR TITLE
Fix for the Continue button alignment on the goals screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -87,7 +87,7 @@
 		padding: 32px 0 48px;
 		display: flex;
 		flex-direction: column;
-		justify-content: left  #{'/*rtl:right*/'};
+		justify-content: flex-start;
 
 		button.is-primary {
 			width: 130px;


### PR DESCRIPTION
This issue was firstly fixed on https://github.com/Automattic/wp-calypso/pull/65550 by defining a specific CSS for RTL as described in [the CSS/SASS coding guidelines for RTL CSS](https://github.com/Automattic/wp-calypso/blob/trunk/docs/coding-guidelines/css.md#right-to-left-rtl) but for some reason that worked locally but not after it was deployed so in this PR we try another approach using `justify-content: flex-start` to let the browser handle the directionality.

#### Proposed Changes

* In the goals screen: The blue button should be aligned to the right of the options.

| Before         | After     |
|--------------|-----------|
| ![image](https://user-images.githubusercontent.com/1881481/178669679-85c09d09-6e96-4696-a4fb-eee7313c7635.png) | <img width="1127" alt="Screen Shot 2565-07-13 at 19 11 23" src="https://user-images.githubusercontent.com/1881481/178746096-1ed17756-d6cc-4187-9bee-67e4bed99366.png">     |

#### Testing Instructions

1. Set language to Arabic or Hebrew
2. Create new site at /start
3. Select domain and free plan
4. Select "Build" from the Where to start page.
5. See that the blue button is aligned to the right of the options

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65521