### PR TITLE
Stepper: Hide progress bar for DIFM step

### DIFF
--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -33,6 +33,8 @@ export function useSiteSetupFlowProgress(
 		case 'intent':
 			beginningSegment = beginningSteps.indexOf( currentStep ) / MAX_STEPS;
 			break;
+		case 'difmStartingPoint':
+			return { progress: 0, count: 0 };
 	}
 
 	switch ( intent ) {


### PR DESCRIPTION
#### Proposed Changes

A progress bar was added to the Stepper flow in #64586. However, if the user chooses the DIFM intent, the DIFM flow inside the Stepper framework has only 1 step - `difmStartingPoint`. So, a progress bar does not make sense for this step. 

|Before|After|
|----|----|
|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/180145110-ace23973-e67a-4e89-8a1c-428e40b4204a.png">|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/180145026-1f3db9f8-9077-4dd4-91bd-3d770dd39bd3.png">|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/goals?siteSlug=${site_slug}`.
* Click on the `Hire a professional to design my website` goal and then click on Continue.
* Confirm that the progress bar in the top of the screen is not present.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - NA
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? - NA
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) - NA
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? - NA

Related to #