### PR TITLE
CI: reduce Authentication E2E frequency to every 3 hours.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -818,7 +818,7 @@ object AuthenticationE2ETests : E2EBuildType(
 	buildTriggers = {
 		schedule {
 			schedulingPolicy = cron {
-				hours = "*/2"
+				hours = "*/3"
 			}
 			branchFilter = "+:<default>"
 			triggerBuild = always()


### PR DESCRIPTION
#### Proposed Changes

This PR alters the frequency of Authentication E2E builds to every 3 hours.
Context: p1658930603213499-slack-C0E1C5NCR, and below:

The reason why we want to reduce the frequency is because of the use of Mailosaur SMS to receive SMS OTP codes. Our tier of service with Mailosaur has only 500 SMS/month and at the rate we are running the Authentication E2E build, we exceed the limit at about 3/4 of the way through the month.

#### Testing Instructions

Ensure the following:
  - [x] Code Style
  - [x] Unit Tests

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #