### PR TITLE
My Home: Update Wpcourses URL

### DIFF
--- a/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
+++ b/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
@@ -19,7 +19,7 @@ const WpCourses = () => {
 			links={ [
 				{
 					externalLink: true,
-					url: 'https://wpcourses.com/course/blogging-beginners-course/',
+					url: 'https://wpcourses.com/course/intro-to-blogging/',
 					text: 'Learn more',
 				},
 			] }

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -20,6 +20,7 @@ import FreePhotoLibrary from 'calypso/my-sites/customer-home/cards/education/fre
 // eslint-disable-next-line inclusive-language/use-inclusive-words
 import RespondToCustomerFeedback from 'calypso/my-sites/customer-home/cards/education/respond-to-customer-feedback';
 import EducationStore from 'calypso/my-sites/customer-home/cards/education/store';
+import WpCourses from 'calypso/my-sites/customer-home/cards/education/wpcourses';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -27,6 +28,7 @@ const cardComponents = {
 	[ EDUCATION_FREE_PHOTO_LIBRARY ]: FreePhotoLibrary,
 	[ EDUCATION_EARN ]: EducationEarn,
 	[ EDUCATION_STORE ]: EducationStore,
+	[ EDUCATION_WPCOURSES ]: WpCourses,
 	[ EDUCATION_FIND_SUCCESS ]: FindSuccess,
 	[ EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK ]: RespondToCustomerFeedback,
 	[ EDUCATION_BLOGGING_QUICK_START ]: BloggingQuickStart,

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -20,7 +20,6 @@ import FreePhotoLibrary from 'calypso/my-sites/customer-home/cards/education/fre
 // eslint-disable-next-line inclusive-language/use-inclusive-words
 import RespondToCustomerFeedback from 'calypso/my-sites/customer-home/cards/education/respond-to-customer-feedback';
 import EducationStore from 'calypso/my-sites/customer-home/cards/education/store';
-import WpCourses from 'calypso/my-sites/customer-home/cards/education/wpcourses';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -28,7 +27,6 @@ const cardComponents = {
 	[ EDUCATION_FREE_PHOTO_LIBRARY ]: FreePhotoLibrary,
 	[ EDUCATION_EARN ]: EducationEarn,
 	[ EDUCATION_STORE ]: EducationStore,
-	[ EDUCATION_WPCOURSES ]: WpCourses,
 	[ EDUCATION_FIND_SUCCESS ]: FindSuccess,
 	[ EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK ]: RespondToCustomerFeedback,
 	[ EDUCATION_BLOGGING_QUICK_START ]: BloggingQuickStart,


### PR DESCRIPTION
#### Proposed Changes

* Update link on Wpcourses card to point to the correct Intro to Blogging course: https://wpcourses.com/course/intro-to-blogging/

<img width="1091" alt="Screen Shot 2022-07-19 at 12 11 44 PM" src="https://user-images.githubusercontent.com/2124984/179798977-38e53dc5-4078-4a6c-8ebf-636adddcef92.png">


#### Testing Instructions

* Switch to this PR, navigate to `/home` on a site that has launched and completed the checklist
* You should see the card outlined in red above
* Clicking the card should bring you to `https://wpcourses.com/course/intro-to-blogging/`

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?