### PR TITLE
Add/dsp widget entrypoint tracking

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 declare global {
 	interface Window {
@@ -47,4 +48,20 @@ export async function showDSPWidgetModal( siteId: number, postId?: number ) {
 			urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
 		} );
 	}
+}
+
+/**
+ * Add tracking when launching the DSP widget, in both tracks event and MC stats.
+ *
+ * @param {string} entryPoint - A slug describing the entry point.
+ */
+export function recordDSPEntryPoint( entryPoint: string ) {
+	const eventProps = {
+		entry_point: entryPoint,
+	};
+
+	return composeAnalytics(
+		recordTracksEvent( 'calypso_dsp_widget_start', eventProps ),
+		bumpStat( 'calypso_dsp_widget_start', entryPoint )
+	);
 }

--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -2,9 +2,9 @@ import config from '@automattic/calypso-config';
 import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import megaphoneIllustration from 'calypso/assets/images/customer-home/illustration--megaphone.svg';
-import { loadDSPWidgetJS, showDSPWidgetModal } from 'calypso/lib/promote-post';
+import { loadDSPWidgetJS, showDSPWidgetModal, recordDSPEntryPoint } from 'calypso/lib/promote-post';
 import { TASK_PROMOTE_POST } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -13,6 +13,7 @@ const PromotePost = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const showPromotePost = config.isEnabled( 'promote-post' );
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -23,6 +24,7 @@ const PromotePost = () => {
 		}
 		setIsLoading( true );
 		await showDSPWidgetModal( selectedSiteId );
+		dispatch( recordDSPEntryPoint( TASK_PROMOTE_POST ) );
 		setIsLoading( false );
 	};
 


### PR DESCRIPTION
#### Intro
Hello! This is my first PR, building off of PR #65996.

#### Proposed Changes
- Add function to record a Tracks event and MC Stat for `calypso_dsp_widget_start` (when the DSP widget is opened) at a particular entry point
- Invoke tracking function on Promote Post button click on the Home Page swipeable tasks

#### Testing Instructions
1. Check out the branch
2. In `development.json`, confirm the `promote-post` feature flag is set to `true`. Also, in order for MC Stats to receive the stat bump, `mc_analytics_enabled` flag needs to be set to `true`.
3. Click on the "Promote a post" button in the swipeable task component on the "My Home" page.

![image](https://user-images.githubusercontent.com/2396764/182221266-df030af6-5735-4059-87c5-ccd7cc28ec72.png)

4. Verify the Tracks Event is recorded (will take ~5 minutes for the event to appear).
5. Verify the MC Stat is recorded (should appear within a minute).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65996