### PR TITLE
Sites Management Page: Remove wrapper div from search field

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -66,11 +66,6 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
-const SearchWrapper = styled.div`
-	width: 390px;
-	max-width: 100%;
-`;
-
 const FilterBar = styled.div`
 	display: flex;
 	align-items: center;
@@ -108,16 +103,14 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 			<PageBodyWrapper>
 				<>
 					<FilterBar>
-						<SearchWrapper>
-							<SitesSearch
-								searchIcon={ <SitesSearchIcon /> }
-								onSearch={ ( term ) => handleQueryParamChange( 'search', term?.trim() ) }
-								isReskinned
-								placeholder={ __( 'Search by name or domain…' ) }
-								disableAutocorrect={ true }
-								defaultValue={ search }
-							/>
-						</SearchWrapper>
+						<SitesSearch
+							searchIcon={ <SitesSearchIcon /> }
+							onSearch={ ( term ) => handleQueryParamChange( 'search', term?.trim() ) }
+							isReskinned
+							placeholder={ __( 'Search by name or domain…' ) }
+							disableAutocorrect={ true }
+							defaultValue={ search }
+						/>
 						<SelectDropdown selectedText={ selectedStatus.title }>
 							{ statuses.map( ( { name, title, count } ) => (
 								<SelectDropdown.Item

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -6,7 +6,5 @@ export const SitesSearch = styled( Search )`
 	height: 42px;
 	overflow: hidden;
 	border: 1px solid #c3c4c7;
-
-	width: 390px !important; // <Search /> CSS specificity is getting in the way, so we need to prioritize our changes.
-	max-width: 100%;
+	flex: 0 1 390px;
 `;

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -6,4 +6,7 @@ export const SitesSearch = styled( Search )`
 	height: 42px;
 	overflow: hidden;
 	border: 1px solid #c3c4c7;
+
+	width: 390px !important; // <Search /> CSS specificity is getting in the way, so we need to prioritize our changes.
+	max-width: 100%;
 `;


### PR DESCRIPTION
Note: This PR was split out from https://github.com/Automattic/wp-calypso/pull/65759 because the merge conflict was a bit gnarly to figure out. h/t @zaguiini

#### Proposed Changes

This is a refactor that removes the wrapper div from around the search box and applies the styles directly to the search box element in order to have it sized and positioned the way we want in the SMP.

I'm not actually convinced this is a good approach (although I wanted to capture Luis' proposed change before closing his PR #65759). When it comes to positioning and sizing I usually find it's better to have the parent use it's own styles (and wrappers if necessary) to position the child the way it wants. Rather than trying to force the child to render itself using padding and margins that it could have never anticipated it'd have. I think the fact `!important` is necessary is a symptom of this.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Everything should still work, and styling must be correct in the SMP.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

