### PR TITLE
seller-celebration-modal: Do not render on non-sell intent sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 /**
  * Show the seller celebration modal
  */
-const SellerCelebrationModal = () => {
+const SellerCelebrationModalInner = () => {
 	const { addEntities } = useDispatch( 'core' );
 
 	useEffect( () => {
@@ -126,6 +126,14 @@ const SellerCelebrationModal = () => {
 			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_seller_celebration_modal_show' ) }
 		/>
 	);
+};
+
+const SellerCelebrationModal = () => {
+	const intent = useSiteIntent();
+	if ( intent === 'sell' ) {
+		return <SellerCelebrationModalInner />;
+	}
+	return null;
 };
 
 export default SellerCelebrationModal;


### PR DESCRIPTION
#### Proposed Changes

* On sites without the sell intent, the `<SellerCelebrationModal>` will no longer do any calculations.
 * One of my older sites does not have the sell intent, so the `<SellerCelebrationModal>` will never be able to render. However, the modal was still making API requests to `has-seen-seller-celebration-modal`, and searching my posts for reoccurring payment blocks. Both are instances of work that will never be needed.
   *  This PR stops this work from being done on sites without the sell intent.
 * Because hooks cannot be called conditionally, and hooks cannot be called after early returns, I made a 'shell' component which only checks the site intent.

**Non-sell intent site fetching `has-seen-seller-celebration-modal`**
![2022-07-18_15-34](https://user-images.githubusercontent.com/937354/179619139-9267cd21-75f6-4247-9b8a-1b3bdec81c35.png)


#### Testing Instructions

* **Without this PR**:
  * A sell-intent site should display the modal when first saving a page containing the payments block.
  * A non-sell-intent site will make requests to the `has-seen-seller-celebration-modal` endpoint.
* **With the PR**
  *  A sell-intent site should continue to display the modal when first saving a page containing the payments block.
  * A non-sell-intent site should no longer make requests to the `has-seen-seller-celebration-modal` endpoint.
* Directions for creating a site, resetting the modal status, causing the modal to trigger, and syncing the ETK to the sandbox are in: #65707

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #