### PR TITLE
Premium themes: Change CTA for premium theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -412,7 +412,9 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 				<div>
 					{ shouldUpgrade ? (
 						<Button primary borderless={ false } onClick={ upgradePlan }>
-							{ translate( 'Unlock theme' ) }
+							{ isEnabled( 'signup/seller-upgrade-modal' )
+								? translate( 'Purchase this theme' )
+								: translate( 'Unlock theme' ) }
 						</Button>
 					) : (
 						<Button primary borderless={ false } onClick={ () => pickDesign() }>


### PR DESCRIPTION
Changes CTA for the design setup view when a premium theme is selected from "Unlock theme" to "Purchase this theme". 

This is behind the `signup/seller-upgrade-modal` flag.

<img width="853" alt="image" src="https://user-images.githubusercontent.com/375980/179784461-9cf95a59-6afa-499c-8142-2209981fc1e6.png">

### Testing
1. Apply this diff.
2. Go to `/setup/designSetup?siteSlug=[YOUR_SITE]`
3. Select a premium theme
4. Verify the CTA reads "Unlock theme"
5. Go to `/setup/designSetup?siteSlug=[YOUR_SITE]&flags=signup/seller-upgrade-modal`
6. Select a premium theme
7. Verify the CTA reads "Purchase this theme"

Closes https://github.com/Automattic/wp-calypso/issues/65702