### PR TITLE
Design Picker: Add pricing information to Theme card

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -4,6 +4,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -109,22 +110,43 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		let text: any = __( 'Free' );
 
 		if ( design.is_premium ) {
-			text = shouldUpgrade ? (
-				<Button
-					isLink={ true }
-					className="design-picker__button-link"
-					onClick={ ( e: any ) => {
-						e.stopPropagation();
-						onCheckout?.();
-					} }
-				>
-					{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
-						? __( 'Included in WordPress.com Premium' )
-						: __( 'Upgrade to Premium' ) }
-				</Button>
-			) : (
-				__( 'Included in your plan' )
-			);
+			text = shouldUpgrade
+				? ( ! isEnabled( 'signup/seller-upgrade-modal' ) && (
+						<Button
+							isLink={ true }
+							className="design-picker__button-link"
+							onClick={ ( e: any ) => {
+								e.stopPropagation();
+								onCheckout?.();
+							} }
+						>
+							{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
+								? __( 'Included in WordPress.com Premium' )
+								: __( 'Upgrade to Premium' ) }
+						</Button>
+				  ) ) ||
+				  createInterpolateElement(
+						sprintf(
+							/* translators: %(price)s - the price of the theme */
+							__( '%(price)s per year or <button>included in WordPress.com Premium</button>' ),
+							{
+								price: design.price,
+							}
+						),
+						{
+							button: (
+								<Button
+									isLink={ true }
+									className="design-picker__button-link"
+									onClick={ ( e: any ) => {
+										e.stopPropagation();
+										onCheckout?.();
+									} }
+								/>
+							),
+						}
+				  )
+				: __( 'Included in your plan' );
 		}
 
 		return <div className="design-picker__pricing-description">{ text }</div>;


### PR DESCRIPTION
#### Proposed Changes

* Adds the pricing information to the theme card.

![Screen Shot 2022-08-01 at 14 41 18](https://user-images.githubusercontent.com/1234758/182209579-cc5c7f42-4286-4fdb-8cf7-dabe5032b5dc.png)

#### Testing Instructions

* Go to `/setup/designSetup?siteSlug=<SITE_SLUG>&flags=signup/seller-upgrade-modal` (note the flag)
* Find a Premium theme, and note the pricing information below the theme's name.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #65698
