### PR TITLE
Revert "Place the WordPress logo in the correct location for RTL Languages"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -86,11 +86,6 @@ button {
 			fill: var( --color-text );
 			stroke: var( --color-text );
 			transform-origin: 0 0;
-
-			.rtl & {
-				/*rtl:ignore*/
-				transform-origin: 100% 0;
-			}
 		}
 
 		.signup-header__right {


### PR DESCRIPTION
#### Proposed Changes

This reverts commit 8c02d6c8ef4d5189d7bc4805334bde72655d3e18.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For the logo position issue:

1. Set language to Arabic or Hebrew
2. Create a new site at /start
3. Select domain and free plan
4. Select "Build" from the Where to start page
5. Verify the WordPress logo is in the correct location (the top right corner)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 465-gh-Automattic/i18n-issues and https://github.com/Automattic/wp-calypso/pull/65178 