### PR TITLE
Revert Redirect post-checkout Business upsell 

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -363,12 +363,12 @@ export class UpsellNudge extends Component {
 		return getThankYouPageUrl( getThankYouPageUrlArguments );
 	};
 
-	handleClickDecline = () => {
-		const { trackUpsellButtonClick, upsellType, siteSlug } = this.props;
+	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
+		const { trackUpsellButtonClick, upsellType } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 
-		const url = `/home/${ siteSlug }`;
+		const url = this.getThankYouPageUrlForIncomingCart( shouldHideUpsellNudges );
 
 		// Removes the destination cookie only if redirecting to the signup destination.
 		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -378,7 +378,8 @@ export class UpsellNudge extends Component {
 			clearSignupDestinationCookie();
 		}
 
-		if ( isURL( url ) ) {
+		// The URL "/setup" is not registered as a page so redirect won't work
+		if ( isURL( url ) || url.startsWith( '/setup' ) ) {
 			window.location.href = url;
 		} else {
 			page.redirect( url );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -378,7 +378,8 @@ export class UpsellNudge extends Component {
 			clearSignupDestinationCookie();
 		}
 
-		// The URL "/setup" is not registered as a page so redirect won't work
+		// The section "/setup" is not defined as a page.js routing path, so page.redirect won't work.
+		// See: https://github.com/Automattic/wp-calypso/blob/trunk/client/sections.js
 		if ( isURL( url ) || url.startsWith( '/setup' ) ) {
 			window.location.href = url;
 		} else {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -2,6 +2,7 @@ import { isMonthly, getPlanByPathSlug, TERM_MONTHLY } from '@automattic/calypso-
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping-cart';
+import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
@@ -377,7 +378,11 @@ export class UpsellNudge extends Component {
 			clearSignupDestinationCookie();
 		}
 
-		window.location.href = url;
+		if ( isURL( url ) ) {
+			window.location.href = url;
+		} else {
+			page.redirect( url );
+		}
 	};
 
 	handleClickAccept = ( buttonAction ) => {


### PR DESCRIPTION
We want to revert the change [Redirect post-checkout Business upsell to Goals page](https://github.com/Automattic/wp-calypso/pull/65773) and confirm that we [redirect customers to onboarding flows after checkout](https://github.com/Automattic/wp-calypso/issues/65869) and the rest of redirections work as expected as discussed in this [comment](https://github.com/Automattic/wp-calypso/pull/65851#issuecomment-1191784295). 

### Changes proposed

- Reverted https://github.com/Automattic/wp-calypso/pull/65773
- Workaround a redirection issue when declining the upsell, `page.redirect( url )` doesn't redirect the path `/setup` because it is not registered as a page so we force the redirection with `location.href`.

### Test plan
Test the flows:

- New sites: Plans → Checkout → Upsell → Decline or Upgrade → Continue site setup onboarding `/goals`.
- Existing sites doing plan upgrade: Checkout → Upsell → Upgrade → Thank you page.
- Existing sites doing plan upgrade: Checkout → Upsell → Decline → Thank you page.
- Existing sites launching a site upgrade: Plans → Checkout → Decline or Upsell → My home (It is required to use an existing domain or purchase one)


Related https://github.com/Automattic/wp-calypso/issues/65869