### PR TITLE
Agency Signup: Add a Tracks event when the agency signup form is rendered

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -72,6 +72,10 @@ export default function AgencySignupForm(): ReactElement {
 		}
 	} );
 
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_agency_signup_start' ) );
+	}, [] );
+
 	return (
 		<Card className="agency-signup-form">
 			<svg


### PR DESCRIPTION
Context: 1201801459945917-as-1202598605316402

#### Proposed Changes

* Agency Signup: Add a Tracks event when the agency signup form is rendered.

#### Testing Instructions

* Checkout PR and run Jetpack Cloud.
* Open up http://jetpack.cloud.localhost:3000/agency/signup
* Check Tracks for the calypso_partner_portal_agency_signup_start event - it might take a couple of minutes for it to show up.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?