### PR TITLE
Sites Dashboard: Move site field constants to their own file

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -1,0 +1,17 @@
+// Performance-optimized request for lists of sites.
+// Don't add more fields because you will make the request slower.
+export const SITE_EXCERPT_REQUEST_FIELDS = [
+	'ID',
+	'URL',
+	'is_coming_soon',
+	'is_private',
+	'launch_status',
+	'icon',
+	'name',
+	'options',
+	'plan',
+] as const;
+
+export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
+
+export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site', 'updated_at' ] as const;

--- a/client/data/sites/site-excerpt-types.ts
+++ b/client/data/sites/site-excerpt-types.ts
@@ -1,22 +1,9 @@
+import {
+	SITE_EXCERPT_COMPUTED_FIELDS,
+	SITE_EXCERPT_REQUEST_FIELDS,
+	SITE_EXCERPT_REQUEST_OPTIONS,
+} from './site-excerpt-constants';
 import type { SiteData, SiteDataOptions } from 'calypso/state/ui/selectors/site-data';
-
-// Performance-optimized request for lists of sites.
-// Don't add more fields because you will make the request slower.
-export const SITE_EXCERPT_REQUEST_FIELDS = [
-	'ID',
-	'URL',
-	'is_coming_soon',
-	'is_private',
-	'launch_status',
-	'icon',
-	'name',
-	'options',
-	'plan',
-] as const;
-
-export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
-
-export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site', 'updated_at' ] as const;
 
 export type SiteExcerptNetworkData = Pick<
 	SiteData,

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -5,11 +5,10 @@ import { urlToSlug } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import getSites from 'calypso/state/selectors/get-sites';
 import {
-	SiteExcerptData,
-	SiteExcerptNetworkData,
 	SITE_EXCERPT_REQUEST_FIELDS,
 	SITE_EXCERPT_REQUEST_OPTIONS,
-} from './site-excerpt-types';
+} from './site-excerpt-constants';
+import { SiteExcerptData, SiteExcerptNetworkData } from './site-excerpt-types';
 
 const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	const siteFilter = config< string[] >( 'site_filter' );


### PR DESCRIPTION
#### Proposed Changes

Discussed here https://github.com/Automattic/wp-calypso/pull/65769#discussion_r926025634

Moved the site excerpts constants out of the "types" file. Because that's a little unexpected.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just smoke testing `/sites-dashboard`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
