### PR TITLE
Import: fix back routing from Pick a design page

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -403,6 +403,9 @@ export const siteSetupFlow: Flow = {
 					} else if ( intent === 'write' ) {
 						// this means we came from write => blogger staring point => choose a design
 						return navigate( 'bloggerStartingPoint' );
+					} else if ( intent === 'import' ) {
+						// this means we came from non-WP transfers => complete screen => click Pick a design button, we go back to goals
+						return navigate( 'goals' );
 					}
 
 					if ( goalsStepEnabled ) {


### PR DESCRIPTION
#### Proposed Changes

* Redirect to the goals page when users who come from the complete screen of non-WP transfer click the back button

#### Testing Instructions

* Go to http://calypso.localhost:3000/setup/import?siteSlug={SITE_slug}
* Enter `https://www.animalmusicweb.com/`
* Go through the import process

<img width="1482" alt="Screen Shot 2022-08-03 at 11 57 06 AM" src="https://user-images.githubusercontent.com/1024985/182520997-fe8b32a7-f069-45a1-854b-b4c0d90b947a.png">

* Click the `Pick a design` button

<img width="913" alt="Screen Shot 2022-08-03 at 11 58 05 AM" src="https://user-images.githubusercontent.com/1024985/182521102-28878daf-8586-4381-8620-58a46b2db384.png">

* Click the back button on the pick a design page

<img width="1683" alt="Screen Shot 2022-08-03 at 11 59 25 AM" src="https://user-images.githubusercontent.com/1024985/182521282-85aa2c1d-8d73-45ca-8ba9-6170ddf62811.png">

* The goals page should appear

<img width="1147" alt="Screen Shot 2022-08-03 at 12 01 10 PM" src="https://user-images.githubusercontent.com/1024985/182521372-f2ad308e-0745-4145-98ba-6583642a7f24.png">

#### Screencast

https://user-images.githubusercontent.com/1024985/181740515-1fea3087-2293-4d86-8e5d-afd7b72720a4.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/66039
