### PR TITLE
Checkout: Add reason for cart item discounts

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -331,10 +331,9 @@ export interface ResponseCart< P = ResponseCartProduct > {
 }
 
 export interface ProductCostOverride {
-	price: number;
+	new_price: number;
+	old_price: number;
 	reason: string;
-	user_facing_reason: string;
-	discount: number;
 }
 
 export interface ResponseCartTaxData {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -330,6 +330,13 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	has_pending_payment?: boolean;
 }
 
+export interface ProductCostOverride {
+	price: number;
+	reason: string;
+	user_facing_reason: string;
+	discount: number;
+}
+
 export interface ResponseCartTaxData {
 	location: {
 		country_code?: string;
@@ -514,6 +521,7 @@ export interface ResponseCartProduct {
 	is_renewal?: boolean;
 	subscription_id?: string;
 	introductory_offer_terms?: IntroductoryOfferTerms;
+	cost_overrides?: ProductCostOverride[];
 
 	// Temporary optional properties for the monthly pricing test
 	related_monthly_plan_cost_display?: string;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -31,6 +31,7 @@ import { isWpComProductRenewal } from './is-wpcom-product-renewal';
 import { joinClasses } from './join-classes';
 import { getPartnerCoupon } from './partner-coupon';
 import IonosLogo from './partner-logo-ionos';
+import { PriceOverrideList } from './price-override-list';
 import type {
 	GSuiteProductUser,
 	ResponseCart,
@@ -893,6 +894,7 @@ function WPLineItem( {
 					<FirstTermDiscountCallout product={ product } />
 					<CouponDiscountCallout product={ product } />
 					<IntroductoryOfferCallout product={ product } />
+					<PriceOverrideList product={ product } />
 				</LineItemMeta>
 			) }
 

--- a/packages/wpcom-checkout/src/price-override-list.tsx
+++ b/packages/wpcom-checkout/src/price-override-list.tsx
@@ -1,0 +1,18 @@
+import type { ResponseCartProduct, ProductCostOverride } from '@automattic/shopping-cart';
+
+export function PriceOverrideList( { product }: { product: ResponseCartProduct } ) {
+	if ( ! product.cost_overrides || product.cost_overrides.length < 1 ) {
+		return null;
+	}
+	return (
+		<div>
+			{ product.cost_overrides.map( ( override ) => (
+				<PriceOverride override={ override } />
+			) ) }
+		</div>
+	);
+}
+
+function PriceOverride( { override }: { override: ProductCostOverride } ) {
+	return <div>{ override.user_facing_reason }</div>;
+}

--- a/packages/wpcom-checkout/src/price-override-list.tsx
+++ b/packages/wpcom-checkout/src/price-override-list.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import type { ResponseCartProduct, ProductCostOverride } from '@automattic/shopping-cart';
 
 export function PriceOverrideList( { product }: { product: ResponseCartProduct } ) {
@@ -14,5 +15,23 @@ export function PriceOverrideList( { product }: { product: ResponseCartProduct }
 }
 
 function PriceOverride( { override }: { override: ProductCostOverride } ) {
-	return <div>{ override.user_facing_reason }</div>;
+	const translate = useTranslate();
+	const percentage = 100 - ( override.new_price / override.old_price ) * 100;
+	switch ( override.reason ) {
+		case 'upsell_bundle_apply_discount':
+			return (
+				<div>{ translate( 'Prorated discount %(percentage)d%%', { args: { percentage } } ) }</div>
+			);
+		case 'domain volume discount':
+			return (
+				<div>
+					{ translate( 'Multiple domain discount %(percentage)d%%', { args: { percentage } } ) }
+				</div>
+			);
+		case 'apply_sale_coupon':
+			return <div>{ translate( 'Discount %(percentage)d%%', { args: { percentage } } ) }</div>;
+		case 'bundled domain credit':
+			return <div>{ translate( 'Bundled domain' ) }</div>;
+	}
+	return null;
 }


### PR DESCRIPTION
#### Proposed Changes

When the shopping-cart endpoint returns a list of the current cart items, each one includes an array of cost overrides that have been applied during the calculation of the price (as of D85024-code).

This PR is an experiment that adds a list of some of those overrides to checkout's line item display. Some of them include a percentage discount, and some include only a reason.

This is part of the work being discussed in https://github.com/Automattic/wp-calypso/issues/65968

**NOTE: this could use some design review and also how it should overlap with https://github.com/Automattic/wp-calypso/pull/66031**

Before: 

<img width="564" alt="Screen Shot 2022-07-27 at 6 54 50 PM" src="https://user-images.githubusercontent.com/2036909/181386275-e2c09e51-3f24-46e1-ab53-4c709ada63f1.png">

After:

<img width="564" alt="Screen Shot 2022-07-27 at 6 51 32 PM" src="https://user-images.githubusercontent.com/2036909/181386168-c1a75715-c8fd-4049-b065-784541b19501.png">

#### Testing Instructions

This currently includes four kinds of discount reasons that will be displayed in the cart. Each one can be tested by following the below steps:

- To get a prorated discount, purchase a plan, then add a higher level plan to your cart (eg: purchase Personal and then add Premium to the cart).
- To get a domain volume discount, add more than 3 domain registrations to your cart at once.
- To get a bundled domain credit, add a plan and a domain to your cart at the same time.
- I'm not sure of any way to get a sale coupon.