### PR TITLE
Jetpack Licensing: Update license revoke dialog to make it fullscreen on mobile and some extra tweaks

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -26,7 +26,6 @@
 			align-self: center;
 		}
 
-
 		&, & p {
 			font-size: 1rem;
 		}
@@ -38,11 +37,32 @@
 		align-items: stretch;
 		background: var( --studio-gray-0 );
 		border: 0;
+		padding: 12px 24px;
 
 		a {
 			margin-right: auto;
 			font-weight: 600;
 			text-decoration: underline;
+		}
+
+		.button {
+			margin-bottom: 16px;
+		}
+
+		/**
+		 * .dialog__action-buttons has flex-direction to column-reverse on mobile
+		 * so with this the button on the bottom has no margin on the bottom,
+		 * but it is the first element on the tree
+		 **/
+		.button:first-child {
+			margin-bottom: 0;
+		}
+
+		@include break-mobile {
+			.button {
+				margin-bottom: 0;
+				margin-left: 10px;
+			}
 		}
 
 

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -13,14 +13,20 @@
 	.dialog__action-buttons {
 		display: flex;
 		justify-content: flex-end;
-		align-items: center;
+		align-items: stretch;
 		background: var( --studio-gray-0 );
 		border: 0;
+
 
 		a {
 			margin-right: auto;
 			font-weight: 600;
 			text-decoration: underline;
+		}
+
+
+		@break-small() {
+			align-items: center;
 		}
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -2,8 +2,30 @@
 @import '@wordpress/base-styles/_mixins.scss';
 
 .revoke-license-dialog {
+	&.dialog.card {
+		max-height: 100vh;
+		max-width: 100vh;
+		margin: 0;
+		align-self: stretch;
+
+
+		@include break-small {
+			max-height: 90%;
+			max-width: 90%;
+			margin: auto 0;
+			align-self: center;
+		}
+	}
+
 	.dialog__content {
 		max-width: 628px;
+		align-self: stretch;
+		height: 100%;
+
+		@include break-small {
+			align-self: center;
+		}
+
 
 		&, & p {
 			font-size: 1rem;
@@ -17,7 +39,6 @@
 		background: var( --studio-gray-0 );
 		border: 0;
 
-
 		a {
 			margin-right: auto;
 			font-weight: 600;
@@ -25,24 +46,22 @@
 		}
 
 
-		@break-small() {
+		@include break-small {
 			align-items: center;
 		}
 	}
 
 	&__heading {
 		margin: -16px -16px 16px;
-		padding: 9px 16px;
+		padding: 24px;
 		font-size: 1.125rem; /* stylelint-disable */
 		font-weight: 600;
 		line-height: 20px;
-		color: var( --studio-red-60 );
+		color: var( --studio-gray-60 );
 		border-bottom: 1px solid var( --studio-gray-5 );
 
-		@include break-mobile() {
+		@include break-mobile {
 			margin: -24px -24px 24px;
-			padding: 9px 24px;
-			line-height: 36px;
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Context: 1199980337313591-as-1202134584709627/f
* Make revoke dialog full screen on mobile
* Make dialog buttons full width on mobile
* Update heading colors and paddings
* Update spacing between action buttons

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue a license
* Revoke a license
* You should see the revoke dialog on mobile respecting the mobile style updates

#### Screenshots
![image](https://user-images.githubusercontent.com/5550190/181084497-ad2e0e28-d4ff-4234-86a4-a99b2a0ee34f.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
