### PR TITLE
Checkout: Change dropdown variant picker to compare prices to lowest price

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -229,7 +229,7 @@ function ItemVariantOptionList( {
 	selectedItem: ResponseCartProduct;
 	handleChange: ( uuid: string, productSlug: string, productId: number ) => void;
 } ) {
-	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
+	const compareTo = variants[ 0 ];
 	return (
 		<OptionList role="listbox" tabIndex={ -1 }>
 			{ variants.map( ( variant, index ) => (

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -189,6 +189,9 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	if ( variants.length < 2 ) {
 		return null;
 	}
+	const selectedVariant =
+		selectedVariantIndex !== null ? variants[ selectedVariantIndex ] : undefined;
+	const compareTo = variants[ 0 ];
 
 	return (
 		<Dropdown aria-expanded={ open } aria-haspopup="listbox" onKeyDown={ handleKeyDown }>
@@ -199,8 +202,8 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				open={ open }
 				role="button"
 			>
-				{ selectedVariantIndex !== null ? (
-					<ItemVariantPrice variant={ variants[ selectedVariantIndex ] } />
+				{ selectedVariant ? (
+					<ItemVariantPrice variant={ selectedVariant } compareTo={ compareTo } />
 				) : (
 					<span>{ translate( 'Pick a product term' ) }</span>
 				) }


### PR DESCRIPTION
#### Proposed Changes

This partially reverts the changes in https://github.com/Automattic/wp-calypso/pull/65998 by changing the drop-down term variant picker on each checkout line item to compare that item's price to the lowest available variant when generating the "Save X%" label.

It's not clear which version is better, but this is here to make it easier to revert to the previous behavior without having to revert the actual PR.

Before:
<img width="626" alt="Screen Shot 2022-07-26 at 6 51 04 PM" src="https://user-images.githubusercontent.com/2036909/181125827-d1cccdf2-59bd-477b-a030-81fbe5006980.png">

After:
<img width="636" alt="Screen Shot 2022-07-26 at 6 51 24 PM" src="https://user-images.githubusercontent.com/2036909/181125820-5708d39d-f0a8-417d-9889-840969fb9fd3.png">


#### Testing Instructions

- Add a product to your cart that has variants (eg: a WordPress.com legacy plan like Premium).
- Visit checkout and click the product variant selector for that product.
- Verify that the options in the selector show a discounted price that matches what the lowest variant's price would be if it were applied to that term, no matter what term is selected. So if the monthly price is $7 and the yearly price is $48, the yearly price should show a discount of 42% (100 - 48/(7 * 12) * 100).
- Select different variants and be sure that the above still holds true for all of them.