### PR TITLE
Update spacing for design preview title

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -213,7 +213,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			}
 
 			@include break-mobile {
-				margin: 12px 0 24px;
+				margin: 20px 0 24px;
 				transform: translateY( -58px );
 				min-height: 42px;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -213,7 +213,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			}
 
 			@include break-mobile {
-				margin: 20px 0 24px;
+				margin: 16px 0 24px;
 				transform: translateY( -58px );
 				min-height: 42px;
 			}

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -2,6 +2,7 @@
 // the signup flow.
 .signup-header {
 	position: absolute;
+	margin-top: 8px;
 	inset-block-start: 0;
 	inset-inline-start: 0;
 	inset-inline-end: 0;

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -55,7 +55,7 @@
 
 	@mixin unstick {
 		position: absolute;
-		top: 1px;
+		top: 8px;
 		left: 11px;
 		right: 16px;
 		padding: 0;

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -55,7 +55,7 @@
 
 	@mixin unstick {
 		position: absolute;
-		top: 8px;
+		top: 9px;
 		left: 11px;
 		right: 16px;
 		padding: 0;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -214,7 +214,7 @@
 
 		@include break-small {
 			position: absolute;
-			top: 0;
+			top: 8px;
 			inset-inline-start: 72px;
 			inset-inline-end: 24px;
 			// Align with wordpress logo in signup-header


### PR DESCRIPTION
#### Proposed Changes

* Update vertical spacing of header on UDP's design preview

#### Testing Instructions

* Go through the SignUp flow to Setup flow
* Confirm that the step header is moved down 8px
<img width="1056" alt="Screenshot%20on%202022-07-29%20at%2011-43-47" src="https://user-images.githubusercontent.com/10071857/181684896-e39c261f-68fb-4433-89b6-f8002b0c9919.png">


Related to p1658951124103259-slack-CRWCHQGUB
