### PR TITLE
 Enable Plugins pages for logged-out users

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -6,12 +6,15 @@ const Header = styled.header`
 	position: fixed;
 	z-index: 10;
 	top: var( --masterbar-height );
-	left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
 	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 	padding: 0 32px;
 	box-sizing: border-box;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
+
+	.layout__secondary ~ .layout__primary & {
+		left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
+	}
 
 	@media ( max-width: 960px ) {
 		// Account for jetpack sites with the old sidebar.

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -6,22 +6,17 @@ const Header = styled.header`
 	position: fixed;
 	z-index: 10;
 	top: var( --masterbar-height );
-	left: 0;
+	left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
+	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 	padding: 0 32px;
 	box-sizing: border-box;
-	width: 100%;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
 
-	.layout__secondary ~ .layout__primary & {
-		left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
-		width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
-
-		@media ( max-width: 960px ) {
-			// Account for jetpack sites with the old sidebar.
-			left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
-			width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
-		}
+	@media ( max-width: 960px ) {
+		// Account for jetpack sites with the old sidebar.
+		left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
+		width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
 	}
 
 	@media ( max-width: 782px ) {

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -6,26 +6,31 @@ const Header = styled.header`
 	position: fixed;
 	z-index: 10;
 	top: var( --masterbar-height );
-	left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
-	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
+	left: 0;
 	padding: 0 32px;
 	box-sizing: border-box;
+	width: 100%;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
 
-	@media ( max-width: 960px ) {
-		// Account for jetpack sites with the old sidebar.
-		left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
-		width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
-	}
+	.layout__secondary ~ .layout__primary & {
+		left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
+		width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 
-	@media ( max-width: 782px ) {
-		width: 100%;
-		left: 0;
-	}
+		@media ( max-width: 960px ) {
+			// Account for jetpack sites with the old sidebar.
+			left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
+			width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
+		}
 
-	@media ( max-width: 660px ) {
-		padding: 0 16px;
+		@media ( max-width: 782px ) {
+			width: 100%;
+			left: 0;
+		}
+
+		@media ( max-width: 660px ) {
+			padding: 0 16px;
+		}
 	}
 `;
 

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -6,20 +6,22 @@ const Header = styled.header`
 	position: fixed;
 	z-index: 10;
 	top: var( --masterbar-height );
-	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
+	left: 0;
 	padding: 0 32px;
 	box-sizing: border-box;
+	width: 100%;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
 
 	.layout__secondary ~ .layout__primary & {
 		left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
-	}
+		width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 
-	@media ( max-width: 960px ) {
-		// Account for jetpack sites with the old sidebar.
-		left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
-		width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
+		@media ( max-width: 960px ) {
+			// Account for jetpack sites with the old sidebar.
+			left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
+			width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
+		}
 	}
 
 	@media ( max-width: 782px ) {

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,11 +1,9 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
 import page from 'page';
-import { useDispatch, useSelector } from 'react-redux';
-import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
+import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES, useCategories } from './use-categories';
+import { useGetCategoryUrl } from './use-get-category-url';
 
 export type Category = {
 	name: string;
@@ -18,10 +16,7 @@ export type Category = {
 
 const Categories = ( { selected }: { selected?: string } ) => {
 	const dispatch = useDispatch();
-
-	const siteId = useSelector( getSelectedSiteId ) as number;
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const { localizePath } = useLocalizedPlugins();
+	const getCategoryUrl = useGetCategoryUrl();
 
 	// We hide these special categories from the category selector
 	const displayCategories = ALLOWED_CATEGORIES.filter(
@@ -29,6 +24,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 	);
 
 	const categories = Object.values( useCategories( displayCategories ) );
+	const categoryUrls = categories.map( ( { slug } ) => getCategoryUrl( slug ) );
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
 
@@ -38,14 +34,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 			} )
 		);
 
-		let url;
-		if ( category.slug !== 'discover' ) {
-			url = `/plugins/browse/${ category.slug }/${ domain || '' }`;
-		} else {
-			url = `/plugins/${ domain || '' }`;
-		}
-
-		page( localizePath( url ) );
+		page( getCategoryUrl( category.slug ) );
 	};
 
 	if ( selected && ! displayCategories.includes( selected ) ) {
@@ -59,6 +48,8 @@ const Categories = ( { selected }: { selected?: string } ) => {
 			className="categories__menu"
 			initialActiveIndex={ current }
 			onClick={ onClick }
+			hrefList={ categoryUrls }
+			forceSwipe={ 'undefined' === typeof window }
 		>
 			{ categories.map( ( category ) => (
 				<span key={ `category-${ category.slug }` }>{ category.name }</span>

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,10 +1,8 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useDispatch, useSelector } from 'react-redux';
-import { localizePluginsPath } from 'calypso/my-sites/plugins/utils';
+import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES, useCategories } from './use-categories';
@@ -23,8 +21,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const { localeSlug } = useTranslate();
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	// We hide these special categories from the category selector
 	const displayCategories = ALLOWED_CATEGORIES.filter(
@@ -48,7 +45,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 			url = `/plugins/${ domain || '' }`;
 		}
 
-		page( localizePluginsPath( url, localeSlug, ! isLoggedIn ) );
+		page( localizePath( url ) );
 	};
 
 	if ( selected && ! displayCategories.includes( selected ) ) {

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,7 +1,10 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useDispatch, useSelector } from 'react-redux';
+import { localizePluginsPath } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES, useCategories } from './use-categories';
@@ -20,6 +23,8 @@ const Categories = ( { selected }: { selected?: string } ) => {
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const { localeSlug } = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// We hide these special categories from the category selector
 	const displayCategories = ALLOWED_CATEGORIES.filter(
@@ -43,7 +48,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 			url = `/plugins/${ domain || '' }`;
 		}
 
-		page( url );
+		page( localizePluginsPath( url, localeSlug, ! isLoggedIn ) );
 	};
 
 	if ( selected && ! displayCategories.includes( selected ) ) {

--- a/client/my-sites/plugins/categories/use-get-category-url.tsx
+++ b/client/my-sites/plugins/categories/use-get-category-url.tsx
@@ -1,0 +1,19 @@
+import { useSelector } from 'react-redux';
+import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function useGetCategoryUrl() {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	let domain = useSelector( ( state ) => getSiteDomain( state, siteId ) ) || '';
+	domain = domain.replace( /\//, '::' );
+	const { localizePath } = useLocalizedPlugins();
+
+	return ( slug: string ): string => {
+		if ( slug !== 'discover' ) {
+			return localizePath( `/plugins/browse/${ slug }/${ domain }` );
+		}
+
+		return localizePath( `/plugins/${ domain }` );
+	};
+}

--- a/client/my-sites/plugins/controller-logged-in.js
+++ b/client/my-sites/plugins/controller-logged-in.js
@@ -1,0 +1,6 @@
+import PluginUpload from './plugin-upload';
+
+export function upload( context, next ) {
+	context.primary = <PluginUpload />;
+	next();
+}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -1,6 +1,7 @@
 import { includes, some } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
+import { redirectLoggedOut } from 'calypso/controller';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import { navigation } from 'calypso/my-sites/controller';
@@ -150,5 +151,15 @@ export function navigationIfLoggedIn( context, next ) {
 		return;
 	}
 
+	next();
+}
+
+export function maybeRedirectLoggedOut( context, next ) {
+	const siteFragment =
+		context.params.site || context.params.site_id || getSiteFragment( context.path );
+
+	if ( siteFragment ) {
+		return redirectLoggedOut( context, next );
+	}
 	next();
 }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -10,7 +10,6 @@ import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
 import PluginDetails from './plugin-details';
 import PluginEligibility from './plugin-eligibility';
-import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
 
 function renderSinglePlugin( context, siteUrl ) {
@@ -112,11 +111,6 @@ export function browsePluginsOrPlugin( context, next ) {
 
 export function browsePlugins( context, next ) {
 	renderPluginsBrowser( context );
-	next();
-}
-
-export function upload( context, next ) {
-	context.primary = <PluginUpload />;
 	next();
 }
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -3,6 +3,8 @@ import page from 'page';
 import { createElement } from 'react';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
+import { navigation } from 'calypso/my-sites/controller';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES } from './categories/use-categories';
@@ -139,5 +141,14 @@ export function scrollTopIfNoHash( context, next ) {
 	if ( typeof window !== 'undefined' && ! window.location.hash ) {
 		window.scrollTo( 0, 0 );
 	}
+	next();
+}
+
+export function navigationIfLoggedIn( context, next ) {
+	if ( isUserLoggedIn( context.store.getState() ) ) {
+		navigation( context, next );
+		return;
+	}
+
 	next();
 }

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -1,8 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import { makeLayout } from 'calypso/controller';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
-	router( [ `/${ langParam }/plugins/*`, `/${ langParam }/plugins` ], makeLayout );
+	router( [ `/${ langParam }/plugins`, `/${ langParam }/plugins/*` ] );
 }

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -1,36 +1,8 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import { makeLayout, ssrSetupLocale } from 'calypso/controller';
-import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
-import { browsePlugins, browsePluginsOrPlugin } from './controller';
+import { makeLayout } from 'calypso/controller';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
-	router(
-		`/${ langParam }/plugins/browse/:category`,
-		ssrSetupLocale,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
-		browsePlugins,
-		makeLayout
-	);
 
-	router(
-		`/${ langParam }/plugins`,
-		ssrSetupLocale,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
-		browsePlugins,
-		makeLayout
-	);
-
-	router(
-		`/${ langParam }/plugins/:plugin`,
-		ssrSetupLocale,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
-		browsePluginsOrPlugin,
-		makeLayout
-	);
-
-	router( '/plugins/*', makeLayout );
+	router( [ `/${ langParam }/plugins/*`, `/${ langParam }/plugins` ], makeLayout );
 }

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -1,0 +1,28 @@
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
+import { browsePlugins, browsePluginsOrPlugin } from './controller';
+
+export default function ( router ) {
+	const langParam = getLanguageRouteParam();
+
+	router(
+		`/${ langParam }/plugins/:plugin`,
+		ssrSetupLocale,
+		setHrefLangLinks,
+		setLocalizedCanonicalUrl,
+		browsePluginsOrPlugin,
+		makeLayout
+	);
+
+	router(
+		[ `/${ langParam }/plugins`, `/${ langParam }/plugins/browse/:category` ],
+		ssrSetupLocale,
+		setHrefLangLinks,
+		setLocalizedCanonicalUrl,
+		browsePlugins,
+		makeLayout
+	);
+
+	router( '/plugins/*', makeLayout );
+}

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -5,6 +5,23 @@ import { browsePlugins, browsePluginsOrPlugin } from './controller';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
+	router(
+		`/${ langParam }/plugins/browse/:category`,
+		ssrSetupLocale,
+		setHrefLangLinks,
+		setLocalizedCanonicalUrl,
+		browsePlugins,
+		makeLayout
+	);
+
+	router(
+		`/${ langParam }/plugins`,
+		ssrSetupLocale,
+		setHrefLangLinks,
+		setLocalizedCanonicalUrl,
+		browsePlugins,
+		makeLayout
+	);
 
 	router(
 		`/${ langParam }/plugins/:plugin`,
@@ -12,15 +29,6 @@ export default function ( router ) {
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
 		browsePluginsOrPlugin,
-		makeLayout
-	);
-
-	router(
-		[ `/${ langParam }/plugins`, `/${ langParam }/plugins/browse/:category` ],
-		ssrSetupLocale,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
-		browsePlugins,
 		makeLayout
 	);
 

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -1,7 +1,8 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { ssrSetupLocale } from 'calypso/controller';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
-	router( [ `/${ langParam }/plugins`, `/${ langParam }/plugins/*` ] );
+	router( [ `/${ langParam }/plugins`, `/${ langParam }/plugins/*` ], ssrSetupLocale );
 }

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -1,7 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import page from 'page';
 import {
 	makeLayout,
+	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
 	render as clientRender,
 } from 'calypso/controller';
@@ -15,6 +15,7 @@ import {
 	plugins,
 	scrollTopIfNoHash,
 	navigationIfLoggedIn,
+	maybeRedirectLoggedOut,
 } from './controller';
 import { upload } from './controller-logged-in';
 
@@ -25,8 +26,9 @@ export default function ( router ) {
 		'[^\\\\/.]+\\.[^\\\\/]+'; // one-or-more non-slash-or-dot chars, then a dot, then one-or-more non-slashes
 	const langParam = getLanguageRouteParam();
 
-	page(
+	router(
 		'/plugins/setup',
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
@@ -34,8 +36,9 @@ export default function ( router ) {
 		clientRender
 	);
 
-	page(
+	router(
 		'/plugins/setup/:site',
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
@@ -45,6 +48,7 @@ export default function ( router ) {
 
 	router(
 		`/${ langParam }/plugins/browse/:category/:site(${ siteId })?`,
+		maybeRedirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
@@ -54,9 +58,18 @@ export default function ( router ) {
 		clientRender
 	);
 
-	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
-	page(
+	router(
+		'/plugins/upload',
+		redirectLoggedOut,
+		scrollTopIfNoHash,
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
+	router(
 		'/plugins/upload/:site_id',
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -76,8 +89,9 @@ export default function ( router ) {
 		clientRender
 	);
 
-	page(
+	router(
 		'/plugins/manage/:site?',
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -86,8 +100,9 @@ export default function ( router ) {
 		clientRender
 	);
 
-	page(
+	router(
 		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
+		maybeRedirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -99,6 +114,7 @@ export default function ( router ) {
 
 	router(
 		`/${ langParam }/plugins/:plugin/:site_id(${ siteId })?`,
+		maybeRedirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
@@ -108,8 +124,9 @@ export default function ( router ) {
 		clientRender
 	);
 
-	page(
+	router(
 		'/plugins/:plugin/eligibility/:site_id',
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -20,10 +20,6 @@ import {
 import { upload } from './controller-logged-in';
 
 export default function ( router ) {
-	const siteId =
-		'\\d+' + // numeric site id
-		'|' + // or
-		'[^\\\\/.]+\\.[^\\\\/]+'; // one-or-more non-slash-or-dot chars, then a dot, then one-or-more non-slashes
 	const langParam = getLanguageRouteParam();
 
 	router(
@@ -47,7 +43,7 @@ export default function ( router ) {
 	);
 
 	router(
-		`/${ langParam }/plugins/browse/:category/:site(${ siteId })?`,
+		`/${ langParam }/plugins/browse/:category/:site?`,
 		maybeRedirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
@@ -113,7 +109,7 @@ export default function ( router ) {
 	);
 
 	router(
-		`/${ langParam }/plugins/:plugin/:site_id(${ siteId })?`,
+		`/${ langParam }/plugins/:plugin/:site_id?`,
 		maybeRedirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
@@ -134,4 +130,6 @@ export default function ( router ) {
 		makeLayout,
 		clientRender
 	);
+
+	router( [ `/${ langParam }/plugins`, `/${ langParam }/plugins/*` ], redirectLoggedOut );
 }

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -3,7 +3,6 @@ import page from 'page';
 import {
 	makeLayout,
 	redirectWithoutLocaleParamIfLoggedIn,
-	redirectLoggedOut,
 	render as clientRender,
 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -15,10 +14,15 @@ import {
 	jetpackCanUpdate,
 	plugins,
 	scrollTopIfNoHash,
+	navigationIfLoggedIn,
 } from './controller';
 import { upload } from './controller-logged-in';
 
 export default function ( router ) {
+	const siteId =
+		'\\d+' + // numeric site id
+		'|' + // or
+		'[^\\\\/.]+\\.[^\\\\/]+'; // one-or-more non-slash-or-dot chars, then a dot, then one-or-more non-slashes
 	const langParam = getLanguageRouteParam();
 
 	page(
@@ -39,6 +43,17 @@ export default function ( router ) {
 		clientRender
 	);
 
+	router(
+		`/${ langParam }/plugins/browse/:category/:site(${ siteId })?`,
+		redirectWithoutLocaleParamIfLoggedIn,
+		scrollTopIfNoHash,
+		siteSelection,
+		navigationIfLoggedIn,
+		browsePlugins,
+		makeLayout,
+		clientRender
+	);
+
 	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/plugins/upload/:site_id',
@@ -51,41 +66,14 @@ export default function ( router ) {
 	);
 
 	router(
-		`/${ langParam }/plugins/:plugin`,
+		`/${ langParam }/plugins`,
 		redirectWithoutLocaleParamIfLoggedIn,
-		scrollTopIfNoHash,
-		browsePluginsOrPlugin,
-		makeLayout
-	);
-
-	router(
-		`/${ langParam }/plugins/:plugin/:site_id`,
-		redirectWithoutLocaleParamIfLoggedIn,
-		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
-		navigation,
-		browsePluginsOrPlugin,
-		makeLayout
-	);
-
-	router(
-		[ `/${ langParam }/plugins`, `/${ langParam }/plugins/browse/:category` ],
-		redirectWithoutLocaleParamIfLoggedIn,
-		scrollTopIfNoHash,
+		navigationIfLoggedIn,
 		browsePlugins,
-		makeLayout
-	);
-
-	router(
-		[ `/${ langParam }/plugins/:site_id`, `/${ langParam }/plugins/browse/:category/:site` ],
-		redirectWithoutLocaleParamIfLoggedIn,
-		redirectLoggedOut,
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		browsePlugins,
-		makeLayout
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -105,6 +93,17 @@ export default function ( router ) {
 		navigation,
 		jetpackCanUpdate,
 		plugins,
+		makeLayout,
+		clientRender
+	);
+
+	router(
+		`/${ langParam }/plugins/:plugin/:site_id(${ siteId })?`,
+		redirectWithoutLocaleParamIfLoggedIn,
+		scrollTopIfNoHash,
+		siteSelection,
+		navigationIfLoggedIn,
+		browsePluginsOrPlugin,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -1,5 +1,11 @@
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	redirectWithoutLocaleParamIfLoggedIn,
+	redirectLoggedOut,
+	render as clientRender,
+} from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	browsePlugins,
@@ -9,10 +15,12 @@ import {
 	jetpackCanUpdate,
 	plugins,
 	scrollTopIfNoHash,
-	upload,
 } from './controller';
+import { upload } from './controller-logged-in';
 
-export default function () {
+export default function ( router ) {
+	const langParam = getLanguageRouteParam();
+
 	page(
 		'/plugins/setup',
 		scrollTopIfNoHash,
@@ -31,16 +39,6 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		'/plugins/browse/:category/:site?',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		browsePlugins,
-		makeLayout,
-		clientRender
-	);
-
 	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/plugins/upload/:site_id',
@@ -52,14 +50,42 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		'/plugins',
+	router(
+		`/${ langParam }/plugins/:plugin`,
+		redirectWithoutLocaleParamIfLoggedIn,
+		scrollTopIfNoHash,
+		browsePluginsOrPlugin,
+		makeLayout
+	);
+
+	router(
+		`/${ langParam }/plugins/:plugin/:site_id`,
+		redirectWithoutLocaleParamIfLoggedIn,
+		redirectLoggedOut,
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		browsePluginsOrPlugin,
+		makeLayout
+	);
+
+	router(
+		[ `/${ langParam }/plugins`, `/${ langParam }/plugins/browse/:category` ],
+		redirectWithoutLocaleParamIfLoggedIn,
+		scrollTopIfNoHash,
+		browsePlugins,
+		makeLayout
+	);
+
+	router(
+		[ `/${ langParam }/plugins/:site_id`, `/${ langParam }/plugins/browse/:category/:site` ],
+		redirectWithoutLocaleParamIfLoggedIn,
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		browsePlugins,
-		makeLayout,
-		clientRender
+		makeLayout
 	);
 
 	page(
@@ -79,16 +105,6 @@ export default function () {
 		navigation,
 		jetpackCanUpdate,
 		plugins,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/plugins/:plugin/:site_id?',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		browsePluginsOrPlugin,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -98,7 +98,7 @@ export default function ( router ) {
 
 	router(
 		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
-		maybeRedirectLoggedOut,
+		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -23,8 +23,9 @@ export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
 	router(
-		'/plugins/setup',
+		`/${ langParam }/plugins/setup`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
@@ -33,8 +34,9 @@ export default function ( router ) {
 	);
 
 	router(
-		'/plugins/setup/:site',
+		`/${ langParam }/plugins/setup/:site`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
@@ -55,8 +57,9 @@ export default function ( router ) {
 	);
 
 	router(
-		'/plugins/upload',
+		`/${ langParam }/plugins/upload`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		sites,
@@ -64,8 +67,9 @@ export default function ( router ) {
 		clientRender
 	);
 	router(
-		'/plugins/upload/:site_id',
+		`/${ langParam }/plugins/upload/:site_id`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -86,8 +90,9 @@ export default function ( router ) {
 	);
 
 	router(
-		'/plugins/manage/:site?',
+		`/${ langParam }/plugins/manage/:site?`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -97,8 +102,9 @@ export default function ( router ) {
 	);
 
 	router(
-		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
+		`/${ langParam }/plugins/:pluginFilter(active|inactive|updates)/:site_id?`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -121,8 +127,9 @@ export default function ( router ) {
 	);
 
 	router(
-		'/plugins/:plugin/eligibility/:site_id',
+		`/${ langParam }/plugins/:plugin/eligibility/:site_id`,
 		redirectLoggedOut,
+		redirectWithoutLocaleParamIfLoggedIn,
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,

--- a/client/my-sites/plugins/package.json
+++ b/client/my-sites/plugins/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.js",
+	"browser": "index.web.js"
+}

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import config from '@automattic/calypso-config';
 import {
 	isFreePlanProduct,
@@ -5,6 +6,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -15,6 +17,7 @@ import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-t
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import {
@@ -65,6 +68,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		: FEATURE_INSTALL_PLUGINS;
 	const incompatiblePlugin = ! isJetpackSelfHosted && ! isCompatiblePlugin( pluginSlug );
 	const userCantManageTheSite = ! userCan( 'manage_options', selectedSite );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const sitePlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSite?.ID, pluginSlug )
 	);
@@ -219,7 +223,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		);
 	}
 
-	if ( ! selectedSite ) {
+	if ( ! selectedSite && isLoggedIn ) {
 		// Check if there is no site selected
 		return (
 			<div className="plugin-details-cta__container">
@@ -280,11 +284,22 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 				/>
 			) }
 			<div className="plugin-details-cta__install">
-				<CTAButton
-					plugin={ plugin }
-					hasEligibilityMessages={ hasEligibilityMessages }
-					disabled={ incompatiblePlugin || userCantManageTheSite }
-				/>
+				{ isLoggedIn ? (
+					<CTAButton
+						plugin={ plugin }
+						hasEligibilityMessages={ hasEligibilityMessages }
+						disabled={ incompatiblePlugin || userCantManageTheSite }
+					/>
+				) : (
+					<Button
+						type="a"
+						className="plugin-details-CTA__install-button"
+						primary
+						href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
+					>
+						{ translate( 'View plans' ) }
+					</Button>
+				) }
 			</div>
 			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 				<div className="plugin-details-cta__t-and-c">
@@ -307,7 +322,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 					) }
 				</div>
 			) }
-			{ shouldUpgrade && (
+			{ shouldUpgrade && isLoggedIn && (
 				<div className="plugin-details-cta__upgrade-required">
 					<span className="plugin-details-cta__upgrade-required-icon">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -7,12 +7,15 @@ import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getPluginAuthorKeyword } from 'calypso/lib/plugins/utils';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
+import { localizePluginsPath } from 'calypso/my-sites/plugins/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
@@ -38,9 +41,13 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 								components: {
 									author: (
 										<a
-											href={ `/plugins/${
-												selectedSite?.slug || ''
-											}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }
+											href={ localizePluginsPath(
+												`/plugins/${
+													selectedSite?.slug || ''
+												}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"`,
+												translate.localeSlug,
+												! isLoggedIn
+											) }
 										>
 											{ plugin.author_name }
 										</a>
@@ -95,6 +102,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const selectedSite = useSelector( getSelectedSite );
 
@@ -122,9 +130,13 @@ function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 							plugin.author_name
 						) : (
 							<a
-								href={ `/plugins/${
-									selectedSite?.slug || ''
-								}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }
+								href={ localizePluginsPath(
+									`/plugins/${ selectedSite?.slug || '' }?s=developer:"${ getPluginAuthorKeyword(
+										plugin
+									) }"`,
+									translate.localeSlug,
+									! isLoggedIn
+								) }
 							>
 								{ plugin.author_name }
 							</a>
@@ -157,6 +169,8 @@ function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 const LIMIT_OF_TAGS = 3;
 function Tags( { plugin } ) {
 	const selectedSite = useSelector( getSelectedSite );
+	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	if ( ! plugin?.tags ) {
 		return null;
@@ -170,7 +184,11 @@ function Tags( { plugin } ) {
 				<a
 					key={ `badge-${ tagKey.replace( ' ', '' ) }` }
 					className="plugin-details-header__tag-badge"
-					href={ `/plugins/browse/${ tagKey }/${ selectedSite?.slug || '' }` }
+					href={ localizePluginsPath(
+						`/plugins/browse/${ tagKey }/${ selectedSite?.slug || '' }`,
+						translate.localeSlug,
+						! isLoggedIn
+					) }
 				>
 					<Badge type="info">{ plugin.tags[ tagKey ] }</Badge>
 				</a>

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -7,15 +7,14 @@ import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getPluginAuthorKeyword } from 'calypso/lib/plugins/utils';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
-import { localizePluginsPath } from 'calypso/my-sites/plugins/utils';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
@@ -41,12 +40,10 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 								components: {
 									author: (
 										<a
-											href={ localizePluginsPath(
+											href={ localizePath(
 												`/plugins/${
 													selectedSite?.slug || ''
-												}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"`,
-												translate.localeSlug,
-												! isLoggedIn
+												}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"`
 											) }
 										>
 											{ plugin.author_name }
@@ -102,7 +99,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	const selectedSite = useSelector( getSelectedSite );
 
@@ -130,12 +127,10 @@ function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 							plugin.author_name
 						) : (
 							<a
-								href={ localizePluginsPath(
+								href={ localizePath(
 									`/plugins/${ selectedSite?.slug || '' }?s=developer:"${ getPluginAuthorKeyword(
 										plugin
-									) }"`,
-									translate.localeSlug,
-									! isLoggedIn
+									) }"`
 								) }
 							>
 								{ plugin.author_name }
@@ -169,8 +164,7 @@ function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 const LIMIT_OF_TAGS = 3;
 function Tags( { plugin } ) {
 	const selectedSite = useSelector( getSelectedSite );
-	const translate = useTranslate();
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	if ( ! plugin?.tags ) {
 		return null;
@@ -184,11 +178,7 @@ function Tags( { plugin } ) {
 				<a
 					key={ `badge-${ tagKey.replace( ' ', '' ) }` }
 					className="plugin-details-header__tag-badge"
-					href={ localizePluginsPath(
-						`/plugins/browse/${ tagKey }/${ selectedSite?.slug || '' }`,
-						translate.localeSlug,
-						! isLoggedIn
-					) }
+					href={ localizePath( `/plugins/browse/${ tagKey }/${ selectedSite?.slug || '' }` ) }
 				>
 					<Badge type="info">{ plugin.tags[ tagKey ] }</Badge>
 				</a>

--- a/client/my-sites/plugins/plugin-details-header/test/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/test/index.jsx
@@ -11,7 +11,28 @@ jest.mock( 'react-redux', () => ( {
 } ) );
 
 jest.mock( '@automattic/calypso-config', () => {
-	const fn = jest.fn();
+	const fn = ( key ) => {
+		if ( 'magnificent_non_en_locales' === key ) {
+			return [
+				'es',
+				'pt-br',
+				'de',
+				'fr',
+				'he',
+				'ja',
+				'it',
+				'nl',
+				'ru',
+				'tr',
+				'id',
+				'zh-cn',
+				'zh-tw',
+				'ko',
+				'ar',
+				'sv',
+			];
+		}
+	};
 	fn.isEnabled = jest.fn();
 	return fn;
 } );

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -27,7 +27,7 @@ import PluginDetailsV2 from 'calypso/my-sites/plugins/plugin-management-v2/plugi
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
-import { siteObjectsToSiteIds, localizePluginsPath } from 'calypso/my-sites/plugins/utils';
+import { siteObjectsToSiteIds, useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -89,7 +89,7 @@ function PluginDetails( props ) {
 		isRequestingForSites( state, siteIds )
 	);
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	// Plugin information.
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -484,12 +484,14 @@ function LegacyPluginDetails( props ) {
 							</Notice>
 						) }
 
-						<SitesListArea
-							fullPlugin={ fullPlugin }
-							isPluginInstalledOnsite={ isPluginInstalledOnsite }
-							billingPeriod={ billingPeriod }
-							{ ...props }
-						/>
+						{ isLoggedIn && (
+							<SitesListArea
+								fullPlugin={ fullPlugin }
+								isPluginInstalledOnsite={ isPluginInstalledOnsite }
+								billingPeriod={ billingPeriod }
+								{ ...props }
+							/>
+						) }
 
 						<PluginDetailsBody
 							fullPlugin={ fullPlugin }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -220,7 +220,7 @@ function PluginDetails( props ) {
 		const items = [
 			{
 				label: translate( 'Plugins' ),
-				href: `/plugins/${ selectedSite?.slug || '' }`,
+				href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 				id: 'plugins',
 				helpBubble: translate(
 					'Add new functionality and integrations to your site with plugins.'
@@ -231,13 +231,13 @@ function PluginDetails( props ) {
 		if ( fullPlugin.name && props.pluginSlug ) {
 			items.push( {
 				label: fullPlugin.name,
-				href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
+				href: localizePath( `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }` ),
 				id: `plugin-${ props.pluginSlug }`,
 			} );
 		}
 
 		dispatch( updateBreadcrumbs( items ) );
-	}, [ fullPlugin.name, props.pluginSlug, selectedSite?.slug, dispatch, translate ] );
+	}, [ fullPlugin.name, props.pluginSlug, selectedSite?.slug, dispatch, translate, localizePath ] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -27,7 +27,7 @@ import PluginDetailsV2 from 'calypso/my-sites/plugins/plugin-management-v2/plugi
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
-import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { siteObjectsToSiteIds, localizePluginsPath } from 'calypso/my-sites/plugins/utils';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -35,6 +35,7 @@ import {
 } from 'calypso/state/analytics/actions';
 import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import {
@@ -88,6 +89,7 @@ function PluginDetails( props ) {
 		isRequestingForSites( state, siteIds )
 	);
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// Plugin information.
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );
@@ -146,7 +148,7 @@ function PluginDetails( props ) {
 	// Fetch WPorg plugin data if needed
 	useEffect( () => {
 		if ( isProductListFetched && ! isMarketplaceProduct && ! isWporgPluginFetched ) {
-			dispatch( wporgFetchPluginData( props.pluginSlug ) );
+			dispatch( wporgFetchPluginData( props.pluginSlug, translate.localeSlug ) );
 		}
 	}, [
 		isProductListFetched,
@@ -154,6 +156,7 @@ function PluginDetails( props ) {
 		isWporgPluginFetched,
 		props.pluginSlug,
 		dispatch,
+		translate.localeSlug,
 	] );
 
 	// Fetch WPcom plugin data if needed
@@ -405,6 +408,7 @@ function LegacyPluginDetails( props ) {
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const showBillingIntervalSwitcher =
 		! isPreinstalledPremiumPluginUpgraded ||

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -105,10 +105,12 @@ function PluginDetails( props ) {
 	const sitePlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSite?.ID, props.pluginSlug )
 	);
-	const userCanManagePlugins = useSelector( ( state ) =>
-		selectedSite?.ID
-			? canCurrentUser( state, selectedSite?.ID, 'manage_options' )
-			: canCurrentUserManagePlugins( state )
+	const userCanManagePlugins = useSelector(
+		( state ) =>
+			! selectedSite ||
+			( selectedSite?.ID
+				? canCurrentUser( state, selectedSite?.ID, 'manage_options' )
+				: canCurrentUserManagePlugins( state ) )
 	);
 
 	const isPluginInstalledOnsite =

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -17,7 +17,8 @@ import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibilit
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
-import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { localizePluginsPath, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
@@ -46,6 +47,7 @@ const PluginsBrowserListElement = ( props ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const localizeUrl = useLocalizeUrl();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
@@ -166,7 +168,7 @@ const PluginsBrowserListElement = ( props ) => {
 	return (
 		<li className={ classNames }>
 			<a
-				href={ pluginLink }
+				href={ localizePluginsPath( pluginLink, translate.localeSlug, ! isLoggedIn ) }
 				className="plugins-browser-item__link"
 				onClick={ trackPluginLinkClick }
 			>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -18,6 +18,7 @@ import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { useLocalizedPlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
@@ -274,6 +275,7 @@ const InstalledInOrPricing = ( {
 	)?.active;
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
 	const active = isWpcomPreinstalled || isPluginActive;
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	let checkmarkColorClass = 'checkmark--active';
 
 	if ( isPreinstalledPremiumPlugin ) {
@@ -329,7 +331,7 @@ const InstalledInOrPricing = ( {
 							) : (
 								<>
 									{ translate( 'Free' ) }
-									{ ! canInstallPlugins && (
+									{ ! canInstallPlugins && isLoggedIn && (
 										<span className="plugins-browser-item__requires-plan-upgrade">
 											{ translate( 'Requires a plan upgrade' ) }
 										</span>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -17,8 +17,7 @@ import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibilit
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
-import { localizePluginsPath, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useLocalizedPlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
@@ -47,7 +46,7 @@ const PluginsBrowserListElement = ( props ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const localizeUrl = useLocalizeUrl();
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
@@ -168,7 +167,7 @@ const PluginsBrowserListElement = ( props ) => {
 	return (
 		<li className={ classNames }>
 			<a
-				href={ localizePluginsPath( pluginLink, translate.localeSlug, ! isLoggedIn ) }
+				href={ localizePath( pluginLink ) }
 				className="plugins-browser-item__link"
 				onClick={ trackPluginLinkClick }
 			>

--- a/client/my-sites/plugins/plugins-browser-item/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/test/index.jsx
@@ -14,7 +14,7 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useDispatch: jest.fn().mockImplementation( () => {} ),
-	useSelector: jest.fn().mockImplementation( ( selector ) => selector() ),
+	useSelector: jest.fn().mockImplementation( ( selector ) => selector( {} ) ),
 } ) );
 
 describe( 'PluginsBrowserItem Incompatible Plugins Message', () => {

--- a/client/my-sites/plugins/plugins-browser/clear-search-button.jsx
+++ b/client/my-sites/plugins/plugins-browser/clear-search-button.jsx
@@ -1,18 +1,25 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { localizePluginsPath } from 'calypso/my-sites/plugins/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const ClearSearchButton = () => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	return (
 		<>
 			&nbsp;
 			<a
 				className={ 'plugins-browser__clear-filters' }
-				href={ '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) }
+				href={ localizePluginsPath(
+					'/plugins' + ( siteSlug ? '/' + siteSlug : '' ),
+					translate.localeSlug,
+					! isLoggedIn
+				) }
 			>
 				{ translate( 'Clear' ) }
 			</a>

--- a/client/my-sites/plugins/plugins-browser/clear-search-button.jsx
+++ b/client/my-sites/plugins/plugins-browser/clear-search-button.jsx
@@ -1,25 +1,20 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import { localizePluginsPath } from 'calypso/my-sites/plugins/utils';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const ClearSearchButton = () => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	return (
 		<>
 			&nbsp;
 			<a
 				className={ 'plugins-browser__clear-filters' }
-				href={ localizePluginsPath(
-					'/plugins' + ( siteSlug ? '/' + siteSlug : '' ),
-					translate.localeSlug,
-					! isLoggedIn
-				) }
+				href={ localizePath( '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) ) }
 			>
 				{ translate( 'Clear' ) }
 			</a>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -57,7 +57,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localizePath } = useLocalizedPlugins();
 
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -57,6 +57,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -57,8 +57,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
-	const { localizePath } = useLocalizedPlugins();
-
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
-import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { siteObjectsToSiteIds, useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getPlugins, isEqualSlugOrId } from 'calypso/state/plugins/installed/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -40,6 +40,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) =>
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
+	const { localizePath } = useLocalizedPlugins();
 
 	const installedPlugins = useSelector( ( state ) =>
 		getPlugins( state, siteObjectsToSiteIds( sites ) )
@@ -64,7 +65,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) =>
 			listName={ category }
 			title={ categoryName }
 			site={ siteSlug }
-			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
+			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? localizePath( listLink ) : false }
 			size={ SHORT_LIST_LENGTH }
 			showPlaceholders={ isFetching }
 			currentSites={ sites }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
 import { setQueryArgs } from 'calypso/lib/query-args';
@@ -110,16 +110,6 @@ const SearchBoxHeader = ( props ) => {
 			searchRef?.current?.setKeyword( '' );
 		}
 	}, [ searchRef, searchTerm ] );
-
-	const clearSearch = useCallback( () => {
-		setQueryArgs( {} );
-	}, [] );
-
-	useEffect( () => {
-		if ( ! searchTerm ) {
-			clearSearch();
-		}
-	}, [ clearSearch, searchTerm ] );
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
 import { setQueryArgs } from 'calypso/lib/query-args';
@@ -110,6 +110,16 @@ const SearchBoxHeader = ( props ) => {
 			searchRef?.current?.setKeyword( '' );
 		}
 	}, [ searchRef, searchTerm ] );
+
+	const clearSearch = useCallback( () => {
+		setQueryArgs( {} );
+	}, [] );
+
+	useEffect( () => {
+		if ( ! searchTerm ) {
+			clearSearch();
+		}
+	}, [ clearSearch, searchTerm ] );
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,7 +1,8 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { useCurrentRoute } from 'calypso/components/route';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -35,12 +36,35 @@ const SearchBox = ( { isMobile, searchTerm, searchBoxRef, isSearching } ) => {
 	);
 };
 
+const SearchLink = ( { searchTerm, currentTerm, onSelect } ) => {
+	const classes = [ 'search-box-header__recommended-searches-list-item' ];
+	const route = useCurrentRoute();
+
+	if ( searchTerm === currentTerm ) {
+		classes.push( 'search-box-header__recommended-searches-list-item-selected' );
+
+		return <span className={ classes.join( ' ' ) }>{ searchTerm }</span>;
+	}
+
+	return (
+		<a
+			href={ `${ route.currentRoute }?s=${ searchTerm }` }
+			className={ classes.join( ' ' ) }
+			onClick={ onSelect }
+			onKeyPress={ onSelect }
+		>
+			{ searchTerm }
+		</a>
+	);
+};
+
 const PopularSearches = ( props ) => {
 	const { searchTerms, searchedTerm, searchBoxRef, popularSearchesRef } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const clickHandler = ( searchTerm ) => ( event ) => {
+		event.preventDefault();
 
-	const onClick = ( searchTerm ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_plugins_popular_searches_click', {
 				search_term: searchTerm,
@@ -61,28 +85,12 @@ const PopularSearches = ( props ) => {
 
 			<div className="search-box-header__recommended-searches-list">
 				{ searchTerms.map( ( searchTerm, n ) => (
-					<Fragment key={ 'search-box-item' + n }>
-						{ searchTerm === searchedTerm ? (
-							<span
-								className="search-box-header__recommended-searches-list-item search-box-header__recommended-searches-list-item-selected"
-								key={ 'recommended-search-item-' + n }
-							>
-								{ searchTerm }
-							</span>
-						) : (
-							<span
-								onClick={ () => onClick( searchTerm ) }
-								onKeyPress={ () => onClick( searchTerm ) }
-								role="link"
-								tabIndex={ 0 }
-								className="search-box-header__recommended-searches-list-item"
-								key={ 'recommended-search-item-' + n }
-							>
-								{ searchTerm }
-							</span>
-						) }
-						{ n !== searchTerms.length - 1 && <>,&nbsp;</> }
-					</Fragment>
+					<SearchLink
+						key={ 'search-box-item' + n }
+						onSelect={ clickHandler( searchTerm ) }
+						searchTerm={ searchTerm }
+						currentTerm={ searchedTerm }
+					/>
 				) ) }
 			</div>
 		</div>

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -76,6 +76,16 @@
 			text-align: center;
 
 			.search-box-header__recommended-searches-list-item {
+				&::after {
+					content: ',';
+					display: inline-block;
+					width: 0;
+					margin-right: 0.5em;
+				}
+				&:last-child::after {
+					content: none;
+				}
+
 				&:hover:not( .search-box-header__recommended-searches-list-item-selected ) {
 					color: var( --color-link );
 					cursor: pointer;

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -115,18 +115,13 @@
 			position: fixed;
 			z-index: 20;
 			top: var( --masterbar-height );
-			left: 0;
-			width: 100%;
+			left: calc( var( --sidebar-width-max ) + 1px );
+			width: calc( 100% - var( --sidebar-width-max ) - 1px );
 			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
 			border-bottom: 1px solid var( --studio-gray-5 );
 			background-color: var( --studio-white );
-
-			.layout__secondary ~ .layout__primary & {
-				left: calc( var( --sidebar-width-max ) + 1px );
-				width: calc( 100% - var( --sidebar-width-max ) - 1px );
-			}
 		}
 
 	}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -105,13 +105,16 @@
 			position: fixed;
 			z-index: 20;
 			top: var( --masterbar-height );
-			left: calc( var( --sidebar-width-max ) + 1px );
 			width: calc( 100% - var( --sidebar-width-max ) - 1px );
 			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
 			border-bottom: 1px solid var( --studio-gray-5 );
 			background-color: var( --studio-white );
+
+			.layout__secondary ~ .layout__primary & {
+				left: calc( var( --sidebar-width-max ) + 1px );
+			}
 		}
 
 	}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -105,7 +105,8 @@
 			position: fixed;
 			z-index: 20;
 			top: var( --masterbar-height );
-			width: calc( 100% - var( --sidebar-width-max ) - 1px );
+			left: 0;
+			width: 100%;
 			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
@@ -114,6 +115,7 @@
 
 			.layout__secondary ~ .layout__primary & {
 				left: calc( var( --sidebar-width-max ) + 1px );
+				width: calc( 100% - var( --sidebar-width-max ) - 1px );
 			}
 		}
 

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -115,13 +115,18 @@
 			position: fixed;
 			z-index: 20;
 			top: var( --masterbar-height );
-			left: calc( var( --sidebar-width-max ) + 1px );
-			width: calc( 100% - var( --sidebar-width-max ) - 1px );
+			left: 0;
+			width: 100%;
 			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
 			border-bottom: 1px solid var( --studio-gray-5 );
 			background-color: var( --studio-white );
+
+			.layout__secondary ~ .layout__primary & {
+				left: calc( var( --sidebar-width-max ) + 1px );
+				width: calc( 100% - var( --sidebar-width-max ) - 1px );
+			}
 		}
 
 	}

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Plugin } from 'calypso/data/marketplace/types';
 import { useESPluginsInfinite } from 'calypso/data/marketplace/use-es-query';
@@ -78,8 +79,9 @@ const usePlugins = ( {
 			? useESPluginsInfinite
 			: useWPORGInfinitePlugins;
 
+	const { localeSlug = '' } = useTranslate();
 	const wporgPluginsOptions = {
-		locale,
+		locale: locale || localeSlug,
 		category,
 		tag,
 		searchTerm: search,

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,7 +1,16 @@
+import { isMagnificentLocale } from '@automattic/i18n-utils';
+
 export function siteObjectsToSiteIds( sites ) {
 	return sites?.map( ( site ) => site.ID ) ?? [];
 }
 
 export function getVisibleSites( sites ) {
 	return sites?.filter( ( site ) => site.visible );
+}
+
+export function localizePluginsPath( path, locale, isLoggedOut = true ) {
+	const shouldPrefix =
+		isLoggedOut && isMagnificentLocale( locale ) && path.startsWith( '/plugins' );
+
+	return shouldPrefix ? `/${ locale }${ path }` : path;
 }

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,4 +1,8 @@
 import { isMagnificentLocale } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function siteObjectsToSiteIds( sites ) {
 	return sites?.map( ( site ) => site.ID ) ?? [];
@@ -8,9 +12,19 @@ export function getVisibleSites( sites ) {
 	return sites?.filter( ( site ) => site.visible );
 }
 
-export function localizePluginsPath( path, locale, isLoggedOut = true ) {
-	const shouldPrefix =
-		isLoggedOut && isMagnificentLocale( locale ) && path.startsWith( '/plugins' );
+export function useLocalizedPlugins() {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { localeSlug: locale } = useTranslate();
 
-	return shouldPrefix ? `/${ locale }${ path }` : path;
+	const localizePath = useCallback(
+		( path ) => {
+			const shouldPrefix =
+				! isLoggedIn && isMagnificentLocale( locale ) && path.startsWith( '/plugins' );
+
+			return shouldPrefix ? `/${ locale }${ path }` : path;
+		},
+		[ isLoggedIn, locale ]
+	);
+
+	return { localizePath };
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -106,9 +106,12 @@ const sections = [
 	},
 	{
 		name: 'plugins',
-		paths: [ '/plugins' ],
+		paths: [ '/plugins', `/([a-z]{2,3}|[a-z]{2}-[a-z]{2})/plugins` ],
 		module: 'calypso/my-sites/plugins',
 		group: 'sites',
+		enableLoggedOut: true,
+		isomorphic: true,
+		title: 'Plugins',
 	},
 	{
 		name: 'marketplace',

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -26,7 +26,7 @@ import 'calypso/state/plugins/init';
 
 const PLUGINS_LIST_DEFAULT_SIZE = 24;
 
-export function fetchPluginData( pluginSlug ) {
+export function fetchPluginData( pluginSlug, locale = '' ) {
 	return async ( dispatch, getState ) => {
 		if ( isFetching( getState(), pluginSlug ) ) {
 			return;
@@ -38,7 +38,10 @@ export function fetchPluginData( pluginSlug ) {
 		} );
 
 		try {
-			const data = await fetchPluginInformation( pluginSlug, getCurrentUserLocale( getState() ) );
+			const data = await fetchPluginInformation(
+				pluginSlug,
+				getCurrentUserLocale( getState() ) || locale
+			);
 
 			dispatch( {
 				type: PLUGINS_WPORG_PLUGIN_RECEIVE,

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -20,7 +20,8 @@ const selectors = {
 	browseAllFree: 'a[href^="/plugins/browse/popular"]',
 	browseAllPaid: 'a[href^="/plugins/browse/paid"]',
 	browseFirstCategory: 'button:has-text("Search Engine Optimization")',
-	categoryButton: ( section: string ) => `button:has-text("${ section }")`,
+	categoryButton: ( section: string ) =>
+		`button:has-text("${ section }"),a:has-text("${ section }")`,
 	breadcrumb: ( section: string ) => `.plugins-browser__header a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',

--- a/packages/components/src/responsive-toolbar-group/index.tsx
+++ b/packages/components/src/responsive-toolbar-group/index.tsx
@@ -15,6 +15,8 @@ const ResponsiveToolbarGroup = ( {
 	onClick = () => null,
 	initialActiveIndex = -1,
 	swipeBreakpoint = '<660px',
+	hrefList = [],
+	forceSwipe = false,
 }: {
 	children: ReactChild[];
 	className?: string;
@@ -24,10 +26,19 @@ const ResponsiveToolbarGroup = ( {
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;
 	swipeBreakpoint?: string;
+
+	/**
+	 * List of href attributes
+	 */
+	hrefList?: string[];
+
+	/**
+	 * Rendering mode
+	 */
+	forceSwipe?: boolean;
 } ) => {
 	const classes = classnames( 'responsive-toolbar-group', className );
-
-	const shouldSwipe = useBreakpoint( swipeBreakpoint );
+	const shouldSwipe = useBreakpoint( swipeBreakpoint ) || forceSwipe;
 
 	if ( shouldSwipe ) {
 		return (
@@ -35,6 +46,7 @@ const ResponsiveToolbarGroup = ( {
 				className={ classes }
 				initialActiveIndex={ initialActiveIndex }
 				onClick={ onClick }
+				hrefList={ hrefList }
 			>
 				{ children }
 			</SwipeGroup>

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -91,7 +91,8 @@
 	}
 
 	// Remove on-focus, on-click border
-	.components-toolbar .components-button::before {
+	.components-toolbar .components-button::before,
+	.components-toolbar .components-button:focus {
 		box-shadow: none;
 	}
 }

--- a/packages/components/src/responsive-toolbar-group/swipe-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/swipe-group.tsx
@@ -1,19 +1,26 @@
-import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton as BaseToolbarButton } from '@wordpress/components';
 import classnames from 'classnames';
 import { ReactChild, useState, useRef, useEffect } from 'react';
+import type { Button } from '@wordpress/components';
 
 import './style.scss';
+
+const ToolbarButton = BaseToolbarButton as React.ComponentType<
+	( BaseToolbarButton.Props & { href?: string } ) | Button.Props
+>;
 
 export default function SwipeGroup( {
 	children,
 	className = '',
 	onClick = () => null,
 	initialActiveIndex = -1,
+	hrefList = [],
 }: {
 	children: ReactChild[];
 	className?: string;
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;
+	hrefList?: string[];
 } ) {
 	const classes = classnames( 'responsive-toolbar-group__swipe', className );
 
@@ -23,7 +30,7 @@ export default function SwipeGroup( {
 	useEffect( () => {
 		setActiveIndex( initialActiveIndex );
 	}, [ initialActiveIndex ] );
-	const ref = useRef< HTMLButtonElement | null >( null );
+	const ref = useRef< HTMLAnchorElement >( null );
 
 	// Scroll to category on load
 	useEffect( () => {
@@ -47,10 +54,15 @@ export default function SwipeGroup( {
 						key={ `button-item-${ index }` }
 						id={ `button-item-${ index }` }
 						isActive={ activeIndex === index }
+						href={ hrefList[ index ] }
 						ref={ activeIndex === index ? ref : null }
-						onClick={ () => {
+						onClick={ ( event: React.MouseEvent ) => {
 							setActiveIndex( index );
 							onClick( index );
+
+							if ( typeof hrefList[ index ] === 'string' ) {
+								event.preventDefault();
+							}
 						} }
 						className="responsive-toolbar-group__swipe-item"
 					>


### PR DESCRIPTION
#### Proposed Changes
More info: pau2Xa-4j7-p2

This allows logged-out users to visit the following Plugin pages:
* The /plugins landing page
* The plugins detail pages – eg. /plugins/mailpoet
* The plugins category pages – eg. /plugins/browse/booking
* Plugins search result pages – eg. /plugins?s=commerce & /plugins/browse/design?s=ecommerce

Changes for this include:
* adjusting the section config to support logged-out routes
* adds data-less SSR routes
* enable localization for logged-out instances by using the URL param (ex. /es/plugins/mailpoet)
* hide current site-specific sections from logged-out users



#### Testing Instructions
* If you're running this on a locale instance, you'll need to run `yarn build-languages` so that the translations work
* Make sure you're logged out
* Go to `/plugins`
* The search box, categories links, and plugins should load and work properly
<img width="320" alt="Screenshot on 2022-08-22 at 14-31-15" src="https://user-images.githubusercontent.com/2749938/185925093-5ad202c7-10fa-47de-a52f-74e39e83e3c2.png">


* Click on one of the categories or popular searches
* The plugins should load and the top bread crumb should work as logged in
<img width="320" alt="Screenshot on 2022-08-22 at 14-37-03" src="https://user-images.githubusercontent.com/2749938/185925278-a0b0f6e2-a441-49ff-8cdf-17511bc13c27.png">


* The search box should also work and the breadcrumbs should update
<img width="320" alt="Screenshot on 2022-08-22 at 14-35-57" src="https://user-images.githubusercontent.com/2749938/185925323-22fcd4d8-b84c-4c0d-a9d6-e0418294a277.png">


* Clicking on any of the plugins should show the Plugin Details page
<img width="320" alt="Screenshot on 2022-08-22 at 14-37-36" src="https://user-images.githubusercontent.com/2749938/185925399-2b76f86a-6029-4807-bdf0-679c68385065.png">


* Go to `/es/plugins` (or any other supported locale prefix)
* Repeat the steps above
* Make sure the translations work as they do when logged in (NOTE: some plugins are not translated)
* The `/es` locale prefix should be maintained in the URLs while navigating through the pages
<img width="320" alt="Screenshot on 2022-08-22 at 15-52-29" src="https://user-images.githubusercontent.com/2749938/185925868-f9825632-68e2-4106-9089-549f705bcced.png">
<img width="320" alt="Screenshot on 2022-08-22 at 15-54-02" src="https://user-images.githubusercontent.com/2749938/185925956-4ed08c53-a242-41bf-81fe-dfe1c748a3e6.png">


* all the links that should be inaccessible and should redirect to log in
  * `/plugins/manage`
  * `/plugins/upload`
  * `/plugins/setup`
  * `/plugins/active`
  * `/plugins/inactive`
  * `/plugins/updates`
  * `/plugins/wordpress-seo-premium/eligibility`
  * any link which has a `SITE_ID` in it (ex. `/plugins/browse/seo/[SITE_ID]`)


* log in and visit the same links
* everything should work as before

#### TODOs

- [x] Enable Plugins pages for logged-out users (Client-side render + localized)
- [x] Enable Server-side rendering for Plugins pages (#66344)
- [x] Replace popular search words and categories spans with crawlable links
- [x] Implement the Logged-out Plugin details page CTA pointing to the /pricing page

