### PR TITLE
seller-celebration-modal: Do not trigger on autosave

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -42,10 +42,14 @@ const SellerCelebrationModal = () => {
 	const previousIsEditorSaving = useRef( false );
 	const { isEditorSaving, hasPaymentsBlock, linkUrl } = useSelect( ( select ) => {
 		if ( isSiteEditor ) {
-			const isSavingSite = select( 'core' ).isSavingEntityRecord( 'root', 'site' );
+			const isSavingSite =
+				select( 'core' ).isSavingEntityRecord( 'root', 'site' ) &&
+				! select( 'core' ).isAutosavingEntityRecord( 'root', 'site' );
 			const page = select( 'core/edit-site' ).getPage();
 			const pageId = parseInt( page?.context?.postId );
-			const isSavingEntity = select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId );
+			const isSavingEntity =
+				select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId ) &&
+				! select( 'core' ).isAutosavingEntityRecord( 'postType', 'page', pageId );
 			const pageEntity = select( 'core' ).getEntityRecord( 'postType', 'page', pageId );
 			const paymentsBlock =
 				pageEntity?.content?.raw?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
@@ -56,11 +60,9 @@ const SellerCelebrationModal = () => {
 			};
 		}
 		const currentPost = select( 'core/editor' ).getCurrentPost();
-		const isSavingEntity = select( 'core' ).isSavingEntityRecord(
-			'postType',
-			currentPost?.type,
-			currentPost?.id
-		);
+		const isSavingEntity =
+			select( 'core' ).isSavingEntityRecord( 'postType', currentPost?.type, currentPost?.id ) &&
+			! select( 'core' ).isAutosavingEntityRecord( 'postType', currentPost?.type, currentPost?.id );
 		const globalBlockCount = select( 'core/block-editor' ).getGlobalBlockCount(
 			'jetpack/recurring-payments'
 		);


### PR DESCRIPTION
#### Proposed Changes

* The `<SellerCelebrationModal>` (#61222) display will now only be triggered on manual save, not autosave.
  * The modal appearing on autosave could be unexpected and jarring. Better to tie it to a manual action.

#### Testing Instructions

**Site Setup**

* Have a site that was created with the sell intent, or create a new one ( https://wordpress.com/start -> Starter plan -> choose "Sell Online" on the "What are your goals?" screen, choose "Start Simple" on the "Set up your store" screen ). I chose a starter plan and it worked; I think any plan will do.
* Reset the status of the modal on the site (helps when retesting). On sandbox, `wp shell` then `update_blog_option( 1234, "has_seen_seller_celebration_modal", false );` where 1234 = your blog id.
* Edit the homepage (Pages -> All Pages, locate the home page and Triple Dot -> Edit)

**Without PR Changes**
* Let the editor load. Change one character in the title. Keep the editor focused and wait 60-90 seconds.
* An autosave will trigger and cause the Seller Celebration Modal to appear:
![image](https://user-images.githubusercontent.com/13437011/156636892-567d4ad8-ed90-4375-918e-1d6f951bb097.png)

**Send PR Changes to Sandbox**
* `cd` into `apps/editing-toolkit` and run `yarn dev --sync`
* Ensure that the actual site, `mysite.wordpress.com` is hosts file redirected to the sandbox
* Reset the status of the modal as described above
* Edit the homepage (in a new tab to reset state)
* Let the editor load. Change one character in the title. Keep the editor focused and wait 60-90 seconds.
* An autosave will trigger (network tab, request with 'autosave') and the Seller Celebration Modal will not appear.
* Click the 'Update' button in the top right to manually save.
* When the save is completed, the modal will appear.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #65449