### PR TITLE
WIP: Moving embed wrapper css to the .help-center class wrapper.

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -316,6 +316,26 @@ body[class^='is-section-'] {
 				border: none;
 			}
 		}
+
+		.wp-block-embed__wrapper {
+			position: relative;
+
+			&::before {
+				content: '';
+				display: block;
+				padding-top: 56.25%;
+			}
+
+			iframe {
+				bottom: 0;
+				height: 100%;
+				left: 0;
+				position: absolute;
+				right: 0;
+				top: 0;
+				width: 100%;
+			}
+		}
 	}
 }
 
@@ -339,26 +359,6 @@ body[class^='is-section-'] {
 
 .help-center-header__text {
 	margin: 1em 0;
-}
-
-.wp-block-embed__wrapper {
-	position: relative;
-
-	&::before {
-		content: '';
-		display: block;
-		padding-top: 56.25%;
-	}
-
-	iframe {
-		bottom: 0;
-		height: 100%;
-		left: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-		width: 100%;
-	}
 }
 
 .components-base-control__label {


### PR DESCRIPTION
#### Proposed Changes

This PR tries to fix visual issues introduced here https://github.com/Automattic/wp-calypso/pull/65888. The changes apply some styles to the `.wp-block-embed__wrapper` CSS class, affecting all instances where it's used. In other words, it affects all oEmbed blocks.

To fix it, it nests all styles into the `.inline-help` CSS class, affecting only to the desired elements.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
