### PR TITLE
theme: Rename isPremiumThemesAvailable -> hasPremiumThemesFeature

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -259,11 +259,11 @@ export class Theme extends Component {
 	};
 
 	getUpsellMessage() {
-		const { isPremiumThemesAvailable, theme, didPurchaseTheme, translate } = this.props;
+		const { hasPremiumThemesFeature, theme, didPurchaseTheme, translate } = this.props;
 
-		if ( didPurchaseTheme && ! isPremiumThemesAvailable ) {
+		if ( didPurchaseTheme && ! hasPremiumThemesFeature ) {
 			return translate( 'You have purchased an annual subscription for this theme' );
-		} else if ( isPremiumThemesAvailable ) {
+		} else if ( hasPremiumThemesFeature ) {
 			return translate( 'The premium theme is included in your plan.' );
 		}
 
@@ -290,7 +290,7 @@ export class Theme extends Component {
 			theme,
 			translate,
 			upsellUrl,
-			isPremiumThemesAvailable,
+			hasPremiumThemesFeature,
 			isPremiumTheme,
 			didPurchaseTheme,
 		} = this.props;
@@ -301,7 +301,7 @@ export class Theme extends Component {
 			'is-actionable': isActionable,
 		} );
 
-		const themeNeedsPurchase = isPremiumTheme && ! isPremiumThemesAvailable && ! didPurchaseTheme;
+		const themeNeedsPurchase = isPremiumTheme && ! hasPremiumThemesFeature && ! didPurchaseTheme;
 		const showUpsell = ! isEnabled( 'signup/seller-upgrade-modal' )
 			? themeNeedsPurchase && upsellUrl
 			: upsellUrl && theme.price && ! active;
@@ -364,7 +364,7 @@ export class Theme extends Component {
 						! isEnabled( 'signup/seller-upgrade-modal' )
 							? 'theme__upsell-icon'
 							: 'theme__upsell-popover',
-						isPremiumThemesAvailable || showPremiumBadge ? 'active' : null
+						hasPremiumThemesFeature || showPremiumBadge ? 'active' : null
 					) }
 					position={ ! isEnabled( 'signup/seller-upgrade-modal' ) ? 'top left' : 'top' }
 				>
@@ -461,7 +461,7 @@ export class Theme extends Component {
 }
 
 export default connect(
-	( state, { theme, siteId, isPremiumThemesAvailable } ) => {
+	( state, { theme, siteId, hasPremiumThemesFeature } ) => {
 		const {
 			themes: { themesUpdate },
 		} = state;
@@ -471,8 +471,8 @@ export default connect(
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
 			isPremiumTheme: getIsThemePremium( state, theme.id ),
-			isPremiumThemesAvailable:
-				isPremiumThemesAvailable?.() ||
+			hasPremiumThemesFeature:
+				hasPremiumThemesFeature?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			siteSlug: getSiteSlug( state, siteId ),
 			didPurchaseTheme: isThemePurchased( state, theme.id, siteId ),

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -58,7 +58,7 @@ describe( 'Theme', () => {
 
 		test( 'Premium site', async () => {
 			const { container } = renderWithState(
-				<Theme { ...props } isPremiumThemesAvailable={ () => true } />
+				<Theme { ...props } hasPremiumThemesFeature={ () => true } />
 			);
 			const popoverTrigger = container.getElementsByClassName( 'theme__upsell-popover' )[ 0 ];
 			await userEvent.hover( popoverTrigger );


### PR DESCRIPTION



#### Proposed Changes

* In the theme component, rename `isPremiumThemesAvailable` -> `hasPremiumThemesFeature`

`isPremiumThemesAvailable` isn't as clear as it could be, since there are now two ways for a premium theme to be available (you can have a plan that provides all premium themes, or you can buy an individual premium theme), and this variable only covers one of them. Rename to  `hasPremiumThemesFeature` for clarity.

#### Testing Instructions

* Have both a free site and a premium plan site
  * Have at least one individually purchased theme on the free plan site 
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-FREE-SITE`
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-FREE-SITE?flags=signup/seller-upgrade-modal`
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-PREMIUM-SITE`
* Visit `http://calypso.localhost:3000/themes/premium/YOUR-PREMIUM-SITE?flags=signup/seller-upgrade-modal`

There should be no changes before and after this PR.

Example of free site + flag turned on
![2022-08-02_15-14](https://user-images.githubusercontent.com/937354/182465137-4b62c01e-2a6d-4a7e-934e-fbc5802ca812.png)
