### PR TITLE
Import: redirecting to the themes page for non-WP transfers

### DIFF
--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -79,8 +80,13 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 	}
 
 	function onSiteViewClick() {
-		recordTracksEvent( 'calypso_site_importer_view_site' );
-		stepNavigator?.goToSiteViewPage?.();
+		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
+			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
+			stepNavigator?.navigate?.( 'designSetup' );
+		} else {
+			recordTracksEvent( 'calypso_site_importer_view_site' );
+			stepNavigator?.goToSiteViewPage?.();
+		}
 	}
 
 	return (

--- a/client/blocks/importer/components/done-button/index.tsx
+++ b/client/blocks/importer/components/done-button/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
@@ -6,19 +7,28 @@ import { ImportJob } from '../../types';
 interface Props {
 	job?: ImportJob;
 	siteId?: number;
+	label?: string;
 	resetImport?: ( siteId: number, importerId: string ) => void;
 	onSiteViewClick?: () => void;
 }
 const DoneButton: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { job, siteId, resetImport, onSiteViewClick } = props;
+	const {
+		job,
+		siteId,
+		label = isEnabled( 'onboarding/import-redirect-to-themes' )
+			? __( 'Pick a design' )
+			: __( 'View site' ),
+		resetImport,
+		onSiteViewClick,
+	} = props;
 
 	function onButtonClick() {
 		onSiteViewClick?.();
 		job && siteId && resetImport && resetImport( siteId, job?.importerId );
 	}
 
-	return <NextButton onClick={ onButtonClick }>{ __( 'View site' ) }</NextButton>;
+	return <NextButton onClick={ onButtonClick }>{ label }</NextButton>;
 };
 
 export default DoneButton;

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -79,8 +80,13 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 	}
 
 	function onSiteViewClick() {
-		recordTracksEvent( 'calypso_site_importer_view_site' );
-		stepNavigator?.goToSiteViewPage?.();
+		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
+			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
+			stepNavigator?.navigate?.( 'designSetup' );
+		} else {
+			recordTracksEvent( 'calypso_site_importer_view_site' );
+			stepNavigator?.goToSiteViewPage?.();
+		}
 	}
 
 	return (

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -79,8 +80,13 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 	}
 
 	function onSiteViewClick() {
-		recordTracksEvent( 'calypso_site_importer_view_site' );
-		stepNavigator?.goToSiteViewPage?.();
+		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
+			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
+			stepNavigator?.navigate?.( 'designSetup' );
+		} else {
+			recordTracksEvent( 'calypso_site_importer_view_site' );
+			stepNavigator?.goToSiteViewPage?.();
+		}
 	}
 
 	return (

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -122,8 +123,13 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function onSiteViewClick() {
-		recordTracksEvent( 'calypso_site_importer_view_site' );
-		stepNavigator?.goToSiteViewPage?.();
+		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
+			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
+			stepNavigator?.navigate?.( 'designSetup' );
+		} else {
+			recordTracksEvent( 'calypso_site_importer_view_site' );
+			stepNavigator?.goToSiteViewPage?.();
+		}
 	}
 
 	return (

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -87,6 +88,13 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ HTML Renders
 	 */
 	function renderHooray() {
+		function onSiteViewClick() {
+			if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
+				stepNavigator?.navigate?.( 'designSetup' );
+			} else {
+				stepNavigator?.goToSiteViewPage?.();
+			}
+		}
 		return (
 			<CompleteScreen
 				siteId={ siteItem?.ID as number }
@@ -95,7 +103,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 				resetImport={ () => {
 					dispatch( resetImport( siteItem?.ID, job?.importerId ) );
 				} }
-				onSiteViewClick={ stepNavigator?.goToSiteViewPage }
+				onSiteViewClick={ onSiteViewClick }
 			/>
 		);
 	}

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -185,6 +185,7 @@ export class ImportEverything extends SectionMigrate {
 						{ translate( 'Congratulations. Your content was successfully imported.' ) }
 					</SubTitle>
 					<DoneButton
+						label={ translate( 'View site' ) }
 						onSiteViewClick={ () => {
 							this.props.recordTracksEvent( 'calypso_site_importer_view_site' );
 							stepNavigator?.goToSiteViewPage?.();

--- a/config/development.json
+++ b/config/development.json
@@ -115,6 +115,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
+		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/starter-plan": false,


### PR DESCRIPTION
#### Proposed Changes

* Changed the call to action on the complete screen of non-WP transfers from the view site page redirection to the view themes page redirection
* Created the new prop `label` for `DoneButton` component because the import-everything screen also uses it and we have to make it overwritable
* Enable this new flow on DEV by setting feature flag - `onboarding/import-redirect-to-themes`

#### Testing Instructions

Test the import content feature of WordPress importer

* Go to http://calypso.localhost:3000/setup/importerWordpress?siteSlug={SITE_SLUG}&from={SELF_HOSTED_SITE}&option=content
* Go through the import process
* You should see the complete screen as below and the label on the done button should be `Pick a design`

<img width="1047" alt="Screen Shot 2022-07-21 at 2 59 23 PM" src="https://user-images.githubusercontent.com/1024985/180916725-0c9eddea-4448-46c0-9075-8dc2ef981f38.png">

* Click the button
* The themes page should appear

<img width="1782" alt="Screen Shot 2022-07-21 at 3 03 53 PM" src="https://user-images.githubusercontent.com/1024985/180916849-d006db4a-2368-4730-ba1b-f7cc470d8b0c.png">

Test the Medium importer

* Go to http://calypso.localhost:3000/setup/importerMedium?siteSlug={SITE_SLUG}
* Go through the import process
* You should see the complete screen as below and the label on the done button should be `Pick a design`

<img width="1047" alt="Screen Shot 2022-07-21 at 2 59 23 PM" src="https://user-images.githubusercontent.com/1024985/180917451-785d8efa-e5bf-4e23-913e-6aa88150094d.png">

* Click the button
* The themes page should appear

<img width="1782" alt="Screen Shot 2022-07-21 at 3 03 53 PM" src="https://user-images.githubusercontent.com/1024985/180916849-d006db4a-2368-4730-ba1b-f7cc470d8b0c.png">

Test the Wix importer

* Go to http://calypso.localhost:3000/setup/importerWix?siteSlug={SITE_SLUG}&from={YOUR_WIX_SITE}
* Go through the import process
* You should see the complete screen as below and the label on the done button should be `Pick a design`

<img width="1047" alt="Screen Shot 2022-07-21 at 2 59 23 PM" src="https://user-images.githubusercontent.com/1024985/180917451-785d8efa-e5bf-4e23-913e-6aa88150094d.png">

* Click the button
* The themes page should appear

<img width="1782" alt="Screen Shot 2022-07-21 at 3 03 53 PM" src="https://user-images.githubusercontent.com/1024985/180916849-d006db4a-2368-4730-ba1b-f7cc470d8b0c.png">

Test the Squarespace importer

* Go to http://calypso.localhost:3000/setup/importerSquarespace?siteSlug={SITE_SLUG}
* Go through the import process
* You should see the complete screen as below and the label on the done button should be `Pick a design`

<img width="1047" alt="Screen Shot 2022-07-21 at 2 59 23 PM" src="https://user-images.githubusercontent.com/1024985/180917451-785d8efa-e5bf-4e23-913e-6aa88150094d.png">

* Click the button
* The themes page should appear

<img width="1782" alt="Screen Shot 2022-07-21 at 3 03 53 PM" src="https://user-images.githubusercontent.com/1024985/180916849-d006db4a-2368-4730-ba1b-f7cc470d8b0c.png">

Test the Blogger importer

* Go to http://calypso.localhost:3000/setup/importerBlogger?siteSlug={SITE_SLUG}
* Go through the import process
* You should see the complete screen as below and the label on the done button should be `Pick a design`

<img width="1047" alt="Screen Shot 2022-07-21 at 2 59 23 PM" src="https://user-images.githubusercontent.com/1024985/180917451-785d8efa-e5bf-4e23-913e-6aa88150094d.png">

* Click the button
* The themes page should appear

<img width="1782" alt="Screen Shot 2022-07-21 at 3 03 53 PM" src="https://user-images.githubusercontent.com/1024985/180916849-d006db4a-2368-4730-ba1b-f7cc470d8b0c.png">

Test the import-everything feature of WordPress importer

* Go to http://calypso.localhost:3000/setup/importerWordpress?siteSlug={SITE_SLUG}&from={SELF_HOSTED_WP_SITE}
* Select import everything
* Go through the import process
* You should see the complete screen as below and the label on the done button should be `View site`

<img width="1242" alt="Screen Shot 2022-07-26 at 11 46 46 AM" src="https://user-images.githubusercontent.com/1024985/180918730-ef929506-a00c-4ab3-b985-e849d2e6141c.png">

* Click the button
* The view site page should appear

<img width="2075" alt="Screen Shot 2022-07-26 at 11 47 05 AM" src="https://user-images.githubusercontent.com/1024985/180918752-60d2dddf-8de6-463f-b187-0d4515954ee4.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/65335