### PR TITLE
Allow premium plugins to be reinstalled

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -28,6 +28,7 @@ export default function CTAButton( {
 	billingPeriod,
 	isJetpackSelfHosted,
 	isSiteConnected,
+	isPluginPurchased,
 } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -71,6 +72,13 @@ export default function CTAButton( {
 	const { isPreinstalledPremiumPlugin, preinstalledPremiumPluginProduct } =
 		usePreinstalledPremiumPlugin( plugin.slug );
 
+	let installButtonText = translate( 'Install and activate' );
+	if ( ! isPluginPurchased && ( isMarketplaceProduct || isPreinstalledPremiumPlugin ) ) {
+		installButtonText = translate( 'Purchase and activate' );
+	} else if ( shouldUpgrade ) {
+		installButtonText = translate( 'Upgrade and activate' );
+	}
+
 	return (
 		<>
 			<PluginCustomDomainDialog
@@ -86,6 +94,7 @@ export default function CTAButton( {
 						isMarketplaceProduct,
 						billingPeriod,
 						eligibleForProPlan,
+						isPluginPurchased,
 					} );
 				} }
 				isDialogVisible={ showAddCustomDomain }
@@ -113,6 +122,7 @@ export default function CTAButton( {
 							isMarketplaceProduct,
 							billingPeriod,
 							eligibleForProPlan,
+							isPluginPurchased,
 						} )
 					}
 				/>
@@ -137,18 +147,12 @@ export default function CTAButton( {
 						eligibleForProPlan,
 						isPreinstalledPremiumPlugin,
 						preinstalledPremiumPluginProduct,
+						isPluginPurchased,
 					} );
 				} }
 				disabled={ ( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false }
 			>
-				{
-					// eslint-disable-next-line no-nested-ternary
-					isMarketplaceProduct || isPreinstalledPremiumPlugin
-						? translate( 'Purchase and activate' )
-						: shouldUpgrade
-						? translate( 'Upgrade and activate' )
-						: translate( 'Install and activate' )
-				}
+				{ installButtonText }
 			</Button>
 			{ isJetpackSelfHosted && isMarketplaceProduct && (
 				<div className="plugin-details-CTA__not-available">
@@ -182,6 +186,7 @@ function onClickInstallPlugin( {
 	eligibleForProPlan,
 	isPreinstalledPremiumPlugin,
 	preinstalledPremiumPluginProduct,
+	isPluginPurchased,
 } ) {
 	dispatch( removePluginStatuses( 'completed', 'error' ) );
 
@@ -205,7 +210,7 @@ function onClickInstallPlugin( {
 
 	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
 
-	if ( isMarketplaceProduct ) {
+	if ( ! isPluginPurchased && isMarketplaceProduct ) {
 		// We need to add the product to the  cart.
 		// Plugin install is handled on the backend by activating the subscription.
 		const variationPeriod = getPeriodVariationValue( billingPeriod );

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -7,6 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
@@ -20,6 +21,7 @@ import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
+import { siteHasPremiumPluginPurchase } from 'calypso/state/purchases/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -145,6 +147,10 @@ const PluginsBrowserListElement = ( props ) => {
 			siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_INSTALL_PLUGINS )
 		) || jetpackNonAtomic;
 
+	const isPluginPurchased = useSelector( ( state ) =>
+		siteHasPremiumPluginPurchase( state, selectedSite?.ID, plugin.slug )
+	);
+
 	if ( isPlaceholder ) {
 		// eslint-disable-next-line no-use-before-define
 		return <Placeholder iconSize={ iconSize } />;
@@ -162,6 +168,7 @@ const PluginsBrowserListElement = ( props ) => {
 
 	return (
 		<li className={ classNames }>
+			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<a
 				href={ pluginLink }
 				className="plugins-browser-item__link"
@@ -220,6 +227,7 @@ const PluginsBrowserListElement = ( props ) => {
 							shouldUpgrade={ shouldUpgrade }
 							canInstallPlugins={ canInstallPlugins }
 							currentSites={ currentSites }
+							isPluginPurchased={ isPluginPurchased }
 						/>
 					) }
 					<div className="plugins-browser-item__additional-info">
@@ -256,6 +264,7 @@ const InstalledInOrPricing = ( {
 	shouldUpgrade,
 	canInstallPlugins,
 	currentSites,
+	isPluginPurchased,
 } ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -315,6 +324,18 @@ const InstalledInOrPricing = ( {
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-gridicon-size */
+	}
+
+	if ( isPluginPurchased ) {
+		return (
+			<div className="plugins-browser-item__installed-and-active-container">
+				<div className="plugins-browser-item__installed ">
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace,wpcalypso/jsx-gridicon-size */ }
+					<Gridicon icon="checkmark" className="checkmark--inactive" size={ 14 } />
+					{ translate( 'Uninstalled' ) }
+				</div>
+			</div>
+		);
 	}
 
 	return (

--- a/client/state/purchases/selectors/index.js
+++ b/client/state/purchases/selectors/index.js
@@ -18,3 +18,4 @@ export { getUserPurchases } from './get-user-purchases';
 export { isUserPaid } from './is-user-paid';
 export { willAtomicSiteRevertAfterPurchaseDeactivation } from './will-atomic-site-revert-after-purchase-deactivation';
 export { siteHasJetpackProductPurchase } from './site-has-jetpack-product-purchase';
+export { siteHasPremiumPluginPurchase } from './site-has-premium-plugin-purchase';

--- a/client/state/purchases/selectors/site-has-premium-plugin-purchase.js
+++ b/client/state/purchases/selectors/site-has-premium-plugin-purchase.js
@@ -1,0 +1,27 @@
+import { getProductsList } from 'calypso/state/products-list/selectors';
+import { getSitePurchases } from './get-site-purchases';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Returns whether a site has purchased a premium plugin.
+ *
+ * @param {object} state global state
+ * @param {number} siteId the site id
+ * @param {string} pluginSlug the plugin slug
+ * @returns {boolean} True if the site has an active purchase for the given plugin, false otherwise.
+ */
+export const siteHasPremiumPluginPurchase = ( state, siteId, pluginSlug ) => {
+	if ( ! siteId || ! pluginSlug ) {
+		return false;
+	}
+
+	const purchases = getSitePurchases( state, siteId );
+	const purchasedProductIds = purchases.map( ( { productId } ) => productId );
+	const products = getProductsList( state );
+	return Object.values( products ).some(
+		( { billing_product_slug, product_id, product_slug } ) =>
+			purchasedProductIds.includes( product_id ) &&
+			( pluginSlug === product_slug || pluginSlug === billing_product_slug )
+	);
+};


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65634

#### Proposed Changes

Looks like the only reason why we prevent users from deleting premium plugins (927-gh-Automattic/wpcomsh) is because they cannot be reinstalled.

This PR introduces changes to allow deleted premium plugins to be installed again if they have been purchased. That way, we can revert changes from 927-gh-Automattic/wpcomsh, effectively removing us the necessity of maintaining a marketplace catalog in wpcomsh.

#### Testing Instructions

TBD

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

