### PR TITLE
Import step: Remove translation fallback

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button } from '@automattic/components';
-import { useLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import React, { ChangeEvent, FormEvent, useState } from 'react';
@@ -27,8 +25,6 @@ interface Props {
 }
 const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const { translate, onInputEnter, onInputChange, onDontHaveSiteAddressClick, hasError } = props;
-	const locale = useLocale();
-	const { hasTranslation } = useI18n();
 
 	const [ urlValue, setUrlValue ] = useState( '' );
 	const [ isValid, setIsValid ] = useState( false );
@@ -53,21 +49,11 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		setSubmitted( true );
 	}
 
-	const newSiteAddressLabel = translate( 'Existing site address' );
-	const oldSiteAddressLabel = translate( 'Enter your site address' );
-	const siteAddressLabel =
-		locale.startsWith( 'en' ) || hasTranslation( newSiteAddressLabel )
-			? newSiteAddressLabel
-			: oldSiteAddressLabel;
-
-	const ownSiteMsg = translate( 'You must own this website.' );
-	const ownSiteMsgTranslationReady = locale.startsWith( 'en' ) || hasTranslation( ownSiteMsg );
-
 	return (
 		<form className={ classnames( 'import-light__capture' ) } onSubmit={ onFormSubmit }>
 			<FormFieldset>
 				<FormLabel>
-					{ createInterpolateElement( siteAddressLabel.toString(), {
+					{ createInterpolateElement( translate( 'Existing site address' ).toString(), {
 						span: createElement( 'span' ),
 					} ) }
 				</FormLabel>
@@ -98,9 +84,9 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 				</Button>
 				<FormSettingExplanation>
 					<span className={ classnames( { 'is-error': showValidationMsg } ) }>
-						{ ! showValidationMsg && ownSiteMsgTranslationReady && (
+						{ ! showValidationMsg && (
 							<>
-								<Icon icon={ bulb } size={ 20 } /> { ownSiteMsg }
+								<Icon icon={ bulb } size={ 20 } /> { translate( 'You must own this website.' ) }
 							</>
 						) }
 						{ showValidationMsg && (


### PR DESCRIPTION
#### Proposed Changes

The proposed changes remove the translation fallback logic that was introduced in https://github.com/Automattic/wp-calypso/pull/65845 to allow new Import step launch before the translations were ready.

Now, [when all necessary strings were translated](https://github.com/Automattic/wp-calypso/pull/65584#issuecomment-1199120729), the fallback logic is not necessary and can be removed to clean up the code.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to http://calypso.localhost:3000/me/account and set your locale to one of the translation languages: https://translate.wordpress.com/deliverables/overview/7450429/
2. Start creating a new site at http://calypso.localhost:3000/start and navigate to the Goals Capture screen where the Import option needs to be selected:
![Markup on 2022-08-03 at 10:07:22](https://user-images.githubusercontent.com/25105483/182557467-e307d0b3-7568-4444-87cf-eacba9429774.png)

4. Once you click on the Continue button, the Import screen should have everything translated to the selected locale language. We are mostly interested in the following two strings:

![Markup on 2022-08-03 at 09:57:53](https://user-images.githubusercontent.com/25105483/182555660-4ab13046-5956-4288-b3ad-1b77f55a9048.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related: #66207