### PR TITLE
Site status displayed in column rather than with badges

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -6,7 +6,6 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import TimeSince from 'calypso/components/time-since';
-import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -123,7 +122,13 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 	const isP2Site = site.options?.is_wpforteams_site;
 
-	const displayStatusBadge = isComingSoon || site.is_private;
+	let siteStatusLabel = __( 'Live' );
+
+	if ( isComingSoon ) {
+		siteStatusLabel = __( 'Coming soon' );
+	} else if ( site.is_private ) {
+		siteStatusLabel = __( 'Private' );
+	}
 
 	return (
 		<ClassNames>
@@ -152,13 +157,6 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 							}
 							subtitle={
 								<ListTileSubtitle>
-									{ displayStatusBadge && (
-										<div style={ { marginRight: '8px' } }>
-											<SitesLaunchStatusBadge>
-												{ isComingSoon ? __( 'Coming soon' ) : __( 'Private' ) }
-											</SitesLaunchStatusBadge>
-										</div>
-									) }
 									<SiteUrl href={ site.URL } target="_blank" rel="noreferrer" title={ site.URL }>
 										{ displaySiteUrl( site.URL ) }
 									</SiteUrl>
@@ -170,6 +168,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 					<Column mobileHidden>
 						{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 					</Column>
+					<Column mobileHidden>{ siteStatusLabel }</Column>
 					<Column style={ { width: '20px' } }>
 						<EllipsisMenu>
 							<VisitDashboardItem site={ site } />

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -42,6 +42,7 @@ export function SitesTable( { className, sites }: SitesTableProps ) {
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
 					<th>{ __( 'Last Publish' ) }</th>
+					<th>{ __( 'Status' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>
 			</thead>


### PR DESCRIPTION
#### Proposed Changes

Part of @SaxonF's design changes proposed in #65871

* Removes the site status badges from the site title
* Adds site status as a new column

![CleanShot 2022-08-03 at 21 34 46@2x](https://user-images.githubusercontent.com/1500769/182576154-984e370c-c522-41fa-9049-af88a0635749.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that status badges no longer appear
* Verify that the values in the column are correct
* Test mobile layout (the column should disappear on mobile)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65871
