### PR TITLE
Sites Dashboard: Add css to increase the Site column space to prevent overflow

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -47,16 +47,13 @@ const SiteName = styled.h2`
 
 const SiteUrl = styled.a`
 	color: var( --studio-gray-60 );
-	max-width: 60%;
-	width: 300px;
-	text-overflow: clip;
+	max-width: 75%;
+	text-overflow: ellipse;
 	overflow: hidden;
 	display: inline-block;
 	&:visited {
 		color: var( --studio-gray-60 );
 	}
-	-webkit-mask-image: linear-gradient( 90deg, #000 90%, transparent );
-	mask-image: linear-gradient( 90deg, #000 60%, transparent );
 `;
 
 const getDashboardUrl = ( slug: string ) => {

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -7,7 +7,6 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
-//import '../../assets/stylesheets/shared/mixins/_long-content-fade.scss';
 
 interface SiteTableRowProps {
 	site: SiteData;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -48,7 +48,7 @@ const SiteName = styled.h2`
 const SiteUrl = styled.a`
 	color: var( --studio-gray-60 );
 	max-width: 75%;
-	text-overflow: ellipse;
+	text-overflow: ellipsis;
 	overflow: hidden;
 	display: inline-block;
 	&:visited {

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -7,6 +7,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+//import '../../assets/stylesheets/shared/mixins/_long-content-fade.scss';
 
 interface SiteTableRowProps {
 	site: SiteData;
@@ -47,9 +48,16 @@ const SiteName = styled.h2`
 
 const SiteUrl = styled.a`
 	color: var( --studio-gray-60 );
+	max-width: 60%;
+	width: 300px;
+	text-overflow: clip;
+	overflow: hidden;
+	display: inline-block;
 	&:visited {
 		color: var( --studio-gray-60 );
 	}
+	-webkit-mask-image: linear-gradient( 90deg, #000 90%, transparent );
+	mask-image: linear-gradient( 90deg, #000 60%, transparent );
 `;
 
 const getDashboardUrl = ( slug: string ) => {
@@ -105,7 +113,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 								href={ site.URL }
 								target="_blank"
 								rel="noreferrer"
-								title={ __( 'Visit Site' ) }
+								title={ site.URL }
 								style={ { marginRight: '8px' } }
 							>
 								{ displaySiteUrl( site.URL ) }

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -39,8 +39,8 @@ export function SitesTable( { className, sites }: SitesTableProps ) {
 		<Table className={ className }>
 			<thead className="sites-table__mobile-hidden">
 				<Row>
-					<th>{ __( 'Site' ) }</th>
-					<th>{ __( 'Plan' ) }</th>
+					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
+					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
 					<th>{ __( 'Last Publish' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>


### PR DESCRIPTION
#### Proposed Changes

* Add css to increase space of site column to prevent overflow.
* Add css to show ellipsis when a site text is too long to fit in the column space. 

#### Testing Instructions

1. Checkout PR 
2. Navigate to `sites-dashboard`
3. Verify long sites does not overflow and shows a fading indicator

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Before
<img width="841" alt="image" src="https://user-images.githubusercontent.com/36432/178254224-a0275b1e-ec28-472e-b71a-8e0eed4f887e.png">

#### After
![image](https://user-images.githubusercontent.com/47489215/179802556-44b226be-2fe3-40fd-b4cd-c9935ba16d32.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/issues/65440