### PR TITLE
Add `onboarding/import-light-url-screen` feature flag to `production.json` and `stage.json` config files

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -46,6 +46,7 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
+		"onboarding/import-light-url-screen": false,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
+		"onboarding/import-light-url-screen": false,
 		"happychat": true,
 		"help": true,
 		"inline-help": true,


### PR DESCRIPTION
#### Proposed Changes

The proposes changes add the `onboarding/import-light-url-screen` feature flag  to `production.json` and `stage.json` config files. This is related to the upcoming launch of the new Import flow (https://github.com/Automattic/wp-calypso/pull/65584), together with the new Goals Capture i2 screen (pdDOJh-vD-p2).

The flag is set to `false` and will be enabled later in the upcoming PR https://github.com/Automattic/wp-calypso/pull/65401.

Related PR where the flag was already added to `horizon.json`, `wpcalypso.json` and `development.json`: https://github.com/Automattic/wp-calypso/pull/65539.

#### Testing Instructions

The PR doesn't include any observable change.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?