### PR TITLE
Enable homepage replace modal on Atomic

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -165,7 +165,7 @@
 		"signup/standard-theme-v13n": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
-		"themes/atomic-homepage-replace": false,
+		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"titan/iframe-control-panel": false,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -112,7 +112,7 @@
 		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
-		"themes/atomic-homepage-replace": false,
+		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -127,7 +127,7 @@
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,
-		"themes/atomic-homepage-replace": false,
+		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -126,7 +126,7 @@
 		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
-		"themes/atomic-homepage-replace": false,
+		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,7 +136,7 @@
 		"signup/standard-theme-v13n": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
-		"themes/atomic-homepage-replace": false,
+		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
This diff enables the homepage replacement modal on Atomic.

### Testing 
1. Apply this diff.
2. Go to an Atomic site.
3. Navigate to `/themes/[YOUR_SITE]`.
4. Select a theme and click on `Activate`.
5. Verify you see the modal.
6. Verify both options work as they do on Simple.

For some themes it might appear to not work but it's a different issue that also happens on Simple, for more info about this see the comments at paYKcK-1Wj-p2

Closes https://github.com/Automattic/wp-calypso/issues/56869