### PR TITLE
Translate string that got missed in previous PR

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -406,13 +406,13 @@ class PurchaseItem extends Component {
 	}
 
 	getPaymentMethod() {
-		const { purchase } = this.props;
+		const { purchase, translate } = this.props;
 
 		if ( purchase.isAutoRenewEnabled && ! hasPaymentMethod( purchase ) ) {
 			return (
 				<div className={ 'purchase-item__no-payment-method' }>
 					<Icon icon={ warningIcon } />
-					<span>You don’t have a payment method to renew this subscription</span>
+					<span>{ translate( 'You don’t have a payment method to renew this subscription' ) }</span>
 				</div>
 			);
 		}


### PR DESCRIPTION
Related to #65365

#### Proposed Changes

Translate raw string which was missed in PR #65365. See @creativecoder's comment [here](https://github.com/Automattic/wp-calypso/pull/65365#issuecomment-1194881997) (thanks!). 

#### Testing Instructions

Code review + checking any type of site should be enough. This string already exist elsewhere in the code base and is already being translated. 

Here's what you should see at `/purchases/subscriptions/DOMAINNAME`
![image](https://user-images.githubusercontent.com/6851384/180973894-58dec4d7-13a3-4e53-935a-f375f8bc5ef3.png)

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), ~~Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)~~?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?