### PR TITLE
Checkout: use hidden radio buttons for wpcom product variant picker

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
@@ -1,8 +1,14 @@
 import { FunctionComponent } from 'react';
 import { ItemVariationDropDown } from './item-variation-dropdown';
+import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
 
-export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
+export const ItemVariationPicker: FunctionComponent<
+	ItemVariationPickerProps & { type: 'dropdown' | 'radio' }
+> = ( props ) => {
+	if ( props.type === 'radio' ) {
+		return <ItemVariationRadioButtons { ...props } />;
+	}
 	return <ItemVariationDropDown { ...props } />;
 };
 

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,0 +1,94 @@
+import { RadioButton } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
+import { ItemVariantPrice } from './variant-price';
+import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+const TermOptions = styled.ul`
+	flex-basis: 100%;
+	margin: 20px 0 0;
+	padding: 0;
+`;
+
+const TermOptionsItem = styled.li`
+	margin: 8px 0 0;
+	padding: 0;
+	list-style: none;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+interface ProductVariantProps {
+	productVariant: WPCOMProductVariant;
+	selectedItem: ResponseCartProduct;
+	onChangeItemVariant: OnChangeItemVariant;
+	isDisabled: boolean;
+	compareTo?: WPCOMProductVariant;
+}
+
+const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
+	productVariant,
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	compareTo,
+} ) => {
+	const translate = useTranslate();
+	const { variantLabel, productSlug, productId } = productVariant;
+	const selectedProductSlug = selectedItem.product_slug;
+	const isChecked = productSlug === selectedProductSlug;
+
+	return (
+		<TermOptionsItem>
+			<RadioButton
+				name={ productSlug + variantLabel }
+				id={ productSlug + variantLabel }
+				value={ productSlug }
+				checked={ isChecked }
+				disabled={ isDisabled }
+				onChange={ () => {
+					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+				} }
+				ariaLabel={ translate( 'Select a different term length' ) as string }
+				label={ <ItemVariantPrice variant={ productVariant } compareTo={ compareTo } /> }
+				children={ [] }
+			/>
+		</TermOptionsItem>
+	);
+};
+
+export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	siteId,
+	productSlug,
+} ) => {
+	const variants = useGetProductVariants( siteId, productSlug );
+
+	if ( variants.length < 2 ) {
+		return null;
+	}
+
+	const compareTo = variants[ 0 ];
+
+	return (
+		<TermOptions className="item-variation-picker">
+			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
+				<ProductVariant
+					key={ productVariant.productSlug + productVariant.variantLabel }
+					selectedItem={ selectedItem }
+					onChangeItemVariant={ onChangeItemVariant }
+					isDisabled={ isDisabled }
+					productVariant={ productVariant }
+					compareTo={ compareTo }
+				/>
+			) ) }
+		</TermOptions>
+	);
+};

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,4 +1,4 @@
-import { isPremium } from '@automattic/calypso-products';
+import { isJetpackPurchasableItem, isPremium } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import {
 	canItemBeRemovedFromCart,
@@ -82,6 +82,9 @@ export function WPOrderReviewLineItems( {
 		coupon: responseCart.coupon,
 		products: responseCart.products,
 	} );
+	const isJetpack = responseCart.products.some( ( product ) =>
+		isJetpackPurchasableItem( product.product_slug )
+	);
 
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
@@ -113,6 +116,7 @@ export function WPOrderReviewLineItems( {
 									isDisabled={ isDisabled }
 									siteId={ siteId }
 									productSlug={ product.product_slug }
+									type={ isJetpack ? 'dropdown' : 'radio' }
 								/>
 							) }
 						</LineItem>


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/65374 we modified the wpcom checkout product term variant picker to use a drop-down list in the same manner as the Jetpack product variant picker. Mostly this was so that the variant picker itself was no longer hidden behind the first step's "Edit" button, which could easily be overlooked. However, the drop-down doesn't give as good a comparison of the product prices. 

This PR is an experiment to switch back to radio buttons but keep the step from having an "Edit" button. To preserve vertical space, this adds a new "Edit" button _just for the line item_ instead.

This is part of the work being discussed in https://github.com/Automattic/wp-calypso/issues/65968

Before:

<img width="626" alt="Screen Shot 2022-07-26 at 6 51 04 PM" src="https://user-images.githubusercontent.com/2036909/181125827-d1cccdf2-59bd-477b-a030-81fbe5006980.png">


After:

<img width="563" alt="Screen Shot 2022-07-28 at 3 25 01 PM" src="https://user-images.githubusercontent.com/2036909/181620912-6c58a136-ce09-480f-9833-5326a471ed87.png">

<img width="565" alt="Screen Shot 2022-07-28 at 3 25 07 PM" src="https://user-images.githubusercontent.com/2036909/181620930-26b873e6-0411-4661-84a7-942da96918d1.png">

Requires https://github.com/Automattic/wp-calypso/pull/65998

#### Testing Instructions

- Add a product to the cart which has term variants (eg: any legacy plan like Premium).
- Visit checkout and verify that you see the variant picker as a list of radio buttons.
- Click to change the currently selected term variant and verify that the price changes as expected.