### PR TITLE
Jetpack Licensing: Make whole sites list item clickable/tappable

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -62,13 +62,17 @@ export default function AssignLicenseForm( {
 	const siteCards = paginate( results, currentPage ).map( ( site: any ) => {
 		if ( -1 !== site.domain.search( search ) || null === search ) {
 			return (
-				<Card key={ site.ID } className="assign-license-form__site-card">
+				<Card
+					key={ site.ID }
+					className="assign-license-form__site-card"
+					onClick={ () => onSelectSite( site.ID ) }
+				>
 					<FormRadio
 						className="assign-license-form__site-card-radio"
 						label={ site.domain }
 						name="site_select"
 						disabled={ isSubmitting }
-						onClick={ () => onSelectSite( site.ID ) }
+						checked={ selectedSite === site.ID }
 					/>
 				</Card>
 			);


### PR DESCRIPTION
#### Proposed Changes

* Context 1202135255440149-as-1202136520713457/f
* Improving mobile accessibility so it is easier to click/tap to select a site from the sites list when assigning a license to a site.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Make sure you have a wordpress.com website
* Issue some license
* When assigning the license to your site, you should be able to click/tap anywhere on the sites list item and the site will be selected.

**Screenshots**
![image](https://user-images.githubusercontent.com/5550190/181062766-1e35d8e4-4483-4952-8bb0-0ed7517398c5.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->