### PR TITLE
Announcement Modal: supports cta link

### DIFF
--- a/client/blocks/announcement-modal/index.jsx
+++ b/client/blocks/announcement-modal/index.jsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { Guide } from '@wordpress/components';
+import { default as pageRouter } from 'page';
 import { useSelector, useDispatch } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -9,7 +10,7 @@ import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/prefe
 
 import './style.scss';
 
-const Page = ( { headline, heading, content, image, cta, handleDismiss } ) => {
+const Page = ( { headline, heading, content, image, cta, handleClick } ) => {
 	return (
 		<div className="announcement-modal__page">
 			<div className="announcement-modal__text">
@@ -22,7 +23,7 @@ const Page = ( { headline, heading, content, image, cta, handleDismiss } ) => {
 				</div>
 				{ cta && (
 					<div className="announcement-modal__cta">
-						<Button primary onClick={ handleDismiss }>
+						<Button primary onClick={ handleClick }>
 							{ cta }
 						</Button>
 					</div>
@@ -54,6 +55,16 @@ const Modal = ( { announcementId, pages, finishButtonText } ) => {
 		);
 	};
 
+	const handleClick = ( ctaLink ) => {
+		dispatch( savePreference( dismissPreference, 1 ) );
+		dispatch(
+			recordTracksEvent( 'calypso_announcement_modal_click', {
+				announcement_id: announcementId,
+			} )
+		);
+		pageRouter( ctaLink );
+	};
+
 	return (
 		<Guide
 			className="announcement-modal"
@@ -72,7 +83,7 @@ const Modal = ( { announcementId, pages, finishButtonText } ) => {
 						heading={ page.heading }
 						content={ page.content }
 						cta={ singlePage ? finishButtonText : null }
-						handleDismiss={ handleDismiss }
+						handleClick={ () => ( page?.ctaLink ? handleClick( page.ctaLink ) : handleDismiss() ) }
 					/>
 				),
 			} ) ) }

--- a/client/my-sites/plugins/plugins-announcement-modal/index.jsx
+++ b/client/my-sites/plugins/plugins-announcement-modal/index.jsx
@@ -5,11 +5,12 @@ import announcementImage from 'calypso/assets/images/marketplace/plugins-browser
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite, getSitePlan } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const PluginsAnnouncementModal = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
+	const selectedSiteUrl = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);
@@ -32,12 +33,13 @@ const PluginsAnnouncementModal = () => {
 				"You can now extend your site's capabilities with premium plugins. Available for purchase on the plugins page."
 			),
 			featureImage: announcementImage,
+			ctaLink: `/plugins/${ selectedSiteUrl }`,
 		},
 	];
 
 	return (
 		<AnnouncementModal
-			announcementId="plugins-page-starter-plan-launch"
+			announcementId="plugins-page-starter-plan-launch2"
 			pages={ announcementPages }
 			finishButtonText={ translate( 'Explore now' ) }
 		/>


### PR DESCRIPTION
#### Proposed Changes

* Supports a `ctaLink` for each modal page in `AnnouncementModal` component
* Adds `/plugins/${ selectedSiteUrl }` as `ctaLink` for the modal launched in https://github.com/Automattic/wp-calypso/pull/65494
* Changes the modal id launched in https://github.com/Automattic/wp-calypso/pull/65494, so that appears again to users.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**On a non-Starter site**
- Go to /plugins make sure the modal doesn't appear

**On a Starter site**
- Go to Plugins make sure the modal does appear
- Go to Home make sure the modal does appear
- Click "Explore now", make sure you are landed to `/plugins` page.
- Check that `calypso_announcement_modal_click` event has been fired. You can check it in Tracks Vigilante extension
![CleanShot 2022-07-19 at 10 56 33@2x](https://user-images.githubusercontent.com/12430020/179697987-08a897ef-91c2-49f6-961f-142cc687ad37.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #64972