### PR TITLE
Design Picker: Update preview header font to Recoleta

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -274,9 +274,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	.step-container > .step-container__header {
 		.formatted-header {
 			h1.formatted-header__title {
-				font-family: $sans;
-				font-weight: 500;
-				font-size: $font-body;
+				font-size: $font-headline-small;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -214,7 +214,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 			@include break-mobile {
 				margin: 12px 0 24px;
-				transform: translateY( -48px );
+				transform: translateY( -58px );
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Swap sans font for brand font in the design preview

**Before**

<img width="1227" alt="Screen Shot 2022-07-20 at 10 56 07 AM" src="https://user-images.githubusercontent.com/2124984/180014313-3d0c3c54-7755-4b32-9f52-ffa455a4a906.png">


**After**

<img width="1225" alt="Screen Shot 2022-07-20 at 10 54 58 AM" src="https://user-images.githubusercontent.com/2124984/180014086-20a821ac-2be3-436b-8d0e-aef86d1333a8.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/setup/designSetup?siteSlug=[yoursite.wordpress.com]`
* Click on a theme to preview it
* The theme title font should be Recoleta

Closes #65701

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?