### PR TITLE
Framework: Refactor away from `_.isPlainObject()`

### DIFF
--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { isPlainObject } from 'lodash';
 import { useDispatch } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 import ArrayPreference from './array-preference';
@@ -20,7 +19,7 @@ export default function Preference( { name, value } ) {
 
 	if ( Array.isArray( value ) ) {
 		preferenceHandler = <ArrayPreference name={ name } value={ value } />;
-	} else if ( isPlainObject( value ) ) {
+	} else if ( typeof value === 'object' && value !== null ) {
 		preferenceHandler = <ObjectPreference name={ name } value={ value } />;
 	} else if ( 'string' === typeof value ) {
 		preferenceHandler = <StringPreference name={ name } value={ value } />;

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,5 +1,5 @@
 import { extendAction } from '@automattic/state-utils';
-import { camelCase, isPlainObject, map, reduce, set, snakeCase } from 'lodash';
+import { camelCase, map, reduce, set, snakeCase } from 'lodash';
 
 const doBypassDataLayer = {
 	meta: {
@@ -23,7 +23,7 @@ export function convertKeysBy( obj, fn ) {
 		return map( obj, ( v ) => convertKeysBy( v, fn ) );
 	}
 
-	if ( isPlainObject( obj ) ) {
+	if ( typeof obj === 'object' && obj !== null ) {
 		return reduce(
 			obj,
 			( result, value, key ) => {

--- a/client/state/posts/utils/get-term-ids-from-edits.js
+++ b/client/state/posts/utils/get-term-ids-from-edits.js
@@ -1,4 +1,4 @@
-import { isEmpty, isPlainObject, map, mapValues, reduce } from 'lodash';
+import { isEmpty, map, mapValues, reduce } from 'lodash';
 
 /**
  * Takes existing term post edits and updates the `terms_by_id` attribute
@@ -18,7 +18,11 @@ export function getTermIdsFromEdits( post ) {
 		( prev, taxonomyTerms, taxonomyName ) => {
 			// Ensures we are working with an array
 			const termsArray = Object.values( taxonomyTerms );
-			if ( termsArray && termsArray.length && ! isPlainObject( termsArray[ 0 ] ) ) {
+			if (
+				termsArray &&
+				termsArray.length &&
+				! ( typeof termsArray[ 0 ] === 'object' && termsArray[ 0 ] !== null )
+			) {
 				return prev;
 			}
 

--- a/client/state/posts/utils/is-terms-equal.js
+++ b/client/state/posts/utils/is-terms-equal.js
@@ -1,4 +1,4 @@
-import { isPlainObject, map, xor } from 'lodash';
+import { map, xor } from 'lodash';
 
 /**
  * Returns truthy if local terms object is the same as the API response
@@ -10,7 +10,7 @@ import { isPlainObject, map, xor } from 'lodash';
 export function isTermsEqual( localTermEdits, savedTerms ) {
 	return Object.entries( localTermEdits ).every( ( [ taxonomy, terms ] ) => {
 		const termsArray = Object.values( terms );
-		const isHierarchical = isPlainObject( termsArray[ 0 ] );
+		const isHierarchical = typeof termsArray[ 0 ] === 'object' && termsArray[ 0 ] !== null;
 		const normalizedEditedTerms = isHierarchical ? map( termsArray, 'ID' ) : termsArray;
 		const normalizedKey = isHierarchical ? 'ID' : 'name';
 		const normalizedSavedTerms = map( savedTerms[ taxonomy ], normalizedKey );

--- a/client/state/site-settings/test/utils.js
+++ b/client/state/site-settings/test/utils.js
@@ -26,7 +26,7 @@ describe( 'utils', () => {
 			const settings = {
 				sharing_show: [ 'page', 'index', 'post' ],
 			};
-			expect( normalizeSettings( settings ).sharing_show ).toBe( settings.sharing_show );
+			expect( normalizeSettings( settings ).sharing_show ).toEqual( settings.sharing_show );
 		} );
 
 		test( 'should convert sharing_show object to array', () => {

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -1,5 +1,3 @@
-import { isPlainObject } from 'lodash';
-
 /**
  * Normalize API Settings
  *
@@ -14,7 +12,7 @@ export function normalizeSettings( settings ) {
 				memo[ key ] = parseInt( settings[ key ] );
 				break;
 			case 'sharing_show':
-				if ( isPlainObject( settings[ key ] ) ) {
+				if ( typeof settings[ key ] === 'object' && settings[ key ] !== null ) {
 					memo[ key ] = Object.values( settings[ key ] );
 				} else {
 					memo[ key ] = settings[ key ];

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -337,7 +337,7 @@ If you really must check the type of a value, however, do the following:
 - String: `typeof value === 'string'`. This doesn't work for strings created with `new String( ... )`, however, so if you really must check for those for whatever reason, be sure to do `typeof value === 'string' || value instanceof String` instead.
 - Number: [`Number.isFinite( value )`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite) for finite numbers only, or `[ Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ].includes( value )` if you'd like to check for infinite numbers. (avoid using Lodash's `isNumber`).
 - Boolean: `value === true || value === false` (don't use Lodash's `isBoolean`, as it's incredibly wasteful).
-- Object: [`isPlainObject( value )`](https://lodash.com/docs#isPlainObject). Try to avoid when possible - we'd like to get rid of Lodash in the long term. In most cases, `typeof value === 'object' && value.constructor === Object` should do the job for plain objects.
+- Object: In most cases, `typeof value === 'object' && value.constructor === Object` should do the job for plain objects.
 - Array: [`Array.isArray( value )`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray). (avoid using Lodash's `isArray`).
 - null: `value === null`.
 - undefined: `value === undefined`.


### PR DESCRIPTION
#### Proposed Changes

This PR is an alternative of #65668 and suggests using simpler checks to ensure we're working with plain objects. We have no reason not support `null` prototypes, so we're keeping it simple.

See https://github.com/WordPress/gutenberg/pull/42471#issuecomment-1186879992 for the motivation for using this package. Ultimately, we're aiming to do the same in Gutenberg.

#### Testing Instructions

* Verify all state tests pass: `yarn test-client state`
* Verify all checks are green and there are no TS errors/warnings introduced.
* Verify the preferences helper still works (displayed when you roll over the environment name in Calypso on non-prod environments).

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?