### PR TITLE
Update/help center fix checkout prod

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -5,7 +5,6 @@ window.configData = {
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
 	happychat_url: 'https://happychat.io/customer',
-	hostname: false,
 	site_filter: [],
 	sections: {},
 	enable_all_sections: false,

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -31,7 +31,6 @@
 		"storybook": "start-storybook"
 	},
 	"dependencies": {
-		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/happychat-connection": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,7 +682,6 @@ __metadata:
   resolution: "@automattic/help-center@workspace:packages/help-center"
   dependencies:
     "@automattic/calypso-color-schemes": "workspace:^"
-    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

Remove some leftovers from https://github.com/Automattic/wp-calypso/pull/65923

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout the branch
- `yarn start`
- Log with a user with id < 10, to not see the FAB but only the Help Center.
- Visit http://calypso.localhost:3000/checkout/YOURSITE.wordpress.com and check that that you see the help center and not the FAB

