### PR TITLE
Seller Experience: Update upgrade modal UI for yearly/monthly plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -46,6 +46,16 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 		}
 	}
 
+	&__subscription-interval {
+		display: flex;
+	}
+
+	&__radio {
+		span {
+			color: var( --studio-green-50 );
+		}
+	}
+
 	h1.upgrade-modal__heading {
 		@extend .wp-brand-font;
 		font-size: $font-headline-medium;
@@ -75,6 +85,7 @@ $design-button-primary-hover-color: var( --color-primary-60 );
         border-radius: 4px;
         font-weight: 500;
         box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
+		width: 100%;
 
         &:hover,
         &:focus {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -34,15 +34,16 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 		}
 	}
 
-	&__star-box {
-		background: var( --studio-gray-100 );
-		border-radius: 4px;
-		fill: white;
-		line-height: 75px;
-		width: 64px;
-		height: 64px;
-		margin-bottom: 25px;
-		text-align: center;
+	&__theme-price {
+		display: flex;
+		align-items: baseline;
+		justify-content: flex-start;
+
+		span {
+			@extend .wp-brand-font;
+			font-size: $font-headline-small;
+			margin-right: 10px;
+		}
 	}
 
 	h1.upgrade-modal__heading {
@@ -53,7 +54,7 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 	}
 
 	p {
-		margin-bottom: 40px;
+		margin-bottom: 35px;
 	}
 
 	&__close {
@@ -67,16 +68,6 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 		}
 	}
 
