### PR TITLE
Repo gardening: enable task to send an alert about closed issues

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, closed]
   issue_comment: # To gather support references in issue comments.
     types: [created]
 concurrency:
@@ -42,4 +42,5 @@ jobs:
          slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
          slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues,gatherSupportReferences'
+         slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues,gatherSupportReferences,replyToCustomersReminder'


### PR DESCRIPTION
#### Proposed Changes

See https://github.com/Automattic/jetpack/pull/25170/

This will be triggered:

- When issues are closed
- When there are at least 10 support references gathered by the action in a comment.
- When the issue has either High or blocker priority.

Internal reference:
pcLjiI-Ro-p2

#### Testing Instructions

* This cannot be tested before it gets merged, but you can see a preview of what this will look like at p1658746047426189-slack-CN2FSK7L4


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?
