### PR TITLE
Jetpack Agency dashboard: enable plugin management in calypso.live

### DIFF
--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -33,7 +33,7 @@
 		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/plugin-management": false,
+		"jetpack/plugin-management": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -60,7 +60,7 @@
 		"backup": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud-agency-dashboard": true,
-		"jetpack-cloud-plugin-management": false,
+		"jetpack-cloud-plugin-management": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": false,
 		"jetpack-cloud-partner-portal": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -54,7 +54,7 @@
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/plugin-management": false,
+		"jetpack/plugin-management": true,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -54,7 +54,7 @@
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/plugin-management": true,
+		"jetpack/plugin-management": false,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,


### PR DESCRIPTION
#### Proposed Changes

* Enable `jetpack/plugin-management` feature flag and `jetpack-cloud-plugin-management` section on the horizon environment so we can access the section from Jetpack cloud live links.

#### Testing Instructions

* Open the Jetpack cloud link (from the PR).
* Make sure you can access the Agency Dashboard.
* Make sure you can see a link to the plugins section on the sidebar.

#### Demo
![image](https://user-images.githubusercontent.com/3418513/182402110-a3daac32-e095-4859-b3bf-f263165f760d.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202693966370103