### PR TITLE
Enable Unified Design Picker

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
-		"signup/design-picker-unified": false,
+		"signup/design-picker-unified": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
-		"signup/design-picker-unified": false,
+		"signup/design-picker-unified": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -112,7 +112,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
-		"signup/design-picker-unified": false,
+		"signup/design-picker-unified": true,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,
 		"signup/inline-help": false,


### PR DESCRIPTION
#### Proposed Changes
Enable the [Unified Design Picker](https://github.com/Automattic/wp-calypso/issues/64998) implemented in https://github.com/Automattic/wp-calypso/pull/65534 in all environments.

#### Testing Instructions
* As per https://github.com/Automattic/wp-calypso/pull/65534