### PR TITLE
Plans: Update "free domain with plan" sidebar upsell to go to domains first

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -57,6 +57,7 @@ class DomainRegistrationSuggestion extends Component {
 		productCost: PropTypes.string,
 		productSaleCost: PropTypes.string,
 		isReskinned: PropTypes.bool,
+		domainAndPlanUpsellFlow: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -171,15 +172,23 @@ class DomainRegistrationSuggestion extends Component {
 	}
 
 	getPriceRule() {
-		const { cart, isDomainOnly, domainsWithPlansOnly, selectedSite, suggestion, flowName } =
-			this.props;
+		const {
+			cart,
+			isDomainOnly,
+			domainsWithPlansOnly,
+			selectedSite,
+			suggestion,
+			flowName,
+			domainAndPlanUpsellFlow,
+		} = this.props;
 		return getDomainPriceRule(
 			domainsWithPlansOnly,
 			selectedSite,
 			cart,
 			suggestion,
 			isDomainOnly,
-			flowName
+			flowName,
+			domainAndPlanUpsellFlow
 		);
 	}
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -54,6 +54,7 @@ class DomainSearchResults extends Component {
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
+		domainAndPlanUpsellFlow: PropTypes.bool,
 	};
 
 	renderDomainAvailability() {
@@ -274,6 +275,7 @@ class DomainSearchResults extends Component {
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
 					isReskinned={ this.props.isReskinned }
+					domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 				/>
 			);
 
@@ -302,6 +304,7 @@ class DomainSearchResults extends Component {
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
 						isReskinned={ this.props.isReskinned }
+						domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 					/>
 				);
 			} );

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -19,6 +19,7 @@ export class FeaturedDomainSuggestions extends Component {
 		showPlaceholders: PropTypes.bool,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
+		domainAndPlanUpsellFlow: PropTypes.bool,
 	};
 
 	getChildProps() {
@@ -33,6 +34,7 @@ export class FeaturedDomainSuggestions extends Component {
 			'selectedSite',
 			'pendingCheckSuggestion',
 			'unavailableDomains',
+			'domainAndPlanUpsellFlow',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -100,7 +100,9 @@ class MapDomainStep extends Component {
 							this.props.selectedSite,
 							this.props.cart,
 							suggestion,
-							false
+							false, // isDomainOnly
+							'', // flowName
+							false // domainAndPlanUpsellFlow
 						) }
 						price={ suggestion.cost }
 						isMappingProduct={ true }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -127,6 +127,7 @@ class RegisterDomainStep extends Component {
 		onSkip: PropTypes.func,
 		promoTlds: PropTypes.array,
 		showAlreadyOwnADomain: PropTypes.bool,
+		domainAndPlanUpsellFlow: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -1349,6 +1350,7 @@ class RegisterDomainStep extends Component {
 				onSkip={ this.props.onSkip }
 				showSkipButton={ this.props.showSkipButton }
 				isReskinned={ this.props.isReskinned }
+				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 			>
 				{ ! this.props.isReskinned &&
 					hasResults &&

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -810,7 +810,8 @@ export function getDomainPriceRule(
 		is_premium?: boolean;
 	},
 	isDomainOnly: boolean,
-	flowName: string
+	flowName: string,
+	domainAndPlanUpsellFlow: boolean
 ): string {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
@@ -822,6 +823,10 @@ export function getDomainPriceRule(
 
 	if ( isMonthlyOrFreeFlow( flowName ) ) {
 		return 'PRICE';
+	}
+
+	if ( domainAndPlanUpsellFlow ) {
+		return 'FREE_WITH_PLAN';
 	}
 
 	if ( isDomainBeingUsedForPlan( cart, suggestion.domain_name ) ) {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -242,6 +242,11 @@ describe( 'getDomainPriceRule()', () => {
 	} );
 
 	describe( 'general', () => {
+		test( 'should return FREE_WITH_PLAN for the domain and plan upsell flow', () => {
+			expect(
+				getDomainPriceRule( false, null, null, { product_slug: 'hi', cost: '14' }, false, '', true )
+			).toBe( 'FREE_WITH_PLAN' );
+		} );
 		test( 'should return FREE_DOMAIN when product slug is empty', () => {
 			expect( getDomainPriceRule( false, null, null, { product_slug: null, cost: '14' } ) ).toBe(
 				'FREE_DOMAIN'

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -75,8 +75,8 @@ const domainSearch = ( context, next ) => {
 					basePath={ sectionify( context.path ) }
 					context={ context }
 					domainAndPlanUpsellFlow={
-						context.query.addDomainFlow !== undefined
-							? context.query.addDomainFlow === 'true'
+						context.query.domainAndPlanPackage !== undefined
+							? context.query.domainAndPlanPackage === 'true'
 							: undefined
 					}
 				/>

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -71,7 +71,15 @@ const domainSearch = ( context, next ) => {
 			<PageViewTracker path="/domains/add/:site" title="Domain Search > Domain Registration" />
 			<DocumentHead title={ translate( 'Domain Search' ) } />
 			<CalypsoShoppingCartProvider>
-				<DomainSearch basePath={ sectionify( context.path ) } context={ context } />
+				<DomainSearch
+					basePath={ sectionify( context.path ) }
+					context={ context }
+					domainAndPlanUpsellFlow={
+						context.query.addDomainFlow !== undefined
+							? context.query.addDomainFlow === 'true'
+							: undefined
+					}
+				/>
 			</CalypsoShoppingCartProvider>
 		</Main>
 	);

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -130,7 +130,14 @@ class DomainSearch extends Component {
 		this.props.recordAddDomainButtonClick( domain, 'domains', isPremium );
 
 		if ( this.props.domainAndPlanUpsellFlow ) {
-			page( `/plans/${ this.props.selectedSiteSlug }?withProduct=${ productSlug }:${ domain }` );
+			// If we are in the domain + annual plan upsell flow, we need to redirect
+			// to the plans page next and let it know that we are still in that flow.
+			// We also need to provide the slug of the product we are adding so it
+			// can be added once the plan is selected.
+			const productAliasForCheckout = `${ productSlug }:${ domain }`;
+			page(
+				`/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=${ productAliasForCheckout }`
+			);
 			return;
 		}
 

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -59,6 +59,7 @@ class DomainSearch extends Component {
 		selectedSite: PropTypes.object,
 		selectedSiteId: PropTypes.number,
 		selectedSiteSlug: PropTypes.string,
+		domainAndPlanUpsellFlow: PropTypes.bool,
 	};
 
 	isMounted = false;
@@ -127,6 +128,11 @@ class DomainSearch extends Component {
 		} = suggestion;
 
 		this.props.recordAddDomainButtonClick( domain, 'domains', isPremium );
+
+		if ( this.props.domainAndPlanUpsellFlow ) {
+			page( `/plans/${ this.props.selectedSiteSlug }?withProduct=${ productSlug }:${ domain }` );
+			return;
+		}
 
 		let registration = domainRegistration( {
 			domain,

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -246,7 +246,9 @@ class DomainSearch extends Component {
 							noticeText={ translate( 'You must verify your email to register new domains.' ) }
 							noticeStatus="is-info"
 						>
-							{ ! hasPlanInCart && <NewDomainsRedirectionNoticeUpsell /> }
+							{ ! hasPlanInCart && ! this.props.domainAndPlanUpsellFlow && (
+								<NewDomainsRedirectionNoticeUpsell />
+							) }
 							<RegisterDomainStep
 								suggestion={ this.getInitialSuggestion() }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -248,6 +248,7 @@ class DomainSearch extends Component {
 							) }
 							<RegisterDomainStep
 								suggestion={ this.getInitialSuggestion() }
+								domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 								onAddDomain={ this.handleAddRemoveDomain }

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -129,18 +129,6 @@ class DomainSearch extends Component {
 
 		this.props.recordAddDomainButtonClick( domain, 'domains', isPremium );
 
-		if ( this.props.domainAndPlanUpsellFlow ) {
-			// If we are in the domain + annual plan upsell flow, we need to redirect
-			// to the plans page next and let it know that we are still in that flow.
-			// We also need to provide the slug of the product we are adding so it
-			// can be added once the plan is selected.
-			const productAliasForCheckout = `${ productSlug }:${ domain }`;
-			page(
-				`/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=${ productAliasForCheckout }`
-			);
-			return;
-		}
-
 		let registration = domainRegistration( {
 			domain,
 			productSlug,
@@ -149,6 +137,15 @@ class DomainSearch extends Component {
 
 		if ( supportsPrivacy ) {
 			registration = updatePrivacyForDomain( registration, true );
+		}
+
+		if ( this.props.domainAndPlanUpsellFlow ) {
+			// If we are in the domain + annual plan upsell flow, we need to redirect
+			// to the plans page next and let it know that we are still in that flow.
+			this.props.shoppingCartManager.addProductsToCart( [ registration ] ).then( () => {
+				page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
+			} );
+			return;
 		}
 
 		this.props.shoppingCartManager

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -300,7 +300,7 @@ export class PlanFeatures extends Component {
 	renderMobileView() {
 		const {
 			redirectToAddDomainFlow,
-			withProduct,
+			domainAndPlanPackage,
 			basePlansPath,
 			canPurchase,
 			isInSignup,
@@ -347,7 +347,7 @@ export class PlanFeatures extends Component {
 		let buttonText = null;
 		let forceDisplayButton = false;
 
-		if ( redirectToAddDomainFlow === true || withProduct ) {
+		if ( redirectToAddDomainFlow === true || domainAndPlanPackage ) {
 			buttonText = translate( 'Add to Cart' );
 			forceDisplayButton = true;
 		}
@@ -568,7 +568,7 @@ export class PlanFeatures extends Component {
 			selectedSiteSlug,
 			shoppingCartManager,
 			redirectToAddDomainFlow,
-			withProduct,
+			domainAndPlanPackage,
 		} = this.props;
 
 		const {
@@ -593,26 +593,10 @@ export class PlanFeatures extends Component {
 			return;
 		}
 
-		if ( withProduct ) {
+		if ( domainAndPlanPackage ) {
 			// In this flow we redirect to checkout with both the plan and domain
 			// product in the cart.
-			shoppingCartManager
-				.addProductsToCart( [
-					{
-						product_slug: productSlug,
-						extra: {
-							afterPurchaseUrl: redirectTo ?? undefined,
-						},
-					},
-				] )
-				.then( () => {
-					if ( withDiscount && this.isMounted ) {
-						return shoppingCartManager.applyCoupon( withDiscount );
-					}
-				} )
-				.then( () => {
-					this.isMounted && page( `/checkout/${ selectedSiteSlug }/${ withProduct }` );
-				} );
+			page( `/checkout/${ selectedSiteSlug }/${ productSlug },${ domainAndPlanPackage }` );
 			return;
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -300,6 +300,7 @@ export class PlanFeatures extends Component {
 	renderMobileView() {
 		const {
 			redirectToAddDomainFlow,
+			withProduct,
 			basePlansPath,
 			canPurchase,
 			isInSignup,
@@ -346,7 +347,7 @@ export class PlanFeatures extends Component {
 		let buttonText = null;
 		let forceDisplayButton = false;
 
-		if ( redirectToAddDomainFlow === true ) {
+		if ( redirectToAddDomainFlow === true || withProduct ) {
 			buttonText = translate( 'Add to Cart' );
 			forceDisplayButton = true;
 		}
@@ -567,6 +568,7 @@ export class PlanFeatures extends Component {
 			selectedSiteSlug,
 			shoppingCartManager,
 			redirectToAddDomainFlow,
+			withProduct,
 		} = this.props;
 
 		const {
@@ -588,6 +590,29 @@ export class PlanFeatures extends Component {
 
 		if ( siteIsPrivateAndGoingAtomic && isInSignup ) {
 			// Let signup do its thing
+			return;
+		}
+
+		if ( withProduct ) {
+			// In this flow we redirect to checkout with both the plan and domain
+			// product in the cart.
+			shoppingCartManager
+				.addProductsToCart( [
+					{
+						product_slug: productSlug,
+						extra: {
+							afterPurchaseUrl: redirectTo ?? undefined,
+						},
+					},
+				] )
+				.then( () => {
+					if ( withDiscount && this.isMounted ) {
+						return shoppingCartManager.applyCoupon( withDiscount );
+					}
+				} )
+				.then( () => {
+					this.isMounted && page( `/checkout/${ selectedSiteSlug }/${ withProduct }` );
+				} );
 			return;
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -596,7 +596,23 @@ export class PlanFeatures extends Component {
 		if ( domainAndPlanPackage ) {
 			// In this flow we redirect to checkout with both the plan and domain
 			// product in the cart.
-			page( `/checkout/${ selectedSiteSlug }/${ productSlug },${ domainAndPlanPackage }` );
+			shoppingCartManager
+				.addProductsToCart( [
+					{
+						product_slug: productSlug,
+						extra: {
+							afterPurchaseUrl: redirectTo ?? undefined,
+						},
+					},
+				] )
+				.then( () => {
+					if ( withDiscount && this.isMounted ) {
+						return shoppingCartManager.applyCoupon( withDiscount );
+					}
+				} )
+				.then( () => {
+					this.isMounted && page( `/checkout/${ selectedSiteSlug }` );
+				} );
 			return;
 		}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -178,6 +178,7 @@ export class PlansFeaturesMain extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isProfessionalEmailPromotionAvailable,
 			redirectToAddDomainFlow,
+			withProduct,
 			translate,
 			locale,
 		} = this.props;
@@ -226,6 +227,7 @@ export class PlansFeaturesMain extends Component {
 				{ this.renderSecondaryFormattedHeader() }
 				<PlanFeatures
 					redirectToAddDomainFlow={ redirectToAddDomainFlow }
+					withProduct={ withProduct }
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					domainName={ domainName }
@@ -437,7 +439,8 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { siteId, redirectToAddDomainFlow, shouldShowPlansFeatureComparison } = this.props;
+		const { siteId, redirectToAddDomainFlow, withProduct, shouldShowPlansFeatureComparison } =
+			this.props;
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
@@ -449,7 +452,7 @@ export class PlansFeaturesMain extends Component {
 
 		// In the "purchase a plan and free domain" flow we do not want to show
 		// monthly plans because monthly plans do not come with a free domain.
-		if ( redirectToAddDomainFlow !== undefined ) {
+		if ( redirectToAddDomainFlow !== undefined || withProduct ) {
 			hidePlanSelector = true;
 		}
 
@@ -488,6 +491,7 @@ export class PlansFeaturesMain extends Component {
 
 PlansFeaturesMain.propTypes = {
 	redirectToAddDomainFlow: PropTypes.bool,
+	withProduct: PropTypes.string,
 	basePlansPath: PropTypes.string,
 	hideFreePlan: PropTypes.bool,
 	hidePersonalPlan: PropTypes.bool,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -178,7 +178,7 @@ export class PlansFeaturesMain extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isProfessionalEmailPromotionAvailable,
 			redirectToAddDomainFlow,
-			withProduct,
+			domainAndPlanPackage,
 			translate,
 			locale,
 		} = this.props;
@@ -227,7 +227,7 @@ export class PlansFeaturesMain extends Component {
 				{ this.renderSecondaryFormattedHeader() }
 				<PlanFeatures
 					redirectToAddDomainFlow={ redirectToAddDomainFlow }
-					withProduct={ withProduct }
+					domainAndPlanPackage={ domainAndPlanPackage }
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					domainName={ domainName }
@@ -439,8 +439,12 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { siteId, redirectToAddDomainFlow, withProduct, shouldShowPlansFeatureComparison } =
-			this.props;
+		const {
+			siteId,
+			redirectToAddDomainFlow,
+			domainAndPlanPackage,
+			shouldShowPlansFeatureComparison,
+		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
@@ -452,7 +456,7 @@ export class PlansFeaturesMain extends Component {
 
 		// In the "purchase a plan and free domain" flow we do not want to show
 		// monthly plans because monthly plans do not come with a free domain.
-		if ( redirectToAddDomainFlow !== undefined || withProduct ) {
+		if ( redirectToAddDomainFlow !== undefined || domainAndPlanPackage ) {
 			hidePlanSelector = true;
 		}
 
@@ -491,7 +495,7 @@ export class PlansFeaturesMain extends Component {
 
 PlansFeaturesMain.propTypes = {
 	redirectToAddDomainFlow: PropTypes.bool,
-	withProduct: PropTypes.string,
+	domainAndPlanPackage: PropTypes.string,
 	basePlansPath: PropTypes.string,
 	hideFreePlan: PropTypes.bool,
 	hidePersonalPlan: PropTypes.bool,

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -39,6 +39,7 @@ export function plans( context, next ) {
 					? context.query.addDomainFlow === 'true'
 					: undefined
 			}
+			withProduct={ context.query.withProduct }
 		/>
 	);
 	next();

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -39,7 +39,7 @@ export function plans( context, next ) {
 					? context.query.addDomainFlow === 'true'
 					: undefined
 			}
-			withProduct={ context.query.withProduct }
+			domainAndPlanPackage={ context.query.domainAndPlanPackage }
 		/>
 	);
 	next();

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -52,6 +52,7 @@ const ProfessionalEmailPromotionWrapper = ( props ) => {
 	return (
 		<PlansFeaturesMain
 			redirectToAddDomainFlow={ props.redirectToAddDomainFlow }
+			withProduct={ props.withProduct }
 			hideFreePlan={ props.hideFreePlan }
 			customerType={ props.customerType }
 			intervalType={ props.intervalType }
@@ -72,6 +73,7 @@ class Plans extends Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
 		redirectToAddDomainFlow: PropTypes.bool,
+		withProduct: PropTypes.string,
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
@@ -163,6 +165,7 @@ class Plans extends Component {
 		return (
 			<ProfessionalEmailPromotionWrapper
 				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
+				withProduct={ this.props.withProduct }
 				hideFreePlan={ true }
 				customerType={ this.props.customerType }
 				intervalType={ this.props.intervalType }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -52,7 +52,7 @@ const ProfessionalEmailPromotionWrapper = ( props ) => {
 	return (
 		<PlansFeaturesMain
 			redirectToAddDomainFlow={ props.redirectToAddDomainFlow }
-			withProduct={ props.withProduct }
+			domainAndPlanPackage={ props.domainAndPlanPackage }
 			hideFreePlan={ props.hideFreePlan }
 			customerType={ props.customerType }
 			intervalType={ props.intervalType }
@@ -73,7 +73,7 @@ class Plans extends Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
 		redirectToAddDomainFlow: PropTypes.bool,
-		withProduct: PropTypes.string,
+		domainAndPlanPackage: PropTypes.string,
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
@@ -165,7 +165,7 @@ class Plans extends Component {
 		return (
 			<ProfessionalEmailPromotionWrapper
 				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
-				withProduct={ this.props.withProduct }
+				domainAndPlanPackage={ this.props.domainAndPlanPackage }
 				hideFreePlan={ true }
 				customerType={ this.props.customerType }
 				intervalType={ this.props.intervalType }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -72,10 +72,17 @@ const ProfessionalEmailPromotionWrapper = ( props ) => {
 
 function DomainAndPlanUpsellNotice() {
 	const translate = useTranslate();
-	const noticeText = translate(
-		'Almost there! Select an annual plan below to get your free domain.'
+	const noticeTitle = translate( 'Almost done' );
+	const noticeDescription = translate( 'Upgrade today to claim your free domain name!' );
+	return (
+		<Banner
+			title={ noticeTitle }
+			description={ noticeDescription }
+			icon="star"
+			showIcon
+			disableHref
+		/>
 	);
-	return <Banner description={ noticeText } icon="star" showIcon disableHref />;
 }
 
 class Plans extends Component {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,11 +2,12 @@ import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, getIntervalTypeForTerm, PLAN_FREE } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { addQueryArgs } from '@wordpress/url';
-import { localize } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -68,6 +69,14 @@ const ProfessionalEmailPromotionWrapper = ( props ) => {
 		/>
 	);
 };
+
+function DomainAndPlanUpsellNotice() {
+	const translate = useTranslate();
+	const noticeText = translate(
+		'Almost there! Select an annual plan below to get your free domain.'
+	);
+	return <Banner description={ noticeText } icon="star" showIcon disableHref />;
+}
 
 class Plans extends Component {
 	static propTypes = {
@@ -182,7 +191,8 @@ class Plans extends Component {
 	}
 
 	render() {
-		const { selectedSite, translate, canAccessPlans, currentPlan } = this.props;
+		const { selectedSite, translate, canAccessPlans, currentPlan, domainAndPlanPackage } =
+			this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
 			return this.renderPlaceholder();
@@ -213,6 +223,7 @@ class Plans extends Component {
 								subHeaderText={ description }
 								align="left"
 							/>
+							{ domainAndPlanPackage && <DomainAndPlanUpsellNotice /> }
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />
 								{ this.renderPlansMain() }


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/51609, we updated the "Free domain with annual plan" sidebar upsell nudge to direct users to pick a plan before searching for a domain (instead of adding one silently in the background). This was to address user confusion and refund requests. However, since the primary goal of users clicking on that upsell is to get a domain, the intervening plans page can itself be confusing.

**The current flow is: Upsell button > Plans page > Domain search > (maybe) Email upsell > Checkout.**

In this PR we modify the upsell flow so that we go to the domains search page first, then the plans page, then directly to checkout. 

**The new flow is: Upsell button > Domain search > Plans page > Checkout.**

There are a few other differences as well:

1. An informational banner will be displayed on the plans page to explain that we are in the upsell flow (see the screenshot below).
2. The email upsell after selecting a domain is skipped in this flow to simplify the steps as requested in https://github.com/Automattic/wp-calypso/issues/66017. 

Some possible problems with this change:

- The plans page supports a `redirectTo` prop that would be used by checkout after the product has been added. This flow will ignore that prop, but since it is added by the `?redirect_to=` query string and this flow is started from a hard-coded link I don't think they will ever be combined.
- The plans page supports a `withDiscount` prop to add a coupon to the cart along with the plan. This flow will ignore that prop, but since it is added by the `?discount=` query string and this flow is started from a hard-coded link I don't think they will ever be combined.
- If you select a domain transfer or domain mapping from the domains search page, you'll effectively leave the upsell flow and will not end up on the plans page when adding the domain product is complete.

Fixes https://github.com/Automattic/wp-calypso/issues/66017

This must be merged first, but the change will not be active until D84928-code is merged to change where the upsell link goes.

#### Screenshots

<img width="272" alt="Screen Shot 2022-07-27 at 12 13 11 PM" src="https://user-images.githubusercontent.com/2036909/181299569-cf2cb735-6058-4fe1-95ff-7ec9bbb48762.png">

<img width="955" alt="Screen Shot 2022-07-28 at 6 03 36 PM" src="https://user-images.githubusercontent.com/2036909/181645073-9663ceb9-c0dc-4a87-b978-0bf68fc20bd0.png">

<img width="1053" alt="Screen Shot 2022-07-27 at 1 37 27 PM" src="https://user-images.githubusercontent.com/2036909/181313056-29173f31-a26d-4d02-a6d7-16cdfbc80f84.png">

#### Testing Instructions

- First, apply D84928-code and sandbox the API.
- Start with a site that has no paid plan.
- Visit the customer home page for the site, eg: http://calypso.localhost:3000/home/example.com
- Click the "Upgrade" button in the sidebar notification that reads "Free domain with an annual plan" (see first screenshot above).
- Verify that you are redirected to the domains page for your site (see second screenshot above).
- Click to select a domain.
- Verify that you are redirected to the plans page (see third screenshot above).
- Click the "Upgrade" button on a plan's card to select that plan.
- Verify that you arrive at checkout with both the plan and the domain in your cart.