### PR TITLE
Help Center: Fix for css targeting

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -276,42 +276,45 @@ button.button.back-button__help-center.is-borderless {
 	}
 }
 
-.help-center {
-	button,
-	input,
-	textarea,
-	select {
-		box-sizing: border-box;
-	}
-
-	h1 {
-		font-weight: 600;
-		margin: 0.67em 0;
-
-		&.site-picker__site-title {
-			font-weight: 400;
-			margin: 0;
+body[class*='is-section-'],
+body[class^='is-section-'] {
+	.help-center {
+		button,
+		input,
+		textarea,
+		select {
+			box-sizing: border-box;
 		}
-	}
 
-	h2,
-	h3 {
-		color: #1d2327;
-		margin: 1em 0;
-	}
+		h1 {
+			font-weight: 600;
+			margin: 0.67em 0;
 
-	label {
-		cursor: pointer;
-	}
+			&.site-picker__site-title {
+				font-weight: 400;
+				margin: 0;
+			}
+		}
 
-	.help-center__container.is-desktop {
-		position: fixed;
-		top: calc( var( --masterbar-height ) + 16px );
-	}
+		h2,
+		h3 {
+			color: #1d2327;
+			margin: 1em 0;
+		}
 
-	.search-card {
-		.search {
-			border: none;
+		label {
+			cursor: pointer;
+		}
+
+		.help-center__container.is-desktop {
+			position: fixed;
+			top: calc( var( --masterbar-height ) + 16px );
+		}
+
+		.search-card {
+			.search {
+				border: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

After shipping to all Calypso, some CSS conflict created trouble in the help center showing. This PR adds more granularity to some CSS to fix this.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn start`
* Help Center should work in all calypso and the editor

