### PR TITLE
Fix conditions that prevent from editing or removing the site's owner

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -22,6 +22,7 @@ import useRemoveExternalContributorMutation from 'calypso/data/external-contribu
 import accept from 'calypso/lib/accept';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite } from 'calypso/state/sites/selectors';
 import withDeleteUser from './with-delete-user';
 
@@ -32,6 +33,7 @@ class DeleteUser extends Component {
 
 	static propTypes = {
 		isMultisite: PropTypes.bool,
+		isAtomic: PropTypes.bool,
 		isJetpack: PropTypes.bool,
 		siteId: PropTypes.number,
 		user: PropTypes.object,
@@ -221,12 +223,12 @@ class DeleteUser extends Component {
 	};
 
 	renderSingleSite = () => {
-		const { translate, isJetpack, siteOwner, user } = this.props;
+		const { translate, isAtomic, isJetpack, siteOwner, user } = this.props;
 
-		// A user should not be able to remove the site owner.
+		// A user should not be able to remove the Atomic or non-Jetpack site owner.
 		if (
 			( ! isJetpack && user.ID === siteOwner ) ||
-			( isJetpack && user.linked_user_ID === siteOwner )
+			( isAtomic && user.linked_user_ID === siteOwner )
 		) {
 			return (
 				<Card className="delete-user__single-site">
@@ -384,6 +386,7 @@ export default localize(
 			return {
 				siteOwner: site?.site_owner,
 				currentUser: getCurrentUser( state ),
+				isAtomic: isSiteAutomatedTransfer( state, siteId ),
 			};
 		},
 		{ recordGoogleEvent }

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -224,7 +224,10 @@ class DeleteUser extends Component {
 		const { translate, isJetpack, siteOwner, user } = this.props;
 
 		// A user should not be able to remove the site owner.
-		if ( ! isJetpack && user.ID === siteOwner ) {
+		if (
+			( ! isJetpack && user.ID === siteOwner ) ||
+			( isJetpack && user.linked_user_ID === siteOwner )
+		) {
 			return (
 				<Card className="delete-user__single-site">
 					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -15,6 +15,7 @@ import ContractorSelect from 'calypso/my-sites/people/contractor-select';
 import RoleSelect from 'calypso/my-sites/people/role-select';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -85,6 +86,7 @@ class EditUserForm extends Component {
 		const {
 			currentUser,
 			user,
+			isAtomic,
 			isJetpack,
 			hasWPCOMAccountLinked,
 			isVip,
@@ -98,12 +100,12 @@ class EditUserForm extends Component {
 		}
 
 		/*
-		 * If the current user is not viewing their own profile,
+		 * On Atomic and non-Jetpack sites, if the current user is not viewing their own profile,
 		 * the user should not be able to edit the site owner's details.
 		 */
 		if (
 			( ( ! isJetpack && user.ID === siteOwner ) ||
-				( isJetpack && user.linked_user_ID === siteOwner ) ) &&
+				( isAtomic && user.linked_user_ID === siteOwner ) ) &&
 			user.ID !== currentUser.ID
 		) {
 			return [];
@@ -362,6 +364,7 @@ export default localize(
 			return {
 				siteOwner: site?.site_owner,
 				currentUser: getCurrentUser( state ),
+				isAtomic: isSiteAutomatedTransfer( state, siteId ),
 				isVip: isVipSite( state, siteId ),
 				isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 				hasWPCOMAccountLinked: false !== user?.linked_user_ID,

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -98,10 +98,14 @@ class EditUserForm extends Component {
 		}
 
 		/*
-		 * If this is not a Jetpack site and the current user is not viewing their own profile,
+		 * If the current user is not viewing their own profile,
 		 * the user should not be able to edit the site owner's details.
 		 */
-		if ( ! isJetpack && user.ID === siteOwner && user.ID !== currentUser.ID ) {
+		if (
+			( ( ! isJetpack && user.ID === siteOwner ) ||
+				( isJetpack && user.linked_user_ID === siteOwner ) ) &&
+			user.ID !== currentUser.ID
+		) {
 			return [];
 		}
 


### PR DESCRIPTION
#### Proposed Changes

Currently, there are conditions that prevent from displaying UX that allows editing or removing the site's owner. Those do not include Atomic sites, and this PR modifies those to include Atomic sites too.

This was tracked under https://github.com/Automattic/wp-calypso/issues/3140  and was done for simple sites under https://github.com/Automattic/wp-calypso/pull/57042 This PR should fix the problem that remains for Atomic sites. Behavior for non-Atomic Jetpack sites (aka self-hosted) is not changed.

This PR addresses the UX issue - it removes UX that shouldn't be displayed at the first place. There is also D84810-code that addresses the server-side part of this problem - fixes checking if editing or removing the owner is allowed in such cases.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Atomic sites

Steps to reproduce:

1. Create an Atomic site
2. Navigate to WPCOM -> Users
3. Invite a new user as Administrator - another WPCOM account
4. Accept invitation received by email
5. Logged as an invited user, navigate to WPCOM -> Users
6. Click on the site's owner

I shouldn’t see the UI that allows for editing the owner’s role or deleting it, and I should see the message instead:

![Screen Shot 2022-07-27 at 13 31 10](https://user-images.githubusercontent.com/727413/181709699-2f8be43d-e066-4b33-a23e-44023ab1fdf6.png)


##### Self-hosted Jetpack sites

Steps to reproduce:

1. Create an ephemeral site (or any site that is initially not connected to WPCOM)
2. Navigate to Plugins
3. Click “Set up Jetpack” and continue the process (it can be Jetpack Free)
4. Navigate to WPCOM -> Users
5. Invite a new user as Administrator - another WPCOM account
6. Accept invitation received by email
7. Logged as an invited user, navigate to WPCOM -> Users
8. Click on the site's owner

I should still see the UI that allows for editing the owner’s role or deleting it:

![Screen Shot 2022-07-29 at 09 39 53](https://user-images.githubusercontent.com/727413/181709678-b6abb7f0-882d-4dd8-a72a-8d6ecbfedee5.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p9F6qB-9M6-p2