### PR TITLE
Send user back to "Sites Dashboard" when leaving start step

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -749,6 +749,9 @@ class DomainsStep extends Component {
 			} else if ( 'general-settings' === source && siteSlug ) {
 				backUrl = `/settings/general/${ siteSlug }`;
 				backLabelText = translate( 'Back to General Settings' );
+			} else if ( 'sites-dashboard' === source ) {
+				backUrl = '/sites-dashboard';
+				backLabelText = translate( 'Back to My Sites' );
 			} else if ( backUrl === this.removeQueryParam( this.props.path ) ) {
 				backUrl = '/sites/';
 				backLabelText = translate( 'Back to My Sites' );

--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -112,7 +112,7 @@ export const NoSitesMessage = ( { status }: SitesContainerProps ) => {
 				"It's time to get your ideas online. We'll guide you through the process of creating a site that best suits your needs."
 			) }
 			action={ __( 'Create your first site' ) }
-			actionURL={ '/start?source=sites-dashboard' }
+			actionURL={ '/start?source=sites-dashboard&ref=calypso-nosites' }
 			illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
 		/>
 	);

--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -112,7 +112,7 @@ export const NoSitesMessage = ( { status }: SitesContainerProps ) => {
 				"It's time to get your ideas online. We'll guide you through the process of creating a site that best suits your needs."
 			) }
 			action={ __( 'Create your first site' ) }
-			actionURL={ '/start?ref=sites-dashboard' }
+			actionURL={ '/start?source=sites-dashboard' }
 			illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
 		/>
 	);

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -71,7 +71,7 @@ export function SitesDashboard( { queryParams }: SitesDashboardProps ) {
 			<PageHeader>
 				<HeaderControls>
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>
-					<Button primary href="/start?source=sites-dashboard">
+					<Button primary href="/start?source=sites-dashboard&ref=sites-dashboard">
 						<Gridicon icon="plus" />
 						<span>{ __( 'New Site' ) }</span>
 					</Button>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -71,7 +71,7 @@ export function SitesDashboard( { queryParams }: SitesDashboardProps ) {
 			<PageHeader>
 				<HeaderControls>
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>
-					<Button primary href="/start?ref=sites-dashboard">
+					<Button primary href="/start?source=sites-dashboard">
 						<Gridicon icon="plus" />
 						<span>{ __( 'New Site' ) }</span>
 					</Button>


### PR DESCRIPTION
#### Proposed Changes

Users can leave a "New Site" flow by using the "Back to My Sites" link. Let's send them back to "Sites Dashboard" in such a case.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `/sites-dashboard` URL
2. Click a "New Site" button
3. On the "Choose a domain" page, click "Back to My Sites"
4. Confirm that Sites Dashboard is displayed and the URL is `/sites-dashboard`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [ ] ~~Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?~~

Related to https://github.com/Automattic/wp-calypso/issues/65183