### PR TITLE
Update marketing/tools text

### DIFF
--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -24,7 +24,7 @@ const MarketingToolsHeader: FunctionComponent< Props > = ( { handleButtonClick }
 
 				<h2 className="tools__header-description">
 					{ translate(
-						"We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and shipment tracking, we have you covered."
+						"We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and SEO tools, we have you covered."
 					) }
 				</h2>
 


### PR DESCRIPTION
#### Proposed Changes
Quick fix on the Marketplace CTA on /marketing/tools replacing `shipment tracking` with `SEO tools`

#### Testing Instructions
1. Go to `/marketing/tools`
2. Check the text, should say `We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and SEO tools, we have you covered.`

#### Screenshot
##### Before
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/402286/181085931-8d2bc298-7373-46b8-b384-6e624c29ffd4.png">

##### After
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/402286/181085546-82cf5d7b-b855-4f6b-8b51-26a168447bd7.png">


Fixes to #64474 
