### PR TITLE
Update/site management style

### DIFF
--- a/client/sites-dashboard/components/sites-badge.tsx
+++ b/client/sites-dashboard/components/sites-badge.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled';
 
 const SitesBadge = styled.span`
 	font-size: 12px;
-	font-weight: 500;
-	color: var( --studio-gray-80 );
-	background-color: var( --studio-gray-5 );
+	color: var( --studio-gray-60 );
+	background-color: var( --studio-gray-0 );
 	padding: 0px 10px;
 	margin-left: 10px;
 	border-radius: 4px;

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -3,9 +3,7 @@ import { css, ClassNames } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import { NoSitesMessage } from './no-sites-message';
 import { SearchableSitesTable } from './searchable-sites-table';
-import { SitesTableFilterTabs } from './sites-table-filter-tabs';
 
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
@@ -16,7 +14,7 @@ interface SitesDashboardQueryParams {
 	search?: string;
 }
 
-const MAX_PAGE_WIDTH = '1184px';
+const MAX_PAGE_WIDTH = '1280px';
 
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's
@@ -35,15 +33,15 @@ const PageHeader = styled.div`
 	${ pagePadding }
 
 	background-color: var( --studio-white );
-	padding-top: 32px;
+	padding-top: 24px;
+	padding-bottom: 24px;
 	box-shadow: inset 0px -1px 0px rgba( 0, 0, 0, 0.05 );
-
-	// Leave enough space for the height of the TabPanel buttons (48px)
-	padding-bottom: calc( 19px + 48px );
 `;
 
 const PageBodyWrapper = styled.div`
 	${ pagePadding }
+	max-width: ${ MAX_PAGE_WIDTH };
+	margin: 0 auto;
 `;
 
 const HeaderControls = styled.div`
@@ -78,30 +76,11 @@ export function SitesDashboard( { queryParams }: SitesDashboardProps ) {
 				</HeaderControls>
 			</PageHeader>
 			<PageBodyWrapper>
-				<ClassNames>
-					{ ( { css } ) => (
-						<SitesTableFilterTabs
-							allSites={ sites }
-							className={ css`
-								${ wideCentered }
-								position: relative;
-								top: -48px;
-							` }
-							filterOptions={ queryParams }
-						>
-							{ ( filteredSites, filterOptions ) =>
-								filteredSites.length ? (
-									<SearchableSitesTable
-										sites={ filteredSites }
-										initialSearch={ queryParams.search }
-									/>
-								) : (
-									<NoSitesMessage status={ filterOptions.status } />
-								)
-							}
-						</SitesTableFilterTabs>
-					) }
-				</ClassNames>
+				<SearchableSitesTable
+					sites={ sites }
+					filterOptions={ queryParams }
+					initialSearch={ queryParams.search }
+				/>
 			</PageBodyWrapper>
 		</main>
 	);

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -2,13 +2,10 @@ import Search from '@automattic/search';
 import styled from '@emotion/styled';
 
 export const SitesSearch = styled( Search )`
-	--color-surface: #f6f7f7;
-	border-radius: 4px;
+	--color-surface: #fff;
+	height: 42px;
 	overflow: hidden;
-	height: 44px;
-
-	// TODO: make the fade optional in the component
-	.search-component__input-fade::before {
-		display: none !important;
-	}
+	border: 1px solid #c3c4c7;
+	width: 100%;
+	max-width: 390px;
 `;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -45,7 +45,7 @@ const SiteName = styled.a`
 	white-space: nowrap;
 	margin-right: 8px;
 	font-weight: 500;
-	font-size: 16px;
+	font-size: 14px;
 	letter-spacing: -0.4px;
 
 	&:hover {
@@ -122,7 +122,15 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 	const isP2Site = site.options?.is_wpforteams_site;
 
-	const displayStatusBadge = isComingSoon || site.is_private;
+	let siteStatusLabel = __( 'Live' );
+
+	if ( isComingSoon ) {
+		siteStatusLabel = __( 'Coming soon' );
+	} else if ( site.is_private ) {
+		siteStatusLabel = __( 'Private' );
+	}
+
+	console.log( 'site:', site );
 
 	return (
 		<ClassNames>
@@ -151,13 +159,6 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							}
 							subtitle={
 								<ListTileSubtitle>
-									{ displayStatusBadge && (
-										<div style={ { marginRight: '8px' } }>
-											<SitesLaunchStatusBadge>
-												{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
-											</SitesLaunchStatusBadge>
-										</div>
-									) }
 									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
 										{ displaySiteUrl( site.URL ) }
 									</SiteUrl>
@@ -167,6 +168,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					</Column>
 					<Column mobileHidden>{ site.plan.product_name_short }</Column>
 					<Column mobileHidden>July 16, 1969</Column>
+					<Column mobileHidden>{ siteStatusLabel }</Column>
 					<Column style={ { width: '20px' } }>
 						<EllipsisMenu>
 							<VisitDashboardItem site={ site } />

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -21,13 +21,13 @@ const Table = styled.table`
 const Row = styled.tr`
 	line-height: 2em;
 	border-bottom: 1px solid #eee;
-	td {
-		padding-top: 12px;
+	th {
 		padding-bottom: 12px;
 		vertical-align: middle;
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.24px;
+		font-weight: normal;
 		color: var( --studio-gray-60 );
 	}
 `;
@@ -42,6 +42,7 @@ export function SitesTable( { className, sites }: SitesTableProps ) {
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
 					<th>{ __( 'Last Publish' ) }</th>
+					<th>{ __( 'Status' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>
 			</thead>


### PR DESCRIPTION
#### Proposed Changes

* Moves status filter from tabs to dropdown
* Little style changes
* Moves status into own column

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #