### PR TITLE
Sites Management Dashboard: Improve experience on smaller screens

### DIFF
--- a/client/sites-dashboard/components/sites-launch-status-badge.tsx
+++ b/client/sites-dashboard/components/sites-launch-status-badge.tsx
@@ -9,6 +9,7 @@ const SitesLaunchStatusBadge = styled.span`
 	border-radius: 4px;
 	line-height: 20px;
 	display: inline-block;
+	white-space: nowrap;
 `;
 
 export default SitesLaunchStatusBadge;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -71,6 +71,12 @@ const SiteListTile = styled( ListTile )`
 	.list-tile__content {
 		min-width: 0;
 	}
+
+	margin-right: 0;
+
+	@media only screen and ( max-width: 781px ) {
+		margin-right: 12px;
+	}
 `;
 
 const ListTileSubtitle = styled.div`
@@ -136,13 +142,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 									</SitesLaunchStatusBadge>
 								</div>
 							) }
-							<SiteUrl
-								href={ site.URL }
-								target="_blank"
-								rel="noreferrer"
-								title={ site.URL }
-								style={ { marginRight: '8px' } }
-							>
+							<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
 								{ displaySiteUrl( site.URL ) }
 							</SiteUrl>
 						</ListTileSubtitle>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -86,6 +86,12 @@ const SiteListTile = styled( ListTile )`
 	}
 `;
 
+const ListTileLeading = styled.a`
+	@media only screen and ( max-width: 781px ) {
+		margin-right: 12px;
+	}
+`;
+
 const ListTileTitle = styled.div`
 	display: flex;
 	align-items: center;
@@ -128,13 +134,12 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 			<Column>
 				<SiteListTile
 					leading={
-						<a
-							style={ { display: 'block' } }
+						<ListTileLeading
 							href={ getDashboardUrl( site.slug ) }
 							title={ __( 'Visit Dashboard' ) }
 						>
 							<SiteIcon siteId={ site.ID } size={ 50 } />
-						</a>
+						</ListTileLeading>
 					}
 					title={
 						<ListTileTitle>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -28,13 +28,15 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	letter-spacing: -0.24px;
 	color: var( --studio-gray-60 );
 
-	${ ( props ) =>
-		props.mobileHidden &&
-		css`
-			@media only screen and ( max-width: 781px ) {
+	@media only screen and ( max-width: 781px ) {
+		${ ( props ) =>
+			props.mobileHidden &&
+			css`
 				display: none;
-			}
-		` }
+			` };
+
+		padding-right: 0;
+	}
 `;
 
 const SiteName = styled.h2`

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,5 +1,5 @@
 import { ListTile } from '@automattic/components';
