### PR TITLE
Unified design picker: Tailored UI based on intent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -79,6 +79,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
 		{
 			vertical_id: siteVerticalId,
+			intent,
 			seed: siteSlugOrId || undefined,
 			_locale: locale,
 		},

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -6,6 +6,7 @@ import type { Category, Design, DesignRecipe } from '@automattic/design-picker/s
 
 interface StarterDesignsQueryParams {
 	vertical_id: string;
+	intent: string;
 	seed?: string;
 	_locale: string;
 }


### PR DESCRIPTION
#### Proposed Changes

- Update query params to send `site intent` 

#### Testing Instructions

- Navigate to /designSetup step
- Check for the intent parameter in Network tab

Related to #65924 
