### PR TITLE
Remove hardcoded Pro plan copy

### DIFF
--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -4,7 +4,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -120,22 +119,19 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		let text: any = __( 'Free' );
 
 		if ( design.is_premium ) {
-			text = createInterpolateElement(
-				shouldUpgrade
-					? __( '<button>Included in the Pro plan</button>' )
-					: __( 'Included in the Pro plan' ),
-				{
-					button: (
-						<Button
-							isLink={ true }
-							className="design-picker__button-link"
-							onClick={ ( e: any ) => {
-								e.stopPropagation();
-								onCheckout?.();
-							} }
-						/>
-					),
-				}
+			text = shouldUpgrade ? (
+				<Button
+					isLink={ true }
+					className="design-picker__button-link"
+					onClick={ ( e: any ) => {
+						e.stopPropagation();
+						onCheckout?.();
+					} }
+				>
+					{ __( 'Included in WordPress.com Premium' ) }
+				</Button>
+			) : (
+				__( 'Included in your plan' )
 			);
 		}
 

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -4,7 +4,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { noop } from 'lodash';
@@ -128,7 +128,9 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						onCheckout?.();
 					} }
 				>
-					{ __( 'Included in WordPress.com Premium' ) }
+					{ hasTranslation( 'Included in WordPress.com Premium' )
+						? __( 'Included in WordPress.com Premium' )
+						: __( 'Upgrade to Premium' ) }
 				</Button>
 			) : (
 				__( 'Included in your plan' )

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -128,7 +128,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						onCheckout?.();
 					} }
 				>
-					{ hasTranslation( 'Included in WordPress.com Premium' )
+					{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
 						? __( 'Included in WordPress.com Premium' )
 						: __( 'Upgrade to Premium' ) }
 				</Button>


### PR DESCRIPTION
There are two instances of the same copy + createInterpolateElement.

#### Proposed Changes

Update the copy and do the following refactor:

- I removed createInterpolateElement and the in-text button to prevent 2 strings to be created for translation. It also felt complicated
- I used 'Included in your plan' because it's already translated
- There's no appropriate translation for 'Included in WordPress.com Premium' that could be reused so I opted to display a meaningful translated string instead, until that one is translated
- The copy said Pro but the link was correctly pointing to Premium

#### Testing Instructions

1. With a Free plan, go to http://calypso.localhost:3000/setup/designSetup?siteSlug=SOME SITE SLUG
2. Make sure you see either Upgrade to Premium, if your language is not English, or 'Included in WordPress.com Premium' if your language is English

<img width="547" alt="Screenshot 2022-07-21 at 17 25 57" src="https://user-images.githubusercontent.com/82778/180239418-cf1fdf24-ee95-49df-9c41-a8110828a1e4.png">

4. Upgrade to Premium
5. Go back to the same page and make sure all premium themes show 'Included in your plan'
<img width="530" alt="Screenshot 2022-07-21 at 17 29 59" src="https://user-images.githubusercontent.com/82778/180239685-33b8ecbf-dc81-40bf-936b-26c45f943ccc.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](https://wp.me/P9HQHe-k8-p2), [Atomic](https://wp.me/P9HQHe-jW-p2), and [self-hosted Jetpack sites](https://wp.me/PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](https://wp.me/PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
