### PR TITLE
fix viewport controlls being hidden on resize

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -1,4 +1,4 @@
-import { isWithinBreakpoint } from '@automattic/viewport';
+import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import page from 'page';
@@ -30,6 +30,7 @@ export default class WebPreviewContent extends Component {
 		iframeScaleRatio: 1,
 		loaded: false,
 		isLoadingSubpage: false,
+		isMobile: isWithinBreakpoint( '<660px' ),
 	};
 
 	setIframeInstance = ( ref ) => {
@@ -50,11 +51,16 @@ export default class WebPreviewContent extends Component {
 		}
 
 		this.props.onDeviceUpdate( this.state.device );
+
+		this.unsubscribeMobileBreakpoint = subscribeIsWithinBreakpoint( '<660px', ( isMobile ) => {
+			this.setState( { isMobile } );
+		} );
 	}
 
 	componentWillUnmount() {
 		window.removeEventListener( 'message', this.handleMessage );
 		window.removeEventListener( 'resize', this.handleResize );
+		this.unsubscribeMobileBreakpoint();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -128,7 +134,9 @@ export default class WebPreviewContent extends Component {
 				return;
 			case 'page-dimensions-on-load':
 			case 'page-dimensions-on-resize':
-				this.setState( { viewport: data.payload } );
+				if ( this.props.autoHeight || this.props.fixedViewportWidth ) {
+					this.setState( { viewport: data.payload } );
+				}
 				return;
 		}
 	};
@@ -347,7 +355,7 @@ export default class WebPreviewContent extends Component {
 					{ ...this.props }
 					showExternal={ this.props.previewUrl ? this.props.showExternal : false }
 					showEditHeaderLink={ this.props.showEditHeaderLink }
-					showDeviceSwitcher={ this.props.showDeviceSwitcher && isWithinBreakpoint( '>660px' ) }
+					showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this.state.isMobile }
 					showUrl={ this.props.showUrl && isWithinBreakpoint( '>960px' ) }
 					selectSeoPreview={ this.selectSEO }
 					isLoading={ this.state.isLoadingSubpage }

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -128,9 +128,7 @@ export default class WebPreviewContent extends Component {
 				return;
 			case 'page-dimensions-on-load':
 			case 'page-dimensions-on-resize':
-				if ( this.props.autoHeight || this.props.fixedViewportWidth ) {
-					this.setState( { viewport: data.payload } );
-				}
+				this.setState( { viewport: data.payload } );
 				return;
 		}
 	};


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/66161

I added a console.log() line in the render method, and saw that render was not being triggered on browser resize.

By setting `state.viewport` whenever the preview is resized, we force it to be re-rendered and recalculate the `isWithinBreakpoint` function which determines whether to show the device viewport switcher on https://github.com/Automattic/wp-calypso/blob/trunk/client/components/web-preview/content.jsx#L352

I think that we could use the subscribeIsWithinBreakpoint functions as we have done in other places, but this way is also simple and works for the entire page using the existing event, although I see it's a bit indirect/magical 🤷.


### Testing instructions

Open the preview on the UDP, resize the page between mobile and desktop as shown in https://github.com/Automattic/wp-calypso/issues/66161, the device selector controls should now always re-appear in desktop mode.
