### PR TITLE
theme: Use isThemePremium selector to determine if a theme is premium

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -20,6 +20,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
+import { isThemePremium as getIsThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
 
@@ -283,7 +284,8 @@ export class Theme extends Component {
 	}
 
 	render() {
-		const { active, price, theme, translate, upsellUrl, isPremiumThemesAvailable } = this.props;
+		const { active, price, theme, translate, upsellUrl, isPremiumThemesAvailable, isPremiumTheme } =
+			this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -299,18 +301,6 @@ export class Theme extends Component {
 			'theme__badge-price-upgrade': ! hasPrice,
 			'theme__badge-price-upsell': showUpsell,
 		} );
-
-		/*
-		 * Check the theme object (not the price prop) for the true price.
-		 * Sometimes it will be an object, other times it will be a string.
-		 * Check both cases to ensure we have a non-zero price.
-		 */
-		let isPremiumTheme = false;
-		if ( typeof theme.price === 'object' && 0 !== theme.price.value ) {
-			isPremiumTheme = true;
-		} else if ( typeof theme.price === 'string' && '' !== theme.price ) {
-			isPremiumTheme = true;
-		}
 
 		/*
 		 * Only show the Premium badge if we're not already showing the price
@@ -472,6 +462,7 @@ export default connect(
 			errorOnUpdate: themesUpdateFailed && themesUpdateFailed.indexOf( theme.id ) > -1,
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
+			isPremiumTheme: getIsThemePremium( state, theme.id ),
 			isPremiumThemesAvailable:
 				isPremiumThemesAvailable?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),


### PR DESCRIPTION
#### Proposed Changes

* Instead of looking at price, use the isThemePremium selector to determine if a theme is premium

#### Testing Instructions

* Visit `http://calypso.localhost:3000/themes/YOURSITE.wordpress.com?flags=signup/seller-upgrade-modal`
* Visit `http://calypso.localhost:3000/themes/YOURSITE.wordpress.com`

**In both cases, the premium indicators should continue to display as previously.**

#### Note

You may need to disable SSR to go directly to the themes page on localhost:
```diff
diff --git a/client/sections.js b/client/sections.js
index 57dec6fe2b..39e2f25e90 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -216,7 +216,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               isomorphic: false,
                title: 'Themes',
        },
        {
@@ -225,7 +225,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               isomorphic: false,
                title: 'Themes',
                trackLoadPerformance: true,
        },
```