### PR TITLE
Checkout: Add Ebanx terms of service

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -7,6 +7,7 @@ import ConciergeRefundPolicy from './concierge-refund-policy';
 import DomainRefundPolicy from './domain-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
+import { EbanxTermsOfService } from './ebanx-terms-of-service';
 import TermsOfService from './terms-of-service';
 import ThirdPartyPluginsTermsOfService from './third-party-plugins-terms-of-service';
 import TitanTermsOfService from './titan-terms-of-service';
@@ -34,6 +35,7 @@ class CheckoutTerms extends Component {
 				<BundledDomainNotice cart={ cart } />
 				<TitanTermsOfService cart={ cart } />
 				<ThirdPartyPluginsTermsOfService cart={ cart } />
+				<EbanxTermsOfService />
 				<AdditionalTermsOfServiceInCart />
 			</Fragment>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
@@ -1,0 +1,39 @@
+import { usePaymentMethod } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { useTranslate } from 'i18n-calypso';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+
+export function EbanxTermsOfService() {
+	const translate = useTranslate();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const currentPaymentMethod = usePaymentMethod();
+
+	const canUseEbanx = responseCart.allowed_payment_methods.includes(
+		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
+	);
+	if ( ! canUseEbanx ) {
+		return;
+	}
+	if ( currentPaymentMethod?.id !== 'card' ) {
+		return;
+	}
+
+	// This text and link was provided by EBanx directly. See https://github.com/Automattic/payments-shilling/issues/983
+	const tosUrl =
+		'http://go.pardot.com/e/779123/br-termos-/2s9d1h/1387578788?h=Y8e15EGjfwatzTqGa7lilIlSEGTaOz-BZC5xFvBZICk';
+	const tosText = translate(
+		'This is an international purchase, which is subject to a currency exchange operation, to be processed by EBANX, according to these {{tosLink}}terms and conditions{{/tosLink}}. By clicking "BUY", you state acknowledgment and acceptance of the terms and conditions of this transaction.',
+		{
+			components: {
+				tosLink: <a href={ tosUrl } target="_blank" rel="noopener noreferrer" />,
+			},
+		}
+	);
+	return (
+		<div>
+			<p>{ tosText }</p>
+		</div>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
@@ -15,7 +15,8 @@ export function EbanxTermsOfService() {
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
 	const isNewEbanxCardSelected = canUseEbanx && currentPaymentMethod?.id === 'card';
-	const isSavedEbanxCardSelected = currentPaymentMethod?.id === 'existing-card-ebanx';
+	const isSavedEbanxCardSelected =
+		currentPaymentMethod?.paymentProcessorId === 'existing-card-ebanx';
 	if ( ! isNewEbanxCardSelected && ! isSavedEbanxCardSelected ) {
 		return null;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
@@ -14,10 +14,9 @@ export function EbanxTermsOfService() {
 	const canUseEbanx = responseCart.allowed_payment_methods.includes(
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
-	if ( ! canUseEbanx ) {
-		return null;
-	}
-	if ( currentPaymentMethod?.id !== 'card' ) {
+	const isNewEbanxCardSelected = canUseEbanx && currentPaymentMethod?.id === 'card';
+	const isSavedEbanxCardSelected = currentPaymentMethod?.id === 'existing-card-ebanx';
+	if ( ! isNewEbanxCardSelected && ! isSavedEbanxCardSelected ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
@@ -1,6 +1,7 @@
 import { usePaymentMethod } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 
@@ -14,10 +15,10 @@ export function EbanxTermsOfService() {
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
 	if ( ! canUseEbanx ) {
-		return;
+		return null;
 	}
 	if ( currentPaymentMethod?.id !== 'card' ) {
-		return;
+		return null;
 	}
 
 	// This text and link was provided by EBanx directly. See https://github.com/Automattic/payments-shilling/issues/983
@@ -31,9 +32,5 @@ export function EbanxTermsOfService() {
 			},
 		}
 	);
-	return (
-		<div>
-			<p>{ tosText }</p>
-		</div>
-	);
+	return <CheckoutTermsItem>{ tosText }</CheckoutTermsItem>;
 }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -484,6 +484,8 @@ export default function CompositeCheckout( {
 			'full-credits': () => fullCreditsProcessor( dataForProcessor ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
+			'existing-card-ebanx': ( transactionData: unknown ) =>
+				existingCardProcessor( transactionData, dataForProcessor ),
 			paypal: () => payPalProcessor( dataForProcessor ),
 		} ),
 		[ dataForProcessor ]

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -61,7 +61,8 @@ export function createExistingCardMethod( {
 
 	return {
 		id,
-		paymentProcessorId: 'existing-card',
+		paymentProcessorId:
+			paymentPartnerProcessorId === 'ebanx' ? 'existing-card-ebanx' : 'existing-card',
 		label: (
 			<ExistingCardLabel
 				last4={ last4 }


### PR DESCRIPTION
#### Proposed Changes

We are required by Ebanx to display a particular TOS string during checkout. This PR adds that string if Ebanx is the selected payment method.

The new text reads: "This is an international purchase, which is subject to a currency exchange operation, to be processed by EBANX, according to these [terms and conditions](http://go.pardot.com/e/779123/br-termos-/2s9d1h/1387578788?h=Y8e15EGjfwatzTqGa7lilIlSEGTaOz-BZC5xFvBZICk). By clicking "BUY", you state acknowledgment and acceptance of the terms and conditions of this transaction."

Fixes 983-gh-Automattic/payments-shilling

#### Screenshots

Before, with new Ebanx card:

<img width="574" alt="Screen Shot 2022-07-20 at 5 47 03 PM" src="https://user-images.githubusercontent.com/2036909/180088528-c85db2f4-b18a-423e-aaab-82a43373a8e8.png">

After, with new Ebanx card:

<img width="570" alt="Screen Shot 2022-07-20 at 5 50 05 PM" src="https://user-images.githubusercontent.com/2036909/180088540-a80034b6-5771-4f4a-b11c-e730999718d3.png">

After, with saved Ebanx card:

<img width="571" alt="Screen Shot 2022-07-20 at 6 12 34 PM" src="https://user-images.githubusercontent.com/2036909/180091433-dc057448-7bcf-456a-a1c2-0ed6ea2de58a.png">


#### Testing Instructions

- Set your user's currency to BRL.
- Add a product to your cart and visit checkout.
- In the contact/billing info step, set your country to "Brazil" and use a fake postal code like `12345-123`.
- Select "Credit or debit card" as your payment method.
- Scroll to the bottom of checkout and verify that you see the new text (described above).
- Select another payment method and verify that the new text disappears.
