### PR TITLE
Add WooCommerce app to the list of apps allowed to do Jetpack Connection

### DIFF
--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -13,7 +13,7 @@ export const REMOTE_PATH_AUTH =
 	'/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&jetpack_connect_login_redirect=true';
 export const REMOTE_PATH_INSTALL =
 	'/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
-export const ALLOWED_MOBILE_APP_REDIRECT_URL_LIST = [ /^wordpress:\/\// ];
+export const ALLOWED_MOBILE_APP_REDIRECT_URL_LIST = [ /^wordpress:\/\//, /^woocommerce:\/\// ];
 export const JPC_PATH_CHECKOUT = '/checkout';
 export const JETPACK_COUPON_PARTNERS = [ 'JPTST', 'IONOS', 'APK', 'AAD', 'RDCO', 'HMOU' ];
 export const JETPACK_COUPON_PRESET_MAPPING = {


### PR DESCRIPTION
#### Proposed Changes

This allows the Jetpack Connection flow to accept and do a `woocommerce://` redirect URL after a connection flow started from the mobile app is successful. The purpose of the redirect url is for the WooCommerce mobile app to be able to capture it and confirm that a successful connection is made.

How it will work from the mobile app side:
1. To start a Jetpack install, activation, and connecting flow from the WooCommerce mobile apps, the app first open  `https://wordpress.com/jetpack/connect?url=[SITE_ADDRESS]&mobile_redirect=woocommerce://jetpack-connected` on a webview,
2. The webview will present the Jetpack Connection flow to users. After the flow is completed, Calypso will eventually redirect to `woocommerce://jetpack-connected`
3. The mobile app will detect if the redirect URL is being opened. The app interprets that as a successful Jetpack connection, after which it will close the web app, and continue the connecting flow inside the app.

#### Testing Instructions

Due to the complexity of the Jetpack Connection flow and its integration with the mobile apps, this PR can't be tested on its own and/or locally. I tried testing the mobile app against the `calypso.live` URL for this PR, but somewhere along the Jetpack Connection flow things move to WordPress.com URL again and as such the redirect does not happen properly (I'm not sure why yet, but seems related to how cookies are created and used).

So instead my plan here is just to rely on the existing automated checks, and then deploy this so the WooCommerce mobile side can work with it properly. This is a relatively small change, I'm not very familiar with the Calypso codebase but from a quick look the modified part should not be causing issue, if any.

Finally, [according to a previous commit message to the same area in the code](https://github.com/Automattic/wp-calypso/commit/f571e758471c266420cfd67f5130aeb96cc22475):

> Currently the list is simply `wordpress://`. The mobile apps may want to use different schemes as part of dev process, such as `wpdebug`, `wpinternal`, so these can be added to the list as needed.

So it feels like it should be safe to add something new to this list. @seear I'm adding you to the reviewer list also, in case you're able to confidence check that as well.

In the event of some unexpected breakage happening, we can revert this.


#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #