### PR TITLE
CI: update TeamCity configurations.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -327,9 +327,9 @@ object P2E2ETests : E2EBuildType(
 				messageFormat = simpleMessageFormat()
 			}
 			branchFilter = "trunk"
-			buildFailed = true
-			buildFinishedSuccessfully = true
 			buildFailedToStart = true
+			buildFailed = true
+			buildFinishedSuccessfully = false
 			buildProbablyHanging = true
 		}
 		notifications {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -783,7 +783,7 @@ object PreReleaseE2ETests : E2EBuildType(
 			branchFilter = "+:<default>"
 			buildFailedToStart = true
 			buildFailed = true
-			buildFinishedSuccessfully = true
+			buildFinishedSuccessfully = false
 			buildProbablyHanging = true
 		}
 	}
@@ -852,14 +852,6 @@ object QuarantinedE2ETests: E2EBuildType(
 		}
 	},
 	buildTriggers = {
-		schedule {
-			schedulingPolicy = cron {
-				hours = "01"
-			}
-			branchFilter = "+:trunk"
-			triggerBuild = always()
-			withPendingChangesOnly = false
-		}
 	}
 )
 


### PR DESCRIPTION
#### Proposed Changes

This PR updates several TeamCity configurations.

Key changes:
- eliminate scheduling for QuarantinedE2E
- reduce notification frequency for P2/Pre-Release tests to **only failures**.

#### Testing Instructions

Ensure the following:
  - [x] Unit Tests
  - [x] Code Style

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [ ] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #