### PR TITLE
Checkout: Prevent adding subdomain site slug as product during checkout

### DIFF
--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -135,6 +135,18 @@ describe( 'getProductSlugFromContext', () => {
 		},
 		{
 			product: undefined,
+			domainOrProduct: subdomainSiteSlug,
+			selectedSite: subdomainSiteSlug,
+			expected: '',
+		},
+		{
+			product: undefined,
+			domainOrProduct: subdomainSiteSlug,
+			selectedSite: domainSiteSlug,
+			expected: '',
+		},
+		{
+			product: undefined,
 			domainOrProduct: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -78,12 +78,18 @@ export function getProductSlugFromContext( { params, store }: PageJS.Context ): 
 
 function doesStringResembleDomain( domainOrProduct: string ): boolean {
 	try {
+		// Domain names should all contain a dot.
 		const hasDot = domainOrProduct.includes( '.' );
 		if ( ! hasDot ) {
 			return false;
 		}
+
+		// Subdomain site slugs contain the install path after two colons.
+		const domainBeforeColons = domainOrProduct.split( '::' )[ 0 ];
+
+		// Domains should be able to become a valid URL.
 		// eslint-disable-next-line no-new
-		new URL( 'http://' + domainOrProduct );
+		new URL( 'http://' + domainBeforeColons );
 		return true;
 	} catch {}
 	return false;


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/65655 which added better URL parsing of checkout URLs to prevent confusion between site slugs and product slugs. However, it missed one possible case: if the URL is something like `/checkout/example.com::blog` (a subdomain site), it might consider `example.com::blog` as a product slug and try to add it to the cart. This PR prevents that.

#### Testing Instructions

Automated tests are included.