### PR TITLE
Plan Overhaul revert: Do not offer Starter plan to install premium plugins

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,4 +1,3 @@
-import { isBlogger, isPersonal, isPremium } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -20,32 +19,18 @@ function getHoldMessages(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ],
 	eligibleForProPlan: boolean,
-	billingPeriod?: string,
-	isMarketplace?: boolean,
-	isLegacyPlan?: boolean
+	billingPeriod?: string
 ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: ( function () {
-				if ( ! isLegacyPlan && isMarketplace ) {
-					return translate( 'Upgrade to a Starter plan' );
-				}
-
-				if ( ! isLegacyPlan && eligibleForProPlan ) {
-					return translate( 'Upgrade to a Pro plan' );
-				}
-
-				return translate( 'Upgrade to a Business plan' );
-			} )(),
+			title: eligibleForProPlan
+				? translate( 'Upgrade to a Pro plan' )
+				: translate( 'Upgrade to a Business plan' ),
 			description: ( function () {
 				if ( context === 'themes' ) {
 					return translate(
 						"You'll also get to install custom plugins, have more storage, and access live support."
 					);
-				}
-
-				if ( isMarketplace ) {
-					return translate( "You'll also get to collect payments and have more storage." );
 				}
 
 				if ( billingPeriod === IntervalLength.MONTHLY ) {
@@ -175,7 +160,6 @@ export function getBlockingMessages(
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
-	isMarketplace?: boolean;
 	isPlaceholder: boolean;
 }
 
@@ -219,27 +203,14 @@ export const HardBlockingNotice = ( {
 	);
 };
 
-export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const plan = selectedSite?.plan;
-	let isLegacyPlan = false;
-	if ( typeof plan !== 'undefined' ) {
-		isLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
-	}
 
 	const eligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
 	const billingPeriod = useSelector( getBillingInterval );
-	const holdMessages = getHoldMessages(
-		context,
-		translate,
-		eligibleForProPlan,
-		billingPeriod,
-		isMarketplace,
-		isLegacyPlan
-	);
+	const holdMessages = getHoldMessages( context, translate, eligibleForProPlan, billingPeriod );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -58,7 +58,6 @@ export const EligibilityWarnings = ( {
 	feature,
 	eligibilityData,
 	isEligible,
-	isMarketplace,
 	isPlaceholder,
 	onProceed,
 	standaloneProceed,
@@ -126,12 +125,7 @@ export const EligibilityWarnings = ( {
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<CompactCard>
-					<HoldList
-						context={ context }
-						holds={ listHolds }
-						isMarketplace={ isMarketplace }
-						isPlaceholder={ isPlaceholder }
-					/>
+					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
 				</CompactCard>
 			) }
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -9,7 +9,6 @@ import {
 	PLAN_BLOGGER_2_YEARS,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_STARTER,
 } from '@automattic/calypso-products';
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
@@ -348,15 +347,9 @@ export function getPluginAuthorProfileKeyword( plugin ) {
  * @param currentPlan
  * @param pluginBillingPeriod
  * @param eligibleForProPlan
- * @param isMarketplace
  * @returns the correct business plan slug depending on current plan and pluginBillingPeriod
  */
-export function businessPlanToAdd(
-	currentPlan,
-	pluginBillingPeriod,
-	eligibleForProPlan,
-	isMarketplace = false
-) {
+export function businessPlanToAdd( currentPlan, pluginBillingPeriod, eligibleForProPlan ) {
 	// Legacy plans always upgrade to business.
 	switch ( currentPlan.product_slug ) {
 		case PLAN_PERSONAL_2_YEARS:
@@ -368,10 +361,6 @@ export function businessPlanToAdd(
 		case PLAN_BLOGGER:
 			return PLAN_BUSINESS;
 		default:
-			// Not on a legacy plan: Can upgrade to Starter, Pro, or Business depending on settings.
-			if ( isMarketplace ) {
-				return PLAN_WPCOM_STARTER;
-			}
 			if ( eligibleForProPlan ) {
 				return PLAN_WPCOM_PRO;
 			}

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -217,8 +217,7 @@ function onClickInstallPlugin( {
 				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
 					billingPeriod,
-					eligibleForProPlan,
-					true
+					eligibleForProPlan
 				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
 				}`

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,12 +1,4 @@
-import {
-	PLAN_BUSINESS_MONTHLY,
-	PLAN_BUSINESS,
-	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_STARTER,
-	isBlogger,
-	isPersonal,
-	isPremium,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -65,17 +57,7 @@ const USPS: React.FC< Props > = ( {
 			return '';
 		}
 
-		const plan = selectedSite?.plan;
-		let isLegacyPlan = false;
-		if ( typeof plan !== 'undefined' ) {
-			isLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
-		}
-
-		if ( ! isLegacyPlan && isMarketplaceProduct ) {
-			return PLAN_WPCOM_STARTER;
-		}
-
-		if ( ! isLegacyPlan && isEligibleForProPlan( state, selectedSite?.ID ) ) {
+		if ( isEligibleForProPlan( state, selectedSite?.ID ) ) {
 			return PLAN_WPCOM_PRO;
 		}
 
@@ -87,11 +69,6 @@ const USPS: React.FC< Props > = ( {
 	} );
 	let planText;
 	switch ( requiredPlan ) {
-		case PLAN_WPCOM_STARTER:
-			planText = translate( 'Included in the Starter plan (%s):', {
-				args: [ planDisplayCost ],
-			} );
-			break;
 		case PLAN_WPCOM_PRO:
 			planText = translate( 'Included in the Pro plan (%s):', {
 				args: [ planDisplayCost ],
@@ -150,27 +127,7 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( shouldUpgrade && requiredPlan === PLAN_WPCOM_STARTER
-			? [
-					{
-						id: 'collect-payments',
-						image: <Gridicon icon="money" size={ 16 } />,
-						text: translate( 'Payments collection' ),
-						eligibilities: [ 'needs-upgrade' ],
-					},
-			  ]
-			: [] ),
-		...( shouldUpgrade && requiredPlan === PLAN_WPCOM_STARTER
-			? [
-					{
-						id: 'storage',
-						image: <Gridicon icon="product" size={ 16 } />,
-						text: translate( '6GB of storage' ),
-						eligibilities: [ 'needs-upgrade' ],
-					},
-			  ]
-			: [] ),
-		...( shouldUpgrade && requiredPlan !== PLAN_WPCOM_STARTER
+		...( shouldUpgrade
 			? [
 					{
 						id: 'hosting',
@@ -180,7 +137,7 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( shouldUpgrade && requiredPlan !== PLAN_WPCOM_STARTER
+		...( shouldUpgrade
 			? [
 					{
 						id: 'support',


### PR DESCRIPTION
#### Proposed Changes

- Stop offering the Starter plan to install premium plugins.
- Sites without the `INSTALL_PURCHASED_PLUGINS` feature (Free, Personal, Premium) will be asked to upgrade to Business before installing premium plugins.
- Sites with the `INSTALL_PURCHASED_PLUGINS` feature (Starter, Pro, Business, eCommerce) will continue to be able to install premium plugins.

#### Testing Instructions

- Use the Calypso live link below
- Switch to site with a Free / Personal / Premium plan
- Go to Plugins
- Select any premium plugin
- Make sure you're asked to upgrade to the Business plan
- Proceed with the purchase
- Make sure your site is transferred to Atomic and the premium plugin has been activated
- Repeat with a site on a Personal or Premium plan
- Switch to site with a Starter / Pro / Business / eCommerce plan
- Go to Plugins
- Select any premium plugin
- Make sure you're NOT asked to upgrade
- Proceed with the purchase
- If your site wasn't Atomic already, make sure it has been transferred to Atomic
- Make sure the premium plugin has been activated


#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 