### PR TITLE
Checkout: Add term variant discount sublabel to each line item

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
@@ -7,3 +7,4 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 };
 
 export * from './types';
+export * from './item-variation-discount-sublabel';

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-discount-sublabel.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-discount-sublabel.tsx
@@ -1,0 +1,60 @@
+import { Theme } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { useGetProductVariants } from '../../hooks/product-variants';
+import { getDiscountPercentageBetweenVariants } from './variant-price';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+const LineItemMeta = styled.div< { theme?: Theme } >`
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	font-size: 14px;
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	align-content: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 2px 10px;
+`;
+
+export function ItemVariationDiscountSublabel( {
+	product,
+	siteId,
+}: {
+	product: ResponseCartProduct;
+	siteId: number | undefined;
+} ) {
+	const variants = useGetProductVariants( siteId, product.product_slug );
+	const translate = useTranslate();
+	const variantForProduct = variants.find(
+		( variant ) => variant.productId === product.product_id
+	);
+	if ( ! variantForProduct ) {
+		return null;
+	}
+	const compareTo = variants[ 0 ];
+	const discountPercentage = getDiscountPercentageBetweenVariants( variantForProduct, compareTo );
+
+	if ( discountPercentage < 1 ) {
+		return null;
+	}
+	if ( variantForProduct.termIntervalInMonths === 12 ) {
+		return (
+			<LineItemMeta>
+				{ translate( 'Annual discount: %(discountPercentage)d%%', {
+					args: { discountPercentage },
+				} ) }
+			</LineItemMeta>
+		);
+	}
+	if ( variantForProduct.termIntervalInMonths === 24 ) {
+		return (
+			<LineItemMeta>
+				{ translate( 'Biennial discount: %(discountPercentage)d%%', {
+					args: { discountPercentage },
+				} ) }
+			</LineItemMeta>
+		);
+	}
+	return null;
+}

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -13,7 +13,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
-import { ItemVariationPicker } from './item-variation-picker';
+import { ItemVariationPicker, ItemVariationDiscountSublabel } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
 import type {
@@ -106,6 +106,9 @@ export function WPOrderReviewLineItems( {
 							onRemoveProductClick={ onRemoveProductClick }
 							onRemoveProductCancel={ onRemoveProductCancel }
 						>
+							{ shouldShowVariantSelector && (
+								<ItemVariationDiscountSublabel product={ product } siteId={ siteId } />
+							) }
 							{ shouldShowVariantSelector && (
 								<ItemVariationPicker
 									selectedItem={ product }


### PR DESCRIPTION
#### Proposed Changes

This PR adds a new sublabel to each checkout line item which has billing term variants (eg: monthly, annual, etc.). The new label compares the product's current price to the lowest available variant (typically the monthly version) and displays the percentage as a discount. (Note that these are not actual "discounts" in the sense that they are not modifications of the product price; each variant is its own product with its own price. These are just comparisons of those prices.)

This is part of the work being discussed in https://github.com/Automattic/wp-calypso/issues/65968

**NOTE: This could use some design review and also how it should overlap with https://github.com/Automattic/wp-calypso/pull/66029**

For example, here we have an annual Personal plan, which costs $48. Its monthly variant costs $7. Since 7 * 12 = 84 (the amount the user would pay in a year if they chose the monthly plan instead), this is a cost savings of 42%, which is displayed below the line item:

<img width="569" alt="Screen Shot 2022-07-27 at 7 43 17 PM" src="https://user-images.githubusercontent.com/2036909/181391279-8bd80ff1-063e-4701-84dc-3ebcd302296f.png">

Here's the same situation when selecting the biennial variant:

<img width="573" alt="Screen Shot 2022-07-27 at 7 51 06 PM" src="https://user-images.githubusercontent.com/2036909/181391535-a147164f-44b6-49e1-9523-3827f3bacf0a.png">

Selecting the monthly variant will not display any discount, but the variant picker will display the discounts for the other variants:

<img width="570" alt="Screen Shot 2022-07-27 at 7 52 11 PM" src="https://user-images.githubusercontent.com/2036909/181391628-9ac9bcdd-fadc-4ed0-9f17-63bac611aa22.png">

#### Testing Instructions

- Add a plan to your cart that has term variants (eg: any legacy plan like Premium).
- Visit checkout.
- Select different billing term variants using the variant selector and verify that for each one, a discount percentage compared to the lowest available variant is displayed (if there is one).