### PR TITLE
Sites Dashboard: Refactor site thumbnail component and `useMshotsImg` hook

### DIFF
--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -23,27 +23,26 @@ export const SiteThumbnail = ( {
 	backgroundColor,
 	children,
 	alt,
-	mShotsUrl,
+	mShotsUrl = '',
 	size = 'small',
 	mshotsOption = MSHOTS_OPTION,
 }: Props ) => {
-	const maybeImage = useMshotsImg( mShotsUrl ?? '', mshotsOption );
+	const { src, isLoading, imgRef } = useMshotsImg( mShotsUrl, mshotsOption );
 
-	const src = maybeImage?.src || '';
-	const visible = !! src && mShotsUrl;
-	const textColor = backgroundColor && getTextColorFromBackground( backgroundColor );
+	const color = backgroundColor && getTextColorFromBackground( backgroundColor );
 
 	const className = classnames(
 		'site-thumbnail',
-		visible ? 'site-thumbnail-visible' : '',
+		! isLoading ? 'site-thumbnail-visible' : '',
 		`site-thumbnail__size-${ size }`
 	);
 
 	const loader = mShotsUrl ? 'site-thumbnail-loader' : '';
 
 	return (
-		<div className={ className } style={ { backgroundColor, color: textColor } }>
-			{ ! visible ? <div className={ loader }>{ children }</div> : <img src={ src } alt={ alt } /> }
+		<div className={ className } style={ { backgroundColor, color } }>
+			{ isLoading && <div className={ loader }>{ children }</div> }
+			{ src && <img ref={ imgRef } src={ src } alt={ alt } loading="lazy" /> }
 		</div>
 	);
 };

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -1,19 +1,14 @@
 import { addQueryArgs } from '@wordpress/url';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 
