### PR TITLE
Use white wp logo on VideoPress Onboarding Step Wrapper.

### DIFF
--- a/client/signup/videopress-step-wrapper/index.jsx
+++ b/client/signup/videopress-step-wrapper/index.jsx
@@ -77,7 +77,7 @@ function VideoPressStepWrapper( {
 				/>
 				<div className="videopress-step-wrapper__footer">
 					<img
-						src="/calypso/images/p2/w-logo.png"
+						src="/calypso/images/p2/w-logo-white.png"
 						className="videopress-step-wrapper__w-logo"
 						alt="WP.com logo"
 					/>

--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -59,11 +59,18 @@
 }
 
 .videopress-step-wrapper__middle {
+	display: flex;
+	flex-direction: column;
+
+	& .step-wrapper {
+		flex: 1;
+	}
+
 	background: var( --videopress-color-background-dark );
 	color: var( --videopress-color-text );
 	box-sizing: border-box;
 	margin: 0 auto;
-	height: 100vh;
+	height: calc( 100vh - 70px );
 	line-height: 1.8;
 	padding: 96px 1.5em 24px;
 
@@ -87,6 +94,10 @@
 	a {
 		color: var( --videopress-color-link );
 		text-decoration: none;
+
+		&:hover {
+			color: var( --videopress-color-link );
+		}
 	}
 
 	.videopress-step-wrapper__header-text {
@@ -150,6 +161,10 @@
 	background: var( --videopress-color-background-button );
 	color: #070707;
 	border-radius: 0;
+
+	&:hover {
+		color: #070707;
+	}
 }
 
 .videopress-step-wrapper__header-text {


### PR DESCRIPTION
#### Proposed Changes

Implements feedback related to the VideoPress step wrapper


> Looks great! A couple of small details:

>    The wpcom logo in the footer is dark, so it can't be seen over black background. Would it be possible to make it white? I believe we can just use w-logo-white.png.
>    The footer itself would look nicer if it's aligned to the bottom of the window if the content of the page is shorter than the viewport. What I'd do is to add display: flex; and flex-direction: column; to .videopress-step-wrapper__middle, and then add flex: 1; to .step-wrapper.
>    .videopress-step-wrapper__middle has height: 100vh;, but there's a 70px white topbar so it creates some unnecessary scroll. I think I'd try replacing the height for height: calc(100vh - 70px); although I haven't checked if that'd work on mobile!
 >   I'm not sure about the "Step 2 of 2" on the topbar, it may be misleading given that there'll be more steps afterwards. Should we just remove it?
 >   The hover color for links is a bit hard to read, as it's pretty dark. I think I'd keep var(--videopress-color-link); for hover too, at least for now.


* Use white wp logo on VideoPress Onboarding Step Wrapper.

#### Testing Instructions

* visit http://calypso.localhost:3000/start/videopress/user and there should be a white W logo at the footer.

Related to https://github.com/Automattic/wp-calypso/pull/65927
