### PR TITLE
Revert #65531 and #65725 (Design Picker: Verticalize standard themes, design_type change)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -45,7 +45,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			showDeviceSwitcher={ false }
 			previewUrl={ getDesignPreviewUrl( design, {
 				language: locale,
-				vertical_id: verticalId,
+				verticalId,
 				viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -362,8 +362,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {
 			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
-			site_title: intent === 'write' ? siteTitle : undefined,
-			vertical_id: isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined,
+			siteTitle: intent === 'write' ? siteTitle : undefined,
 		} );
 
 		const stepContent = (
@@ -533,7 +532,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			previewOnly={ newDesignEnabled }
 			hasDesignOptionHeader={ ! newDesignEnabled }
-			verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined }
 		/>
 	);
 

--- a/config/development.json
+++ b/config/development.json
@@ -159,7 +159,6 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
-		"signup/standard-theme-v13n": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -108,7 +108,6 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
-		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -120,7 +120,6 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
-		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -120,7 +120,6 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
-		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,7 +131,6 @@
 		"signup/stepper-flow": true,
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
-		"signup/standard-theme-v13n": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -31,7 +31,6 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-config": "workspace:^",
 		"@automattic/domain-utils": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/happychat-connection": "workspace:^",

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -300,10 +300,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		if ( anchorDesigns.indexOf( selectedDesign.template ) < 0 ) {
 			// Send vertical_id only if the current design is generated design or we enabled the v13n of standard themes
 			const vertical_id =
-				selectedDesign.design_type === 'vertical' || isEnabled( 'signup/standard-theme-v13n' )
-					? siteVerticalId
-					: undefined;
-
+				!! recipe || isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined;
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Design } from '@automattic/design-picker/src/types';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -298,15 +297,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		 */
 		const anchorDesigns = [ 'hannah', 'gilbert', 'riley' ];
 		if ( anchorDesigns.indexOf( selectedDesign.template ) < 0 ) {
-			// Send vertical_id only if the current design is generated design or we enabled the v13n of standard themes
-			const vertical_id =
-				!! recipe || isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined;
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',
 				body: {
 					trim_content: true,
-					vertical_id: vertical_id || undefined,
+					vertical_id: siteVerticalId || undefined,
 					pattern_ids: recipe?.pattern_ids,
 					header_pattern_ids: recipe?.header_pattern_ids || [],
 					footer_pattern_ids: recipe?.footer_pattern_ids || [],

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -11,10 +11,6 @@ import {
 	AtomicSoftwareStatus,
 } from '../types';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: () => false,
-} ) );
-
 const client_id = 'magic_client_id';
 const client_secret = 'magic_client_secret';
 const mockedClientCredentials = { client_id, client_secret };

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -16,10 +16,6 @@ import {
 	SiteError,
 } from '../types';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: () => false,
