### PR TITLE
theme: Replace price test with a new themeNeedsPurchase variable

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -284,8 +284,16 @@ export class Theme extends Component {
 	}
 
 	render() {
-		const { active, price, theme, translate, upsellUrl, isPremiumThemesAvailable, isPremiumTheme } =
-			this.props;
+		const {
+			active,
+			price,
+			theme,
+			translate,
+			upsellUrl,
+			isPremiumThemesAvailable,
+			isPremiumTheme,
+			didPurchaseTheme,
+		} = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -293,12 +301,12 @@ export class Theme extends Component {
 			'is-actionable': isActionable,
 		} );
 
-		const hasPrice = /\d/g.test( price );
+		const themeNeedsPurchase = isPremiumTheme && ! isPremiumThemesAvailable && ! didPurchaseTheme;
 		const showUpsell = ! isEnabled( 'signup/seller-upgrade-modal' )
-			? hasPrice && upsellUrl
+			? themeNeedsPurchase && upsellUrl
 			: upsellUrl && theme.price && ! active;
 		const priceClass = classNames( 'theme__badge-price', {
-			'theme__badge-price-upgrade': ! hasPrice,
+			'theme__badge-price-upgrade': ! themeNeedsPurchase,
 			'theme__badge-price-upsell': showUpsell,
 		} );
 
@@ -306,7 +314,7 @@ export class Theme extends Component {
 		 * Only show the Premium badge if we're not already showing the price
 		 * and the theme isn't the active theme.
 		 */
-		const showPremiumBadge = isPremiumTheme && ! hasPrice && ! active;
+		const showPremiumBadge = isPremiumTheme && ! themeNeedsPurchase && ! active;
 
 		const themeDescription = decodeEntities( description );
 


### PR DESCRIPTION

#### Proposed Changes

* Replace `const hasPrice = /\d/g.test( price );` with `const themeNeedsPurchase = isPremiumTheme && ! isPremiumThemesAvailable && ! didPurchaseTheme; ` for clarity
  * The variable acts the same, works the same as before
  * There should be no changes in behavior.

Themes can have several states:
  * (1) Non-premium theme
  * (2) Premium theme, and you need to buy either a plan or the theme before you can use it 
  * (3) Premium theme, and you have purchased it individually
  * (4) Premium theme, and your plan provides access to all premium themes

Previously, the component checked and cross referenced `props.price` vs `themes.price` to determine which of these 4 states you were in. I am changing it to use more straightforward variables like `isPremiumTheme` and `didPurchaseTheme`.

The old variable `const hasPrice = /\d/g.test( price );` is looking to see if the theme is in state (2).

The new code `const themeNeedsPurchase = isPremiumTheme && ! isPremiumThemesAvailable && ! didPurchaseTheme; ` expresses this in a clearer way.

#### Testing Instructions

* Have both a free site and a premium plan site
  * Have at least one individually purchased theme on the free plan site 
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-FREE-SITE`
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-FREE-SITE?flags=signup/seller-upgrade-modal`
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-PREMIUM-SITE`
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-PREMIUM-SITE?flags=signup/seller-upgrade-modal`

There should be no changes before and after this PR.

Example of free site + flag turned on
![2022-08-02_15-14](https://user-images.githubusercontent.com/937354/182465137-4b62c01e-2a6d-4a7e-934e-fbc5802ca812.png)

