### PR TITLE
Sites Management Dashboard: Make ListTile component more customizable

### DIFF
--- a/packages/components/src/list-tile/index.tsx
+++ b/packages/components/src/list-tile/index.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable no-nested-ternary */
+import classNames from 'classnames';
+import React, { cloneElement, isValidElement } from 'react';
 import './style.scss';
 
 type Props = {
@@ -5,9 +8,18 @@ type Props = {
 	subtitle: string | React.ReactElement;
 	leading?: React.ReactNode | React.ReactElement;
 	trailing?: React.ReactNode | React.ReactElement;
+	className?: string;
+	contentClassName?: string;
 };
 
-export const ListTile = ( { title, subtitle, leading, trailing }: Props ) => {
+export const ListTile = ( {
+	className,
+	contentClassName,
+	title,
+	subtitle,
+	leading,
+	trailing,
+}: Props ) => {
 	if ( typeof title === 'string' ) {
 		title = <h2 className="list-tile__title"> { title } </h2>;
 	}
@@ -15,14 +27,32 @@ export const ListTile = ( { title, subtitle, leading, trailing }: Props ) => {
 		subtitle = <span className="list-tile__subtitle"> { subtitle } </span>;
 	}
 
+	const leadingElement =
+		typeof leading === 'string' ? (
+			<div className="list-tile__leading">{ leading }</div>
+		) : isValidElement( leading ) ? (
+			cloneElement( leading, {
+				className: classNames( 'list-tile__leading', leading.props.className ),
+			} )
+		) : null;
+
+	const trailingElement =
+		typeof trailing === 'string' ? (
+			<div className="list-tile__trailing">{ trailing }</div>
+		) : isValidElement( trailing ) ? (
+			cloneElement( trailing, {
+				className: classNames( 'list-tile__trailing', trailing.props.className ),
+			} )
+		) : null;
+
 	return (
-		<div className="list-tile">
-			{ leading && <div className="list-tile__leading">{ leading }</div> }
-			<div style={ { width: '100%' } }>
+		<div className={ classNames( 'list-tile', className ) }>
+			{ leadingElement }
+			<div className={ classNames( 'list-tile__content', contentClassName ) }>
 				{ title }
 				{ subtitle }
 			</div>
-			{ trailing && <div>{ trailing }</div> }
+			{ trailingElement }
 		</div>
 	);
 };

--- a/packages/components/src/list-tile/style.scss
+++ b/packages/components/src/list-tile/style.scss
@@ -3,27 +3,27 @@
     align-items: center;
     line-height: 1;
     margin-right: 20px;
+}
 
-	.list-tile__leading {
-		margin-right: 20px;
-	}
+.list-tile__leading {
+    margin-right: 20px;
+}
 
-    .list-tile__title {
-        font-weight: 500;
-	    font-size: 1rem;
-	    letter-spacing: -0.4px;
-	    color: var( --studio-gray-100 );
-    }
+.list-tile__title {
+    font-weight: 500;
+    font-size: 1rem;
+    letter-spacing: -0.4px;
+    color: var( --studio-gray-100 );
+}
 
-    .list-tile__subtitle {
-        font-size: 0.875rem;
-	    line-height: 20px;
-	    letter-spacing: -0.24px;
-	    color: var( --studio-gray-60 );
-        overflow: hidden;
-        text-overflow: ellipsis;
-        text-rendering: auto;
-        max-height: 40px;
-        white-space: normal;
-    }
+.list-tile__subtitle {
+    font-size: 0.875rem;
+    line-height: 20px;
+    letter-spacing: -0.24px;
+    color: var( --studio-gray-60 );
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-rendering: auto;
+    max-height: 40px;
+    white-space: normal;
 }


### PR DESCRIPTION
#### Proposed Changes

Allow customization of class names and elements for the `<ListTile />` component.

I also de-scoped `.list-title__*` CSS selectors to decrease the specificity of the elements. If we don't do that, we'll need to override the CSS with `!important`, for example.

#### Testing Instructions

Check out this branch and check that there are no visual changes in SMD.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?