### PR TITLE
Redirect post-checkout Business upsell to Goals page

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -2,7 +2,6 @@ import { isMonthly, getPlanByPathSlug, TERM_MONTHLY } from '@automattic/calypso-
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping-cart';
-import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
@@ -364,12 +363,12 @@ export class UpsellNudge extends Component {
 		return getThankYouPageUrl( getThankYouPageUrlArguments );
 	};
 
-	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
-		const { trackUpsellButtonClick, upsellType } = this.props;
+	handleClickDecline = () => {
+		const { trackUpsellButtonClick, upsellType, siteSlug } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 
-		const url = this.getThankYouPageUrlForIncomingCart( shouldHideUpsellNudges );
+		const url = `/setup/goals?siteSlug=${ siteSlug }&notice=purchase-success`;
 
 		// Removes the destination cookie only if redirecting to the signup destination.
 		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
@@ -378,13 +377,7 @@ export class UpsellNudge extends Component {
 			clearSignupDestinationCookie();
 		}
 
-		// If url starts with http, use browser redirect.
-		// If url is a route, use page router.
-		if ( isURL( url ) ) {
-			window.location.href = url;
-		} else {
-			page.redirect( url );
-		}
+		window.location.href = url;
 	};
 
 	handleClickAccept = ( buttonAction ) => {


### PR DESCRIPTION
#### Proposed Changes

More info: pdgrnI-1sh#comment-2563-p2

This changes the redirect URL for the Business Upsell decline action to go to Goals page instead of Thank you.

#### Testing Instructions

* Purchase a Premium plan
* On the Business Upsell Nudge page, select the `No thanks, I don't need plugins` button
<img width="420" alt="Screenshot on 2022-07-20 at 12-30-10" src="https://user-images.githubusercontent.com/2749938/179950046-a8546171-57ec-4e02-8c9b-feaf56098dfb.png">

* You should be redirected to the Goals page
<img width="420" alt="Screenshot on 2022-07-20 at 12-30-38" src="https://user-images.githubusercontent.com/2749938/179949995-fdd91399-3b3d-4bc1-9881-0a55a485e637.png">


Related to #
