### PR TITLE
Design picker: Remove fse badge

### DIFF
--- a/packages/design-picker/src/components/badge-container/__tests__/index.tsx
+++ b/packages/design-picker/src/components/badge-container/__tests__/index.tsx
@@ -30,13 +30,11 @@ describe( '<BadgeContainer /> integration', () => {
 		expect( premiumBadge ).toBeTruthy();
 	} );
 
-	it( 'should not render badges, but the svg', async () => {
+	it( 'should not render badges', async () => {
 		const renderedContent = render( <BadgeContainer /> );
 
-		const foundSvg = renderedContent.container.querySelector( 'svg' );
 		const premiumBadge = renderedContent.container.querySelector( '.premium-badge' );
 
-		expect( foundSvg ).toBeTruthy();
 		expect( premiumBadge ).toBeFalsy();
 	} );
 } );

--- a/packages/design-picker/src/components/badge-container/index.tsx
+++ b/packages/design-picker/src/components/badge-container/index.tsx
@@ -23,40 +23,7 @@ const BadgeContainer: FunctionComponent< Props > = ( {
 		}
 	}
 
-	return (
-		<div className="badge-container">
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 16 16"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path
-					d="M12.6667 2H3.33333C2.59695 2 2 2.59695 2 3.33333V12.6667C2 13.403 2.59695 14 3.33333 14H12.6667C13.403 14 14 13.403 14 12.6667V3.33333C14 2.59695 13.403 2 12.6667 2Z"
-					stroke="#50575E"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
-				<path
-					d="M2 6H14"
-					stroke="#50575E"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
-				<path
-					d="M6 14V6"
-					stroke="#50575E"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
-			</svg>
-			{ getBadge() }
-		</div>
-	);
+	return <div className="badge-container">{ getBadge() }</div>;
 };
 
 export default BadgeContainer;


### PR DESCRIPTION
As per this discussion p1658256698659569-slack-C0Q664T29 the FSE badge is removed from the design picker for the time being.

### Testing
1. Apply this diff.
2. Go to the Design picker `/setup/designSetup?siteSlug=[YOUR_SITE]`.
3. Verify you don't see the FSE badge

| Before  | After |
| ------------- | ------------- |
| <img width="741" alt="image" src="https://user-images.githubusercontent.com/375980/179832007-710d9b31-bb10-442b-9709-3aa75ebf7389.png"> | <img width="738" alt="image" src="https://user-images.githubusercontent.com/375980/179831906-594f915a-8992-4543-b42a-c84ea2ec2754.png">  |