-import { css } from '@emotion/react';
+import { ClassNames, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -74,11 +74,6 @@ const SiteUrl = styled.a`
 
 const SiteListTile = styled( ListTile )`
 	line-height: initial;
-
-	.list-tile__content {
-		min-width: 0;
-	}
-
 	margin-right: 0;
 
 	@media only screen and ( max-width: 781px ) {
@@ -130,48 +125,55 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	const displayStatusBadge = isComingSoon || site.is_private;
 
 	return (
-		<Row>
-			<Column>
-				<SiteListTile
-					leading={
-						<ListTileLeading
-							href={ getDashboardUrl( site.slug ) }
-							title={ __( 'Visit Dashboard' ) }
-						>
-							<SiteIcon siteId={ site.ID } size={ 50 } />
-						</ListTileLeading>
-					}
-					title={
-						<ListTileTitle>
-							<SiteName href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
-								{ site.name ? site.name : __( '(No Site Title)' ) }
-							</SiteName>
-							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-						</ListTileTitle>
-					}
-					subtitle={
-						<ListTileSubtitle>
-							{ displayStatusBadge && (
-								<div style={ { marginRight: '8px' } }>
-									<SitesLaunchStatusBadge>
-										{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
-									</SitesLaunchStatusBadge>
-								</div>
-							) }
-							<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
-								{ displaySiteUrl( site.URL ) }
-							</SiteUrl>
-						</ListTileSubtitle>
-					}
-				/>
-			</Column>
-			<Column mobileHidden>{ site.plan.product_name_short }</Column>
-			<Column mobileHidden>July 16, 1969</Column>
-			<Column style={ { width: '20px' } }>
-				<EllipsisMenu>
-					<VisitDashboardItem site={ site } />
-				</EllipsisMenu>
-			</Column>
-		</Row>
+		<ClassNames>
+			{ ( { css } ) => (
+				<Row>
+					<Column>
+						<SiteListTile
+							contentClassName={ css`
+								min-width: 0;
+							` }
+							leading={
+								<ListTileLeading
+									href={ getDashboardUrl( site.slug ) }
+									title={ __( 'Visit Dashboard' ) }
+								>
+									<SiteIcon siteId={ site.ID } size={ 50 } />
+								</ListTileLeading>
+							}
+							title={
+								<ListTileTitle>
+									<SiteName href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
+										{ site.name ? site.name : __( '(No Site Title)' ) }
+									</SiteName>
+									{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
+								</ListTileTitle>
+							}
+							subtitle={
+								<ListTileSubtitle>
+									{ displayStatusBadge && (
+										<div style={ { marginRight: '8px' } }>
+											<SitesLaunchStatusBadge>
+												{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
+											</SitesLaunchStatusBadge>
+										</div>
+									) }
+									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
+										{ displaySiteUrl( site.URL ) }
+									</SiteUrl>
+								</ListTileSubtitle>
+							}
+						/>
+					</Column>
+					<Column mobileHidden>{ site.plan.product_name_short }</Column>
+					<Column mobileHidden>July 16, 1969</Column>
+					<Column style={ { width: '20px' } }>
+						<EllipsisMenu>
+							<VisitDashboardItem site={ site } />
+						</EllipsisMenu>
+					</Column>
+				</Row>
+			) }
+		</ClassNames>
 	);
 }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,4 +1,5 @@
 import { ListTile } from '@automattic/components';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -15,21 +16,25 @@ interface SiteTableRowProps {
 const Row = styled.tr`
 	line-height: 2em;
 	border-bottom: 1px solid #eee;
-	td {
-		padding-top: 12px;
-		padding-bottom: 12px;
-		padding-right: 24px;
-		vertical-align: middle;
-		font-size: 14px;
-		line-height: 20px;
-		letter-spacing: -0.24px;
-		color: var( --studio-gray-60 );
-	}
-	@media only screen and ( max-width: 781px ) {
-		.sites-table-row__mobile-hidden {
-			display: none;
-		}
-	}
+`;
+
+const Column = styled.td< { mobileHidden?: boolean } >`
+	padding-top: 12px;
+	padding-bottom: 12px;
+	padding-right: 24px;
+	vertical-align: middle;
+	font-size: 14px;
+	line-height: 20px;
+	letter-spacing: -0.24px;
+	color: var( --studio-gray-60 );
+
+	${ ( props ) =>
+		props.mobileHidden &&
+		css`
+			@media only screen and ( max-width: 781px ) {
+				display: none;
+			}
+		` }
 `;
 
 const SiteName = styled.h2`
@@ -82,7 +87,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 
 	return (
 		<Row>
-			<td>
+			<Column>
 				<ListTile
 					leading={
 						<a
@@ -121,14 +126,14 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 						</div>
 					}
 				/>
-			</td>
-			<td className="sites-table-row__mobile-hidden">{ site.plan.product_name_short }</td>
-			<td className="sites-table-row__mobile-hidden">July 16, 1969</td>
-			<td style={ { width: '20px' } }>
+			</Column>
+			<Column mobileHidden>{ site.plan.product_name_short }</Column>
+			<Column mobileHidden>July 16, 1969</Column>
+			<Column style={ { width: '20px' } }>
 				<EllipsisMenu>
 					<VisitDashboardItem site={ site } />
 				</EllipsisMenu>
-			</td>
+			</Column>
 		</Row>
 	);
 }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -39,16 +39,23 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	}
 `;
 
-const SiteName = styled.h2`
+const SiteName = styled.a`
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	margin-right: 8px;
 	font-weight: 500;
 	font-size: 16px;
 	letter-spacing: -0.4px;
-	color: var( --studio-gray-100 );
-	a {
-		color: inherit;
-		&:hover {
-			text-decoration: underline;
-		}
+
+	&:hover {
+		text-decoration: underline;
+	}
+
+	&,
+	&:hover,
+	&:visited {
+		color: var( --studio-gray-100 );
 	}
 `;
 
@@ -77,6 +84,12 @@ const SiteListTile = styled( ListTile )`
 	@media only screen and ( max-width: 781px ) {
 		margin-right: 12px;
 	}
+`;
+
+const ListTileTitle = styled.div`
+	display: flex;
+	align-items: center;
+	margin-bottom: 8px;
 `;
 
 const ListTileSubtitle = styled.div`
@@ -124,14 +137,12 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 						</a>
 					}
 					title={
-						<div style={ { display: 'flex', alignItems: 'center', marginBottom: '8px' } }>
-							<SiteName style={ { marginRight: '8px' } }>
-								<a href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
-									{ site.name ? site.name : __( '(No Site Title)' ) }
-								</a>
+						<ListTileTitle>
+							<SiteName href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
+								{ site.name ? site.name : __( '(No Site Title)' ) }
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-						</div>
+						</ListTileTitle>
 					}
 					subtitle={
 						<ListTileSubtitle>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -53,8 +53,6 @@ const SiteName = styled.h2`
 `;
 
 const SiteUrl = styled.a`
-	color: var( --studio-gray-60 );
-	max-width: 75%;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	display: inline-block;
@@ -64,6 +62,14 @@ const SiteUrl = styled.a`
 	&:hover,
 	&:visited {
 		color: var( --studio-gray-60 );
+	}
+`;
+
+const SiteListTile = styled( ListTile )`
+	line-height: initial;
+
+	.list-tile__content {
+		min-width: 0;
 	}
 `;
 
@@ -101,7 +107,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	return (
 		<Row>
 			<Column>
-				<ListTile
+				<SiteListTile
 					leading={
 						<a
 							style={ { display: 'block' } }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -58,9 +58,18 @@ const SiteUrl = styled.a`
 	text-overflow: ellipsis;
 	overflow: hidden;
 	display: inline-block;
+	line-height: 1;
+
+	&,
+	&:hover,
 	&:visited {
 		color: var( --studio-gray-60 );
 	}
+`;
+
+const ListTileSubtitle = styled.div`
+	display: flex;
+	align-items: center;
 `;
 
 const getDashboardUrl = ( slug: string ) => {
@@ -87,6 +96,8 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 	const isP2Site = site.options?.is_wpforteams_site;
 
+	const displayStatusBadge = isComingSoon || site.is_private;
+
 	return (
 		<Row>
 			<Column>
@@ -111,7 +122,14 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 						</div>
 					}
 					subtitle={
-						<div>
+						<ListTileSubtitle>
+							{ displayStatusBadge && (
+								<div style={ { marginRight: '8px' } }>
+									<SitesLaunchStatusBadge>
+										{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
+									</SitesLaunchStatusBadge>
+								</div>
+							) }
 							<SiteUrl
 								href={ site.URL }
 								target="_blank"
@@ -121,11 +139,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							>
 								{ displaySiteUrl( site.URL ) }
 							</SiteUrl>
-							{ site.is_private && ! isComingSoon && (
-								<SitesLaunchStatusBadge>Private</SitesLaunchStatusBadge>
-							) }
-							{ isComingSoon && <SitesLaunchStatusBadge>Coming soon</SitesLaunchStatusBadge> }
-						</div>
+						</ListTileSubtitle>
 					}
 				/>
 			</Column>


### PR DESCRIPTION
#### Proposed Changes

This PR enhances the UX for smaller screens by applying better utilizing screen space and ellipsing long text.

I also moved the site badge to the left so it doesn't jump around on the right, bringing visual consistency.

The experience on mid-sized screens was also enhanced. It now only ellipsis when there's absolutely no space left.

#### Testing Instructions

Check out this branch and play around with the screen dimensions in the DevTools.

#### Screenshots

| This branch | `trunk` |
| ------------ | ------- |
| ![fixed](https://user-images.githubusercontent.com/26530524/179835254-9e1e4f34-2d6a-4573-8cea-be2e74f5991d.png) | ![trunk](https://user-images.githubusercontent.com/26530524/179835280-bad3deaa-e7f9-406b-af39-d6e7c6a71065.png) |
| ![fixed-intermediary](https://user-images.githubusercontent.com/26530524/179835305-c65bafc4-90f1-4054-b552-33b1ebf60c08.png) | ![trunk-intermediary](https://user-images.githubusercontent.com/26530524/179835324-05662345-f979-4ad2-ad70-989066492301.png) |

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?