### PR TITLE
Updated the tooltip/description for live chat in plans grid

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1375,15 +1375,14 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS ]: {
 		getSlug: () => FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
-		getTitle: () => i18n.translate( 'Live chat support 24X5' ),
-		getDescription: () =>
-			i18n.translate( 'Live chat is available 24 hours a day from Monday through Friday.' ),
+		getTitle: () => i18n.translate( 'Live chat support' ),
+		getDescription: () => i18n.translate( 'Live chat support' ),
 	},
 
 	[ FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS ]: {
 		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
-		getTitle: () => i18n.translate( 'Live chat support 24X7' ),
-		getDescription: () => i18n.translate( 'Live chat is available 24/7.' ),
+		getTitle: () => i18n.translate( 'Live chat support' ),
+		getDescription: () => i18n.translate( 'Live chat support' ),
 	},
 
 	[ FEATURE_JETPACK_VIDEOPRESS ]: {


### PR DESCRIPTION
#### Proposed Changes

* Removed 24x5 and 24x7 from the chat support feature title/description (tooltip) in the plans grid.
* Ref p1658164531049969/1658157549.672649-slack-C03D472D64C
* The tooltip says the same as the title (for now) due to translations, but we'll follow up with a more catchy copy here.

#### Testing Instructions

* Go to /start, verify that the plans grid does not say 24x7 and 24x5 under live chat
* Go to /plans/<site>/ and verify the same.
* Check in another locale, the content should be translated already (translations exist).
![Screenshot 2022-07-19 at 09 07 25](https://user-images.githubusercontent.com/52675688/179689076-2a0b6ea8-0590-4cb1-9fba-aaa372a348b1.png)
![Screenshot 2022-07-19 at 09 09 14](https://user-images.githubusercontent.com/52675688/179689089-9c0f0cbd-75ce-4ec3-b0da-dae968357de5.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #