### PR TITLE
Fix & improve the Publicize share post upsell for Jetpack sites.

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,7 +1,14 @@
-import { findFirstSimilarPlanKey, TYPE_PREMIUM, TERM_ANNUALLY } from '@automattic/calypso-products';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	findFirstSimilarPlanKey,
+	TYPE_PREMIUM,
+	TERM_ANNUALLY,
+	TYPE_SECURITY_T1,
+} from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import ExternalLink from 'calypso/components/external-link';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import {
 	getSitePlanRawPrice,
@@ -11,18 +18,21 @@ import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const UpgradeToPremiumNudgePure = ( props ) => {
-	const { price, planSlug, translate, userCurrency, canUserUpgrade, isJetpack } = props;
+	const { price, planSlug, siteSlug, translate, userCurrency, canUserUpgrade, isJetpack } = props;
 
 	let featureList;
 	if ( isJetpack ) {
 		featureList = [
+			translate( 'Share posts that have already been published.' ),
 			translate( 'Schedule your social messages in advance.' ),
-			translate( 'Easy monetization options' ),
-			translate( 'VideoPress support' ),
-			translate( 'Daily Malware Scanning' ),
+			translate( 'Plus all the additional features included with Jetpack Security, such as:.' ),
+			translate( 'Real-time cloud backups.' ),
+			translate( 'Real-time malware scanning.' ),
+			translate( 'Comment and form spam protection.' ),
 		];
 	} else {
 		featureList = [
+			translate( 'Share posts that have already been published.' ),
 			translate( 'Schedule your social messages in advance.' ),
 			translate( 'Remove all advertising from your site.' ),
 			translate( 'Enjoy live chat support.' ),
@@ -45,7 +55,30 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			list={ featureList }
 			plan={ planSlug }
 			showIcon
-			title={ translate( 'Upgrade to a Premium Plan!' ) }
+			title={
+				isJetpack
+					? translate( 'Upgrade to Jetpack Security to unlock additional features.' )
+					: translate( 'Upgrade to a Premium Plan!' )
+			}
+			{ ...( isJetpack && {
+				description: translate(
+					"Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post. However, our Security and Complete plan users can also share content that has already been published, and schedule their posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}",
+					{
+						components: {
+							ExternalLink: (
+								<ExternalLink
+									href={ `https://jetpack.com/support/publicize/#re-sharing-your-content` }
+									icon={ true }
+									onClick={ () =>
+										recordTracksEvent( 'calypso_publicize_post_share_learn_more_click' )
+									}
+								/>
+							),
+						},
+					}
+				),
+				href: `/checkout/${ siteSlug }/jetpack_security_t1_yearly`,
+			} ) }
 		/>
 	);
 };
@@ -58,7 +91,7 @@ export const UpgradeToPremiumNudge = connect( ( state, ownProps ) => {
 	const { isJetpack, siteId } = ownProps;
 	const currentPlanSlug = ( getSitePlan( state, getSelectedSiteId( state ) ) || {} ).product_slug;
 	const proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, {
-		type: TYPE_PREMIUM,
+		type: isJetpack ? TYPE_SECURITY_T1 : TYPE_PREMIUM,
 		...( isJetpack ? { term: TERM_ANNUALLY } : {} ),
 	} );
 

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -25,10 +25,9 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 		featureList = [
 			translate( 'Share posts that have already been published.' ),
 			translate( 'Schedule your social messages in advance.' ),
-			translate( 'Plus all the additional features included with Jetpack Security, such as:.' ),
-			translate( 'Real-time cloud backups.' ),
-			translate( 'Real-time malware scanning.' ),
-			translate( 'Comment and form spam protection.' ),
+			translate(
+				'Enjoy all other Jetpack Security features, including real-time cloud backups, real-time malware scanning, comment and form spam protection, and more.'
+			),
 		];
 	} else {
 		featureList = [

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -61,7 +61,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			}
 			{ ...( isJetpack && {
 				description: translate(
-					"Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post. However, our Security and Complete plan users can also share content that has already been published, and schedule their posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}",
+					'Publicize makes it easy to share your new posts on your social media networks automatically. With a Jetpack Security or Complete plan, you can share content that has already been published and can also schedule posts to be shared at a specific time. However, our Security and Complete plan users can also share content that has already been published, and schedule their posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}',
 					{
 						components: {
 							ExternalLink: (

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -9,6 +9,7 @@ import formatCurrency from '@automattic/format-currency';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import ExternalLink from 'calypso/components/external-link';
+import { preventWidows } from 'calypso/lib/formatting';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import {
 	getSitePlanRawPrice,
@@ -25,8 +26,10 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 		featureList = [
 			translate( 'Share posts that have already been published.' ),
 			translate( 'Schedule your social messages in advance.' ),
-			translate(
-				'Enjoy all other Jetpack Security features, including real-time cloud backups, real-time malware scanning, comment and form spam protection, and more.'
+			preventWidows(
+				translate(
+					'Enjoy all other Jetpack Security features, including real-time cloud backups, real-time malware scanning, comment and form spam protection, and more.'
+				)
 			),
 		];
 	} else {


### PR DESCRIPTION
#### Proposed Changes

Prior to this PR, the "Post Share" upsell, for Jetpack sites (non dotcom sites) was pointing to the WordPress Pro product, which is undesired because WordPress Pro is not a Jetpack product. Additionally it was very unclear **why** Jetpack Publicize was requiring the user to upgrade in order to "Publicize" (Share) their post. (See before & after screenshots)

**Why is Publicize requiring an upgrade to share the post?**

Publicize allows you to share your site’s posts on several social media networks automatically **only at the time when you publish a new post**. However, if the site has a Jetpack Security or Complete plan, users can also share content **that has already been published**, and schedule their posts to be shared at a specific time.  Learn more [here](https://jetpack.com/support/publicize/#re-sharing-your-content).  Prior to this PR, this was very unclear.

**BEFORE:** (Self-hosted Jetpack site)

![Markup 2022-07-18 at 11 00 15](https://user-images.githubusercontent.com/11078128/179541499-46909e98-c508-4e29-aec2-8f6a7151e45c.png)

**AFTER:** (Self-hosted Jetpack site)

![Screenshot on 2022-07-19 at 09-46-19](https://user-images.githubusercontent.com/11078128/179766320-208b08ff-6db0-41c6-9c27-3f029567c7ff.png)


**Additional Note:**  This PR simply fixes the broken CTA, and updates the upsell copy (for Jetpack sites only) in order to make it more clear to users why they need to upgrade in order to share the post, just for now...  Design and/or Marketing may want to review this upsell and may want to consider modifying the design and/or copy of the upsell in a followup ticket/PR. But at least for now, this PR makes it functional and more clear.

Asana ticket: 1164141197617539-as-1202607189129008/f

#### Testing Instructions

- Checkout this PR and spin up Calypso blue. (`yarn start`).
- Select a Jetpack site that has a free plan ("Jetpack Free"). You may want to create a Jurassic.ninja site, and connect Jetpack to your wordpress.com account.
- Go to **Posts** (`http://calypso.localhost:3000/posts/:site`)  (replace `:site` with your site slug).
- If you don't have any social-media sites already connected, click the **_settings_** link in the "_Connect an account to get started_" Notice. (See screenshot below)
![Markup 2022-07-18 at 11 20 06](https://user-images.githubusercontent.com/11078128/179545632-8ab6de62-9ce3-4f6d-9ce0-b8bda831ec54.png)
- Make sure you are currently logged-in to one of your social media accounts, like Facebook, Twitter, Linkedin, or Tumbler.
- Connect one of your social accounts. (You won't need to share anything.. We're just connecting it.)
- Now go back to **Posts** (`http://calypso.localhost:3000/posts/:site`)  (replace `:site` with your site slug).
- On one of your posts, click the three-dots icon ( ... ) to open the dropdown menu.
- Select "Share Post".
- Verify you see the updated upsell and it looks like the "AFTER" screenshot above.
- Verify clicking the CTA takes you to /checkout with Jetpack Security in the cart.
- To view the regression, before this PR, view the upsell on wordpress.com (`https://wordpress.com/posts/:site`).
- When finished testing this PR, remember to disconnect your social media account. ;)

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **NO**
- [X] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? **Yes**
- [x] Have you checked for TypeScript, React or other console errors? **Yes**
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) **N/A**
- [X] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? **Yes**



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202607189129008