### PR TITLE
Plans Revert: revise and re-enable Free spec.

### DIFF
--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -1,4 +1,5 @@
 /**
+ * @group calypso-release
  */
 
 import {
@@ -12,6 +13,7 @@ import {
 	LoginPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared';
 import type { NewUserResponse } from '@automattic/calypso-e2e';
 
 declare const browser: Browser;
@@ -79,11 +81,6 @@ describe(
 				const plan = await sidebarComponent.getCurrentPlanName();
 				expect( plan ).toBe( 'Free' );
 			} );
-
-			it( 'Navigate to Upgrades > Plans', async function () {
-				sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Upgrade', 'Plans' );
-			} );
 		} );
 
 		afterAll( async function () {
@@ -96,18 +93,11 @@ describe(
 				userDetails.body.bearer_token
 			);
 
-			const response = await restAPIClient.closeAccount( {
+			await apiCloseAccount( restAPIClient, {
 				userID: userDetails.body.user_id,
-				username: testUser.username,
+				username: userDetails.body.username,
 				email: testUser.email,
 			} );
-
-			if ( response.success !== true ) {
-				console.warn( `Failed to delete user ID ${ userDetails.body.user_id }` );
-			} else {
-				console.log( `Successfully deleted user ID ${ userDetails.body.user_id }` );
-			}
-			return response;
 		} );
 	}
 );


### PR DESCRIPTION
#### Proposed Changes

This PR revises and re-enables the Plans: Free spec.

Key changes:
- use the shared cleanup script;
- re-add the group `calypso-release`.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65855