### PR TITLE
Add Last Publish date on Sites Dashboard grid

### DIFF
--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -2,6 +2,16 @@ import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useHumanDate } from 'calypso/lib/human-date';
 
+/**
+ * @typedef {Object}   TimeSinceProps
+ * @property {string}  date       The timestamp to render
+ * @property {string=} dateFormat Moment format string for the tooltip, default = 'll'
+ * @property {string=} className  Forwarded to underlying <time> element
+ */
+
+/**
+ * @param {TimeSinceProps} props
+ */
 function TimeSince( { className, date, dateFormat = 'll' } ) {
 	const moment = useLocalizedMoment();
 	const fullDate = useMemo( () => moment( date ).format( 'llll' ), [ moment, date ] );

--- a/client/components/time-since/index.tsx
+++ b/client/components/time-since/index.tsx
@@ -2,17 +2,13 @@ import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useHumanDate } from 'calypso/lib/human-date';
 
-/**
- * @typedef {Object}   TimeSinceProps
- * @property {string}  date       The timestamp to render
- * @property {string=} dateFormat Moment format string for the tooltip, default = 'll'
- * @property {string=} className  Forwarded to underlying <time> element
- */
+interface TimeSinceProps {
+	date: string;
+	dateFormat?: string;
+	className?: string;
+}
 
-/**
- * @param {TimeSinceProps} props
- */
-function TimeSince( { className, date, dateFormat = 'll' } ) {
+function TimeSince( { className, date, dateFormat = 'll' }: TimeSinceProps ) {
 	const moment = useLocalizedMoment();
 	const fullDate = useMemo( () => moment( date ).format( 'llll' ), [ moment, date ] );
 	const humanDate = useHumanDate( date, dateFormat );

--- a/client/data/sites/site-excerpt-types.ts
+++ b/client/data/sites/site-excerpt-types.ts
@@ -16,7 +16,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
 
-export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site' ] as const;
+export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site', 'updated_at' ] as const;
 
 export type SiteExcerptNetworkData = Pick<
 	SiteData,

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -168,7 +168,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					</Column>
 					<Column mobileHidden>{ site.plan.product_name_short }</Column>
 					<Column mobileHidden>
-						<TimeSince date={ site.options?.updated_at } />
+						{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '-' }
 					</Column>
 					<Column style={ { width: '20px' } }>
 						<EllipsisMenu>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import SiteIcon from 'calypso/blocks/site-icon';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import TimeSince from 'calypso/components/time-since';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -166,7 +167,9 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 						/>
 					</Column>
 					<Column mobileHidden>{ site.plan.product_name_short }</Column>
-					<Column mobileHidden>July 16, 1969</Column>
+					<Column mobileHidden>
+						<TimeSince date={ site.options?.updated_at } />
+					</Column>
 					<Column style={ { width: '20px' } }>
 						<EllipsisMenu>
 							<VisitDashboardItem site={ site } />

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -168,7 +168,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					</Column>
 					<Column mobileHidden>{ site.plan.product_name_short }</Column>
 					<Column mobileHidden>
-						{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '-' }
+						{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 					</Column>
 					<Column style={ { width: '20px' } }>
 						<EllipsisMenu>

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -60,6 +60,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'site_segment',
 	'software_version',
 	'timezone',
+	'updated_at',
 	'upgraded_filetypes_enabled',
 	'unmapped_url',
 	'verification_services_codes',

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -52,6 +52,6 @@ export interface SiteDataOptions {
 	is_difm_lite_in_progress: boolean;
 	is_domain_only: boolean;
 	difm_lite_site_options?: DIFMLiteSiteOptions;
-	updated_at: string | undefined;
+	updated_at?: string;
 	// TODO: fill out the rest of this
 }

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -52,5 +52,6 @@ export interface SiteDataOptions {
 	is_difm_lite_in_progress: boolean;
 	is_domain_only: boolean;
 	difm_lite_site_options?: DIFMLiteSiteOptions;
+	updated_at: string | undefined;
 	// TODO: fill out the rest of this
 }


### PR DESCRIPTION
#### Proposed Changes

* PR adds the `updated_at` option to the site's store and displays the formatted date as the "Last Publish" column value.
* It also adds JSDoc prop annotation for the TimeSince component to improve parameters validation in the IDE

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load Sites Dashboard at `/sites-dashboard`
2. Confirm that the Last Publish date is displayed for sites and it is nicely formatted (e.g. "4m ago", "2d ago", "Dec 3, 2021")

![Screen Shot 2022-07-21 at 09 30 29](https://user-images.githubusercontent.com/727413/180155979-8c02a8cc-ccf9-4b8d-ae9e-4ac07fdaae5c.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [ ] ~~Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?~~

Related to https://github.com/Automattic/wp-calypso/issues/65168