### PR TITLE
HelpCenter (BackToTopButton): attach to scroll events of the parent element

### DIFF
--- a/packages/help-center/src/components/back-to-top-button.tsx
+++ b/packages/help-center/src/components/back-to-top-button.tsx
@@ -6,21 +6,8 @@ import classnames from 'classnames';
 import type { FC } from 'react';
 import './back-to-top-button.scss';
 
-const getScrollParent = ( el: HTMLElement | null ) => {
-	let node = el;
-
-	while ( node !== null ) {
-		if ( node.scrollHeight > node.clientHeight ) {
-			return node;
-		}
-		node = node.parentElement;
-	}
-
-	return null;
-};
-
 export const BackToTopButton: FC = () => {
-	const elementRef = useRef( null );
+	const elementRef = useRef< HTMLButtonElement | null >( null );
 	const scrollParentRef = useRef< HTMLElement | null >( null );
 	const { __ } = useI18n();
 
@@ -41,7 +28,7 @@ export const BackToTopButton: FC = () => {
 
 	useEffect( () => {
 		if ( elementRef.current ) {
-			scrollParentRef.current = getScrollParent( elementRef.current );
+			scrollParentRef.current = elementRef.current.parentElement;
 		}
 	}, [ elementRef ] );
 


### PR DESCRIPTION
The back-to-top button was trying to automatically determine which is the scroll container. However, in the case where the content is currently loading, there will be no changes in height it would fail to determine the correct container.
This PR ties the scroll container to the parentElement of the button

#### Proposed Changes

* Listen to scroll events of the parent element

#### Testing Instructions

- Checkout this branch
- In apps/editing-toolkit run yarn dev --sync
- In a sandboxed simple site open the new help center
- Open the help center
- Open an article and scroll down
- Check if the back-to-top button appears

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #