### PR TITLE
[ETK/Error-Reporting][Sentry] Pass a dynamic release name based of the WPCOM git hash to Sentry

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -3,6 +3,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addAction } from '@wordpress/hooks';
 
 const shouldActivateSentry = window.A8C_ETK_ErrorReporting_Config?.shouldActivateSentry === 'true';
+
 /**
  * Errors that happened before this script had a chance to load
  * are captured in a global array. See `./index.php`.
@@ -11,12 +12,11 @@ const headErrors = window._jsErr || [];
 const headErrorHandler = window._headJsErrorHandler;
 
 function activateSentry() {
+	const SENTRY_RELEASE_NAME = window.A8C_ETK_ErrorReporting_Config.releaseName;
+
 	Sentry.init( {
 		dsn: 'https://658ae291b00242148af6b76494d4a49a@o248881.ingest.sentry.io/5876245',
-		// Set tracesSampleRate to 1.0 to capture 100%
-		// of transactions for performance monitoring.
-		// We recommend adjusting this value in production
-		release: 'wpcom-test-01',
+		release: SENTRY_RELEASE_NAME,
 	} );
 
 	// Capture exceptions from Gutenberg React Error Boundaries

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -117,7 +117,7 @@ function enqueue_script() {
 		'A8C_ETK_ErrorReporting_Config',
 		array(
 			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
-			'releaseName'          => defined( WPCOM_DEPLOYED_GIT_HASH ) ? 'WPCOM_' . WPCOM_DEPLOYED_GIT_HASH : 'WPCOM_NO_RELEASE',
+			'releaseName'          => defined( 'WPCOM_DEPLOYED_GIT_HASH' ) ? 'WPCOM_' . WPCOM_DEPLOYED_GIT_HASH : 'WPCOM_NO_RELEASE',
 		)
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -117,6 +117,7 @@ function enqueue_script() {
 		'A8C_ETK_ErrorReporting_Config',
 		array(
 			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
+			'releaseName'          => 'WPCOM_' . ( defined( WPCOM_DEPLOYED_GIT_HASH ) ? WPCOM_DEPLOYED_GIT_HASH : 'DEFAULT' ),
 		)
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -117,7 +117,7 @@ function enqueue_script() {
 		'A8C_ETK_ErrorReporting_Config',
 		array(
 			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
-			'releaseName'          => 'WPCOM_' . WPCOM_DEPLOYED_GIT_HASH,
+			'releaseName'          => defined( WPCOM_DEPLOYED_GIT_HASH ) ? 'WPCOM_' . WPCOM_DEPLOYED_GIT_HASH : 'WPCOM_NO_RELEASE',
 		)
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -117,7 +117,7 @@ function enqueue_script() {
 		'A8C_ETK_ErrorReporting_Config',
 		array(
 			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
-			'releaseName'          => 'WPCOM_' . ( defined( WPCOM_DEPLOYED_GIT_HASH ) ? WPCOM_DEPLOYED_GIT_HASH : 'DEFAULT' ),
+			'releaseName'          => 'WPCOM_' . WPCOM_DEPLOYED_GIT_HASH,
 		)
 	);
 }


### PR DESCRIPTION
Project: p9oQ9f-18L-p2

#### Proposed Changes

In D84565-code, systems added a global constant called `WPCOM_DEPLOYED_GIT_HASH` that always points to the current git hash HEAD deployed in WPCOM. This hash is used to build a release name that is finally passed as part of the Sentry SDK `init`  for the `wpcom-gutenberg-wp-admin` project. The final release name is a string in the following format: `WPCOM_<WPCOM_DEPLOYED_GIT_HASH>`.

In practice, this means that after each new WPCOM release, this constant gets updated with the new hash, and we get a new `release`* created in Sentry (to be done, the diff link will be pasted here later); finally, the SDK for the `wpcom-gutenberg-wp-admin` project in Sentry is instantiated with the new release name. 

As a bonus, we try to keep the WPCOM-specific parts of the code isolated and to a minimum. The only part that references WPCOM is the `WPCOM_DEPLOYED_GIT_HASH` constant. The frontend JS data that's passed through `wp_localize_script` is called `releaseName`. This was done to make it slightly easier to generalize this logic in the future, in case we want to allow other WordPress instances (other than WPCOM) to setup Error Reporting and/or decouple from Sentry.

_*[a Sentry release](https://docs.sentry.io/product/releases/)._

#### Testing Instructions

* Sync this build of ETK to your sandbox
* In your browser devtools, open the JS console for your test simple site, and type: `window.A8C_ETK_ErrorReporting_Config?.releaseName`, it should return `"WPCOM_<SHA>"`. 

#### TODO

- [ ] Pass the release name to the TC build that uploads source-maps for Gutenberg. 
- [ ] Improve/abstract release name in a global constant (see: https://github.com/Automattic/wp-calypso/pull/66186#discussion_r936073901).
- [ ] Create release in Sentry after each WPCOM deploy (WIP - is @ D85265-code)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to
* Systems-Request:  pMz3w-fwg-p2;
* Diff adding the `WPCOM_DEPLOYED_GIT_HASH` constant: D84565-code;
* Diff to create the Sentry release after each WPCOM deploy: D85265-code;
* https://github.com/Automattic/wp-calypso/pull/63313
* https://github.com/Automattic/wp-calypso/pull/63313
* https://github.com/Automattic/wp-calypso/pull/62965
* https://github.com/Automattic/wp-calypso/pull/63260
* https://github.com/Automattic/wp-calypso/pull/66315