### PR TITLE
Fix `fetchPriority` prop to prevent React warning

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -55,8 +55,8 @@ export class WebPreviewModal extends Component {
 		frontPageMetaDescription: PropTypes.string,
 		// A post object used to override the selected post in the SEO preview
 		overridePost: PropTypes.object,
-		// iframe's fetchPriority.
-		fetchPriority: PropTypes.string,
+		// iframe's fetchpriority.
+		fetchpriority: PropTypes.string,
 		// Set height based on page content. This requires the page to post it's dimensions as message.
 		autoHeight: PropTypes.bool,
 		// Fixes the viewport width of the iframe if provided.

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -383,7 +383,7 @@ export default class WebPreviewContent extends Component {
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
-								fetchPriority={ fetchPriority ? fetchPriority : undefined }
+								fetchpriority={ fetchPriority ? fetchPriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
 							/>
 						</div>

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -320,7 +320,7 @@ export default class WebPreviewContent extends Component {
 	}
 
 	render() {
-		const { translate, toolbarComponent: ToolbarComponent, fetchPriority, autoHeight } = this.props;
+		const { translate, toolbarComponent: ToolbarComponent, fetchpriority, autoHeight } = this.props;
 		const isLoaded = this.state.loaded && ( ! autoHeight || this.state.viewport !== null );
 
 		const className = classNames( this.props.className, 'web-preview__inner', {
@@ -383,7 +383,7 @@ export default class WebPreviewContent extends Component {
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
-								fetchpriority={ fetchPriority ? fetchPriority : undefined }
+								fetchpriority={ fetchpriority ? fetchpriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
 							/>
 						</div>
@@ -458,8 +458,8 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
-	// iframe's fetchPriority.
-	fetchPriority: PropTypes.string,
+	// iframe's fetchpriority.
+	fetchpriority: PropTypes.string,
 	// Set height based on page content. This requires the page to post it's dimensions as message.
 	autoHeight: PropTypes.bool,
 	// The toolbar should sticky or not

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -53,7 +53,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 				components: { strong: <strong /> },
 			} ) }
 			toolbarComponent={ PreviewToolbar }
-			fetchPriority={ isSelected ? 'high' : 'low' }
+			fetchpriority={ isSelected ? 'high' : 'low' }
 			autoHeight
 			siteId={ site?.ID }
 			url={ site?.URL }


### PR DESCRIPTION
#### Proposed Changes

Correct the `fetchPriority` DOM property to be `fetchpriority`, and stop React from throwing an error in development environments.

#### Testing Instructions

There are 2 places you can see this fix. From a local build of Calypso (`yarn start`)

* Visit `/setup/designSetup?siteSlug=example.wordpress.com`, click on any of the themes to see a preview
* From the My Sites section of Calypso, click the home icon next to the site title to see a preview of the site.

Without this change, you'll see an error in the JS console:

```
Warning: React does not recognize the `fetchPriority` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fetchpriority` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

With this change, you not see that error.

#### Pre-merge Checklist


- n/a [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- n/a Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- n/a Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- n/a Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #65442
