### PR TITLE
`PlanTypeSelector`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/my-sites/plans-features-main/test/plan-type-selector.jsx
+++ b/client/my-sites/plans-features-main/test/plan-type-selector.jsx
@@ -33,7 +33,7 @@ describe( '<PlanTypeSelector />', () => {
 		expect( radios[ 0 ] ).toHaveTextContent( 'Blogs and personal sites' );
 		expect( radios[ 1 ] ).toHaveTextContent( 'Business sites and online stores' );
 
-		expect( screen.queryByRole( 'radio', { checked: true } ) ).toBe( radios[ 0 ] );
+		expect( radios[ 0 ] ).toBeChecked();
 	} );
 
 	test( 'Should show IntervalTypeToggle when kind is set to `interval`', () => {
@@ -53,7 +53,7 @@ describe( '<PlanTypeSelector />', () => {
 		expect( radios[ 0 ] ).toHaveTextContent( 'Pay monthly' );
 		expect( radios[ 1 ] ).toHaveTextContent( 'Pay annually' );
 
-		expect( screen.queryByRole( 'radio', { checked: true } ) ).toBe( radios[ 0 ] );
+		expect( radios[ 0 ] ).toBeChecked();
 	} );
 } );
 
@@ -71,6 +71,8 @@ describe( '<CustomerTypeToggle />', () => {
 		render( <CustomerTypeToggle { ...props } /> );
 
 		const radios = screen.getAllByRole( 'radio' );
+
+		expect( radios ).toHaveLength( 2 );
 
 		expect( radios[ 0 ] ).toHaveAttribute( 'href', '?customerType=personal&plan=free_plan' );
 		expect( radios[ 0 ] ).toHaveAttribute( 'aria-checked', 'true' );

--- a/client/my-sites/plans-features-main/test/plan-type-selector.jsx
+++ b/client/my-sites/plans-features-main/test/plan-type-selector.jsx
@@ -1,13 +1,20 @@
+/** @jest-environment jsdom */
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( Component ) => ( props ) => <Component { ...props } translate={ ( x ) => x } />,
 	numberFormat: ( x ) => x,
 	translate: ( x ) => x,
 	useTranslate: jest.fn( () => ( x ) => x ),
 } ) );
