### PR TITLE
Professional Email: Hide optional fields in the "Add mailbox" form for consistency with the Email Comparison view

### DIFF
--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { PropsWithChildren, useState } from 'react';
+import { MouseEvent, PropsWithChildren, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -29,10 +29,15 @@ import {
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/add-mailboxes/titan-unused-mailboxes-notice';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import { NewMailBoxList } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
+import PasswordResetTipField from 'calypso/my-sites/email/form/mailboxes/components/password-reset-tip-field';
 import getMailProductForProvider from 'calypso/my-sites/email/form/mailboxes/components/selectors/get-mail-product-for-provider';
 import getCartItems from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-cart-items';
 import { getEmailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
+import {
+	FIELD_ALTERNATIVE_EMAIL,
+	FIELD_NAME,
+} from 'calypso/my-sites/email/form/mailboxes/constants';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import {
@@ -48,6 +53,7 @@ import {
 	isRequestingSiteDomains,
 } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { HiddenFieldNames } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { translate } from 'i18n-calypso';
 
@@ -223,6 +229,10 @@ const MailboxesForm = ( {
 } ): JSX.Element => {
 	const [ isAddingToCart, setIsAddingToCart ] = useState( false );
 	const [ isValidating, setIsValidating ] = useState( false );
+	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
+		FIELD_NAME,
+		FIELD_ALTERNATIVE_EMAIL,
+	] );
 
 	const cartKey = useCartKey();
 	const cartManager = useShoppingCart( cartKey );
@@ -230,6 +240,11 @@ const MailboxesForm = ( {
 	if ( isLoadingDomains || ! emailProduct ) {
 		return <AddEmailAddressesCardPlaceholder />;
 	}
+
+	const showAlternateEmailField = ( event: MouseEvent< HTMLElement > ) => {
+		event.preventDefault();
+		setHiddenFieldNames( [ FIELD_NAME ] );
+	};
 
 	const onCancel = () => {
 		recordClickEvent( {
@@ -290,6 +305,7 @@ const MailboxesForm = ( {
 			<Card>
 				<NewMailBoxList
 					areButtonsBusy={ isAddingToCart || isValidating }
+					hiddenFieldNames={ hiddenFieldNames }
 					onSubmit={ onSubmit }
 					onCancel={ onCancel }
 					provider={ provider }
@@ -297,7 +313,11 @@ const MailboxesForm = ( {
 					showAddNewMailboxButton
 					showCancelButton
 					submitActionText={ translate( 'Continue' ) }
-				/>
+				>
+					{ hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
+						<PasswordResetTipField tipClickHandler={ showAlternateEmailField } />
+					) }
+				</NewMailBoxList>
 			</Card>
 		</>
 	);

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -45,6 +45,7 @@ import {
 	emailManagementInbox,
 	emailManagementTitanSetUpMailbox,
 } from 'calypso/my-sites/email/paths';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
@@ -227,6 +228,7 @@ const MailboxesForm = ( {
 	emailProduct: ProductListItem | null;
 	goToEmail: () => void;
 } ): JSX.Element => {
+	const userEmail = useSelector( getCurrentUserEmail );
 	const [ isAddingToCart, setIsAddingToCart ] = useState( false );
 	const [ isValidating, setIsValidating ] = useState( false );
 	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
@@ -306,6 +308,7 @@ const MailboxesForm = ( {
 				<NewMailBoxList
 					areButtonsBusy={ isAddingToCart || isValidating }
 					hiddenFieldNames={ hiddenFieldNames }
+					initialFieldValues={ { [ FIELD_ALTERNATIVE_EMAIL ]: userEmail } }
 					onSubmit={ onSubmit }
 					onCancel={ onCancel }
 					provider={ provider }

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.scss
@@ -12,7 +12,3 @@
 		padding-right: 12px;
 	}
 }
-
-.professional-email-card__change-it-button {
-	color: var( --color-link );
-}

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.tsx
@@ -1,10 +1,9 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { translate, useTranslate } from 'i18n-calypso';
 import { MouseEvent, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getTitanProductName } from 'calypso/lib/titan';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -17,6 +16,7 @@ import {
 	HiddenFieldNames,
 	NewMailBoxList,
 } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
+import PasswordResetTipField from 'calypso/my-sites/email/form/mailboxes/components/password-reset-tip-field';
 import {
 	FIELD_ALTERNATIVE_EMAIL,
 	FIELD_NAME,
@@ -64,46 +64,6 @@ const professionalEmailCardInformation: ProviderCardProps = {
 	get features() {
 		return getTitanFeatures();
 	},
-};
-
-const PasswordResetTipField = ( {
-	userEmail,
-	showAlternateEmailField,
-	hiddenFieldNames,
-}: {
-	hiddenFieldNames: string[];
-	showAlternateEmailField: ( event: MouseEvent< HTMLElement > ) => void;
-	userEmail: string;
-} ) => {
-	const translate = useTranslate();
-
-	if ( ! hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) ) {
-		return null;
-	}
-
-	return (
-		<FormSettingExplanation>
-			{ translate(
-				'Your password reset email is {{strong}}%(userEmail)s{{/strong}}. {{a}}Change it{{/a}}.',
-				{
-					args: {
-						userEmail,
-					},
-					components: {
-						strong: <strong />,
-						a: (
-							<Button
-								href="#"
-								className="professional-email-card__change-it-button"
-								onClick={ showAlternateEmailField }
-								plain
-							/>
-						),
-					},
-				}
-			) }
-		</FormSettingExplanation>
-	);
 };
 
 const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactElement => {
@@ -177,11 +137,9 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactEl
 			submitActionText={ translate( 'Purchase' ) }
 			{ ...getUpsellProps( { isDomainInCart, siteSlug } ) }
 		>
-			<PasswordResetTipField
-				hiddenFieldNames={ hiddenFieldNames }
-				showAlternateEmailField={ showAlternateEmailField }
-				userEmail={ userEmail }
-			/>
+			{ hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
+				<PasswordResetTipField tipClickHandler={ showAlternateEmailField } />
+			) }
 		</NewMailBoxList>
 	);
 

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -25,6 +25,7 @@ import {
 	MailboxFormFieldBase,
 	MutableFormFieldNames,
 } from 'calypso/my-sites/email/form/mailboxes/types';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -80,7 +81,7 @@ interface MailboxListProps {
 }
 
 const NewMailBoxList = (
-	props: MailboxListProps & { children?: JSX.Element }
+	props: MailboxListProps & { children?: ReactNode }
 ): JSX.Element | null => {
 	const translate = useTranslate();
 

--- a/client/my-sites/email/form/mailboxes/components/password-reset-tip-field/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/password-reset-tip-field/index.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { MouseEvent } from 'react';
+import { useSelector } from 'react-redux';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+
+import './style.scss';
+
+const PasswordResetTipField = ( {
+	tipClickHandler,
+}: {
+	tipClickHandler: ( event: MouseEvent< HTMLElement > ) => void;
+} ) => {
+	const translate = useTranslate();
+	const userEmail = useSelector( getCurrentUserEmail );
+
+	return (
+		<FormSettingExplanation>
+			{ translate(
+				'Your password reset email is {{strong}}%(userEmail)s{{/strong}}. {{a}}Change it{{/a}}.',
+				{
+					args: {
+						userEmail,
+					},
+					components: {
+						strong: <strong />,
+						a: (
+							<Button
+								href="#"
+								className="password-reset-tip-field__change-it-button"
+								onClick={ tipClickHandler }
+								plain
+							/>
+						),
+					},
+				}
+			) }
+		</FormSettingExplanation>
+	);
+};
+
+export default PasswordResetTipField;

--- a/client/my-sites/email/form/mailboxes/components/password-reset-tip-field/style.scss
+++ b/client/my-sites/email/form/mailboxes/components/password-reset-tip-field/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/variables';
 
 .password-reset-tip-field__change-it-button {
 	color: var( --color-link );

--- a/client/my-sites/email/form/mailboxes/components/password-reset-tip-field/style.scss
+++ b/client/my-sites/email/form/mailboxes/components/password-reset-tip-field/style.scss
@@ -1,0 +1,4 @@
+
+.password-reset-tip-field__change-it-button {
+	color: var( --color-link );
+}

--- a/client/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form.tsx
@@ -1,11 +1,19 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useCreateTitanMailboxMutation } from 'calypso/data/emails/use-create-titan-mailbox-mutation';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/add-mailboxes/add-users-placeholder';
-import { NewMailBoxList } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
+import {
+	HiddenFieldNames,
+	NewMailBoxList,
+} from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
+import PasswordResetTipField from 'calypso/my-sites/email/form/mailboxes/components/password-reset-tip-field';
+import {
+	FIELD_ALTERNATIVE_EMAIL,
+	FIELD_NAME,
+} from 'calypso/my-sites/email/form/mailboxes/constants';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { emailManagementTitanSetUpThankYou } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -106,21 +114,35 @@ const TitanSetUpMailboxForm = ( {
 	const translate = useTranslate();
 	const [ isValidating, setIsValidating ] = useState( false );
 	const handleCompleteSetup = useHandleCompleteSetup( selectedDomainName, setIsValidating );
+	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
+		FIELD_NAME,
+		FIELD_ALTERNATIVE_EMAIL,
+	] );
 
 	if ( ! areSiteDomainsLoaded ) {
 		return <AddEmailAddressesCardPlaceholder />;
 	}
 
+	const showAlternateEmailField = ( event: MouseEvent< HTMLElement > ) => {
+		event.preventDefault();
+		setHiddenFieldNames( [ FIELD_NAME ] );
+	};
+
 	return (
 		<Card>
 			<NewMailBoxList
 				areButtonsBusy={ isValidating }
+				hiddenFieldNames={ hiddenFieldNames }
 				isAutoFocusEnabled
 				onSubmit={ handleCompleteSetup }
 				provider={ EmailProvider.Titan }
 				selectedDomainName={ selectedDomainName }
 				submitActionText={ translate( 'Complete setup' ) }
-			/>
+			>
+				{ hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
+					<PasswordResetTipField tipClickHandler={ showAlternateEmailField } />
+				) }
+			</NewMailBoxList>
 		</Card>
 	);
 };

--- a/client/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form.tsx
@@ -17,6 +17,7 @@ import {
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { emailManagementTitanSetUpThankYou } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
@@ -112,6 +113,7 @@ const TitanSetUpMailboxForm = ( {
 	selectedDomainName,
 }: TitanSetUpMailboxFormProps ) => {
 	const translate = useTranslate();
+	const userEmail = useSelector( getCurrentUserEmail );
 	const [ isValidating, setIsValidating ] = useState( false );
 	const handleCompleteSetup = useHandleCompleteSetup( selectedDomainName, setIsValidating );
 	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
@@ -133,6 +135,7 @@ const TitanSetUpMailboxForm = ( {
 			<NewMailBoxList
 				areButtonsBusy={ isValidating }
 				hiddenFieldNames={ hiddenFieldNames }
+				initialFieldValues={ { [ FIELD_ALTERNATIVE_EMAIL ]: userEmail } }
 				isAutoFocusEnabled
 				onSubmit={ handleCompleteSetup }
 				provider={ EmailProvider.Titan }


### PR DESCRIPTION
#### Proposed Changes

* Hide the "Full name" and "Alternative Email" fields of the "Add mailbox" and "Set up mailbox" forms to make them consistent with existing behaviour in stacked email comparison forms.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a Professional Email subscription
* Navigate to the Email plan page [/email/<:domain>/manage/<:site>](http://calypso.localhost:3000/email/<:domain>/manage/<:site>)
* Proceed to add a new mailbox using the "Add new mailboxes" link/CTA
    * Step **A**). Confirm that the "Full name" and "Password reset" fields are no longer visible
    * Step **B**). Confirm that you can still purchase additional mailboxes
* Externally delete a mailbox from the external provider's control panel. This should activate the "Set up mailbox" CTA in the Email plan page [/email/<:domain>/manage/<:site>](http://calypso.localhost:3000/email/<:domain>/manage/<:site>)
* Proceed to set up a mailbox using the "Setup mailbox" link/CTA
    * Confirm steps **A**) and **B**) above 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


