### PR TITLE
Sites Dashboard: Fix fuzzy search race condition

### DIFF
--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -1,5 +1,5 @@
 import Fuse from 'fuse.js';
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 const defaultOptions = {
 	threshold: 0.4,
@@ -47,16 +47,19 @@ export const useFuzzySearch = < T >( {
 		} );
 	} );
 
-	useEffect( () => {
-		fuseInstance.setCollection( data );
-	}, [ fuseInstance, data ] );
+	const [ results, setRestults ] = useState( data );
 
-	const results = useMemo( () => {
+	useEffect( () => {
 		if ( ! query ) {
-			return data;
+			setRestults( data );
+			return;
 		}
 
-		return fuseInstance.search( query ).map( ( { item } ) => item );
+		// Every tiime the query or the data changes, we update the collection
+		// This assignment takes less than 1ms for hundreds or thousands of items
+		fuseInstance.setCollection( data );
+		const results = fuseInstance.search( query ).map( ( { item } ) => item );
+		setRestults( results );
 	}, [ fuseInstance, query, data ] );
 
 	return results;

--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -47,19 +47,19 @@ export const useFuzzySearch = < T >( {
 		} );
 	} );
 
-	const [ results, setRestults ] = useState( data );
+	const [ results, setResults ] = useState( data );
 
 	useEffect( () => {
 		if ( ! query ) {
-			setRestults( data );
+			setResults( data );
 			return;
 		}
 
-		// Every tiime the query or the data changes, we update the collection
-		// This assignment takes less than 1ms for hundreds or thousands of items
+		// Every time the query or the data changes, we update the collection
+		// This assignment takes less than 1ms for thousands of items
 		fuseInstance.setCollection( data );
 		const results = fuseInstance.search( query ).map( ( { item } ) => item );
-		setRestults( results );
+		setResults( results );
 	}, [ fuseInstance, query, data ] );
 
 	return results;

--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -48,8 +48,8 @@ export const useFuzzySearch = < T >( {
 		// Every time the query or the data changes, we update the collection
 		// This assignment takes less than 1ms for thousands of items
 		fuseInstance.setCollection( data );
-		const results = fuseInstance.search( query ).map( ( { item } ) => item );
-		return results;
+
+		return fuseInstance.search( query ).map( ( { item } ) => item );
 	}, [ fuseInstance, query, data ] );
 
 	return results;


### PR DESCRIPTION
#### Proposed Changes

* Fix the custom hook use-fuzzy-search that returned a wrong cached results.
The hook had a race condition and the execution of `fuseInstance.setCollection` was happening after the cache with the `useMemo`. I've unified both behaviours under only one useMemo.

Assigning the data every time the query changes is not time-consuming. Less than 1ms per thousand sites.

#### Testing Instructions

* Go to /sites-dashboard
* Enter a text to search
* Change between tabs

#### Screencast

**Before: Inconsistent behaviour**


https://user-images.githubusercontent.com/779993/180037867-a3ac6da3-a5b8-46a5-8250-524cfb39af38.mp4



**After: Fixed behaviour**

https://user-images.githubusercontent.com/779993/180037742-cc977e9e-0655-41e6-b82b-77de2552667d.mp4


#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/pull/65769#issuecomment-1190231540