### PR TITLE
Plans Revert: revise Pro into Business spec.

### DIFF
--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -21,10 +21,10 @@ import type { SiteDetails } from '@automattic/calypso-e2e';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com eCommerce site as exising user' ),
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Business site as exising user' ),
 	function () {
 		const blogName = DataHelper.getBlogName();
-		const planName = 'eCommerce';
+		const planName = 'Business';
 
 		let testAccount: TestAccount;
 		let page: Page;

--- a/test/e2e/specs/plans/plans__signup-ecommerce.ts
+++ b/test/e2e/specs/plans/plans__signup-ecommerce.ts
@@ -1,4 +1,5 @@
 /**
+ * @group calypso-release
  */
 
 import {
@@ -7,7 +8,6 @@ import {
 	SignupPickPlanPage,
 	StartSiteFlow,
 	SidebarComponent,
-	PlansPage,
 	RestAPIClient,
 	CartCheckoutPage,
 	TestAccount,
@@ -15,14 +15,16 @@ import {
 	MediaPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiDeleteSite } from '../shared';
 import type { SiteDetails } from '@automattic/calypso-e2e';
 
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Pro site as exising user' ),
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com eCommerce site as exising user' ),
 	function () {
 		const blogName = DataHelper.getBlogName();
+		const planName = 'eCommerce';
 
 		let testAccount: TestAccount;
 		let page: Page;
@@ -53,16 +55,16 @@ describe(
 				await domainSearchComponent.selectDomain( '.wordpress.com' );
 			} );
 
-			it( 'Select WordPress.com Pro plan', async function () {
+			it( `Select WordPress.com ${ planName } plan`, async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				siteDetails = await signupPickPlanPage.selectPlan( 'Premium' ); // Placeholder
+				siteDetails = await signupPickPlanPage.selectPlan( planName );
 
 				siteCreatedFlag = true;
 			} );
 
 			it( 'See secure checkout', async function () {
 				cartCheckoutPage = new CartCheckoutPage( page );
-				await cartCheckoutPage.validateCartItem( 'WordPress.com Pro' );
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
 			} );
 
 			it( 'Enter payment details', async function () {
@@ -82,29 +84,19 @@ describe(
 			} );
 		} );
 
-		describe( 'Validate WordPress.com Pro functionality', function () {
+		describe( `Validate WordPress.com ${ planName } functionality`, function () {
 			let sidebarComponent: SidebarComponent;
 
-			it( 'Sidebar states user is on WordPress.com Pro plan', async function () {
+			it( `Sidebar states user is on WordPress.com ${ planName } plan`, async function () {
 				sidebarComponent = new SidebarComponent( page );
-				const plan = await sidebarComponent.getCurrentPlanName();
-				expect( plan ).toBe( 'Pro' );
-			} );
-
-			it( 'Navigate to Upgrades > Plans', async function () {
-				sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Upgrades', 'Plans' );
-			} );
-
-			it( 'Plans page states user is on WordPress.com Pro plan', async function () {
-				const plansPage = new PlansPage( page );
-				await plansPage.validateActivePlan( 'Premium' ); // Placeholder
+				const currentPlan = await sidebarComponent.getCurrentPlanName();
+				expect( currentPlan ).toBe( planName );
 			} );
 
 			it( 'Validate storage capacity', async function () {
 				await sidebarComponent.navigate( 'Media' );
 				const mediaPage = new MediaPage( page );
-				expect( await mediaPage.hasStorageCapacity( 50 ) ).toBe( true );
+				expect( await mediaPage.hasStorageCapacity( 200 ) ).toBe( true );
 			} );
 		} );
 
@@ -118,21 +110,7 @@ describe(
 				password: testAccount.credentials.password,
 			} );
 
-			const response = await restAPIClient.deleteSite( siteDetails );
-
-			// If the response is `null` then no action has been
-			// performed.
-			if ( response ) {
-				// The only correct response is the string
-				// "deleted".
-				if ( response.status !== 'deleted' ) {
-					console.warn(
-						`Failed to delete siteID ${ siteDetails.id }.\nExpected: "deleted", Got: ${ response.status }`
-					);
-				} else {
-					console.log( `Successfully deleted siteID ${ siteDetails.id }.` );
-				}
-			}
+			await apiDeleteSite( restAPIClient, siteDetails );
 		} );
 	}
 );


### PR DESCRIPTION
#### Proposed Changes

This PR revises and re-enables the Pro spec as the new Business spec.

Key changes:
- extract plan name as constant instead of scattering it across the spec as hardcoded value;
- use shared cleanup script;
- update the value used to verify functionality for media gallery.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #