### PR TITLE
Homepage replacement on AT: Fix default behaviour

### DIFF
--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -45,6 +45,8 @@ export function activate(
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
 		}
 
+		keepCurrentHomepage = isSiteAtomic( getState(), siteId ) ? true : keepCurrentHomepage;
+
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
 			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
 			// If theme is already installed, installation will silently fail,
@@ -53,8 +55,6 @@ export function activate(
 				installAndActivateTheme( installId, siteId, source, purchased, keepCurrentHomepage )
 			);
 		}
-
-		keepCurrentHomepage = isSiteAtomic( getState(), siteId ) ? true : keepCurrentHomepage;
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased, keepCurrentHomepage ) );
 	};

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -54,6 +54,8 @@ export function activate(
 			);
 		}
 
+		keepCurrentHomepage = isSiteAtomic( getState(), siteId ) ? true : keepCurrentHomepage;
+
 		return dispatch( activateTheme( themeId, siteId, source, purchased, keepCurrentHomepage ) );
 	};
 }


### PR DESCRIPTION
The current behaviour on Atomic is to always preserve the home page. 
This PR sets the `dont_change_homepage` to `true` on the `themes/mine` POST request that is made when the `Activate` button is pressed. If this change is not added now, when this PR (1046-gh-Automattic/wpcomsh) is merged the default action would change on Atomic to "Always replace homepage" and we don't want that.

### Testing
1. Apply this PR.
2. Go to a Simple site.
3. Verify changing themes works as expected on its two flavors (replacing and preserving homepage).
4. Go to an Atomic site.
5. Verify changing themes preserves the homepage, the behaviour should be the same as WP.com.