### PR TITLE
Launchpad: Create step in Stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -35,6 +35,7 @@ export { default as letsGetStarted } from './lets-get-started';
 export { default as intro } from './intro';
 export { default as linkInBioSetup } from './link-in-bio-setup';
 export { default as chooseADomain } from './choose-a-domain';
+export { default as launchpad } from './launchpad';
 
 export type StepPath =
 	| 'courses'
@@ -73,4 +74,5 @@ export type StepPath =
 	| 'chooseADomain'
 	| 'linkInBioSetup'
 	| 'newsletterSetup'
-	| 'intro';
+	| 'intro'
+	| 'launchpad';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,0 +1,58 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+// import './style.scss';
+
+function PlaceHolderChecklist() {
+	return (
+		<ul style={ { textAlign: 'center' } }>
+			<li>Item 1</li>
+			<li>Item 2</li>
+			<li>Item 3</li>
+			<li>Item 4</li>
+		</ul>
+	);
+}
+
+function PlaceHolderPreview() {
+	return <div style={ { textAlign: 'center' } }>Preview here</div>;
+}
+
+const Launchpad: Step = ( { navigation } ) => {
+	const translate = useTranslate();
+	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
+
+	// TODO: Replace inline styling with classname and scss styling
+	const stepContent = (
+		<div style={ { display: 'flex', flexDirection: 'column', justifyContent: 'center' } }>
+			<PlaceHolderChecklist />
+			<PlaceHolderPreview />
+		</div>
+	);
+
+	return (
+		<>
+			<DocumentHead title={ almostReadyToLaunchText } />
+			<StepContainer
+				stepName={ 'launchpad' }
+				goNext={ navigation.goNext }
+				skipLabelText={ translate( 'Go to Admin' ) }
+				skipButtonAlign={ 'top' }
+				hideBack={ true }
+				stepContent={ stepContent }
+				formattedHeader={
+					<FormattedHeader
+						id={ 'launchpad-header' }
+						headerText={ <>{ almostReadyToLaunchText }</> }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default Launchpad;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -4,7 +4,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
-// import './style.scss';
+import './style.scss';
 
 function PlaceHolderChecklist() {
 	return (
@@ -25,9 +25,8 @@ const Launchpad: Step = ( { navigation } ) => {
 	const translate = useTranslate();
 	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
 
-	// TODO: Replace inline styling with classname and scss styling
 	const stepContent = (
-		<div style={ { display: 'flex', flexDirection: 'column', justifyContent: 'center' } }>
+		<div className="launchpad__content">
 			<PlaceHolderChecklist />
 			<PlaceHolderPreview />
 		</div>
@@ -39,6 +38,7 @@ const Launchpad: Step = ( { navigation } ) => {
 			<StepContainer
 				stepName={ 'launchpad' }
 				goNext={ navigation.goNext }
+				isWideLayout={ true }
 				skipLabelText={ translate( 'Go to Admin' ) }
 				skipButtonAlign={ 'top' }
 				hideBack={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -1,0 +1,5 @@
+.launchpad__content {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { StepPath } from './internals/steps-repository';
@@ -10,7 +11,11 @@ export const linkInBio: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'linkInBioSetup' ] as StepPath[];
+		return [
+			'intro',
+			'linkInBioSetup',
+			...( isEnabled( 'signup/launchpad' ) ? [ 'launchpad' ] : [] ),
+		] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/newsletters.ts
+++ b/client/landing/stepper/declarative-flow/newsletters.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { StepPath } from './internals/steps-repository';
@@ -10,7 +11,11 @@ export const newsletters: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'newsletterSetup', 'launchpad' ] as StepPath[];
+		return [
+			'intro',
+			'newsletterSetup',
+			...( isEnabled( 'signup/launchpad' ) ? [ 'launchpad' ] : [] ),
+		] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/newsletters.ts
+++ b/client/landing/stepper/declarative-flow/newsletters.ts
@@ -10,7 +10,7 @@ export const newsletters: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'newsletterSetup' ] as StepPath[];
+		return [ 'intro', 'newsletterSetup', 'launchpad' ] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { StepPath } from './internals/steps-repository';
@@ -10,7 +11,11 @@ export const podcasts: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'letsGetStarted', 'chooseADomain' ] as StepPath[];
+		return [
+			'letsGetStarted',
+			'chooseADomain',
+			...( isEnabled( 'signup/launchpad' ) ? [ 'launchpad' ] : [] ),
+		] as StepPath[];
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -37,6 +37,7 @@ export const siteSetupFlow: Flow = {
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 
 		return [
+			'launchpad',
 			...( isEnabled( 'signup/goals-step' ) && isEnabledFTM ? [ 'goals' ] : [] ),
 			...( isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM ? [ 'vertical' ] : [] ),
 			'intent',

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -37,7 +37,6 @@ export const siteSetupFlow: Flow = {
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 
 		return [
-			'launchpad',
 			...( isEnabled( 'signup/goals-step' ) && isEnabledFTM ? [ 'goals' ] : [] ),
 			...( isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM ? [ 'vertical' ] : [] ),
 			'intent',

--- a/config/development.json
+++ b/config/development.json
@@ -166,6 +166,7 @@
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
 		"signup/standard-theme-v13n": true,
+		"signup/launchpad": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,6 +111,7 @@
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
 		"signup/standard-theme-v13n": false,
+		"signup/launchpad": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,

--- a/config/production.json
+++ b/config/production.json
@@ -127,6 +127,7 @@
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
 		"signup/standard-theme-v13n": false,
+		"signup/launchpad": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -127,6 +127,7 @@
 		"signup/woo-verify-email": false,
 		"signup/theme-preview-screen": true,
 		"signup/standard-theme-v13n": false,
+		"signup/launchpad": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,


### PR DESCRIPTION
## Proposed Changes

* Create a launchpad step to be reused in stepper flows

## Screenshots
<img width="1281" alt="Screen Shot 2022-08-02 at 6 33 38 PM" src="https://user-images.githubusercontent.com/5414230/182505003-481ff33f-49a6-4691-9d65-66043b104b21.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Navigate to the calypso repo in a terminal
* Run `yarn start`
* Open http://calypso.localhost:3000/setup/launchpad?flow=newsletters
* Verify that the page exists
* In the terminal, cancel the yarn client build process
* Switch the `signup/launchpad` property in `config/development.json` to false
* Run `yarn start`
* Open http://calypso.localhost:3000/setup/launchpad?flow=newsletters
* Verify that no launchpad page is loaded

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66119
