### PR TITLE
Social Sign Up: Set auth token and redirect if user has >= 1 site

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -35,7 +35,7 @@ export type SiteExcerptData = Pick<
 	options?: Pick< SiteDataOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
 };
 
-const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
+export const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	const siteFilter = config< string[] >( 'site_filter' );
 	return wpcom.me().sites( {
 		apiVersion: '1.2',


### PR DESCRIPTION
See #65652

## Proposed Changes

1. If a user visits `/start/user` and signs in with Google or Apple, the auth token is set.
2. If, after completing 1, they already have a site, they're redirected to `/home`, instead of unexpectedly being dropped into the domain step.

## Testing Instructions

See "Testing Instructions" in #64957 to set up a working `wpcalypso.wordpress.com` environment on your local machine. Hopefully it will be easier in the future: p1658341128755219-slack-C4EUDHL80

In your `wpcalypso.wordpress.com` local environment:

1. Make sure you're logged out.
2. Navigate to `/start/user`.
3. Sign in via Google to an existing WordPress.com user account with at least one site.
4. Verify you're redirected to `/home` after successful login.
5. Log out again.
6. Sign in via Google to an existing WordPress.com user account with zero sites.
7. Verify you're redirected to `/start/domains` after a successful login.
8. Log out again.
9. Sign in via Google with an email address that doesn't yet have a WordPress.com site.
10. Verify you're redirected to `/start/domains` but not logged in.