### PR TITLE
theme: use isThemePurchased selector to detect purchase

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -21,6 +21,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
 import { isThemePremium as getIsThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
+import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
 
@@ -258,10 +259,9 @@ export class Theme extends Component {
 	};
 
 	getUpsellMessage() {
-		const { isPremiumThemesAvailable, theme, price, translate } = this.props;
-		const hasPrice = /\d/g.test( price );
+		const { isPremiumThemesAvailable, theme, didPurchaseTheme, translate } = this.props;
 
-		if ( ! hasPrice && theme.price && ! isPremiumThemesAvailable ) {
+		if ( didPurchaseTheme && ! isPremiumThemesAvailable ) {
 			return translate( 'You have purchased an annual subscription for this theme' );
 		} else if ( isPremiumThemesAvailable ) {
 			return translate( 'The premium theme is included in your plan.' );
@@ -467,6 +467,7 @@ export default connect(
 				isPremiumThemesAvailable?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			siteSlug: getSiteSlug( state, siteId ),
+			didPurchaseTheme: isThemePurchased( state, theme.id, siteId ),
 		};
 	},
 	{ recordTracksEvent, setThemesBookmark, updateThemes }

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -71,7 +71,7 @@ describe( 'Theme', () => {
 		} );
 
 		test( 'Purchased a premium theme', async () => {
-			const { container } = renderWithState( <Theme { ...props } price={ null } /> );
+			const { container } = renderWithState( <Theme { ...props } didPurchaseTheme={ true } /> );
 			const popoverTrigger = container.getElementsByClassName( 'theme__upsell-popover' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 


### PR DESCRIPTION
#### Proposed Changes

* Use `isThemePurchased` to figure out if a theme is purchased, instead of comparing props.price vs theme.price

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a free site with one premium theme purchased
* Visit `http://calypso.localhost:3000/themes/YOURSITE.wordpress.com?flags=signup/seller-upgrade-modal`
* Check that the popup text continues to correctly distinguish between purchased premium themes and non purchased ones

![2022-08-02_09-58](https://user-images.githubusercontent.com/937354/182406516-c35b4b26-0e65-4144-8c3d-e7f7085b0076.png)

#### Note

You may need to disable SSR to go directly to the themes page on localhost:
```diff
diff --git a/client/sections.js b/client/sections.js
index 57dec6fe2b..39e2f25e90 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -216,7 +216,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               isomorphic: false,
                title: 'Themes',
        },
        {
@@ -225,7 +225,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               isomorphic: false,
                title: 'Themes',
                trackLoadPerformance: true,
        },
```

