### PR TITLE
Enhancement: Add is-scary styling to disconnect button

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -38,7 +38,6 @@ const SharingServiceAction = ( {
 		label = translate( 'Reconnecting…', {
 			context: 'Sharing: Publicize reconnect pending button label',
 		} );
-		warning = true;
 	} else if ( isConnecting ) {
 		label = translate( 'Connecting…', {
 			context: 'Sharing: Publicize connect pending button label',
@@ -51,14 +50,11 @@ const SharingServiceAction = ( {
 		} else {
 			label = translate( 'Disconnect', { context: 'Sharing: Publicize disconnect button label' } );
 		}
-		if ( 'must-disconnect' === status ) {
-			warning = true;
-		}
+		warning = true;
 	} else if ( 'reconnect' === status || 'refresh-failed' === status ) {
 		label = translate( 'Reconnect', {
 			context: 'Sharing: Publicize reconnect pending button label',
 		} );
-		warning = true;
 	} else {
 		label = translate( 'Connect', { context: 'Sharing: Publicize connect pending button label' } );
 	}
@@ -111,7 +107,10 @@ const SharingServiceAction = ( {
 
 	return (
 		<Button scary={ warning } compact onClick={ onClick } disabled={ isPending }>
-			{ label }
+			{ 'reconnect' === status || 'refresh-failed' === status || isRefreshing ? (
+				<Gridicon icon="notice-outline" size={ 16 } />
+			) : null }
+			<span>{ label }</span>
 		</Button>
 	);
 };


### PR DESCRIPTION
This is a very small enhancement type of change to help users identify disconnect buttons easier, thus improving UX.

#### Proposed Changes

* Set `warning` to be true for disconnect button, which applies the `is-scary` class.
* Removed `warning` from reconnect and refreshing state as discussed
* Added exclamation mark icon to Reconnect button

#### Product discussion

p1658412564152429-slack-C02JJ910CNL

#### Testing Instructions

- Disconnect and Reconnect button in Jetpack Cloud should look like this:

<img width="1018" alt="CleanShot 2022-07-22 at 14 57 47@2x" src="https://user-images.githubusercontent.com/36671565/180443994-815673f3-6e14-4d0a-94b3-f0fc4d2adc66.png">

- Disconnect and Reconnect button in Calypso should look like this:

<img width="1055" alt="CleanShot 2022-07-22 at 14 58 01@2x" src="https://user-images.githubusercontent.com/36671565/180444032-9dd8d88d-3588-43fc-b75a-a2a3e61bbe2c.png">



Fixes #64454