### PR TITLE
Plugin Management: Redirect to site's plugin page when clicked on plugin feature states

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import type {
 	AllowedTypes,
@@ -249,6 +250,12 @@ const getLinks = (
 		case 'plugin': {
 			link = `https://wordpress.com/plugins/updates/${ siteUrl }`;
 			isExternalLink = true;
+			// FIXME: Remove this condition when we enable plugin management in production
+			if ( config.isEnabled( 'jetpack/plugin-management' ) ) {
+				link =
+					status === 'warning' ? `/plugin/updates/${ siteUrl }` : `/plugins/manage/${ siteUrl }`;
+				isExternalLink = false;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR changes feature states in the Plugin Updates column to redirect to the site's plugin page when clicked on it.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/plugin-status-links-in-agency-dashbord` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Check Icon*,* or **# Updates** in the Plugin Updates column and verify you are being redirected to the plugins page of the site(/plugins/manage|updates/:site). Clicking on **Check Icon** should redirect you to /plugins/manage/:site and **# Updates** should redirect you to /plugins/updates/:site. 

> **_NOTE:_**  All the required style and UI enhancements will be done in the upcoming PRs

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to  202518759611394-as-1202534044814253