### PR TITLE
Prevent unnecessary renders in PurchaseNotice

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/purchase-notice/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/purchase-notice/index.jsx
@@ -16,10 +16,7 @@ function PurchaseNotice() {
 			hasPaymentNotice.current = true;
 			createNotice(
 				'info',
-				__(
-					'Welcome to the Pro plan! Premium blocks are now available to use.',
-					'full-site-editing'
-				),
+				__( 'Congrats! Premium blocks are now available to use.', 'full-site-editing' ),
 				{
 					isDismissible: true,
 					type: 'snackbar',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/purchase-notice/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/purchase-notice/index.jsx
@@ -1,19 +1,19 @@
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import './style.scss';
 
 function PurchaseNotice() {
-	const [ hasPaymentNotice, setHasPaymentNotice ] = useState( false );
+	const hasPaymentNotice = useRef( false );
 	const { createNotice } = useDispatch( noticesStore );
 
 	useEffect( () => {
 		const noticePattern = /[&?]notice=([\w_-]+)/;
 		const match = noticePattern.exec( document.location.search );
 		const notice = match && match[ 1 ];
-		if ( 'purchase-success' === notice && hasPaymentNotice === false ) {
-			setHasPaymentNotice( true );
+		if ( 'purchase-success' === notice && hasPaymentNotice.current === false ) {
+			hasPaymentNotice.current = true;
 			createNotice(
 				'info',
 				__(
@@ -26,7 +26,7 @@ function PurchaseNotice() {
 				}
 			);
 		}
-	} );
+	}, [ createNotice ] );
 
 	return null;
 }


### PR DESCRIPTION
#### Proposed Changes

Performance improvements as recommended on #62021.

* Provide appropriate dependencies to `useEffect`
* Switch from `useState` to `useRef`


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a sandboxed site
* [Sync](https://github.com/Automattic/wp-calypso/tree/trunk/apps) calypso's `editing-toolkit` app to your sandbox
* Open a post editor `http://calypso.localhost:3000/post/<site>/<post-id>?notice=purchase-success`

<img width="1300" alt="Screen Shot 2022-06-06 at 12 42 24" src="https://user-images.githubusercontent.com/1234758/172154227-6efa0988-20d9-41a0-b5a5-63292416a032.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ NA ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ NA ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ NA ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #65777
