### PR TITLE
step-container: Stop blocking click events (Redux)

### DIFF
--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -169,10 +169,24 @@ const StepContainer: React.FC< Props > = ( {
 				{ shouldStickyNavButtons && (
 					<WordPressLogo className="step-container__navigation-logo" size={ 24 } />
 				) }
-				{ ! hideBack && <BackButton /> }
-				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
-				{ ! hideNext && <NextButton /> }
-				{ customizedActionButtons }
+				{ ! hideBack && (
+					<div className="step-container__navigation-mouse">
+						<BackButton />
+					</div>
+				) }
+				{ ! hideSkip && skipButtonAlign === 'top' && (
+					<div className="step-container__navigation-mouse">
+						<SkipButton />
+					</div>
+				) }
+				{ ! hideNext && (
+					<div className="step-container__navigation-mouse">
+						<NextButton />
+					</div>
+				) }
+				{ customizedActionButtons && (
+					<div className="step-container__navigation-mouse">{ customizedActionButtons }</div>
+				) }
 			</ActionButtons>
 			{ ! hideFormattedHeader && (
 				<div className="step-container__header">

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -169,24 +169,10 @@ const StepContainer: React.FC< Props > = ( {
 				{ shouldStickyNavButtons && (
 					<WordPressLogo className="step-container__navigation-logo" size={ 24 } />
 				) }
-				{ ! hideBack && (
-					<div className="step-container__navigation-mouse">
-						<BackButton />
-					</div>
-				) }
-				{ ! hideSkip && skipButtonAlign === 'top' && (
-					<div className="step-container__navigation-mouse">
-						<SkipButton />
-					</div>
-				) }
-				{ ! hideNext && (
-					<div className="step-container__navigation-mouse">
-						<NextButton />
-					</div>
-				) }
-				{ customizedActionButtons && (
-					<div className="step-container__navigation-mouse">{ customizedActionButtons }</div>
-				) }
+				{ ! hideBack && <BackButton /> }
+				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
+				{ ! hideNext && <NextButton /> }
+				{ customizedActionButtons }
 			</ActionButtons>
 			{ ! hideFormattedHeader && (
 				<div className="step-container__header">

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -139,6 +139,12 @@
 	/**
 	 *	Navigation
 	 */
+	.step-container__navigation {
+		   pointer-events: none;
+	}
+	.step-container__navigation-mouse {
+		   pointer-events: auto;
+	}
 	.step-container__navigation.action-buttons {
 		background-color: $white;
 		height: 60px;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -140,10 +140,10 @@
 	 *	Navigation
 	 */
 	.step-container__navigation {
-		   pointer-events: none;
-	}
-	.step-container__navigation-mouse {
-		   pointer-events: auto;
+		pointer-events: none;
+		* {
+			pointer-events: auto;
+		}
 	}
 	.step-container__navigation.action-buttons {
 		background-color: $white;


### PR DESCRIPTION
#### Proposed Changes

Steps in stepper are in an absolute positioned div, where the middle of it is transparent:

![2022-07-25_16-59](https://user-images.githubusercontent.com/937354/180883299-2400e61e-6077-4d68-ab6e-fc874b5757ad.png)

If you try to select text in the title, you cannot, because the absolute positioned div is blocking the title under it:

https://user-images.githubusercontent.com/937354/180883364-83d0d333-e262-4fbe-8751-1e160e47f9b9.mp4

The same mechanism is blocking the mouseover for the tooltip in ( #65944 ).
This PR puts `pointer-events: none;` on the main absolute positioned div, and restores `pointer-events: auto;` on all descendants of that div.

**Implementation change vs last PR**: Instead of using wrapper divs to restore `pointer-events: auto`, we use CSS to select all descendants by putting a rule on `.step-container__navigation *`.


#### Testing Instructions

* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE.wordpress.com`
  * Click on a theme
  * You should now be able to click on and select the text in the title. On production, this will not work.

![2022-07-26_09-24](https://user-images.githubusercontent.com/937354/181030729-87ddec1e-a8c6-4d88-968d-341bdac57dba.png)

* [Important] Regression check
  * Try to use a variety of stepper features. The buttons at the top, like "Back", "Next",  "skip for now", "start with [theme]", and whatever else can display should always work
  * The biggest risk of this PR is that it inadvertently makes something that used to work in stepper now unclickable.
  * Also try different browser widths
* [Important] The regression reported here should no longer exist: https://github.com/Automattic/wp-calypso/pull/65971#issuecomment-1196908494
  * "Skip to Dashboard" on the `/setup/goals?siteSlug=YOURSITE.wordpress.com` page should continue to be on the top right
![2022-07-27_10-25](https://user-images.githubusercontent.com/937354/181289724-5f5856ba-f557-482e-87fb-162b92f72f45.png)


Related to #65944
