### PR TITLE
Revert/recent seller celebrational modal changes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -42,14 +42,10 @@ const SellerCelebrationModal = () => {
 	const previousIsEditorSaving = useRef( false );
 	const { isEditorSaving, hasPaymentsBlock, linkUrl } = useSelect( ( select ) => {
 		if ( isSiteEditor ) {
-			const isSavingSite =
-				select( 'core' ).isSavingEntityRecord( 'root', 'site' ) &&
-				! select( 'core' ).isAutosavingEntityRecord( 'root', 'site' );
+			const isSavingSite = select( 'core' ).isSavingEntityRecord( 'root', 'site' );
 			const page = select( 'core/edit-site' ).getPage();
 			const pageId = parseInt( page?.context?.postId );
-			const isSavingEntity =
-				select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId ) &&
-				! select( 'core' ).isAutosavingEntityRecord( 'postType', 'page', pageId );
+			const isSavingEntity = select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId );
 			const pageEntity = select( 'core' ).getEntityRecord( 'postType', 'page', pageId );
 			const paymentsBlock =
 				pageEntity?.content?.raw?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
@@ -60,9 +56,11 @@ const SellerCelebrationModal = () => {
 			};
 		}
 		const currentPost = select( 'core/editor' ).getCurrentPost();
-		const isSavingEntity =
-			select( 'core' ).isSavingEntityRecord( 'postType', currentPost?.type, currentPost?.id ) &&
-			! select( 'core' ).isAutosavingEntityRecord( 'postType', currentPost?.type, currentPost?.id );
+		const isSavingEntity = select( 'core' ).isSavingEntityRecord(
+			'postType',
+			currentPost?.type,
+			currentPost?.id
+		);
 		const globalBlockCount = select( 'core/block-editor' ).getGlobalBlockCount(
 			'jetpack/recurring-payments'
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 /**
  * Show the seller celebration modal
  */
-const SellerCelebrationModalInner = () => {
+const SellerCelebrationModal = () => {
 	const { addEntities } = useDispatch( 'core' );
 
 	useEffect( () => {
@@ -126,14 +126,6 @@ const SellerCelebrationModalInner = () => {
 			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_seller_celebration_modal_show' ) }
 		/>
 	);
-};
-
-const SellerCelebrationModal = () => {
-	const intent = useSiteIntent();
-	if ( intent === 'sell' ) {
-		return <SellerCelebrationModalInner />;
-	}
-	return null;
 };
 
 export default SellerCelebrationModal;


### PR DESCRIPTION
#### Proposed Changes

* Revert (https://github.com/Automattic/wp-calypso/pull/65707) and (https://github.com/Automattic/wp-calypso/pull/65708)
* There have been recent problems with ETK. I don't know if this is related but it minimizes the change surface.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #