### PR TITLE
Sites Dashboard: Compute site slug used in sites dashboard, because it can't be requested

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { useQuery } from 'react-query';
 import { useStore } from 'react-redux';
+import { urlToSlug } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import getSites from 'calypso/state/selectors/get-sites';
 import { SiteData, SiteDataOptions } from 'calypso/state/ui/selectors/site-data';
@@ -13,20 +14,28 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'is_coming_soon',
 	'is_private',
 	'launch_status',
-	'slug',
 	'icon',
 	'name',
 	'options',
 	'plan',
 ] as const;
 
+export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
+
 export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site' ] as const;
 
-export type SiteExcerptData = Pick< SiteData, typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] > & {
+type SiteExcerptNetworkData = Pick< SiteData, typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] > & {
 	options?: Pick< SiteDataOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
 };
 
-const fetchSites = (): Promise< { sites: SiteExcerptData[] } > => {
+export type SiteExcerptData = Pick<
+	SiteData,
+	typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] | typeof SITE_EXCERPT_COMPUTED_FIELDS[ number ]
+> & {
+	options?: Pick< SiteDataOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
+};
+
+const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	const siteFilter = config< string[] >( 'site_filter' );
 	return wpcom.me().sites( {
 		apiVersion: '1.2',
@@ -44,7 +53,7 @@ export const useSiteExcerptsQuery = () => {
 
 	return useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
 		staleTime: 1000 * 60 * 5, // 5 minutes
-		select: ( data ) => data?.sites,
+		select: ( data ) => data?.sites.map( computeFields ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we
 			// only want to get the initial state. We don't want to be updated when the
@@ -62,4 +71,14 @@ export const useSiteExcerptsQuery = () => {
 // make strong guarantees about `t`.
 function notNullish< T >( t: T | null | undefined ): t is T {
 	return t !== null && t !== undefined;
+}
+
+function computeFields( data: SiteExcerptNetworkData ): SiteExcerptData {
+	return {
+		...data,
+		// TODO: The algorithm Calypso uses to compute slugs is more sophisticated
+		// because it deals with comflicting URLs (see /client/state/sites/selectors/get-site-slug.js)
+		// We may need to request more site options to properly compute the slug.
+		slug: urlToSlug( data.URL ),
+	};
 }


### PR DESCRIPTION
#### Proposed Changes

The primary links in the sites dashboard are broken since #65690. We had assumed we could request the `slug` as part of the `/me/sites` request, however that field is actually computed on the client.

- The `getSites()` selector populates the array using the `getSite()` selector https://github.com/Automattic/wp-calypso/blob/12687cf918f9f073d8e09ab39a4cb069d0448d1c/client/state/selectors/get-sites.js#L21
- `getSite()` returns some fields that are computed (i.e. not in the raw `state.sites.items` array) https://github.com/Automattic/wp-calypso/blob/12687cf918f9f073d8e09ab39a4cb069d0448d1c/client/state/sites/selectors/get-site.js#L32
- The slug actually comes from the `getSiteSlug()` selector https://github.com/Automattic/wp-calypso/blob/12687cf918f9f073d8e09ab39a4cb069d0448d1c/client/state/sites/selectors/get-site-computed-attributes.js#L27

This is a quick fix that calculates the site slug using a naive method so that the dashboard isn't broken. However we will probably need to request some more fields to do it properly (or maybe move slug calculation to the backend?)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Comment out the `initialData` option in the `useSiteExcerptsQuery()` hook. This was the quickest way to ensure we weren't getting data from the redux store (where the slug has already been computed for us)
* Test the links in `/sites-dashboard` work

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #