### PR TITLE
ETK: Starter_Page_Templates: Only calculate cache key when needed

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -21,6 +21,7 @@ class Starter_Page_Templates {
 
 	/**
 	 * Cache key for templates array.
+	 * Please access with the  ->get_templates_cache_key() getter.
 	 *
 	 * @var string
 	 */
@@ -30,22 +31,32 @@ class Starter_Page_Templates {
 	 * Starter_Page_Templates constructor.
 	 */
 	private function __construct() {
-		$this->templates_cache_key = implode(
-			'_',
-			array(
-				'starter_page_templates',
-				A8C_ETK_PLUGIN_VERSION,
-				get_option( 'site_vertical', 'default' ),
-				$this->get_verticals_locale(),
-			)
-		);
-
 		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'init', array( $this, 'register_meta_field' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
 		add_action( 'delete_attachment', array( $this, 'clear_sideloaded_image_cache' ) );
 		add_action( 'switch_theme', array( $this, 'clear_templates_cache' ) );
+	}
+
+	/**
+	 * Gets the cache key for templates array, after setting it if it hasn't been set yet.
+	 *
+	 * @return string
+	 */
+	public function get_templates_cache_key() {
+		if ( empty( $this->templates_cache_key ) ) {
+			$this->templates_cache_key = implode(
+				'_',
+				array(
+					'starter_page_templates',
+					A8C_ETK_PLUGIN_VERSION,
+					get_option( 'site_vertical', 'default' ),
+					$this->get_verticals_locale(),
+				)
+			);
+		}
+		return $this->templates_cache_key;
 	}
 
 	/**
@@ -200,7 +211,7 @@ class Starter_Page_Templates {
 	 * @return array Containing page templates or nothing if an error occurred.
 	 */
 	public function get_page_templates() {
-		$page_template_data = get_transient( $this->templates_cache_key );
+		$page_template_data = get_transient( $this->get_templates_cache_key() );
 
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 
@@ -234,7 +245,7 @@ class Starter_Page_Templates {
 
 			// Only save to cache if we have not overridden the source site.
 			if ( false === $override_source_site ) {
-				set_transient( $this->templates_cache_key, $page_template_data, DAY_IN_SECONDS );
+				set_transient( $this->get_templates_cache_key(), $page_template_data, DAY_IN_SECONDS );
 			}
 
 			return $page_template_data;
@@ -259,7 +270,7 @@ class Starter_Page_Templates {
 	 * Deletes cached templates data when theme switches.
 	 */
 	public function clear_templates_cache() {
-		delete_transient( $this->templates_cache_key );
+		delete_transient( $this->get_templates_cache_key() );
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

* In Starter_Page_Templates, Delay generating a cache key until it's needed.
  * Generating the cache key is potentially slow because of a translation filter on verticals.
  * Writeup is here: p55Cj4-1LL-p2  

#### Testing Instructions


* It's probably easiest to edit `./wp-content/plugins/editing-toolkit-plugin/prod/starter-page-templates/class-starter-page-templates.php` directly on sandbox.
* Add logging to look at the cache_key before and after the PR. Example:

```diff
diff --git a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
index 58ba78ac60..aeed0b9910 100644
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -212,6 +212,8 @@ class Starter_Page_Templates {
         */
        public function get_page_templates() {
                $page_template_data = get_transient( $this->get_templates_cache_key() );
+               error_log("Cache key access 1:");
+               error_log($this->get_templates_cache_key());
 
                $override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 
@@ -245,6 +247,8 @@ class Starter_Page_Templates {
 
                        // Only save to cache if we have not overridden the source site.
                        if ( false === $override_source_site ) {
+                               error_log("Cache key access 2:");
+                               error_log($this->get_templates_cache_key());
                                set_transient( $this->get_templates_cache_key(), $page_template_data, DAY_IN_SECONDS );
                        }
 
@@ -270,6 +274,8 @@ class Starter_Page_Templates {
         * Deletes cached templates data when theme switches.
         */
        public function clear_templates_cache() {
+               error_log("Cache key access 3:");
+               error_log($this->get_templates_cache_key());
                delete_transient( $this->get_templates_cache_key() );
        }

```
* Visit `/wp-admin/post-new.php` on a sandboxed simple site and examine the logs
* The cache key should be the same before and after the PR, but it will only be generated when needed. For example `post-new.php` will continue to generate the cache key, but `/rest/v1.1/sites/1234/features` will not.

Related to #