### PR TITLE
Videopress Onboarding: confirm email step

### DIFF
--- a/client/signup/config/constants.js
+++ b/client/signup/config/constants.js
@@ -1,0 +1,1 @@
+export const VIDEOPRESS_ONBOARDING_FLOW_STEPS = [ 'user', 'videopress-confirm-email' ];

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import { VIDEOPRESS_ONBOARDING_FLOW_STEPS } from './constants';
 
 const noop = () => {};
 
@@ -246,7 +247,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'videopress',
-			steps: [ 'user', 'videopress-site' ],
+			steps: VIDEOPRESS_ONBOARDING_FLOW_STEPS,
 			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
 			description: 'VideoPress signup flow',
 			lastModified: '2022-07-06',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -60,6 +60,7 @@ const stepNameToModuleName = {
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',
 	'videopress-site': 'videopress-site',
+	'videopress-confirm-email': 'videopress-confirm-email',
 	'reader-landing': 'reader-landing',
 	'p2-details': 'p2-details',
 	'p2-site': 'p2-site',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -800,11 +800,14 @@ export function generateSteps( {
 			stepName: 'transfer',
 			dependencies: [ 'siteSlug', 'siteConfirmed' ],
 		},
-
 		'videopress-site': {
 			stepName: 'videopress-site',
 			apiRequestFunction: createWpForTeamsSite,
 			providesDependencies: [ 'siteSlug' ],
+		},
+		'videopress-confirm-email': {
+			stepName: 'videopress-confirm-email',
+			fulfilledStepCallback: excludeStepIfEmailVerified,
 		},
 	};
 }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -31,6 +31,7 @@ import {
 	getStepUrl,
 	isP2Flow,
 	isVideoPressFlow,
+	getVideoPressOnboardingTotalSteps,
 } from 'calypso/signup/utils';
 import VideoPressStepWrapper from 'calypso/signup/videopress-step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -414,6 +415,10 @@ export class UserStep extends Component {
 			return translate( 'Continue' );
 		}
 
+		if ( isVideoPressFlow( flowName ) ) {
+			return translate( 'Continue' );
+		}
+
 		if ( this.userCreationPending() ) {
 			return translate( 'Creating Your Account…' );
 		}
