### PR TITLE
Fix one of the default links in the help center

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -49,10 +49,10 @@ class Help extends PureComponent {
 				image: helpWebsite,
 			},
 			{
-				link: 'https://wordpress.com/support/pro-plan/',
+				link: 'https://wordpress.com/support/business-plan/',
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(
-					'Learn more about installing a custom theme or plugin using the Pro plan.'
+					'Learn more about installing a custom theme or plugin using the Business plan.'
 				),
 				image: helpPlugins,
 			},


### PR DESCRIPTION
One of the top-three links points to the now-legacy Pro plan

#### Proposed Changes

Point the link back to Business using the already-translated copy from before the changes in #63867

#### Testing Instructions

1. Go to /help logged-in
2. Uploading custom plugins and themes should say Business instead of Pro, and should point to the right support article.

<img width="960" alt="Screenshot 2022-07-21 at 16 05 32" src="https://user-images.githubusercontent.com/82778/180224702-c09f242b-065a-4da5-b73d-9e536823b082.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](https://wp.me/P9HQHe-k8-p2), [Atomic](https://wp.me/P9HQHe-jW-p2), and [self-hosted Jetpack sites](https://wp.me/PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](https://wp.me/PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