-} ) );
-
 describe( 'Site', () => {
 	const siteDetailsResponse: SiteDetails = {
 		ID: 12345,

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -18,10 +18,6 @@ import {
 import { SiteDetails } from '../types';
 import type { State } from '../reducer';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: () => false,
-} ) );
-
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	default: jest.fn(),

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -128,7 +128,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								key={ design.slug }
 								thumbnailUrl={ getDesignPreviewUrl( design, {
 									language: locale,
-									vertical_id: verticalId,
+									verticalId,
 									viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 									viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 									use_screenshot_overrides: true,

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -31,25 +31,15 @@ interface DesignPreviewImageProps {
 	design: Design;
 	locale: string;
 	highRes: boolean;
-	verticalId?: string;
 }
 
-const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
-	design,
-	locale,
-	highRes,
-	verticalId,
-} ) => {
+const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale, highRes } ) => {
 	const scrollable = design.preview !== 'static';
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	return (
 		<MShotsImage
-			url={ getDesignPreviewUrl( design, {
-				language: locale,
-				vertical_id: verticalId,
-				use_screenshot_overrides: true,
-			} ) }
+			url={ getDesignPreviewUrl( design, { language: locale, use_screenshot_overrides: true } ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""
 			options={ getMShotOptions( { scrollable, highRes, isMobile } ) }
@@ -72,7 +62,6 @@ interface DesignButtonProps {
 	hasDesignOptionHeader?: boolean;
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
-	verticalId?: string;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -88,7 +77,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable = false,
 	onCheckout = undefined,
-	verticalId,
 } ) => {
 	const { __ } = useI18n();
 
@@ -177,12 +165,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					</div>
 				) : (
 					<div className="design-picker__image-frame-inside">
-						<DesignPreviewImage
-							design={ design }
-							locale={ locale }
-							highRes={ highRes }
-							verticalId={ verticalId }
-						/>
+						<DesignPreviewImage design={ design } locale={ locale } highRes={ highRes } />
 					</div>
 				) }
 			</span>
@@ -327,7 +310,6 @@ export interface DesignPickerProps {
 	previewOnly?: boolean;
 	hasDesignOptionHeader?: boolean;
 	onCheckout?: any;
-	verticalId?: string;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -356,7 +338,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	previewOnly = false,
 	hasDesignOptionHeader = true,
 	onCheckout = undefined,
-	verticalId,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -404,7 +385,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						previewOnly={ previewOnly }
 						hasDesignOptionHeader={ hasDesignOptionHeader }
 						onCheckout={ onCheckout }
-						verticalId={ verticalId }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -64,8 +64,8 @@ export interface Design {
 
 export interface DesignPreviewOptions {
 	language?: string;
-	vertical_id?: string;
-	site_title?: string;
+	verticalId?: string;
+	siteTitle?: string;
 	viewport_width?: number;
 	viewport_height?: number;
 	use_screenshot_overrides?: boolean;

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -50,8 +50,8 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should append the preview options to the query params', () => {
 			const options: DesignPreviewOptions = {
 				language: 'id',
-				vertical_id: '3',
-				site_title: 'Design Title',
+				verticalId: '3',
+				siteTitle: 'Design Title',
 				viewport_width: 1280,
 				viewport_height: 700,
 			};
@@ -65,7 +65,7 @@ describe( 'Design Picker designs utils', () => {
 		// in a `background-url: url( ... )` CSS rule the parentheses will break it.
 		it( 'should escape parentheses within the site title', () => {
 			const options: DesignPreviewOptions = {
-				site_title: 'Mock(Design)(Title)',
+				siteTitle: 'Mock(Design)(Title)',
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -22,7 +22,7 @@ export const getDesignPreviewUrl = (
 		footer_pattern_ids: recipe?.footer_pattern_ids
 			? recipe?.footer_pattern_ids.join( ',' )
 			: undefined,
-		vertical_id: options.vertical_id,
+		vertical_id: options.verticalId,
 		language: options.language,
 		...( options.viewport_width && { viewport_width: options.viewport_width } ),
 		viewport_height: options.viewport_height || DEFAULT_VIEWPORT_HEIGHT,
@@ -30,7 +30,7 @@ export const getDesignPreviewUrl = (
 		use_screenshot_overrides: options.use_screenshot_overrides,
 	} );
 
-	const siteTitle = options.site_title || design.title;
+	const siteTitle = options.siteTitle || design.title;
 	if ( siteTitle ) {
 		// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped
 		// parentheses in the URL break it. `addQueryArgs` and `encodeURIComponent` don't escape

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,7 +445,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/data-stores@workspace:packages/data-stores"
   dependencies:
-    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/domain-utils": "workspace:^"
     "@automattic/format-currency": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

* Revert #65531 #65725
* See https://github.com/Automattic/wp-calypso/issues/65775#issuecomment-1190677613 and below
  * The goal is to bring us back to a stable, deployable ETK without errors.
* Also p1658343876651439-slack-C02DQP0FP

#### Testing Instructions

* Test the ETK Build



Related to #65775