### PR TITLE
E2E: make Site Importer selectors version-agnostic.

### DIFF
--- a/test/e2e/specs/onboarding/setup__importer.ts
+++ b/test/e2e/specs/onboarding/setup__importer.ts
@@ -73,9 +73,18 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		it( 'Start an invalid WordPress import typo', async () => {
 			// 1.gravatar.com is guaranteed never to be a valid DNS
 			await startImportFlow.enterURL( 'zz.gravatar.com' );
-			await startImportFlow.validateErrorCapturePage(
-				'The address you entered is not valid. Please try again.'
-			);
+
+			// Support both Legacy and Goals Capture versions
+			// of the error message.
+			// See https://github.com/Automattic/wp-calypso/issues/65792
+			await Promise.race( [
+				startImportFlow.validateErrorCapturePage(
+					'The address you entered is not valid. Please try again.'
+				),
+				startImportFlow.validateErrorCapturePage(
+					'Please enter a valid website address. You can copy and paste.'
+				),
+			] );
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/start__importer.ts
+++ b/test/e2e/specs/onboarding/start__importer.ts
@@ -73,9 +73,18 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		it( 'Start an invalid WordPress import typo', async () => {
 			// 1.gravatar.com is guaranteed never to be a valid DNS
 			await startImportFlow.enterURL( 'zz.gravatar.com' );
-			await startImportFlow.validateErrorCapturePage(
-				'The address you entered is not valid. Please try again.'
-			);
+
+			// Support both Legacy and Goals Capture versions
+			// of the error message.
+			// See https://github.com/Automattic/wp-calypso/issues/65792
+			await Promise.race( [
+				startImportFlow.validateErrorCapturePage(
+					'The address you entered is not valid. Please try again.'
+				),
+				startImportFlow.validateErrorCapturePage(
+					'Please enter a valid website address. You can copy and paste.'
+				),
+			] );
 		} );
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR updates the selectors used by `StartImportFlow` to be more version-agnostic (ie. less prone to layout and screen changes).

Key changes:
- change the `dontHaveASiteButton` selector to work off the text regex;
- update the `validateURLCapturePage` to check for the URL instead;
- add Promise.race where needed in specs to support both versions of the importer.


#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Closes https://github.com/Automattic/wp-calypso/issues/65792.
