### PR TITLE
Marketplace: Move components into it's own modules

### DIFF
--- a/client/my-sites/plugins/plugins-browser/clear-search-button.jsx
+++ b/client/my-sites/plugins/plugins-browser/clear-search-button.jsx
@@ -1,0 +1,23 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import './style.scss';
+
+const ClearSearchButton = () => {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
+
+	return (
+		<>
+			&nbsp;
+			<a
+				className={ 'plugins-browser__clear-filters' }
+				href={ '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) }
+			>
+				{ translate( 'Clear' ) }
+			</a>
+		</>
+	);
+};
+
+export default ClearSearchButton;

--- a/client/my-sites/plugins/plugins-browser/full-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/full-list-view/index.jsx
@@ -3,8 +3,8 @@ import InfiniteScroll from 'calypso/components/infinite-scroll';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import usePlugins from '../../use-plugins';
 import ClearSearchButton from '../clear-search-button';
-import usePlugins from '../use-plugins';
 
 const FullListView = ( { category, siteSlug, sites } ) => {
 	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {

--- a/client/my-sites/plugins/plugins-browser/full-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/full-list-view/index.jsx
@@ -1,0 +1,58 @@
+import { useTranslate } from 'i18n-calypso';
+import InfiniteScroll from 'calypso/components/infinite-scroll';
+import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
+import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
+import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import ClearSearchButton from '../clear-search-button';
+import usePlugins from '../use-plugins';
+
+const FullListView = ( { category, siteSlug, sites } ) => {
+	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
+		category,
+		infinite: true,
+	} );
+
+	const categories = useCategories();
+	const categoryName = categories[ category ]?.name || category;
+	const translate = useTranslate();
+
+	let title = '';
+	if ( categoryName && pagination ) {
+		title = translate(
+			'Found %(total)s plugin under "%(categoryName)s"',
+			'Found %(total)s plugins under "%(categoryName)s"',
+			{
+				count: pagination.results,
+				textOnly: true,
+				args: {
+					total: pagination.results,
+					categoryName,
+				},
+			}
+		);
+	}
+
+	return (
+		<>
+			<PluginsBrowserList
+				plugins={ plugins }
+				listName={ category }
+				subtitle={
+					<>
+						{ title }
+						<ClearSearchButton />
+					</>
+				}
+				site={ siteSlug }
+				showPlaceholders={ isFetching }
+				currentSites={ sites }
+				variant={ PluginsBrowserListVariant.InfiniteScroll }
+				extended
+			/>
+
+			<InfiniteScroll nextPageMethod={ fetchNextPage } />
+		</>
+	);
+};
+
+export default FullListView;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -21,14 +21,12 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
-import InfiniteScroll from 'calypso/components/infinite-scroll';
 import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
-import NoResults from 'calypso/my-sites/no-results';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
@@ -36,8 +34,6 @@ import EducationFooter from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
-import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
-import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import {
@@ -47,7 +43,6 @@ import {
 } from 'calypso/state/analytics/actions';
 import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
-import { getPlugins, isEqualSlugOrId } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
@@ -60,7 +55,6 @@ import {
 	isJetpackSite,
 	isRequestingSites,
 	getSiteAdminUrl,
-	getSiteDomain,
 } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSiteId,
@@ -69,253 +63,14 @@ import {
 } from 'calypso/state/ui/selectors';
 import './style.scss';
 import usePlugins from '../use-plugins';
+import FullListView from './full-list-view';
+import SearchListView from './search-list-view';
+import SingleListView from './single-list-view';
 
 /**
  * Module variables
  */
 const SHORT_LIST_LENGTH = 6;
-
-const ClearSearch = () => {
-	const siteSlug = useSelector( getSelectedSiteSlug );
-	const translate = useTranslate();
-
-	return (
-		<>
-			&nbsp;
-			<a
-				className={ 'plugins-browser__clear-filters' }
-				href={ '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) }
-			>
-				{ translate( 'Clear' ) }
-			</a>
-		</>
-	);
-};
-const SearchListView = ( {
-	search: searchTerm,
-	pluginsPagination,
-	pluginsBySearchTerm,
-	fetchNextPage,
-	isFetchingPluginsBySearchTerm,
-	siteSlug,
-	siteId,
-	sites,
-	categoryName,
-} ) => {
-	const dispatch = useDispatch();
-
-	const translate = useTranslate();
-
-	useEffect( () => {
-		if ( searchTerm && pluginsPagination?.page === 1 ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_results_show', {
-					search_term: searchTerm,
-					results_count: pluginsPagination?.results,
-					blog_id: siteId,
-				} )
-			);
-		}
-
-		if ( searchTerm && pluginsPagination ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_results_page', {
-					search_term: searchTerm,
-					page: pluginsPagination.page,
-					results_count: pluginsPagination?.results,
-					blog_id: siteId,
-				} )
-			);
-		}
-	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
-
-	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
-		let title = translate( 'Search results for "%(searchTerm)s"', {
-			textOnly: true,
-			args: { searchTerm },
-		} );
-
-		if ( pluginsPagination ) {
-			title = translate(
-				'Found %(total)s plugin for "%(searchTerm)s"',
-				'Found %(total)s plugins for "%(searchTerm)s"',
-				{
-					count: pluginsPagination.results,
-					textOnly: true,
-					args: {
-						total: pluginsPagination.results,
-						searchTerm,
-					},
-				}
-			);
-
-			if ( categoryName ) {
-				title = translate(
-					'Found %(total)s plugin for "%(searchTerm)s" under "%(categoryName)s"',
-					'Found %(total)s plugins for "%(searchTerm)s" under "%(categoryName)s"',
-					{
-						count: pluginsPagination.results,
-						textOnly: true,
-						args: {
-							total: pluginsPagination.results,
-							searchTerm,
-							categoryName,
-						},
-					}
-				);
-			}
-		}
-
-		return (
-			<>
-				<PluginsBrowserList
-					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
-					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
-					subtitle={
-						<>
-							{ title }
-							<ClearSearch />
-						</>
-					}
-					showReset={ true }
-					site={ siteSlug }
-					showPlaceholders={ isFetchingPluginsBySearchTerm }
-					currentSites={ sites }
-					variant={ PluginsBrowserListVariant.Paginated }
-					extended
-				/>
-				<InfiniteScroll nextPageMethod={ fetchNextPage } />
-			</>
-		);
-	}
-
-	return (
-		<div className="plugins-browser__no-results">
-			<NoResults
-				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
-					textOnly: true,
-					components: { searchTerm: <em>{ searchTerm }</em> },
-				} ) }
-			/>
-		</div>
-	);
-};
-
-const FullListView = ( { category, siteSlug, sites } ) => {
-	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
-		category,
-		infinite: true,
-	} );
-
-	const categories = useCategories();
-	const categoryName = categories[ category ]?.name || category;
-	const translate = useTranslate();
-
-	let title = '';
-	if ( categoryName && pagination ) {
-		title = translate(
-			'Found %(total)s plugin under "%(categoryName)s"',
-			'Found %(total)s plugins under "%(categoryName)s"',
-			{
-				count: pagination.results,
-				textOnly: true,
-				args: {
-					total: pagination.results,
-					categoryName,
-				},
-			}
-		);
-	}
-
-	return (
-		<>
-			<PluginsBrowserList
-				plugins={ plugins }
-				listName={ category }
-				subtitle={
-					<>
-						{ title }
-						<ClearSearch />
-					</>
-				}
-				site={ siteSlug }
-				showPlaceholders={ isFetching }
-				currentSites={ sites }
-				variant={ PluginsBrowserListVariant.InfiniteScroll }
-				extended
-			/>
-
-			<InfiniteScroll nextPageMethod={ fetchNextPage } />
-		</>
-	);
-};
-
-const PluginSingleListView = ( {
-	category,
-	pluginsByCategoryPopular,
-	isFetchingPluginsByCategoryPopular,
-	pluginsByCategoryFeatured,
-	isFetchingPluginsByCategoryFeatured,
-	paidPlugins,
-	isFetchingPaidPlugins,
-	siteSlug,
-	sites,
-} ) => {
-	const translate = useTranslate();
-
-	const siteId = useSelector( getSelectedSiteId );
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-
-	const categories = useCategories();
-	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
-
-	const installedPlugins = useSelector( ( state ) =>
-		getPlugins( state, siteObjectsToSiteIds( sites ) )
-	);
-
-	let plugins;
-	let isFetching;
-	if ( category === 'popular' ) {
-		plugins = pluginsByCategoryPopular;
-		isFetching = isFetchingPluginsByCategoryPopular;
-	} else if ( category === 'featured' ) {
-		plugins = pluginsByCategoryFeatured;
-		isFetching = isFetchingPluginsByCategoryFeatured;
-	} else if ( category === 'paid' ) {
-		plugins = paidPlugins;
-		isFetching = isFetchingPaidPlugins;
-	} else {
-		return null;
-	}
-
-	plugins = plugins
-		.filter( isNotBlocked )
-		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
-
-	let listLink = '/plugins/browse/' + category;
-	if ( domain ) {
-		listLink = '/plugins/browse/' + category + '/' + domain;
-	}
-
-	if ( ! isFetching && plugins.length === 0 ) {
-		return null;
-	}
-
-	return (
-		<PluginsBrowserList
-			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
-			listName={ category }
-			title={ categoryName }
-			site={ siteSlug }
-			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
-			size={ SHORT_LIST_LENGTH }
-			showPlaceholders={ isFetching }
-			currentSites={ sites }
-			variant={ PluginsBrowserListVariant.Fixed }
-			extended
-		/>
-	);
-};
 
 const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSlug } ) => {
 	const translate = useTranslate();
@@ -474,25 +229,6 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	);
 }
 
