### PR TITLE
Remove background color from tag on focus

### DIFF
--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -93,7 +93,7 @@
 					font-weight: normal;
 					line-height: 1.4;
 					display: flex;
-
+					
 					span {
 						flex-grow: 2;
 					}
@@ -117,7 +117,6 @@
 					}
 
 					&:focus {
-						background: var( --color-primary );
 						color: var( --color-text-inverted );
 
 						.gridicon {


### PR DESCRIPTION
#### Proposed Changes

Fix focus style for articles 

**Before this fix:**



<img width="412" alt="image" src="https://user-images.githubusercontent.com/2653810/180798726-91bd24aa-3b56-4f20-9deb-4081ef1342bb.png">

**After this fix:**



<img width="413" alt="image" src="https://user-images.githubusercontent.com/2653810/180798938-2f5c14e7-3b18-4754-a9f0-e0974fae26cf.png">


#### Testing Instructions

* Open then help-center and "search for any help", 
* Type the word "domain" to get results ( or any other )
* Navigate using `tab` button from the keyboard.


#### Expected result

You should see the focus without any background color. Just with borders.


Related to #65929
Fixes #65929