### PR TITLE
fix mobile padding on unified design picker 

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -388,6 +388,7 @@
 	}
 	.design-picker__grid {
 		@supports ( display: grid ) {
+			row-gap: 40px;
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 24px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -87,14 +87,14 @@
 			@include break-medium {
 				grid-template-columns: 1fr 1fr;
 				column-gap: 24px;
-				row-gap: 40px;
+				row-gap: 20px;
 			}
 		}
 
 		.design-picker__grid-minimal {
 			display: grid;
 			grid-template-columns: 1fr;
-			row-gap: 48px;
+			row-gap: 28px;
 			margin: 0 0 30px;
 
 			@include break-medium {
@@ -231,8 +231,6 @@
 	.design-picker__pricing-description {
 		text-align: left;
 		color: #50575e;
-		z-index: 1;
-		position: absolute;
 	}
 
 
@@ -388,7 +386,6 @@
 	}
 	.design-picker__grid {
 		@supports ( display: grid ) {
-			row-gap: 40px;
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 24px;
@@ -445,7 +442,6 @@
 			@include break-medium {
 				grid-template-columns: 1fr;
 				column-gap: 24px;
-				row-gap: 40px;
 			}
 
 			@include break-large {


### PR DESCRIPTION
#### Proposed Changes
Tiny PR to fix the row gap on the mobile version of the unified design picker. Fixes https://github.com/Automattic/wp-calypso/issues/66160

Before: 
<img width="239" alt="Screen Shot 2022-08-03 at 3 31 38 pm" src="https://user-images.githubusercontent.com/22446385/182532925-02c72c70-9ccd-466b-bf30-3caaa32337bc.png">

After:
<img width="239" alt="Screen Shot 2022-08-03 at 3 31 32 pm" src="https://user-images.githubusercontent.com/22446385/182532947-8418fc8d-44a4-4e13-9244-3ea1ff32ecfd.png">

Desktop is unaffected, as it had 40px row gap already.
#### Testing Instructions
Load design picker in mobile & desktop