### PR TITLE
HelpCenter: speed up search query

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -91,10 +91,6 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 			$response = json_decode( wp_remote_retrieve_body( $body ) );
 		}
 
-		return rest_ensure_response(
-			array(
-				'wordpress_support_links' => $response,
-			)
-		);
+		return rest_ensure_response( $response );
 	}
 }

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -19,9 +19,9 @@ export const HelpCenterEmbedResult: React.FC = () => {
 	const sectionName = useSelector( getSectionName );
 
 	const params = new URLSearchParams( search );
-	const postId = params.get( 'postId' );
-	const blogId = params.get( 'blogId' );
-	const link = state ? state.link : params.get( 'link' );
+	const postId = state?.post_id ?? params.get( 'postId' );
+	const blogId = state?.blog_id ?? params.get( 'blogId' );
+	const link = state?.link ?? params.get( 'link' );
 
 	useEffect( () => {
 		if ( state ) {

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -120,7 +120,7 @@ function HelpSearchResults( {
 	);
 	const { data: searchData, isLoading: isSearching } = useHelpSearchQuery( searchQuery, locale );
 
-	const searchResults = searchData?.wordpress_support_links ?? [];
+	const searchResults = searchData ?? [];
 	const hasAPIResults = searchResults.length > 0;
 
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -24,14 +24,8 @@ import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-u
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { useHelpSearchQuery } from '../hooks/use-help-search-query';
+import { SearchResult } from '../types';
 import PlaceholderLines from './placeholder-lines';
-
-interface SearchResult {
-	link: string;
-	title: string | React.ReactChild;
-	icon?: string;
-	post_id?: number;
-}
 
 interface SearchResultsSection {
 	type: string;

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -12,7 +12,7 @@ import { Icon, page } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, LinkProps } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { Article } from '../types';
@@ -24,13 +24,18 @@ type Props = {
 	supportSite?: SiteDetails;
 };
 
-function getPostUrl( article: Article, query: string, locale: string ) {
-	if ( 'en' !== locale ) {
-		return {
-			pathname: article.link,
-		};
+const ConfigurableLink: React.FC< { external: boolean; fullUrl: string } & LinkProps > = ( {
+	external,
+	fullUrl,
+	...props
+} ) => {
+	if ( external ) {
+		return <a href={ fullUrl } target="_blank" rel="noreferrer noopener" { ...props } />;
 	}
+	return <Link { ...props } />;
+};
 
+function getPostUrl( article: Article, query: string ) {
 	// if it's a wpcom support article, it has an ID
 	if ( article.post_id ) {
 		const params = new URLSearchParams( {
@@ -89,13 +94,14 @@ export function SibylArticles( { message = '', supportSite }: Props ) {
 			>
 				{ articles.map( ( article ) => (
 					<li key={ article.link }>
-						<Link
-							to={ getPostUrl( article as Article, message, locale ) }
-							target={ 'en' !== locale ? '_blank' : '' }
+						<ConfigurableLink
+							to={ getPostUrl( article as Article, message ) }
+							external={ 'en' !== locale }
+							fullUrl={ article.link }
 						>
 							<Icon icon={ page } />
 							{ article.title }
-						</Link>
+						</ConfigurableLink>
 					</li>
 				) ) }
 			</ul>

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { useQuery } from 'react-query';
+import { useQueryClient, useQuery } from 'react-query';
 import { SearchResult } from '../types';
 
 interface APIFetchOptions {
@@ -12,6 +12,8 @@ export const useHelpSearchQuery = (
 	locale = 'en',
 	queryOptions: Record< string, unknown > = {}
 ) => {
+	const queryClient = useQueryClient();
+
 	return useQuery< SearchResult[] >(
 		[ 'help', search ],
 		() =>
@@ -20,6 +22,20 @@ export const useHelpSearchQuery = (
 				path: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
 			} as APIFetchOptions ),
 		{
+			onSuccess: async ( data ) => {
+				if ( ! data[ 0 ].content ) {
+					const newData = await Promise.all(
+						data.map( async ( result: SearchResult ) => {
+							const article: { [ content: string ]: string } = await apiFetch( {
+								global: true,
+								path: `/wpcom/v2/help-center/fetch-post?blog_id=${ result.blog_id }&post_id=${ result.post_id }`,
+							} as APIFetchOptions );
+							return { ...result, content: article.content };
+						} )
+					);
+					queryClient.setQueryData( [ 'help', search ], newData );
+				}
+			},
 			refetchOnWindowFocus: false,
 			refetchOnMount: false,
 			enabled: !! search,

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
+import { SearchResult } from '../types';
 
 interface APIFetchOptions {
 	global: boolean;
@@ -11,9 +12,7 @@ export const useHelpSearchQuery = (
 	locale = 'en',
 	queryOptions: Record< string, unknown > = {}
 ) => {
-	// NEED TO UPDATE TYPES BEFORE MERGING
-	const queryClient = useQueryClient();
-	return useQuery< [ any ] >(
+	return useQuery< SearchResult[] >(
 		[ 'help', search ],
 		() =>
 			apiFetch( {
@@ -21,20 +20,6 @@ export const useHelpSearchQuery = (
 				path: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
 			} as APIFetchOptions ),
 		{
-			onSuccess: async ( data: any ) => {
-				if ( ! data[ 0 ].content ) {
-					const newData = await Promise.all(
-						data.map( async ( result: any ) => {
-							const article: any = await apiFetch( {
-								global: true,
-								path: `/wpcom/v2/help-center/fetch-post?blog_id=${ result.blog_id }&post_id=${ result.post_id }`,
-							} as APIFetchOptions );
-							return { ...result, content: article.content };
-						} )
-					);
-					queryClient.setQueryData( [ 'help', search ], newData );
-				}
-			},
 			refetchOnWindowFocus: false,
 			refetchOnMount: false,
 			enabled: !! search,

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -35,3 +35,11 @@ export interface Article {
 export interface FeatureFlags {
 	loadNextStepsTutorial: boolean;
 }
+
+export interface SearchResult {
+	link: string;
+	title: string | React.ReactChild;
+	icon?: string;
+	post_id?: number;
+	blog_id?: number;
+}

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -39,6 +39,7 @@ export interface FeatureFlags {
 export interface SearchResult {
 	link: string;
 	title: string | React.ReactChild;
+	content?: string;
 	icon?: string;
 	post_id?: number;
 	blog_id?: number;


### PR DESCRIPTION
## Proposed Changes

This removes the content from the API fetch during the initial search in HelpCenter and offloads it to a second api call from the OnSuccess of the useQuery. This allows the search to run quicker in the beginning and prefetch the content for a faster load of the content.

## Testing Instructions

1. Open your sandbox and pull down this diff - D84391-code
2. Sandbox your API and test site
3. Pull this branch and yarn dev --sync from editing-toolkit
4. Go to help center and search the support guides.
5. [Download the plugin](https://teamcity.a8c.com/repository/download/calypso_WPComPlugins_EditorToolKit/8252645:id/editing-toolkit.zip) and test in AT