### PR TITLE
Jetpack Agency Dashboard: Fix misalignment of tooltip in the agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -177,6 +177,7 @@ export default function SiteStatusContent( {
 						ref={ statusContentRef }
 						onMouseEnter={ handleShowTooltip }
 						onMouseLeave={ handleHideTooltip }
+						className="sites-overview__row-status"
 					>
 						{ updatedContent }
 					</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -35,6 +35,10 @@
 			}
 		}
 
+		.sites-overview__row-status {
+			display: block;
+			max-width: fit-content;
+		}
 		a {
 			display: flex;
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the issue with tooltip misalignment with the feature states(Backup, Scan, etc.) in the agency dashboard. 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/tooltip-misalignment-in-agency-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Hover over any feature states(Backup, Scan, etc) and verify the tooltip is aligned correctly with the value

Before

![image (4) (1)](https://user-images.githubusercontent.com/10586875/180937915-a3f2c13d-d5b3-434c-8fa8-1c67a6276733.png)

After

<img width="852" alt="Screenshot 2022-07-26 at 11 28 41 AM" src="https://user-images.githubusercontent.com/10586875/180937588-bc45e456-40aa-4c9e-9867-ce8850e6b6f6.png">

<img width="788" alt="Screenshot 2022-07-26 at 11 54 13 AM" src="https://user-images.githubusercontent.com/10586875/180937883-d1c8bd1a-ef5a-4442-87aa-533ce285548e.png">

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202619025189113-as-1202658052594371