### PR TITLE
Checkout: show new HelpCenter independent of locale

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,7 +31,6 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -372,10 +371,7 @@ export default withCurrentRoute(
 
 		const isEditor = getSectionName( state ) === 'gutenberg-editor';
 		const isCheckout = getSectionName( state ) === 'checkout';
-		const userAllowedToHelpCenter = shouldShowHelpCenterToUser(
-			getCurrentUserId( state ),
-			getCurrentLocaleSlug( state )
-		);
+		const userAllowedToHelpCenter = shouldShowHelpCenterToUser( getCurrentUserId( state ) );
 
 		const disableFAB =
 			( ( isEditor && config.isEnabled( 'editor/help-center' ) ) ||

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -252,11 +252,11 @@ class MasterbarLoggedIn extends Component {
 	};
 
 	renderCheckout() {
-		const { isCheckoutPending, previousPath, siteSlug, isJetpackNotAtomic, title, user, locale } =
+		const { isCheckoutPending, previousPath, siteSlug, isJetpackNotAtomic, title, user } =
 			this.props;
 
 		const userAllowedToHelpCenter =
-			config.isEnabled( 'checkout/help-center' ) && shouldShowHelpCenterToUser( user.ID, locale );
+			config.isEnabled( 'checkout/help-center' ) && shouldShowHelpCenterToUser( user.ID );
 
 		return (
 			<AsyncLoad
@@ -497,7 +497,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	render() {
-		const { isInEditor, isCheckout, isCheckoutPending, user, locale } = this.props;
+		const { isInEditor, isCheckout, isCheckoutPending, user } = this.props;
 		const { isMobile } = this.state;
 
 		if ( isCheckout || isCheckoutPending ) {
@@ -506,7 +506,7 @@ class MasterbarLoggedIn extends Component {
 		if ( isMobile ) {
 			if (
 				config.isEnabled( 'editor/help-center' ) &&
-				shouldShowHelpCenterToUser( user.ID, locale ) &&
+				shouldShowHelpCenterToUser( user.ID ) &&
 				isInEditor
 			) {
 				return (

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -27,7 +27,6 @@ import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 import { setHelpCenterVisible } from 'calypso/state/ui/help-center-visible/actions';
@@ -151,7 +150,6 @@ export default function CheckoutHelpLink() {
 		happyChatAvailable,
 		presalesChatAvailable,
 		section,
-		locale,
 		userId,
 		supportVariationDetermined,
 		supportVariation,
@@ -160,7 +158,6 @@ export default function CheckoutHelpLink() {
 			happyChatAvailable: isHappychatAvailable( state ),
 			presalesChatAvailable: isPresalesChatAvailable( state ),
 			section: getSectionName( state ),
-			locale: getCurrentLocaleSlug( state ),
 			userId: getCurrentUserId( state ),
 			supportVariationDetermined: isSupportVariationDetermined( state ),
 			supportVariation: getSupportVariation( state ),
@@ -172,7 +169,7 @@ export default function CheckoutHelpLink() {
 	const userAllowedToHelpCenter = !! (
 		userId &&
 		config.isEnabled( 'checkout/help-center' ) &&
-		shouldShowHelpCenterToUser( userId, locale )
+		shouldShowHelpCenterToUser( userId )
 	);
 
 	const handleHelpButtonClicked = () => {

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,7 +1,7 @@
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
-export function shouldShowHelpCenterToUser( userId: number, locale: string ) {
+export function shouldShowHelpCenterToUser( userId: number ) {
 	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
-	return userSegment < currentSegment && locale === 'en';
+	return userSegment < currentSegment;
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR removes the english locale check, to enable the new help center in checkout for all locales

| Before  | After |
| ------------- | ------------- |
|  <img width="1255" alt="Screenshot 2022-07-25 at 14 38 46" src="https://user-images.githubusercontent.com/7000684/180779224-19adce24-1068-43e7-8023-2dc71574bd49.png"> |  <img width="1254" alt="Screenshot 2022-07-25 at 14 30 30" src="https://user-images.githubusercontent.com/7000684/180779395-47bbb94b-a08e-4a79-a862-b8fd5a6e63b4.png"> |

#### Testing Instructions
- Checkout this branch
- In your profile -> account settings. Change the language to something other than english
- Visit the checkout page
- Verify if the new HC loads and FAB is hidden


Related to #