### PR TITLE
Sites Dashboard: Use `react-query` to fetch `SiteExcerptData`

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -3,7 +3,6 @@ import { useQuery } from 'react-query';
 import { useStore } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import { SiteData, SiteDataOptions } from 'calypso/state/ui/selectors/site-data';
-import { notNullish } from './util';
 
 // Performance-optimized request for lists of sites.
 // Don't add more fields because you will make the request slower.
@@ -39,7 +38,7 @@ const fetchSites = (): Promise< { sites: SiteExcerptData[] } > => {
 	} );
 };
 
-export const useSitesDataQuery = () => {
+export const useSiteExcerptsQuery = () => {
 	const sites = useStore().getState().sites.items;
 
 	let reduxData = undefined;
@@ -58,3 +57,7 @@ export const useSitesDataQuery = () => {
 		},
 	} );
 };
+
+function notNullish< T >( t: T | null | undefined ): t is T {
+	return t !== null && t !== undefined;
+}

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -5,7 +5,7 @@ import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
 import { SitesTable } from './sites-table';
-import type { SiteExcerptData } from '../use-sites-data-query';
+import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
 interface SearchableSitesTableProps {
 	sites: SiteExcerptData[];

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -21,7 +21,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 			return sites;
 		}
 
-		return searchCollection( sites, term.toLowerCase(), [ 'URL', 'domain', 'name', 'slug' ] );
+		return searchCollection( sites, term.toLowerCase(), [ 'URL', 'name', 'slug' ] );
 	}, [ term, sites ] );
 
 	const handleSearch = ( rawTerm: string ) => setTerm( rawTerm.trim() );

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -5,10 +5,10 @@ import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
 import { SitesTable } from './sites-table';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { SiteExcerptData } from '../use-sites-data-query';
 
 interface SearchableSitesTableProps {
-	sites: SiteData[];
+	sites: SiteExcerptData[];
 }
 
 export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import EmptyContent from 'calypso/components/empty-content';
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
 import { SearchableSitesTable } from './searchable-sites-table';
+import type { SiteExcerptData } from '../use-sites-data-query';
 
 const EmptySites = styled( EmptyContent )`
 	display: flex;
@@ -20,7 +20,7 @@ const Title = styled.div`
 	margin-top: 50%;
 `;
 type SitesContainerProps = {
-	sites: SiteData[];
+	sites: SiteExcerptData[];
 	status: string;
 };
 

--- a/client/sites-dashboard/components/sites-container.tsx
+++ b/client/sites-dashboard/components/sites-container.tsx
@@ -3,7 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import EmptyContent from 'calypso/components/empty-content';
 import { SearchableSitesTable } from './searchable-sites-table';
-import type { SiteExcerptData } from '../use-sites-data-query';
+import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
 const EmptySites = styled( EmptyContent )`
 	display: flex;

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -2,8 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useSelector } from 'react-redux';
-import getSites from 'calypso/state/selectors/get-sites';
+import { useSitesDataQuery } from '../use-sites-data-query';
 import { notNullish } from '../util';
 import { SitesContainer } from './sites-container';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
@@ -60,7 +59,11 @@ const DashboardHeading = styled.h1`
 
 export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 	const { __ } = useI18n();
-	const sites = useSelector( getSites );
+	const { data: sites } = useSitesDataQuery();
+
+	if ( ! sites ) {
+		return null;
+	}
 
 	return (
 		<main>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -3,7 +3,6 @@ import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import { notNullish } from '../util';
 import { SitesContainer } from './sites-container';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
@@ -59,7 +58,7 @@ const DashboardHeading = styled.h1`
 
 export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 	const { __ } = useI18n();
