### PR TITLE
Signup: add link-in-bio flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -128,6 +128,21 @@ export function generateFlows( {
 			},
 		},
 		{
+			name: 'link-in-bio',
+			steps: getAddOnsStep(
+				isEnabled( 'signup/professional-email-step' )
+					? [ 'user', 'domains', 'emails', 'plans' ]
+					: [ 'user', 'domains', 'plans' ]
+			),
+			destination: ( dependencies ) => getStepperFlowDestination( dependencies, 'link-in-bio' ),
+			description: 'Beginning of the flow to create a link in bio',
+			lastModified: '2022-07-28',
+			showRecaptcha: true,
+			get pageTitle() {
+				return translate( 'Link in Bio' );
+			},
+		},
+		{
 			name: 'with-add-ons',
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ 'user', 'domains', 'emails', 'plans', 'add-ons' ]

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -123,6 +123,7 @@ export function generateFlows( {
 			description: 'Beginning of the flow to create a newsletter',
 			lastModified: '2022-07-28',
 			showRecaptcha: true,
+			hideBackButton: true,
 			get pageTitle() {
 				return translate( 'Newsletters' );
 			},
@@ -138,6 +139,7 @@ export function generateFlows( {
 			description: 'Beginning of the flow to create a link in bio',
 			lastModified: '2022-07-28',
 			showRecaptcha: true,
+			hideBackButton: true,
 			get pageTitle() {
 				return translate( 'Link in Bio' );
 			},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -43,6 +43,7 @@ import {
 	getStepSectionName,
 	getValidPath,
 	getFlowPageTitle,
+	getFlowHideBack,
 	shouldForceLogin,
 	isReskinnedFlow,
 } from './utils';
@@ -313,6 +314,7 @@ export default {
 			stepSectionName,
 			stepComponent,
 			pageTitle: getFlowPageTitle( flowName, userLoggedIn ),
+			hideBackButton: getFlowHideBack( flowName, userLoggedIn ),
 			isManageSiteFlow,
 		} );
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -142,6 +142,7 @@ class Signup extends Component {
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
+		hideBackButton: PropTypes.bool,
 		siteType: PropTypes.string,
 		stepSectionName: PropTypes.string,
 	};
@@ -742,13 +743,6 @@ class Signup extends Component {
 			return this.props.siteId && waitToRenderReturnValue;
 		}
 
-		const showPageTitle = () => {
-			if ( this.props.flowName === 'newsletters' || this.props.flowName === 'link-in-bio' ) {
-				return this.props.pageTitle;
-			}
-			return false;
-		};
-
 		const isReskinned = isReskinnedFlow( this.props.flowName );
 		const olarkIdentity = config( 'olark_chat_identity' );
 		const olarkSystemsGroupId = '2dfd76a39ce77758f128b93942ae44b5';
@@ -765,7 +759,7 @@ class Signup extends Component {
 						<SignupHeader
 							shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
 							isReskinned={ isReskinned }
-							pageTitle={ showPageTitle() }
+							pageTitle={ this.props.hideBackButton && this.props.pageTitle }
 							rightComponent={
 								showProgressIndicator( this.props.flowName ) && (
 									<FlowProgressIndicator

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -743,7 +743,7 @@ class Signup extends Component {
 		}
 
 		const showPageTitle = () => {
-			if ( this.props.flowName === 'newsletters' ) {
+			if ( this.props.flowName === 'newsletters' || this.props.flowName === 'link-in-bio' ) {
 				return this.props.pageTitle;
 			}
 			return false;

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -13,9 +13,10 @@ export default class SignupHeader extends Component {
 	};
 
 	render() {
-		const { pageTitle } = this.props;
+		const { pageTitle, shouldShowLoadingScreen, isReskinned, rightComponent } = this.props;
+
 		const logoClasses = classnames( 'wordpress-logo', {
-			'is-large': this.props.shouldShowLoadingScreen && ! this.props.isReskinned,
+			'is-large': shouldShowLoadingScreen && ! isReskinned,
 		} );
 
 		return (
@@ -24,9 +25,7 @@ export default class SignupHeader extends Component {
 				{ pageTitle && <h1>{ pageTitle }</h1> }
 				{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }
-				<div className="signup-header__right">
-					{ ! this.props.shouldShowLoadingScreen && this.props.rightComponent }
-				</div>
+				<div className="signup-header__right">{ ! shouldShowLoadingScreen && rightComponent }</div>
 			</div>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -725,7 +725,7 @@ class DomainsStep extends Component {
 			return null;
 		}
 
-		const { isAllDomains, translate, isReskinned } = this.props;
+		const { isAllDomains, translate, isReskinned, hideBackButton } = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;
 		const source = this.props.queryObject?.source;
@@ -784,7 +784,7 @@ class DomainsStep extends Component {
 				isExternalBackUrl={ isExternalBackUrl }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
-				hideBack={ this.props.flowName === 'newsletters' || this.props.flowName === 'link-in-bio' }
+				hideBack={ hideBackButton }
 				stepContent={
 					<div>
 						{ ! this.props.productsLoaded && <QueryProductsList /> }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -784,7 +784,7 @@ class DomainsStep extends Component {
 				isExternalBackUrl={ isExternalBackUrl }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
-				hideBack={ this.props.flowName === 'newsletters' }
+				hideBack={ this.props.flowName === 'newsletters' || this.props.flowName === 'link-in-bio' }
 				stepContent={
 					<div>
 						{ ! this.props.productsLoaded && <QueryProductsList /> }

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -118,7 +118,8 @@ class EmailsStep extends Component {
 	}
 
 	render() {
-		const { flowName, translate, stepName, positionInFlow, signupDependencies } = this.props;
+		const { flowName, translate, stepName, positionInFlow, signupDependencies, hideBackButton } =
+			this.props;
 		const backUrl = 'start/domains/';
 		const headerText = translate( 'Add Professional Email' );
 		const domainName = signupDependencies.domainItem?.meta;
@@ -145,7 +146,7 @@ class EmailsStep extends Component {
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ translate( 'Back' ) }
 				hideSkip={ false }
-				hideBack={ this.props.flowName === 'newsletters' }
+				hideBack={ hideBackButton }
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }
 				skipLabelText={ translate( 'Buy an email later' ) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -297,8 +297,15 @@ export class PlansStep extends Component {
 	}
 
 	plansFeaturesSelection() {
-		const { flowName, stepName, positionInFlow, translate, hasInitializedSitesBackUrl, steps } =
-			this.props;
+		const {
+			flowName,
+			stepName,
+			positionInFlow,
+			translate,
+			hasInitializedSitesBackUrl,
+			steps,
+			hideBackButton,
+		} = this.props;
 
 		const headerText = this.getHeaderText();
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
@@ -339,7 +346,7 @@ export class PlansStep extends Component {
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					hideBack={ this.props.flowName === 'newsletters' }
+					hideBack={ hideBackButton }
 					isWideLayout={ true }
 					stepContent={ this.plansFeaturesList() }
 					allowBackFirstStep={ !! hasInitializedSitesBackUrl }

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -91,6 +91,11 @@ export function getFlowPageTitle( flowName, isUserLoggedIn ) {
 	return flow.pageTitle || translate( 'Create a site' );
 }
 
+export function getFlowHideBack( flowName, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
+	return flow.hideBackButton || false;
+}
+
 export function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {
 	const siteStepProgress = find( signupProgress, ( step ) => step.stepName === stepName );
 	return siteStepProgress ? siteStepProgress[ fieldName ] : null;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -185,6 +185,7 @@
 		"onboarding-with-email",
 		"with-add-ons",
 		"newsletters",
+		"link-in-bio",
 		"setup-site",
 		"account",
 		"do-it-for-me",


### PR DESCRIPTION
## Proposed Changes

This extends the existing signup flow by adding a `link-in-bio` flow. Along with the flow I added a new util function to determine if the the flow title or nav buttons should be shown.

More details on the new flow can be found here - BcUdhLlhAp7UHtQHNTI4zA-fi-1865%3A18108

## Screenshots

| Mobile | Desktop |
| - | - |
| ![Markup on 2022-07-29 at 18-04-59](https://user-images.githubusercontent.com/33258733/181802958-9227de49-eade-471c-bf4e-cc8705bb9719.png) | ![Markup on 2022-07-29 at 18-05-29](https://user-images.githubusercontent.com/33258733/181802996-efc77f49-f8a3-49da-b828-e4809214475e.png) |


## Testing Instructions

1. Pull branch and run `yarn start`
2. Navigate to http://calypso.localhost:3000/start/link-in-bio
3. Signup for a new account using a test email address that is NOT an Automattic address (this will end in an error if you don't)
4. Go through the entire signup and you should be redirected to `http://calypso.localhost:3000/setup?flow=link-in-bio&siteSlug=[SITE SLUG].wordpress.com`
5. That should then put you on `http://calypso.localhost:3000/setup/letsGetStarted?flow=newsletters&siteSlug=[SITE SLUG].wordpress.com`
6. PLEASE also check out the normal flow to make sure it is unaffected http://calypso.localhost:3000/start

## Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?