### PR TITLE
Fix Jetpack post-connection redirects.

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
@@ -52,11 +51,9 @@ import InstallInstructions from './install-instructions';
 import JetpackConnect from './main';
 import NoDirectAccessError from './no-direct-access-error';
 import {
-	clearPlan,
 	isCalypsoStartedConnection,
 	persistMobileRedirect,
 	retrieveMobileRedirect,
-	retrievePlan,
 	storePlan,
 } from './persistence-utils';
 import OrgCredentialsForm from './remote-credentials';
@@ -144,37 +141,42 @@ export function offerResetRedirects( context, next ) {
 
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+	const queryRedirect = context.query.redirect;
+	const hasPaidPlan = selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null;
+	const isNotJetpack = selectedSite ? ! isJetpackSite( state, selectedSite.ID ) : null;
 
 	// Redirect AT sites back to wp-admin
 	const isAutomatedTransfer = selectedSite
 		? isSiteAutomatedTransfer( state, selectedSite.ID )
 		: null;
 	if ( isAutomatedTransfer ) {
-		debug( 'controller: offerResetRedirects -> redirecting WoA back to wp-admin', context.params );
+		debug(
+			'controller: offerResetRedirects -> redirecting WoA site back to wp-admin',
+			context.params
+		);
 		return navigate( selectedSite.URL + JETPACK_ADMIN_PATH );
 	}
 
-	// If site has a paid plan or is not a Jetpack site, redirect to Calypso's Plans page
-	const hasPlan = selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null;
-	const isNotJetpack = selectedSite ? ! isJetpackSite( state, selectedSite.ID ) : null;
-	if ( hasPlan || isNotJetpack ) {
+	if ( isNotJetpack ) {
 		debug(
-			'controller: offerResetRedirects -> redirecting to /plans since site has a plan or is not a Jetpack site',
+			'controller: offerResetRedirects -> redirecting to /plans since site is not a Jetpack site',
 			context.params
 		);
-		return navigate( CALYPSO_PLANS_PAGE + selectedSite.slug );
+		return page.redirect( CALYPSO_PLANS_PAGE + selectedSite.slug );
 	}
 
-	// If the user previously selected Jetpack Free, redirect them to their wp-admin page
-	const storedPlan = retrievePlan();
-	clearPlan();
-	if ( storedPlan === PLAN_JETPACK_FREE ) {
+	// If the site already has a paid plan, skip the plans/products page and redirect back to wp-admin.
+	if ( hasPaidPlan ) {
 		debug(
-			'controller: offerResetRedirects -> redirecting to wp-admin because the user got here by clicking Jetpack Free',
+			'controller: offerResetRedirects -> redirecting to back to wp-admin because site already has a paid plan',
 			context.params
 		);
-		navigate( context.query.redirect || selectedSite.options.admin_url );
-		return;
+
+		if ( queryRedirect ) {
+			return navigate( queryRedirect );
+		} else if ( selectedSite ) {
+			return navigate( selectedSite.URL + JETPACK_ADMIN_PATH );
+		}
 	}
 
 	// If current user is not an admin (can't purchase plans), redirect the user to /posts if
@@ -188,7 +190,6 @@ export function offerResetRedirects( context, next ) {
 			return page.redirect( CALYPSO_REDIRECTION_PAGE );
 		}
 
-		const queryRedirect = context.query.redirect;
 		if ( queryRedirect ) {
 			navigate( queryRedirect );
 		} else if ( selectedSite ) {


### PR DESCRIPTION
This PR fixes 2 issues with the Jetpack post-connection redirects:
- Remove inconsistent redirect after selecting Jetpack Free.  1164141197617539-as-1202607189129001/f
- If jetpack site has paid plan, skip the plans page. 1164141197617539-as-1201932053356704/f

### Proposed Changes

**Remove inconsistent redirect after selecting Jetpack Free:**
Prior to this PR, when disconnecting Jetpack and reconnecting again, on the first reconnection the plans page is skipped, and on the second reconnection the plans page is shown, and so on. This behavior is no longer needed and relevant because the Jetpack connect flow has changed now that the siteless license-based checkout is in place. Also, this inconsistency is causing flakiness on our e2e tests.

This PR fixes this inconsistent redirection, and now the plans page is shown on every reconnection. (Unless the user already has a paid plan (See below) )

**If the Jetpack site has a paid plan, skip plans page:**
Prior to this PR Jetpack users who already have a paid plan or product for their site were still being shown the plans page after reconnection. This was (understandably) causing user confusion because they already have a paid plan/product, and the only way to actually proceed past this screen is to scroll down and select Jetpack Free, which is very counter-intuitive and some users feared it was the wrong choice and might actually downgrade or remove their existing paid plan.

This PR fixes this so that when reconnecting Jetpack, and the site already has a paid Plan, the plans page is skipped and the user is redirected to their site wp-admin dashboard.

### Testing Instructions

**Test that post-connection redirects to the plans page consistently every time when the site does not own any paid plans or products.**
1. Checkout this PR and spin up calypso blue (`yarn start`)
1. Create a Jurassic.ninja site
1. Click "Set up Jetpack" to connect Jetpack.
1. You'll be redirected to the Authorization page (`/jetpack/connect/authorize?..`), in the URL replace `https://wordpress.com` with `http://calypso.localhost:3000` and press enter to reload the page in Calypso dev environment.
1. Click "Approve" to authorize the connection.
1. Verify you are redirected to the `/jetpack/connect/plans/:site` plans page.
1. Select "Jetpack Free", verify you are redirected back to the site Jetpack dashboard (Recommendations assistant).
1. Navigate to the "At a glance" tab, scroll down and click "Manage site connection".
1. Click "Disconnect" and then once disconnected, dismiss the popout by clicking "No thank you".
1. Follow steps 3 thru 9 again a couple more times, and verify you are redirected back to the Plans page consistently upon every reconnection.

**Test that post-connection redirect skips the Plans page when the site already has a paid plan or product:**
1. Next, purchase any Jetpack paid plan or product.
1. Navigate to the "At a glance" tab, scroll down and click "Manage site connection".
1. Click "Disconnect" and then once disconnected, dismiss the popout by clicking "No thank you".
1. Follow steps 3 thru 5 above to reconnect Jetpack.
1. upon reconnection, verify you are redirected back to the wp-admin Jetpack dashboard every time (Because the site now already has a paid plan or product).

**Unit tests:**
This PR does not add or modify any unit tests, however just to be thorough, we can run all the jetpack-connect tests:
- run `yarn test-client client/jetpack-connect`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **NO, N/A**
- [X] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? **Yes**
- [X] Have you checked for TypeScript, React or other console errors? **Yes**
- [X] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) **N/A**
- [X] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? **No, N/A**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202607189129001