### PR TITLE
Theme Subscription: Added meta handling for theme subscription

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -97,6 +97,7 @@ import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { getThemeNameFromMeta } from 'calypso/state/themes/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
@@ -875,6 +876,12 @@ class ManagePurchase extends Component {
 			preventRenewal = ! isRenewable( purchase );
 		}
 
+		let theme = null;
+		if ( isPurchaseTheme ) {
+			const themeId = getThemeNameFromMeta( purchase.meta );
+			theme = <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } />;
+		}
+
 		return (
 			<Fragment>
 				<QueryStoredCards />
@@ -887,7 +894,7 @@ class ManagePurchase extends Component {
 					selectedSiteId={ this.props.selectedSiteId }
 				/>
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
-				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
+				{ theme }
 
 				<HeaderCake backHref={ this.props.purchaseListUrl }>
 					{ this.props.cardTitle || titles.managePurchase }
@@ -1002,6 +1009,11 @@ export default connect(
 		const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
 		const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
 		const relatedMonthlyPlanPrice = getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug );
+		let theme;
+		if ( isPurchaseTheme ) {
+			const themeId = getThemeNameFromMeta( purchase.meta );
+			theme = getCanonicalTheme( state, siteId, themeId );
+		}
 		return {
 			hasLoadedDomains,
 			hasLoadedSites,
@@ -1023,7 +1035,7 @@ export default connect(
 			renewableSitePurchases,
 			plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, undefined ),
 			isPurchaseTheme,
-			theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
+			theme,
 			isAtomicSite: isSiteAtomic( state, siteId ),
 			relatedMonthlyPlanSlug,
 			relatedMonthlyPlanPrice,

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -70,6 +70,7 @@ import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
 import { requestThenActivate } from 'calypso/state/themes/actions';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
+import { getThemeNameFromMeta } from 'calypso/state/themes/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AtomicStoreThankYouCard from './atomic-store-thank-you-card';
 import BloggerPlanDetails from './blogger-plan-details';
@@ -275,7 +276,7 @@ export class CheckoutThankYou extends Component {
 			purchases.length > 0 &&
 			purchases.every( isTheme )
 		) {
-			const themeId = purchases[ 0 ].meta;
+			const themeId = getThemeNameFromMeta( purchases[ 0 ].meta );
 			// Mark that we've done the redirect, and do the actual redirect once the state is recorded
 			this.setState( { didThemeRedirect: true }, () => {
 				this.props.requestThenActivate( themeId, this.props.selectedSite.ID, 'calypstore', true );

--- a/client/state/themes/selectors/is-theme-purchased.js
+++ b/client/state/themes/selectors/is-theme-purchased.js
@@ -15,7 +15,7 @@ import 'calypso/state/themes/init';
  */
 export function isThemePurchased( state, themeId, siteId ) {
 	const sitePurchases = getSitePurchases( state, siteId );
-	return sitePurchases.find( ( purchase ) => {
+	return !! sitePurchases.find( ( purchase ) => {
 		if ( purchase?.productSlug === 'premium_theme' ) {
 			const purchaseThemeId = getThemeNameFromMeta( purchase.meta );
 			return themeId === purchaseThemeId;

--- a/client/state/themes/selectors/is-theme-purchased.js
+++ b/client/state/themes/selectors/is-theme-purchased.js
@@ -15,7 +15,7 @@ import 'calypso/state/themes/init';
  */
 export function isThemePurchased( state, themeId, siteId ) {
 	const sitePurchases = getSitePurchases( state, siteId );
-	return !! sitePurchases.find( ( purchase ) => {
+	return sitePurchases.some( ( purchase ) => {
 		if ( purchase?.productSlug === 'premium_theme' ) {
 			const purchaseThemeId = getThemeNameFromMeta( purchase.meta );
 			return themeId === purchaseThemeId;

--- a/client/state/themes/selectors/is-theme-purchased.js
+++ b/client/state/themes/selectors/is-theme-purchased.js
@@ -1,5 +1,5 @@
-import { some } from 'lodash';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getThemeNameFromMeta } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
 
@@ -15,5 +15,11 @@ import 'calypso/state/themes/init';
  */
 export function isThemePurchased( state, themeId, siteId ) {
 	const sitePurchases = getSitePurchases( state, siteId );
-	return some( sitePurchases, { productSlug: 'premium_theme', meta: themeId } );
+	return sitePurchases.find( ( purchase ) => {
+		if ( purchase?.productSlug === 'premium_theme' ) {
+			const purchaseThemeId = getThemeNameFromMeta( purchase.meta );
+			return themeId === purchaseThemeId;
+		}
+		return false;
+	} );
 }

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -250,8 +250,7 @@ export function getThemeTaxonomySlugs( theme, taxonomy ) {
  * @returns {string} The theme name.
  */
 export function getThemeNameFromMeta( meta ) {
-	const hasBillingPeriod =
-		meta.endsWith( '-monthly' ) || meta.endsWith( '-yearly' );
+	const hasBillingPeriod = meta.endsWith( '-monthly' ) || meta.endsWith( '-yearly' );
 
 	if ( ! hasBillingPeriod ) return meta;
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -251,7 +251,7 @@ export function getThemeTaxonomySlugs( theme, taxonomy ) {
  */
 export function getThemeNameFromMeta( meta ) {
 	const hasBillingPeriod =
-		meta.lastIndexOf( '-monthly' ) > -1 || meta.lastIndexOf( '-yearly' ) > -1;
+		meta.endsWith( '-monthly' ) || meta.endsWith( '-yearly' );
 
 	if ( ! hasBillingPeriod ) return meta;
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -242,3 +242,19 @@ export function getThemeTaxonomySlugs( theme, taxonomy ) {
 	const items = get( theme, [ 'taxonomies', taxonomy ], [] );
 	return items.map( ( { slug } ) => slug );
 }
+
+/**
+ * Returns the theme name extract from meta.
+ *
+ * @param  {string}  meta The purchase meta.
+ * @returns {string} The theme name.
+ */
+export function getThemeNameFromMeta( meta ) {
+	const hasBillingPeriod =
+		meta.lastIndexOf( '-monthly' ) > -1 || meta.lastIndexOf( '-yearly' ) > -1;
+
+	if ( ! hasBillingPeriod ) return meta;
+
+	const lastIndex = meta.lastIndexOf( '-' );
+	return meta.slice( 0, lastIndex );
+}


### PR DESCRIPTION
This PR works together with D84731-code.

It adds a helper function to extract the theme name from the purchase meta, which now includes the billing period:
`<theme-slug>-<yearly|monthly>`

It also makes use of this function when dealing with theme subscription activation.

It shouldn't have any problems with current purchases.

Testing instruction on the diff.