### PR TITLE
WooCommerce.com login - move ToS above actions

### DIFF
--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -54,10 +54,10 @@ class SocialConnectPrompt extends Component {
 			<Card className="login__social-connect-prompt">
 				<div className="login__social-connect-prompt-logos">
 					{ this.props.linkingSocialService === 'google' && (
-						<GoogleIcon className="login__social-connect-prompt-logo" />
+						<GoogleIcon className="login__social-connect-prompt-logo is-google" />
 					) }
 					{ this.props.linkingSocialService === 'apple' && (
-						<AppleIcon className="login__social-connect-prompt-logo" />
+						<AppleIcon className="login__social-connect-prompt-logo is-apple" />
 					) }
 					<svg
 						className="login__social-connect-prompt-dots"

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -489,6 +489,12 @@
 		text-decoration: underline;
 	}
 
+	.signup-form__terms-of-service-link {
+		a {
+			font-size: inherit;
+		}
+	}
+
 	background: #e6e6e6;
 	min-height: 100%;
 
@@ -677,7 +683,7 @@
 		}
 	}
 
-	$woo-form-whitespace: 90px;
+	$woo-form-whitespace: 85px;
 	$woo-form-whitespace-660: 20px;
 
 	.card {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -606,7 +606,6 @@
 		}
 	}
 
-	.login__form-action,
 	.magic-login__form-action {
 		text-align: center;
 		margin-top: 25px;
@@ -625,8 +624,10 @@
 		}
 
 		.login__social-tos {
-			margin: 2.5em auto 0;
+			margin: 0 auto 2.5em;
 			max-width: 100%;
+			order: -1;
+
 			a {
 				font-size: inherit;
 			}
@@ -778,6 +779,7 @@
 		border-top: $woo-form-divider-border;
 		border-bottom: $woo-form-divider-border;
 		padding-top: 44px;
+		padding-bottom: 44px;
 		text-align: center;
 	}
 
@@ -838,8 +840,7 @@
 		font-size: $woo-font-size-small;
 		line-height: 28px;
 		color: $woo-gray-40;
-		margin: 8px;
-		order: 1;
+		margin: 25px 8px 8px;
 		a {
 			font-size: inherit;
 		}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -573,6 +573,10 @@
 		}
 	}
 
+	.login__form-header {
+		margin-bottom: 8px;
+	}
+
 	.form-password-input .form-password-input__toggle-visibility {
 		top: 18px;
 	}
@@ -612,15 +616,19 @@
 	}
 
 	.login__social-buttons {
-		$woo-social-button-spacing: 8px;
+		$woo-social-button-spacing: 6px;
 		margin-top: 0;
 
 		.social-buttons__button {
 			border-color: $woo-label-color;
 			color: $woo-label-color;
-			padding: 4px 35px;
+			padding: 4px 6px;
 			font-size: $woo-font-size-base;
 			width: 100%;
+		}
+
+		.social-buttons__service-name {
+			margin-left: 7px;
 		}
 
 		.login__social-tos {
@@ -646,12 +654,12 @@
 					width: calc( 50% - #{$woo-social-button-spacing} );
 				}
 
-				:first-child {
+				> :first-child {
 					margin-left: auto;
 					margin-right: $woo-social-button-spacing;
 				}
 
-				:last-child {
+				> :last-child {
 					margin-left: $woo-social-button-spacing;
 					margin-right: auto;
 				}
@@ -659,12 +667,17 @@
 		}
 	}
 
+	.step-wrapper,
 	.wp-login__main.main,
 	.magic-login.main {
-		max-width: 778px;
+		max-width: 96%;
+
+		@media screen and ( min-width: 600px ) {
+			max-width: 570px;
+		}
 	}
 
-	$woo-form-whitespace: 40px;
+	$woo-form-whitespace: 90px;
 	$woo-form-whitespace-660: 20px;
 
 	.card {
@@ -683,8 +696,25 @@
 	.step-wrapper {
 		background: #fff;
 		box-sizing: border-box;
-		padding: 40px 0 20px;
+		padding: 30px 0;
 		width: 100%;
+	}
+
+	.login__social-connect-prompt-logo {
+		height: 58px;
+		width: 58px;
+
+		&:first-child {
+			width: 48px;
+			height: 48px;
+			margin-right: 3px;
+		}
+
+		// move apple icon slightly to the top so it looks more centered
+		&.is-apple {
+			position: relative;
+			top: -3px;
+		}
 	}
 
 	.login__form,
@@ -695,7 +725,7 @@
 	.two-factor-authentication__actions,
 	.two-factor-authentication__verification-code-form,
 	.step-wrapper__header,
-	.magic-login__form .logged-out-form,
+	.login__social-connect-prompt,
 	.magic-login__request-link {
 		padding-left: $woo-form-whitespace;
 		padding-right: $woo-form-whitespace;
@@ -703,6 +733,10 @@
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
 		}
+	}
+	.magic-login__form .logged-out-form {
+		padding-left: 0;
+		padding-right: 0;
 	}
 
 	.magic-login__form-header {
@@ -746,7 +780,6 @@
 
 	.step-wrapper {
 		margin: 0 auto 50px;
-		max-width: 778px;
 	}
 
 	.logged-out-form {
@@ -798,7 +831,7 @@
 			line-height: 28px;
 			text-align: center;
 			color: $woo-purple-60;
-			padding: 16px 24px;
+			padding: 8px 24px;
 			text-decoration: none;
 			&:hover {
 				text-decoration: underline;


### PR DESCRIPTION
#### Proposed Changes

ToS texts were moved above action buttons for both "regular" and social login.

Additionally, @wagveloso pointed out that the form should be narrower. Form width and other spacings were updated accordingly to designs in Figma BRQO7Z06r6AS4HOg86BuoN-fi-3043%3A7869 (all styles are nested inside `.woo` class - commit https://github.com/Automattic/wp-calypso/pull/66117/commits/3d27d85f58e0386b700369f1f6e1525eaa5554f8). 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On WooCommerce.test click login
- Replace _https://wordpress.com/_ with _http://calypso.localhost:3000/_ in the url (make sure that you followed the steps from the Calypo's [Getting Started](https://github.com/Automattic/wp-calypso/blob/trunk/README.md#getting-started) section of the README file)
- Go through the login flow and verify that the Terms of Service are displayed above the action buttons
- Go through login and registration screen and verify that width of login/registration form is correct
- Please test around this issue

#### Screenshots
![image](https://user-images.githubusercontent.com/4765119/182796376-625b646d-2d2e-4821-80d8-5862afe86ece.png)
![image](https://user-images.githubusercontent.com/4765119/182796439-4cd28439-9cb9-4286-b98d-24a30122da47.png)
