### PR TITLE
Disable goals step on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
-		"signup/goals-step": true,
+		"signup/goals-step": false,
 		"signup/goals-step-2": false,
 		"signup/ftm-flow-non-en": true,
 		"signup/hero-flow-non-en": true,


### PR DESCRIPTION
#### Proposed Changes

* Turn of goals step feature flag in production, it's causing existing user sites to get wiped out: p1658416912566239-slack-C02FMH4G8

#### Testing Instructions

* Switch to this PR
* Navigate to `/setup/?siteSlug=existingsite.wordpress.com`
* Go through the signup flow
* You should not see the goals step in signup on production

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
