### PR TITLE
Sites Dashboard: Refactor `<SitesContainer>` into a seperate component for dealing with empty states

### DIFF
--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -2,10 +2,8 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import EmptyContent from 'calypso/components/empty-content';
-import { SearchableSitesTable } from './searchable-sites-table';
-import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
-const EmptySites = styled( EmptyContent )`
+const NoSitesLayout = styled( EmptyContent )`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -20,19 +18,15 @@ const Title = styled.div`
 	margin-top: 50%;
 `;
 type SitesContainerProps = {
-	sites: SiteExcerptData[];
 	status: string;
 };
 
-export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
+export const NoSitesMessage = ( { status }: SitesContainerProps ) => {
 	const { __ } = useI18n();
-	if ( sites.length > 0 ) {
-		return <SearchableSitesTable sites={ sites } />;
-	}
 
 	if ( status === 'launched' ) {
 		return (
-			<EmptySites
+			<NoSitesLayout
 				title={ <Title> { __( "You haven't launched a site" ) } </Title> }
 				line={
 					<SecondaryText>
@@ -59,7 +53,7 @@ export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 
 	if ( status === 'private' ) {
 		return (
-			<EmptySites
+			<NoSitesLayout
 				title={ <Title> { __( 'You have no private sites' ) } </Title> }
 				line={
 					<SecondaryText>
@@ -86,7 +80,7 @@ export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 
 	if ( status === 'coming-soon' ) {
 		return (
-			<EmptySites
+			<NoSitesLayout
 				title={ <Title> { __( 'You have no coming soon sites' ) } </Title> }
 				line={
 					<SecondaryText>
@@ -112,7 +106,7 @@ export const SitesContainer = ( { sites, status }: SitesContainerProps ) => {
 	}
 
 	return (
-		<EmptySites
+		<NoSitesLayout
 			title={ __( 'Create your first site' ) }
 			line={ __(
 				"It's time to get your ideas online. We'll guide you through the process of creating a site that best suits your needs."

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -86,7 +86,7 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 						>
 							{ ( filteredSites, status ) =>
 								filteredSites.length ? (
-									<SearchableSitesTable sites={ sites } />
+									<SearchableSitesTable sites={ filteredSites } />
 								) : (
 									<NoSitesMessage status={ status } />
 								)

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -3,7 +3,8 @@ import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import { SitesContainer } from './sites-container';
+import { NoSitesMessage } from './no-sites-message';
+import { SearchableSitesTable } from './searchable-sites-table';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
@@ -83,9 +84,13 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 							` }
 							launchStatus={ launchStatus }
 						>
-							{ ( filteredSites, status ) => (
-								<SitesContainer sites={ filteredSites } status={ status } />
-							) }
+							{ ( filteredSites, status ) =>
+								filteredSites.length ? (
+									<SearchableSitesTable sites={ sites } />
+								) : (
+									<NoSitesMessage status={ status } />
+								)
+							}
 						</SitesTableFilterTabs>
 					) }
 				</ClassNames>


### PR DESCRIPTION
This PR lifts the responsibility for rendering the searchable table up into the parent `<SitesDashboard>` component, allowing `<SitesContainer>` to turn into a "dumber" component that just knows how to render empty state messages.

My hope is that eventually you should be able to glance at the `<SitesDashboard>` component and see all of the major parts of the dashboard UI. The buttons, search boxes, tabs and table would all be portable and sharable components, but the dashboard is thing inside the Calypso app that glues them all together. This might increase the size of the `<SitesDashboard>` component, but I don't think that's anything to fear. It should be mostly JSX, with the fancy logic relegated to other components and hooks.
It will also minimise the amount of "prop drilling" needed for basic things like selected tab state and filtered sites list.

#### Proposed Changes

* Lift `<SearchableSitesTable>` into the `<SitesDashboard>` component
* Rename `<SitesContainer>` to `<NoSitesMessage>`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the dashboard. It should work exactly as before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #