### PR TITLE
Checkout: Always show monthly price in variant dropdown

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -269,7 +269,7 @@ function ItemVariantOption( {
 			onClick={ onSelect }
 			selected={ isSelected }
 		>
-			<ItemVariantPrice variant={ variant } compareTo={ compareTo } />
+			<ItemVariantPrice variant={ variant } compareTo={ compareTo } showPrice />
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -23,21 +23,6 @@ const Discount = styled.span`
 	}
 `;
 
-const DoNotPayThis = styled.del`
-	text-decoration: line-through;
-	margin-right: 8px;
-	color: #646970;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-
-	.item-variant-option--selected & {
-		color: #fff;
-	}
-`;
-
 const Price = styled.span`
 	color: #646970;
 
@@ -112,14 +97,9 @@ export const ItemVariantPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
+	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
-	const formattedCurrentPrice = myFormatCurrency( variant.price, variant.currency );
-	const compareToPriceForVariantTerm = compareTo
-		? getVariantPriceForTerm( compareTo, variant.termIntervalInMonths )
-		: undefined;
-	const formattedCompareToPriceForVariantTerm = compareToPriceForVariantTerm
-		? myFormatCurrency( compareToPriceForVariantTerm, variant.currency )
-		: undefined;
+	const formattedMonthlyPrice = myFormatCurrency( variant.pricePerMonth, variant.currency );
 	const discountPercentage = getDiscountPercentageBetweenVariants( variant, compareTo );
 
 	return (
@@ -134,10 +114,11 @@ export const ItemVariantPrice: FunctionComponent< {
 				{ discountPercentage > 0 && ! isMobile && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				{ discountPercentage > 0 && (
-					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
-				) }
-				<Price>{ formattedCurrentPrice }</Price>
+				<Price>
+					{ translate( '%(monthlyPrice)s/month', {
+						args: { monthlyPrice: formattedMonthlyPrice },
+					} ) }
+				</Price>
 			</span>
 		</Variant>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -96,7 +96,8 @@ export function getDiscountPercentageBetweenVariants(
 export const ItemVariantPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
-} > = ( { variant, compareTo } ) => {
+	showPrice?: boolean;
+} > = ( { variant, compareTo, showPrice } ) => {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
 	const formattedMonthlyPrice = myFormatCurrency( variant.pricePerMonth, variant.currency );
@@ -106,19 +107,21 @@ export const ItemVariantPrice: FunctionComponent< {
 		<Variant>
 			<Label>
 				{ variant.variantLabel }
-				{ discountPercentage > 0 && isMobile && (
+				{ showPrice && discountPercentage > 0 && isMobile && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
 			</Label>
 			<span>
-				{ discountPercentage > 0 && ! isMobile && (
+				{ showPrice && discountPercentage > 0 && ! isMobile && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				<Price>
-					{ translate( '%(monthlyPrice)s/month', {
-						args: { monthlyPrice: formattedMonthlyPrice },
-					} ) }
-				</Price>
+				{ showPrice && (
+					<Price>
+						{ translate( '%(monthlyPrice)s/month', {
+							args: { monthlyPrice: formattedMonthlyPrice },
+						} ) }
+					</Price>
+				) }
 			</span>
 		</Variant>
 	);

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -38,6 +38,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",
+		"@automattic/format-currency": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.3.0",
 		"@stripe/stripe-js": "^1.17.1",

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -596,21 +596,36 @@ function LineItemSublabelAndPrice( { product }: { product: ResponseCartProduct }
 
 		const options = {
 			args: {
-				sublabel,
+				productLabel: sublabel,
+				monthlyPrice: product.item_subtotal_monthly_cost_display,
 				price: product.item_original_subtotal_display,
 			},
 		};
 
 		if ( isMonthlyProduct( product ) ) {
-			return <>{ translate( '%(sublabel)s: %(price)s per month', options ) }</>;
+			return <>{ translate( '%(productLabel)s: %(price)s per month', options ) }</>;
 		}
 
 		if ( isYearly( product ) ) {
-			return <>{ translate( '%(sublabel)s: %(price)s per year', options ) }</>;
+			return (
+				<>
+					{ translate(
+						'%(productLabel)s: %(monthlyPrice)s/month, billed %(price)s per year',
+						options
+					) }
+				</>
+			);
 		}
 
 		if ( isBiennially( product ) ) {
-			return <>{ translate( '%(sublabel)s: %(price)s per two years', options ) }</>;
+			return (
+				<>
+					{ translate(
+						'%(productLabel)s: %(monthlyPrice)s/month, billed %(price)s every two years',
+						options
+					) }
+				</>
+			);
 		}
 	}
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -610,7 +610,7 @@ function LineItemSublabelAndPrice( { product }: { product: ResponseCartProduct }
 			args: {
 				sublabel: sublabel,
 				monthlyPrice: formatCurrencyForLineItem( monthlyPriceInteger, product.currency, {
-					smallestUnit: true,
+					isSmallestUnit: true,
 				} ),
 				price: product.item_original_subtotal_display,
 			},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,6 +1494,7 @@ __metadata:
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
+    "@automattic/format-currency": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@emotion/styled": ^11.3.0
     "@stripe/stripe-js": ^1.17.1


### PR DESCRIPTION
#### Proposed Changes

Suggested by @lucasmendes-design, this PR changes the checkout product term variant picker to display monthly prices for each product variant rather than the product's subtotal.

This is part of the work being discussed in https://github.com/Automattic/wp-calypso/issues/65968

Before:

<img width="566" alt="Screen Shot 2022-07-28 at 6 23 26 PM" src="https://user-images.githubusercontent.com/2036909/181647319-660a4bc5-5acf-4d2e-b377-4566042a71d5.png">

After:

<img width="563" alt="Screen Shot 2022-07-28 at 6 26 35 PM" src="https://user-images.githubusercontent.com/2036909/181647640-984b1c91-4981-4a23-83d4-17d55abdb8b9.png">


#### Testing Instructions

- Add a product that has term variants to your shopping cart (eg: any legacy plan like Premium).
- Visit checkout and verify that the term variant picker shows the prices as monthly no matter which term is selected.