### PR TITLE
Remove the login/qr-code-login config

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -81,16 +81,14 @@ export default ( router ) => {
 		);
 	}
 
-	if ( config.isEnabled( 'login/qr-code-login' ) ) {
-		router(
-			[ `/log-in/qr/${ lang }` ],
-			redirectLoggedIn,
-			setLocaleMiddleware(),
-			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
-			qrCodeLogin,
-			makeLoggedOutLayout
-		);
-	}
+	router(
+		[ `/log-in/qr/${ lang }` ],
+		redirectLoggedIn,
+		setLocaleMiddleware(),
+		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		qrCodeLogin,
+		makeLoggedOutLayout
+	);
 
 	router(
 		[

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -251,7 +251,7 @@ export class LoginLinks extends Component {
 	}
 
 	renderQrCodeLoginLink() {
-		if ( ! config.isEnabled( 'login/qr-code-login' ) || this.props.twoFactorAuthType ) {
+		if ( this.props.twoFactorAuthType ) {
 			return null;
 		}
 		if ( this.props.isLoggedIn ) {

--- a/config/development.json
+++ b/config/development.json
@@ -99,7 +99,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": true,
 		"login/magic-login": true,
-		"login/qr-code-login": true,
 		"logmein": true,
 		"happychat": true,
 		"mailchimp": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -78,7 +78,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,
-		"login/qr-code-login": true,
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-test": true,


### PR DESCRIPTION
Make the QR code login available in production.

#### Proposed Changes

* Now that the QR code login is available in the Jetpack App. 
Lets enable this in production as well. 

#### Testing Instructions

* Does the app build?
* Is the login via the QR code available to user in /log-in/qr url?
