### PR TITLE
Signup: add newsletters flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -14,6 +14,7 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
+	getNewsletterDestination = noop,
 	getAddOnsStep = noop,
 } = {} ) {
 	const flows = [
@@ -110,6 +111,21 @@ export function generateFlows( {
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
 			showRecaptcha: true,
+		},
+		{
+			name: 'newsletters',
+			steps: getAddOnsStep(
+				isEnabled( 'signup/professional-email-step' )
+					? [ 'user', 'domains', 'emails', 'plans' ]
+					: [ 'user', 'domains', 'plans' ]
+			),
+			destination: getNewsletterDestination,
+			description: 'Beginning of the flow to create a newsletter',
+			lastModified: '2022-07-28',
+			showRecaptcha: true,
+			get pageTitle() {
+				return translate( 'Newsletters' );
+			},
 		},
 		{
 			name: 'with-add-ons',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -14,7 +14,7 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
-	getNewsletterDestination = noop,
+	getStepperFlowDestination = noop,
 	getAddOnsStep = noop,
 } = {} ) {
 	const flows = [
@@ -119,7 +119,7 @@ export function generateFlows( {
 					? [ 'user', 'domains', 'emails', 'plans' ]
 					: [ 'user', 'domains', 'plans' ]
 			),
-			destination: getNewsletterDestination,
+			destination: ( dependencies ) => getStepperFlowDestination( dependencies, 'newsletters' ),
 			description: 'Beginning of the flow to create a newsletter',
 			lastModified: '2022-07-28',
 			showRecaptcha: true,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -166,7 +166,7 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 }
 
 function getStepperFlowDestination( dependencies, stepperFlow ) {
-	return `/setup?flow=${ stepperFlow }&=${ dependencies.siteSlug }`;
+	return `/setup?flow=${ stepperFlow }&siteSlug=${ dependencies.siteSlug }`;
 }
 
 const flows = generateFlows( {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -165,8 +165,8 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
-function getNewsletterDestination( { siteSlug } ) {
-	return `/setup/hello?siteSlug=${ siteSlug }`;
+function getStepperFlowDestination( dependencies, stepperFlow ) {
+	return `/setup?flow=${ stepperFlow }&=${ dependencies.siteSlug }`;
 }
 
 const flows = generateFlows( {
@@ -182,7 +182,7 @@ const flows = generateFlows( {
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
 	getAddOnsStep,
-	getNewsletterDestination,
+	getStepperFlowDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -165,6 +165,10 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
+function getNewsletterDestination( { siteSlug } ) {
+	return `/setup/hello?siteSlug=${ siteSlug }`;
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -178,6 +182,7 @@ const flows = generateFlows( {
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
 	getAddOnsStep,
+	getNewsletterDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -758,6 +758,7 @@ class Signup extends Component {
 						<SignupHeader
 							shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
 							isReskinned={ isReskinned }
+							pageTitle={ this.props.pageTitle }
 							rightComponent={
 								showProgressIndicator( this.props.flowName ) && (
 									<FlowProgressIndicator

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -9,6 +9,7 @@ export default class SignupHeader extends Component {
 		shouldShowLoadingScreen: PropTypes.bool,
 		isReskinned: PropTypes.bool,
 		rightComponent: PropTypes.node,
+		pageTitle: PropTypes.string,
 	};
 
 	render() {
@@ -19,11 +20,7 @@ export default class SignupHeader extends Component {
 		return (
 			<div className="signup-header">
 				<WordPressLogo size={ 120 } className={ logoClasses } />
-
-				{ /* Ideally, this is where the back button
-			   would live. But thats hard to move, it seems. */ }
-				<div className="signup-header__left" />
-
+				<h1>{ this.props.pageTitle }</h1>
 				{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }
 				<div className="signup-header__right">

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/onboarding/styles/mixins';
+
 // A masterbar-like header just for
 // the signup flow.
 .signup-header {
@@ -28,6 +30,16 @@
 		&.is-large {
 			transform: scale( 1 ) translateY( 80px );
 		}
+	}
+
+	h1 {
+		@include onboarding-font-recoleta;
+		position: absolute;
+		color: var( --color-text );
+		top: 20px;
+		left: 56px;
+		font-size: 18;
+		font-family: 'Recoleta';
 	}
 
 	.signup-header__left {

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -42,12 +42,6 @@
 		font-family: 'Recoleta';
 	}
 
-	.signup-header__left {
-		position: absolute;
-		inset-block-start: 12px;
-		inset-inline-start: 16px;
-	}
-
 	.signup-header__right {
 		position: absolute;
 		inset-block-start: 12px;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -784,6 +784,7 @@ class DomainsStep extends Component {
 				isExternalBackUrl={ isExternalBackUrl }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
+				hideBack={ this.props.flowName === 'newsletters' }
 				stepContent={
 					<div>
 						{ ! this.props.productsLoaded && <QueryProductsList /> }

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -145,6 +145,7 @@ class EmailsStep extends Component {
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ translate( 'Back' ) }
 				hideSkip={ false }
+				hideBack={ this.props.flowName === 'newsletters' }
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }
 				skipLabelText={ translate( 'Buy an email later' ) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -339,6 +339,7 @@ export class PlansStep extends Component {
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
+					hideBack={ this.props.flowName === 'newsletters' }
 					isWideLayout={ true }
 					stepContent={ this.plansFeaturesList() }
 					allowBackFirstStep={ !! hasInitializedSitesBackUrl }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -182,6 +182,7 @@
 		"onboarding",
 		"onboarding-with-email",
 		"with-add-ons",
+		"newsletters",
 		"setup-site",
 		"account",
 		"do-it-for-me",


### PR DESCRIPTION
## Proposed Changes

This extends the existing signup flow by adding a `newsletters` flow. Along with the flow I added a new function to generate the return because we will be forwarding a few other flows to stepper in the same manner.

To match the styling I added the flowName to the `signup-header` and removed the unnecessary div.

More details on the new flow [can be found here](BcUdhLlhAp7UHtQHNTI4zA-fi-1870%3A19865)

## Testing Instructions

1. Pull branch and run `yarn start`
2. Navigate to http://calypso.localhost:3000/start/newsletters
3. Signup for a new account using a test email address that is NOT an Automattic address (this will end in an error if you don't)
4. Go through the entire signup and you should be redirected to `http://calypso.localhost:3000/setup?flow=newsletters&siteSlug=[SITE SLUG].wordpress.com`
5. That should then put you on `http://calypso.localhost:3000/setup/letsGetStarted?flow=newsletters&siteSlug=[SITE SLUG].wordpress.com`

## Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?