### PR TITLE
Goals Capture: Add combo & total prop to the track events.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -14,6 +14,8 @@ import './style.scss';
 
 type TracksGoalsSelectEventProperties = {
 	goals: string;
+	combo: string;
+	total: number;
 	write?: number;
 	promote?: number;
 	sell?: number;
@@ -65,6 +67,8 @@ const GoalsStep: Step = ( { navigation } ) => {
 	) => {
 		const eventProperties: TracksGoalsSelectEventProperties = {
 			goals: serializeGoals( goals ),
+			combo: goals.sort().join( ',' ),
+			total: goals.length,
 			intent,
 		};
 


### PR DESCRIPTION
#### Proposed Changes

`combo` prop stores comma-delimited goals in alphabetical order.
`total` prop stores total number of goals.

#### Testing Instructions

- Go to the Goals Step via `/setup/goals?siteSlug=your_site_here.wordpress.com`.
- Run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in the devtool console.
- Select one goal, multiple goals, no goals and click on the Continue button.
- From the devtool console, check if the `calypso_signup_goals_select` event is fired and the prop values for `combo` and `total` prop is there.

![2022-07-18_14-48-46](https://user-images.githubusercontent.com/1287077/179505469-82f87dd7-a4ef-43c8-b82a-4dcd18057354.png)

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Fixes #65671