-export function mshotsUrl( targetUrl: string, options: MShotsOptions, count = 0 ): string {
+export function mshotsUrl( targetUrl: string, options: MShotsOptions ): string {
 	if ( ! targetUrl ) {
 		return '';
 	}
 	const mshotsUrl = 'https://s0.wp.com/mshots/v1/';
-	const mshotsRequest = addQueryArgs( mshotsUrl + encodeURIComponent( targetUrl ), {
-		...options,
-		count,
-	} );
+	const mshotsRequest = addQueryArgs( mshotsUrl + encodeURIComponent( targetUrl ), options );
 	return mshotsRequest;
 }
-
-const MAXTRIES = 10;
 
 export type MShotsOptions = {
 	vpw: number;
@@ -24,98 +19,29 @@ export type MShotsOptions = {
 	requeue?: boolean;
 };
 
-// This custom react hook returns undefined while the image is loading and
-// a HTMLImageElement (i.e. the class you get from `new Image()`) once loading
-// is complete.
-//
-// It also triggers a re-render (via setState()) when the value changes, so just
-// check if it's truthy and then treat it like any other Image.
-//
-// Note the loading may occur immediately and synchronously if the image is
-// already or may take up to several seconds if mshots has to generate and cache
-// new images.
-//
-// The calling code doesn't need to worry about the details except that you'll
-// want some sort of loading display.
-//
-// Inspired by https://stackoverflow.com/a/60458593
 export const useMshotsImg = (
 	src: string,
 	options: MShotsOptions
-): HTMLImageElement | undefined => {
-	const [ loadedImg, setLoadedImg ] = useState< HTMLImageElement >();
-	const [ count, setCount ] = useState( 0 );
-	const previousSrc = useRef( src );
+): {
+	src: string;
+	isLoading: boolean;
+	imgRef: React.MutableRefObject< HTMLImageElement | null >;
+} => {
+	const mshotUrl = useMemo( () => mshotsUrl( src, options ), [ src, options ] );
+	const imgRef = useRef< HTMLImageElement >( null );
+	const [ isLoading, setIsLoading ] = useState( true );
 
-	const imgRef = useRef< HTMLImageElement >();
-	const timeoutIdRef = useRef< number >();
-
-	const previousImg = useRef< HTMLImageElement >();
-	const previousOptions = useRef< MShotsOptions >();
-	// Oddly, we need to assign to current here after ref creation in order to
-	// pass the equivalence check and avoid a spurious reset
-	previousOptions.current = options;
-
-	// Note: Mshots doesn't care about the "count" param, but it is important
-	// to browser caching. Getting this wrong looks like the url resolving
-	// before the image is ready.
 	useEffect( () => {
-		if ( src.length === 0 ) {
-			return;
+		if ( mshotUrl.length > 0 && imgRef?.current && ! imgRef.current.onload ) {
+			imgRef.current.onload = () => {
+				setIsLoading( false );
+			};
 		}
+	}, [ imgRef, mshotUrl ] );
 
-		// If there's been a "props" change we need to reset everything:
-		if (
-			options !== previousOptions.current ||
-			( src !== previousSrc.current && imgRef.current )
-		) {
-			// Make sure an old image can't trigger a spurious state update
-			if ( previousImg.current && previousImg.current.onload ) {
-				previousImg.current.onload = null;
-				if ( timeoutIdRef.current ) {
-					clearTimeout( timeoutIdRef.current );
-					timeoutIdRef.current = undefined;
-				}
-			}
-
-			setLoadedImg( undefined );
-			setCount( 0 );
-			previousImg.current = imgRef.current;
-
-			previousOptions.current = options;
-			previousSrc.current = src;
-		}
-
-		const srcUrl = mshotsUrl( src, options, count );
-		const newImage = new Image();
-		newImage.onload = () => {
-			// Detect default image (Don't request a 400x300 image).
-			//
-			// If this turns out to be a problem, it might help to know that the
-			// http request status for the default is a 307. Unfortunately we
-			// don't get the request through an img element so we'd need to
-			// take a completely different approach using ajax.
-			if ( newImage.naturalWidth !== 400 || newImage.naturalHeight !== 300 ) {
-				// Note we're using the naked object here, not the ref, because
-				// this is the callback on the image itself. We'd never want
-				// the image to finish loading and set some other image.
-				setLoadedImg( newImage );
-			} else if ( count < MAXTRIES ) {
-				// Only refresh 10 times
-				// Triggers a target.src change with increasing timeouts
-				timeoutIdRef.current = setTimeout( () => setCount( ( count ) => count + 1 ), count * 500 );
-			}
-		};
-		newImage.src = srcUrl;
-		imgRef.current = newImage;
-
-		return () => {
-			if ( imgRef.current && imgRef.current.onload ) {
-				imgRef.current.onload = null;
-			}
-			clearTimeout( timeoutIdRef.current );
-		};
-	}, [ src, count, options ] );
-
-	return loadedImg;
+	return {
+		src: mshotUrl,
+		isLoading,
+		imgRef,
+	};
 };

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -1,14 +1,18 @@
 import { addQueryArgs } from '@wordpress/url';
 import { useState, useEffect, useMemo, useRef } from 'react';
 
-export function mshotsUrl( targetUrl: string, options: MShotsOptions ): string {
+export function mshotsUrl( targetUrl: string, options: MShotsOptions, countToRefresh = 0 ): string {
 	if ( ! targetUrl ) {
 		return '';
 	}
 	const mshotsUrl = 'https://s0.wp.com/mshots/v1/';
-	const mshotsRequest = addQueryArgs( mshotsUrl + encodeURIComponent( targetUrl ), options );
+	const mshotsRequest = addQueryArgs( mshotsUrl + encodeURIComponent( targetUrl ), {
+		...options,
+		countToRefresh,
+	} );
 	return mshotsRequest;
 }
+const MAXTRIES = 10;
 
 export type MShotsOptions = {
 	vpw: number;
@@ -25,23 +29,49 @@ export const useMshotsImg = (
 ): {
 	src: string;
 	isLoading: boolean;
+	isError: boolean;
 	imgRef: React.MutableRefObject< HTMLImageElement | null >;
 } => {
-	const mshotUrl = useMemo( () => mshotsUrl( src, options ), [ src, options ] );
+	const [ retryCount, setRetryCount ] = useState( 0 );
+	const mshotUrl = useMemo(
+		() => mshotsUrl( src, options, retryCount ),
+		[ src, options, retryCount ]
+	);
 	const imgRef = useRef< HTMLImageElement >( null );
 	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isError, setIsError ] = useState( false );
 
 	useEffect( () => {
+		let timeout: number;
 		if ( mshotUrl.length > 0 && imgRef?.current && ! imgRef.current.onload ) {
 			imgRef.current.onload = () => {
-				setIsLoading( false );
+				// MShot Loading image is 400x300px.
+				// MShot 404 image is 748×561px
+				const hasLoadingImgDimensions =
+					imgRef?.current?.naturalWidth === 400 && imgRef?.current.naturalHeight === 300;
+				if ( ! hasLoadingImgDimensions ) {
+					setIsLoading( false );
+				} else if ( retryCount < MAXTRIES ) {
+					// Only refresh 10 times
+					timeout = setTimeout(
+						() => setRetryCount( ( retryCount ) => retryCount + 1 ),
+						retryCount * 500
+					);
+				}
+			};
+			imgRef.current.onerror = () => {
+				setIsError( true );
 			};
 		}
-	}, [ imgRef, mshotUrl ] );
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [ imgRef, mshotUrl, retryCount ] );
 
 	return {
 		src: mshotUrl,
 		isLoading,
+		isError,
 		imgRef,
 	};
 };


### PR DESCRIPTION
#### Proposed Changes

In my opinion, using refs to compare the previous values and generating "fake" DOM elements to run some functions doesn't follow the react patterns.

* Refactor `useMshotsImg` hook

I've found that almost the same component is used here: `packages/onboarding/src/mshots-image/index.tsx`, maybe we can use just our improved component.


#### Testing Instructions

* Follow the test instructions on https://github.com/Automattic/wp-calypso/pull/65868


Related to https://github.com/Automattic/wp-calypso/pull/65868
