### PR TITLE
Checkout: Use subtotals when deciding to display discount reason

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -403,7 +403,7 @@ export interface ResponseCartProduct {
 	cost_before_coupon?: number;
 
 	/**
-	 * The cart item's price before a coupon (if any) was applied.
+	 * The difference between `cost_before_coupon` and the actual price.
 	 *
 	 * Note that the difference may be caused by many factors, not just coupons.
 	 * It's best not to rely on it.

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -299,22 +299,125 @@ export interface ResponseCartMessage {
 }
 
 export interface ResponseCartProduct {
+	uuid: string;
 	product_name: string;
 	product_slug: string;
 	product_id: number;
 	currency: string;
+
+	/**
+	 * The cart item's original price in the currency's smallest unit.
+	 *
+	 * @deprecated Use item_original_cost_integer or item_original_subtotal_integer.
+	 */
 	product_cost_integer: number;
+
+	/**
+	 * The cart item's original price formatted for the locale with currency.
+	 *
+	 * @deprecated Use item_original_cost_display or item_original_subtotal_display.
+	 */
 	product_cost_display: string;
-	item_original_cost_integer: number; // without discounts or volume, with quantity
-	item_original_cost_display: string; // without discounts or volume, with quantity
+
+	/**
+	 * The cart item's original price without volume in the currency's smallest unit.
+	 *
+	 * Discounts and volume are not included, but quantity is included.
+	 */
+	item_original_cost_integer: number;
+
+	/**
+	 * The cart item's original price without volume formatted for the locale with currency.
+	 *
+	 * Discounts and volume are not included, but quantity is included.
+	 */
+	item_original_cost_display: string;
+
+	/**
+	 * The monthly term subtotal of a cart item formatted for the locale with currency.
+	 */
 	item_subtotal_monthly_cost_display: string;
+
+	/**
+	 * The monthly term subtotal of a cart item in the currency's smallest unit.
+	 */
 	item_subtotal_monthly_cost_integer: number;
-	item_original_subtotal_integer: number; // without discounts, with volume
-	item_original_subtotal_display: string; // without discounts, with volume
-	item_original_cost_for_quantity_one_integer: number; // without discounts or volume, and quantity 1
-	item_original_cost_for_quantity_one_display: string; // without discounts or volume, and quantity 1
+
+	/**
+	 * The cart item's original price with volume in the currency's smallest unit.
+	 *
+	 * Discounts are not included, but volume and quantity are included.
+	 */
+	item_original_subtotal_integer: number;
+
+	/**
+	 * The cart item's original price with volume formatted for the locale with currency.
+	 *
+	 * Discounts are not included, but volume and quantity are included.
+	 */
+	item_original_subtotal_display: string;
+
+	/**
+	 * The cart item's original price for quantity 1 in the currency's smallest unit.
+	 *
+	 * Discounts are not included, but volume is included.
+	 */
+	item_original_cost_for_quantity_one_integer: number;
+
+	/**
+	 * The cart item's original price for quantity 1 formatted for the locale with currency.
+	 *
+	 * Discounts are not included, but volume is included.
+	 */
+	item_original_cost_for_quantity_one_display: string;
+
+	/**
+	 * The cart item's subtotal in the currency's smallest unit.
+	 */
 	item_subtotal_integer: number;
+
+	/**
+	 * The cart item's subtotal formatted for the locale with currency.
+	 */
 	item_subtotal_display: string;
+
+	/**
+	 * The cart item's subtotal without volume.
+	 *
+	 * @deprecated This is a float and is unreliable. Use item_subtotal_integer or item_subtotal_display.
+	 */
+	cost: number;
+
+	/**
+	 * The cart item's original price.
+	 *
+	 * @deprecated This is a float and is unreliable. Use item_original_subtotal_integer or item_original_subtotal_display.
+	 */
+	cost_before_coupon?: number;
+
+	/**
+	 * The difference between the original price and the actual price.
+	 *
+	 * Note that the difference may be caused by many factors, not just coupons.
+	 *
+	 * @deprecated This is a float and is unreliable. Use coupon_savings_integer or coupon_savings_display.
+	 */
+	coupon_savings?: number;
+
+	/**
+	 * The difference between the original subtotal and the actual subtotal formatted for the locale with currency.
+	 *
+	 * Note that the difference may be caused by many factors, not just coupons.
+	 */
+	coupon_savings_display?: string;
+
+	/**
+	 * The difference between the original price and the actual price in the currency's smallest unit.
+	 *
+	 * Note that the difference may be caused by many factors, not just coupons.
+	 */
+	coupon_savings_integer?: number;
+
 	price_tier_minimum_units?: number | null;
 	price_tier_maximum_units?: number | null;
 	is_domain_registration: boolean;
@@ -328,18 +431,6 @@ export interface ResponseCartProduct {
 	quantity: number | null;
 	current_quantity: number | null;
 	extra: ResponseCartProductExtra;
-	uuid: string;
-	/**
-	 * @deprecated This is a float and is unreliable. Use item_subtotal_integer or item_subtotal_display.
-	 */
-	cost: number;
-	cost_before_coupon?: number;
-	/**
-	 * @deprecated This is a float and is unreliable. Use coupon_savings_integer or coupon_savings_display.
-	 */
-	coupon_savings?: number;
-	coupon_savings_display?: string;
-	coupon_savings_integer?: number;
 	item_tax: number;
 	product_type: string;
 	included_domain_purchase_amount: number;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -389,32 +389,42 @@ export interface ResponseCartProduct {
 	cost: number;
 
 	/**
-	 * The cart item's original price.
+	 * The cart item's price before a coupon (if any) was applied.
 	 *
-	 * @deprecated This is a float and is unreliable. Use item_original_subtotal_integer or item_original_subtotal_display.
+	 * This is slightly misleading because although this is the product's cost
+	 * before a coupon was applied, it already includes sale coupons (which are
+	 * actually discounts), and other discounts and does not include certain
+	 * other price changes (eg: domain discounts). It's best not to rely on it.
+	 *
+	 * @deprecated This is a float and is unreliable. Use
+	 * item_original_subtotal_integer or item_original_subtotal_display if you
+	 * can, although those have slightly different meanings.
 	 */
 	cost_before_coupon?: number;
 
 	/**
-	 * The difference between the original price and the actual price.
+	 * The cart item's price before a coupon (if any) was applied.
 	 *
 	 * Note that the difference may be caused by many factors, not just coupons.
+	 * It's best not to rely on it.
 	 *
 	 * @deprecated This is a float and is unreliable. Use coupon_savings_integer or coupon_savings_display.
 	 */
 	coupon_savings?: number;
 
 	/**
-	 * The difference between the original subtotal and the actual subtotal formatted for the locale with currency.
+	 * The difference between `cost_before_coupon` and the actual price formatted for the locale with currency.
 	 *
 	 * Note that the difference may be caused by many factors, not just coupons.
+	 * It's best not to rely on it.
 	 */
 	coupon_savings_display?: string;
 
 	/**
-	 * The difference between the original price and the actual price in the currency's smallest unit.
+	 * The difference between `cost_before_coupon` and the actual price in the currency's smallest unit.
 	 *
 	 * Note that the difference may be caused by many factors, not just coupons.
+	 * It's best not to rely on it.
 	 */
 	coupon_savings_integer?: number;
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -678,18 +678,23 @@ function isCouponApplied( { coupon_savings_integer = 0 }: ResponseCartProduct ) 
 function FirstTermDiscountCallout( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const planSlug = product.product_slug;
-	const origCost = product.item_original_cost_integer;
-	const cost = product.product_cost_integer;
+	const origCost = product.item_original_subtotal_integer;
+	const finalCost = product.item_subtotal_integer;
 	const isRenewal = product.is_renewal;
 
+	// Do not display discount reason if there is an introductory offer.
 	if ( product.introductory_offer_terms?.enabled ) {
 		return null;
 	}
 
 	if (
+		// Do not display discount reason for non-wpcom, non-jetpack products.
 		( ! isWpComPlan( planSlug ) && ! isJetpackProductSlug( planSlug ) ) ||
-		origCost <= cost ||
+		// Do not display discount reason if there is no discount.
+		origCost <= finalCost ||
+		// Do not display discount reason if this is a renewal.
 		isRenewal ||
+		// Do not display discount reason if a coupon is applied.
 		isCouponApplied( product )
 	) {
 		return null;


### PR DESCRIPTION
#### Proposed Changes

The `FirstTermDiscountCallout` component in checkout was added (in its current form) in https://github.com/Automattic/wp-calypso/pull/50383. To determine if it should display text like `Discount for first year` below a discounted product price, it compares the product's undiscounted price to its discounted price; if the discounted price is not lower than the undiscounted price, it will not display the text. However, for both prices the code uses the "cost" fields of the product returned by the shopping cart endpoint (`item_original_cost_integer` and `product_cost_integer`, respectively). Both of those fields use the product's cost excluding volume, and before any discounts are applied. Therefore they will never display a discount.

The original logic did actually work until D82241-code, when product cost calculation in the shopping cart endpoint was refactored to clarify its source (pbOQVh-1VA-p2).

This PR changes the price comparison in `FirstTermDiscountCallout` to use the product "subtotal" fields (`item_original_subtotal_integer` and `item_subtotal_integer`) instead so that the discount reason will be displayed.

Fixes https://github.com/Automattic/wp-calypso/issues/65972

#### Screenshots

Before:

![checkout-discount-after](https://user-images.githubusercontent.com/235183/181043319-014174ca-1332-464f-bdef-babdd19b679b.png)

After:

![checkout-discount-before](https://user-images.githubusercontent.com/235183/181043324-7a11f715-b6fe-4662-842c-8bacf56a62cc.png)

#### Testing Instructions

- Buy a plan (for example, a Premium plan).
- From the Plans page, choose a higher plan to upgrade to (for example, a Business plan).
- In checkout, look at the price that is shown and verify you see a "Discount for first year" or similar below the discounted amount.