### PR TITLE
Help Center: Show in checkout production

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -5,6 +5,7 @@ window.configData = {
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	happychat_url: 'https://happychat.io/customer',
+	hostname: false,
 	site_filter: [],
 	sections: {},
 	enable_all_sections: false,

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -156,11 +156,10 @@ function createSlideshow() {
 	} );
 }
 
-let slideshowCSSPresent = document.head.querySelector( `link[href="${ SLIDESHOW_URLS.CSS }"]` );
-
 function embedSlideshow( domNode ) {
 	debug( 'processing slideshow for', domNode );
 
+	let slideshowCSSPresent = document.head.querySelector( `link[href="${ SLIDESHOW_URLS.CSS }"]` );
 	// set global variable required by JetpackSlideshow
 	window.jetpackSlideshowSettings = {
 		spinner: SLIDESHOW_URLS.SPINNER,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,7 +31,6 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -372,10 +371,7 @@ export default withCurrentRoute(
 
 		const isEditor = getSectionName( state ) === 'gutenberg-editor';
 		const isCheckout = getSectionName( state ) === 'checkout';
-		const userAllowedToHelpCenter = shouldShowHelpCenterToUser(
-			getCurrentUserId( state ),
-			getCurrentLocaleSlug( state )
-		);
+		const userAllowedToHelpCenter = shouldShowHelpCenterToUser( getCurrentUserId( state ) );
 
 		const disableFAB =
 			( ( isEditor && config.isEnabled( 'editor/help-center' ) ) ||

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -252,11 +252,11 @@ class MasterbarLoggedIn extends Component {
 	};
 
 	renderCheckout() {
-		const { isCheckoutPending, previousPath, siteSlug, isJetpackNotAtomic, title, user, locale } =
+		const { isCheckoutPending, previousPath, siteSlug, isJetpackNotAtomic, title, user } =
 			this.props;
 
 		const userAllowedToHelpCenter =
-			config.isEnabled( 'checkout/help-center' ) && shouldShowHelpCenterToUser( user.ID, locale );
+			config.isEnabled( 'checkout/help-center' ) && shouldShowHelpCenterToUser( user.ID );
 
 		return (
 			<AsyncLoad
@@ -497,7 +497,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	render() {
-		const { isInEditor, isCheckout, isCheckoutPending, user, locale } = this.props;
+		const { isInEditor, isCheckout, isCheckoutPending, user } = this.props;
 		const { isMobile } = this.state;
 
 		if ( isCheckout || isCheckoutPending ) {
@@ -506,7 +506,7 @@ class MasterbarLoggedIn extends Component {
 		if ( isMobile ) {
 			if (
 				config.isEnabled( 'editor/help-center' ) &&
-				shouldShowHelpCenterToUser( user.ID, locale ) &&
+				shouldShowHelpCenterToUser( user.ID ) &&
 				isInEditor
 			) {
 				return (

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -27,7 +27,6 @@ import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 import { setHelpCenterVisible } from 'calypso/state/ui/help-center-visible/actions';
@@ -151,7 +150,6 @@ export default function CheckoutHelpLink() {
 		happyChatAvailable,
 		presalesChatAvailable,
 		section,
-		locale,
 		userId,
 		supportVariationDetermined,
 		supportVariation,
@@ -160,7 +158,6 @@ export default function CheckoutHelpLink() {
 			happyChatAvailable: isHappychatAvailable( state ),
 			presalesChatAvailable: isPresalesChatAvailable( state ),
 			section: getSectionName( state ),
-			locale: getCurrentLocaleSlug( state ),
 			userId: getCurrentUserId( state ),
 			supportVariationDetermined: isSupportVariationDetermined( state ),
 			supportVariation: getSupportVariation( state ),
@@ -172,7 +169,7 @@ export default function CheckoutHelpLink() {
 	const userAllowedToHelpCenter = !! (
 		userId &&
 		config.isEnabled( 'checkout/help-center' ) &&
-		shouldShowHelpCenterToUser( userId, locale )
+		shouldShowHelpCenterToUser( userId )
 	);
 
 	const handleHelpButtonClicked = () => {

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,3 +1,4 @@
+import { shouldTargetWpcom } from '@automattic/help-center';
 import apiFetch from '@wordpress/api-fetch';
 import { filter, forEach, compact, partition, get } from 'lodash';
 import { v4 as uuid } from 'uuid';
@@ -36,7 +37,7 @@ function fetchForKey( postKey, isHelpCenter = false, isSimpleSite = true ) {
 
 	if ( postKey.blogId ) {
 		if ( isHelpCenter ) {
-			return isSimpleSite
+			return shouldTargetWpcom( isSimpleSite )
 				? wpcomRequest( {
 						path: `help/article/${ encodeURIComponent( postKey.blogId ) }/${ encodeURIComponent(
 							postKey.postId

--- a/config/production.json
+++ b/config/production.json
@@ -31,7 +31,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"editor/help-center": true,
-		"checkout/help-center": false,
+		"checkout/help-center": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -31,6 +31,7 @@
 		"storybook": "start-storybook"
 	},
 	"dependencies": {
+		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/happychat-connection": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,8 +1,8 @@
-import { shouldTargetWpcom } from '@automattic/help-center';
 import apiFetch from '@wordpress/api-fetch';
 import { useQueryClient, useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { SearchResult } from '../types';
+import { shouldTargetWpcom } from '../utils';
 
 interface APIFetchOptions {
 	global: boolean;

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,3 +1,4 @@
+import { shouldTargetWpcom } from '@automattic/help-center';
 import apiFetch from '@wordpress/api-fetch';
 import { useQueryClient, useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -19,7 +20,7 @@ export const useHelpSearchQuery = (
 	return useQuery< SearchResult[] >(
 		[ 'help', search ],
 		() =>
-			isSimpleSite
+			shouldTargetWpcom( isSimpleSite )
 				? wpcomRequest( {
 						path: `help/search/wpcom?query=${ search }&locale=${ locale }`,
 						apiNamespace: 'wpcom/v2/',
@@ -34,7 +35,7 @@ export const useHelpSearchQuery = (
 				if ( ! data[ 0 ].content ) {
 					const newData = await Promise.all(
 						data.map( async ( result: SearchResult ) => {
-							const article: { [ content: string ]: string } = isSimpleSite
+							const article: { [ content: string ]: string } = shouldTargetWpcom( isSimpleSite )
 								? await wpcomRequest( {
 										path: `help/article/${ result.blog_id }/${ result.post_id }`,
 										apiNamespace: 'wpcom/v2/',

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -9,4 +9,4 @@ export { execute, checkAPIThenInitializeDirectly, askDirectlyQuestion } from './
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
 export * from './support-variations';
-export { shouldShowHelpCenterToUser } from './utils';
+export { shouldShowHelpCenterToUser, shouldTargetWpcom } from './utils';

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,5 +1,24 @@
-import config from '@automattic/calypso-config';
-
+// list of valid origins for wpcom requests.
+// taken from wpcom-proxy-request (rest-proxy/provider-v2.0.js)
+const wpcomAllowedOrigins = [
+	'https://wordpress.com',
+	'https://cloud.jetpack.com',
+	'http://wpcalypso.wordpress.com', // for running docker on dev instances
+	'http://widgets.wp.com',
+	'https://widgets.wp.com',
+	'https://dev-mc.a8c.com',
+	'https://mc.a8c.com',
+	'https://dserve.a8c.com',
+	'http://calypso.localhost:3000',
+	'https://calypso.localhost:3000',
+	'http://jetpack.cloud.localhost:3000',
+	'https://jetpack.cloud.localhost:3000',
+	'http://calypso.localhost:3001',
+	'https://calypso.localhost:3001',
+	'https://calypso.live',
+	'http://127.0.0.1:41050',
+	'http://send.linguine.localhost:3000',
+];
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
 export function shouldShowHelpCenterToUser( userId: number ) {
@@ -8,6 +27,23 @@ export function shouldShowHelpCenterToUser( userId: number ) {
 	return userSegment < currentSegment;
 }
 
+/**
+ * Shelved from rest-proxy/provider-v2.0.js.
+ * This returns true for all WPCOM origins except Atomic sites.
+ *
+ * @param origin
+ * @returns
+ */
+export function iAllowedOrigin( origin: string ) {
+	// sites in the allow-list and some subdomains of "calypso.live" and "wordpress.com"
+	// are allowed without further check
+	return (
+		wpcomAllowedOrigins.includes( origin ) ||
+		origin.match( /^https:\/\/[a-z0-9-]+\.calypso\.live$/ ) ||
+		origin.match( /^https:\/\/([a-z0-9-]+\.)+wordpress\.com$/ )
+	);
+}
+
 export function shouldTargetWpcom( isSimpleSite: boolean ) {
-	return isSimpleSite || window.location.hostname === config( 'hostname' );
+	return isSimpleSite || iAllowedOrigin( window.location.origin );
 }

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -34,7 +34,7 @@ export function shouldShowHelpCenterToUser( userId: number ) {
  * @param origin
  * @returns
  */
-export function iAllowedOrigin( origin: string ) {
+export function isAllowedOrigin( origin: string ) {
 	// sites in the allow-list and some subdomains of "calypso.live" and "wordpress.com"
 	// are allowed without further check
 	return (
@@ -45,5 +45,5 @@ export function iAllowedOrigin( origin: string ) {
 }
 
 export function shouldTargetWpcom( isSimpleSite: boolean ) {
-	return isSimpleSite || iAllowedOrigin( window.location.origin );
+	return isSimpleSite || isAllowedOrigin( window.location.origin );
 }

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,7 +1,13 @@
+import config from '@automattic/calypso-config';
+
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
 export function shouldShowHelpCenterToUser( userId: number, locale: string ) {
-	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
+	const currentSegment = 100; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
 	return userSegment < currentSegment && locale === 'en';
+}
+
+export function shouldTargetWpcom( isSimpleSite: boolean ) {
+	return isSimpleSite || window.location.hostname === config( 'hostname' );
 }

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -2,10 +2,10 @@ import config from '@automattic/calypso-config';
 
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
-export function shouldShowHelpCenterToUser( userId: number, locale: string ) {
-	const currentSegment = 100; //percentage of users that will see the Help Center, not the FAB
+export function shouldShowHelpCenterToUser( userId: number ) {
+	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
-	return userSegment < currentSegment && locale === 'en';
+	return userSegment < currentSegment;
 }
 
 export function shouldTargetWpcom( isSimpleSite: boolean ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,7 @@ __metadata:
   resolution: "@automattic/help-center@workspace:packages/help-center"
   dependencies:
     "@automattic/calypso-color-schemes": "workspace:^"
+    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

This PR sets the `checkout/help-center` flag to true for production, so showing the help center in production on the checkout page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn start`
* Log with a user with id < 10, to not see the FAB but only the Help Center.
* Visit http://calypso.localhost:3000/checkout/YOURSITE.wordpress.com and check that that you see the help center and not the FAB


