### PR TITLE
Design Picker: Add popover to fse badge

### DIFF
--- a/packages/design-picker/src/components/badge-container/index.tsx
+++ b/packages/design-picker/src/components/badge-container/index.tsx
@@ -1,5 +1,7 @@
+import { Popover } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { FunctionComponent, useRef, useState } from 'react';
 import PremiumBadge from '../premium-badge';
-import type { FunctionComponent } from 'react';
 
 import './style.scss';
 
@@ -23,6 +25,12 @@ const BadgeContainer: FunctionComponent< Props > = ( {
 		}
 	}
 
+	const divRef = useRef( null );
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+
+	const { __ } = useI18n();
+	const tooltipText = __( 'This theme is full site editing capable', __i18n_text_domain__ );
+
 	return (
 		<div className="badge-container">
 			<svg
@@ -31,6 +39,9 @@ const BadgeContainer: FunctionComponent< Props > = ( {
 				viewBox="0 0 16 16"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
+				ref={ divRef }
+				onMouseEnter={ () => setIsPopoverVisible( true ) }
+				onMouseLeave={ () => setIsPopoverVisible( false ) }
 			>
 				<path
 					d="M12.6667 2H3.33333C2.59695 2 2 2.59695 2 3.33333V12.6667C2 13.403 2.59695 14 3.33333 14H12.6667C13.403 14 14 13.403 14 12.6667V3.33333C14 2.59695 13.403 2 12.6667 2Z"
@@ -54,6 +65,14 @@ const BadgeContainer: FunctionComponent< Props > = ( {
 					strokeLinejoin="round"
 				/>
 			</svg>
+			<Popover
+				className="badge-container__fse-popover"
+				context={ divRef.current }
+				isVisible={ isPopoverVisible }
+				position="top left"
+			>
+				{ tooltipText }
+			</Popover>
 			{ getBadge() }
 		</div>
 	);

--- a/packages/design-picker/src/components/badge-container/style.scss
+++ b/packages/design-picker/src/components/badge-container/style.scss
@@ -3,4 +3,27 @@
 	display: flex;
     justify-content: right;
     align-items: center;
+
+}
+
+.badge-container__fse-popover {
+	max-width: 300px;
+	outline: none;
+	.popover__inner {
+		background-color: #000;
+		color: #eee;
+		padding: 0.25rem;
+		border-radius: 4px;
+		border: 0;
+	}
+	&.is-top-left {
+		.popover__arrow {
+			&::before {
+				border-top-color: #000 !important;
+			}
+		}
+	}
+	.popover__arrow {
+		border: 10px dashed transparent;
+	}
 }


### PR DESCRIPTION
Adds a popover over the FSE badge.

### Testing
1. Apply this diff.
2. Go to design picker for a site you own `/setup/designSetup?siteSlug=[YOUR_SITE]`.
3. Hover over the FSE badge.
4. You should see this: <img width="362" alt="image" src="https://user-images.githubusercontent.com/375980/179826238-11f4265a-693f-45b3-84ec-98cc9f5fda30.png">

Closes https://github.com/Automattic/wp-calypso/issues/65700