### PR TITLE
Plans Grids: show correct discount rounding

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -346,7 +346,7 @@ class ManagePurchase extends Component {
 	renderRenewAnnuallyNavItem() {
 		const { translate, purchase, relatedMonthlyPlanPrice } = this.props;
 		const annualPrice = getRenewalPrice( purchase ) / 12;
-		const savings = Math.round(
+		const savings = Math.floor(
 			( 100 * ( relatedMonthlyPlanPrice - annualPrice ) ) / relatedMonthlyPlanPrice
 		);
 		return this.renderRenewalNavItem(

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -68,7 +68,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 		} = this.props;
 
 		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
-			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
+			const discountRate = Math.floor( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
 			return translate( `Save %(discountRate)s%% by paying annually`, { args: { discountRate } } );
 		}
 
@@ -100,7 +100,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 		if ( ! isMonthlyPlan ) {
 			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
 
-			const discountRate = Math.round(
+			const discountRate = Math.floor(
 				( 100 * ( rawPriceForMonthlyPlan - annualPricePerMonth ) ) / rawPriceForMonthlyPlan
 			);
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -242,7 +242,7 @@ export class PlanFeaturesHeader extends Component {
 		const rawPrice = relatedMonthlyPlan.raw_price;
 
 		const annualPricePerMonth = relatedYearlyPlan.raw_price / 12;
-		const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
+		const discountRate = Math.floor( 100 * ( ( rawPrice - annualPricePerMonth ) / rawPrice ) );
 
 		const isLoading = typeof rawPrice !== 'number';
 		const annualDiscountText = translate( `You're saving %(discountRate)s%% by paying annually`, {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -276,7 +276,7 @@ export class PlanFeaturesHeader extends Component {
 
 		if ( ( isInSignup || isLoggedInMonthlyPricing ) && isMonthlyPlan && relatedYearlyPlan ) {
 			const annualPricePerMonth = relatedYearlyPlan.raw_price / 12;
-			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
+			const discountRate = Math.floor( 100 * ( ( rawPrice - annualPricePerMonth ) / rawPrice ) );
 			return translate( `Save %(discountRate)s%% by paying annually`, { args: { discountRate } } );
 		}
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -307,7 +307,7 @@ export class PlanFeaturesHeader extends Component {
 			return null;
 		}
 
-		const discountPercent = Math.round( ( 100 * ( rawPrice - discountPrice ) ) / rawPrice );
+		const discountPercent = Math.floor( ( 100 * ( rawPrice - discountPrice ) ) / rawPrice );
 		if ( discountPercent <= 0 ) {
 			return null;
 		}
@@ -326,7 +326,7 @@ export class PlanFeaturesHeader extends Component {
 
 		if ( isYearly && relatedMonthlyPlan && relatedYearlyPlan ) {
 			const annualPricePerMonth = relatedYearlyPlan.raw_price / 12;
-			const discountRate = Math.round(
+			const discountRate = Math.floor(
 				( 100 * ( relatedMonthlyPlan.raw_price - annualPricePerMonth ) ) /
 					relatedMonthlyPlan.raw_price
 			);

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -303,7 +303,7 @@ function useMaxDiscount( plans: string[] ): number {
 			const discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id );
 			const yearlyPlanCost = discountPrice || rawPrice || 0;
 
-			return Math.round(
+			return Math.floor(
 				( ( monthlyPlanAnnualCost - yearlyPlanCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100
 			);
 		} );

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -54,7 +54,7 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 		monthlyPlanPrice: getPlanRawPrice( state, mediumPlanMonthly.getProductId() ) || 0,
 	} ) );
 
-	const percentageSavings = Math.round(
+	const percentageSavings = Math.floor(
 		( 1 - mediumPlanPrices.annualPlanMonthlyPrice / mediumPlanPrices.monthlyPlanPrice ) * 100
 	);
 

--- a/packages/data-stores/src/plans/mock/store/products.ts
+++ b/packages/data-stores/src/plans/mock/store/products.ts
@@ -20,7 +20,7 @@ export const STORE_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
 	pathSlug: 'premium',
 	price: '€8',
 	annualPrice: '€96',
-	annualDiscount: 43,
+	annualDiscount: 42,
 };
 export const STORE_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
 	productId: 1013,
@@ -30,5 +30,5 @@ export const STORE_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
 	rawPrice: 14,
 	price: '€14',
 	annualPrice: '€168',
-	annualDiscount: 43,
+	annualDiscount: 42,
 };

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -62,7 +62,7 @@ function calculateDiscounts( planProducts: PlanProduct[] ) {
 		if ( annualPlan && monthlyPlan ) {
 			const annualCostIfPaidMonthly = monthlyPlan.rawPrice * 12;
 			const annualCostIfPaidAnnually = annualPlan.rawPrice;
-			const discount = Math.round(
+			const discount = Math.floor(
 				100 * ( 1 - annualCostIfPaidAnnually / annualCostIfPaidMonthly )
 			);
 			annualPlan.annualDiscount = discount;


### PR DESCRIPTION
Checkout uses `Math.floor()` to show annual (and biannual) discount rates, but everywhere else `Math.round()` to show the same rate. This causes the variant picker in Checkout to show a slightly lower discount rate.

This PR updates all instances to use `Math.floor()` since we're technically not giving the user the full percentage point of discount rate (e.g 42.85% is not actually 43%).

Fixes: #65969

<img width="1552" alt="calypso plans" src="https://user-images.githubusercontent.com/942359/182171864-53a8f568-af09-4ea5-8a03-5be455ccc989.png">
<img width="1552" alt="signup plans" src="https://user-images.githubusercontent.com/942359/182171923-711f23f3-9b58-4980-9ab5-63e3f63e0e03.png">


**To test:**

To test the plans layout in Calypso:
- on a new site, or site with access to legacy plans (personal, premium, business)
- visit /plans page - it should match the first screenshot above
- note the discount rate for each plan (e.g. "You're saving 42% by paying annually")
- add a plan to your cart and visit Checkout
- verify that the discount rate shown in the variation picker dropdown matches the rate from the plans page

To test the plans layout in Signup (uses the `PlansFeatureComparison` component for Desktop views):
- on desktop, visit /start and proceed through to the plans step
- the Plans step should match the second screenshot above
- note the discount rate for each plan (e.g. "You're saving 42% by paying annually")
- add a plan to your cart and visit Checkout
- verify that the discount rate shown in the variation picker dropdown matches the rate from the plans page