### PR TITLE
Revert "step-container: Stop blocking click events (#65971)"

### DIFF
--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -169,24 +169,10 @@ const StepContainer: React.FC< Props > = ( {
 				{ shouldStickyNavButtons && (
 					<WordPressLogo className="step-container__navigation-logo" size={ 24 } />
 				) }
-				{ ! hideBack && (
-					<div className="step-container__navigation-mouse">
-						<BackButton />
-					</div>
-				) }
-				{ ! hideSkip && skipButtonAlign === 'top' && (
-					<div className="step-container__navigation-mouse">
-						<SkipButton />
-					</div>
-				) }
-				{ ! hideNext && (
-					<div className="step-container__navigation-mouse">
-						<NextButton />
-					</div>
-				) }
-				{ customizedActionButtons && (
-					<div className="step-container__navigation-mouse">{ customizedActionButtons }</div>
-				) }
+				{ ! hideBack && <BackButton /> }
+				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
+				{ ! hideNext && <NextButton /> }
+				{ customizedActionButtons }
 			</ActionButtons>
 			{ ! hideFormattedHeader && (
 				<div className="step-container__header">

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -139,12 +139,6 @@
 	/**
 	 *	Navigation
 	 */
-	.step-container__navigation {
-		   pointer-events: none;
-	}
-	.step-container__navigation-mouse {
-		   pointer-events: auto;
-	}
 	.step-container__navigation.action-buttons {
 		background-color: $white;
 		height: 60px;


### PR DESCRIPTION
This reverts commit 85c98cc6718eb62153fe69f0b78fab910938ff7d.

#### Proposed Changes

* Revert "step-container: Stop blocking click events (#65971)"

#### Testing Instructions

* In the goals screen, the Skip To Dashboard link should be on the right side as originally intended in #64847
![screen_shot_2022-07-27_at_5 06 00_pm](https://user-images.githubusercontent.com/937354/181268018-7e05f182-05d9-4d4c-820b-a35d7b4704f9.png)

