### PR TITLE
Do not set site title if users have not provided one during onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -3,7 +3,6 @@ import { Onboard } from '@automattic/data-stores';
 import { useDesignsBySite } from '@automattic/design-picker';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useTranslate } from 'i18n-calypso';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -77,7 +76,6 @@ export const siteSetupFlow: Flow = {
 		useDesignsBySite( site );
 	},
 	useStepNavigation( currentStep, navigate ) {
-		const translate = useTranslate();
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -105,8 +103,7 @@ export const siteSetupFlow: Flow = {
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, saveSiteTitle } =
-			useDispatch( SITE_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
@@ -138,23 +135,6 @@ export const siteSetupFlow: Flow = {
 
 					if ( intent === SiteIntent.Write && ! selectedDesign ) {
 						pendingActions.push( setThemeOnSite( siteSlug, WRITE_INTENT_DEFAULT_THEME ) );
-					}
-
-					// Set a default site title in case users have not set one during the onboarding flow.
-					if ( site && site.name?.trim() === '' ) {
-						let siteTitle = '';
-						switch ( intent ) {
-							case SiteIntent.Write:
-								siteTitle = translate( 'My blog' );
-								break;
-							case SiteIntent.Sell:
-								siteTitle = translate( 'My store' );
-								break;
-							default:
-								siteTitle = translate( 'My site' );
-						}
-
-						pendingActions.push( saveSiteTitle( site.ID, siteTitle ) );
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.replace( to ) );


### PR DESCRIPTION
#### Proposed Changes

This PR updates the behavior so that we no longer set the site title if users don't provide one during the onboarding flow. 
See https://github.com/Automattic/wp-calypso/pull/65834#discussion_r932546200 for more context behind this change. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Goals Capture screen `/setup/goals?siteSlug=${site_slug}`
* Select either "Write & Publish" or "Sell online" goal and click the "Continue" button.
* Continue with the onboarding until you're asked to give a site title, click the "Continue" button without providing one.
* Complete the onboarding, and head to the dashboard.
* Ensure that the site domain is displayed where the site name should normally go.

Alternatively:
* Head to the Goals Capture screen `/setup/goals?siteSlug=${site_slug}`
* In the Goals Capture screen, click "Skip to dashboard".
* Once in the dashboard, ensure that the text "Site title" is displayed where the site name should normally go.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

