### PR TITLE
Show domain USP in marketplace only if the billing interval is yearly

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -132,7 +132,7 @@ export const PlanUSPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, billin
 	}
 
 	const filteredUSPS = [
-		...( isFreePlan ? [ translate( 'Free domain for one year' ) ] : [] ),
+		...( isFreePlan && isAnnualPeriod ? [ translate( 'Free domain for one year' ) ] : [] ),
 		translate( 'Best-in-class hosting' ),
 		supportText,
 	];
@@ -214,7 +214,7 @@ function LegacyUSPS( { shouldUpgrade, isFreePlan, isMarketplaceProduct, billingP
 					},
 			  ]
 			: [] ),
-		...( isFreePlan
+		...( isFreePlan && isAnnualPeriod
 			? [
 					{
 						id: 'domain',

--- a/client/my-sites/plugins/use-plugins-support-text/index.js
+++ b/client/my-sites/plugins/use-plugins-support-text/index.js
@@ -35,7 +35,7 @@ export default function usePluginsSupportText() {
 	);
 	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
 	const supportTextNonPro = isLiveSupport
-		? translate( 'Live chat support 24x7' )
+		? translate( 'Live chat support' )
 		: translate( 'Unlimited Email Support' );
 	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
 	return supportText;


### PR DESCRIPTION
#### Proposed Changes

* This PR will show the "Free domain for one year" USP in the plugin sidebar _only_ if the user has toggled the interval to "Yearly" (as we don't include domains in monthly plans). Adding a plugin with monthly billing from the Free plan, also adds a monthly plan to the user's cart. 
* Also removes the 24/7 promise from live chat, similar to what's been done in the plans grid in both logged in and logged out context.

**TBD: Do we want to rather show another text for monthly -- or strike it out? The jumping of the sidebar when toggling looks a bit rough.** 

#### Testing Instructions
* Spin up locally, or visit the calypso.live link below.
* Go to a Free site
* Go to plugins, and pick any plugin you like.
* The "Free domain for one year" USP should only show when the toggle is set to "yearly" and be hidden when toggled to "monthly"
* You can test on any other plan (Starter, Pro, Business, Premium), and verify that the domain USP is not shown (this is the existing behavior).
* Text for live chat support should be translated to non-EN locales.


https://user-images.githubusercontent.com/52675688/181735118-9c8c7c22-7784-4695-9079-828bd2f2204a.mov




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
Closes Automattic/martech#992