-	const { data: sites } = useSiteExcerptsQuery();
+	const { data: sites = [] } = useSiteExcerptsQuery();
 
 	return (
 		<main>
@@ -76,7 +75,7 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 				<ClassNames>
 					{ ( { css } ) => (
 						<SitesTableFilterTabs
-							allSites={ sites.filter( notNullish ) }
+							allSites={ sites }
 							className={ css`
 								${ wideCentered }
 								position: relative;

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -61,10 +61,6 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 	const { __ } = useI18n();
 	const { data: sites } = useSitesDataQuery();
 
-	if ( ! sites ) {
-		return null;
-	}
-
 	return (
 		<main>
 			<PageHeader>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useSitesDataQuery } from '../use-sites-data-query';
+import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { notNullish } from '../util';
 import { SitesContainer } from './sites-container';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
@@ -59,7 +59,7 @@ const DashboardHeading = styled.h1`
 
 export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 	const { __ } = useI18n();
-	const { data: sites } = useSitesDataQuery();
+	const { data: sites } = useSiteExcerptsQuery();
 
 	return (
 		<main>

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -5,17 +5,17 @@ import { removeQueryArgs } from '@wordpress/url';
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/url';
 import SitesBadge from './sites-badge';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data'; // eslint-disable-line no-restricted-imports
+import type { SiteExcerptData } from '../use-sites-data-query';
 
 interface SitesTableFilterTabsProps {
-	allSites: SiteData[];
-	children( filteredSites: SiteData[], status: string ): JSX.Element;
+	allSites: SiteExcerptData[];
+	children( filteredSites: SiteExcerptData[], status: string ): JSX.Element;
 	className?: string;
 	launchStatus?: string;
 }
 
 interface FilteredSites {
-	[ name: string ]: SiteData[];
+	[ name: string ]: SiteExcerptData[];
 }
 
 interface SiteTab extends Omit< TabPanel.Tab, 'title' > {
@@ -96,7 +96,7 @@ export function SitesTableFilterTabs( {
 	);
 }
 
-function filterSites( sites: SiteData[], filterType: string ): SiteData[] {
+function filterSites( sites: SiteExcerptData[], filterType: string ): SiteExcerptData[] {
 	return sites.filter( ( site ) => {
 		const isComingSoon =
 			site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -5,7 +5,7 @@ import { removeQueryArgs } from '@wordpress/url';
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/url';
 import SitesBadge from './sites-badge';
-import type { SiteExcerptData } from '../use-sites-data-query';
+import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
 interface SitesTableFilterTabsProps {
 	allSites: SiteExcerptData[];

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -6,10 +6,10 @@ import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { SiteExcerptData } from '../use-sites-data-query';
 
 interface SiteTableRowProps {
-	site: SiteData;
+	site: SiteExcerptData;
 }
 
 const Row = styled.tr`
@@ -60,7 +60,7 @@ const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
 };
 
-const VisitDashboardItem = ( { site }: { site: SiteData } ) => {
+const VisitDashboardItem = ( { site }: { site: SiteExcerptData } ) => {
 	const { __ } = useI18n();
 	return (
 		<PopoverMenuItem href={ getDashboardUrl( site.slug ) }>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -6,7 +6,7 @@ import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
-import type { SiteExcerptData } from '../use-sites-data-query';
+import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
 interface SiteTableRowProps {
 	site: SiteExcerptData;

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SitesTableRow from './sites-table-row';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { SiteExcerptData } from '../use-sites-data-query';
 
 interface SitesTableProps {
 	className?: string;
-	sites: SiteData[];
+	sites: SiteExcerptData[];
 }
 
 const Table = styled.table`

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SitesTableRow from './sites-table-row';
-import type { SiteExcerptData } from '../use-sites-data-query';
+import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
 interface SitesTableProps {
 	className?: string;

--- a/client/sites-dashboard/use-sites-data-query.ts
+++ b/client/sites-dashboard/use-sites-data-query.ts
@@ -1,0 +1,45 @@
+import config from '@automattic/calypso-config';
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import { SiteData, SiteDataOptions } from 'calypso/state/ui/selectors/site-data';
+
+// Performance-optimized request for lists of sites.
+// Don't add more fields because you will make the request slower.
+export const SITE_EXCERPT_REQUEST_FIELDS = [
+	'ID',
+	'URL',
+	'is_coming_soon',
+	'is_private',
+	'launch_status',
+	'slug',
+	'icon',
+	'name',
+	'options',
+	'plan',
+] as const;
+
+export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site' ] as const;
+
+export type SiteExcerptData = Pick< SiteData, typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] > & {
+	options: Pick< SiteDataOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
+};
+
+const fetchSites = (): Promise< { sites: SiteExcerptData[] } > => {
+	const siteFilter = config< string[] >( 'site_filter' );
+	return wpcom.me().sites( {
+		apiVersion: '1.2',
+		site_visibility: 'all',
+		include_domain_only: true,
+		site_activity: 'active',
+		fields: SITE_EXCERPT_REQUEST_FIELDS.join( ',' ),
+		options: SITE_EXCERPT_REQUEST_OPTIONS.join( ',' ),
+		filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
+	} );
+};
+
+export const useSitesDataQuery = () =>
+	useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
+		enabled: true,
+		staleTime: 1000 * 60 * 5, // 5 minutes
+		select: ( data ) => data?.sites ?? [],
+	} );

--- a/client/sites-dashboard/use-sites-data-query.ts
+++ b/client/sites-dashboard/use-sites-data-query.ts
@@ -1,7 +1,9 @@
 import config from '@automattic/calypso-config';
 import { useQuery } from 'react-query';
+import { useStore } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import { SiteData, SiteDataOptions } from 'calypso/state/ui/selectors/site-data';
+import { notNullish } from './util';
 
 // Performance-optimized request for lists of sites.
 // Don't add more fields because you will make the request slower.
@@ -21,7 +23,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site' ] as const;
 
 export type SiteExcerptData = Pick< SiteData, typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] > & {
-	options: Pick< SiteDataOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
+	options?: Pick< SiteDataOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
 };
 
 const fetchSites = (): Promise< { sites: SiteExcerptData[] } > => {
@@ -37,9 +39,22 @@ const fetchSites = (): Promise< { sites: SiteExcerptData[] } > => {
 	} );
 };
 
-export const useSitesDataQuery = () =>
-	useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
-		enabled: true,
+export const useSitesDataQuery = () => {
+	const sites = useStore().getState().sites.items;
+
+	let reduxData = undefined;
+	if ( sites && Object.values( sites ) ) {
+		reduxData = {
+			sites: Object.values( sites ).filter( notNullish ),
+		};
+	}
+
+	return useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
 		staleTime: 1000 * 60 * 5, // 5 minutes
-		select: ( data ) => data?.sites ?? [],
+		select: ( data ) => data?.sites,
+		initialData: reduxData,
+		placeholderData: {
+			sites: [],
+		},
 	} );
+};

--- a/client/sites-dashboard/util.ts
+++ b/client/sites-dashboard/util.ts
@@ -1,4 +1,0 @@
-/// TODO: Move this into @automattic/js-utils or something like that
-export function notNullish< T >( t: T | null | undefined ): t is T {
-	return t !== null && t !== undefined;
-}

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -7,6 +7,7 @@ export interface SiteData {
 	slug: string;
 	domain: string;
 	locale: string;
+	icon?: SiteDataIcon;
 	options?: SiteDataOptions;
 	wpcom_url?: string;
 	jetpack?: boolean;
@@ -18,6 +19,11 @@ export interface SiteData {
 	is_coming_soon?: boolean;
 	launch_status?: string;
 	// TODO: fill out the rest of this
+}
+
+export interface SiteDataIcon {
+	ico: string;
+	img: string;
 }
 
 export interface SiteDataPlan {


### PR DESCRIPTION
Alternative to #65593, based on feedback from @tyxla https://github.com/Automattic/wp-calypso/pull/65593#pullrequestreview-1040027902
See #65490

## Proposed Changes

Introduces a `SiteExcerptData` concept, powered by `react-query`, to display a limited set of site data on the Sites Dashboard for better performance. See analysis in pdKhl6-v6-p2

**This pull request is not yet complete.** I'm looking for: feedback on the overall approach, as well as opinions on what "complete" looks like from a technical perspective (tests, etc.)

Consider this an opportunity to educate a PHP hacker!

## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Clear the `calypso_store` in IndexDB.
3. Refresh the page.
4. Observe your list of sites load after the API request completes.
5. Observe new `calypso_store` entries for `query-state-<num>` and `redux-state-<num>`.
6. Delete the `query-state-<num>` entry.
7. Refresh the page.
8. Observe your list of sites appear without delay.
9. Observe the `query-state-<num>` populated from Redux data (each site will have fields that aren't present in the excerpts subset of data).

## Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #