### PR TITLE
E2E: update TOTP Authentication spec to add redirect

### DIFF
--- a/test/e2e/specs/authentication/authentication__totp.ts
+++ b/test/e2e/specs/authentication/authentication__totp.ts
@@ -2,21 +2,54 @@
  * @group authentication
  */
 
-import { DataHelper, TestAccount } from '@automattic/calypso-e2e';
+import { DataHelper, LoginPage, SecretsManager, TOTPClient } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
+	const credentials = SecretsManager.secrets.testAccounts.totpUser;
 	let page: Page;
-	let testAccount: TestAccount;
+	let loginPage: LoginPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 	} );
 
-	it( 'Authenticate as user with TOTP 2FA code', async function () {
-		testAccount = new TestAccount( 'totpUser' );
-		await testAccount.authenticate( page );
+	// This spec intentionally manually calls individual
+	// methods from LoginPage to separate out the steps that
+	// are bundled together in the TestAccount class.
+	it( 'Navigate to Login page', async function () {
+		await page.goto(
+			DataHelper.getCalypsoURL(
+				'log-in?site=e2eflowtestingtotp.wordpress.com&redirect_to=%2Fsettings%2Fgeneral'
+			)
+		);
+	} );
+
+	it( 'Enter username', async function () {
+		loginPage = new LoginPage( page );
+		await loginPage.fillUsername( credentials.username );
+		await loginPage.clickSubmit();
+	} );
+
+	it( 'Enter password', async function () {
+		await loginPage.fillPassword( credentials.password );
+	} );
+
+	it( 'Submit form', async function () {
+		await Promise.all( [ page.waitForNavigation(), loginPage.clickSubmit() ] );
+	} );
+
+	it( 'Enter 2FA code', async function () {
+		const totpClient = new TOTPClient( credentials.totpKey as string );
+		const code = totpClient.getToken();
+
+		await loginPage.submitVerificationCode( code );
+	} );
+
+	it( 'User is redirected to Settings > General Settings', async function () {
+		const redirectedURL = DataHelper.getCalypsoURL( '/settings/general' );
+		await page.waitForURL( `${ redirectedURL }/${ credentials.primarySite }` );
 	} );
 } );

--- a/test/e2e/specs/authentication/authentication__totp.ts
+++ b/test/e2e/specs/authentication/authentication__totp.ts
@@ -20,9 +20,10 @@ describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
 	// methods from LoginPage to separate out the steps that
 	// are bundled together in the TestAccount class.
 	it( 'Navigate to Login page', async function () {
+		// Test redirect to full URL.
 		await page.goto(
 			DataHelper.getCalypsoURL(
-				'log-in?site=e2eflowtestingtotp.wordpress.com&redirect_to=%2Fsettings%2Fgeneral'
+				`log-in?site=${ credentials.primarySite }&redirect_to=%2Fsettings%2Fgeneral%2F${ credentials.primarySite }`
 			)
 		);
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR updates the Authentication: TOTP spec.

Key changes:
- split out the login steps into individual steps for finer granularity;
- add the redirect portion to the spec, which was the cause of the outage;

This should be the last spec that needs to be implemented as part of the [Authentication E2E project](pciE2j-18A-p2). 

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [ ] Authentication E2E

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #