### PR TITLE
[GB 13.7.x] Open Site Editor in the Gutenframe by using the `site-editor.php` route

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -858,7 +858,7 @@ const mapStateToProps = (
 
 	const siteAdminUrl =
 		editorType === 'site'
-			? getSiteAdminUrl( state, siteId, 'themes.php?page=gutenberg-edit-site' )
+			? getSiteAdminUrl( state, siteId, 'site-editor.php' )
 			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
 
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl ?? '' );

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -12,7 +12,7 @@ export const getSiteEditorUrl = ( state, siteId ) => {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
 	if ( ! shouldLoadGutenframe( state, siteId ) ) {
-		return `${ siteAdminUrl }themes.php?page=gutenberg-edit-site`;
+		return `${ siteAdminUrl }site-editor.php`;
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );


### PR DESCRIPTION
#### Proposed Changes

Gutenberg 13.7 deprecates the old `themes.php?page=gutenberg-edit-site` and `admin.php?page=gutenberg-edit-site` in favor of WP core's `site-editor.php`. This PR changes the Site Editor admin route to `site-editor.php` in the Gutenframe.

#### Testing Instructions

* Build Calypso from this branch, access `calypso.localhost:3000`;
* Apply this diff to your sandbox: D84749-code and D8488-code -- it has backward-compatible fixes for 13.7 that should be tested with 13.6, too;
* Open a sandboxed site that still has Gutenberg 13.6;
* Open the Site Editor by clicking the `Appearance->Site Editor` menu item. It should open the editor inside the Gutenframe and shouldn't redirect to the wp-admin page!
* Open the regular editor, it should load correctly, from the Gutenframe, too.
* Now use a site that has Gutenberg 13.7.3 installed (or apply the `gutenberg-edge` sticker to your existing site);
* Reload your local Calypso web app instance in the browser;
* Test the Site Editor and the editor - they should load from the Gutenframe.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
### Further context:

* Related to https://github.com/WordPress/gutenberg/pull/42643 and https://github.com/WordPress/gutenberg/pull/41306.
* PSA: p4TIVU-acs-p2
* Slack discussion: p1658338410941839-slack-CHN6J22MP