### PR TITLE
Replace Pro mention with Business in Jetpack Backup upsell

### DIFF
--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -126,9 +126,9 @@ const BackupUpsellBody: FunctionComponent = () => {
 				{ isAdmin && isWPcomSite && (
 					<PromoCardCTA
 						cta={ {
-							text: translate( 'Upgrade to Pro Plan' ),
+							text: translate( 'Upgrade to Business Plan' ),
 							action: {
-								url: `/checkout/${ siteSlug }/pro`,
+								url: `/checkout/${ siteSlug }/business`,
 								onClick: onUpgradeClick,
 								selfTarget: true,
 							},
@@ -153,7 +153,9 @@ const BackupUpsellBody: FunctionComponent = () => {
 
 			{ isWPcomSite && ! hasFullActivityLogFeature && (
 				<>
-					<h2 className="backup__subheader">{ translate( 'Also included in the Pro Plan' ) }</h2>
+					<h2 className="backup__subheader">
+						{ translate( 'Also included in the Business Plan' ) }
+					</h2>
 
 					<PromoSection { ...promos } />
 				</>


### PR DESCRIPTION
#### Proposed Changes

Replace `Pro` with `Business` in the Jetpack Backup upsell messages.

<img width="420" alt="Screenshot on 2022-07-21 at 15-19-41" src="https://user-images.githubusercontent.com/2749938/180212124-01c0facf-c28f-4faa-a608-0050ca19ca30.png">


#### Testing Instructions

* Go to the Jetpack -> Backup page on a Free site
* The CTA and headlines should mention the Business plan
* Clicking the CTA should also add a Business plan to the cart

<img width="420" alt="Screenshot on 2022-07-21 at 15-14-11" src="https://user-images.githubusercontent.com/2749938/180211699-55a97118-06c1-435e-b188-f6b2a2b69b86.png">


