### PR TITLE
Sites Management Dashboard: use tagged template literal for CSS classes instead of wrapper component

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
 		"@automattic/wpcom-checkout": "workspace:^",
 		"@babel/core": "^7.17.5",
+		"@emotion/css": "^11.9.0",
 		"@emotion/jest": "^11.5.0",
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,5 +1,5 @@
 import { useFuzzySearch } from '@automattic/search';
-import { ClassNames } from '@emotion/react';
+import { css } from '@emotion/css';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import page from 'page';
@@ -35,31 +35,27 @@ export function SearchableSitesTable( { sites, initialSearch }: SearchableSitesT
 	};
 
 	return (
-		<ClassNames>
-			{ ( { css } ) => (
-				<>
-					<div
-						className={ css`
-							margin: 32px 0;
-							width: 286px;
-							max-width: 100%;
-						` }
-					>
-						<SitesSearch
-							searchIcon={ <SitesSearchIcon /> }
-							onSearch={ handleSearch }
-							isReskinned
-							placeholder={ __( 'Search by name or domain…' ) }
-							defaultValue={ initialSearch }
-						/>
-					</div>
-					{ results.length > 0 ? (
-						<SitesTable sites={ results } />
-					) : (
-						<h2>{ __( 'No sites match your search.' ) }</h2>
-					) }
-				</>
+		<>
+			<div
+				className={ css`
+					margin: 32px 0;
+					width: 286px;
+					max-width: 100%;
+				` }
+			>
+				<SitesSearch
+					searchIcon={ <SitesSearchIcon /> }
+					onSearch={ handleSearch }
+					isReskinned
+					placeholder={ __( 'Search by name or domain…' ) }
+					defaultValue={ initialSearch }
+				/>
+			</div>
+			{ results.length > 0 ? (
+				<SitesTable sites={ results } />
+			) : (
+				<h2>{ __( 'No sites match your search.' ) }</h2>
 			) }
-		</ClassNames>
+		</>
 	);
 }

--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,5 +1,4 @@
 import { useFuzzySearch } from '@automattic/search';
-import { css } from '@emotion/css';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import page from 'page';
@@ -36,21 +35,13 @@ export function SearchableSitesTable( { sites, initialSearch }: SearchableSitesT
 
 	return (
 		<>
-			<div
-				className={ css`
-					margin: 32px 0;
-					width: 286px;
-					max-width: 100%;
-				` }
-			>
-				<SitesSearch
-					searchIcon={ <SitesSearchIcon /> }
-					onSearch={ handleSearch }
-					isReskinned
-					placeholder={ __( 'Search by name or domain…' ) }
-					defaultValue={ initialSearch }
-				/>
-			</div>
+			<SitesSearch
+				searchIcon={ <SitesSearchIcon /> }
+				onSearch={ handleSearch }
+				isReskinned
+				placeholder={ __( 'Search by name or domain…' ) }
+				defaultValue={ initialSearch }
+			/>
 			{ results.length > 0 ? (
 				<SitesTable sites={ results } />
 			) : (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,5 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
-import { css, ClassNames } from '@emotion/react';
+import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
@@ -21,15 +21,15 @@ const MAX_PAGE_WIDTH = '1184px';
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's
 // background color and border needs to be able to extend into that padding.
-const pagePadding = css`
-	padding-left: 32px;
-	padding-right: 32px;
-`;
+const pagePadding = {
+	paddingLeft: '32px',
+	paddingRight: '32px',
+};
 
-const wideCentered = css`
-	max-width: ${ MAX_PAGE_WIDTH };
-	margin: 0 auto;
-`;
+const wideCentered = {
+	maxWidth: MAX_PAGE_WIDTH,
+	margin: '0 auto',
+};
 
 const PageHeader = styled.div`
 	${ pagePadding }
@@ -78,30 +78,23 @@ export function SitesDashboard( { queryParams }: SitesDashboardProps ) {
 				</HeaderControls>
 			</PageHeader>
 			<PageBodyWrapper>
-				<ClassNames>
-					{ ( { css } ) => (
-						<SitesTableFilterTabs
-							allSites={ sites }
-							className={ css`
-								${ wideCentered }
-								position: relative;
-								top: -48px;
-							` }
-							filterOptions={ queryParams }
-						>
-							{ ( filteredSites, filterOptions ) =>
-								filteredSites.length ? (
-									<SearchableSitesTable
-										sites={ filteredSites }
-										initialSearch={ queryParams.search }
-									/>
-								) : (
-									<NoSitesMessage status={ filterOptions.status } />
-								)
-							}
-						</SitesTableFilterTabs>
-					) }
-				</ClassNames>
+				<SitesTableFilterTabs
+					allSites={ sites }
+					className={ css`
+						${ wideCentered }
+						position: relative;
+						top: -48px;
+					` }
+					filterOptions={ queryParams }
+				>
+					{ ( filteredSites, filterOptions ) =>
+						filteredSites.length ? (
+							<SearchableSitesTable sites={ filteredSites } initialSearch={ queryParams.search } />
+						) : (
+							<NoSitesMessage status={ filterOptions.status } />
+						)
+					}
+				</SitesTableFilterTabs>
 			</PageBodyWrapper>
 		</main>
 	);

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,5 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
-import { css } from '@emotion/css';
+import { css, CSSObject } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
@@ -21,7 +21,7 @@ const MAX_PAGE_WIDTH = '1184px';
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's
 // background color and border needs to be able to extend into that padding.
-const pagePadding = {
+const pagePadding: CSSObject = {
 	paddingLeft: '32px',
 	paddingRight: '32px',
 };

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -7,6 +7,10 @@ export const SitesSearch = styled( Search )`
 	overflow: hidden;
 	height: 44px;
 
+	margin: 32px 0;
+	width: 286px !important; // <Search /> CSS specificity is getting in the way, so we need to prioritize our changes.
+	max-width: 100%;
+
 	// TODO: make the fade optional in the component
 	.search-component__input-fade::before {
 		display: none !important;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,5 +1,5 @@
 import { ListTile } from '@automattic/components';
-import { ClassNames, css } from '@emotion/react';
+import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -30,10 +30,9 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 
 	@media only screen and ( max-width: 781px ) {
 		${ ( props ) =>
-			props.mobileHidden &&
-			css`
-				display: none;
-			` };
+			props.mobileHidden && {
+				display: 'none',
+			} };
 
 		padding-right: 0;
 	}
@@ -125,55 +124,51 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	const displayStatusBadge = isComingSoon || site.is_private;
 
 	return (
-		<ClassNames>
-			{ ( { css } ) => (
-				<Row>
-					<Column>
-						<SiteListTile
-							contentClassName={ css`
-								min-width: 0;
-							` }
-							leading={
-								<ListTileLeading
-									href={ getDashboardUrl( site.slug ) }
-									title={ __( 'Visit Dashboard' ) }
-								>
-									<SiteIcon siteId={ site.ID } size={ 50 } />
-								</ListTileLeading>
-							}
-							title={
-								<ListTileTitle>
-									<SiteName href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
-										{ site.name ? site.name : __( '(No Site Title)' ) }
-									</SiteName>
-									{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-								</ListTileTitle>
-							}
-							subtitle={
-								<ListTileSubtitle>
-									{ displayStatusBadge && (
-										<div style={ { marginRight: '8px' } }>
-											<SitesLaunchStatusBadge>
-												{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
-											</SitesLaunchStatusBadge>
-										</div>
-									) }
-									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
-										{ displaySiteUrl( site.URL ) }
-									</SiteUrl>
-								</ListTileSubtitle>
-							}
-						/>
-					</Column>
-					<Column mobileHidden>{ site.plan.product_name_short }</Column>
-					<Column mobileHidden>July 16, 1969</Column>
-					<Column style={ { width: '20px' } }>
-						<EllipsisMenu>
-							<VisitDashboardItem site={ site } />
-						</EllipsisMenu>
-					</Column>
-				</Row>
-			) }
-		</ClassNames>
+		<Row>
+			<Column>
+				<SiteListTile
+					contentClassName={ css`
+						min-width: 0;
+					` }
+					leading={
+						<ListTileLeading
+							href={ getDashboardUrl( site.slug ) }
+							title={ __( 'Visit Dashboard' ) }
+						>
+							<SiteIcon siteId={ site.ID } size={ 50 } />
+						</ListTileLeading>
+					}
+					title={
+						<ListTileTitle>
+							<SiteName href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
+								{ site.name ? site.name : __( '(No Site Title)' ) }
+							</SiteName>
+							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
+						</ListTileTitle>
+					}
+					subtitle={
+						<ListTileSubtitle>
+							{ displayStatusBadge && (
+								<div style={ { marginRight: '8px' } }>
+									<SitesLaunchStatusBadge>
+										{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
+									</SitesLaunchStatusBadge>
+								</div>
+							) }
+							<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
+								{ displaySiteUrl( site.URL ) }
+							</SiteUrl>
+						</ListTileSubtitle>
+					}
+				/>
+			</Column>
+			<Column mobileHidden>{ site.plan.product_name_short }</Column>
+			<Column mobileHidden>July 16, 1969</Column>
+			<Column style={ { width: '20px' } }>
+				<EllipsisMenu>
+					<VisitDashboardItem site={ site } />
+				</EllipsisMenu>
+			</Column>
+		</Row>
 	);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,7 +3456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/css@npm:^11.7.1":
+"@emotion/css@npm:^11.7.1, @emotion/css@npm:^11.9.0":
   version: 11.9.0
   resolution: "@emotion/css@npm:11.9.0"
   dependencies:
@@ -12407,6 +12407,7 @@ __metadata:
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
     "@automattic/wpcom-checkout": "workspace:^"
     "@babel/core": ^7.17.5
+    "@emotion/css": ^11.9.0
     "@emotion/jest": ^11.5.0
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0


### PR DESCRIPTION
#### Proposed Changes

We're using a `ClassNames` wrapper component so it provides us the ability to generate class name strings on-the-fly based on a template literal. This is cumbersome, especially when reviewing PRs because unrelated lines are touched.

So I took the liberty to install the `@emotion/css` package, which transforms the template literal into a class name string, effectively removing the need for that wrapper component.

cc @Automattic/team-calypso-frameworks 

#### Testing Instructions

Everything should still work, and styling must be correct in the SMD.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/pull/65756#discussion_r924911904.