### PR TITLE
Fix copy in Publicize share-post upsell.

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -64,7 +64,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			}
 			{ ...( isJetpack && {
 				description: translate(
-					'Publicize makes it easy to share your new posts on your social media networks automatically. With a Jetpack Security or Complete plan, you can share content that has already been published and can also schedule posts to be shared at a specific time. However, our Security and Complete plan users can also share content that has already been published, and schedule their posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}',
+					'Publicize makes it easy to share your new posts on your social media networks automatically. With a Jetpack Security or Complete plan, you can share content that has already been published and can also schedule posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}',
 					{
 						components: {
 							ExternalLink: (


### PR DESCRIPTION
#### Proposed Changes

This PR removes the unnecessary, redundant sentence in the Publicize 'share-post' upsell.  It was accidentally left in there in PR #65689.

The unnecessary, redundant sentence is: `However, our Security and Complete plan users can also share content that has already been published, and schedule their posts to be shared at a specific time.`  (See _**Before**_ and _**After**_ screenshot below)

**BEFORE:**
![Markup 2022-07-19 at 15 42 36](https://user-images.githubusercontent.com/11078128/179835601-14ed0d62-97c3-43b1-a8cf-2ca1fca693b1.png)

**AFTER:** 
![Markup 2022-07-19 at 15 43 27](https://user-images.githubusercontent.com/11078128/179835641-615d4f18-aaa4-43c1-b61a-2ffe94ef177d.png)


#### Testing Instructions

**Quick review:**
It is probably sufficient enough to compare the screenshots above, and simply verify that the **After** screenshot looks correct, and the redundant sentence has been removed

**Long thorough review:** ( This full test is probably not necessary, unless you feel compelled to do so.  I have personally tested these steps myself and everything looks good.) 👍
- Checkout this PR and spin up Calypso blue. (`yarn start`).
- Select a Jetpack site that has a free plan ("Jetpack Free"). You may want to create a Jurassic.ninja site, and connect Jetpack to your wordpress.com account.
- Go to **Posts** (`http://calypso.localhost:3000/posts/:site`)  (replace `:site` with your site slug).
- If you don't have any social-media sites already connected, click the **_settings_** link in the "_Connect an account to get started_" Notice. (See screenshot below)
![Markup 2022-07-18 at 11 20 06](https://user-images.githubusercontent.com/11078128/179545632-8ab6de62-9ce3-4f6d-9ce0-b8bda831ec54.png)
- Make sure you are currently logged-in to one of your social media accounts, like Facebook, Twitter, Linkedin, or Tumbler.
- Connect one of your social accounts. (You won't need to share anything.. We're just connecting it.)
- Now go back to **Posts** (`http://calypso.localhost:3000/posts/:site`)  (replace `:site` with your site slug).
- On one of your posts, click the three-dots icon ( ... ) to open the dropdown menu.
- Select "Share Post".
- Verify you see the updated upsell and it looks like the "AFTER" screenshot above.

Related to: #65689