### PR TITLE
Fix - Ensure the display of JITM modal is tracked

### DIFF
--- a/client/blocks/jitm/templates/modal.jsx
+++ b/client/blocks/jitm/templates/modal.jsx
@@ -17,8 +17,6 @@ export default function ModalTemplate( {
 	title,
 	trackImpression,
 } ) {
-	trackImpression && trackImpression();
-
 	// technically, non-dismissable jitms are authorable, however, that doesn't make any sense as a modal.
 	const [ isDismissed, setDismissed ] = useState( [] );
 	const translate = useTranslate();
@@ -64,6 +62,7 @@ export default function ModalTemplate( {
 				{
 					content: (
 						<>
+							{ trackImpression && trackImpression() }
 							<div className="modal__container">
 								{ /* todo: allow specifying this text via jitm configuration */ }
 								<p className="modal__limited-offer">{ title }</p>
@@ -77,7 +76,7 @@ export default function ModalTemplate( {
 											onClick();
 											setDismissed( isDismissed.concat( [ featureClass ] ) );
 										} }
-										tabindex={ -2 }
+										tabIndex={ -2 }
 									>
 										{ CTA.message }
 									</Button>


### PR DESCRIPTION
#### Proposed Changes

* Fixed the issue where the display of the JITM modal does not get tracked, even when `tracks.display` is defined in the JITM settings
* Fixed the warning of using `Invalid DOM property `tabindex` (should be `tabIndex` with uppercase `I`)
<img width="982" alt="tabIndex-warning" src="https://user-images.githubusercontent.com/104910361/179573589-ed2e3a61-db62-4934-b484-5e8f9ca86f4d.png">

#### Testing Instructions

1. Enable the Professional Email JITM modal
2. When the modal shows up, check the tracking calls in Vigilante to ensure the following event `calypso_wpcom_embedded_inbox_engagement_customers_impression` is tracked, sending the following properties:
* `cta_name`: `wpcom-embedded-inbox`
* `id`: `embedded_inbox_engagement_customers`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #