### PR TITLE
Prefix the plugins cache keys with a version number

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -13,7 +13,12 @@ const plugisApiBase = '/marketplace/products';
 const featuredPluginsApiBase = '/plugins/featured';
 const pluginsApiNamespace = 'wpcom/v2';
 
-const getCacheKey = ( key: string ): QueryKey => [ 'wpcom-plugins', key ];
+const WPCOM_PLUGINS_CACHE_VERSION = 1;
+const getCacheKey = ( key: string ): QueryKey => [
+	WPCOM_PLUGINS_CACHE_VERSION.toString(),
+	'wpcom-plugins',
+	key,
+];
 
 const fetchWPCOMPlugins = ( type: Type, searchTerm?: string, tag?: string ) => {
 	const [ search, author ] = extractSearchInformation( searchTerm );

--- a/client/data/marketplace/utils.ts
+++ b/client/data/marketplace/utils.ts
@@ -1,6 +1,8 @@
 import { QueryKey } from 'react-query';
 import { PluginQueryOptions } from './types';
 
+const PLUGINS_CACHE_VERSION = 1;
+
 export const getPluginsListKey = (
 	key: QueryKey,
 	options: PluginQueryOptions,
@@ -16,5 +18,5 @@ export const getPluginsListKey = (
 		options.tag && ! options.searchTerm ? options.tag : '',
 	];
 
-	return [ key, ...keyParams ];
+	return [ PLUGINS_CACHE_VERSION.toString(), key, ...keyParams ];
 };


### PR DESCRIPTION
#### Proposed Changes

Prefix the plugin's cache keys with a version number. 

This allow us to drop a given plugin cache as soon as the deploy reaches production if we want to.

#### Testing Instructions
* Spin this branch locally and run `yarn start`
* Go to `/plugins` page
* Open the Browser dev tools and go to the `Network` tab
* Search for `wordpress.org`
* You may see a result, reload the page and you shouldn't see it anymore (because its cached)
* Change the `PLUGINS_CACHE_VERSION` variable on `client/data/marketplace/utils.ts`
* Reload the page and re-check the network tab with `wordpress.org` search
* You MUST see one request being made again, due to the last cache not being in use anymore

![Kapture 2022-07-29 at 18 22 26](https://user-images.githubusercontent.com/5039531/181854005-b3e9ac1a-dd1f-4649-b6a2-67b6eee3b1fb.gif)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->