### PR TITLE
Checkout: Change term variant picker discount display to compare against selected price

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -241,7 +241,7 @@ function ItemVariantOptionList( {
 					onSelect={ () =>
 						handleChange( selectedItem.uuid, variant.productSlug, variant.productId )
 					}
-					selectedVariant={ selectedVariant }
+					compareTo={ selectedVariant }
 					variant={ variant }
 				/>
 			) ) }
@@ -252,12 +252,12 @@ function ItemVariantOptionList( {
 function ItemVariantOption( {
 	isSelected,
 	onSelect,
-	selectedVariant,
+	compareTo,
 	variant,
 }: {
 	isSelected: boolean;
 	onSelect: () => void;
-	selectedVariant?: WPCOMProductVariant;
+	compareTo?: WPCOMProductVariant;
 	variant: WPCOMProductVariant;
 } ) {
 	const { variantLabel, productId, productSlug } = variant;
@@ -271,7 +271,7 @@ function ItemVariantOption( {
 			onClick={ onSelect }
 			selected={ isSelected }
 		>
-			<ItemVariantPrice variant={ variant } selectedVariant={ selectedVariant } />
+			<ItemVariantPrice variant={ variant } compareTo={ compareTo } />
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -232,6 +232,9 @@ function ItemVariantOptionList( {
 	selectedItem: ResponseCartProduct;
 	handleChange: ( uuid: string, productSlug: string, productId: number ) => void;
 } ) {
+	const selectedVariant = variants.find(
+		( variant ) => variant.productId === selectedItem.product_id
+	);
 	return (
 		<OptionList role="listbox" tabIndex={ -1 }>
 			{ variants.map( ( variant, index ) => (
@@ -241,9 +244,7 @@ function ItemVariantOptionList( {
 					onSelect={ () =>
 						handleChange( selectedItem.uuid, variant.productSlug, variant.productId )
 					}
-					selectedVariant={
-						highlightedVariantIndex ? variants[ highlightedVariantIndex ] : undefined
-					}
+					selectedVariant={ selectedVariant }
 					variant={ variant }
 				/>
 			) ) }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -203,7 +203,10 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				role="button"
 			>
 				{ selectedVariantIndex !== null ? (
-					<ItemVariantPrice variant={ variants[ selectedVariantIndex ] } />
+					<ItemVariantPrice
+						variant={ variants[ selectedVariantIndex ] }
+						selectedVariant={ variants[ selectedVariantIndex ] }
+					/>
 				) : (
 					<span>{ translate( 'Pick a product term' ) }</span>
 				) }
@@ -238,6 +241,9 @@ function ItemVariantOptionList( {
 				<ItemVariantOption
 					key={ variant.productSlug + variant.variantLabel }
 					variant={ variant }
+					selectedVariant={
+						highlightedVariantIndex ? variants[ highlightedVariantIndex ] : undefined
+					}
 					highlightedVariantIndex={ highlightedVariantIndex }
 					index={ index }
 					selectedItem={ selectedItem }
@@ -251,11 +257,13 @@ function ItemVariantOptionList( {
 function ItemVariantOption( {
 	variant,
 	highlightedVariantIndex,
+	selectedVariant,
 	index,
 	selectedItem,
 	handleChange,
 }: {
 	variant: WPCOMProductVariant;
+	selectedVariant: WPCOMProductVariant | undefined;
 	highlightedVariantIndex: number | null;
 	index: number;
 	selectedItem: ResponseCartProduct;
@@ -273,7 +281,7 @@ function ItemVariantOption( {
 			onClick={ () => handleChange( selectedItem.uuid, productSlug, productId ) }
 			selected={ isSelected }
 		>
-			<ItemVariantPrice variant={ variant } />
+			<ItemVariantPrice variant={ variant } selectedVariant={ selectedVariant } />
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { useGetProductVariants } from '../../hooks/product-variants';
 import { ItemVariantPrice } from './variant-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
@@ -101,14 +101,11 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	const [ open, setOpen ] = useState( false );
 	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );
 
-	const selectedVariantIndex = useMemo( () => {
-		for ( let i = 0; i < variants.length; ++i ) {
-			if ( variants[ i ].productId === selectedItem.product_id ) {
-				return i;
-			}
-		}
-		return null;
-	}, [ selectedItem.product_id, variants ] );
+	const selectedVariantIndexRaw = variants.findIndex(
+		( variant ) => variant.productId === selectedItem.product_id
+	);
+	// findIndex returns -1 if it fails and we want null.
+	const selectedVariantIndex = selectedVariantIndexRaw > 0 ? selectedVariantIndexRaw : null;
 
 	// reset the dropdown highlight when the selected product changes
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -229,9 +229,7 @@ function ItemVariantOptionList( {
 	selectedItem: ResponseCartProduct;
 	handleChange: ( uuid: string, productSlug: string, productId: number ) => void;
 } ) {
-	const selectedVariant = variants.find(
-		( variant ) => variant.productId === selectedItem.product_id
-	);
+	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	return (
 		<OptionList role="listbox" tabIndex={ -1 }>
 			{ variants.map( ( variant, index ) => (
@@ -241,7 +239,7 @@ function ItemVariantOptionList( {
 					onSelect={ () =>
 						handleChange( selectedItem.uuid, variant.productSlug, variant.productId )
 					}
-					compareTo={ selectedVariant }
+					compareTo={ compareTo }
 					variant={ variant }
 				/>
 			) ) }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -203,10 +203,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				role="button"
 			>
 				{ selectedVariantIndex !== null ? (
-					<ItemVariantPrice
-						variant={ variants[ selectedVariantIndex ] }
-						selectedVariant={ variants[ selectedVariantIndex ] }
-					/>
+					<ItemVariantPrice variant={ variants[ selectedVariantIndex ] } />
 				) : (
 					<span>{ translate( 'Pick a product term' ) }</span>
 				) }
@@ -240,14 +237,14 @@ function ItemVariantOptionList( {
 			{ variants.map( ( variant, index ) => (
 				<ItemVariantOption
 					key={ variant.productSlug + variant.variantLabel }
-					variant={ variant }
+					isSelected={ index === highlightedVariantIndex }
+					onSelect={ () =>
+						handleChange( selectedItem.uuid, variant.productSlug, variant.productId )
+					}
 					selectedVariant={
 						highlightedVariantIndex ? variants[ highlightedVariantIndex ] : undefined
 					}
-					highlightedVariantIndex={ highlightedVariantIndex }
-					index={ index }
-					selectedItem={ selectedItem }
-					handleChange={ handleChange }
+					variant={ variant }
 				/>
 			) ) }
 		</OptionList>
@@ -255,22 +252,17 @@ function ItemVariantOptionList( {
 }
 
 function ItemVariantOption( {
-	variant,
-	highlightedVariantIndex,
+	isSelected,
+	onSelect,
 	selectedVariant,
-	index,
-	selectedItem,
-	handleChange,
+	variant,
 }: {
+	isSelected: boolean;
+	onSelect: () => void;
+	selectedVariant?: WPCOMProductVariant;
 	variant: WPCOMProductVariant;
-	selectedVariant: WPCOMProductVariant | undefined;
-	highlightedVariantIndex: number | null;
-	index: number;
-	selectedItem: ResponseCartProduct;
-	handleChange: ( uuid: string, productSlug: string, productId: number ) => void;
 } ) {
 	const { variantLabel, productId, productSlug } = variant;
-	const isSelected = index === highlightedVariantIndex;
 	return (
 		<Option
 			id={ productId.toString() }
@@ -278,7 +270,7 @@ function ItemVariantOption( {
 			aria-label={ variantLabel }
 			data-product-slug={ productSlug }
 			role="option"
-			onClick={ () => handleChange( selectedItem.uuid, productSlug, productId ) }
+			onClick={ onSelect }
 			selected={ isSelected }
 		>
 			<ItemVariantPrice variant={ variant } selectedVariant={ selectedVariant } />

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -3,8 +3,8 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 export type WPCOMProductSlug = string;
 
 export type WPCOMProductVariant = {
-	currentPrice: number;
-	currentPricePerMonth: number;
+	price: number;
+	pricePerMonth: number;
 	termIntervalInMonths: number;
 	currency: string;
 	productId: number;

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -3,9 +3,10 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 export type WPCOMProductSlug = string;
 
 export type WPCOMProductVariant = {
-	discountPercentage: number;
-	formattedCurrentPrice: string | null;
-	formattedPriceBeforeDiscount: string | null;
+	currentPrice: number;
+	currentPricePerMonth: number;
+	termIntervalInMonths: number;
+	currency: string;
 	productId: number;
 	productSlug: WPCOMProductSlug;
 	variantLabel: string;

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -83,26 +83,26 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 
 export const ItemVariantPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
-	selectedVariant?: WPCOMProductVariant;
-} > = ( { variant, selectedVariant } ) => {
+	compareTo?: WPCOMProductVariant;
+} > = ( { variant, compareTo } ) => {
 	const isMobile = useMobileBreakpoint();
-	// This is the price that the selectedVariant would be if it was using the
-	// billing term of the variant. For example, if the price of the selected
+	// This is the price that the compareTo variant would be if it was using the
+	// billing term of the variant. For example, if the price of the compareTo
 	// variant was 120 per year, and the variant we are displaying here is 5 per
-	// month, then `priceOfSelectedVariantForThisTerm` would be (120 / 12) * 1,
+	// month, then `compareToPriceForVariantTerm` would be (120 / 12) * 1,
 	// or 10 (per month). In this case, selecting the variant would save the user
 	// 50% (5 / 10).
-	const priceOfSelectedVariantForThisTerm = selectedVariant
-		? selectedVariant.pricePerMonth * variant.termIntervalInMonths
+	const compareToPriceForVariantTerm = compareTo
+		? compareTo.pricePerMonth * variant.termIntervalInMonths
 		: undefined;
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
-	const discountPercentage = priceOfSelectedVariantForThisTerm
-		? Math.floor( 100 - ( variant.price / priceOfSelectedVariantForThisTerm ) * 100 )
+	const discountPercentage = compareToPriceForVariantTerm
+		? Math.floor( 100 - ( variant.price / compareToPriceForVariantTerm ) * 100 )
 		: 0;
 	const formattedCurrentPrice = myFormatCurrency( variant.price, variant.currency );
-	const formattedSelectedPriceForTerm = priceOfSelectedVariantForThisTerm
-		? myFormatCurrency( priceOfSelectedVariantForThisTerm, variant.currency )
+	const formattedCompareToPriceForVariantTerm = compareToPriceForVariantTerm
+		? myFormatCurrency( compareToPriceForVariantTerm, variant.currency )
 		: undefined;
 
 	return (
@@ -117,7 +117,9 @@ export const ItemVariantPrice: FunctionComponent< {
 				{ discountPercentage > 0 && ! isMobile && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				{ discountPercentage > 0 && <DoNotPayThis>{ formattedSelectedPriceForTerm }</DoNotPayThis> }
+				{ discountPercentage > 0 && (
+					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
+				) }
 				<Price>{ formattedCurrentPrice }</Price>
 			</span>
 		</Variant>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -95,8 +95,10 @@ export const ItemVariantPrice: FunctionComponent< {
 	const priceOfSelectedVariantForThisTerm = selectedVariant
 		? selectedVariant.currentPricePerMonth * variant.termIntervalInMonths
 		: undefined;
+	// Extremely low "discounts" are possible if the price of the longer term has been rounded
+	// if they cannot be rounded to at least a percentage point we should not show them.
 	const discountPercentage = priceOfSelectedVariantForThisTerm
-		? variant.currentPrice / priceOfSelectedVariantForThisTerm
+		? Math.floor( 100 - ( variant.currentPrice / priceOfSelectedVariantForThisTerm ) * 100 )
 		: 0;
 	const formattedCurrentPrice = myFormatCurrency( variant.currentPrice, variant.currency );
 	const formattedSelectedPriceForTerm = priceOfSelectedVariantForThisTerm

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -83,7 +83,7 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 
 export const ItemVariantPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
-	selectedVariant: WPCOMProductVariant;
+	selectedVariant?: WPCOMProductVariant;
 } > = ( { variant, selectedVariant } ) => {
 	const isMobile = useMobileBreakpoint();
 	// This is the price that the selectedVariant would be if it was using the
@@ -92,14 +92,16 @@ export const ItemVariantPrice: FunctionComponent< {
 	// month, then `priceOfSelectedVariantForThisTerm` would be (120 / 12) * 1,
 	// or 10 (per month). In this case, selecting the variant would save the user
 	// 50% (5 / 10).
-	const priceOfSelectedVariantForThisTerm =
-		selectedVariant.currentPricePerMonth * variant.termIntervalInMonths;
-	const discountPercentage = variant.currentPrice / priceOfSelectedVariantForThisTerm;
+	const priceOfSelectedVariantForThisTerm = selectedVariant
+		? selectedVariant.currentPricePerMonth * variant.termIntervalInMonths
+		: undefined;
+	const discountPercentage = priceOfSelectedVariantForThisTerm
+		? variant.currentPrice / priceOfSelectedVariantForThisTerm
+		: 0;
 	const formattedCurrentPrice = myFormatCurrency( variant.currentPrice, variant.currency );
-	const formattedSelectedPriceForTerm = myFormatCurrency(
-		priceOfSelectedVariantForThisTerm,
-		variant.currency
-	);
+	const formattedSelectedPriceForTerm = priceOfSelectedVariantForThisTerm
+		? myFormatCurrency( priceOfSelectedVariantForThisTerm, variant.currency )
+		: undefined;
 
 	return (
 		<Variant>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -93,14 +93,14 @@ export const ItemVariantPrice: FunctionComponent< {
 	// or 10 (per month). In this case, selecting the variant would save the user
 	// 50% (5 / 10).
 	const priceOfSelectedVariantForThisTerm = selectedVariant
-		? selectedVariant.currentPricePerMonth * variant.termIntervalInMonths
+		? selectedVariant.pricePerMonth * variant.termIntervalInMonths
 		: undefined;
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
 	const discountPercentage = priceOfSelectedVariantForThisTerm
-		? Math.floor( 100 - ( variant.currentPrice / priceOfSelectedVariantForThisTerm ) * 100 )
+		? Math.floor( 100 - ( variant.price / priceOfSelectedVariantForThisTerm ) * 100 )
 		: 0;
-	const formattedCurrentPrice = myFormatCurrency( variant.currentPrice, variant.currency );
+	const formattedCurrentPrice = myFormatCurrency( variant.price, variant.currency );
 	const formattedSelectedPriceForTerm = priceOfSelectedVariantForThisTerm
 		? myFormatCurrency( priceOfSelectedVariantForThisTerm, variant.currency )
 		: undefined;

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -28,12 +28,20 @@ import type { ProductListItem } from 'calypso/state/products-list/selectors/get-
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
 
-function myFormatCurrency( price: number, code: string, options = {} ) {
+export function myFormatCurrency( price: number, code: string, options = {} ): string {
 	const precision = CURRENCIES[ code ].precision;
 	const EPSILON = Math.pow( 10, -precision ) - 0.000000001;
 
 	const hasCents = Math.abs( price % 1 ) >= EPSILON;
-	return formatCurrency( price, code, hasCents ? options : { ...options, precision: 0 } );
+	const formatted = formatCurrency(
+		price,
+		code,
+		hasCents ? options : { ...options, precision: 0 }
+	);
+	if ( ! formatted ) {
+		throw new Error( `Failed to format price '${ price }' in currency '${ code }'` );
+	}
+	return formatted;
 }
 
 export interface AvailableProductVariant {

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -101,21 +101,21 @@ export function useGetProductVariants(
 
 	const getProductVariantFromAvailableVariant = useCallback(
 		( variant: AvailableProductVariant ): WPCOMProductVariant => {
-			const currentPrice =
+			const price =
 				variant.introductoryOfferPrice !== null
 					? variant.introductoryOfferPrice
 					: variant.priceFinal || variant.priceFull;
 
 			const termIntervalInMonths = getBillingMonthsForTerm( variant.plan.term );
-			const currentPricePerMonth = currentPrice / termIntervalInMonths;
+			const pricePerMonth = price / termIntervalInMonths;
 
 			return {
 				variantLabel: getTermText( variant.plan.term, translate ),
 				productSlug: variant.planSlug,
 				productId: variant.product.product_id,
-				currentPrice,
+				price,
 				termIntervalInMonths: getBillingMonthsForTerm( variant.plan.term ),
-				currentPricePerMonth,
+				pricePerMonth,
 				currency: variant.product.currency_code,
 			};
 		},

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -213,16 +213,14 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
+			const currentVariantItem = await screen.findByRole( 'option', {
+				name: getVariantItemTextForInterval( cartPlan ),
+			} );
 			const variantItem = await screen.findByRole( 'option', {
 				name: getVariantItemTextForInterval( expectedVariant ),
 			} );
-			const variantItems = await screen.findAllByRole( 'option' );
 
-			// The discount does not appear until the item is selected.
-			await user.click( variantItem );
-
-			const lowestVariantItem = variantItems[ 0 ];
-			const lowestVariantSlug = lowestVariantItem.dataset.productSlug;
+			const currentVariantSlug = currentVariantItem.dataset.productSlug;
 			const variantSlug = variantItem.dataset.productSlug;
 
 			const variantData = getPlansItemsState().find(
@@ -230,13 +228,13 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			);
 			const finalPrice = variantData.raw_price;
 			const variantInterval = variantData.bill_period;
-			const lowestVariantData = getPlansItemsState().find(
-				( plan ) => plan.product_slug === lowestVariantSlug
+			const currentVariantData = getPlansItemsState().find(
+				( plan ) => plan.product_slug === currentVariantSlug
 			);
-			const lowestVariantPrice = lowestVariantData.raw_price;
-			const lowestVariantInterval = lowestVariantData.bill_period;
-			const intervalsInVariant = Math.round( variantInterval / lowestVariantInterval );
-			const priceBeforeDiscount = lowestVariantPrice * intervalsInVariant;
+			const currentVariantPrice = currentVariantData.raw_price;
+			const currentVariantInterval = currentVariantData.bill_period;
+			const intervalsInVariant = Math.round( variantInterval / currentVariantInterval );
+			const priceBeforeDiscount = currentVariantPrice * intervalsInVariant;
 
 			const discountPercentage = Math.floor( 100 - ( finalPrice / priceBeforeDiscount ) * 100 );
 			expect( screen.getByText( `Save ${ discountPercentage }%` ) ).toBeInTheDocument();
@@ -259,9 +257,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			const variantItem = await screen.findByRole( 'option', {
 				name: getVariantItemTextForInterval( expectedVariant ),
 			} );
-
-			// The discount does not appear until the item is selected.
-			await user.click( variantItem );
 
 			expect( within( variantItem ).queryByText( /Save \d+%/ ) ).not.toBeInTheDocument();
 		}

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -767,13 +767,13 @@ export function createTestReduxStore() {
 						currency_code: planWithoutDomainBiannual.currency,
 					},
 					[ planLevel2.product_slug ]: {
-						product_id: planWithoutDomain.product_id,
-						product_slug: planWithoutDomain.product_slug,
+						product_id: planLevel2.product_id,
+						product_slug: planLevel2.product_slug,
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planWithoutDomain.item_subtotal_display,
-						currency_code: planWithoutDomain.currency,
+						cost_display: planLevel2.item_subtotal_display,
+						currency_code: planLevel2.currency,
 					},
 					[ planLevel2Monthly.product_slug ]: {
 						product_id: planLevel2Monthly.product_id,


### PR DESCRIPTION
#### Proposed Changes

This modifies the checkout term variant picker (recently changed to use a drop-down and match the Jetpack one in https://github.com/Automattic/wp-calypso/pull/65374) so that each of its options displays a percentage discount of the variant's price when compared to the selected variant. 

Previously, each variant was shown with a discount compared to the **lowest-priced variant** (typically the monthly price). This makes some sense when looking at all available prices (and nicely shows the benefit of the currently selected variant), but this comparison is counter-intuitive in a drop-down format. The current behavior comes from https://github.com/Automattic/wp-calypso/pull/53904 which reads:

> Finally, to prevent confusion about what the "Save X%" numbers mean in cases where the monthly price is not shown, this also modifies the discount percentage shown on each product variant, which is currently based on the monthly price for that variant, so that it now is based on the smallest displayed variant's price.

As a side-effect, this no longer shows any discount for the currently selected variant because when compared to itself, there is no discount.

Before:

<img width="636" alt="Screen Shot 2022-07-26 at 6 51 24 PM" src="https://user-images.githubusercontent.com/2036909/181125820-5708d39d-f0a8-417d-9889-840969fb9fd3.png">

After:

<img width="626" alt="Screen Shot 2022-07-26 at 6 51 04 PM" src="https://user-images.githubusercontent.com/2036909/181125827-d1cccdf2-59bd-477b-a030-81fbe5006980.png">

**Note:** this PR refactors how the options are displayed, but if we ever want to revert most of this change and once again compare each price to the lowest variant, we only need to change this one statement to select the first variant instead:

https://github.com/Automattic/wp-calypso/blob/36fe1551d5948fe21f5ccbd20dd330e88d646f89/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx#L232

#### Testing Instructions

- Add a product to your cart that has variants (eg: a WordPress.com legacy plan like Premium).
- Visit checkout and click the product variant selector for that product.
- Verify that the options in the selector show a discounted price that matches what the selected product's price would be if it were applied to that term. So if the yearly price is $96 and is selected, and the biennial price is $180, the biennial price should display as a 6% discount (because $96 paid for the biennial term would be $192, which is 6% more than the actual price of $180).
- Select different variants and be sure that the above still holds true for all of them.