### PR TITLE
Unified design picker: Add check for flag "signup/standard-theme-v13n" when verticalizing standard themes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -344,7 +344,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		<UnifiedDesignPicker
 			generatedDesigns={ generatedDesigns }
 			staticDesigns={ staticDesigns }
-			verticalId={ siteVerticalId }
+			verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined }
 			locale={ locale }
 			onSelect={ pickDesign }
 			onPreview={ previewDesign }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -344,7 +344,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		<UnifiedDesignPicker
 			generatedDesigns={ generatedDesigns }
 			staticDesigns={ staticDesigns }
-			verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined }
+			verticalId={ siteVerticalId }
 			locale={ locale }
 			onSelect={ pickDesign }
 			onPreview={ previewDesign }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -478,11 +478,11 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 				designs={ staticDesigns }
 				premiumBadge={ premiumBadge }
 				categorization={ categorization }
+				verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? verticalId : undefined }
 				previewOnly={ previewOnly }
 				hasDesignOptionHeader={ hasDesignOptionHeader }
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				onCheckout={ onCheckout }
-				verticalId={ verticalId }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

This PR adds a check for the `signup/standard-theme-v13n` flag to determine whether to verticalize standard themes or not.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to `/setup/designSetup?siteSlug=${site_slug}` and expect to see both generated and standard designs verticalized.
2. Head to `/setup/designSetup?siteSlug=${site_slug}&flags=-signup/standard-theme-v13n` and expect to see just the generated designs verticalized.
