### PR TITLE
Show “Something else” in the initial drop down suggestion list in vertical screen

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -76,8 +76,6 @@ const SelectVertical: React.FC< Props > = ( {
 						: []
 				}
 				isLoading={ isDebouncing || isLoadingDefaultVertical || isLoadingSuggestions }
-				// @TODO: Finally remove if not used becasue now we are forcing it as true for a quick try
-				isShowSkipOption
 				isDisableInput={ isLoadingDefaultVertical }
 				onInputChange={ ( searchTerm: string ) => {
 					setHasUserInput( searchTerm !== '' );

--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -76,7 +76,8 @@ const SelectVertical: React.FC< Props > = ( {
 						: []
 				}
 				isLoading={ isDebouncing || isLoadingDefaultVertical || isLoadingSuggestions }
-				isShowSkipOption={ hasUserInput }
+				// @TODO: Finally remove if not used becasue now we are forcing it as true for a quick try
+				isShowSkipOption
 				isDisableInput={ isLoadingDefaultVertical }
 				onInputChange={ ( searchTerm: string ) => {
 					setHasUserInput( searchTerm !== '' );

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -13,7 +13,6 @@ interface Props {
 	searchTerm: string;
 	suggestions: Vertical[];
 	isLoading?: boolean | undefined;
-	isShowSkipOption?: boolean | undefined;
 	isDisableInput?: boolean | undefined;
 	onInputChange?: ( value: string ) => void;
 	onSelect?: ( vertical: Vertical ) => void;
@@ -24,7 +23,6 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	searchTerm,
 	suggestions,
 	isLoading,
-	isShowSkipOption,
 	isDisableInput,
 	onInputChange,
 	onSelect,
@@ -123,10 +121,6 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 			return [];
 		}
 
-		if ( ! isShowSkipOption ) {
-			return suggestions || [];
-		}
-
 		return suggestions.concat( [
 			{
 				value: '',
@@ -134,7 +128,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 				category: 0 < suggestions.length ? '—' : '',
 			},
 		] );
-	}, [ translate, suggestions, isLoading, isShowSuggestions, isShowSkipOption ] );
+	}, [ translate, suggestions, isLoading, isShowSuggestions ] );
 
 	useEffect( () => {
 		if ( ! ( window.visualViewport && isMobile ) ) {


### PR DESCRIPTION
### Proposed changes

We want to add the option "Something else" in the initial drop-down suggestion list on the vertical screen as a quick fix to help us learn more about what is happening because we see that a significant number of users (20-30%) are not selecting a vertical on the vertical screen.

|  Before | After |
|--------|--------|
|<img width="835" alt="Screen Shot 2565-07-18 at 15 59 47" src="https://user-images.githubusercontent.com/1881481/179478741-54b3f8e8-6b4e-40cd-b9c4-b927fee3d166.png">|<img width="678" alt="Screen Shot 2565-07-18 at 16 04 28" src="https://user-images.githubusercontent.com/1881481/179478953-068f7bb4-2e97-4d52-b12c-f1e6809f1d03.png">|


Related 89-gh-Automattic/ganon-issues