### PR TITLE
Close Account: rework the available options so user can close account with Atomic site

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -135,28 +135,7 @@ class AccountSettingsClose extends Component {
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
-						{ ! isLoading && hasAtomicSites && (
-							<Fragment>
-								<p className="account-close__body-copy">
-									{ translate(
-										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
-									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate(
-										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
-									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
-										components: {
-											a: <ActionPanelLink href="/help/contact" />,
-										},
-									} ) }
-								</p>
-							</Fragment>
-						) }
-						{ ! isLoading && hasCancelablePurchases && ! hasAtomicSites && (
+						{ ! isLoading && hasCancelablePurchases && (
 							<Fragment>
 								<p className="account-close__body-copy">
 									{ translate( 'You still have active purchases on your account.' ) }
@@ -174,6 +153,23 @@ class AccountSettingsClose extends Component {
 								</p>
 							</Fragment>
 						) }
+						{ ! isLoading && hasAtomicSites && ! hasCancelablePurchases && (
+							<Fragment>
+								<p className="account-close__body-copy">
+									{ translate(
+										'We are still in the process of removing one or more of your sites. This process normally takes 15-20 minutes. Once removal is completed, you should be able to close your account from this page.'
+									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
+										components: {
+											a: <ActionPanelLink href="/help/contact" />,
+										},
+									} ) }
+								</p>
+							</Fragment>
+						) }
+
 						{ ( isLoading || isDeletePossible ) && (
 							<Fragment>
 								<p className="account-close__body-copy">
@@ -227,18 +223,22 @@ class AccountSettingsClose extends Component {
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ ( isLoading || isDeletePossible ) && (
-							<Button scary onClick={ this.handleDeleteClick }>
+							<Button
+								scary
+								onClick={ this.handleDeleteClick }
+								data-testid={ 'close-account-button' }
+							>
 								<Gridicon icon="trash" />
 								{ translate( 'Close account', { context: 'button label' } ) }
 							</Button>
 						) }
-						{ hasAtomicSites && (
-							<Button primary href="/help/contact">
+						{ hasAtomicSites && ! hasCancelablePurchases && (
+							<Button primary href="/help/contact" data-testid={ 'contact-support-button' }>
 								{ translate( 'Contact support' ) }
 							</Button>
 						) }
-						{ hasCancelablePurchases && ! hasAtomicSites && (
-							<Button primary href="/me/purchases">
+						{ hasCancelablePurchases && (
+							<Button primary href="/me/purchases" data-testid={ 'manage-purchases-button' }>
 								{ translate( 'Manage purchases', { context: 'button label' } ) }
 							</Button>
 						) }

--- a/client/me/account-close/test/main.js
+++ b/client/me/account-close/test/main.js
@@ -16,7 +16,7 @@ describe( 'AccountSettingsClose', () => {
 		expect( screen.queryByTestId( 'manage-purchases-button' ) ).toBeInTheDocument();
 	} );
 
-	it( 'Tells user to wait if Atomic site is being deleted', () => {
+	it( 'Tells user to wait if they still have an Atomic site', () => {
 		render(
 			<ReduxProvider store={ createTestStore( false, true ) }>
 				<AccountSettingsClose />

--- a/client/me/account-close/test/main.js
+++ b/client/me/account-close/test/main.js
@@ -41,7 +41,7 @@ function createTestStore( is_refundable, is_automated_transfer ) {
 			currentUser: {
 				id: 1,
 				user: {
-					primary_blog: 'test',
+					primary_blog: 'example',
 				},
 			},
 			purchases: {
@@ -56,7 +56,7 @@ function createTestStore( is_refundable, is_automated_transfer ) {
 			},
 			sites: {
 				items: {
-					'example.com': {
+					1234: {
 						ID: '1234',
 						URL: 'http://example.com',
 						is_wpcom_atomic: true,

--- a/client/me/account-close/test/main.js
+++ b/client/me/account-close/test/main.js
@@ -56,9 +56,9 @@ function createTestStore( is_refundable, is_automated_transfer ) {
 			},
 			sites: {
 				items: {
-					'www.test.com': {
-						ID: 'www.test.com',
-						URL: 'http://www.test.com',
+					'example.com': {
+						ID: '1234',
+						URL: 'http://example.com',
 						is_wpcom_atomic: true,
 						options: {
 							is_automated_transfer,

--- a/client/me/account-close/test/main.js
+++ b/client/me/account-close/test/main.js
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import AccountSettingsClose from '../main';
+
+describe( 'AccountSettingsClose', () => {
+	it( 'Shows Manage purchases button when refundable purchases exist', () => {
+		render(
+			<ReduxProvider store={ createTestStore( true, true ) }>
+				<AccountSettingsClose />
+			</ReduxProvider>
+		);
+		expect( screen.queryByTestId( 'manage-purchases-button' ) ).toBeInTheDocument();
+	} );
+
+	it( 'Tells user to wait if Atomic site is being deleted', () => {
+		render(
+			<ReduxProvider store={ createTestStore( false, true ) }>
+				<AccountSettingsClose />
+			</ReduxProvider>
+		);
+		expect( screen.queryByTestId( 'contact-support-button' ) ).toBeInTheDocument();
+	} );
+
+	it( 'Allows user to close account if no refundable purchases & no Atomic site', () => {
+		render(
+			<ReduxProvider store={ createTestStore( false, false ) }>
+				<AccountSettingsClose />
+			</ReduxProvider>
+		);
+		expect( screen.queryByTestId( 'close-account-button' ) ).toBeInTheDocument();
+	} );
+} );
+
+function createTestStore( is_refundable, is_automated_transfer ) {
+	return createReduxStore(
+		{
+			currentUser: {
+				id: 1,
+				user: {
+					primary_blog: 'test',
+				},
+			},
+			purchases: {
+				hasLoadedUserPurchasesFromServer: true,
+				data: [
+					{
+						is_refundable,
+						user_id: 1,
+						product_slug: 'premium_theme',
+					},
+				],
+			},
+			sites: {
+				items: {
+					'www.test.com': {
+						ID: 'www.test.com',
+						URL: 'http://www.test.com',
+						is_wpcom_atomic: true,
+						options: {
+							is_automated_transfer,
+						},
+					},
+				},
+			},
+		},
+		( state ) => {
+			return state;
+		}
+	);
+}


### PR DESCRIPTION
Fixes #57399
Related to #65636

#### Proposed Changes

Users should be able to close accounts with Atomic sites without needing to contact support. This change enables that. Now, if the user has an Atomic site, they need to remove the purchase and then wait for the site to be removed, and then they can close the account themselves; previously, their only option was to contact support. 

There is a small window where the user has to wait to completely close their account but this is still an improvement on what currently exists. A [second PR](https://github.com/Automattic/wp-calypso/pull/65636/#issuecomment-1189032726) will follow that will allow the user to speed up the deletion of the Atomic site and reduce the time of this window. 

#### Testing Instructions

1. Create or reuse a user account with an Atomic site
2. Go to `/me/account` and scroll to the bottom and choose "Close your account permanently"
3. You should see the following:
![image](https://user-images.githubusercontent.com/6851384/180247364-7ee9b631-0921-49ed-9754-67b21a81270a.png)
4. Click "Manage purchases" and cancel all purchases you have
5. Return to `/me/account/close` and you should see the text `We are still in the process of removing one or more of your sites. This process normally takes 15-20 minutes. Once removal is completed, you should be able to close your account from this page.`
6. If you wait approx. 5 minutes then refresh your Atomic site should have been deleted and you should be able to close your account as normal:
![image](https://user-images.githubusercontent.com/6851384/179985298-b66bbb03-af02-4f9f-95fb-5ade86a5b66f.png)
7. You should complete the close account process and confirm you can fully close your account:
![image](https://user-images.githubusercontent.com/6851384/179985422-17342581-a9ce-4d77-88df-c1c09bdb87e7.png)

You can repeat the account closure process for a user with a simple site with no purchases. For this, you should see the content in the screenshot for step 6 above. 

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