-const PLUGIN_SLUGS_BLOCKLIST = [];
-
-function isNotBlocked( plugin ) {
-	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
-}
-
-/**
- * Returns a boolean indicating if a plugin is already installed or not
- *
- * @param plugin plugin object to be tested
- * @param installedPlugins list of installed plugins aggregated by plugin slug
- * @returns Boolean weather a plugin is not installed on not
- */
-function isNotInstalled( plugin, installedPlugins ) {
-	return ! installedPlugins.find( ( installedPlugin ) =>
-		isEqualSlugOrId( plugin.slug, installedPlugin )
-	);
-}
-
 const PluginBrowserContent = ( props ) => {
 	const requiredPlansPurchasedPlugins = useSelector( ( state ) =>
 		getPlansForFeature( state, props.selectedSite?.ID, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS )
@@ -529,12 +265,12 @@ const PluginBrowserContent = ( props ) => {
 							<UpgradeNudge { ...props } />
 						) }
 					</div>
-					<PluginSingleListView { ...props } category="paid" />
+					<SingleListView { ...props } category="paid" />
 				</>
 			) }
 			{ ( hasInstallPurchasedPlugins || lowerPlanAvailable ) && <UpgradeNudge { ...props } /> }
-			<PluginSingleListView { ...props } category="featured" />
-			<PluginSingleListView { ...props } category="popular" />
+			<SingleListView { ...props } category="featured" />
+			<SingleListView { ...props } category="popular" />
 		</>
 	);
 };

