### PR TITLE
Help Center: Fix events bugs and increase the size of the user pool to 30%

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -389,7 +389,7 @@ function load_help_center() {
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
-	$current_segment = 10; // segment of existing users that will get the help center in %.
+	$current_segment = 30; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 
 	if ( $is_proxied || $user_segment < $current_segment ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -31,7 +31,7 @@ function HelpCenterContent() {
 	}, [ data, isLoading ] );
 
 	const handleToggleHelpCenter = () => {
-		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'open' }`, {
+		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -22,20 +22,18 @@ export const HelpCenterEmbedResult: React.FC = () => {
 	const postId = state?.post_id ?? params.get( 'postId' );
 	const blogId = state?.blog_id ?? params.get( 'blogId' );
 	const link = state?.link ?? params.get( 'link' );
+	const query = state?.query ?? params.get( 'query' );
 
 	useEffect( () => {
-		if ( state ) {
-			const { query, link } = state;
-			const tracksData = {
-				search_query: query,
-				location: 'help-center',
-				section: sectionName,
-				result_url: link,
-			};
+		const tracksData = {
+			search_query: query,
+			location: 'help-center',
+			section: sectionName,
+			result_url: link,
+		};
 
-			recordTracksEvent( `calypso_inlinehelp_article_open`, tracksData );
-		}
-	}, [ state, sectionName ] );
+		recordTracksEvent( `calypso_inlinehelp_article_open`, tracksData );
+	}, [ query, link, sectionName ] );
 
 	const redirectToSearchOrHome = () => {
 		if ( state?.query ) {

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -22,7 +22,7 @@ const wpcomAllowedOrigins = [
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
 export function shouldShowHelpCenterToUser( userId: number ) {
-	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
+	const currentSegment = 30; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
 	return userSegment < currentSegment;
 }


### PR DESCRIPTION
#### Proposed Changes

* This fixes the open event to make it identical to the inline help's (change `open` to `show`).
* Fixes the article view event as it was only firing when Router's location `state` is defined, which is only one way we determine which article was opened.
* Changes the user pool to 30%. 

#### Testing Instructions

Only the article event needs testing. In the help center, open an article, an event should fire.
