### PR TITLE
Fix/update contextual help urls

### DIFF
--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -35,7 +35,7 @@ export const defaultFallbackLinks = [
 	},
 	{
 		get link() {
-			return localizeUrl( 'https://wordpress.com/support/pro-plan/' );
+			return localizeUrl( 'https://wordpress.com/support/business-plan/' );
 		},
 		post_id: 134940,
 		get title() {
@@ -376,9 +376,9 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 		},
 		{
 			get link() {
-				return localizeUrl( 'https://wordpress.com/support/manage-your-account/' );
+				return localizeUrl( 'https://wordpress.com/support/video-tutorials/manage-your-account/' );
 			},
-			post_id: 130826,
+			post_id: 185309,
 			get title() {
 				return __( 'Manage Your Account', __i18n_text_domain__ );
 			},
@@ -825,7 +825,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 		},
 		{
 			get link() {
-				return localizeUrl( 'https://wordpress.com/support/pro-plan/' );
+				return localizeUrl( 'https://wordpress.com/support/business-plan/' );
 			},
 			post_id: 134940,
 			get title() {
@@ -1409,7 +1409,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			intent: SELL_INTENT,
 			get link() {
 				return localizeUrl(
-					'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/',
+					'https://wordpress.com/support/video-tutorials/video-tutorials-add-payments-features-to-your-site-with-our-guides/',
 					__i18n_text_domain__
 				);
 			},
@@ -1801,7 +1801,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 		{
 			get link() {
 				return localizeUrl(
-					'https://wordpress.com/support/transfer-domain-registration/',
+					'https://wordpress.com/support/domains/transfer-domain-registration/',
 					__i18n_text_domain__
 				);
 			},

--- a/packages/data-stores/test/contextual-help.tsx
+++ b/packages/data-stores/test/contextual-help.tsx
@@ -31,46 +31,48 @@ async function expectNoRedirect( link: string ) {
 	} );
 }
 
-describe( 'All defaultFallbackLinks links should have status 200', () => {
-	for ( const item of defaultFallbackLinks ) {
-		it( `${ item.link } should not redirect`, async () => {
-			await expectNoRedirect( item.link );
-		} );
-	}
-} );
-
-describe( 'All bloggerFallbackLinks links should have status 200', () => {
-	for ( const item of bloggerFallbackLinks ) {
-		it( `${ item.link } should not redirect`, async () => {
-			await expectNoRedirect( item.link );
-		} );
-	}
-} );
-
-describe( 'All videosForSection links should have status 200', () => {
-	const sections = Object.values( videosForSection );
-	for ( const item of sections ) {
-		for ( const subItem of item ) {
-			it( `${ subItem.link } should not redirect`, async () => {
-				await expectNoRedirect( subItem.link );
+describe.skip( "disable tests because they're too flaly", () => {
+	describe( 'All defaultFallbackLinks links should have status 200', () => {
+		for ( const item of defaultFallbackLinks ) {
+			it( `${ item.link } should not redirect`, async () => {
+				await expectNoRedirect( item.link );
 			} );
 		}
-	}
-} );
+	} );
 
-describe( 'All contextLinksForSection links should have status 200', () => {
-	const sections = Object.values( contextLinksForSection );
-	for ( const item of sections ) {
-		if ( Array.isArray( item ) ) {
+	describe( 'All bloggerFallbackLinks links should have status 200', () => {
+		for ( const item of bloggerFallbackLinks ) {
+			it( `${ item.link } should not redirect`, async () => {
+				await expectNoRedirect( item.link );
+			} );
+		}
+	} );
+
+	describe( 'All videosForSection links should have status 200', () => {
+		const sections = Object.values( videosForSection );
+		for ( const item of sections ) {
 			for ( const subItem of item ) {
 				it( `${ subItem.link } should not redirect`, async () => {
 					await expectNoRedirect( subItem.link );
 				} );
 			}
-		} else {
-			it( `${ item.link } should not redirect`, async () => {
-				await expectNoRedirect( item.link );
-			} );
 		}
-	}
+	} );
+
+	describe( 'All contextLinksForSection links should have status 200', () => {
+		const sections = Object.values( contextLinksForSection );
+		for ( const item of sections ) {
+			if ( Array.isArray( item ) ) {
+				for ( const subItem of item ) {
+					it( `${ subItem.link } should not redirect`, async () => {
+						await expectNoRedirect( subItem.link );
+					} );
+				}
+			} else {
+				it( `${ item.link } should not redirect`, async () => {
+					await expectNoRedirect( item.link );
+				} );
+			}
+		}
+	} );
 } );

--- a/packages/data-stores/test/contextual-help.tsx
+++ b/packages/data-stores/test/contextual-help.tsx
@@ -31,48 +31,46 @@ async function expectNoRedirect( link: string ) {
 	} );
 }
 
-describe.skip( "disable tests because they're too flaly", () => {
-	describe( 'All defaultFallbackLinks links should have status 200', () => {
-		for ( const item of defaultFallbackLinks ) {
-			it( `${ item.link } should not redirect`, async () => {
-				await expectNoRedirect( item.link );
+describe( 'All defaultFallbackLinks links should have status 200', () => {
+	for ( const item of defaultFallbackLinks ) {
+		it( `${ item.link } should not redirect`, async () => {
+			await expectNoRedirect( item.link );
+		} );
+	}
+} );
+
+describe( 'All bloggerFallbackLinks links should have status 200', () => {
+	for ( const item of bloggerFallbackLinks ) {
+		it( `${ item.link } should not redirect`, async () => {
+			await expectNoRedirect( item.link );
+		} );
+	}
+} );
+
+describe( 'All videosForSection links should have status 200', () => {
+	const sections = Object.values( videosForSection );
+	for ( const item of sections ) {
+		for ( const subItem of item ) {
+			it( `${ subItem.link } should not redirect`, async () => {
+				await expectNoRedirect( subItem.link );
 			} );
 		}
-	} );
+	}
+} );
 
-	describe( 'All bloggerFallbackLinks links should have status 200', () => {
-		for ( const item of bloggerFallbackLinks ) {
-			it( `${ item.link } should not redirect`, async () => {
-				await expectNoRedirect( item.link );
-			} );
-		}
-	} );
-
-	describe( 'All videosForSection links should have status 200', () => {
-		const sections = Object.values( videosForSection );
-		for ( const item of sections ) {
+describe( 'All contextLinksForSection links should have status 200', () => {
+	const sections = Object.values( contextLinksForSection );
+	for ( const item of sections ) {
+		if ( Array.isArray( item ) ) {
 			for ( const subItem of item ) {
 				it( `${ subItem.link } should not redirect`, async () => {
 					await expectNoRedirect( subItem.link );
 				} );
 			}
+		} else {
+			it( `${ item.link } should not redirect`, async () => {
+				await expectNoRedirect( item.link );
+			} );
 		}
-	} );
-
-	describe( 'All contextLinksForSection links should have status 200', () => {
-		const sections = Object.values( contextLinksForSection );
-		for ( const item of sections ) {
-			if ( Array.isArray( item ) ) {
-				for ( const subItem of item ) {
-					it( `${ subItem.link } should not redirect`, async () => {
-						await expectNoRedirect( subItem.link );
-					} );
-				}
-			} else {
-				it( `${ item.link } should not redirect`, async () => {
-					await expectNoRedirect( item.link );
-				} );
-			}
-		}
-	} );
+	}
 } );


### PR DESCRIPTION
#### Proposed Changes

All the links are updated as described on the issue. <strike> and the unit tests are back.</strike>
<strike>To run unit tests please use `yarn test-packages contextual` from the root folder of the repo.</strike>

Note: The only new `ID` is [this](https://github.com/Automattic/wp-calypso/compare/fix/update-contextual-help-urls?expand=1#diff-6d39187f2b4fcd93d310f0d46196fac312353c60a2e3017b744fd5f9303d635dR381), all the others have the same `ID` on the new and old url 

Related to #65964
Fixes #65964