@@ -480,7 +485,7 @@ export class UserStep extends Component {
 				stepIndicator={ this.props.translate( 'Step %(currentStep)s of %(totalSteps)s', {
 					args: {
 						currentStep: 1,
-						totalSteps: 2, // TODO: change as we add more steps.
+						totalSteps: getVideoPressOnboardingTotalSteps(),
 					},
 				} ) }
 			>

--- a/client/signup/steps/videopress-confirm-email/index.jsx
+++ b/client/signup/steps/videopress-confirm-email/index.jsx
@@ -1,0 +1,172 @@
+import { Button } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { check } from '@wordpress/icons';
+import debugFactory from 'debug';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector, useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import {
+	getVideoPressOnboardingTotalSteps,
+	getVideoPressOnboardingStepNumber,
+} from 'calypso/signup/utils';
+import VideoPressStepWrapper from 'calypso/signup/videopress-step-wrapper';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import './style.scss';
+
+const debug = debugFactory( 'calypso:signup:videopress-confirm-email' );
+
+function VideoPressConfirmEmail( {
+	flowName,
+	goToNextStep,
+	isEmailVerified,
+	positionInFlow,
+	stepName,
+	submitSignupStep,
+	refParameter,
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const userEmail = useSelector( getCurrentUserEmail );
+	debug( 'User email: %s', userEmail );
+
+	const [ emailResendCount, setEmailResendCount ] = useState( 0 );
+	const EMAIL_RESEND_MAX = 3;
+
+	const mailIcon = (
+		<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M30.0003 11.25H10.0003C8.84973 11.25 7.91699 12.1827 7.91699 13.3333V26.6667C7.91699 27.8173 8.84973 28.75 10.0003 28.75H30.0003C31.1509 28.75 32.0837 27.8173 32.0837 26.6667V13.3333C32.0837 12.1827 31.1509 11.25 30.0003 11.25Z"
+				stroke=""
+				strokeWidth="1.5"
+			/>
+			<path d="M8.33301 11.666L19.9997 21.666L31.6663 11.666" stroke="" strokeWidth="1.5" />
+		</svg>
+	);
+
+	// Remember that we loaded, not skipped, this step for the user.
+	// We also need to store the original refParameter, as the redirect on email verification
+	// loses it.
+	useEffect( () => {
+		if ( userEmail ) {
+			dispatch(
+				saveSignupStep( { stepName, ...( refParameter && { storedRefParameter: refParameter } ) } )
+			);
+
+			debug( 'Email confirmation step loaded for %s', userEmail );
+		}
+	}, [ userEmail, dispatch, stepName, refParameter ] );
+
+	const handleResendEmailClick = () => {
+		if ( emailResendCount >= EMAIL_RESEND_MAX ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_signup_videopress_confirm_email_request_resend' );
+
+		wpcom.req
+			.post( {
+				path: '/me/send-verification-email',
+				body: {
+					from: 'videopress-signup',
+				},
+			} )
+			.then( () => {
+				setEmailResendCount( emailResendCount + 1 );
+				dispatch(
+					successNotice( translate( 'Verification email resent. Please check your inbox.' ) )
+				);
+			} )
+			.catch( () => {
+				dispatch( errorNotice( translate( 'Unable to resend email. Please try again later.' ) ) );
+			} );
+	};
+
+	const handleNextStepClick = () => {
+		debug( 'Email confirmation step completed for %s', userEmail );
+		recordTracksEvent( 'calypso_signup_videopress_confirm_email_step_submit' );
+		submitSignupStep( { stepName } );
+
+		goToNextStep();
+	};
+
+	const renderCheckEmailNotice = () => {
+		return (
+			<>
+				<div className="videopress-confirm-email__message">
+					{ translate(
+						"We've sent an email with a verification link to {{strong}}%(email)s{{/strong}}. Please follow that link to confirm your email address and continue.",
+						{
+							args: { email: userEmail },
+							components: { strong: <strong /> },
+						}
+					) }
+				</div>
+				{ emailResendCount < EMAIL_RESEND_MAX && (
+					<div className="videopress-confirm-email__actions">
+						<div className="videopress-confirm-email__actions-text">
+							{ translate( 'Are you having issues receiving it?' ) }
+						</div>
+						<div className="videopress-confirm-email__buttons">
+							<Button
+								className="videopress-confirm-email__resend-email"
+								onClick={ handleResendEmailClick }
+							>
+								{ translate( 'Resend the verification email' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+			</>
+		);
+	};
+
+	const renderPostConfirmationNotice = () => {
+		return (
+			<>
+				<div className="videopress-confirm-email__message">
+					{ translate(
+						"Thanks for confirming your email address. Your account is now active. We're almost finished!"
+					) }
+				</div>
+				<div className="videopress-confirm-email__buttons">
+					<Button
+						className="videopress-confirm-email__continue"
+						isPrimary={ true }
+						onClick={ handleNextStepClick }
+					>
+						{ translate( 'Continue' ) }
+					</Button>
+				</div>
+			</>
+		);
+	};
+
+	return (
+		userEmail && (
+			<VideoPressStepWrapper
+				flowName={ flowName }
+				stepName={ stepName }
+				positionInFlow={ positionInFlow }
+				headerIcon={ isEmailVerified ? check : mailIcon }
+				headerText={
+					isEmailVerified ? translate( 'Email confirmed' ) : translate( 'Check your email' )
+				}
+				stepIndicator={ translate( 'Step %(currentStep)s of %(totalSteps)s', {
+					args: {
+						currentStep: getVideoPressOnboardingStepNumber( stepName ),
+						totalSteps: getVideoPressOnboardingTotalSteps(),
+					},
+				} ) }
+			>
+				<div className="videopress-confirm-email">
+					{ isEmailVerified ? renderPostConfirmationNotice() : renderCheckEmailNotice() }
+				</div>
+			</VideoPressStepWrapper>
+		)
+	);
+}
+
+export default VideoPressConfirmEmail;

--- a/client/signup/steps/videopress-confirm-email/style.scss
+++ b/client/signup/steps/videopress-confirm-email/style.scss
@@ -1,0 +1,83 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.is-videopress-confirm-email {
+	.videopress-step-wrapper {
+		@include break-small {
+			// padding-left: 20px;
+			// padding-right: 20px;
+			// max-width: 500px;
+		}
+	}
+
+	.videopress-step-wrapper__header {
+		margin-bottom: 0;
+	}
+
+	.videopress-step-wrapper__header-icon {
+		background: var( --videopress-color-background-dark );
+		color: var( --videopress-color-text );
+
+		svg {
+			stroke: var( --videopress-color-link );
+			width: 36px;
+			height: 36px;
+			border: 1px solid var( --videopress-color-link );
+			border-radius: 50%; /* stylelint-disable-line */
+			padding: 8px;
+		}
+	}
+
+	button.videopress-confirm-email__resend-email,
+	button.videopress-confirm-email__change-email {
+		background: none;
+		color: var( --videopress-color-link );
+		text-decoration: underline;
+		width: fit-content;
+		padding: 0;
+		margin: 0;
+		font-size: var( --videopress-font-size-form-xxs );
+		border-radius: 0;
+
+		&:hover {
+			outline: none;
+			background: none;
+		}
+
+		&:focus {
+			outline: thin dotted;
+			box-shadow: none;
+		}
+	}
+
+	button.videopress-confirm-email__continue {
+		max-width: 228px;
+	}
+}
+
+.videopress-confirm-email__message {
+	text-align: center;
+	margin-bottom: 3em;
+}
+
+.videopress-confirm-email__actions {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding-top: 3em;
+	font-size: var( --videopress-font-size-form-xxs );
+}
+
+.videopress-confirm-email__actions-text {
+	color: var( --videopress-color-text-light );
+}
+
+.videopress-confirm-email__buttons {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.videopress-confirm-email__buttons-separator {
+	padding: 0 1em;
+}

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -5,6 +5,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
 import steps from 'calypso/signup/config/steps-pure';
+import { VIDEOPRESS_ONBOARDING_FLOW_STEPS } from './config/constants';
 
 const { defaultFlowName } = flows;
 
@@ -113,6 +114,14 @@ export function getThemeForDesignType( designType ) {
 		default:
 			return 'pub/twentyseventeen';
 	}
+}
+
+export function getVideoPressOnboardingTotalSteps() {
+	return VIDEOPRESS_ONBOARDING_FLOW_STEPS.length;
+}
+
+export function getVideoPressOnboardingStepNumber( stepName ) {
+	return VIDEOPRESS_ONBOARDING_FLOW_STEPS.indexOf( stepName ) + 1;
 }
 
 export function getFilteredSteps( flowName, progress, isUserLoggedIn ) {


### PR DESCRIPTION
### Proposed Changes
*  Create the comfirm email screen of the flow: the signup screen.

<img width="641" alt="Screenshot 2022-07-25 at 2 01 22 PM" src="https://user-images.githubusercontent.com/500744/180762652-931a25a8-ff31-4a48-96b9-f0c626545c2f.png">

### Testing Instructions

* Start your local dev and navigate to http://calypso.localhost:3000/start/videopress
* You are redirected to http://calypso.localhost:3000/start/videopress/user
* fill email details and click 'Create your account'.
* You are then in http://calypso.localhost:3000/start/videopress/videopress-confirm-email
* You will need to refresh your page for the view to render. This is a known thing.
* looks like the pic above

