### PR TITLE
Stepper: Pass user object to initializeAnalytics

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -74,10 +74,6 @@ window.AppBoot = async () => {
 	requestAllBlogsAccess();
 
 	setupWpDataDebug();
-	// User is left undefined here because the user account will not be created
-	// until after the user has completed the flow.
-	// This also saves us from having to pull in lib/user/user and it's dependencies.
-	initializeAnalytics( undefined, generateGetSuperProps() );
 	addHotJarScript();
 	retargetFullStory();
 	// Add accessible-focus listener.
@@ -94,6 +90,8 @@ window.AppBoot = async () => {
 	await loadPersistedState();
 	const user = ( await initializeCurrentUser() ) as unknown;
 	const userId = ( user as CurrentUser ).ID;
+
+	initializeAnalytics( user, generateGetSuperProps() );
 
 	const initialState = getInitialState( initialReducer, userId );
 	const reduxStore = createReduxStore( initialState, initialReducer );


### PR DESCRIPTION
#### Proposed Changes
Slack: p1658488852348459-slack-C02TCEHP3HA
* Passes the current user object to `initializeAnalytics` called when starting the Stepper framework.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the network tab and navigate to `/setup/goals?siteSlug=<site slug>`.
* Check requests to `https://pixel.wp.com/t.gif`.
* Confirm that the query string params satisfy the following criteria:
  * `_ut` should be `wpcom:user_id`
  * `_ui` should be the user id of the logged-in user.
  * `_ul` should be the username of the logged-in user.
<img width="412" alt="image" src="https://user-images.githubusercontent.com/5436027/180438674-4d580d73-ff49-4fbc-aae1-3c94163b4cbf.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? -NA
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)? -NA
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) -NA
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP? -NA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