+jest.mock( '@automattic/components', () => ( {
+	Popover: () => <div />,
+} ) );
 
 import { PLAN_FREE } from '@automattic/calypso-products';
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import PlanTypeSelector, { CustomerTypeToggle } from '../plan-type-selector';
+
+const render = ( el, options ) => renderWithProvider( el, { ...options } );
 
 describe( '<PlanTypeSelector />', () => {
 	const myProps = {
@@ -17,25 +24,36 @@ describe( '<PlanTypeSelector />', () => {
 	};
 
 	test( 'Should show CustomerTypeToggle when kind is set to `customer`', () => {
-		const comp = shallow(
-			<PlanTypeSelector { ...myProps } kind="customer" customerType="personal" />
-		);
+		render( <PlanTypeSelector { ...myProps } kind="customer" customerType="personal" /> );
 
-		expect( comp.find( 'CustomerTypeToggle' ).length ).toBe( 1 );
+		expect( screen.getByRole( 'radiogroup' ) ).toHaveClass( 'is-customer-type-toggle' );
 
-		// customerType prop is passed to the child component
-		expect( comp.find( 'CustomerTypeToggle[customerType="personal"]' ).length ).toBe( 1 );
+		const radios = screen.queryAllByRole( 'radio' );
+
+		expect( radios[ 0 ] ).toHaveTextContent( 'Blogs and personal sites' );
+		expect( radios[ 1 ] ).toHaveTextContent( 'Business sites and online stores' );
+
+		expect( screen.queryByRole( 'radio', { checked: true } ) ).toBe( radios[ 0 ] );
 	} );
 
 	test( 'Should show IntervalTypeToggle when kind is set to `interval`', () => {
-		const comp = shallow(
-			<PlanTypeSelector { ...myProps } kind="interval" intervalType="monthly" />
+		render(
+			<PlanTypeSelector
+				{ ...myProps }
+				kind="interval"
+				intervalType="monthly"
+				eligibleForWpcomMonthlyPlans
+			/>
 		);
 
-		expect( comp.find( 'IntervalTypeToggle' ).length ).toBe( 1 );
+		expect( screen.getByRole( 'radiogroup' ) ).toHaveClass( 'price-toggle' );
 
-		// customerType prop is passed to the child component
-		expect( comp.find( 'IntervalTypeToggle[intervalType="monthly"]' ).length ).toBe( 1 );
+		const radios = screen.queryAllByRole( 'radio' );
+
+		expect( radios[ 0 ] ).toHaveTextContent( 'Pay monthly' );
+		expect( radios[ 1 ] ).toHaveTextContent( 'Pay annually' );
+
+		expect( screen.queryByRole( 'radio', { checked: true } ) ).toBe( radios[ 0 ] );
 	} );
 } );
 
@@ -46,68 +64,45 @@ describe( '<CustomerTypeToggle />', () => {
 		withWPPlanTabs: true,
 	};
 
-	beforeEach( () => {
-		global.document = {
-			location: {
-				search: '',
-			},
-		};
-	} );
+	afterEach( () => {} );
 
 	test( "Should select personal tab when it's requested", () => {
 		const props = { ...myProps, customerType: 'personal' };
-		const comp = shallow( <CustomerTypeToggle { ...props } /> );
-		expect( comp.find( 'SegmentedControl' ).length ).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=personal&plan=free_plan"]' ).length
-		).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=personal&plan=free_plan"]' ).props()
-				.selected
-		).toBe( true );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=business&plan=free_plan"]' ).length
-		).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=business&plan=free_plan"]' ).props()
-				.selected
-		).toBe( false );
+		render( <CustomerTypeToggle { ...props } /> );
+
+		const radios = screen.getAllByRole( 'radio' );
+
+		expect( radios[ 0 ] ).toHaveAttribute( 'href', '?customerType=personal&plan=free_plan' );
+		expect( radios[ 0 ] ).toHaveAttribute( 'aria-checked', 'true' );
+
+		expect( radios[ 1 ] ).toHaveAttribute( 'href', '?customerType=business&plan=free_plan' );
+		expect( radios[ 1 ] ).toHaveAttribute( 'aria-checked', 'false' );
 	} );
 
 	test( "Should select business tab when it's requested", () => {
 		const props = { ...myProps, customerType: 'business' };
-		const comp = shallow( <CustomerTypeToggle { ...props } /> );
-		expect( comp.find( 'SegmentedControl' ).length ).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=personal&plan=free_plan"]' ).length
-		).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=personal&plan=free_plan"]' ).props()
-				.selected
-		).toBe( false );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=business&plan=free_plan"]' ).length
-		).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?customerType=business&plan=free_plan"]' ).props()
-				.selected
-		).toBe( true );
+		render( <CustomerTypeToggle { ...props } /> );
+
+		const radios = screen.getAllByRole( 'radio' );
+
+		expect( radios[ 0 ] ).toHaveAttribute( 'href', '?customerType=personal&plan=free_plan' );
+		expect( radios[ 0 ] ).toHaveAttribute( 'aria-checked', 'false' );
+
+		expect( radios[ 1 ] ).toHaveAttribute( 'href', '?customerType=business&plan=free_plan' );
+		expect( radios[ 1 ] ).toHaveAttribute( 'aria-checked', 'true' );
 	} );
 
 	test( 'Should generate tabs links based on the current search parameters', () => {
-		global.document.location.search = '?fake=1';
+		history.replaceState( {}, '', '?fake=1' );
 
 		const props = { ...myProps, customerType: 'business' };
-		const comp = shallow( <CustomerTypeToggle { ...props } /> );
+		render( <CustomerTypeToggle { ...props } /> );
 
-		expect( comp.find( 'SegmentedControl' ).length ).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?fake=1&customerType=personal&plan=free_plan"]' )
-				.length
-		).toBe( 1 );
-		expect(
-			comp.find( 'SegmentedControlItem[path="?fake=1&customerType=business&plan=free_plan"]' )
-				.length
-		).toBe( 1 );
+		const radios = screen.getAllByRole( 'radio' );
+
+		expect( radios[ 0 ] ).toHaveAttribute( 'href', '?fake=1&customerType=personal&plan=free_plan' );
+		expect( radios[ 1 ] ).toHaveAttribute( 'href', '?fake=1&customerType=business&plan=free_plan' );
+
+		history.replaceState( {}, '', location.pathname );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `PlanTypeSelector`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 