### PR TITLE
Enable the `marketplace-jetpack-plugin-search` flag on the wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -76,7 +76,7 @@
 		"mailchimp": true,
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR sets the `marketplace-jetpack-plugin-search` by default on the wpcalypso environment

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins`
* Search for a phrase
* Check on the network tab that the request goes to the marketplace search API (https://public-api.wordpress.com/rest/v1.3/marketplace/search)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66089
