### PR TITLE
Help Center: Restrict help-center CSS to the help center

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -5,362 +5,364 @@
 
 $head-foot-height: 50px;
 
-.components-card.help-center__container {
-	position: absolute;
-	background-color: #fff;
-	color: #000;
-	z-index: 9999;
-	cursor: default;
-	transition: max-height 0.5s;
+.help-center {
+	.components-card.help-center__container {
+		position: absolute;
+		background-color: #fff;
+		color: #000;
+		z-index: 9999;
+		cursor: default;
+		transition: max-height 0.5s;
 
-	button.button-primary,
-	button.button-secondary {
-		font-size: $font-title-small;
-	}
-
-	.button {
-		font-size: $font-body-small;
-	}
-
-	& > div {
-		display: flex;
-		flex-direction: column;
-	}
-
-	button.components-button:focus {
-		box-shadow: none;
-		outline: none;
-	}
-
-	.help-center__container-header {
-		height: $head-foot-height;
-		padding: 16px 8px 16px 16px;
-
-		// This icon does not accept size prop due to a bug - https://github.com/WordPress/gutenberg/pull/40315
-		// We can remove this when the bug is fixed
-		.help-center-header__minimize svg {
-			transform: scale( 0.7, 1 );
-			transform-origin: center;
+		button.button-primary,
+		button.button-secondary {
+			font-size: $font-title-small;
 		}
 
-		.help-center-header__text {
-			max-width: 300px;
+		.button {
 			font-size: $font-body-small;
-			font-weight: 500;
+		}
+
+		& > div {
 			display: flex;
-			align-items: center;
+			flex-direction: column;
+		}
 
-			svg {
-				margin-right: 3px;
+		button.components-button:focus {
+			box-shadow: none;
+			outline: none;
+		}
+
+		.help-center__container-header {
+			height: $head-foot-height;
+			padding: 16px 8px 16px 16px;
+
+			// This icon does not accept size prop due to a bug - https://github.com/WordPress/gutenberg/pull/40315
+			// We can remove this when the bug is fixed
+			.help-center-header__minimize svg {
+				transform: scale( 0.7, 1 );
+				transform-origin: center;
 			}
 
-			.help-center-header__article-title {
-				overflow: hidden;
-				white-space: nowrap;
-				text-overflow: ellipsis;
-				max-width: 200px;
+			.help-center-header__text {
+				max-width: 300px;
+				font-size: $font-body-small;
+				font-weight: 500;
+				display: flex;
+				align-items: center;
+
+				svg {
+					margin-right: 3px;
+				}
+
+				.help-center-header__article-title {
+					overflow: hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
+					max-width: 200px;
+				}
 			}
+		}
+
+		.help-center__container-content {
+			overflow-y: auto;
+			padding: 16px;
+		}
+
+		.help-center__container-footer {
+			height: auto;
+			padding: 16px;
+
+			// hide when empty
+			&:empty {
+				display: none;
+			}
+		}
+
+		&.is-desktop {
+			top: calc( #{$header-height} + 16px );
+			right: 16px;
+			width: 410px;
+			height: 80vh;
+			max-height: 800px;
+			box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
+			overflow: auto;
+
+			.help-center__container-header {
+				cursor: move;
+			}
+
+			.help-center__container-content {
+				flex-grow: 1;
+				height: calc( 80vh - #{$head-foot-height} * 2 );
+				position: relative;
+			}
+
+			&.is-minimized {
+				min-height: $head-foot-height;
+			}
+		}
+
+		&.is-mobile {
+			top: 45px;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			max-height: 100%;
+
+			.help-center__container-content {
+				flex: auto;
+			}
+
+			.help-center__container-footer {
+				margin-bottom: 0;
+			}
+
+			&.is-minimized {
+				min-height: $head-foot-height;
+				top: calc( 100vh - #{$head-foot-height} );
+			}
+		}
+
+		.components-button {
+			&:hover {
+				box-shadow: none;
+				color: inherit;
+			}
+		}
+
+		&.is-mobile.is-minimized,
+		&.is-desktop.is-minimized {
+			max-height: $head-foot-height;
+		}
+
+		.help-center-header__unread-count {
+			display: inline-block;
+			margin-left: 8px;
+			padding: 2px 6px;
+			background: var( --studio-pink-50 );
+			border-radius: 20px; // stylelint-disable-line scales/radii
+			font-size: $font-body-extra-small;
+			color: white;
+		}
+
+		.help-center-header__a8c-only-badge {
+			display: inline-block;
+			margin-left: 8px;
+			padding: 2px 6px;
+			background: lightgray;
+			border-radius: 4px;
+			font-size: $font-body-extra-small;
+			color: var( --studio-gray-50 );
+			text-transform: uppercase;
+		}
+	}
+
+	.ticket-success-screen__help-center {
+		text-align: center;
+
+		.ticket-success-screen__help-center-heading {
+			font-size: $font-title-small;
+			color: $studio-gray-100;
+			margin: 16px;
+			font-weight: 400;
+		}
+		.ticket-success-screen__help-center-message {
+			font-size: $font-body-small;
+			color: $studio-gray-50;
+			margin: 0;
+		}
+	}
+
+	@keyframes fadeIn {
+		0% {
+			opacity: 0;
+		}
+
+		100% {
+			opacity: 1;
+		}
+	}
+
+	@keyframes fadeOut {
+		0% {
+			opacity: 1;
+		}
+
+		100% {
+			opacity: 0;
+		}
+	}
+
+	button.button.back-button__help-center.is-borderless {
+		display: flex;
+		align-items: center;
+		color: black;
+		font-size: $font-body-small;
+		padding-right: 5px;
+
+		&:focus {
+			color: #043959;
+			box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba( 79, 148, 212, 0.8 );
+			outline: 1px solid transparent;
+			border-color: inherit;
 		}
 	}
 
 	.help-center__container-content {
-		overflow-y: auto;
-		padding: 16px;
-	}
+		padding: 0 !important;
 
-	.help-center__container-footer {
-		height: auto;
-		padding: 16px;
-
-		// hide when empty
-		&:empty {
-			display: none;
+		> *:not( iframe ) {
+			padding: 16px;
 		}
 	}
 
-	&.is-desktop {
-		top: calc( #{$header-height} + 16px );
-		right: 16px;
-		width: 410px;
-		height: 80vh;
-		max-height: 800px;
-		box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
-		overflow: auto;
-
-		.help-center__container-header {
-			cursor: move;
-		}
-
-		.help-center__container-content {
-			flex-grow: 1;
-			height: calc( 80vh - #{$head-foot-height} * 2 );
-			position: relative;
-		}
-
-		&.is-minimized {
-			min-height: $head-foot-height;
-		}
-	}
-
-	&.is-mobile {
-		top: 45px;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		max-height: 100%;
-
-		.help-center__container-content {
-			flex: auto;
-		}
-
-		.help-center__container-footer {
-			margin-bottom: 0;
-		}
-
-		&.is-minimized {
-			min-height: $head-foot-height;
-			top: calc( 100vh - #{$head-foot-height} );
-		}
-	}
-
-	.components-button {
-		&:hover {
-			box-shadow: none;
-			color: inherit;
-		}
-	}
-
-	&.is-mobile.is-minimized,
-	&.is-desktop.is-minimized {
-		max-height: $head-foot-height;
-	}
-
-	.help-center-header__unread-count {
-		display: inline-block;
-		margin-left: 8px;
-		padding: 2px 6px;
-		background: var( --studio-pink-50 );
-		border-radius: 20px; // stylelint-disable-line scales/radii
-		font-size: $font-body-extra-small;
-		color: white;
-	}
-
-	.help-center-header__a8c-only-badge {
-		display: inline-block;
-		margin-left: 8px;
-		padding: 2px 6px;
-		background: lightgray;
-		border-radius: 4px;
-		font-size: $font-body-extra-small;
-		color: var( --studio-gray-50 );
-		text-transform: uppercase;
-	}
-}
-
-.ticket-success-screen__help-center {
-	text-align: center;
-
-	.ticket-success-screen__help-center-heading {
-		font-size: $font-title-small;
-		color: $studio-gray-100;
-		margin: 16px;
-		font-weight: 400;
-	}
-	.ticket-success-screen__help-center-message {
-		font-size: $font-body-small;
-		color: $studio-gray-50;
-		margin: 0;
-	}
-}
-
-@keyframes fadeIn {
-	0% {
-		opacity: 0;
-	}
-
-	100% {
-		opacity: 1;
-	}
-}
-
-@keyframes fadeOut {
-	0% {
-		opacity: 1;
-	}
-
-	100% {
-		opacity: 0;
-	}
-}
-
-button.button.back-button__help-center.is-borderless {
-	display: flex;
-	align-items: center;
-	color: black;
-	font-size: $font-body-small;
-	padding-right: 5px;
-
-	&:focus {
-		color: #043959;
-		box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba( 79, 148, 212, 0.8 );
-		outline: 1px solid transparent;
-		border-color: inherit;
-	}
-}
-
-.help-center__container-content {
-	padding: 0 !important;
-
-	> *:not( iframe ) {
-		padding: 16px;
-	}
-}
-
-.help-center-sibyl-articles__list {
-	list-style: none;
-	box-sizing: border-box;
-	padding: 0;
-
-	> li {
+	.help-center-sibyl-articles__list {
+		list-style: none;
+		box-sizing: border-box;
 		padding: 0;
 
-		> a {
-			display: flex;
-			align-items: center;
-			text-decoration: none;
-			color: var( --studio-gray-100 );
-			margin-bottom: 16px;
-			font-size: $font-body-small;
+		> li {
+			padding: 0;
 
-			&:hover {
-				background: var( --color-neutral-0 );
-			}
-		}
-	}
+			> a {
+				display: flex;
+				align-items: center;
+				text-decoration: none;
+				color: var( --studio-gray-100 );
+				margin-bottom: 16px;
+				font-size: $font-body-small;
 
-	svg {
-		margin-right: 15px;
-		border-radius: 2px;
-		display: block;
-		padding: 8px;
-		background: var( --studio-gray-0 );
-		fill: var( --studio-blue-50 );
-		flex-shrink: 0;
-	}
-}
-
-.help-center-search-results__title,
-.help-center__section-title {
-	font-size: $font-body-small;
-	font-weight: 500;
-	color: var( --studio-gray-100 );
-}
-
-.help-center-sibyl-articles__container {
-	padding-top: 0;
-}
-
-.help-center-container__loading,
-.help-center-contact-page__loading {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
-
-	.spinner__outer {
-		border-top-color: var( --wp-admin-theme-color );
-	}
-	.spinner__inner {
-		border-top-color: var( --wp-admin-theme-color );
-		border-right-color: var( --wp-admin-theme-color );
-	}
-}
-
-body[class*='is-section-'],
-body[class^='is-section-'] {
-	.help-center {
-		button,
-		input,
-		textarea,
-		select {
-			box-sizing: border-box;
-		}
-
-		h1 {
-			font-weight: 600;
-			margin: 0.67em 0;
-
-			&.site-picker__site-title {
-				font-weight: 400;
-				margin: 0;
+				&:hover {
+					background: var( --color-neutral-0 );
+				}
 			}
 		}
 
-		h2,
-		h3 {
-			color: #1d2327;
-			margin: 1em 0;
-		}
-
-		label {
-			cursor: pointer;
-		}
-
-		.help-center__container.is-desktop {
-			position: fixed;
-			top: calc( var( --masterbar-height ) + 16px );
-		}
-
-		.search-card {
-			.search {
-				border: none;
-			}
+		svg {
+			margin-right: 15px;
+			border-radius: 2px;
+			display: block;
+			padding: 8px;
+			background: var( --studio-gray-0 );
+			fill: var( --studio-blue-50 );
+			flex-shrink: 0;
 		}
 	}
-}
 
-.help-center-contact-form {
-	.button:not( .back-button__help-center ) {
-		line-height: 2.71428571;
-		min-height: 40px;
-		margin-bottom: 4px;
-		vertical-align: middle;
-	}
-}
-
-.help-center-contact-form__label,
-.site-picker__label {
-	font-size: $font-body-small;
-}
-
-.help-center-sibyl-articles__list {
-	margin: 0;
-}
-
-.help-center-header__text {
-	margin: 1em 0;
-}
-
-.wp-block-embed__wrapper {
-	position: relative;
-
-	&::before {
-		content: '';
-		display: block;
-		padding-top: 56.25%;
+	.help-center-search-results__title,
+	.help-center__section-title {
+		font-size: $font-body-small;
+		font-weight: 500;
+		color: var( --studio-gray-100 );
 	}
 
-	iframe {
-		bottom: 0;
+	.help-center-sibyl-articles__container {
+		padding-top: 0;
+	}
+
+	.help-center-container__loading,
+	.help-center-contact-page__loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		height: 100%;
-		left: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-		width: 100%;
-	}
-}
 
-.components-base-control__label {
-	color: var( --studio-gray-60 );
+		.spinner__outer {
+			border-top-color: var( --wp-admin-theme-color );
+		}
+		.spinner__inner {
+			border-top-color: var( --wp-admin-theme-color );
+			border-right-color: var( --wp-admin-theme-color );
+		}
+	}
+
+	body[class*='is-section-'],
+	body[class^='is-section-'] {
+		.help-center {
+			button,
+			input,
+			textarea,
+			select {
+				box-sizing: border-box;
+			}
+
+			h1 {
+				font-weight: 600;
+				margin: 0.67em 0;
+
+				&.site-picker__site-title {
+					font-weight: 400;
+					margin: 0;
+				}
+			}
+
+			h2,
+			h3 {
+				color: #1d2327;
+				margin: 1em 0;
+			}
+
+			label {
+				cursor: pointer;
+			}
+
+			.help-center__container.is-desktop {
+				position: fixed;
+				top: calc( var( --masterbar-height ) + 16px );
+			}
+
+			.search-card {
+				.search {
+					border: none;
+				}
+			}
+		}
+	}
+
+	.help-center-contact-form {
+		.button:not( .back-button__help-center ) {
+			line-height: 2.71428571;
+			min-height: 40px;
+			margin-bottom: 4px;
+			vertical-align: middle;
+		}
+	}
+
+	.help-center-contact-form__label,
+	.site-picker__label {
+		font-size: $font-body-small;
+	}
+
+	.help-center-sibyl-articles__list {
+		margin: 0;
+	}
+
+	.help-center-header__text {
+		margin: 1em 0;
+	}
+
+	.wp-block-embed__wrapper {
+		position: relative;
+
+		&::before {
+			content: '';
+			display: block;
+			padding-top: 56.25%;
+		}
+
+		iframe {
+			bottom: 0;
+			height: 100%;
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: 0;
+			width: 100%;
+		}
+	}
+
+	.components-base-control__label {
+		color: var( --studio-gray-60 );
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

* This fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/65888 that overwrites videopress player CSS. This fix restricts the CSS to the help-center to prevent undefined behavior in the editor and everywhere else.

#### Testing Instructions

1. Checkout this branch.
2. run `yarn start`.
3. Go to `apps/editing-toolkit` folder.
4. Run `yarn dev --sync`.
5. Sandbox testing10percent2022simple.wordpress.com.
6. In incognito, login using a 10% User ID from the secret store.
7. Go to https://wordpress.com/themes/testing10percent2022simple.wordpress.com.
8. Help Center should work normally.
9. Create a post and add the video block, it should look normal.

Related to #65888
