### PR TITLE
Revert "Restore choose domain later link"

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -73,7 +73,8 @@ class ReskinSideExplainer extends Component {
 					subtitle2 = null;
 				}
 
-				ctaText = translate( 'Choose my domain later' );
+				ctaText = false;
+
 				break;
 
 			case 'use-your-domain':


### PR DESCRIPTION
Reverts Automattic/wp-calypso#65891
Needed because the translations haven't kicked in.