### PR TITLE
Jetpack post-connection: Redirect secondary user back to wp-admin.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -714,9 +714,15 @@ export class JetpackAuthorize extends Component {
 	getRedirectionTarget() {
 		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
 		const { partnerSlug, selectedPlanSlug, siteHasJetpackPaidProduct } = this.props;
+
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if ( 'pressable' === partnerSlug ) {
-			return `/start/pressable-nux?blogid=${ clientId }`;
+			const pressableTarget = `/start/pressable-nux?blogid=${ clientId }`;
+			debug(
+				'authorization-form: getRedirectionTarget -> This is a Pressable site, redirection target is: %s',
+				pressableTarget
+			);
+			return pressableTarget;
 		}
 
 		// If the redirect is part of a Jetpack plan or product go to the checkout page
@@ -724,21 +730,32 @@ export class JetpackAuthorize extends Component {
 			productSlug.includes( 'jetpack' )
 		);
 		if ( jetpackCheckoutSlugs.includes( selectedPlanSlug ) ) {
+			const checkoutTarget = `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
 			// Once we decide we want to redirect the user to the checkout page and that there is a
 			// valid plan, we can safely remove it from the session storage
 			clearPlan();
+			debug(
+				'authorization-form: getRedirectionTarget -> Valid plan retrived from localStorage, redirection target is: %s',
+				checkoutTarget
+			);
 			return `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
 		}
 
 		// If the site has a Jetpack paid product send the user back to wp-admin rather than to the Plans page.
 		if ( siteHasJetpackPaidProduct ) {
+			debug(
+				'authorization-form: getRedirectionTarget -> Site already has a paid product, redirection target is: %s',
+				redirectAfterAuth
+			);
 			return redirectAfterAuth;
 		}
 
-		return addQueryArgs(
+		const jpcTarget = addQueryArgs(
 			{ redirect: redirectAfterAuth },
 			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
 		);
+		debug( 'authorization-form: getRedirectionTarget -> Redirection target is: %s', jpcTarget );
+		return jpcTarget;
 	}
 
 	renderFooterLinks() {


### PR DESCRIPTION
#### Proposed Changes

This PR makes the Jetpack connection redirect back to the site's wp-admin dashboard, instead of the /jetpack/connect/plans page, when connecting a secondary Jetpack user.

#### Implementation notes:

- Added additional `debug()` output in `authorize.js` and `controller.js`. Just to make it easier to understand and debug post-connection redirects.
- Switched code block conditions so that _first_ we check if the user has the capability to manage plans before attempting to redirect to the /plans page.

Asana Task: 1164141197617539-as-1202125492209094/f

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this PR and spin up Calypso blue (`yarn start`).
- Make sure you're logged into WordPress.com with your A8C wordpress.com account.
- Create a Jurassic Ninja site (Select "More Options" --> include WooCommerce) then "Launch single site".
- Go to your site wp-admin, skip store setup (or enter dummy data, either way).
- Go to Jetpack dashboard, and connect Jetpack ("Setup Jetpack now")
- You'll be redirected to the Authorization page (`/jetpack/connect/authorize?..`), in the URL replace `https://wordpress.com` with `http://calypso.localhost:3000` and press enter to reload the page in Calypso dev environment.
- Click "Approve" to authorize the connection.
- Verify you are redirected to the `/jetpack/connect/plans/:site` plans page.
- Select "Jetpack Free" product, and verify you are redirected back to the site Jetpack dashboard (Recommendations assistant).
- In wp-admin go to Users --> Add new. Add a new user, role: "Shop Manager" (Remember the new username and password, we'll need it to login in the next steps).
- Log out your current user
- In a new incognito window, open the site /wp-adnin and log-in with the new user credentials you created.
- Go to Jetpack -> Dashboard. (At a glance)
- Scroll down to "Account Creation" and click, "Connect your WordPress.com account" link. Then "Connect your user account" button.
- Either create a new wordpress.com account, or log in to en existing wordpress.com account that you own (That is different than your A8C account.)
- Once logged in, you'll be redirected to the Authorization page (`/jetpack/connect/authorize?..`). In the URL replace `https://wordpress.com` with `http://calypso.localhost:3000` and press enter to reload the page in Calypso dev environment.
- Open the browser console, enter `localStorage.setItem('debug', 'calypso:jetpack-connect*'); - Reload the page again to make sure you are seeing 'calypso:jetpack-connect*' debug statements in the console.
- Click "Authorize".
- Verify you are redirected back to the site's wp-admin dashboard (Not the `/jetpack/connect/plans/:site` plans page).
- Verify in the console you see a debug output that says, "`controller: offerResetRedirects -> redirecting to wp-admin because user role cannot manage options.`"


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **N/A**
- [X] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? 
- [X] Have you checked for TypeScript, React or other console errors? Yes
- [X] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) **N/A**
- [X] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? **N/A**

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202125492209094