### PR TITLE
Licensing Portal: Pass new setup intent ids to the payment method creation api

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
@@ -63,6 +63,7 @@ export async function assignNewCardProcessor(
 		const result = await saveCreditCard( {
 			token,
 			useAsPrimaryPaymentMethod: Boolean( useAsPrimaryPaymentMethod ),
+			stripeSetupIntentId,
 		} );
 
 		return makeSuccessResponse( result );

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
@@ -1,17 +1,17 @@
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 
+interface Params {
+	token: string;
+	useAsPrimaryPaymentMethod: boolean;
+	stripeSetupIntentId: string;
+}
+
 export async function saveCreditCard( {
 	token,
 	useAsPrimaryPaymentMethod,
-}: {
-	token: string;
-	useAsPrimaryPaymentMethod: boolean;
-} ): Promise< unknown > {
-	const additionalData = getParamsForApi( {
-		useAsPrimaryPaymentMethod,
-	} );
-
+	stripeSetupIntentId,
+}: Params ): Promise< unknown > {
 	const response = await wpcomJpl.req.post(
 		{
 			apiNamespace: 'wpcom/v2',
@@ -19,9 +19,11 @@ export async function saveCreditCard( {
 		},
 		{
 			payment_method_id: token,
-			...( additionalData ?? {} ),
+			use_as_primary_payment_method: useAsPrimaryPaymentMethod,
+			stripe_setup_intent_id: stripeSetupIntentId,
 		}
 	);
+
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_partner_portal_add_new_credit_card_error' );
 		throw new Error( response );
@@ -29,10 +31,4 @@ export async function saveCreditCard( {
 
 	recordTracksEvent( 'calypso_partner_portal_add_new_credit_card' );
 	return response;
-}
-
-function getParamsForApi( { useAsPrimaryPaymentMethod }: { useAsPrimaryPaymentMethod: boolean } ) {
-	return {
-		use_as_primary_payment_method: useAsPrimaryPaymentMethod,
-	};
 }


### PR DESCRIPTION
#### Proposed Changes

* Licensing Portal: Pass newly created setup intent ids over when creating new payment methods as they are needed in the backend.

#### Testing Instructions

* In order to test this PR you need a partner account - please reach out to team Avalon to get one.
* Check out PR and run Jetpack Cloud locally.
* Open up Licensing -> Payment Methods.
* Add a new payment method and confirm the setup intent id is passed in the POST request to `https://public-api.wordpress.com/wpcom/v2/jetpack-licensing/stripe/payment-method`:
```
payment_method_id: "pm_ABCDEFG"
stripe_setup_intent_id: "seti_ABCDEFG"
use_as_primary_payment_method: true
```

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