-	&__actions {
-		display: flex;
-		justify-content: space-between;
-	}
-
-	&__cancel.button {
-		border-radius: 4px;
-		width: 47%;
-	}
-
 	&__upgrade.button.is-primary {
 		background: $design-button-primary-color;
         border-color: $design-button-primary-color;
@@ -84,7 +75,6 @@ $design-button-primary-hover-color: var( --color-primary-60 );
         border-radius: 4px;
         font-weight: 500;
         box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
-		width: 47%;
 
         &:hover,
         &:focus {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -36,6 +36,7 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 
 	&__theme-price {
 		display: flex;
+		margin-bottom: 5px;
 		align-items: baseline;
 		justify-content: flex-start;
 
@@ -48,23 +49,36 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 
 	&__subscription-interval {
 		display: flex;
+		margin-bottom: 15px;
+
+		.form-label {
+			margin-right: 15px;
+
+			&:last-of-type {
+				margin-right: 0;
+			}
+		}
 	}
 
-	&__radio {
-		span {
-			color: var( --studio-green-50 );
-		}
+	&__plan-nudge {
+		color: var( --color-text-subtle );
+		font-size: $font-body-small;
+	}
+
+	&__subscription-savings {
+		color: var( --studio-green-50 );
+		margin-left: 8px;
 	}
 
 	h1.upgrade-modal__heading {
 		@extend .wp-brand-font;
-		font-size: $font-headline-medium;
+		font-size: $font-headline-small;
 		line-height: 1.1;
-		margin-bottom: 25px;
+		margin-bottom: 15px;
 	}
 
 	p {
-		margin-bottom: 35px;
+		margin-bottom: 20px;
 	}
 
 	&__close {
@@ -84,6 +98,7 @@ $design-button-primary-hover-color: var( --color-primary-60 );
         padding: 9px 25px;
         border-radius: 4px;
         font-weight: 500;
+		margin-bottom: 15px;
         box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
 		width: 100%;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -63,11 +63,16 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 	&__plan-nudge {
 		color: var( --color-text-subtle );
 		font-size: $font-body-small;
+
+		button {
+			color: var( --wp-admin-theme-color );
+			cursor: pointer;
+		}
 	}
 
 	&__subscription-savings {
 		color: var( --studio-green-50 );
-		margin-left: 8px;
+		margin-left: 4px;
 	}
 
 	h1.upgrade-modal__heading {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -9,9 +9,24 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 	flex-direction: column;
 	padding: 0;
 
+	&.loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		max-width: 775px;
+	}
+
 	@include break-medium() {
 		flex-direction: row;
 		max-width: 775px;
+
+		&.loading {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 775px;
+			height: 430px;
+		}
 	}
 
 	&__col {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -1,6 +1,8 @@
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormRadio from 'calypso/components/forms/form-radio';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
 import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
 import ThemeFeatures from './theme-features';
@@ -20,7 +22,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const features = theme.data && theme.data.taxonomies.features;
 	const featuresHeading = translate( 'Theme features' ) as string;
 	const themeProduct = useSelect( ( select ) =>
-		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'premium-theme' )
+		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'premium_theme' )
 	);
 	const themePrice = themeProduct?.combined_cost_display;
 
@@ -38,10 +40,30 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 						'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
 					) }
 				</p>
+				<div className="upgrade-modal__theme-price">
+					<span>{ themePrice }</span>
+					{ translate( 'per year' ) }
+				</div>
+				<div className="upgrade-modal__subscription-interval">
+					{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
+					<FormFieldset>
+						<FormRadio
+							className="upgrade-modal__radio"
+							label={ translate( 'Monthly' ) }
+							value="monthly"
+						/>
+						<FormRadio
+							className="upgrade-modal__radio"
+							label={ translate( 'Yearly <span>(Save $51)</span>', {
+								element: {
+									span: <span />,
+								},
+							} ) }
+							value="yearly"
+						/>
+					</FormFieldset>
+				</div>
 				<div className="upgrade-modal__actions">
-					<Button className="upgrade-modal__cancel" onClick={ () => closeModal() }>
-						{ translate( 'Cancel' ) }
-					</Button>
 					<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
 						{ translate( 'Buy and activate theme' ) }
 					</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -2,7 +2,6 @@ import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/componen
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
@@ -45,44 +44,49 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 				</p>
 				<div className="upgrade-modal__theme-price">
 					<span>{ themePrice }</span>
-					{ translate( 'per year' ) }
+					{ subInterval === 'annually' ? translate( 'per year' ) : translate( 'per month' ) }
 				</div>
 				<div className="upgrade-modal__subscription-interval">
-					{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
-					<FormFieldset>
-						<FormLabel>
-							<FormRadio
-								id="subscription-interval-monthly"
-								name="subscription-interval"
-								label={ translate( 'Monthly' ) }
-								className="upgrade-modal__radio"
-								value="monthly"
-								checked={ 'monthly' === subInterval }
-								onChange={ () => setSubInterval( 'monthly' ) }
-							/>
-						</FormLabel>
-						<FormLabel>
-							<FormRadio
-								id="subscription-interval-annually"
-								name="subscription-interval"
-								className="upgrade-modal__radio"
-								label={ translate( 'Annually {{span}}(Save $51){{/span}}', {
-									components: {
-										span: <span />,
-									},
-								} ) }
-								value="annually"
-								checked={ 'annually' === subInterval }
-								onChange={ () => setSubInterval( 'annually' ) }
-							/>
-						</FormLabel>
-					</FormFieldset>
+					<FormLabel>
+						<FormRadio
+							id="subscription-interval-monthly"
+							name="subscription-interval"
+							label={ translate( 'Monthly' ) }
+							className="upgrade-modal__radio"
+							value="monthly"
+							checked={ 'monthly' === subInterval }
+							onChange={ () => setSubInterval( 'monthly' ) }
+						/>
+					</FormLabel>
+					<FormLabel>
+						{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
+						<FormRadio
+							id="subscription-interval-annually"
+							name="subscription-interval"
+							className="upgrade-modal__radio"
+							label={ translate( 'Annually {{span}}(Save $51){{/span}}', {
+								components: {
+									span: <span className="upgrade-modal__subscription-savings" />,
+								},
+							} ) }
+							value="annually"
+							checked={ 'annually' === subInterval }
+							onChange={ () => setSubInterval( 'annually' ) }
+						/>
+					</FormLabel>
 				</div>
 				<div className="upgrade-modal__actions">
 					<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
 						{ translate( 'Buy and activate theme' ) }
 					</Button>
 				</div>
+				<p className="upgrade-modal__plan-nudge">
+					{ translate( 'or get it for free when on the {{a}}Premium plan{{/a}}', {
+						components: {
+							a: <a href="#" rel="noreferrer noopener" />,
+						},
+					} ) }
+				</p>
 			</div>
 			<div className="upgrade-modal__col">
 				<div className="upgrade-modal__included">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -19,11 +19,10 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const theme = useThemeDetails( slug );
 	const features = theme.data && theme.data.taxonomies.features;
 	const featuresHeading = translate( 'Theme features' ) as string;
-	const plan = useSelect( ( select ) =>
-		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'pro-plan' )
+	const themeProduct = useSelect( ( select ) =>
+		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'premium-theme' )
 	);
-	const planName = plan?.product_name;
-	const planPrice = plan?.combined_cost_display;
+	const themePrice = themeProduct?.combined_cost_display;
 
 	return (
 		<Dialog
@@ -33,20 +32,10 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			isFullScreen
 		>
 			<div className="upgrade-modal__col">
-				<div className="upgrade-modal__star-box">
-					<Gridicon icon="star" size={ 24 } />
-				</div>
 				<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
 				<p>
-					{ /* Translators: planName is the name of the plan, planPrice is the plan price in the user's currency */ }
 					{ translate(
-						"This theme requires %(planName)s to unlock. It's %(planPrice)s a year, risk-free with a 14-day money-back guarantee.",
-						{
-							args: {
-								planName,
-								planPrice,
-							},
-						}
+						'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
 					) }
 				</p>
 				<div className="upgrade-modal__actions">
@@ -54,20 +43,13 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 						{ translate( 'Cancel' ) }
 					</Button>
 					<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
-						{ translate( 'Upgrade plan' ) }
+						{ translate( 'Buy and activate theme' ) }
 					</Button>
 				</div>
 			</div>
 			<div className="upgrade-modal__col">
 				<div className="upgrade-modal__included">
-					<h2>
-						{ /* Translators: planName is the name of the plan */ }
-						{ translate( 'Included with %(planName)s', {
-							args: {
-								planName,
-							},
-						} ) }
-					</h2>
+					<h2>{ translate( 'Included with your purchase' ) }</h2>
 					<ul>
 						<li className="upgrade-modal__included-item">
 							<Gridicon icon="checkmark" size={ 16 } />
@@ -75,15 +57,11 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 						</li>
 						<li className="upgrade-modal__included-item">
 							<Gridicon icon="checkmark" size={ 16 } />
-							{ translate( 'Access to premium themes' ) }
+							{ translate( 'Dozens of free themes' ) }
 						</li>
 						<li className="upgrade-modal__included-item">
 							<Gridicon icon="checkmark" size={ 16 } />
-							{ translate( "Access to 1000's of plugins" ) }
-						</li>
-						<li className="upgrade-modal__included-item">
-							<Gridicon icon="checkmark" size={ 16 } />
-							{ translate( 'Unlimited support' ) }
+							{ translate( 'Unlimited customer support via email' ) }
 						</li>
 					</ul>
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -1,7 +1,9 @@
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
 import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
@@ -19,6 +21,7 @@ interface UpgradeModalProps {
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
 	const theme = useThemeDetails( slug );
+	const [ subInterval, setSubInterval ] = useState( 'annually' );
 	const features = theme.data && theme.data.taxonomies.features;
 	const featuresHeading = translate( 'Theme features' ) as string;
 	const themeProduct = useSelect( ( select ) =>
@@ -47,20 +50,32 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 				<div className="upgrade-modal__subscription-interval">
 					{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
 					<FormFieldset>
-						<FormRadio
-							className="upgrade-modal__radio"
-							label={ translate( 'Monthly' ) }
-							value="monthly"
-						/>
-						<FormRadio
-							className="upgrade-modal__radio"
-							label={ translate( 'Yearly <span>(Save $51)</span>', {
-								element: {
-									span: <span />,
-								},
-							} ) }
-							value="yearly"
-						/>
+						<FormLabel>
+							<FormRadio
+								id="subscription-interval-monthly"
+								name="subscription-interval"
+								label={ translate( 'Monthly' ) }
+								className="upgrade-modal__radio"
+								value="monthly"
+								checked={ 'monthly' === subInterval }
+								onChange={ () => setSubInterval( 'monthly' ) }
+							/>
+						</FormLabel>
+						<FormLabel>
+							<FormRadio
+								id="subscription-interval-annually"
+								name="subscription-interval"
+								className="upgrade-modal__radio"
+								label={ translate( 'Annually {{span}}(Save $51){{/span}}', {
+									components: {
+										span: <span />,
+									},
+								} ) }
+								value="annually"
+								checked={ 'annually' === subInterval }
+								onChange={ () => setSubInterval( 'annually' ) }
+							/>
+						</FormLabel>
 					</FormFieldset>
 				</div>
 				<div className="upgrade-modal__actions">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -81,9 +81,9 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 					</Button>
 				</div>
 				<p className="upgrade-modal__plan-nudge">
-					{ translate( 'or get it for free when on the {{a}}Premium plan{{/a}}', {
+					{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
 						components: {
-							a: <a href="#" rel="noreferrer noopener" />,
+							button: <Button onClick={ () => checkout() } plain />,
 						},
 					} ) }
 				</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -1,9 +1,11 @@
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
 import { useSelect } from '@wordpress/data';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
 import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
 import ThemeFeatures from './theme-features';
@@ -20,98 +22,122 @@ interface UpgradeModalProps {
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
 	const theme = useThemeDetails( slug );
-	const [ subInterval, setSubInterval ] = useState( 'annually' );
+	const [ subInterval, setSubInterval ] = useState( 'yearly' );
 	const features = theme.data && theme.data.taxonomies.features;
 	const featuresHeading = translate( 'Theme features' ) as string;
-	const themeProduct = useSelect( ( select ) =>
-		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'premium_theme' )
+	const themeYearlyProduct = useSelect(
+		( select ) => select( PRODUCTS_LIST_STORE ).getProductBySlug( 'pro-plan' ) //Pass combination of `slug` and `subInterval` to selector to get theme price
 	);
-	const themePrice = themeProduct?.combined_cost_display;
+	const themeMonthlyProduct = useSelect(
+		( select ) => select( PRODUCTS_LIST_STORE ).getProductBySlug( 'pro-plan-monthly' ) //Pass combination of `slug` and `subInterval` to selector to get theme price
+	);
+	const themePrice =
+		subInterval === 'yearly'
+			? themeYearlyProduct?.combined_cost_display
+			: themeMonthlyProduct?.combined_cost_display;
+
+	let savings = 0;
+	if ( themeMonthlyProduct?.cost && themeYearlyProduct?.cost ) {
+		savings = Math.floor(
+			( 1 - themeYearlyProduct?.cost / ( themeMonthlyProduct?.cost * 12 ) ) * 100
+		);
+	}
+
+	//Wait until we have theme and product data to show content
+	const isLoading = ! themeYearlyProduct?.cost || ! themeMonthlyProduct?.cost || ! theme.data;
 
 	return (
 		<Dialog
-			className="upgrade-modal"
+			className={ classNames( 'upgrade-modal', { loading: isLoading } ) }
 			isVisible={ isOpen }
 			onClose={ () => closeModal() }
 			isFullScreen
 		>
-			<div className="upgrade-modal__col">
-				<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
-				<p>
-					{ translate(
-						'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
-					) }
-				</p>
-				<div className="upgrade-modal__theme-price">
-					<span>{ themePrice }</span>
-					{ subInterval === 'annually' ? translate( 'per year' ) : translate( 'per month' ) }
-				</div>
-				<div className="upgrade-modal__subscription-interval">
-					<FormLabel>
-						<FormRadio
-							id="subscription-interval-monthly"
-							name="subscription-interval"
-							label={ translate( 'Monthly' ) }
-							className="upgrade-modal__radio"
-							value="monthly"
-							checked={ 'monthly' === subInterval }
-							onChange={ () => setSubInterval( 'monthly' ) }
-						/>
-					</FormLabel>
-					<FormLabel>
-						{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
-						<FormRadio
-							id="subscription-interval-annually"
-							name="subscription-interval"
-							className="upgrade-modal__radio"
-							label={ translate( 'Annually {{span}}(Save $51){{/span}}', {
+			{ isLoading && <LoadingEllipsis /> }
+			{ ! isLoading && (
+				<>
+					<div className="upgrade-modal__col">
+						<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
+						<p>
+							{ translate(
+								'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
+							) }
+						</p>
+						<div className="upgrade-modal__theme-price">
+							<span>{ themePrice }</span>
+							{ subInterval === 'yearly' ? translate( 'per year' ) : translate( 'per month' ) }
+						</div>
+						<div className="upgrade-modal__subscription-interval">
+							<FormLabel>
+								<FormRadio
+									id="subscription-interval-monthly"
+									name="subscription-interval"
+									label={ translate( 'Monthly' ) }
+									className="upgrade-modal__radio"
+									value="monthly"
+									checked={ 'monthly' === subInterval }
+									onChange={ () => setSubInterval( 'monthly' ) }
+								/>
+							</FormLabel>
+							<FormLabel>
+								{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
+								<FormRadio
+									id="subscription-interval-yearly"
+									name="subscription-interval"
+									className="upgrade-modal__radio"
+									label={ translate( 'Annually {{span}}(Save %(savings)s%){{/span}}', {
+										args: {
+											savings,
+										},
+										components: {
+											span: <span className="upgrade-modal__subscription-savings" />,
+										},
+									} ) }
+									value="yearly"
+									checked={ 'yearly' === subInterval }
+									onChange={ () => setSubInterval( 'yearly' ) }
+								/>
+							</FormLabel>
+						</div>
+						<div className="upgrade-modal__actions">
+							<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
+								{ translate( 'Buy and activate theme' ) }
+							</Button>
+						</div>
+						<p className="upgrade-modal__plan-nudge">
+							{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
 								components: {
-									span: <span className="upgrade-modal__subscription-savings" />,
+									button: <Button onClick={ () => checkout() } plain />,
 								},
 							} ) }
-							value="annually"
-							checked={ 'annually' === subInterval }
-							onChange={ () => setSubInterval( 'annually' ) }
-						/>
-					</FormLabel>
-				</div>
-				<div className="upgrade-modal__actions">
-					<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
-						{ translate( 'Buy and activate theme' ) }
+						</p>
+					</div>
+					<div className="upgrade-modal__col">
+						<div className="upgrade-modal__included">
+							<h2>{ translate( 'Included with your purchase' ) }</h2>
+							<ul>
+								<li className="upgrade-modal__included-item">
+									<Gridicon icon="checkmark" size={ 16 } />
+									{ translate( 'Best-in-class hosting' ) }
+								</li>
+								<li className="upgrade-modal__included-item">
+									<Gridicon icon="checkmark" size={ 16 } />
+									{ translate( 'Dozens of free themes' ) }
+								</li>
+								<li className="upgrade-modal__included-item">
+									<Gridicon icon="checkmark" size={ 16 } />
+									{ translate( 'Unlimited customer support via email' ) }
+								</li>
+							</ul>
+						</div>
+						{ features && <ThemeFeatures features={ features } heading={ featuresHeading } /> }
+					</div>
+					<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
+						<Gridicon icon="cross" size={ 12 } />
+						<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
 					</Button>
-				</div>
-				<p className="upgrade-modal__plan-nudge">
-					{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
-						components: {
-							button: <Button onClick={ () => checkout() } plain />,
-						},
-					} ) }
-				</p>
-			</div>
-			<div className="upgrade-modal__col">
-				<div className="upgrade-modal__included">
-					<h2>{ translate( 'Included with your purchase' ) }</h2>
-					<ul>
-						<li className="upgrade-modal__included-item">
-							<Gridicon icon="checkmark" size={ 16 } />
-							{ translate( 'Best-in-class hosting' ) }
-						</li>
-						<li className="upgrade-modal__included-item">
-							<Gridicon icon="checkmark" size={ 16 } />
-							{ translate( 'Dozens of free themes' ) }
-						</li>
-						<li className="upgrade-modal__included-item">
-							<Gridicon icon="checkmark" size={ 16 } />
-							{ translate( 'Unlimited customer support via email' ) }
-						</li>
-					</ul>
-				</div>
-				{ features && <ThemeFeatures features={ features } heading={ featuresHeading } /> }
-			</div>
-			<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
-				<Gridicon icon="cross" size={ 12 } />
-				<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
-			</Button>
+				</>
+			) }
 		</Dialog>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* Account for upcoming changes to theme subscriptions in the modal copy, styles, and actions.
* Add radio buttons for selecting monthly or yearly subscriptions
* Add loading state to wait for theme and product data
* TODO: Get actual premium pricing data (waiting on #65569 )
* TODO: Figure out where link to plan under button should go (checkout with plan?)
* TODO: Pass subscription choice back to checkout function so we know what subscription to add to the cart

**Before**

<img width="808" alt="175143842-25ab9aaa-3dd8-43ed-9469-95b68b5b52f0" src="https://user-images.githubusercontent.com/2124984/179833332-94d3a784-177c-48e1-937c-eeec7f5ab447.png">

**After**

<img width="808" alt="Screen Shot 2022-07-20 at 9 54 56 AM" src="https://user-images.githubusercontent.com/2124984/180000438-75e6543d-044d-4f1c-87a8-53503e6278df.png">


#### Testing Instructions

* Switch to this PR and navigate to `/setup/?siteSlug=[your test site]&flags=signup/seller-upgrade-modal` on a site on the free plan
* Choose a Premium theme
* Click the "Unlock theme" button in the preview
* The above modal should appear.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #65138