### PR TITLE
format-currency: Add isSmallestUnit option to support integer amounts

### DIFF
--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -1,3 +1,96 @@
 # Format currency
 
 A library for formatting currency.
+
+Exports two functions:
+
+## formatCurrency()
+
+`formatCurrency( number: number, code: string, options: FormatCurrencyOptions = {} ): string | null`
+
+Formats money with a given currency code.
+
+The currency will define the properties to use for this formatting, but those properties can be overridden using the options. Be careful when doing this.
+
+For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
+
+Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
+
+Will return null if the currency code is unknown or if the number is not a number. Will also return null if `isSmallestUnit` is set and the number is not an integer.
+
+## getCurrencyObject()
+
+`getCurrencyObject( number: number, code: string, options: FormatCurrencyOptions = {} ): CurrencyObject | null`
+
+Returns a formatted price object.
+
+The currency will define the properties to use for this formatting, but those properties can be overridden using the options. Be careful when doing this.
+
+For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
+
+Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
+
+Will return null if the currency code is unknown or if the number is not a number. Will also return null if `isSmallestUnit` is set and the number is not an integer.
+
+## FormatCurrencyOptions
+
+An object with the following properties:
+
+### `decimal?: string`
+
+The symbol separating the integer part of a decimal from its fraction.
+
+Will be set automatically by the currency code.
+
+### `grouping?: string`
+
+The symbol separating the thousands part of an amount from its hundreds.
+
+Will be set automatically by the currency code.
+
+### `precision?: number`
+
+The symbol separating the thousands part of an amount from its hundreds.
+
+Will be set automatically by the currency code.
+
+### `symbol?: string`
+
+The currency symbol.
+
+Will be set automatically by the currency code.
+
+### `stripZeros?: boolean`
+
+Forces any decimal zeros to be hidden if set.
+
+For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
+
+For currencies without decimals (eg: JPY), this has no effect.
+
+### `isSmallestUnit?: boolean`
+
+Changes function to treat number as an integer in the currency's smallest unit.
+
+Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). If this option is false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
+
+## CurrencyObject
+
+An object with the following properties:
+
+### `sign: '-'|''`
+
+The symbol to use for negative values.
+
+### `symbol: string`
+
+The currency symbol (eg: `$` for USD).
+
+### `integer: string`
+
+The integer part of a decimal currency.
+
+### `fraction: string`
+
+The decimal part of a decimal currency.
+

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -11,16 +11,16 @@ export * from './types';
 /**
  * Formats money with a given currency code
  *
- * @param   {number}     number              number to format; assumed to be a float unless isSmallestUnit is set.
- * @param   {string}     code                currency code e.g. 'USD'
- * @param   {object}     options             options object
- * @param   {string}     options.decimal     decimal symbol e.g. ','
- * @param   {string}     options.grouping    thousands separator
- * @param   {number}     options.precision   decimal digits
- * @param   {string}     options.symbol      currency symbol e.g. 'A$'
- * @param   {boolean}    options.stripZeros  whether to remove trailing zero cents
- * @param   {boolean}    options.isSmallestUnit  true if the number is an integer in the currency's smallest unit.
- * @returns {?string}                        A formatted string.
+ * @param      {number}     number                    number to format; assumed to be a float unless isSmallestUnit is set.
+ * @param      {string}     code                      currency code e.g. 'USD'
+ * @param      {object}     options                   options object
+ * @param      {string}     options.decimal           decimal symbol e.g. ','
+ * @param      {string}     options.grouping          thousands separator
+ * @param      {number}     options.precision         decimal digits
+ * @param      {string}     options.symbol            currency symbol e.g. 'A$'
+ * @param      {boolean}    options.stripZeros        whether to remove trailing zero cents
+ * @param      {boolean}    options.isSmallestUnit    whether the number is an integer in the currency's smallest unit.
+ * @returns    {?string}    A formatted string.
  */
 export default function formatCurrency(
 	number: number,
@@ -54,15 +54,15 @@ export default function formatCurrency(
 /**
  * Returns a formatted price object.
  *
- * @param   {number}     number              number to format; assumed to be a float unless isSmallestUnit is set.
- * @param   {string}     code                currency code e.g. 'USD'
- * @param   {object}     options             options object
- * @param   {string}     options.decimal     decimal symbol e.g. ','
- * @param   {string}     options.grouping    thousands separator
- * @param   {number}     options.precision   decimal digits
- * @param   {string}     options.symbol      currency symbol e.g. 'A$'
- * @param   {boolean}    options.isSmallestUnit  true if the number is an integer in the currency's smallest unit.
- * @returns {?CurrencyObject}                        A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
+ * @param      {number}             number                    number to format; assumed to be a float unless isSmallestUnit is set.
+ * @param      {string}             code                      currency code e.g. 'USD'
+ * @param      {object}             options                   options object
+ * @param      {string}             options.decimal           decimal symbol e.g. ','
+ * @param      {string}             options.grouping          thousands separator
+ * @param      {number}             options.precision         decimal digits
+ * @param      {string}             options.symbol            currency symbol e.g. 'A$'
+ * @param      {boolean}            options.isSmallestUnit    whether the number is an integer in the currency's smallest unit.
+ * @returns    {?CurrencyObject}    A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
  */
 export function getCurrencyObject(
 	number: number,

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -11,7 +11,7 @@ export * from './types';
 /**
  * Formats money with a given currency code
  *
- * @param   {number}     number              number to format; assumed to be a float unless isInSmallestUnit is set.
+ * @param   {number}     number              number to format; assumed to be a float unless isSmallestUnit is set.
  * @param   {string}     code                currency code e.g. 'USD'
  * @param   {object}     options             options object
  * @param   {string}     options.decimal     decimal symbol e.g. ','
@@ -19,7 +19,7 @@ export * from './types';
  * @param   {number}     options.precision   decimal digits
  * @param   {string}     options.symbol      currency symbol e.g. 'A$'
  * @param   {boolean}    options.stripZeros  whether to remove trailing zero cents
- * @param   {boolean}    options.smallestUnit  true if the number is an integer in the currency's smallest unit.
+ * @param   {boolean}    options.isSmallestUnit  true if the number is an integer in the currency's smallest unit.
  * @returns {?string}                        A formatted string.
  */
 export default function formatCurrency(
@@ -31,12 +31,12 @@ export default function formatCurrency(
 	if ( ! currencyDefaults || isNaN( number ) ) {
 		return null;
 	}
-	const { decimal, grouping, precision, symbol, smallestUnit } = {
+	const { decimal, grouping, precision, symbol, isSmallestUnit } = {
 		...currencyDefaults,
 		...options,
 	};
 	const sign = number < 0 ? '-' : '';
-	if ( smallestUnit ) {
+	if ( isSmallestUnit ) {
 		if ( ! Number.isInteger( number ) ) {
 			return null;
 		}
@@ -54,14 +54,14 @@ export default function formatCurrency(
 /**
  * Returns a formatted price object.
  *
- * @param   {number}     number              number to format; assumed to be a float unless isInSmallestUnit is set.
+ * @param   {number}     number              number to format; assumed to be a float unless isSmallestUnit is set.
  * @param   {string}     code                currency code e.g. 'USD'
  * @param   {object}     options             options object
  * @param   {string}     options.decimal     decimal symbol e.g. ','
  * @param   {string}     options.grouping    thousands separator
  * @param   {number}     options.precision   decimal digits
  * @param   {string}     options.symbol      currency symbol e.g. 'A$'
- * @param   {boolean}    options.smallestUnit  true if the number is an integer in the currency's smallest unit.
+ * @param   {boolean}    options.isSmallestUnit  true if the number is an integer in the currency's smallest unit.
  * @returns {?CurrencyObject}                        A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
  */
 export function getCurrencyObject(
@@ -73,12 +73,12 @@ export function getCurrencyObject(
 	if ( ! currencyDefaults || isNaN( number ) ) {
 		return null;
 	}
-	const { decimal, grouping, precision, symbol, smallestUnit } = {
+	const { decimal, grouping, precision, symbol, isSmallestUnit } = {
 		...currencyDefaults,
 		...options,
 	};
 	const sign = number < 0 ? '-' : '';
-	if ( smallestUnit ) {
+	if ( isSmallestUnit ) {
 		if ( ! Number.isInteger( number ) ) {
 			return null;
 		}

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -9,18 +9,33 @@ export { CURRENCIES } from './currencies';
 export * from './types';
 
 /**
- * Formats money with a given currency code
+ * Formats money with a given currency code.
  *
- * @param      {number}     number                    number to format; assumed to be a float unless isSmallestUnit is set.
- * @param      {string}     code                      currency code e.g. 'USD'
- * @param      {object}     options                   options object
- * @param      {string}     options.decimal           decimal symbol e.g. ','
- * @param      {string}     options.grouping          thousands separator
- * @param      {number}     options.precision         decimal digits
- * @param      {string}     options.symbol            currency symbol e.g. 'A$'
- * @param      {boolean}    options.stripZeros        whether to remove trailing zero cents
- * @param      {boolean}    options.isSmallestUnit    whether the number is an integer in the currency's smallest unit.
- * @returns    {?string}    A formatted string.
+ * The currency will define the properties to use for this formatting, but
+ * those properties can be overridden using the options. Be careful when doing
+ * this.
+ *
+ * For currencies that include decimals, this will always return the amount
+ * with decimals included, even if those decimals are zeros. To exclude the
+ * zeros, use the `stripZeros` option. For example, the function will normally
+ * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+ * return `$10` instead.
+ *
+ * Since rounding errors are common in floating point math, sometimes a price
+ * is provided as an integer in the smallest unit of a currency (eg: cents in
+ * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+ * operate on integer numbers instead. If this option is not set or false, the
+ * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+ * option is true, it will return `$10.25` instead.
+ *
+ * Will return null if the currency code is unknown or if the number is not a
+ * number. Will also return null if `isSmallestUnit` is set and the number is
+ * not an integer.
+ *
+ * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
+ * @param      {string}                   code       currency code e.g. 'USD'
+ * @param      {FormatCurrencyOptions}    options    options object
+ * @returns    {?string}                  A formatted string.
  */
 export default function formatCurrency(
 	number: number,
@@ -54,15 +69,31 @@ export default function formatCurrency(
 /**
  * Returns a formatted price object.
  *
- * @param      {number}             number                    number to format; assumed to be a float unless isSmallestUnit is set.
- * @param      {string}             code                      currency code e.g. 'USD'
- * @param      {object}             options                   options object
- * @param      {string}             options.decimal           decimal symbol e.g. ','
- * @param      {string}             options.grouping          thousands separator
- * @param      {number}             options.precision         decimal digits
- * @param      {string}             options.symbol            currency symbol e.g. 'A$'
- * @param      {boolean}            options.isSmallestUnit    whether the number is an integer in the currency's smallest unit.
- * @returns    {?CurrencyObject}    A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
+ * The currency will define the properties to use for this formatting, but
+ * those properties can be overridden using the options. Be careful when doing
+ * this.
+ *
+ * For currencies that include decimals, this will always return the amount
+ * with decimals included, even if those decimals are zeros. To exclude the
+ * zeros, use the `stripZeros` option. For example, the function will normally
+ * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+ * return `$10` instead.
+ *
+ * Since rounding errors are common in floating point math, sometimes a price
+ * is provided as an integer in the smallest unit of a currency (eg: cents in
+ * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+ * operate on integer numbers instead. If this option is not set or false, the
+ * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+ * option is true, it will return `$10.25` instead.
+ *
+ * Will return null if the currency code is unknown or if the number is not a
+ * number. Will also return null if `isSmallestUnit` is set and the number is
+ * not an integer.
+ *
+ * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
+ * @param      {string}                   code       currency code e.g. 'USD'
+ * @param      {FormatCurrencyOptions}    options    options object
+ * @returns    {?CurrencyObject}          A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
  */
 export function getCurrencyObject(
 	number: number,

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -6,6 +6,8 @@ export { getCurrencyDefaults };
 
 export { CURRENCIES } from './currencies';
 
+export * from './types';
+
 /**
  * Formats money with a given currency code
  *

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -4,6 +4,7 @@ export interface FormatCurrencyOptions {
 	precision?: number;
 	symbol?: string;
 	stripZeros?: boolean;
+	smallestUnit?: boolean;
 }
 
 export interface CurrencyObject {

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -1,9 +1,51 @@
 export interface FormatCurrencyOptions {
+	/**
+	 * The symbol separating the integer part of a decimal from its fraction.
+	 *
+	 * Will be set automatically by the currency code.
+	 */
 	decimal?: string;
+
+	/**
+	 * The symbol separating the thousands part of an amount from its hundreds.
+	 *
+	 * Will be set automatically by the currency code.
+	 */
 	grouping?: string;
+
+	/**
+	 * The symbol separating the thousands part of an amount from its hundreds.
+	 *
+	 * Will be set automatically by the currency code.
+	 */
 	precision?: number;
+
+	/**
+	 * The currency symbol.
+	 *
+	 * Will be set automatically by the currency code.
+	 */
 	symbol?: string;
+
+	/**
+	 * Forces any decimal zeros to be hidden if set.
+	 *
+	 * For example, the function will normally format `10.00` in `USD` as
+	 * `$10.00` but when this option is true, it will return `$10` instead.
+	 *
+	 * For currencies without decimals (eg: JPY), this has no effect.
+	 */
 	stripZeros?: boolean;
+
+	/**
+	 * Changes function to treat number as an integer in the currency's smallest unit.
+	 *
+	 * Since rounding errors are common in floating point math, sometimes a price
+	 * is provided as an integer in the smallest unit of a currency (eg: cents in
+	 * USD or yen in JPY). If this option is false, the function will format the
+	 * amount `1025` in `USD` as `$1,025.00`, but when the option is true, it
+	 * will return `$10.25` instead.
+	 */
 	isSmallestUnit?: boolean;
 }
 

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -4,7 +4,7 @@ export interface FormatCurrencyOptions {
 	precision?: number;
 	symbol?: string;
 	stripZeros?: boolean;
-	smallestUnit?: boolean;
+	isSmallestUnit?: boolean;
 }
 
 export interface CurrencyObject {

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -50,7 +50,7 @@ export interface FormatCurrencyOptions {
 }
 
 export interface CurrencyObject {
-	sign: string;
+	sign: '-' | '';
 	symbol: string;
 	integer: string;
 	fraction: string;

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -31,6 +31,16 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
+	test( 'formats a number to localized currency for smallest unit', () => {
+		const money = formatCurrency( 9932, 'USD', { smallestUnit: true } );
+		expect( money ).toBe( '$99.32' );
+	} );
+
+	test( 'formats a number to localized currency for smallest unit for non-decimal currency', () => {
+		const money = formatCurrency( 9932, 'JPY', { smallestUnit: true } );
+		expect( money ).toBe( '¥9,932' );
+	} );
+
 	test( 'returns no trailing zero cents when stripZeros set to true (USD)', () => {
 		const money = formatCurrency( 9800900, 'USD', { precision: 2 } );
 		expect( money ).toBe( '$9,800,900.00' );
@@ -137,6 +147,27 @@ describe( 'formatCurrency', () => {
 				sign: '',
 			} );
 		} );
+
+		test( 'handles a number in the smallest unit', () => {
+			const money = getCurrencyObject( 9932, 'USD', { smallestUnit: true } );
+			expect( money ).toEqual( {
+				symbol: '$',
+				integer: '99',
+				fraction: '.32',
+				sign: '',
+			} );
+		} );
+
+		test( 'handles a number in the smallest unit for non-decimal currency', () => {
+			const money = getCurrencyObject( 9932, 'JPY', { smallestUnit: true } );
+			expect( money ).toEqual( {
+				symbol: '¥',
+				integer: '9,932',
+				fraction: '',
+				sign: '',
+			} );
+		} );
+
 		describe( 'supported currencies', () => {
 			test( 'USD', () => {
 				const money = getCurrencyObject( 9800900.32, 'USD' );

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -41,6 +41,11 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '¥9,932' );
 	} );
 
+	test( 'returns null if the number is a float and smallest unit is true', () => {
+		const money = formatCurrency( 9932.1, 'USD', { isSmallestUnit: true } );
+		expect( money ).toBe( null );
+	} );
+
 	test( 'returns no trailing zero cents when stripZeros set to true (USD)', () => {
 		const money = formatCurrency( 9800900, 'USD', { precision: 2 } );
 		expect( money ).toBe( '$9,800,900.00' );
@@ -166,6 +171,11 @@ describe( 'formatCurrency', () => {
 				fraction: '',
 				sign: '',
 			} );
+		} );
+
+		test( 'returns null if the number is a float and the smallest unit is set', () => {
+			const money = getCurrencyObject( 9932.1, 'USD', { isSmallestUnit: true } );
+			expect( money ).toEqual( null );
 		} );
 
 		describe( 'supported currencies', () => {

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -32,12 +32,12 @@ describe( 'formatCurrency', () => {
 	} );
 
 	test( 'formats a number to localized currency for smallest unit', () => {
-		const money = formatCurrency( 9932, 'USD', { smallestUnit: true } );
+		const money = formatCurrency( 9932, 'USD', { isSmallestUnit: true } );
 		expect( money ).toBe( '$99.32' );
 	} );
 
 	test( 'formats a number to localized currency for smallest unit for non-decimal currency', () => {
-		const money = formatCurrency( 9932, 'JPY', { smallestUnit: true } );
+		const money = formatCurrency( 9932, 'JPY', { isSmallestUnit: true } );
 		expect( money ).toBe( '¥9,932' );
 	} );
 
@@ -149,7 +149,7 @@ describe( 'formatCurrency', () => {
 		} );
 
 		test( 'handles a number in the smallest unit', () => {
-			const money = getCurrencyObject( 9932, 'USD', { smallestUnit: true } );
+			const money = getCurrencyObject( 9932, 'USD', { isSmallestUnit: true } );
 			expect( money ).toEqual( {
 				symbol: '$',
 				integer: '99',
@@ -159,7 +159,7 @@ describe( 'formatCurrency', () => {
 		} );
 
 		test( 'handles a number in the smallest unit for non-decimal currency', () => {
-			const money = getCurrencyObject( 9932, 'JPY', { smallestUnit: true } );
+			const money = getCurrencyObject( 9932, 'JPY', { isSmallestUnit: true } );
 			expect( money ).toEqual( {
 				symbol: '¥',
 				integer: '9,932',


### PR DESCRIPTION
#### Proposed Changes

The `@automattic/format-currency` package handles formatting floating point numbers like `2345.23` for a locale like `$2,345.23`. However, since rounding errors in floating point math are common, most payment systems use integers like `234523` for a currency amount, keeping the number in the currency's smallest unit (eg: cents for USD, yen for JPY).

This PR adds a new option to the functions exported by the `format-currency` package: `isSmallestUnit?: boolean`. If true, the functions will assume that the amount is an integer instead of a floating point number and convert it for display appropriately.

This may be needed by https://github.com/Automattic/wp-calypso/pull/66066 but also could come in handy in other places.

#### Testing Instructions

Automated tests are included.