### PR TITLE
Sites Dashboard: calculate the site slug depending on URL collisions

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -10,8 +10,14 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'name',
 	'options',
 	'plan',
+	'jetpack',
 ] as const;
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
 
-export const SITE_EXCERPT_REQUEST_OPTIONS = [ 'is_wpforteams_site', 'updated_at' ] as const;
+export const SITE_EXCERPT_REQUEST_OPTIONS = [
+	'is_wpforteams_site',
+	'updated_at',
+	'is_redirect',
+	'unmapped_url',
+] as const;

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -1,7 +1,8 @@
 import config from '@automattic/calypso-config';
 import { useQuery } from 'react-query';
 import { useStore } from 'react-redux';
-import { urlToSlug } from 'calypso/lib/url';
+import { getJetpackSiteCollisions, getUnmappedUrl } from 'calypso/lib/site/utils';
+import { urlToSlug, withoutHttp } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import getSites from 'calypso/state/selectors/get-sites';
 import {
@@ -28,7 +29,7 @@ export const useSiteExcerptsQuery = () => {
 
 	return useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
 		staleTime: 1000 * 60 * 5, // 5 minutes
-		select: ( data ) => data?.sites.map( computeFields ),
+		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we
 			// only want to get the initial state. We don't want to be updated when the
@@ -48,12 +49,28 @@ function notNullish< T >( t: T | null | undefined ): t is T {
 	return t !== null && t !== undefined;
 }
 
-function computeFields( data: SiteExcerptNetworkData ): SiteExcerptData {
-	return {
-		...data,
-		// TODO: The algorithm Calypso uses to compute slugs is more sophisticated
-		// because it deals with comflicting URLs (see /client/state/sites/selectors/get-site-slug.js)
-		// We may need to request more site options to properly compute the slug.
-		slug: urlToSlug( data.URL ),
+// Gets the slug for a site, it also considers the unmapped URL,
+// if the site is a redirect or the domain has a jetpack collision.
+function getSiteSlug( site: SiteExcerptNetworkData, conflictingSites: number[] = [] ) {
+	if ( ! site ) {
+		return '';
+	}
+
+	const isSiteConflicting = conflictingSites.includes( site.ID );
+
+	if ( site.options?.is_redirect || isSiteConflicting ) {
+		return withoutHttp( getUnmappedUrl( site ) || '' );
+	}
+
+	return urlToSlug( site.URL );
+}
+
+function computeFields( allSites: SiteExcerptNetworkData[] ) {
+	const conflictingSites = getJetpackSiteCollisions( allSites );
+	return function computeFieldsSite( data: SiteExcerptNetworkData ): SiteExcerptData {
+		return {
+			...data,
+			slug: getSiteSlug( data, conflictingSites ),
+		};
 	};
 }

--- a/client/lib/site/test/utils.js
+++ b/client/lib/site/test/utils.js
@@ -1,4 +1,4 @@
-import { isMainNetworkSite } from 'calypso/lib/site/utils';
+import { isMainNetworkSite, getJetpackSiteCollisions } from 'calypso/lib/site/utils';
 
 describe( 'Site Utils', () => {
 	describe( 'isMainNetworkSite', () => {
@@ -73,6 +73,44 @@ describe( 'Site Utils', () => {
 				options: {},
 			};
 			expect( isMainNetworkSite( site ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getJetpackSiteCollisions', () => {
+		test( 'Should return an empty array when the list of sites is empty.', () => {
+			expect( getJetpackSiteCollisions( [] ) ).toEqual( [] );
+		} );
+
+		test( 'Should return an empty array when there are no site collisions.', () => {
+			const sitesNoCollisions = [
+				{
+					ID: 1111111111,
+					URL: 'https://dummy1',
+					jetpack: true,
+				},
+				{
+					ID: 2222222222,
+					URL: 'https://dummy2',
+					jetpack: false,
+				},
+			];
+			expect( getJetpackSiteCollisions( sitesNoCollisions ) ).toEqual( [] );
+		} );
+
+		test( 'Should return an array of IDs with the WP site collisioning with the Jetpack site.', () => {
+			const sitesWithCollision = [
+				{
+					ID: 1111111111,
+					URL: 'https://samedomain',
+					jetpack: true,
+				},
+				{
+					ID: 2222222222,
+					URL: 'https://samedomain',
+					jetpack: false,
+				},
+			];
+			expect( getJetpackSiteCollisions( sitesWithCollision ) ).toEqual( [ 2222222222 ] );
 		} );
 	} );
 } );

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -122,3 +122,25 @@ export function getUnmappedUrl( site ) {
 
 	return site.options.main_network_site || site.options.unmapped_url;
 }
+
+/**
+ * Returns a filtered array of WordPress.com site IDs where a Jetpack site
+ * exists in the set of sites with the same URL.
+ *
+ * @param {Array} siteList Array of site objects
+ * @returns {number[]} Array of site IDs with URL collisions
+ */
+export function getJetpackSiteCollisions( siteList ) {
+	return siteList
+		.filter( ( siteItem ) => {
+			const siteUrlSansProtocol = withoutHttp( siteItem.URL );
+			return (
+				! siteItem.jetpack &&
+				siteList.some(
+					( jetpackSite ) =>
+						jetpackSite.jetpack && siteUrlSansProtocol === withoutHttp( jetpackSite.URL )
+				)
+			);
+		} )
+		.map( ( siteItem ) => siteItem.ID );
+}

--- a/client/state/sites/selectors/get-site-collisions.js
+++ b/client/state/sites/selectors/get-site-collisions.js
@@ -1,5 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
-import { withoutHttp } from 'calypso/lib/url';
+import { getJetpackSiteCollisions } from 'calypso/lib/site/utils';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 
 /**
@@ -11,16 +11,5 @@ import getSitesItems from 'calypso/state/selectors/get-sites-items';
  */
 export default createSelector( ( state ) => {
 	const sitesItems = Object.values( getSitesItems( state ) );
-	return sitesItems
-		.filter( ( site ) => {
-			const siteUrlSansProtocol = withoutHttp( site.URL );
-			return (
-				! site.jetpack &&
-				sitesItems.some(
-					( jetpackSite ) =>
-						jetpackSite.jetpack && siteUrlSansProtocol === withoutHttp( jetpackSite.URL )
-				)
-			);
-		} )
-		.map( ( site ) => site.ID );
+	return getJetpackSiteCollisions( sitesItems );
 }, getSitesItems );

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -53,5 +53,7 @@ export interface SiteDataOptions {
 	is_domain_only: boolean;
 	difm_lite_site_options?: DIFMLiteSiteOptions;
 	updated_at?: string;
+	is_redirect?: boolean;
+	unmapped_url?: string;
 	// TODO: fill out the rest of this
 }


### PR DESCRIPTION
#### Proposed Changes

* Build the site slug depending if the site is a redirect or a jetpack collision.
The site slug is used to create the link to the calypso dashboard.

#### Screencast

*Test redirect*

https://user-images.githubusercontent.com/779993/180805029-6c4059f1-f4ca-474f-8e09-b63204cad785.mp4

*Test jetpack domain collision (Voice-over)*

https://user-images.githubusercontent.com/779993/180990751-3495c1bd-7e92-40bb-92dd-f1f4063f37f0.mp4


#### Testing Instructions

**Test redirect**

* Purchase a redirect website following these instructions https://wordpress.com/support/site-redirect/
* Go to `sites-dashboard`
* Observe the title for that site links correctly to the calypso dashboard using the unmapped URL

**Test jetpack domain collision**

There is a screencast with sound explaining the public steps of this process.

* Create an external jetpack site. And do not connect it.
* Copy the external URL
* Buy a WP annual plan, choose `Connect your domain`, and map the copied URL
* You won't be able to make the domain primary. For that, you need to go to DARC, search your URL and click on the link `set as primary?`
* Go to the site dashboard, clear the indexedDB and Observe the title links to the Dashboard using the external URL
* Connect your jetpack site created in step 1.
* Go to the site dashboard, clear the indexedDB or wait 5 minutes and refresh.
* Observe Two sites appears with the same external URL.
* Observe the title links to the correct dashboard for each one. The WP site will use the wp.com subdomain. The Jetpack site will use the external URL.


#### Pre-merge Checklist



- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Closes #65767