### PR TITLE
Checkout: Make Jetpack masterbar logo visible on pending page

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,6 +31,7 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -324,7 +325,10 @@ export default withCurrentRoute(
 		( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
 			const sectionGroup = currentSection?.group ?? null;
 			const sectionName = currentSection?.name ?? null;
-			const siteId = getSelectedSiteId( state );
+			// Falls back to using the user's primary site if no site has been selected
+			// by the user yet
+			const currentSelectedSiteId = getSelectedSiteId( state );
+			const siteId = currentSelectedSiteId || getPrimarySiteId( state );
 			const sectionJitmPath = getMessagePathForJITM( currentRoute );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 			const isJetpack =

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,7 +31,7 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import getSelectedOrPrimarySiteId from 'calypso/state/selectors/get-selected-or-primary-site-id';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -325,14 +325,13 @@ export default withCurrentRoute(
 		( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
 			const sectionGroup = currentSection?.group ?? null;
 			const sectionName = currentSection?.name ?? null;
-			// Falls back to using the user's primary site if no site has been selected
-			// by the user yet
-			const currentSelectedSiteId = getSelectedSiteId( state );
-			const siteId = currentSelectedSiteId || getPrimarySiteId( state );
+			const selectedOrPrimarySiteId = getSelectedOrPrimarySiteId( state );
+			const siteId = getSelectedSiteId( state );
 			const sectionJitmPath = getMessagePathForJITM( currentRoute );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 			const isJetpack =
-				( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
+				( isJetpackSite( state, selectedOrPrimarySiteId ) &&
+					! isAtomicSite( state, selectedOrPrimarySiteId ) ) ||
 				currentRoute.startsWith( '/checkout/jetpack' );
 			const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
 			const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,7 +31,6 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import getSelectedOrPrimarySiteId from 'calypso/state/selectors/get-selected-or-primary-site-id';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -325,13 +324,11 @@ export default withCurrentRoute(
 		( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
 			const sectionGroup = currentSection?.group ?? null;
 			const sectionName = currentSection?.name ?? null;
-			const selectedOrPrimarySiteId = getSelectedOrPrimarySiteId( state );
 			const siteId = getSelectedSiteId( state );
 			const sectionJitmPath = getMessagePathForJITM( currentRoute );
 			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 			const isJetpack =
-				( isJetpackSite( state, selectedOrPrimarySiteId ) &&
-					! isAtomicSite( state, selectedOrPrimarySiteId ) ) ||
+				( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 				currentRoute.startsWith( '/checkout/jetpack' );
 			const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
 			const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -82,7 +82,9 @@ const CheckoutMasterbar = ( {
 	const showCloseButton = isLeavingAllowed && ! isJetpack;
 
 	return (
-		<Masterbar>
+		<Masterbar
+			className={ classnames( 'masterbar--is-checkout', { 'masterbar--is-jetpack': isJetpack } ) }
+		>
 			<div className="masterbar__secure-checkout">
 				{ showCloseButton && (
 					<Item

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -41,7 +41,8 @@ $masterbar-color-secondary: #101517;
 		border-bottom: 1px solid var( --studio-orange-60 );
 	}
 
-	.is-section-checkout.is-jetpack-site & {
+	.is-section-checkout.is-jetpack-site &,
+	.is-section-checkout-pending.is-jetpack-site & {
 		background-color: var( --color-jetpack-masterbar-background );
 		border-bottom: 1px solid var( --color-jetpack-masterbar-border );
 		color: var( --color-jetpack-masterbar-text );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -41,8 +41,7 @@ $masterbar-color-secondary: #101517;
 		border-bottom: 1px solid var( --studio-orange-60 );
 	}
 
-	.is-section-checkout.is-jetpack-site &,
-	.is-section-checkout-pending.is-jetpack-site & {
+	&.masterbar--is-checkout.masterbar--is-jetpack {
 		background-color: var( --color-jetpack-masterbar-background );
 		border-bottom: 1px solid var( --color-jetpack-masterbar-border );
 		color: var( --color-jetpack-masterbar-text );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -206,7 +206,7 @@ $masterbar-color-secondary: #101517;
 	.gridicon {
 		fill: var( --color-masterbar-text ); // only because safari gets currentColor wrong
 
-		.is-section-checkout.is-jetpack-site & {
+		.masterbar--is-checkout.masterbar--is-jetpack & {
 			fill: var( --color-jetpack-masterbar-text );
 		}
 	}
@@ -220,7 +220,7 @@ $masterbar-color-secondary: #101517;
 			background: var( --color-masterbar-item-hover-background );
 			color: var( --color-masterbar-text );
 
-			.is-section-checkout.is-jetpack-site & {
+			.masterbar--is-checkout.masterbar--is-jetpack & {
 				background: var( --color-jetpack-masterbar-item-hover-background );
 				color: var( --color-jetpack-masterbar-text );
 			}
@@ -235,7 +235,7 @@ $masterbar-color-secondary: #101517;
 			color: var( --color-masterbar-text );
 		}
 
-		.is-section-checkout.is-jetpack-site & {
+		.masterbar--is-checkout.masterbar--is-jetpack & {
 			box-shadow: inset 0 0 0 2px var( --color-jetpack-masterbar-item-hover-background );
 			color: var( --color-jetpack-masterbar-text );
 		}
@@ -267,7 +267,7 @@ $masterbar-color-secondary: #101517;
 		margin-right: 15px;
 		cursor: pointer;
 
-		.is-section-checkout.is-jetpack-site & {
+		.masterbar--is-checkout.masterbar--is-jetpack & {
 			border-right: 1px solid var( --color-jetpack-masterbar-border );
 		}
 
@@ -852,7 +852,7 @@ a.masterbar__quick-language-switcher {
 			margin-left: 0;
 		}
 
-		.is-jetpack-site & {
+		.masterbar--is-jetpack & {
 			color: var( --color-jetpack-masterbar-text );
 			transform: translateY( -1px );
 		}


### PR DESCRIPTION
#### Proposed Changes

The post-checkout "pending" page is shown very briefly after a purchase is complete. Its masterbar shows a logo for either WordPress.com or Jetpack, depending on the identity of the selected site. The WordPress.com logo is light and the Jetpack logo is dark. The background of the masterbar behind this logo is dark normally, but is light if the site is Jetpack and is on page in the checkout "section". However, the "pending" page is not in the checkout section; it is in the "checkout-pending" section. The result is that the (dark) Jetpack logo will be shown on the (dark) masterbar background, rendering it invisible.

This PR modifies the styles so that the light masterbar background will show on the checkout pending section as well.

This works for Jetpack sites, but there's an edge case that this PR also fixes. If there is no selected site, the masterbar will show the logo for the user's primary site instead. If this site is a Jetpack site, it will use the dark Jetpack logo. However, the background of the masterbar is only light if the layout is for a Jetpack site, and the `Layout` component does not check the user's primary site like the masterbar does.

This PR modifies the checkout masterbar to use its own classnames to determine if the Jetpack styles should be applied.

Fixes https://github.com/Automattic/wp-calypso/issues/66139

Before:

<img width="571" alt="jetpack-masterbar-logo-before" src="https://user-images.githubusercontent.com/2036909/182246628-6bf217a0-d5aa-4cc8-9b5a-11a1b5df74fa.png">

After:

<img width="653" alt="Screen Shot 2022-08-01 at 5 06 54 PM" src="https://user-images.githubusercontent.com/2036909/182246729-c83d8470-2134-48ae-bb39-cc29b2399440.png">

#### Testing Instructions

First test the style changes:

- You'll need a Jetpack site.
- Visit https://wordpress.com/checkout/thank-you/YOUR-SITE-SLUG-HERE/pending/12345 for that site.
- Verify that the Jetpack icon in the masterbar is visible.

To test the Layout changes:

- Make a Jetpack site your primary site. You can do this on https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs
- Visit https://wordpress.com/checkout/thank-you/no-site/pending/12345.
- Verify that the Jetpack icon in the masterbar is visible.