### PR TITLE
Added tags 'blocks' & 'editor' to 'Design' section. (#65811)

### DIFF
--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -85,7 +85,7 @@ export function useCategories(
 			description: __( 'Design' ),
 			icon: 'grid',
 			slug: 'design',
-			tags: [ 'design' ],
+			tags: [ 'design', 'blocks', 'editor' ],
 		},
 		donations: {
 			name: __( 'Donations' ),


### PR DESCRIPTION
#### Proposed Changes

Added tags 'blocks' & 'editor' to 'Design' section.(#65811)

#### Testing Instructions

1. Go to Plugins section from My-Sites
2. Click on 'Design' plugins.
3. Notice that plugins tagged with 'editor' & 'blocks' are also appearing.

*
Before:
![image](https://user-images.githubusercontent.com/3984908/180134901-6e14aa94-b9e1-4843-87cc-19b346d226e9.png)

After:

<img width="1435" alt="Screenshot 2022-07-21 at 10 45 11 AM" src="https://user-images.githubusercontent.com/3984908/180134947-a0b3cf0d-61ee-4fbb-80fe-67a827384006.png">



Related to #65811
