### PR TITLE
Homepage replace on Atomic: Add switch to toggle the behaviour

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -163,6 +163,7 @@
 		"signup/standard-theme-v13n": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"themes/atomic-homepage-replace": false,
 		"themes/premium": true,
 		"titan/iframe-control-panel": false,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,6 +111,7 @@
 		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"themes/atomic-homepage-replace": false,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -126,6 +126,7 @@
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,
+		"themes/atomic-homepage-replace": false,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -125,6 +125,7 @@
 		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"themes/atomic-homepage-replace": false,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -135,6 +135,7 @@
 		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"themes/atomic-homepage-replace": false,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
This flag will be used to put the homepage replacement on Atomic feature behind a flag, allowing it to be turned on/off.

### Testing
N/A