### PR TITLE
Fix: Make confirmation dialog more compact

### DIFF
--- a/client/my-sites/marketing/connections/account-dialog.scss
+++ b/client/my-sites/marketing/connections/account-dialog.scss
@@ -1,5 +1,7 @@
-.account-dialog.dialog {
-	max-width: 520px;
+.account-dialog.dialog.card {
+	margin-left: 24px;
+	margin-right: 24px;
+	max-width: 800px;
 }
 
 .account-dialog__authorizing-service {


### PR DESCRIPTION
#### Proposed Changes

This change is a UX improvement to make the connection confirmation dialog in Social more compact.

There was a `max-width` property set already for the dialog, however the css rule was wrong, and the _Dialog_ component's built-in [max-width property](https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/dialog/style.scss#L35) was overwriting it all this time.

* Fixed CSS rule, so it is not overwritten
* Changed `max-width` to _800px_ - discussion on linked issue
* Added margin to left and right, so dialog won't get smushed on small screens


#### Testing Instructions

* Dialog shouldn't be wider than 800px
* On small screens there should be a margin on the left and right side

#### Dialog on 16:9 screen 
<img width="800" alt="CleanShot 2022-07-25 at 14 13 07@2x" src="https://user-images.githubusercontent.com/36671565/180775125-8a09824b-4a5f-4d29-bdec-20739676bef9.png">

#### Dialog on small screen
<img width="300" alt="CleanShot 2022-07-25 at 14 13 44@2x" src="https://user-images.githubusercontent.com/36671565/180775202-264cdf76-b4a5-4fe9-9982-e3e57de5e02a.png">

In Calypso it should look the same.

Fixes #64452