### PR TITLE
Update pull request template to remove wp.me links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,10 @@ Both the PR author and reviewer are responsible for ensuring the checklist is co
 -->
 
 - [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
-- [ ] Have you tested the feature in [Simple](https://wp.me/P9HQHe-k8-p2), [Atomic](https://wp.me/P9HQHe-jW-p2), and [self-hosted Jetpack sites](https://wp.me/PCYsg-g6b-p2)?
+- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
 - [ ] Have you checked for TypeScript, React or other console errors?
-- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
-- [ ] Have we sent any new strings [for translation](https://wp.me/PCYsg-1vr-p2) ASAP?
+- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
+- [ ] Have you sent any new strings for translation(PCYsg-1vr-p2) ASAP?
 
 <!--
 Link a related issue to this PR. If the PR does not immediately resolve the issue,

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Both the PR author and reviewer are responsible for ensuring the checklist is co
 - [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
 - [ ] Have you checked for TypeScript, React or other console errors?
 - [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
-- [ ] Have you sent any new strings for translation(PCYsg-1vr-p2) ASAP?
+- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?
 
 <!--
 Link a related issue to this PR. If the PR does not immediately resolve the issue,


### PR DESCRIPTION
#### Proposed Changes

* Updates pr template to remove links to wp.me

These links get auto converted when you edit/create a PR using this template resulting in broken links to 404's like https://github.com/Automattic/wp-calypso/pull/P9HQHe-k8-p2-p2 example can be seen below where the Simple, Atomic, and self-hosted Jetpack sites links don't work.

#### Testing Instructions

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

#### Old:

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

#### New:

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #