### PR TITLE
Theme Showcase: Updating design for the theme popover on the themes page

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -257,12 +257,12 @@ export class Theme extends Component {
 	};
 
 	getUpsellMessage() {
-		const { isPremiumThemesAvaiable, theme, price, translate } = this.props;
+		const { isPremiumThemesAvailable, theme, price, translate } = this.props;
 		const hasPrice = /\d/g.test( price );
 
-		if ( ! hasPrice && theme.price && ! isPremiumThemesAvaiable ) {
+		if ( ! hasPrice && theme.price && ! isPremiumThemesAvailable ) {
 			return translate( 'You have purchased an annual subscription for this theme' );
-		} else if ( isPremiumThemesAvaiable ) {
+		} else if ( isPremiumThemesAvailable ) {
 			return translate( 'The premium theme is included in your plan.' );
 		}
 
@@ -283,7 +283,7 @@ export class Theme extends Component {
 	}
 
 	render() {
-		const { active, price, theme, translate, upsellUrl, isPremiumThemesAvaiable } = this.props;
+		const { active, price, theme, translate, upsellUrl, isPremiumThemesAvailable } = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -366,7 +366,7 @@ export class Theme extends Component {
 						! isEnabled( 'signup/seller-upgrade-modal' )
 							? 'theme__upsell-icon'
 							: 'theme__upsell-popover',
-						isPremiumThemesAvaiable || showPremiumBadge ? 'active' : null
+						isPremiumThemesAvailable || showPremiumBadge ? 'active' : null
 					) }
 					position={ ! isEnabled( 'signup/seller-upgrade-modal' ) ? 'top left' : 'top' }
 				>
@@ -463,7 +463,7 @@ export class Theme extends Component {
 }
 
 export default connect(
-	( state, { theme, siteId, isPremiumThemesAvaiable } ) => {
+	( state, { theme, siteId, isPremiumThemesAvailable } ) => {
 		const {
 			themes: { themesUpdate },
 		} = state;
@@ -472,8 +472,8 @@ export default connect(
 			errorOnUpdate: themesUpdateFailed && themesUpdateFailed.indexOf( theme.id ) > -1,
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
-			isPremiumThemesAvaiable:
-				isPremiumThemesAvaiable?.() ||
+			isPremiumThemesAvailable:
+				isPremiumThemesAvailable?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -442,7 +442,7 @@ export class Theme extends Component {
 						{ showPremiumBadge && ! isEnabled( 'signup/seller-upgrade-modal' ) && (
 							<span className="theme__badge-premium">{ translate( 'Premium' ) }</span>
 						) }
-						{ ! isEnabled( 'signup/seller-upgrade-modal' ) && (
+						{ ( ! isEnabled( 'signup/seller-upgrade-modal' ) || active ) && (
 							<span className={ priceClass }>{ price }</span>
 						) }
 						{ upsell }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -19,6 +19,7 @@ import { decodeEntities } from 'calypso/lib/formatting';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
@@ -242,6 +243,20 @@ export class Theme extends Component {
 		);
 	};
 
+	goToCheckout = () => {
+		const { siteSlug, eligibleForProPlan } = this.props;
+		const plan = eligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';
+
+		if ( siteSlug ) {
+			const params = new URLSearchParams();
+			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
+
+			window.location.href = `/checkout/${ encodeURIComponent(
+				siteSlug
+			) }/${ plan }?${ params.toString() }`;
+		}
+	};
+
 	getUpsellMessage() {
 		const { isPremiumThemesAvaiable, eligibleForProPlan, theme, price, translate } = this.props;
 		const hasPrice = /\d/g.test( price );
@@ -264,7 +279,7 @@ export class Theme extends Component {
 				}
 			),
 			{
-				Link: <LinkButton isLink />,
+				Link: <LinkButton isLink onClick={ this.goToCheckout } />,
 			}
 		);
 	}
@@ -334,7 +349,7 @@ export class Theme extends Component {
 			</div>
 		) : (
 			<div>
-				<div class="theme__upsell-header">{ translate( 'Premium theme' ) }</div>
+				<div className="theme__upsell-header">{ translate( 'Premium theme' ) }</div>
 				<div>{ this.getUpsellMessage() }</div>
 			</div>
 		);
@@ -459,6 +474,7 @@ export default connect(
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
 			isPremiumThemesAvaiable: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			eligibleForProPlan: isEligibleForProPlan( state, siteId ),
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},
 	{ recordTracksEvent, setThemesBookmark, updateThemes }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -349,8 +349,10 @@ export class Theme extends Component {
 			</div>
 		) : (
 			<div>
-				<div className="theme__upsell-header">{ translate( 'Premium theme' ) }</div>
-				<div>{ this.getUpsellMessage() }</div>
+				<div data-testid="upsell-header" className="theme__upsell-header">
+					{ translate( 'Premium theme' ) }
+				</div>
+				<div data-testid="upsell-message">{ this.getUpsellMessage() }</div>
 			</div>
 		);
 		const upsell = showUpsell && (
@@ -463,7 +465,7 @@ export class Theme extends Component {
 }
 
 export default connect(
-	( state, { theme, siteId } ) => {
+	( state, { theme, siteId, isPremiumThemesAvaiable } ) => {
 		const {
 			themes: { themesUpdate },
 		} = state;
@@ -472,7 +474,9 @@ export default connect(
 			errorOnUpdate: themesUpdateFailed && themesUpdateFailed.indexOf( theme.id ) > -1,
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
-			isPremiumThemesAvaiable: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
+			isPremiumThemesAvaiable:
+				isPremiumThemesAvaiable?.() ||
+				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			eligibleForProPlan: isEligibleForProPlan( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -16,7 +16,6 @@ import PulsingDot from 'calypso/components/pulsing-dot';
 import Tootlip from 'calypso/components/tooltip';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -244,8 +243,8 @@ export class Theme extends Component {
 	};
 
 	goToCheckout = () => {
-		const { siteSlug, eligibleForProPlan } = this.props;
-		const plan = eligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';
+		const { siteSlug } = this.props;
+		const plan = 'premium';
 
 		if ( siteSlug ) {
 			const params = new URLSearchParams();
@@ -258,7 +257,7 @@ export class Theme extends Component {
 	};
 
 	getUpsellMessage() {
-		const { isPremiumThemesAvaiable, eligibleForProPlan, theme, price, translate } = this.props;
+		const { isPremiumThemesAvaiable, theme, price, translate } = this.props;
 		const hasPrice = /\d/g.test( price );
 
 		if ( ! hasPrice && theme.price && ! isPremiumThemesAvaiable ) {
@@ -269,13 +268,12 @@ export class Theme extends Component {
 
 		return createInterpolateElement(
 			sprintf(
-				/* translators: the "price" is the price of the theme, example: U$50; the "planName" can be "Pro plan" or "Premium plan". */
+				/* translators: the "price" is the price of the theme, example: U$50; */
 				translate(
-					'This premium theme is included in the <Link>%(planName)s</Link>, or you can purchase individually for %(price)s a year'
+					'This premium theme is included in the <Link>Premium plan</Link>, or you can purchase individually for %(price)s a year'
 				),
 				{
 					price: theme.price,
-					planName: eligibleForProPlan ? translate( 'Pro plan' ) : translate( 'Premium plan' ),
 				}
 			),
 			{
@@ -477,7 +475,6 @@ export default connect(
 			isPremiumThemesAvaiable:
 				isPremiumThemesAvaiable?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
-			eligibleForProPlan: isEligibleForProPlan( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -116,6 +116,45 @@ $theme-info-height: 54px;
 }
 
 .theme__upsell-popover {
+	svg {
+		transform: scale( 0.8 );
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		border-radius: 100%;
+		display: inline-block;
+		width: 30px;
+		height: 30px;
+		z-index: 0;
+		padding: 3px 4px 5px 3px;
+		box-sizing: border-box;
+	}
+	&:not( .active ) svg:hover {
+		background: #000;
+		fill: #fff;
+	}
+	&.active svg {
+		background: #008a20;
+		fill: #fff;
+	}
+	&.popover.info-popover__tooltip {
+		.popover__inner {
+			max-width: 245px;
+			padding: 24px;
+			text-align: center;
+			border-radius: 4px;
+			border: 0;
+			box-shadow: 0 3px 8px rgba( 0, 0, 0, 0.12 ), 0 3px 1px rgba( 0, 0, 0, 0.04 );
+		}
+		.popover__arrow {
+			display: none;
+		}
+	}
+	.theme__upsell-header {
+		font-weight: 500;
+		line-height: 20px;
+	}
+}
+
+.theme__upsell-popover {
 	text-align: center;
 }
 

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -58,7 +58,7 @@ describe( 'Theme', () => {
 
 		test( 'Premium site', async () => {
 			const { container } = renderWithState(
-				<Theme { ...props } isPremiumThemesAvaiable={ () => true } />
+				<Theme { ...props } isPremiumThemesAvailable={ () => true } />
 			);
 			const popoverTrigger = container.getElementsByClassName( 'theme__upsell-popover' )[ 0 ];
 			await userEvent.hover( popoverTrigger );

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { Theme } from '../';
+
+jest.mock( 'calypso/components/popover-menu', () => 'components--popover--menu' );
+jest.mock( 'calypso/components/popover-menu/item', () => 'components--popover--menu-item' );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = () => 'development';
+	mock.isEnabled = jest.fn( () => {
+		return true;
+	} );
+	return mock;
+} );
+
+describe( 'Theme', () => {
+	const props = {
+		theme: {
+			id: 'twentyseventeen',
+			name: 'Twenty Seventeen',
+			screenshot:
+				'https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1',
+			price: 'U$50',
+		},
+		price: 'U$50',
+		upsellUrl: 'premium/plan',
+		buttonContents: { dummyAction: { label: 'Dummy action', action: jest.fn() } }, // TODO: test if called when clicked
+		translate: ( string ) => string,
+		setThemesBookmark: () => {},
+		onScreenshotClick: () => {},
+	};
+
+	function renderWithState( content ) {
+		const initialState = {};
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		return render( <Provider store={ store }>{ content }</Provider> );
+	}
+
+	describe( 'Premium theme popover', () => {
+		test( 'Free site', async () => {
+			const { container } = renderWithState( <Theme { ...props } /> );
+			const popoverTrigger = container.getElementsByClassName( 'theme__upsell-popover' )[ 0 ];
+			await userEvent.hover( popoverTrigger );
+
+			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
+			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
+			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
+				'This premium theme is included in the'
+			);
+		} );
+
+		test( 'Premium site', async () => {
+			const { container } = renderWithState(
+				<Theme { ...props } isPremiumThemesAvaiable={ () => true } />
+			);
+			const popoverTrigger = container.getElementsByClassName( 'theme__upsell-popover' )[ 0 ];
+			await userEvent.hover( popoverTrigger );
+
+			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
+			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
+			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
+				'The premium theme is included in your plan.'
+			);
+		} );
+
+		test( 'Purchased a premium theme', async () => {
+			const { container } = renderWithState( <Theme { ...props } price={ null } /> );
+			const popoverTrigger = container.getElementsByClassName( 'theme__upsell-popover' )[ 0 ];
+			await userEvent.hover( popoverTrigger );
+
+			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
+			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
+			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
+				'You have purchased an annual subscription for this theme'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Remove the pricing information for the premium themes.
* Add the new texts on the popover.
* The popover is now displayed by hovering over the start icon instead of clicking on it.
* Apply the design changes for the popover.

##### Premium theme not purchased / Premium theme purchased
<img width="618" alt="Screen Shot 2022-07-20 at 16 27 19" src="https://user-images.githubusercontent.com/1234758/180065849-8f0a19bc-6a0c-4ccc-8881-61f6adce77c7.png">

##### Hovering premium theme included in the premium plan
<img width="402" alt="Screen Shot 2022-07-20 at 16 27 52" src="https://user-images.githubusercontent.com/1234758/180066083-8ff70bc2-68af-47df-ab97-5207979d012f.png">

#####  Hovering a purchased theme
<img width="381" alt="Screen Shot 2022-07-20 at 16 27 26" src="https://user-images.githubusercontent.com/1234758/180066032-fe4c0408-6b64-4e4e-aabd-425dbf700ad2.png">

##### Hovering a theme on a free site
<img width="445" alt="Screen Shot 2022-07-20 at 16 26 30" src="https://user-images.githubusercontent.com/1234758/180068704-4185fbaa-cf5d-4d27-82f6-1e65f3b45dbb.png">



#### Testing Instructions

* Go to `/themes/[SITE_SLUG]?flags=signup/seller-upgrade-modal` on a free site and check that premium themes show the information to upgrade.
* Go to `/themes/[SITE_SLUG]?flags=signup/seller-upgrade-modal` on a Pro site and check if the start icon is green and the text is appropriate for the Pro site.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](https://wp.me/P9HQHe-k8-p2), [Atomic](https://wp.me/P9HQHe-jW-p2), and [self-hosted Jetpack sites](https://wp.me/PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](https://wp.me/PCYsg-1vr-p2) ASAP?

Closes #65705
