### PR TITLE
Update: use new endpoint to retrieve backup related activities

### DIFF
--- a/client/data/activity-log/use-rewindable-activity-log-query.js
+++ b/client/data/activity-log/use-rewindable-activity-log-query.js
@@ -4,13 +4,13 @@ import { filterStateToApiQuery } from 'calypso/state/activity-log/utils';
 import fromActivityLogApi from 'calypso/state/data-layer/wpcom/sites/activity/from-api';
 import { getFilterKey } from './utils';
 
-export default function useActivityLogQuery( siteId, filter, options ) {
+export default function useRewindableActivityLogQuery( siteId, filter, options ) {
 	return useQuery(
-		[ 'activity-log', siteId, getFilterKey( filter ) ],
+		[ 'rewindable-activity-log', siteId, getFilterKey( filter ) ],
 		() =>
 			wpcom.req
 				.get(
-					{ path: `/sites/${ siteId }/activity`, apiNamespace: 'wpcom/v2' },
+					{ path: `/sites/${ siteId }/activity/rewindable`, apiNamespace: 'wpcom/v2' },
 					filterStateToApiQuery( filter )
 				)
 				.then( fromActivityLogApi ),

--- a/client/data/activity-log/utils.js
+++ b/client/data/activity-log/utils.js
@@ -1,0 +1,26 @@
+const KNOWN_FILTER_OPTIONS = [
+	'action',
+	'after',
+	'aggregate',
+	'before',
+	'by',
+	'dateRange',
+	'group',
+	'name',
+	'notGroup',
+	'number',
+	'on',
+	'sortOrder',
+];
+
+export function getFilterKey( filter ) {
+	return KNOWN_FILTER_OPTIONS.filter( ( opt ) => filter[ opt ] !== undefined )
+		.map( ( opt ) => {
+			const optionValue = filter[ opt ];
+			const cacheKeyValue = Array.isArray( optionValue )
+				? optionValue.slice().sort().join( ',' )
+				: optionValue;
+			return `${ opt }=${ cacheKeyValue }`;
+		} )
+		.join( '-' );
+}

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
+import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewindable-activity-log-query';
 import {
 	DELTA_ACTIVITIES,
 	getDeltaActivitiesByType,
@@ -138,7 +139,7 @@ export const useRealtimeBackupStatus = ( siteId, selectedDate ) => {
 		successOnly: true,
 	} );
 
-	const activityLog = useActivityLogQuery(
+	const activityLog = useRewindableActivityLogQuery(
 		siteId,
 		{
 			before: moment( selectedDate ).endOf( 'day' ).toISOString(),


### PR DESCRIPTION
#### Proposed Changes

This PR continues enhances new endpoint for a backup page which should return only rewindable activities. This will allow us to fix an old issue where for users with lots of daily activities some backup points were missed. It also should provide performance improvements.

We are switching to a completely new endpoint so thorough testing is required. We are also using it only in one place for now to reduce the risks, if everything works as expected we will expand to all API calls on the Backup page.

#### Testing Instructions
Update the branch locally or use the builds of this branch.

##### Note
On calypso.localhost and cloud.jetpack.lolhost set up Timezone properly for your JN website, which will allow to observe more stable results.

##### Realtime backups
-  Create a JN site (or use one) and purchase [backup](https://wordpress.com/checkout/jetpack/jetpack_backup_t1_yearly) plan.
- Make several actions on the site (install/activate plugins, add users).
- Run build locally `yarn start`
- Navigate to `http://calypso.localhost:3000/backup/--Your JN site--` and check that it displays correctly. You can compare to `http://wordpress.com/backup/--Your JN site--`. 
- You can check the network tab in dev tools and search for `activity/rewindable?` to see that the new endpoint is used.
- Run `yarn start-jetpack-cloud-p` and check the same for `http://jetpack.cloud.localhost:3001/backup/--Your JN site--` and `https://cloud.jetpack.com/backup/--Your JN site--`

##### Daily backups
We don't provide any changes here so it could be just a sanity check everything still works as expected.

-  Create a JN site (or use one) and purchase `https://wordpress.com/checkout/jetpack_backup_daily/--Your JN site--` plan.
- Make several actions on the site (install/activate plugins, add users).
- Run build locally `yarn start`
- Navigate to `http://calypso.localhost:3000/backup/--Your JN site--` and check that it displays correctly. You can compare to `http://wordpress.com/backup/--Your JN site--`. 
- Run `yarn start-jetpack-cloud-p` and check the same for `http://jetpack.cloud.localhost:3001/backup/--Your JN site--` and `https://cloud.jetpack.com/backup/--Your JN site--` 

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? (There are no tests for this PR as we don't basically added any logic here)
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to #
1164141197617539-as-1201763904638117/f