### PR TITLE
Help Center: Simple sites direct request to apis

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -20,11 +20,6 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 		$this->namespace                       = 'wpcom/v2';
 		$this->rest_base                       = 'help-center/fetch-post';
 		$this->wpcom_is_site_specific_endpoint = false;
-		$this->is_wpcom                        = false;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->is_wpcom = true;
-		}
 	}
 
 	/**
@@ -64,18 +59,13 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 		$blog_id = $request['blog_id'];
 		$post_id = $request['post_id'];
 
-		if ( $this->is_wpcom ) {
-			require_once WP_CONTENT_DIR . '/lib/reader-site-post/class.wpcom-reader-site-post.php';
-			$response = \WPCOM_Reader_Site_Post::get_site_post( $blog_id, $post_id );
-		} else {
-			$body = Client::wpcom_json_api_request_as_user(
-				'/help/article/' . $blog_id . '/' . $post_id
-			);
-			if ( is_wp_error( $body ) ) {
-				return $body;
-			}
-			$response = json_decode( wp_remote_retrieve_body( $body ) );
+		$body = Client::wpcom_json_api_request_as_user(
+			'/help/article/' . $blog_id . '/' . $post_id
+		);
+		if ( is_wp_error( $body ) ) {
+			return $body;
 		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		return rest_ensure_response( $response );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -80,6 +80,8 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 			return $body;
 		}
 
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
 		return rest_ensure_response( $response );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -20,11 +20,6 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 		$this->namespace                       = 'wpcom/v2';
 		$this->rest_base                       = 'help-center/search';
 		$this->wpcom_is_site_specific_endpoint = false;
-		$this->is_wpcom                        = false;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->is_wpcom = true;
-		}
 	}
 
 	/**
@@ -73,22 +68,16 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 		$query  = $request['query'];
 		$locale = $request['locale'];
 
-		if ( $this->is_wpcom ) {
-			$response = \WPCOM_Help_Search::search_wpcom_support( $query, $locale );
-		} else {
-			$query_parameters = array(
-				'query'  => $query,
-				'locale' => $locale,
-			);
-			$body             = Client::wpcom_json_api_request_as_user(
-				'/help/search/wpcom?' . http_build_query( $query_parameters )
-			);
+		$query_parameters = array(
+			'query'  => $query,
+			'locale' => $locale,
+		);
+		$body             = Client::wpcom_json_api_request_as_user(
+			'/help/search/wpcom?' . http_build_query( $query_parameters )
+		);
 
-			if ( is_wp_error( $body ) ) {
-				return $body;
-			}
-
-			$response = json_decode( wp_remote_retrieve_body( $body ) );
+		if ( is_wp_error( $body ) ) {
+			return $body;
 		}
 
 		return rest_ensure_response( $response );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -20,11 +20,6 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 		$this->namespace                       = 'wpcom/v2';
 		$this->rest_base                       = 'help-center/support-availability';
 		$this->wpcom_is_site_specific_endpoint = false;
-		$this->is_wpcom                        = false;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->is_wpcom = true;
-		}
 	}
 
 	/**
@@ -99,15 +94,11 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_chat_support_eligibility() {
-		if ( $this->is_wpcom ) {
-			$response = \WPCOM_Help_Eligibility::get_user_chat_support_eligibility();
-		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/chat/mine' );
-			if ( is_wp_error( $body ) ) {
-				return $body;
-			}
-			$response = json_decode( wp_remote_retrieve_body( $body ) );
+		$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/chat/mine' );
+		if ( is_wp_error( $body ) ) {
+			return $body;
 		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		return rest_ensure_response( $response );
 	}

--- a/client/components/data/query-reader-post/index.jsx
+++ b/client/components/data/query-reader-post/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { isPostKeyLike } from 'calypso/reader/post-key';
 import { fetchPost } from 'calypso/state/reader/posts/actions';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 
 class QueryReaderPost extends Component {
 	static propTypes = {
@@ -20,9 +21,9 @@ class QueryReaderPost extends Component {
 	}
 
 	maybeFetch = () => {
-		const { post, postKey, isHelpCenter } = this.props;
+		const { post, postKey, isHelpCenter, isSimpleSite } = this.props;
 		if ( isPostKeyLike( postKey ) && ( ! post || post._state === 'minimal' ) ) {
-			this.props.fetchPost( postKey, isHelpCenter );
+			this.props.fetchPost( postKey, isHelpCenter, isSimpleSite );
 		}
 	};
 
@@ -35,6 +36,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		post: getPostByKey( state, ownProps.postKey ),
 		isHelpCenter: ownProps.isHelpCenter,
+		isSimpleSite: getIsSimpleSite( state ),
 	} ),
 	{ fetchPost }
 )( QueryReaderPost );

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -35,19 +35,16 @@ function fetchForKey( postKey, isHelpCenter = false, isSimpleSite = true ) {
 
 	if ( postKey.blogId ) {
 		if ( isHelpCenter ) {
-			return isSimpleSite
-				? apiFetch( {
-						global: true,
-						path: `/wpcom/v2/help/article/${ encodeURIComponent(
-							postKey.blogId
-						) }/${ encodeURIComponent( postKey.postId ) }`,
-				  } )
-				: apiFetch( {
-						global: true,
-						path: `/wpcom/v2/help-center/fetch-post?post_id=${ encodeURIComponent(
+			return apiFetch( {
+				global: true,
+				path: isSimpleSite
+					? `/wpcom/v2/help/article/${ encodeURIComponent( postKey.blogId ) }/${ encodeURIComponent(
 							postKey.postId
-						) }&blog_id=${ encodeURIComponent( postKey.blogId ) }`,
-				  } );
+					  ) }`
+					: `/wpcom/v2/help-center/fetch-post?post_id=${ encodeURIComponent(
+							postKey.postId
+					  ) }&blog_id=${ encodeURIComponent( postKey.blogId ) }`,
+			} );
 		}
 
 		return wpcom.req.get(

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -25,7 +25,7 @@ function trackRailcarRender( post ) {
 	tracks.recordTracksEvent( 'calypso_traintracks_render', post.railcar );
 }
 
-function fetchForKey( postKey, isHelpCenter ) {
+function fetchForKey( postKey, isHelpCenter = false, isSimpleSite = true ) {
 	const query = {};
 
 	const contentWidth = readerContentWidth();
@@ -34,19 +34,28 @@ function fetchForKey( postKey, isHelpCenter ) {
 	}
 
 	if ( postKey.blogId ) {
-		return isHelpCenter
-			? apiFetch( {
-					global: true,
-					path: `/wpcom/v2/help-center/fetch-post?post_id=${ encodeURIComponent(
-						postKey.postId
-					) }&blog_id=${ encodeURIComponent( postKey.blogId ) }`,
-			  } )
-			: wpcom.req.get(
-					`/read/sites/${ encodeURIComponent( postKey.blogId ) }/posts/${ encodeURIComponent(
-						postKey.postId
-					) }`,
-					query
-			  );
+		if ( isHelpCenter ) {
+			return isSimpleSite
+				? apiFetch( {
+						global: true,
+						path: `/wpcom/v2/help/article/${ encodeURIComponent(
+							postKey.blogId
+						) }/${ encodeURIComponent( postKey.postId ) }`,
+				  } )
+				: apiFetch( {
+						global: true,
+						path: `/wpcom/v2/help-center/fetch-post?post_id=${ encodeURIComponent(
+							postKey.postId
+						) }&blog_id=${ encodeURIComponent( postKey.blogId ) }`,
+				  } );
+		}
+
+		return wpcom.req.get(
+			`/read/sites/${ encodeURIComponent( postKey.blogId ) }/posts/${ encodeURIComponent(
+				postKey.postId
+			) }`,
+			query
+		);
 	}
 	const { postId, feedId, ...params } = postKey;
 	return wpcom.req.get(
@@ -114,26 +123,28 @@ export const receivePosts = ( posts ) => ( dispatch ) => {
 };
 
 const requestsInFlight = new Set();
-export const fetchPost = ( postKey, isHelpCenter ) => ( dispatch ) => {
-	const requestKey = keyToString( postKey );
-	if ( requestsInFlight.has( requestKey ) ) {
-		return;
-	}
+export const fetchPost =
+	( postKey, isHelpCenter = false, isSimpleSite = true ) =>
+	( dispatch ) => {
+		const requestKey = keyToString( postKey );
+		if ( requestsInFlight.has( requestKey ) ) {
+			return;
+		}
 
-	requestsInFlight.add( requestKey );
-	function removeKey() {
-		requestsInFlight.delete( requestKey );
-	}
-	return fetchForKey( postKey, isHelpCenter )
-		.then( ( data ) => {
-			removeKey();
-			return dispatch( receivePosts( [ data ] ) );
-		} )
-		.catch( ( error ) => {
-			removeKey();
-			return dispatch( receiveErrorForPostKey( error, postKey ) );
-		} );
-};
+		requestsInFlight.add( requestKey );
+		function removeKey() {
+			requestsInFlight.delete( requestKey );
+		}
+		return fetchForKey( postKey, isHelpCenter, isSimpleSite )
+			.then( ( data ) => {
+				removeKey();
+				return dispatch( receivePosts( [ data ] ) );
+			} )
+			.catch( ( error ) => {
+				removeKey();
+				return dispatch( receiveErrorForPostKey( error, postKey ) );
+			} );
+	};
 
 function receiveErrorForPostKey( error, postKey ) {
 	return {

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -8,18 +8,20 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
-	enabled = true
+	isSimpleSite = true
 ) {
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
 			await wpcomRequest( {
-				path: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
+				path: isSimpleSite
+					? `help/eligibility/${ supportType === 'OTHER' ? 'all' : 'chat' }/mine`
+					: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
 			} ),
 		{
-			enabled,
+			enabled: isSimpleSite,
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,
 		}

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -8,20 +8,18 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
-	isSimpleSite = true
+	enabled = true
 ) {
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
 			await wpcomRequest( {
-				path: isSimpleSite
-					? `help/eligibility/${ supportType === 'OTHER' ? 'all' : 'chat' }/mine`
-					: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
+				path: `help/eligibility/${ supportType === 'OTHER' ? 'all' : 'chat' }/mine`,
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
 			} ),
 		{
-			enabled: isSimpleSite,
+			enabled,
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,
 		}

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -18,15 +18,12 @@ export const useHelpSearchQuery = (
 	return useQuery< SearchResult[] >(
 		[ 'help', search ],
 		() =>
-			isSimpleSite
-				? apiFetch< LinksForSection[] >( {
-						global: true,
-						path: `/wpcom/v2/help/search/wpcom?query=${ search }&locale=${ locale }`,
-				  } as APIFetchOptions )
-				: apiFetch< { wordpress_support_links: LinksForSection[] } >( {
-						global: true,
-						path: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
-				  } as APIFetchOptions ).then( ( result ) => result?.wordpress_support_links ),
+			apiFetch( {
+				global: true,
+				path: isSimpleSite
+					? `/wpcom/v2/help/search/wpcom?query=${ search }&locale=${ locale }`
+					: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
+			} as APIFetchOptions ),
 		{
 			onSuccess: async ( data ) => {
 				if ( ! data[ 0 ].content ) {

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -10,6 +10,7 @@ interface APIFetchOptions {
 export const useHelpSearchQuery = (
 	search: string,
 	locale = 'en',
+	isSimpleSite = true,
 	queryOptions: Record< string, unknown > = {}
 ) => {
 	const queryClient = useQueryClient();
@@ -17,10 +18,15 @@ export const useHelpSearchQuery = (
 	return useQuery< SearchResult[] >(
 		[ 'help', search ],
 		() =>
-			apiFetch( {
-				global: true,
-				path: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
-			} as APIFetchOptions ),
+			isSimpleSite
+				? apiFetch< LinksForSection[] >( {
+						global: true,
+						path: `/wpcom/v2/help/search/wpcom?query=${ search }&locale=${ locale }`,
+				  } as APIFetchOptions )
+				: apiFetch< { wordpress_support_links: LinksForSection[] } >( {
+						global: true,
+						path: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
+				  } as APIFetchOptions ).then( ( result ) => result?.wordpress_support_links ),
 		{
 			onSuccess: async ( data ) => {
 				if ( ! data[ 0 ].content ) {

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -31,7 +31,9 @@ export const useHelpSearchQuery = (
 						data.map( async ( result: SearchResult ) => {
 							const article: { [ content: string ]: string } = await apiFetch( {
 								global: true,
-								path: `/wpcom/v2/help-center/fetch-post?blog_id=${ result.blog_id }&post_id=${ result.post_id }`,
+								path: isSimpleSite
+									? `/wpcom/v2/help/article/${ result.blog_id }/${ result.post_id }`
+									: `/wpcom/v2/help-center/fetch-post?blog_id=${ result.blog_id }&post_id=${ result.post_id }`,
 							} as APIFetchOptions );
 							return { ...result, content: article.content };
 						} )


### PR DESCRIPTION
#### Proposed Changes

For simple sites, send directly the calls for `search`, `fetch` and `support` not to the ETK endpoints but directly to the right endpoints. Atomic sites will still send their requests to ETK.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* 'yarn dev --sync` from `apps/editing-toolkit`
* Check that everything works
* Check that calls are directed to the right endpoints in simple sites.
* Test that Atomic still works

