### PR TITLE
Replace Pro mentions with Business

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -174,7 +174,7 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan?.product_slug ?? '' }`
 		),
-		description: __( 'Upgrade to the Pro plan and set up your WooCommerce store.' ),
+		description: __( 'Upgrade to the Business plan and set up your WooCommerce store.' ),
 	};
 
 	const domain = stagingDomain;

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -58,7 +58,7 @@ const PremiumPlanDetails = ( {
 					isPremiumPlan
 						? translate(
 								'With your plan, all WordPress.com advertising has been removed from your site.' +
-									'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
+									' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
 						  )
 						: translate(
 								'With your plan, all WordPress.com advertising has been removed from your site.'

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -58,7 +58,7 @@ const PremiumPlanDetails = ( {
 					isPremiumPlan
 						? translate(
 								'With your plan, all WordPress.com advertising has been removed from your site.' +
-									' You can upgrade to a Pro plan to also remove the WordPress.com footer credit.'
+									'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
 						  )
 						: translate(
 								'With your plan, all WordPress.com advertising has been removed from your site.'


### PR DESCRIPTION
#### Proposed Changes

Replace Pro mention with Business.

#### Testing Instructions

1. Apply this PR.
2. Go to `http://calypso.localhost:3000/setup/wooConfirm?siteSlug=<YOUR_SITE>` where `<YOUR_SITE>` is a free site.
3. Verify that the message to upgrade reads: `Upgrade to the Business plan and set up your WooCommerce store`.
<img width="420" alt="Screenshot on 2022-07-21 at 16-22-19" src="https://user-images.githubusercontent.com/2749938/180227610-f923f958-758f-45ab-8e97-621a61acf7e6.png">

