### PR TITLE
Unified design picker: Event tracking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -227,7 +227,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const handleBackClick = () => {
 		if ( isPreviewingDesign ) {
 			recordTracksEvent( 'calypso_signup_design_preview_exit', {
-				...getEventPropsByDesign( selectedDesign ),
+				...getEventPropsByDesign( selectedDesign as Design ),
 			} );
 
 			setSelectedDesign( undefined );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -226,9 +226,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	const handleBackClick = () => {
 		if ( isPreviewingDesign ) {
-			recordTracksEvent( 'calypso_signup_design_preview_exit', {
-				...getEventPropsByDesign( selectedDesign as Design ),
-			} );
+			recordTracksEvent(
+				'calypso_signup_design_preview_exit',
+				getEventPropsByDesign( selectedDesign as Design )
+			);
 
 			setSelectedDesign( undefined );
 			setIsPreviewingDesign( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -21,7 +21,6 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
-import useTrackScrollPageFromTop from '../../../../hooks/use-track-scroll-page-from-top';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
@@ -238,9 +237,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		goBack();
 	};
-
-	// Track scroll event to make sure people are scrolling on mobile.
-	useTrackScrollPageFromTop( isMobile && ! isPreviewingDesign, flow || '', STEP_NAME );
 
 	// Make sure people is at the top when entering/leaving preview mode.
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -227,6 +227,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	const handleBackClick = () => {
 		if ( isPreviewingDesign ) {
+			recordTracksEvent( 'calypso_signup_design_preview_exit', {
+				...getEventPropsByDesign( selectedDesign ),
+			} );
+
 			setSelectedDesign( undefined );
 			setIsPreviewingDesign( false );
 			return;

--- a/packages/design-picker/src/components/design-picker-category-filter/unified-design-picker-category-filter.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/unified-design-picker-category-filter.tsx
@@ -1,4 +1,5 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks'; // eslint-disable-line no-restricted-imports
 import type { Category } from '../../types';
 import type { ReactElement } from 'react';
 import './style.scss';
@@ -16,6 +17,11 @@ export function UnifiedDesignPickerCategoryFilter( {
 }: Props ): ReactElement | null {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
+
+		recordTracksEvent( 'calypso_signup_unified_design_select_category', {
+			category: category?.slug,
+		} );
+
 		onSelect( category?.slug );
 	};
 	const initialActiveIndex = categories.findIndex( ( { slug } ) => slug === selectedSlug );

--- a/packages/design-picker/src/lib-wp.d.ts
+++ b/packages/design-picker/src/lib-wp.d.ts
@@ -1,1 +1,2 @@
 declare module 'calypso/lib/wp';
+declare module 'calypso/lib/analytics/tracks';


### PR DESCRIPTION
# Proposed Changes

Update these events to the UDP (unified design picker):

  - When the user changes the standard theme filter.
  - When the user exits design preview.
  - [Remove](p1658743219007269/1658739854.826669-slack-CRWCHQGUB) useTrackScrollPageFromTop in UDP
# Testing Instructions

### Set up.

1.  Open your dev tools, go to the Network tab, and clear all entries so you can monitor new network activity.
2.  In the search/filter box on the network tab, type `t.gif`. This will filter network activity so you can see events.
3.  When making some actions, click on the request and navigate to `Payload` tab to check all the event parameters

### Expected

| Tracking | Recording |
|-------|---|
|  On exit design preview <br>  `calypso_signup_design_preview_exit` | <details> <video src="https://user-images.githubusercontent.com/10071857/181249704-14b77e3e-db95-4eb8-aefe-8f9e281fba03.mp4"> </details>  |
|  On standard theme's categories change <br> `calypso_signup_unified_design_select_category`  |  <details> <video src="https://user-images.githubusercontent.com/10071857/181249678-68c57e11-5fa6-4cfb-80e4-76dedbda5267.mp4"> </details> |

Related #65925