### PR TITLE
add siteId as param to themeHasAutoLoadingHomepage

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -300,7 +300,7 @@ export default connect(
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),
-			hasAutoLoadingHomepage: themeHasAutoLoadingHomepage( state, installingThemeId ),
+			hasAutoLoadingHomepage: themeHasAutoLoadingHomepage( state, installingThemeId, siteId ),
 			isCurrentTheme: isThemeActive( state, installingThemeId, siteId ),
 			isVisible: shouldShowHomepageWarning( state, installingThemeId ),
 		};

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -291,7 +291,7 @@ const ConnectedThanksModal = connect(
 
 		const isAtomic = isSiteAtomic( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
-		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId );
+		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId, siteId );
 
 		// Atomic & Jetpack do not have auto-loading-homepage behavior, so we trigger the layout picker for them.
 		const customizeUrl =

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -37,7 +37,7 @@ export function activate(
 		 * allowing cancel it if it's desired.
 		 */
 		if (
-			themeHasAutoLoadingHomepage( getState(), themeId ) &&
+			themeHasAutoLoadingHomepage( getState(), themeId, siteId ) &&
 			! isJetpackSite( getState(), siteId ) &&
 			! isSiteAtomic( getState(), siteId ) &&
 			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )

--- a/client/state/themes/selectors/theme-has-auto-loading-homepage.js
+++ b/client/state/themes/selectors/theme-has-auto-loading-homepage.js
@@ -1,4 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { includes } from 'lodash';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { getThemeTaxonomySlugs } from 'calypso/state/themes/utils';
 
@@ -9,9 +11,24 @@ import 'calypso/state/themes/init';
  *
  * @param {object} state   Global state tree
  * @param {string} themeId An identifier for the theme
+ * @param {number} siteId  An identifier for the site
  * @returns {boolean} True if the theme has auto loading homepage. Otherwise, False.
  */
-export function themeHasAutoLoadingHomepage( state, themeId ) {
+export function themeHasAutoLoadingHomepage( state, themeId, siteId ) {
+	if ( isEnabled( 'themes/atomic-homepage-replace' ) ) {
+		const atomic = isSiteAtomic( state, siteId );
+		const atomicAutoLoading = includes(
+			getThemeTaxonomySlugs( getTheme( state, siteId, themeId ), 'theme_feature' ),
+			'auto-loading-homepage'
+		);
+
+		// If the Atomic site has the theme in its library, use that value.
+		if ( atomic && atomicAutoLoading ) {
+			return atomicAutoLoading;
+		}
+	}
+
+	// Fall back to the full `wpcom` library.
 	return includes(
 		getThemeTaxonomySlugs( getTheme( state, 'wpcom', themeId ), 'theme_feature' ),
 		'auto-loading-homepage'


### PR DESCRIPTION
Add the siteId param to `themeHasAutoLoadingHomepage` selector so we can check themes for the `auto-loading-homepage` tag whether on WPCOM or individual Atomic sites. The logic to check on Atomic sites is guarded behind the `themes/atomic-homepage-replace` so this PR has no visible change.

This is a PR that splits the work done in this [other PR](https://github.com/Automattic/wp-calypso/pull/65060).

### Testing
1. Apply this PR.
2. Go to the theme showcase on a Simple site and verify everything works as always when changing a theme; clicking 'Activate' and preserving or replacing site homepage.
3. Go to the theme showcase on an Atomic site and verify everything works as always when changing a theme; clicking 'Activate' should preserve the homepage.


Related to https://github.com/Automattic/wp-calypso/issues/56869