### PR TITLE
Add Premium badge to premium themes in the design preview header

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
@@ -2,4 +2,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	.premium-badge {
+		font-family: $sans;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
@@ -1,0 +1,5 @@
+.design-picker-design-title__container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,0 +1,34 @@
+import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { PremiumBadge } from '@automattic/design-picker';
+import { useSelect } from '@wordpress/data';
+import { useSite } from '../../../../hooks/use-site';
+import { SITE_STORE } from '../../../../stores';
+import type { Design } from '@automattic/design-picker';
+import type { FC } from 'react';
+
+type Props = {
+	designTitle: string;
+	selectedDesign: Design;
+};
+
+const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } ) => {
+	const site = useSite();
+	// TODO: This does not check for individual theme purchases yet.
+	const isPremiumThemeAvailable = Boolean(
+		useSelect(
+			( select ) =>
+				site && select( SITE_STORE ).siteHasFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
+		)
+	);
+
+	if ( selectedDesign.is_premium ) {
+		return (
+			<div>
+				{ designTitle } <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
+			</div>
+		);
+	}
+	return <div>{ designTitle }</div>;
+};
+
+export default DesignPickerDesignTitle;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -5,6 +5,7 @@ import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { Design } from '@automattic/design-picker';
 import type { FC } from 'react';
+import './design-picker-design-title.scss';
 
 type Props = {
 	designTitle: string;
@@ -23,8 +24,9 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 
 	if ( selectedDesign.is_premium ) {
 		return (
-			<div>
-				{ designTitle } <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
+			<div className="design-picker-design-title__container">
+				{ designTitle }
+				<PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
 			</div>
 		);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -369,6 +369,16 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
+
+		let headerDesignTitle = <div>{ designTitle }</div>;
+		if ( selectedDesign.is_premium ) {
+			headerDesignTitle = (
+				<div>
+					{ designTitle } <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
+				</div>
+			);
+		}
+
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {
 			language: locale,
@@ -450,7 +460,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 					formattedHeader={
 						<FormattedHeader
 							id={ 'design-setup-header' }
-							headerText={ designTitle }
+							headerText={ headerDesignTitle }
 							align={ isMobile ? 'left' : 'center' }
 						/>
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -29,6 +29,7 @@ import useTrackScrollPageFromTop from '../../../../hooks/use-track-scroll-page-f
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
+import DesignPickerDesignTitle from './design-picker-design-title';
 import GeneratedDesignPickerWebPreview from './generated-design-picker-web-preview';
 import PreviewToolbar from './preview-toolbar';
 import StickyPositioner from './sticky-positioner';
@@ -369,15 +370,9 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
-
-		let headerDesignTitle = <div>{ designTitle }</div>;
-		if ( selectedDesign.is_premium ) {
-			headerDesignTitle = (
-				<div>
-					{ designTitle } <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
-				</div>
-			);
-		}
+		const headerDesignTitle = (
+			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
+		);
 
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -25,6 +25,7 @@ import useTrackScrollPageFromTop from '../../../../hooks/use-track-scroll-page-f
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
+import DesignPickerDesignTitle from './design-picker-design-title';
 import PreviewToolbar from './preview-toolbar';
 import UpgradeModal from './upgrade-modal';
 import type { Step, ProvidedDependencies } from '../../types';
@@ -250,6 +251,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	if ( selectedDesign && isPreviewingDesign ) {
 		const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';
+		const headerDesignTitle = (
+			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
+		);
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {
 			language: locale,
@@ -319,7 +323,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				formattedHeader={
 					<FormattedHeader
 						id={ 'design-setup-header' }
-						headerText={ designTitle }
+						headerText={ headerDesignTitle }
 						align={ isMobile ? 'left' : 'center' }
 					/>
 				}

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -19,6 +19,7 @@
 	.premium-badge__logo {
 		margin-top: -1px;
 		margin-right: 3px;
+		fill: currentColor;
 	}
 
 	.components-tooltip .components-popover__content {


### PR DESCRIPTION
#### Proposed Changes

* Add Premium badge to premium themes in the design preview header

![2022-07-25_16-46](https://user-images.githubusercontent.com/937354/180882800-b0d55b40-3e5e-48e8-847d-a70ff2b26ad0.png)


#### Testing Instructions

* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE.wordpress.com&flags=-signup/design-picker-unified`
* Also visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE.wordpress.com&flags=signup/design-picker-unified`
* Click on a premium theme, on the preview page, observe the header and look for the premium badge
* Go back, repeat for a non-premium theme, the badge should be missing

----


#### Issue with mouseover

If you mouseover the badge, the tooltip does not appear. This is related to the way the steps are implemented in stepper. The steps are in an absolute positioned div, where the middle of it is transparent:

![2022-07-25_16-59](https://user-images.githubusercontent.com/937354/180883299-2400e61e-6077-4d68-ab6e-fc874b5757ad.png)

If you try to select text in the title, you cannot, because the absolute positioned div is blocking the title under it:

https://user-images.githubusercontent.com/937354/180883364-83d0d333-e262-4fbe-8751-1e160e47f9b9.mp4

The same mechanism is blocking the mouseover for the tooltip in this change.
I have a potential fix, but I don't know if it will break anything. I also wasn't sure if I should put it in this PR, or another PR, or if we should not do it. (Update: Created PR #65971)

( See #65971 for the diff )

This blocks mouse events on the absolutely positioned div and restores them to the buttons on either side of it that are filled in. Once again, not sure if it works completely because I'm pretty new to stepper.



Related to #65786