### PR TITLE
Set default site title text to My blog/store/site instead of the selected vertical text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -97,7 +97,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 		recordTracksEvent( 'calypso_signup_intent_select', eventProperties );
 	};
 
-	const handleSubmit = async ( submittedGoals: Onboard.SiteGoal[] ) => {
+	const handleSubmit = ( submittedGoals: Onboard.SiteGoal[] ) => {
 		setGoals( submittedGoals );
 
 		const intent = goalsToIntent( submittedGoals );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -4,10 +4,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
-import { useSite } from '../../../../hooks/use-site';
 import { GoalsCaptureContainer } from './goals-capture-container';
 import SelectGoals from './select-goals';
 import type { Step } from '../../types';
@@ -47,22 +46,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 	const { setGoals, setIntent, clearImportGoal, clearDIFMGoal, resetIntent } =
 		useDispatch( ONBOARD_STORE );
-
-	const site = useSite();
-	const { saveSiteTitle } = useDispatch( SITE_STORE );
 	const refParameter = getQueryArgs()?.ref as string;
-
-	const getSiteTitle = ( intent: Onboard.SiteIntent ) => {
-		if ( intent === Onboard.SiteIntent.Write ) {
-			return translate( 'My blog' );
-		}
-
-		if ( intent === Onboard.SiteIntent.Sell ) {
-			return translate( 'My store' );
-		}
-
-		return translate( 'My site' );
-	};
 
 	useEffect( () => {
 		if ( ! displayAllGoals ) {
@@ -118,9 +102,6 @@ const GoalsStep: Step = ( { navigation } ) => {
 
 		const intent = goalsToIntent( submittedGoals );
 		setIntent( intent );
-		if ( site ) {
-			await saveSiteTitle( site.ID, getSiteTitle( intent ) );
-		}
 
 		recordGoalsSelectTracksEvent( submittedGoals, intent );
 		recordIntentSelectTracksEvent( submittedGoals, intent );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -53,11 +53,11 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const refParameter = getQueryArgs()?.ref as string;
 
 	const getSiteTitle = ( intent: Onboard.SiteIntent ) => {
-		if ( intent === Onboarding.SiteIntent.Write ) {
+		if ( intent === Onboard.SiteIntent.Write ) {
 			return translate( 'My blog' );
 		}
 
-		if ( intent === Onboarding.SiteIntent.Sell ) {
+		if ( intent === Onboard.SiteIntent.Sell ) {
 			return translate( 'My store' );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -28,7 +28,6 @@ type TracksGoalsSelectEventProperties = {
 };
 
 const SiteGoal = Onboard.SiteGoal;
-const SiteIntent = Onboard.SiteIntent;
 const { serializeGoals, goalsToIntent } = Onboard.utils;
 
 const displayAllGoals = isEnabled( 'signup/goals-step-2' );
@@ -78,7 +77,10 @@ const GoalsStep: Step = ( { navigation } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const recordGoalsSelectTracksEvent = ( goals: SiteGoal[], intent: SiteIntent ) => {
+	const recordGoalsSelectTracksEvent = (
+		goals: Onboard.SiteGoal[],
+		intent: Onboard.SiteIntent
+	) => {
 		const eventProperties: TracksGoalsSelectEventProperties = {
 			goals: serializeGoals( goals ),
 			combo: goals.sort().join( ',' ),
@@ -97,7 +99,10 @@ const GoalsStep: Step = ( { navigation } ) => {
 		recordTracksEvent( 'calypso_signup_goals_select', eventProperties );
 	};
 
-	const recordIntentSelectTracksEvent = ( submittedGoals: SiteGoal[], intent: SiteIntent ) => {
+	const recordIntentSelectTracksEvent = (
+		submittedGoals: Onboard.SiteGoal[],
+		intent: Onboard.SiteIntent
+	) => {
 		const hasImportGoal = submittedGoals.includes( SiteGoal.Import );
 
 		const eventProperties = {
@@ -108,7 +113,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 		recordTracksEvent( 'calypso_signup_intent_select', eventProperties );
 	};
 
-	const handleSubmit = async ( submittedGoals: SiteGoal[] ) => {
+	const handleSubmit = async ( submittedGoals: Onboard.SiteGoal[] ) => {
 		setGoals( submittedGoals );
 
 		const intent = goalsToIntent( submittedGoals );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -52,7 +52,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const { saveSiteTitle } = useDispatch( SITE_STORE );
 	const refParameter = getQueryArgs()?.ref as string;
 
-	const getSiteTitle = ( intent: SiteIntent ) => {
+	const getSiteTitle = ( intent: Onboard.SiteIntent ) => {
 		if ( intent === SiteIntent.Write ) {
 			return translate( 'My blog' );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -53,11 +53,11 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const refParameter = getQueryArgs()?.ref as string;
 
 	const getSiteTitle = ( intent: Onboard.SiteIntent ) => {
-		if ( intent === SiteIntent.Write ) {
+		if ( intent === Onboarding.SiteIntent.Write ) {
 			return translate( 'My blog' );
 		}
 
-		if ( intent === SiteIntent.Sell ) {
+		if ( intent === Onboarding.SiteIntent.Sell ) {
 			return translate( 'My store' );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -1,18 +1,22 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Onboard } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import siteVerticalImage from 'calypso/assets/images/onboarding/site-vertical.svg';
+import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
-import { SITE_STORE } from '../../../../stores';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import SiteVerticalForm from './form';
 import type { Step } from '../../types';
 import type { Vertical } from 'calypso/components/select-vertical/types';
+
+const { goalsToIntent } = Onboard.utils;
 
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
@@ -23,6 +27,8 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const siteVertical = useSelect(
 		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site?.ID ) ) || undefined
 	);
+	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
+	const intent = goalsToIntent( goals );
 	const translate = useTranslate();
 	const headerText = translate( 'What’s your website about?' );
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
@@ -30,6 +36,18 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' ) ?? ! isEnglishLocale;
 	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
+
+	const siteTitleText = React.useMemo( () => {
+		if ( intent === 'write' ) {
+			return translate( 'My blog' );
+		}
+
+		if ( intent === 'sell' ) {
+			return translate( 'My store' );
+		}
+
+		return translate( 'My site' );
+	}, [ intent, translate ] );
 
 	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
 		setVertical( vertical );
@@ -44,7 +62,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 			setIsBusy( true );
 			await saveSiteSettings( site.ID, {
 				site_vertical_id: value,
-				blogname: label,
+				blogname: siteTitleText,
 			} );
 			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
 				user_input: userInput,
@@ -61,34 +79,37 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	}
 
 	return (
-		<StepContainer
-			stepName={ 'site-vertical' }
-			goBack={ goalsCaptureStepEnabled ? goBack : undefined }
-			goNext={ goNext }
-			headerImageUrl={ siteVerticalImage }
-			skipLabelText={ translate( 'Skip to dashboard' ) }
-			skipButtonAlign={ 'top' }
-			isHorizontalLayout={ true }
-			hideBack={ ! goalsCaptureStepEnabled }
-			formattedHeader={
-				<FormattedHeader
-					id={ 'site-vertical-header' }
-					headerText={ headerText }
-					subHeaderText={ subHeaderText }
-					align={ 'left' }
-				/>
-			}
-			stepContent={
-				<SiteVerticalForm
-					defaultVertical={ siteVertical }
-					isSkipSynonyms={ Boolean( isSkipSynonyms ) }
-					isBusy={ isBusy }
-					onSelect={ handleSiteVerticalSelect }
-					onSubmit={ handleSubmit }
-				/>
-			}
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			<DocumentHead title={ headerText } />
+			<StepContainer
+				stepName={ 'site-vertical' }
+				goBack={ goalsCaptureStepEnabled ? goBack : undefined }
+				goNext={ goNext }
+				headerImageUrl={ siteVerticalImage }
+				skipLabelText={ translate( 'Skip to dashboard' ) }
+				skipButtonAlign={ 'top' }
+				isHorizontalLayout={ true }
+				hideBack={ ! goalsCaptureStepEnabled }
+				formattedHeader={
+					<FormattedHeader
+						id={ 'site-vertical-header' }
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+						align={ 'left' }
+					/>
+				}
+				stepContent={
+					<SiteVerticalForm
+						defaultVertical={ siteVertical }
+						isSkipSynonyms={ Boolean( isSkipSynonyms ) }
+						isBusy={ isBusy }
+						onSelect={ handleSiteVerticalSelect }
+						onSubmit={ handleSubmit }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -3,6 +3,7 @@ import { Onboard } from '@automattic/data-stores';
 import { useDesignsBySite } from '@automattic/design-picker';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -76,6 +77,7 @@ export const siteSetupFlow: Flow = {
 		useDesignsBySite( site );
 	},
 	useStepNavigation( currentStep, navigate ) {
+		const translate = useTranslate();
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -103,7 +105,8 @@ export const siteSetupFlow: Flow = {
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress, resetGoals, resetIntent, resetSelectedDesign } =
 			useDispatch( ONBOARD_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, saveSiteTitle } =
+			useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
@@ -135,6 +138,22 @@ export const siteSetupFlow: Flow = {
 
 					if ( intent === SiteIntent.Write && ! selectedDesign ) {
 						pendingActions.push( setThemeOnSite( siteSlug, WRITE_INTENT_DEFAULT_THEME ) );
+					}
+
+					// Set a default site title in case users have not set one during the onboarding flow.
+					if ( site && site.name.trim() === '' ) {
+						let siteTitle = translate( 'My site ' );
+						switch ( intent ) {
+							case SiteIntent.Write:
+								siteTitle = translate( 'My blog' );
+								break;
+
+							case SiteIntent.Sell:
+								siteTitle = translate( 'My store' );
+								break;
+						}
+
+						pendingActions.push( saveSiteTitle( site.ID, siteTitle ) );
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.replace( to ) );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -142,15 +142,16 @@ export const siteSetupFlow: Flow = {
 
 					// Set a default site title in case users have not set one during the onboarding flow.
 					if ( site && site.name?.trim() === '' ) {
-						let siteTitle = translate( 'My site ' );
+						let siteTitle = '';
 						switch ( intent ) {
 							case SiteIntent.Write:
 								siteTitle = translate( 'My blog' );
 								break;
-
 							case SiteIntent.Sell:
 								siteTitle = translate( 'My store' );
 								break;
+							default:
+								siteTitle = translate( 'My site' );
 						}
 
 						pendingActions.push( saveSiteTitle( site.ID, siteTitle ) );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -141,7 +141,7 @@ export const siteSetupFlow: Flow = {
 					}
 
 					// Set a default site title in case users have not set one during the onboarding flow.
-					if ( site && site.name.trim() === '' ) {
+					if ( site && site.name?.trim() === '' ) {
 						let siteTitle = translate( 'My site ' );
 						switch ( intent ) {
 							case SiteIntent.Write:


### PR DESCRIPTION
#### Proposed Changes

This PR sets a default site title if users have exited the onboarding flow without setting one. The site title will depend on the goals users have selected in the Goals Capture screen.

* If the goals resolve to the Write intent, set the site title to "My blog".
* If the goals resolve to the Seller intent, set the site title to "My store".
* The rest of the intents will default the site title to "My site".

Also, this PR also updates the document title to "What's your website about".

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Goals Capture screen `/setup/goals?siteSlug=${site_slug}`

Test Write intent:
* Select "Write & Publish" as goal, and click on the "Continue" button.
* Select any vertical (or none), and click on the "Continue" button.
* Ensure that the site title is empty, and complete/skip the onboarding flow.
* Ensure that after the onboarding, the site title is set to "My blog".
![Screen Shot 2022-07-26 at 6 00 31 PM](https://user-images.githubusercontent.com/797888/180980052-70e4d28d-fa3c-49db-9f8f-e82d819707fc.png)

Test Seller intent:
* Repeat the process, but now selecting the goal "Sell online".
* Ensure that the site title is empty, and complete/skip the onboarding flow.
* Ensure that after the onboarding, the site title is set to "My store".
![Screen Shot 2022-07-26 at 6 00 40 PM](https://user-images.githubusercontent.com/797888/180980067-4dbe815a-b0c8-4eb9-b6f6-78588cf9e170.png)

Test other intents:
* Repeat the process, but now selecting the goal "Promote myself or business".
* Complete/skip the onboarding flow.
* Once in the dashboard, ensure that the site title is "My site".
![Screen Shot 2022-07-26 at 6 00 22 PM](https://user-images.githubusercontent.com/797888/180980009-68368ed2-9cc9-4264-bd12-2abf2d935f7b.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #65530