--- a/client/my-sites/plugins/plugins-browser/search-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/search-list-view/index.jsx
@@ -1,0 +1,131 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import InfiniteScroll from 'calypso/components/infinite-scroll';
+import NoResults from 'calypso/my-sites/no-results';
+import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
+import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import ClearSearchButton from '../clear-search-button';
+
+/**
+ * Module variables
+ */
+const PLUGIN_SLUGS_BLOCKLIST = [];
+
+function isNotBlocked( plugin ) {
+	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
+}
+
+const SearchListView = ( {
+	search: searchTerm,
+	pluginsPagination,
+	pluginsBySearchTerm,
+	fetchNextPage,
+	isFetchingPluginsBySearchTerm,
+	siteSlug,
+	siteId,
+	sites,
+	categoryName,
+} ) => {
+	const dispatch = useDispatch();
+
+	const translate = useTranslate();
+
+	useEffect( () => {
+		if ( searchTerm && pluginsPagination?.page === 1 ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_show', {
+					search_term: searchTerm,
+					results_count: pluginsPagination?.results,
+					blog_id: siteId,
+				} )
+			);
+		}
+
+		if ( searchTerm && pluginsPagination ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_page', {
+					search_term: searchTerm,
+					page: pluginsPagination.page,
+					results_count: pluginsPagination?.results,
+					blog_id: siteId,
+				} )
+			);
+		}
+	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
+
+	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
+		let title = translate( 'Search results for "%(searchTerm)s"', {
+			textOnly: true,
+			args: { searchTerm },
+		} );
+
+		if ( pluginsPagination ) {
+			title = translate(
+				'Found %(total)s plugin for "%(searchTerm)s"',
+				'Found %(total)s plugins for "%(searchTerm)s"',
+				{
+					count: pluginsPagination.results,
+					textOnly: true,
+					args: {
+						total: pluginsPagination.results,
+						searchTerm,
+					},
+				}
+			);
+
+			if ( categoryName ) {
+				title = translate(
+					'Found %(total)s plugin for "%(searchTerm)s" under "%(categoryName)s"',
+					'Found %(total)s plugins for "%(searchTerm)s" under "%(categoryName)s"',
+					{
+						count: pluginsPagination.results,
+						textOnly: true,
+						args: {
+							total: pluginsPagination.results,
+							searchTerm,
+							categoryName,
+						},
+					}
+				);
+			}
+		}
+
+		return (
+			<>
+				<PluginsBrowserList
+					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
+					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
+					subtitle={
+						<>
+							{ title }
+							<ClearSearchButton />
+						</>
+					}
+					showReset={ true }
+					site={ siteSlug }
+					showPlaceholders={ isFetchingPluginsBySearchTerm }
+					currentSites={ sites }
+					variant={ PluginsBrowserListVariant.Paginated }
+					extended
+				/>
+				<InfiniteScroll nextPageMethod={ fetchNextPage } />
+			</>
+		);
+	}
+
+	return (
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		<div className="plugins-browser__no-results">
+			<NoResults
+				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
+					textOnly: true,
+					components: { searchTerm: <em>{ searchTerm }</em> },
+				} ) }
+			/>
+		</div>
+	);
+};
+
+export default SearchListView;

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -1,0 +1,102 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
+import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
+import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { getPlugins, isEqualSlugOrId } from 'calypso/state/plugins/installed/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+/**
+ * Module variables
+ */
+const SHORT_LIST_LENGTH = 6;
+
+const PLUGIN_SLUGS_BLOCKLIST = [];
+
+function isNotBlocked( plugin ) {
+	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
+}
+
+/**
+ * Returns a boolean indicating if a plugin is already installed or not
+ *
+ * @param plugin plugin object to be tested
+ * @param installedPlugins list of installed plugins aggregated by plugin slug
+ * @returns Boolean weather a plugin is not installed on not
+ */
+function isNotInstalled( plugin, installedPlugins ) {
+	return ! installedPlugins.find( ( installedPlugin ) =>
+		isEqualSlugOrId( plugin.slug, installedPlugin )
+	);
+}
+
+const SingleListView = ( {
+	category,
+	pluginsByCategoryPopular,
+	isFetchingPluginsByCategoryPopular,
+	pluginsByCategoryFeatured,
+	isFetchingPluginsByCategoryFeatured,
+	paidPlugins,
+	isFetchingPaidPlugins,
+	siteSlug,
+	sites,
+} ) => {
+	const translate = useTranslate();
+
+	const siteId = useSelector( getSelectedSiteId );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
+	const categories = useCategories();
+	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
+
+	const installedPlugins = useSelector( ( state ) =>
+		getPlugins( state, siteObjectsToSiteIds( sites ) )
+	);
+
+	let plugins;
+	let isFetching;
+	if ( category === 'popular' ) {
+		plugins = pluginsByCategoryPopular;
+		isFetching = isFetchingPluginsByCategoryPopular;
+	} else if ( category === 'featured' ) {
+		plugins = pluginsByCategoryFeatured;
+		isFetching = isFetchingPluginsByCategoryFeatured;
+	} else if ( category === 'paid' ) {
+		plugins = paidPlugins;
+		isFetching = isFetchingPaidPlugins;
+	} else {
+		return null;
+	}
+
+	plugins = plugins
+		.filter( isNotBlocked )
+		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
+
+	let listLink = '/plugins/browse/' + category;
+	if ( domain ) {
+		listLink = '/plugins/browse/' + category + '/' + domain;
+	}
+
+	if ( ! isFetching && plugins.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<PluginsBrowserList
+			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
+			listName={ category }
+			title={ categoryName }
+			site={ siteSlug }
+			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
+			size={ SHORT_LIST_LENGTH }
+			showPlaceholders={ isFetching }
+			currentSites={ sites }
+			variant={ PluginsBrowserListVariant.Fixed }
+			extended
+		/>
+	);
+};
+
+export default SingleListView;


### PR DESCRIPTION
#### Proposed Changes

Following phase 1 here pdh6GB-14m-p2, we move `PluginSingleListView`, `FullListView`, and `SearchListView` components into it's own folders

#### Testing Instructions

1.  Go to `/plugins`
2. Check if `Discover` is working without errors.
3. Same as (2) but filtering for a category
4. Same as (2) but searching for plugins

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixed #64540
