### PR TITLE
Sites Dashboard: Restore computed `slug` for `react-query` sites data

### DIFF
--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -51,6 +51,8 @@ export interface SiteDataOptions {
 	is_wpforteams_site: boolean;
 	is_difm_lite_in_progress: boolean;
 	is_domain_only: boolean;
+	is_redirect?: boolean;
 	difm_lite_site_options?: DIFMLiteSiteOptions;
+	unmapped_url?: string;
 	// TODO: fill out the rest of this
 }


### PR DESCRIPTION
See conversation in https://github.com/Automattic/wp-calypso/issues/65490#issuecomment-1189029079

## Proposed Changes

Mostly, but doesn't completely, restores the computed `slug` property for `react-query` sites data.

The one missing condition is `isSiteConflicting`:

https://github.com/Automattic/wp-calypso/blob/18ff765697cd7b8f81e4aa818a456d10e628f862/client/state/sites/selectors/get-site-slug.js#L23-L25

I'd love some direction on how I could add that using the `react-query` data we have, instead of touching the Redux store. Very specific direction (e.g. "create a X function that does Y and goes in Z") would be a huge bonus, as I'm still learning how everything is done in Calypso.

## Testing Instructions

1. Visit `/sites-dashboard`.
2. Clear `calypso_store` in IndexDB.
3. Refresh the page.
4. Observe dashboard links like `http://calypso.localhost:3000/home/domain.com`, instead of `http://calypso.localhost:3000/home/undefined`.

## Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?
