### PR TITLE
Jetpack Agency Dashboard: Move the /plugins/manage redirect from rendering to routing

### DIFF
--- a/client/jetpack-cloud/sections/plugin-management/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/controller.tsx
@@ -1,8 +1,21 @@
+import config from '@automattic/calypso-config';
+import page from 'page';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import Header from '../agency-dashboard/header';
 import DashboardSidebar from '../agency-dashboard/sidebar';
 import PluginsOverview from './plugins-overview';
 
 export function pluginManagementContext( context: PageJS.Context, next: VoidFunction ): void {
+	const state = context.store.getState();
+	const isAgency = isAgencyUser( state );
+	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
+	const isPluginManagementEnabled = config.isEnabled( 'jetpack/plugin-management' );
+
+	if ( ! isAgency || ! isAgencyEnabled || ! isPluginManagementEnabled ) {
+		page.redirect( '/' );
+		return;
+	}
+
 	const { filter = 'all', site } = context.params;
 	const { s: search } = context.query;
 	context.header = <Header />;

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { ReactElement, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -12,7 +10,6 @@ import {
 	hasActivePartnerKey,
 	hasFetchedPartner,
 	isFetchingPartner,
-	isAgencyUser,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 
@@ -39,17 +36,6 @@ export default function PluginsOverview( {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );
-	const isAgency = useSelector( isAgencyUser );
-	const isPluginManagementEnabled = config.isEnabled( 'jetpack/plugin-management' );
-
-	useEffect( () => {
-		if ( hasFetched ) {
-			if ( ! isAgency || ! isPluginManagementEnabled ) {
-				page.redirect( '/' );
-				return;
-			}
-		}
-	}, [ hasFetched, isAgency, isPluginManagementEnabled ] );
 
 	// Reset selected site id for multi-site view since it is never reset
 	// and the <PluginsMain /> component behaves differently when there


### PR DESCRIPTION
#### Proposed Changes

Non-agency users who reach the `/plugins/manage` route are redirected to `/`. This PR moves that redirect so that it occurs during routing instead of rendering in order to improve the page loading speed.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. With an agency user visit `/plugins/manage`. Verify that the page loads.
2. With a non-agency user visit `/plugins/manage`. Verify that you are quickly redirected to `/` (which will currently also redirect to `/landing`).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202648984787437