### PR TITLE
Change to use design_type to determine whether to send vertical id or…

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -300,7 +300,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		if ( anchorDesigns.indexOf( selectedDesign.template ) < 0 ) {
 			// Send vertical_id only if the current design is generated design or we enabled the v13n of standard themes
 			const vertical_id =
-				!! recipe || isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined;
+				selectedDesign.design_type === 'vertical' || isEnabled( 'signup/standard-theme-v13n' )
+					? siteVerticalId
+					: undefined;
+
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
#### Proposed Changes

* https://github.com/Automattic/wp-calypso/pull/65531 uses `recipe` to check whether the selected design is generated or not but it's wrong as all of the designs have that property 😔. Hence, this PR changes to use `design_type` to check whether it's generated or not (Or is it better to check `recipe?.pattern_ids`?)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?siteSlug=<your_site>&flags=-signup/standard-theme-v13n`
* Select the non-generated design
* Check the payload of the `theme-setup` endpoint and the `vertical_id` is not sent

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #