### PR TITLE
Reenable e2e tests for adding template parts

### DIFF
--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -79,7 +79,7 @@ describe(
 
 		// These events are currently broken :(. See https://github.com/Automattic/wp-calypso/issues/62924.
 		// eslint-disable-next-line jest/no-disabled-tests
-		describe.skip( 'wpcom_block_editor_template_part_choose_existing/replace', function () {
+		describe( 'wpcom_block_editor_template_part_choose_existing/replace', function () {
 			let page: Page;
 			let testAccount: TestAccount;
 			let fullSiteEditorPage: FullSiteEditorPage;

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -77,8 +77,6 @@ describe(
 			} );
 		} );
 
-		// These events are currently broken :(. See https://github.com/Automattic/wp-calypso/issues/62924.
-		// eslint-disable-next-line jest/no-disabled-tests
 		describe( 'wpcom_block_editor_template_part_choose_existing/replace', function () {
 			let page: Page;
 			let testAccount: TestAccount;


### PR DESCRIPTION
### Context

Changes to Gutenberg had broken Tracks events for adding/replacing template parts via the block editor. That issue has been fixed. But because that was broken, associated e2e tests were disabled. This pull request simply re-enables them. 

Related Issue: https://github.com/Automattic/wp-calypso/issues/62924
Related PR for fixing underlying issue: https://github.com/Automattic/wp-calypso/pull/65870

### Proposed Changes

I've simply removed .skip() from the associated tests and tested to confirm that the original tests still work correctly. 

### Testing Instructions

1) Follow the instructions in [wp-calypso/test/e2e/README.md](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md) to enabled yourself to run e2e 
tests locally. 

2) Once set up, you can run just the tests for this one changed file with `yarn jest specs/editor-tracking/editor-tracking__fse-template-events`. Confirm that the newly enabled tests pass. 

NOTE: You will see a failing test from the file above for 'wpcom_block_editor_template_part_detach_blocks event fires with correct block_names and template_part_id'. This is an existing test failure, not affected by the current PR. I'll create a separate issue to fix that.
