### PR TITLE
Sites Dashboard Page: replace history when search or tab status change

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -162,8 +162,8 @@ function handleQueryParamChange(
 	const pathWithQuery = window.location.pathname + window.location.search;
 
 	if ( paramValue ) {
-		page( addQueryArgs( pathWithQuery, { [ paramName ]: paramValue } ) );
+		page.replace( addQueryArgs( pathWithQuery, { [ paramName ]: paramValue } ) );
 	} else {
-		page( removeQueryArgs( pathWithQuery, paramName ) );
+		page.replace( removeQueryArgs( pathWithQuery, paramName ) );
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Skip browser history when search or status change

#### Testing Instructions

* Navigate to `/sites-dashboard`
* Enter a text to search
* Click on some status tabs
* Click back on your browser
* Observe none of those changes were saved in the history stack, and you navigated to the previous page.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

- Fixes #65762
- Related to #65733 , I suggest to don't saving the tab state in the history either.
