### PR TITLE
App Banner: Remove the banner experiemnt

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -7,7 +7,6 @@ import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import versionCompare from 'calypso/lib/version-compare';
 import {
 	bumpStat,
@@ -106,11 +105,11 @@ export class AppBanner extends Component {
 		return this.isiOS() || this.isAndroid();
 	}
 
-	dismiss = ( experimentIsControl, event ) => {
+	dismiss = ( event ) => {
 		event.preventDefault();
 
 		const { currentSection, dismissedUntil } = this.props;
-		this.props.saveDismissTime( currentSection, dismissedUntil, experimentIsControl );
+		this.props.saveDismissTime( currentSection, dismissedUntil );
 		this.props.dismissAppBanner();
 	};
 
@@ -151,61 +150,45 @@ export class AppBanner extends Component {
 		const { title, copy } = getAppBannerData( translate, currentSection );
 
 		return (
-			<ProvideExperimentData name="calypso_mobileweb_appbanner_frequency_20220128_v2">
-				{ ( isLoading, experimentAssignment ) => {
-					if ( isLoading ) {
-						return null;
-					}
-
-					return (
-						<div
-							className={ classNames( 'app-banner-overlay' ) }
-							ref={ this.preventNotificationsClose }
-						>
-							<Card
-								className={ classNames( 'app-banner', 'is-compact', currentSection ) }
-								ref={ this.preventNotificationsClose }
-							>
-								<TrackComponentView
-									eventName="calypso_mobile_app_banner_impression"
-									eventProperties={ {
-										page: currentSection,
-									} }
-									statGroup="calypso_mobile_app_banner"
-									statName="impression"
-								/>
-								<div className="app-banner__circle is-top-left is-yellow" />
-								<div className="app-banner__circle is-top-right is-blue" />
-								<div className="app-banner__circle is-bottom-right is-red" />
-								<div className="app-banner__text-content">
-									<div className="app-banner__title">
-										<span> { title } </span>
-									</div>
-									<div className="app-banner__copy">
-										<span> { copy } </span>
-									</div>
-								</div>
-								<div className="app-banner__buttons">
-									<Button
-										primary
-										className="app-banner__open-button"
-										onClick={ this.openApp }
-										href={ this.getDeepLink() }
-									>
-										{ translate( 'Open in app' ) }
-									</Button>
-									<Button
-										className="app-banner__no-thanks-button"
-										onClick={ this.dismiss.bind( null, ! experimentAssignment?.variationName ) }
-									>
-										{ translate( 'No thanks' ) }
-									</Button>
-								</div>
-							</Card>
+			<div className={ classNames( 'app-banner-overlay' ) } ref={ this.preventNotificationsClose }>
+				<Card
+					className={ classNames( 'app-banner', 'is-compact', currentSection ) }
+					ref={ this.preventNotificationsClose }
+				>
+					<TrackComponentView
+						eventName="calypso_mobile_app_banner_impression"
+						eventProperties={ {
+							page: currentSection,
+						} }
+						statGroup="calypso_mobile_app_banner"
+						statName="impression"
+					/>
+					<div className="app-banner__circle is-top-left is-yellow" />
+					<div className="app-banner__circle is-top-right is-blue" />
+					<div className="app-banner__circle is-bottom-right is-red" />
+					<div className="app-banner__text-content">
+						<div className="app-banner__title">
+							<span> { title } </span>
 						</div>
-					);
-				} }
-			</ProvideExperimentData>
+						<div className="app-banner__copy">
+							<span> { copy } </span>
+						</div>
+					</div>
+					<div className="app-banner__buttons">
+						<Button
+							primary
+							className="app-banner__open-button"
+							onClick={ this.openApp }
+							href={ this.getDeepLink() }
+						>
+							{ translate( 'Open in app' ) }
+						</Button>
+						<Button className="app-banner__no-thanks-button" onClick={ this.dismiss }>
+							{ translate( 'No thanks' ) }
+						</Button>
+					</div>
+				</Card>
+			</div>
 		);
 	}
 }
@@ -277,7 +260,7 @@ const mapDispatchToProps = {
 			recordTracksEvent( 'calypso_mobile_app_banner_open', { page: sectionName } ),
 			bumpStat( 'calypso_mobile_app_banner', 'banner_open' )
 		),
-	saveDismissTime: ( sectionName, currentDimissTimes, isControl ) =>
+	saveDismissTime: ( sectionName, currentDimissTimes ) =>
 		withAnalytics(
 			composeAnalytics(
 				recordTracksEvent( 'calypso_mobile_app_banner_dismiss', { page: sectionName } ),
@@ -285,7 +268,7 @@ const mapDispatchToProps = {
 			),
 			savePreference(
 				APP_BANNER_DISMISS_TIMES_PREFERENCE,
-				getNewDismissTimes( sectionName, currentDimissTimes, isControl )
+				getNewDismissTimes( sectionName, currentDimissTimes )
 			)
 		),
 	dismissAppBanner,

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -59,10 +59,10 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 	return null;
 }
 
-function getDismissTimes( isControl ) {
+function getDismissTimes() {
 	const currentTime = Date.now();
-	const longerTime = isControl ? ONE_MONTH_IN_MILLISECONDS : TWO_WEEKS_IN_MILLISECONDS;
-	const shorterTime = isControl ? ONE_WEEK_IN_MILLISECONDS : ONE_DAY_IN_MILLISECONDS;
+	const longerTime = TWO_WEEKS_IN_MILLISECONDS;
+	const shorterTime = ONE_DAY_IN_MILLISECONDS;
 
 	return {
 		longerDuration: currentTime + longerTime,
@@ -70,8 +70,8 @@ function getDismissTimes( isControl ) {
 	};
 }
 
-export function getNewDismissTimes( dismissedSection, currentDismissTimes, isControl ) {
-	const dismissTimes = getDismissTimes( isControl );
+export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
+	const dismissTimes = getDismissTimes();
 
 	return reduce(
 		ALLOWED_SECTIONS,


### PR DESCRIPTION
#### Proposed Changes

* Removed the Experiment that sees if the duration change does have any impact on the install rate. 
pbxNRc-1l9-p2 

#### Testing Instructions

Testing instructions

- Apply the PR
- Enable "mobile" testing mode using dev tools in your browser of choice
- Go to http://calypso.localhost:3000/read
- Verify you see the App Banner 'Open In App' banner
-  If you do not, you can reset your preferences by entering Desktop mode in your browser, hovering the Dev button in the bottom right, then preferences, then tapping the X next to appBannerDismissTimes. Then reload the page
- Tap the no thanks button
- Enter Desktop mode and enter the dev preferences again, and look for: appBannerDismissTimes
- Verify the section you were currently on's timestamp is set for 2 weeks from now
- 8.a Note: You can test this by pasting the timestamp into: https://www.unixtimestamp.com/
- Verify the other sections are set for 1 day from now


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?



Related to https://github.com/Automattic/wp-calypso/pull/61047