### PR TITLE
Social Login: Add Tracks events for button click, success, disconnect

### DIFF
--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import AppleLoginButton from 'calypso/components/social-buttons/apple';
 import GoogleLoginButton from 'calypso/components/social-buttons/google';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/actions';
 import { isRequesting } from 'calypso/state/login/selectors';
@@ -34,6 +35,30 @@ class SocialLoginActionButton extends Component {
 		this.setState( { fetchingUser: false } );
 	};
 
+	recordLoginSuccess = ( service ) => {
+		this.props.recordTracksEvent( 'calypso_login_social_login_success', {
+			social_account_type: service,
+			starting_point: 'social-connect',
+		} );
+	};
+
+	handleButtonClick = () => {
+		const { isConnected, service } = this.props;
+
+		if ( isConnected ) {
+			this.disconnectFromSocialService();
+			this.props.recordTracksEvent( 'calypso_login_social_disconnect', {
+				social_account_type: service,
+				starting_point: 'social-connect',
+			} );
+		} else {
+			this.props.recordTracksEvent( 'calypso_login_social_button_click', {
+				social_account_type: service,
+				starting_point: 'social-connect',
+			} );
+		}
+	};
+
 	handleSocialServiceResponse = ( response ) => {
 		const { service } = this.props;
 
@@ -50,6 +75,8 @@ class SocialLoginActionButton extends Component {
 				return;
 			}
 
+			this.recordLoginSuccess( service );
+
 			socialInfo = {
 				...socialInfo,
 				access_token: tokens.access_token,
@@ -61,6 +88,8 @@ class SocialLoginActionButton extends Component {
 			if ( ! response.id_token ) {
 				return;
 			}
+
+			this.recordLoginSuccess( service );
 
 			const userData = response.user || {};
 
@@ -94,7 +123,7 @@ class SocialLoginActionButton extends Component {
 				disabled={ disabled }
 				compact={ true }
 				isPrimary={ ! isConnected }
-				onClick={ isConnected && this.disconnectFromSocialService }
+				onClick={ this.handleButtonClick }
 			>
 				{ buttonLabel }
 			</FormButton>
@@ -108,6 +137,7 @@ class SocialLoginActionButton extends Component {
 			return (
 				<GoogleLoginButton
 					clientId={ config( 'google_oauth_client_id' ) }
+					onClick={ this.handleButtonClick }
 					responseHandler={ this.handleSocialServiceResponse }
 				>
 					{ actionButton }
@@ -121,6 +151,7 @@ class SocialLoginActionButton extends Component {
 				<AppleLoginButton
 					clientId={ config( 'apple_oauth_client_id' ) }
 					uxMode={ uxMode }
+					onClick={ this.handleButtonClick }
 					responseHandler={ this.handleSocialServiceResponse }
 					redirectUri={ redirectUri }
 					socialServiceResponse={ this.props.socialServiceResponse }
@@ -142,5 +173,6 @@ export default connect(
 		connectSocialUser,
 		disconnectSocialUser,
 		fetchCurrentUser,
+		recordTracksEvent,
 	}
 )( localize( SocialLoginActionButton ) );


### PR DESCRIPTION
See #65649

## Proposed Changes

Adds the following Tracks events to `/me/security/social-login`:

* `calypso_login_social_button_click` - Social login button clicked.
* `calypso_login_social_login_success` - Social login success.
* `calypso_login_social_disconnect` - Social login disconnected.

https://user-images.githubusercontent.com/36432/180222115-411acf93-255b-401e-bf6e-95ba496d2cb3.mp4

## Testing Instructions

See "Testing Instructions" in #64957 to set up a working `wpcalypso.wordpress.com` environment on your local machine. Hopefully it will be easier in the future: p1658341128755219-slack-C4EUDHL80

In your `wpcalypso.wordpress.com` local environment:

1. Navigate to `/me/security/social-login`
2. Run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in your console.
3. Refresh the page for the debug to take effect.
4. Click on Google's "Connect" button.
5. Observe `calypso_login_social_button_click` logged in your console.
6. Successfully complete the Google connect flow.
7. Observe `calypso_login_social_login_success` logged in your console.
8. Click on Google's "Disconnect" button.
9. Observe `calypso_login_social_disconnect` logged in your console.