### PR TITLE
Pull request template comment ordering

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,23 +11,25 @@ Add as many details as possible to help others reproduce the issue and test the 
 
 *
 
-<!--
-Link a related issue to this PR. If the PR does not immediately resolve the issue,
-for example, it requires a separate deployment to production, avoid
-using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
-the linked issue.
--->
-
 #### Pre-merge Checklist
 
+<!--
 Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.
 
 Both the PR author and reviewer are responsible for ensuring the checklist is completed.
+-->
 
 - [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
 - [ ] Have you tested the feature in [Simple](https://wp.me/P9HQHe-k8-p2), [Atomic](https://wp.me/P9HQHe-jW-p2), and [self-hosted Jetpack sites](https://wp.me/PCYsg-g6b-p2)?
 - [ ] Have you checked for TypeScript, React or other console errors?
 - [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
 - [ ] Have we sent any new strings [for translation](https://wp.me/PCYsg-1vr-p2) ASAP?
+
+<!--
+Link a related issue to this PR. If the PR does not immediately resolve the issue,
+for example, it requires a separate deployment to production, avoid
+using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
+the linked issue.
+-->
 
 Related to #


### PR DESCRIPTION
Noticed the order of things wasn't quite right after we updated this template in https://github.com/Automattic/wp-calypso/pull/64814

#### Proposed Changes

- Moves "related to" comment next to related to
- Comments out pre merge checklist instructions

#### Testing Instructions

* Github pull request template update

Related to https://github.com/Automattic/wp-calypso/pull/64814