### PR TITLE
ESLint: update `jsx-classname-namespace` rule to check only for BEM convention.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -387,12 +387,7 @@ module.exports = {
 		'react/forbid-foreign-prop-types': 'error',
 
 		// enforce our classname namespacing rules
-		'wpcalypso/jsx-classname-namespace': [
-			2,
-			{
-				rootFiles: [ 'index.js', 'index.jsx', 'main.js', 'main.jsx' ],
-			},
-		],
+		'wpcalypso/jsx-classname-namespace': 'error',
 
 		// Disallow importing of native node modules, with some exceptions
 		// - url because we use it all over the place to parse and build urls

--- a/apps/editing-toolkit/.eslintrc.js
+++ b/apps/editing-toolkit/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
 
 		// FSE components render in a Gutenberg environment and should
 		// conform to those naming conventions instead of Calypso's.
-		'wpcalypso/jsx-classname-namespace': 0,
+		'wpcalypso/jsx-classname-namespace': 'off',
 	},
 	ignorePatterns: [ '**/dist/*', '**/synced-newspack-blocks/*' ],
 	overrides: [

--- a/apps/o2-blocks/.eslintrc.js
+++ b/apps/o2-blocks/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 	},
 	rules: {
 		'react/react-in-jsx-scope': 0,
-		'wpcalypso/jsx-classname-namespace': 0,
+		'wpcalypso/jsx-classname-namespace': 'off',
 	},
 	overrides: [
 		{

--- a/packages/eslint-plugin-wpcalypso/docs/rules/jsx-classname-namespace.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/jsx-classname-namespace.md
@@ -1,8 +1,6 @@
 # Ensure JSX className adheres to CSS namespace guidelines
 
-If JSX element includes `className`, it must include the containing directory name as the component name for the root element, or as a component prefix for child elements (with `__` separating component and element names).
-
-[See Calypso CSS guidelines for more information](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/coding-guidelines/css.md)
+If JSX element includes `className`, it must follow the [Block-Element-Modifier](https://en.bem.info/methodology/naming-convention/) naming principle.
 
 ## Rule Details
 
@@ -11,7 +9,7 @@ The following patterns are considered warnings:
 ```jsx
 // client/sample-component/index.js
 export function myComponent1() {
-	return <div className="sample" />;
+	return <div className="sampleVisibleDiv" />;
 }
 
 // client/another-sample/index.js
@@ -29,7 +27,7 @@ The following patterns are not warnings:
 ```jsx
 // client/sample-component/index.js
 export function myComponent1() {
-	return <div className="sample-component" />;
+	return <div className="sample__visible" />;
 }
 
 // client/another-sample/index.js
@@ -39,48 +37,5 @@ export function myComponent2() {
 			<div className="another-sample__child" />
 		</div>
 	);
-}
-```
-
-## Options
-
-This rule accepts an object as its first option:
-
-- `"rootFiles"` (default: `[ index.js, index.jsx ]`) array of filenames allowed to contain root component in each folder.
-
-For example, you can allow `index.jsx` and `main.jsx`:
-
-```json
-{
-	"jsx-classname-namespace": [
-		"error",
-		{
-			"rootFiles": [ "index.jsx", "main.jsx" ]
-		}
-	]
-}
-```
-
-Examples of **correct** code for this rule with `rootFiles` set to `[ 'foo.js' ]`: (watch the filename)
-
-```jsx
-/* rule config:
-	jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]
-*/
-// client/sample-component/foo.js
-export default function () {
-	return <div className="sample" />;
-}
-```
-
-Examples of **incorrect** code for this rule with `rootFiles` set to `[ 'foo.js' ]`: (watch the filename)
-
-```jsx
-/* rule config:
-	jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]
-*/
-// client/sample-component/index.js
-export default function () {
-	return <div className="sample" />;
 }
 ```

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-classname-namespace.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-classname-namespace.js
@@ -9,15 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { RuleTester } = require( 'eslint' );
-const formatMessage = require( '../../../test-utils/format-message' );
-const rule = require( '../jsx-classname-namespace' );
-
-//------------------------------------------------------------------------------
-// Constants
-//------------------------------------------------------------------------------
-
-const EXPECTED_FOO_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo__ prefix' } );
+import { RuleTester } from 'eslint';
+import rule, { ERROR_MESSAGE } from '../jsx-classname-namespace';
 
 //------------------------------------------------------------------------------
 // Tests
@@ -32,11 +25,11 @@ new RuleTester( {
 } ).run( 'jsx-classname-namespace', rule, {
 	valid: [
 		{
-			code: 'export default function() { return <Foo className="foo" />; }',
+			code: 'export default function() { return <Foo className="quux foo" />; }',
 			filename: '/tmp/foo/index.js',
 		},
 		{
-			code: 'export default function() { return <Foo className="quux foo" />; }',
+			code: 'function child() { return <Foo className="quux foo__child" />; }',
 			filename: '/tmp/foo/index.js',
 		},
 		{
@@ -88,57 +81,56 @@ new RuleTester( {
 			filename: '/tmp/foo/foo-child.js',
 		},
 		{
-			code: 'export default function() { return <div className="foo"></div>; }',
-			filename: '/tmp/foo/bar.js',
-			options: [ { rootFiles: [ 'bar.js' ] } ],
-		},
-		{
-			code: 'export default class Foo { child() { return <div className="foo" />; } render() { return this.child(); } };',
+			code: 'export default function() { return <Foo className="foo-child__child-attribute" />; }',
 			filename: '/tmp/foo/index.js',
 		},
 	],
 
 	invalid: [
 		{
-			code: 'export default function() { return <Foo className="foobar" />; }',
-			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
-		},
-		{
-			code: 'export default () => <Foo className="foobar" />;',
-			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
-		},
-		{
-			code: 'export default function() { return <Foo className="quux foobar" />; }',
-			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
-		},
-		{
-			code: 'function child() { return <Foo className="foobar__child" />; }',
-			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
-		},
-		{
-			code: 'function child() { return <Foo className="quux foobar__child" />; }',
-			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
-		},
-		{
 			code: 'export default function() { return <div className="foo__" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
+			errors: [ { message: ERROR_MESSAGE } ],
 		},
 		{
 			code: 'export default function() { return <Foo className="foo__child_example" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
+			errors: [ { message: ERROR_MESSAGE } ],
 		},
 		{
-			code: 'export default function() { return <div className="bar"></div>; }',
-			filename: '/tmp/foo/bar.js',
-			options: [ { rootFiles: [ 'bar.js' ] } ],
-			errors: [ { message: EXPECTED_FOO_ERROR } ],
+			code: 'export default function() { return <Foo className="camelCase" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
+		},
+		{
+			code: 'export default function() { return <Foo className="Sentencecase" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
+		},
+		{
+			code: 'export default function() { return <Foo className="ALLCAPSCASE" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
+		},
+		{
+			code: 'export default function() { return <Foo className="TitleCase" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
+		},
+		{
+			code: 'export default function() { return <Foo className="snake_case" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
+		},
+		{
+			code: 'export default function() { return <Foo className="SNAKE_CASE_WITH_CAPS" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
+		},
+		{
+			code: 'export default function() { return <Foo className="foo__class__attribute" />; }',
+			filename: '/tmp/foo/index.js',
+			errors: [ { message: ERROR_MESSAGE } ],
 		},
 	],
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/66096 and changes the `jsx-classname-namespace` rule.

Key changes:
- simplify the rule to check only for BEM naming convention on classnames.

Details:
The `jsx-classname-namespace` rule in its current implementation is overly restrictive and results in [at least 300+ instances where it has been disabled as of 2019](p4TIVU-9gL-p2).

As discussed in p4TIVU-9Ok-p2#comment-11203 and p9oQ9f-1fu-p2, this PR aims to replace the existing rule with a simpler check that ensures compliance with [BEM convention](https://en.bem.info/methodology/naming-convention/). 

At this time it appears that this change will result in an immediate reduction of errors by 240 and a reduction of 322 for warnings.

![image](https://user-images.githubusercontent.com/6549265/182432466-acdd1251-16c6-48e3-b67d-c5f242499a0c.png)

**Note**: this PR does not remove references to `/* eslint-disable wpcalypso/jsx-classname-namespace */` that exist in the codebase already. That will be handled in another 20% task.

#### Testing Instructions

Ensure the following:
  - [ ] Unit Tests
  - [ ] Check Code Style

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66096