### PR TITLE
Global Styles Tracking: Customize debounce function

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -226,7 +226,7 @@ const buildGlobalStylesEventProps = ( keyMap, value ) => {
 let lastCalled;
 let originalGSObject;
 let functionTimeoutId;
-const debounceTimer = 300;
+const debounceTimer = 500;
 /**
  * Builds and sends tracks events for global styles changes. Debouncing is necessary to avoid
  * spamming tracks events with updates when sliding inputs such as a color picker are in use,


### PR DESCRIPTION
### Context

Fixes #58118

We had previously added debouncing to global styles Tracks events. This prevents spamming Tracks events when using continuous controls like sliders or color pickers. However, some controls change multiple styles at the same time, and thus simultaneously triggering multiple Tracks events. Because of debouncing, such simultaneous events are not tracked correctly - only the last event is tracked.

You can see this issue by going to Site Editor > Global Styles > Text and changing Appearance, which updates both font weight and font style at the same time: 

![global styles - text - appearance](https://user-images.githubusercontent.com/21228350/181137678-834cb9f1-e890-47db-9122-306e7b323a2b.png)

### Proposed Changes

1) To solve the original problem, we refactored from lodash debounce to a custom debounce method that uses some specific timing checks and other logic to evaluate when to debounce, and to ensure the right global styles are ultimately updated.

2) We found a separate bug where debouncing wasn't working (even on trunk) when the debounce time was set too low. To address that, we've increased the debounce time from 100ms to 500ms. 

### Testing Instructions

**Set up.**

- Checkout this branch. Run yarn install from the the calypso root and yarn dev --sync from the wpcom-block-editor directory.
- Ensure you are sandboxing widgets.
- Ensure you can see tracks events. You can do this by installing the [Tracks Vigilante Chrome extension](https://github.com/Automattic/tracks-chrome-extension), or by opening your dev tools, going to the Network tab, and filtering for `t.gif`. This will filter network activity so you just see Tracks events.

**Tests.**

1) Go to the site editor. 

2) Test that there are no regressive breakages. 
- Test a simple change to confirm normal tracking is still working. Go to Site Editor > Global Styles > Typography > Text, and update the font family. Confirm that a wpcom_block_editor_global_styles_update event shows with appropriate meta data. 
- Confirm that debouncing is still working. Go to Site Editor > Global Styles > Colors, select Background Color, and try sliding the color picker around for a while. You should only see a wpcom_block_editor_global_styles_update event when you stop moving for a bit. If debouncing is not working correctly, you'll see events being constantly emitted as you slide the color picker around. 

3) Test the fix. Go to Site Editor > Global Styles > Typography > Text and update Appearance. Be sure to select an option that changes both font weight and font style (ie, default to "Light Italic", or "Light Italic" to just "Bold"). Confirm that TWO wpcom_block_editor_global_styles_update events now show in the network tab, one for fontWeight and one for fontStyle. 

### Other

Co-Authored-By: @edanzer 