### PR TITLE
Plans: Change plan price selectors to remove lodash get

### DIFF
--- a/client/my-sites/plans-comparison/use-plan-prices.tsx
+++ b/client/my-sites/plans-comparison/use-plan-prices.tsx
@@ -1,4 +1,5 @@
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '@automattic/calypso-products';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useSelector } from 'react-redux';
 import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
 import type { WPComPlan } from '@automattic/calypso-products';
@@ -31,7 +32,9 @@ export default function usePlanPrices( plans: WPComPlan[] ): PlanPrices[] {
 			const [ price, discountPrice ] = [
 				getPlanRawPrice( state, productId ),
 				getDiscountedRawPrice( state, productId ),
-			].map( toMonthlyPrice( plan ) );
+			]
+				.filter( isValueTruthy )
+				.map( toMonthlyPrice( plan ) );
 
 			if ( ! discountPrice ) {
 				return { price };

--- a/client/my-sites/plans-comparison/use-plan-prices.tsx
+++ b/client/my-sites/plans-comparison/use-plan-prices.tsx
@@ -1,5 +1,4 @@
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '@automattic/calypso-products';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useSelector } from 'react-redux';
 import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
 import type { WPComPlan } from '@automattic/calypso-products';
@@ -30,11 +29,9 @@ export default function usePlanPrices( plans: WPComPlan[] ): PlanPrices[] {
 		return plans.map( ( plan ) => {
 			const productId = plan.getProductId();
 			const [ price, discountPrice ] = [
-				getPlanRawPrice( state, productId ),
-				getDiscountedRawPrice( state, productId ),
-			]
-				.filter( isValueTruthy )
-				.map( toMonthlyPrice( plan ) );
+				getPlanRawPrice( state, productId ) ?? 0,
+				getDiscountedRawPrice( state, productId ) ?? 0,
+			].map( toMonthlyPrice( plan ) );
 
 			if ( ! discountPrice ) {
 				return { price };

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -233,10 +233,10 @@ function useMaxDiscount( plans: string[] ): number {
 				return 0;
 			}
 
-			const monthlyPlanAnnualCost = getPlanRawPrice( state, monthlyPlan.product_id ) * 12;
+			const monthlyPlanAnnualCost = ( getPlanRawPrice( state, monthlyPlan.product_id ) ?? 0 ) * 12;
 			const rawPrice = getPlanRawPrice( state, yearlyPlan.product_id );
 			const discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id );
-			const yearlyPlanCost = discountPrice || rawPrice;
+			const yearlyPlanCost = discountPrice || rawPrice || 0;
 
 			return Math.round(
 				( ( monthlyPlanAnnualCost - yearlyPlanCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100

--- a/client/state/plans/selectors/get-discounted-raw-price.js
+++ b/client/state/plans/selectors/get-discounted-raw-price.js
@@ -9,7 +9,7 @@ import 'calypso/state/plans/init';
  * @param  {object}  state     global state
  * @param  {number}  productId the plan productId
  * @param  {boolean} isMonthly if true, returns monthly price
- * @returns {number}  plan price
+ * @returns {number|null}  plan price
  */
 export function getDiscountedRawPrice( state, productId, isMonthly = false ) {
 	const plan = getPlan( state, productId );

--- a/client/state/plans/selectors/get-discounted-raw-price.js
+++ b/client/state/plans/selectors/get-discounted-raw-price.js
@@ -1,5 +1,4 @@
 import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
-import { get } from 'lodash';
 import { getPlan } from './plan';
 
 import 'calypso/state/plans/init';
@@ -14,7 +13,9 @@ import 'calypso/state/plans/init';
  */
 export function getDiscountedRawPrice( state, productId, isMonthly = false ) {
 	const plan = getPlan( state, productId );
-	if ( get( plan, 'raw_price', -1 ) < 0 || get( plan, 'orig_cost', -1 ) < 0 ) {
+	const rawPrice = plan?.raw_price ?? -1;
+	const origCost = plan?.orig_cost ?? -1;
+	if ( rawPrice < 0 || origCost < 0 ) {
 		return null;
 	}
 

--- a/client/state/plans/selectors/get-plan-raw-price.js
+++ b/client/state/plans/selectors/get-plan-raw-price.js
@@ -9,7 +9,7 @@ import 'calypso/state/plans/init';
  * @param  {object}  state     global state
  * @param  {number}  productId the plan productId
  * @param  {boolean} isMonthly if true, returns monthly price
- * @returns {number}  plan price
+ * @returns {number|null}  plan price
  */
 export function getPlanRawPrice( state, productId, isMonthly = false ) {
 	const plan = getPlan( state, productId );

--- a/client/state/plans/selectors/get-plan-raw-price.js
+++ b/client/state/plans/selectors/get-plan-raw-price.js
@@ -1,5 +1,4 @@
 import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
-import { get } from 'lodash';
 import { getPlan } from './plan';
 
 import 'calypso/state/plans/init';
@@ -14,10 +13,12 @@ import 'calypso/state/plans/init';
  */
 export function getPlanRawPrice( state, productId, isMonthly = false ) {
 	const plan = getPlan( state, productId );
-	if ( get( plan, 'raw_price', -1 ) < 0 ) {
+	const rawPrice = plan?.raw_price ?? -1;
+	const origCost = plan?.orig_cost ?? 0;
+	if ( rawPrice < 0 ) {
 		return null;
 	}
-	const price = get( plan, 'orig_cost', 0 ) || plan.raw_price;
+	const price = origCost || plan.raw_price;
 
 	return isMonthly ? calculateMonthlyPriceForPlan( plan.product_slug, price ) : price;
 }


### PR DESCRIPTION
#### Proposed Changes

The plan price selectors `getDiscountedRawPrice()` and `getPlanRawPrice()` both use lodash `get()` to look for the `raw_price` and `orig_cost` properties of a plan object as returned by the `/plans` API endpoint. This PR refactors those functions to use nullish coalescing instead. There are two reasons for this:

1. There is a multi-year project to remove lodash from calypso.
2. lodash `get()` treats `null` as a set value. This means that if the plans endpoint returns a `null` value, that will be used instead of the fallback. The result is very strange bugs like the one "fixed" by D85035-code. That bug happened because the endpoint began returning `null` for the `orig_cost` property instead of not returning the property at all. To JavaScript, this changed the value of the property from `undefined` to `null`, and `get(plan, 'orig_cost', -1)` now returned `null` instead of `-1`. However, `plan?.orig_cost ?? -1` will always be `-1` even for `null`.

Before:

<img width="417" alt="crossed-out-plans" src="https://user-images.githubusercontent.com/2036909/181655974-d54e893e-f159-4f94-962b-301f3b920f11.png">

After:

<img width="427" alt="no-crossed-out-plans" src="https://user-images.githubusercontent.com/2036909/181655978-5d01ef20-0055-4913-a580-00cf4ad24411.png">


#### Testing Instructions

- Apply D85049-code (to revert D85035-code) and sandbox the API.
- Visit `/start/plans`. If you see a domain search form, search for and select any domain.
- When you see the plans listed, verify that the prices do not display a crossed-out price.