### PR TITLE
Restore recent seller celebrational modal changes (#65707) and (#65708)

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 /**
  * Show the seller celebration modal
  */
-const SellerCelebrationModal = () => {
+const SellerCelebrationModalInner = () => {
 	const { addEntities } = useDispatch( 'core' );
 
 	useEffect( () => {
@@ -42,10 +42,14 @@ const SellerCelebrationModal = () => {
 	const previousIsEditorSaving = useRef( false );
 	const { isEditorSaving, hasPaymentsBlock, linkUrl } = useSelect( ( select ) => {
 		if ( isSiteEditor ) {
-			const isSavingSite = select( 'core' ).isSavingEntityRecord( 'root', 'site' );
+			const isSavingSite =
+				select( 'core' ).isSavingEntityRecord( 'root', 'site' ) &&
+				! select( 'core' ).isAutosavingEntityRecord( 'root', 'site' );
 			const page = select( 'core/edit-site' ).getPage();
 			const pageId = parseInt( page?.context?.postId );
-			const isSavingEntity = select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId );
+			const isSavingEntity =
+				select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId ) &&
+				! select( 'core' ).isAutosavingEntityRecord( 'postType', 'page', pageId );
 			const pageEntity = select( 'core' ).getEntityRecord( 'postType', 'page', pageId );
 			const paymentsBlock =
 				pageEntity?.content?.raw?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
@@ -56,11 +60,9 @@ const SellerCelebrationModal = () => {
 			};
 		}
 		const currentPost = select( 'core/editor' ).getCurrentPost();
-		const isSavingEntity = select( 'core' ).isSavingEntityRecord(
-			'postType',
-			currentPost?.type,
-			currentPost?.id
-		);
+		const isSavingEntity =
+			select( 'core' ).isSavingEntityRecord( 'postType', currentPost?.type, currentPost?.id ) &&
+			! select( 'core' ).isAutosavingEntityRecord( 'postType', currentPost?.type, currentPost?.id );
 		const globalBlockCount = select( 'core/block-editor' ).getGlobalBlockCount(
 			'jetpack/recurring-payments'
 		);
@@ -124,6 +126,14 @@ const SellerCelebrationModal = () => {
 			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_seller_celebration_modal_show' ) }
 		/>
 	);
+};
+
+const SellerCelebrationModal = () => {
+	const intent = useSiteIntent();
+	if ( intent === 'sell' ) {
+		return <SellerCelebrationModalInner />;
+	}
+	return null;
 };
 
 export default SellerCelebrationModal;


### PR DESCRIPTION
This reverts commit 675babdaa29f7e4791f563ca27d288840536ec90.

#### Proposed Changes

* Earlier this week, I created (https://github.com/Automattic/wp-calypso/pull/65707) and (https://github.com/Automattic/wp-calypso/pull/65708)
* These changes to the ETK were stacked with several other changes.
* The ETK was crashing on load and we didn't know was causing the issues (See: #65775).
* To eliminate it as a potential cause, I reverted my changes to the ETK in case they caused the issue (#65789).
* However, we determined that the modal changes were not the cause of the ETK crashing and addressed the real issue.
* Now that the ETK is stable, this restores the changes I reverted as a part of our investigation.

#### Testing Instructions

* See #65707 - yarn dev --sync on a sell intent site and check that the modal only appears on proper saves


Related to #65449