### PR TITLE
Goals caputre: useCanUserManageOptions should return 'requesting' anytime sites are being requested

### DIFF
--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -8,15 +8,19 @@ import { useSiteSlugParam } from './use-site-slug-param';
 export function useCanUserManageOptions() {
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSelect(
-		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
+		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug ),
+		undefined
 	);
-
 	const isRequesting = useSelector( ( state ) => isRequestingSites( state ) );
 	const hasManageOptionsCap = useSelector( ( state ) =>
 		canCurrentUser( state, siteId as number, 'manage_options' )
 	);
 
+	if ( isRequesting ) {
+		return 'requesting';
+	}
+
 	if ( siteId ) {
-		return isRequesting ? 'requesting' : hasManageOptionsCap ?? false;
+		return hasManageOptionsCap ?? false;
 	}
 }


### PR DESCRIPTION
The issue that is being fixed, is seeing the flashing loading screen when opening `goals` capture screen.
![2022-07-15_14-14-00 (1)](https://user-images.githubusercontent.com/2019970/179512558-2bd5cb3d-e40b-44fe-a570-922e3f16f6ad.gif)

This issue was introduced with the following PR: https://github.com/Automattic/wp-calypso/pull/64204

The problem is with the return value from `useCanUserManageOptions` and how it is used inside of `useAssertConditions` in `site-setup-flow.ts`. The `useAssertConditions` returns the following in the exact order on initial render of the `site-setup-flow`:
 1. `undefined`
 2. `requesting`
 3.  <`boolean`>
Therefore as per `useAssertConditions` first time it is run it will return result of:
```{ state: AssertConditionState.SUCCESS }```
However shortly after when it is re-rendered its return will now be:
```{ state: AssertConditionState.CHECKING }```
Then finally:
```{ state: AssertConditionState.SUCCESS }```

#### Proposed Changes
* return `requesting` anytime `useSelector( ( state ) => isRequestingSites( state ) )` returns true. Even when `siteId` is (just yet) `undefined`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `http://calypso.localhost:3000/setup/goals?siteSlug=<YOUR SITE>`
2. See that after the goals capture page loads there is no flashing loading screen

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #