### PR TITLE
E2E: extend EmailClient timeout to wait for slow-delivering SMS.

### DIFF
--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -55,6 +55,7 @@ export class EmailClient {
 		// initialized, or a specified timestamp.
 		const message = await this.client.messages.get( inboxId, searchCriteria, {
 			receivedAfter: receivedAfter !== undefined ? receivedAfter : this.startTimestamp,
+			timeout: 90 * 1000, // Sometimes SMS is slow to be received.
 		} );
 		return message;
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR extends the timeout for EmailClient to wait for SMS delivery which may take a long time.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] Authentications E2E

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Closes #65793