### PR TITLE
Sites Management Dashboard: Use fuzzy search instead of simple search

### DIFF
--- a/client/sites-dashboard/components/searchable-sites-table.tsx
+++ b/client/sites-dashboard/components/searchable-sites-table.tsx
@@ -1,9 +1,8 @@
+import { useFuzzySearch } from '@automattic/search';
 import { ClassNames } from '@emotion/react';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import page from 'page';
-import { useMemo, useState } from 'react';
-import { searchCollection } from 'calypso/components/search-sites/utils';
 import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
 import { SitesTable } from './sites-table';
@@ -17,19 +16,15 @@ interface SearchableSitesTableProps {
 export function SearchableSitesTable( { sites, initialSearch }: SearchableSitesTableProps ) {
 	const { __ } = useI18n();
 
-	const [ term, setTerm ] = useState( initialSearch );
-
-	const filteredSites = useMemo( () => {
-		if ( ! term ) {
-			return sites;
-		}
-
-		return searchCollection( sites, term.toLowerCase(), [ 'URL', 'name', 'slug' ] );
-	}, [ term, sites ] );
+	const { setQuery, results } = useFuzzySearch( {
+		data: sites,
+		keys: [ 'URL', 'name', 'slug' ],
+		initialQuery: initialSearch,
+	} );
 
 	const handleSearch = ( rawTerm: string ) => {
 		const trimmedTerm = rawTerm.trim();
-		setTerm( trimmedTerm );
+		setQuery( trimmedTerm );
 		if ( trimmedTerm.length ) {
 			page(
 				addQueryArgs( window.location.pathname + window.location.search, { search: trimmedTerm } )
@@ -53,14 +48,13 @@ export function SearchableSitesTable( { sites, initialSearch }: SearchableSitesT
 						<SitesSearch
 							searchIcon={ <SitesSearchIcon /> }
 							onSearch={ handleSearch }
-							delaySearch
 							isReskinned
 							placeholder={ __( 'Search by name or domain…' ) }
 							defaultValue={ initialSearch }
 						/>
 					</div>
-					{ filteredSites.length > 0 ? (
-						<SitesTable sites={ filteredSites } />
+					{ results.length > 0 ? (
+						<SitesTable sites={ results } />
 					) : (
 						<h2>{ __( 'No sites match your search.' ) }</h2>
 					) }


### PR DESCRIPTION
#### Proposed Changes

After the introduction of the `useFuzzySearch` hook, it's time for us to use it.

#### Testing Instructions

Open SMD and try mistakenly searching for a blog. It should return the result, even with typos.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/issues/65169.