### PR TITLE
Calypso Config: Don't throw error when missing the config data

### DIFF
--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -15,10 +15,26 @@ declare global {
  *
  * @module config/index
  */
-if ( 'undefined' === typeof window || ! window.configData ) {
-	throw new ReferenceError(
-		'No configuration was found: please see packages/calypso-config/README.md for more information'
-	);
+if ( 'undefined' === typeof window ) {
+	throw new Error( 'Trying to initialize the configuration outside of a browser context.' );
+}
+
+if ( ! window.configData ) {
+	if ( 'development' === process.env.NODE_ENV ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			'%cNo configuration was found: ' +
+				'%cPlease see ' +
+				'%cpackages/calypso-config/README.md ' +
+				'%cfor more information.',
+			'color: red; font-size: 120%', // error prefix
+			'color: white;', // message
+			'color: #0267ff;', // calypso-config README.md file reference
+			'color: white' // message
+		);
+	}
+
+	window.configData = {};
 }
 
 const isDesktop = window.electron !== undefined;


### PR DESCRIPTION
#### Proposed Changes

* According to p1658343876651439-slack-C02DQP0FP, if the ETK plugin imports some packages that rely on `@automattic/calypso-config` unintentionally, something might be broken. Hence, I think it might be better to use `console.error` to show the error message instead of throwing the error directly.

Any thoughts?

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch to your local calypso
* Add the following code to`packages/data-stores/src/site/actions.ts`
  ```js
  import { isEnabled } from '@automattic/calypso-config';

  ...

  console.log( isEnabled( 'blablabla' ) );
  ```
* Go to `apps/editing-toolkit` and run `yarn dev --sync`
* Visit a sandboxed p2 post URL and appending `?concat_js=yes` ( example: 2cf1e-pb ).
* Type `@...` in a p2 comment box, and you will see the error as followed but the ETK plugin still works well

  ![image](https://user-images.githubusercontent.com/13596067/180156750-d9a2b11d-d7d6-4425-9509-5fce3fde049e.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to https://github.com/Automattic/wp-calypso/issues/65775#issuecomment-1190677613