### PR TITLE
Unify owner deleting prevention for simple and atomic sites

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -309,7 +309,8 @@ class DeleteUser extends Component {
 	};
 
 	render() {
-		const { translate, isJetpack, isMultisite, siteOwner, user, currentUser } = this.props;
+		const { translate, isAtomic, isJetpack, isMultisite, siteOwner, user, currentUser } =
+			this.props;
 
 		// A user should not be able to remove themself.
 		if ( ! isJetpack && user.ID === currentUser.ID ) {
@@ -319,10 +320,10 @@ class DeleteUser extends Component {
 			return null;
 		}
 
-		// A user should not be able to remove the site owner.
+		// A user should not be able to remove the Atomic or non-Jetpack site owner.
 		if (
 			( ! isJetpack && user.ID === siteOwner ) ||
-			( isJetpack && user.linked_user_ID === siteOwner )
+			( isAtomic && user.linked_user_ID === siteOwner )
 		) {
 			return (
 				<Card className="delete-user__single-site">

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -223,36 +223,7 @@ class DeleteUser extends Component {
 	};
 
 	renderSingleSite = () => {
-		const { translate, isAtomic, isJetpack, siteOwner, user } = this.props;
-
-		// A user should not be able to remove the Atomic or non-Jetpack site owner.
-		if (
-			( ! isJetpack && user.ID === siteOwner ) ||
-			( isAtomic && user.linked_user_ID === siteOwner )
-		) {
-			return (
-				<Card className="delete-user__single-site">
-					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
-					<p className="delete-user__explanation">
-						{ translate(
-							'You cannot delete the site owner. Please transfer ownership of this site to a different account before deleting this user. {{supportLink}}Learn more.{{/supportLink}}',
-							{
-								components: {
-									supportLink: (
-										<InlineSupportLink
-											supportPostId={ 102743 }
-											supportLink={ localizeUrl(
-												'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
-											) }
-										/>
-									),
-								},
-							}
-						) }
-					</p>
-				</Card>
-			);
-		}
+		const { translate } = this.props;
 
 		return (
 			<Card className="delete-user__single-site">
@@ -338,15 +309,46 @@ class DeleteUser extends Component {
 	};
 
 	render() {
+		const { translate, isJetpack, isMultisite, siteOwner, user, currentUser } = this.props;
+
 		// A user should not be able to remove themself.
-		if ( ! this.props.isJetpack && this.props.user.ID === this.props.currentUser.ID ) {
+		if ( ! isJetpack && user.ID === currentUser.ID ) {
 			return null;
 		}
-		if ( this.props.isJetpack && this.props.user.linked_user_ID === this.props.currentUser.ID ) {
+		if ( isJetpack && user.linked_user_ID === currentUser.ID ) {
 			return null;
 		}
 
-		return this.props.isMultisite ? this.renderMultisite() : this.renderSingleSite();
+		// A user should not be able to remove the site owner.
+		if (
+			( ! isJetpack && user.ID === siteOwner ) ||
+			( isJetpack && user.linked_user_ID === siteOwner )
+		) {
+			return (
+				<Card className="delete-user__single-site">
+					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
+					<p className="delete-user__explanation">
+						{ translate(
+							'You cannot delete the site owner. Please transfer ownership of this site to a different account before deleting this user. {{supportLink}}Learn more.{{/supportLink}}',
+							{
+								components: {
+									supportLink: (
+										<InlineSupportLink
+											supportPostId={ 102743 }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
+											) }
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				</Card>
+			);
+		}
+
+		return isMultisite ? this.renderMultisite() : this.renderSingleSite();
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

Currently, when the admin user edits the Jetpack site's owner, we do not display the remove button, and we display informative text instead. For simple sites we don't display the text, and we still display the remove button. This PR implements it for simple sites too.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a simple site
2. Invite another user to the site as an Administrator
3. Accept the invitation, log in as the other user
4. Navigate to the site, then Users
5. Edit the site's owner user

Confirm that there is no "Remove" button there and that informative text is displayed:

![Screen Shot 2022-07-27 at 13 31 10](https://user-images.githubusercontent.com/727413/181244510-71b1a305-4577-4414-9161-92add49767df.png)

Test the same for Jetpack sites.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~~Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66011
