### PR TITLE
Sites Dashboard: Persist search value as `?search=` and between tabs

### DIFF
--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -18,7 +18,7 @@ const Title = styled.div`
 	margin-top: 50%;
 `;
 type SitesContainerProps = {
-	status: string;
+	status?: string;
 };
 
 export const NoSitesMessage = ( { status }: SitesContainerProps ) => {

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,5 +1,7 @@
 import { ClassNames } from '@emotion/react';
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import page from 'page';
 import { useMemo, useState } from 'react';
 import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesSearch } from './sites-search';
@@ -9,12 +11,13 @@ import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query
 
 interface SearchableSitesTableProps {
 	sites: SiteExcerptData[];
+	initialSearch?: string;
 }
 
-export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
+export function SearchableSitesTable( { sites, initialSearch }: SearchableSitesTableProps ) {
 	const { __ } = useI18n();
 
-	const [ term, setTerm ] = useState( '' );
+	const [ term, setTerm ] = useState( initialSearch );
 
 	const filteredSites = useMemo( () => {
 		if ( ! term ) {
@@ -24,7 +27,17 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 		return searchCollection( sites, term.toLowerCase(), [ 'URL', 'name', 'slug' ] );
 	}, [ term, sites ] );
 
-	const handleSearch = ( rawTerm: string ) => setTerm( rawTerm.trim() );
+	const handleSearch = ( rawTerm: string ) => {
+		const trimmedTerm = rawTerm.trim();
+		setTerm( trimmedTerm );
+		if ( trimmedTerm.length ) {
+			page(
+				addQueryArgs( window.location.pathname + window.location.search, { search: trimmedTerm } )
+			);
+		} else {
+			page( removeQueryArgs( window.location.pathname + window.location.search, 'search' ) );
+		}
+	};
 
 	return (
 		<ClassNames>
@@ -43,6 +56,7 @@ export function SearchableSitesTable( { sites }: SearchableSitesTableProps ) {
 							delaySearch
 							isReskinned
 							placeholder={ __( 'Search by name or domain…' ) }
+							defaultValue={ initialSearch }
 						/>
 					</div>
 					{ filteredSites.length > 0 ? (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -8,7 +8,12 @@ import { SearchableSitesTable } from './searchable-sites-table';
 import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
-	launchStatus?: string;
+	queryParams: SitesDashboardQueryParams;
+}
+
+interface SitesDashboardQueryParams {
+	status?: string;
+	search?: string;
 }
 
 const MAX_PAGE_WIDTH = '1184px';
@@ -57,7 +62,7 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
-export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
+export function SitesDashboard( { queryParams }: SitesDashboardProps ) {
 	const { __ } = useI18n();
 	const { data: sites = [] } = useSiteExcerptsQuery();
 
@@ -82,13 +87,16 @@ export function SitesDashboard( { launchStatus }: SitesDashboardProps ) {
 								position: relative;
 								top: -48px;
 							` }
-							launchStatus={ launchStatus }
+							filterOptions={ queryParams }
 						>
-							{ ( filteredSites, status ) =>
+							{ ( filteredSites, filterOptions ) =>
 								filteredSites.length ? (
-									<SearchableSitesTable sites={ filteredSites } />
+									<SearchableSitesTable
+										sites={ filteredSites }
+										initialSearch={ queryParams.search }
+									/>
 								) : (
-									<NoSitesMessage status={ status } />
+									<NoSitesMessage status={ filterOptions.status } />
 								)
 							}
 						</SitesTableFilterTabs>

--- a/client/sites-dashboard/components/sites-table-filter-tabs.tsx
+++ b/client/sites-dashboard/components/sites-table-filter-tabs.tsx
@@ -1,21 +1,25 @@
 import styled from '@emotion/styled';
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { removeQueryArgs } from '@wordpress/url';
+import { removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import page from 'page';
-import { addQueryArgs } from 'calypso/lib/url';
 import SitesBadge from './sites-badge';
 import type { SiteExcerptData } from 'calypso/data/sites/use-site-excerpts-query';
 
 interface SitesTableFilterTabsProps {
 	allSites: SiteExcerptData[];
-	children( filteredSites: SiteExcerptData[], status: string ): JSX.Element;
+	children( filteredSites: SiteExcerptData[], filterOptions: SitesTableFilterOptions ): JSX.Element;
 	className?: string;
-	launchStatus?: string;
+	filterOptions: SitesTableFilterOptions;
 }
 
 interface FilteredSites {
 	[ name: string ]: SiteExcerptData[];
+}
+
+interface SitesTableFilterOptions {
+	status?: string;
+	search?: string;
 }
 
 interface SiteTab extends Omit< TabPanel.Tab, 'title' > {
@@ -48,7 +52,7 @@ export function SitesTableFilterTabs( {
 	allSites,
 	children: renderContents,
 	className,
-	launchStatus,
+	filterOptions,
 }: SitesTableFilterTabsProps ) {
 	const { __ } = useI18n();
 
@@ -59,8 +63,8 @@ export function SitesTableFilterTabs( {
 		{ name: 'coming-soon', title: __( 'Coming soon' ) },
 	];
 
-	const initialTabName = tabs.find( ( tab ) => tab.name === launchStatus )
-		? launchStatus
+	const initialTabName = tabs.find( ( tab ) => tab.name === filterOptions.status )
+		? filterOptions.status
 		: undefined;
 
 	const filteredSites: FilteredSites = tabs.reduce(
@@ -76,6 +80,7 @@ export function SitesTableFilterTabs( {
 				<SitesBadge>{ filteredSites[ name ].length }</SitesBadge>
 			</>
 		),
+		filterOptions: filterOptions,
 	} ) );
 
 	return (
@@ -87,11 +92,11 @@ export function SitesTableFilterTabs( {
 				page(
 					'all' === tabName
 						? removeQueryArgs( window.location.pathname + window.location.search, 'status' )
-						: addQueryArgs( { status: tabName }, window.location.pathname + window.location.search )
+						: addQueryArgs( window.location.pathname + window.location.search, { status: tabName } )
 				);
 			} }
 		>
-			{ ( tab ) => renderContents( filteredSites[ tab.name ], tab.name ) }
+			{ ( tab ) => renderContents( filteredSites[ tab.name ], tab.filterOptions ) }
 		</SitesTabPanel>
 	);
 }

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -17,7 +17,12 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
-			<SitesDashboard launchStatus={ context.query.status } />
+			<SitesDashboard
+				queryParams={ {
+					search: context.query.search,
+					status: context.query.status,
+				} }
+			/>
 		</>
 	);
 	next();


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65605
Fixes https://github.com/Automattic/wp-calypso/issues/65603
Original review in #65644

## Proposed Changes

Persists the search input value in the URL as `?search=<value>` and also when switching between tabs.

<img width="932" alt="image" src="https://user-images.githubusercontent.com/36432/179278666-e479d7f2-cf15-49f7-869f-b8882ce828ff.png">

## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Enter a search query.
3. See search query appended to URL as `?search=<value>`.
4. Switch to a different launch status tab.
5. See the search query appear in the search field, and applied to the list of sites.
6. Clear the search field.
7. See the search query removed from the URL.

## Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?