### PR TITLE
seller-celebration-modal: Require a payment block to be selected once

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/seller-celebration-modal/use-has-selected-payment-block-once.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/seller-celebration-modal/use-has-selected-payment-block-once.js
@@ -1,0 +1,63 @@
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Watch the user's block selection and keep a note if they ever select a payments
+ * block.
+ * A payments block is any block with 'payments' in the name, like jetpack/simple-payments
+ * or jetpack/recurring-payments.
+ * Selecting a block whose direct parent has 'payments' in the name also counts.
+ * This is to account for clicking inside the button in a payments block, for example.
+ *
+ * @returns {boolean} Has the user selected a payments block (or a direct descendant) at least once?
+ */
+const useHasSelectedPaymentBlockOnce = () => {
+	const [ hasSelectedPaymentsOnce, setHasSelectedPaymentsOnce ] = useState( false );
+
+	// Get the name of the currently selected block
+	const selectedBlockName = useSelect( ( select ) => {
+		// Special case: We know we're returning true, so we don't need to find block names.
+		if ( hasSelectedPaymentsOnce ) {
+			return '';
+		}
+
+		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+		return selectedBlock?.name ?? '';
+	} );
+
+	// Get the name of the currently selected block's direct parent, if one exists
+	const parentSelectedBlockName = useSelect( ( select ) => {
+		// Special case: We know we're returning true, so we don't need to find block names.
+		if ( hasSelectedPaymentsOnce ) {
+			return '';
+		}
+
+		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+		if ( selectedBlock?.clientId ) {
+			const parentIds = select( 'core/block-editor' ).getBlockParents( selectedBlock?.clientId );
+			if ( parentIds && parentIds.length ) {
+				const parent = select( 'core/block-editor' ).getBlock( parentIds[ parentIds.length - 1 ] );
+				return parent?.name ?? '';
+			}
+		}
+		return '';
+	} );
+
+	// On selection change, set hasSelectedPaymentsOnce=true if block name or parent's block name contains 'payments'
+	useEffect( () => {
+		if (
+			! hasSelectedPaymentsOnce &&
+			( selectedBlockName.includes( 'payments' ) || parentSelectedBlockName.includes( 'payments' ) )
+		) {
+			setHasSelectedPaymentsOnce( true );
+		}
+	}, [
+		selectedBlockName,
+		parentSelectedBlockName,
+		hasSelectedPaymentsOnce,
+		setHasSelectedPaymentsOnce,
+	] );
+
+	return hasSelectedPaymentsOnce;
+};
+export default useHasSelectedPaymentBlockOnce;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -44,7 +44,7 @@ const SellerCelebrationModalInner = () => {
 	const previousIsEditorSaving = useRef( false );
 	const hasSelectedPaymentsOnce = useHasSelectedPaymentBlockOnce();
 
-	const { isEditorSaving, linkUrl } = useSelect( ( select ) => {
+	const { isEditorSaving, hasPaymentsBlock, linkUrl } = useSelect( ( select ) => {
 		if ( isSiteEditor ) {
 			const isSavingSite =
 				select( 'core' ).isSavingEntityRecord( 'root', 'site' ) &&
@@ -55,9 +55,12 @@ const SellerCelebrationModalInner = () => {
 				select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId ) &&
 				! select( 'core' ).isAutosavingEntityRecord( 'postType', 'page', pageId );
 			const pageEntity = select( 'core' ).getEntityRecord( 'postType', 'page', pageId );
+			const paymentsBlock =
+				pageEntity?.content?.raw?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
 
 			return {
 				isEditorSaving: isSavingSite || isSavingEntity,
+				hasPaymentsBlock: paymentsBlock,
 				linkUrl: pageEntity?.link,
 			};
 		}
@@ -66,9 +69,13 @@ const SellerCelebrationModalInner = () => {
 		const isSavingEntity =
 			select( 'core' ).isSavingEntityRecord( 'postType', currentPost?.type, currentPost?.id ) &&
 			! select( 'core' ).isAutosavingEntityRecord( 'postType', currentPost?.type, currentPost?.id );
+		const globalBlockCount = select( 'core/block-editor' ).getGlobalBlockCount(
+			'jetpack/recurring-payments'
+		);
 
 		return {
 			isEditorSaving: isSavingEntity,
+			hasPaymentsBlock: globalBlockCount > 0,
 			linkUrl: currentPost.link,
 		};
 	} );
@@ -83,6 +90,7 @@ const SellerCelebrationModalInner = () => {
 			previousIsEditorSaving.current &&
 			! hasDisplayedModal &&
 			intent === 'sell' &&
+			hasPaymentsBlock &&
 			hasSelectedPaymentsOnce &&
 			! hasSeenSellerCelebrationModal
 		) {
@@ -95,6 +103,7 @@ const SellerCelebrationModalInner = () => {
 		isEditorSaving,
 		hasDisplayedModal,
 		intent,
+		hasPaymentsBlock,
 		hasSelectedPaymentsOnce,
 		hasSeenSellerCelebrationModal,
 		updateHasSeenSellerCelebrationModal,


### PR DESCRIPTION
#### Proposed Changes

* **In order for the SellerCelebrationModal to display, the user must now have selected a payments block at least once before saving.**
* The SellerCelebrationModal is a one-time popup that appears when a user saves a page containing a payments block on a site with the sell intent.
  * The idea is to stop the modal from appearing in this scenario: I create a new sell intent site, I edit the homepage, I modify the title and hit save.
  * We want to keep the modal appearing when users are legitimately adding or editing a payment block for the first time, but to not overwhelm the user if they are making a simple non-payments change at first.
  * I tried to do some things to check that the payment block's content was updated from the default, using `getEntityRecordEdits` and `getReferenceByDistinctEdits`, but was not successful. It was also becoming a bit of a rabbit hole.
  * As a compromise, I'm using "user has selected a payments block at least once" as a proxy for the user properly setting up a payments block. If you add a payments block, it will be selected, and same with editing.  This isn't perfect, but is better than before.

![image](https://user-images.githubusercontent.com/545779/178287859-7bbed5f9-75c4-4d1b-b234-5809b12d935c.png)

#### Testing Instructions

**Site Setup**

* Have a site that was created with the sell intent, or create a new one ( https://wordpress.com/start -> Starter plan -> choose "Sell Online" on the "What are your goals?" screen, choose "Start Simple" on the "Set up your store" screen ). I chose a starter plan and it worked; I think any plan will do.
* Reset the status of the modal on the site (helps when retesting). On sandbox, `wp shell` then `update_blog_option( 1234, "has_seen_seller_celebration_modal", false );` where 1234 = your blog id.
* Edit the homepage (Pages -> All Pages, locate the home page and Triple Dot -> Edit)

**Send PR Changes to Sandbox**

* `cd` into `apps/editing-toolkit` and run `yarn dev --sync`
* Ensure that the actual site, `mysite.wordpress.com` is hosts file redirected to the sandbox
* Reset the status of the modal as described above

**Edit title only; should not see modal**

* Edit the homepage (in a new tab to reset state)
* Let the editor load. Change one character in the title.
* Click the 'Update' button in the top right to manually save.
* When the save is completed, the modal should not appear.

**Select or add a payments block, should see modal**

* Now select the payments block, or the button in the payments block, and change some text.
* Click the 'Update' button in the top right to manually save.
* Now the modal should appear.

You can also test by resetting status, making a new page without a payments block and saving it, then adding a payments block and saving it.


Related to #65449