### PR TITLE
Extra theme search bar top margin on mobile for logged out users

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 /*
  * Search card and text input
  */
@@ -28,7 +31,11 @@
 		flex: 0 1 auto;
 		height: 36px;
 		border: solid 1px var( --color-neutral-10 );
-		margin: 10px;
+		margin: 2rem 10px 10px;
+
+		@include break-mobile() {
+			margin: 10px;
+		}
 
 		&.has-focus,
 		&.has-focus:hover {


### PR DESCRIPTION
#### Proposed Changes

Add extra top margin to the mobile theme search for logged out users.

#### Testing Instructions

Prior to applying the PR, the theme search bar looks like this on mobile for logged-out users.
![image](https://user-images.githubusercontent.com/917632/179788085-9936ed64-92e5-446c-a5d0-3b360dd64b87.png)

After applying the PR, it should look like this
<img width="423" alt="image" src="https://user-images.githubusercontent.com/917632/179788179-20a4b281-4556-4fd8-b3f1-7293f917df46.png">


#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [NA] Have you checked for TypeScript, React or other console errors?
- [NA] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [NA] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Fixes 65645