### PR TITLE
Import step: Add fallback for missing string translations

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import React, { ChangeEvent, FormEvent, useState } from 'react';
@@ -25,6 +27,8 @@ interface Props {
 }
 const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const { translate, onInputEnter, onInputChange, onDontHaveSiteAddressClick, hasError } = props;
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
 
 	const [ urlValue, setUrlValue ] = useState( '' );
 	const [ isValid, setIsValid ] = useState( false );
@@ -49,11 +53,18 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		setSubmitted( true );
 	}
 
+	const newSiteAddressLabel = translate( 'Existing site address' );
+	const oldSiteAddressLabel = translate( 'Enter your site address' );
+	const siteAddressLabel =
+		locale.startsWith( 'en' ) || hasTranslation( newSiteAddressLabel )
+			? newSiteAddressLabel
+			: oldSiteAddressLabel;
+
 	return (
 		<form className={ classnames( 'import-light__capture' ) } onSubmit={ onFormSubmit }>
 			<FormFieldset>
 				<FormLabel>
-					{ createInterpolateElement( translate( 'Existing site address' ).toString(), {
+					{ createInterpolateElement( siteAddressLabel.toString(), {
 						span: createElement( 'span' ),
 					} ) }
 				</FormLabel>

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -60,6 +60,9 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 			? newSiteAddressLabel
 			: oldSiteAddressLabel;
 
+	const ownSiteMsg = translate( 'You must own this website.' );
+	const ownSiteMsgTranslationReady = locale.startsWith( 'en' ) || hasTranslation( ownSiteMsg );
+
 	return (
 		<form className={ classnames( 'import-light__capture' ) } onSubmit={ onFormSubmit }>
 			<FormFieldset>
@@ -95,9 +98,9 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 				</Button>
 				<FormSettingExplanation>
 					<span className={ classnames( { 'is-error': showValidationMsg } ) }>
-						{ ! showValidationMsg && (
+						{ ! showValidationMsg && ownSiteMsgTranslationReady && (
 							<>
-								<Icon icon={ bulb } size={ 20 } /> { translate( 'You must own this website.' ) }
+								<Icon icon={ bulb } size={ 20 } /> { ownSiteMsg }
 							</>
 						) }
 						{ showValidationMsg && (


### PR DESCRIPTION
The changes proposed in this PR add fallback logic for strings that haven't been translated yet. This will allow us to ship the new Goals Capture screen before the translations are ready.

Related discussion: pdDOJh-vD-p2#comment-421.

#### Proposed Changes

* If the translation of `Existing site address` is not ready yet, the old string `Enter your site address` will be used instead
* if the translation of `You must own this website.` is not ready yet, the whole section with light build (tip icon) won't be displayed (because we don't have any usable translated string available)

| Before | After |
| ------------- | ------------- |
| ![Markup on 2022-07-21 at 17:14:41](https://user-images.githubusercontent.com/25105483/180250057-2f6d5d5c-43b3-4b61-bf99-a92e6ca645f9.png) | ![Markup on 2022-07-21 at 17:17:02](https://user-images.githubusercontent.com/25105483/180250483-6cb7d53a-0d56-4d61-9e60-7f260a3bc656.png) |

#### Testing Instructions

1. Navigate to http://calypso.localhost:3000/me/account and set your locale to one of the languages that is missing translation: https://translate.wordpress.com/deliverables/overview/7450429/
2. Start creating a new site at http://calypso.localhost:3000/start and navigate to the Goals Capture screen where the Import option needs to be selected:

![Markup on 2022-07-21 at 17:09:42](https://user-images.githubusercontent.com/25105483/180249106-a184b472-ae53-4f7a-9582-4817f182cb61.png)

3. Once you click on the Continue button, the Import screen should have everything translated (as can be seen in the After screenshot above).

In other words, there should be no English word, the fallback string should be used and the light-bulb / tip section should not be displayed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->