### PR TITLE
Launch: Populate domain suggestions when launching from My Home.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -460,8 +460,8 @@ class RegisterDomainStep extends Component {
 			delayTimeout: 1000,
 			describedBy: 'step-header',
 			dir: 'ltr',
-			defaultValue: this.state.lastQuery,
-			value: this.state.lastQuery,
+			defaultValue: this.state.hideInitialQuery ? '' : this.state.lastQuery,
+			value: this.state.hideInitialQuery ? '' : this.state.lastQuery,
 			inputLabel: this.props.translate( 'What would you like your domain name to be?' ),
 			minLength: MIN_QUERY_LENGTH,
 			maxLength: 60,
@@ -760,6 +760,7 @@ class RegisterDomainStep extends Component {
 				lastDomainSearched: null,
 				isQueryInvalid: false,
 				lastQuery: cleanedQuery,
+				hideInitialQuery: false,
 				loadingResults,
 				loadingSubdomainResults: loadingResults,
 				pageNumber: 1,
@@ -1129,6 +1130,7 @@ class RegisterDomainStep extends Component {
 				lastQuery: domain,
 				lastVertical: this.props.vertical,
 				lastFilters: this.state.filters,
+				hideInitialQuery: false,
 			},
 			this.save
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -469,6 +469,9 @@ class DomainsStep extends Component {
 			get( this.props, 'queryObject.new', '' ) ||
 			get( this.props, 'signupDependencies.suggestedDomain' );
 
+		// Search using the initial query but do not show the query on the search input field.
+		const hideInitialQuery = get( this.props, 'queryObject.hide_initial_query', false ) === 'yes';
+
 		if (
 			// If we landed here from /domains Search or with a suggested domain.
 			initialQuery &&
@@ -479,6 +482,7 @@ class DomainsStep extends Component {
 				initialState.searchResults = null;
 				initialState.subdomainSearchResults = null;
 				initialState.loadingResults = true;
+				initialState.hideInitialQuery = hideInitialQuery;
 			}
 		}
 

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -35,6 +35,16 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 
 		const siteSlug = getSiteSlug( getState(), siteId );
 
+		// Adding domain queries auto-populate the domain suggestions in the domain step.
+		const domainQuery = {
+			new: siteSlug,
+			search: 'yes',
+			hide_initial_query: 'yes',
+		};
+
 		// TODO: consider using the `page` library instead of calling using `location.href` here
-		window.location.href = addQueryArgs( { siteSlug, source }, '/start/launch-site' );
+		window.location.href = addQueryArgs(
+			{ siteSlug, source, ...domainQuery },
+			'/start/launch-site'
+		);
 	};


### PR DESCRIPTION
#### Proposed Changes

Populate domain suggestions based on site slug when launching site from My Home.

#### Testing Instructions

* Create a site using `/start`.
  * Play around with the domain step just to ensure there's no regression.
* Go to **My Home > Launch your site** to the world and click the **Launch** button.
* On the domain step, you should see:
  * Domain suggestions are automatically populated.
  * Search input box should show the placeholder text "Search...".
  * The URL should contain `&new=yoursitehere.wordpress.com&search=yes&hide_initial_query=yes`.
  
 If all good, also test `/domains` to ensure there's no regression.


https://user-images.githubusercontent.com/1287077/180427326-52dc45b5-95d4-49ea-a739-41c77896c909.mp4


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65362