### PR TITLE
Add newsletter setup step

### DIFF
--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -1,0 +1,88 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { FormFileUpload } from '@wordpress/components';
+import { Icon, upload } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import React from 'react';
+import ImageEditor from 'calypso/blocks/image-editor';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import './style.scss';
+
+export type SiteIconWithPickerProps = {
+	selectedFile: File | undefined;
+	onSelect: ( file: File ) => void;
+	site: SiteDetails | null;
+	imageEditorClassName?: string;
+	uploadFieldClassName?: string;
+};
+export function SiteIconWithPicker( {
+	selectedFile,
+	onSelect,
+	site,
+	imageEditorClassName,
+	uploadFieldClassName,
+}: SiteIconWithPickerProps ) {
+	const { __ } = useI18n();
+
+	const [ selectedFileUrl, setSelectedFileUrl ] = React.useState< string | undefined >();
+	const [ editingFileName, setEditingFileName ] = React.useState< string >();
+	const [ editingFile, setEditingFile ] = React.useState< string >();
+	const [ imageEditorOpen, setImageEditorOpen ] = React.useState< boolean >( false );
+	const isLoading = ! site;
+	const siteIconUrl = site?.icon?.img;
+
+	return (
+		<>
+			{ site && editingFile && imageEditorOpen && (
+				<ImageEditor
+					className={ classNames( 'site-icon-with-picker__image-editor', imageEditorClassName ) }
+					siteId={ site.ID }
+					media={ {
+						src: editingFile,
+					} }
+					allowedAspectRatios={ [ 'ASPECT_1X1' ] }
+					onDone={ ( _error: Error | null, image: Blob ) => {
+						onSelect( new File( [ image ], editingFileName || 'site-logo.png' ) );
+						setSelectedFileUrl( URL.createObjectURL( image ) );
+						setImageEditorOpen( false );
+					} }
+					onCancel={ () => {
+						setEditingFile( undefined );
+						setEditingFileName( undefined );
+						setImageEditorOpen( false );
+					} }
+				/>
+			) }
+			<FormFieldset
+				className={ classNames( 'site-icon-with-picker__site-icon', uploadFieldClassName ) }
+				disabled={ isLoading }
+			>
+				<FormFileUpload
+					className={ classNames( 'site-icon-with-picker__upload-button', {
+						'has-icon-or-image': selectedFile || siteIconUrl,
+					} ) }
+					accept=".jpg,.jpeg,.gif,.png"
+					onChange={ ( event ) => {
+						if ( event.target.files?.[ 0 ] ) {
+							setEditingFileName( event.target.files?.[ 0 ].name );
+							setEditingFile( URL.createObjectURL( event.target.files?.[ 0 ] ) );
+							setImageEditorOpen( true );
+							// onChange won't fire if the user picks the same file again
+							// delete the value so users can reselect the same file again
+							event.target.value = '';
+						}
+					} }
+				>
+					{ selectedFileUrl || siteIconUrl ? (
+						<img src={ selectedFileUrl || siteIconUrl } alt={ site?.name } />
+					) : (
+						<Icon icon={ upload } />
+					) }
+					<span>
+						{ selectedFileUrl || siteIconUrl ? __( 'Replace' ) : __( 'Upload publication icon' ) }
+					</span>
+				</FormFileUpload>
+			</FormFieldset>
+		</>
+	);
+}

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -1,0 +1,56 @@
+.site-icon-with-picker__image-editor {
+	position: absolute;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 2;
+	min-width: 50vw;
+
+	use {
+		fill: white;
+	}
+}
+
+.site-icon-with-picker__site-icon {
+	text-align: center;
+}
+
+.form-fieldset.site-icon-with-picker__site-icon {
+	width: 80px;
+}
+
+button.components-button.site-icon-with-picker__upload-button {
+	display: inline-block;
+	height: 80px;
+	width: 80px;
+	padding: 0;
+	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	position: relative;
+	border: 1px dashed var( --studio-gray-60 );
+	background-size: contain;
+	margin-bottom: 40px;
+
+	&.has-icon-or-image {
+		border: none;
+	}
+
+	img {
+		height: 80px;
+		width: 80px;
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	}
+	svg {
+		width: 80px;
+		height: 80px;
+		padding: 26px;
+		box-sizing: border-box;
+	}
+	span {
+		position: absolute;
+		width: 200px;
+		display: block;
+		text-align: center;
+		margin-top: 10px;
+		margin-left: -75%;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -52,6 +52,7 @@ button {
  * Site Setup
  */
 .site-setup,
+.newsletter-setup,
 .anchor-fm {
 	position: relative;
 	padding: 60px 0 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -29,6 +29,7 @@ export { default as error } from './error-step';
 export { default as wooConfirm } from './woo-confirm';
 export { default as wooVerifyEmail } from './woo-verify-email';
 export { default as editEmail } from './edit-email';
+export { default as newsletterSetup } from './newsletter-setup';
 export { default as difmStartingPoint } from './difm-starting-point';
 export { default as letsGetStarted } from './lets-get-started';
 export { default as intro } from './intro';
@@ -69,4 +70,5 @@ export type StepPath =
 	| 'difmStartingPoint'
 	| 'letsGetStarted'
 	| 'chooseADomain'
+	| 'newsletterSetup'
 	| 'intro';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -1,4 +1,5 @@
 import { Button, FormInputValidation } from '@automattic/components';
+import { useSiteLogoMutation } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { FormFileUpload } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -6,16 +7,17 @@ import { Icon, upload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import React, { FormEvent, useEffect } from 'react';
+import ImageEditor from 'calypso/blocks/image-editor';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
 import type { Step } from '../../types';
+
 import './style.scss';
 
 const NewsletterSetup: Step = ( { navigation } ) => {
@@ -29,8 +31,14 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ siteTitle, setSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
 	const [ url, setUrl ] = React.useState( '' );
-
+	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
+	const [ selectedFileUrl, setSelectedFileUrl ] = React.useState< string | undefined >();
+	const [ editingFileName, setEditingFileName ] = React.useState< string >();
+	const [ editingFile, setEditingFile ] = React.useState< string >();
+	const [ imageEditorOpen, setImageEditorOpen ] = React.useState< boolean >( false );
+	const { mutateAsync: setSiteLogo, isLoading: isUploadingIcon } = useSiteLogoMutation( site?.ID );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
+	const isLoading = ! site || isUploadingIcon;
 
 	useEffect( () => {
 		if ( ! site ) {
@@ -59,6 +67,14 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 				has_tagline: !! tagline,
 			} );
 
+			if ( selectedFile ) {
+				try {
+					await setSiteLogo( selectedFile );
+				} catch ( _error ) {
+					// communicate the error to the user
+				}
+			}
+
 			submit?.( { siteTitle, tagline } );
 		}
 	};
@@ -85,67 +101,105 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			: '';
 
 	const stepContent = (
-		<form className="newsletter-setup__form" onSubmit={ onSubmit }>
-			<FormFieldset className="newsletter-setup__publication-icon" disabled={ ! site }>
-				<FormFileUpload
-					className={ classNames( 'newsletter-setup__publication-button', {
-						'has-icon': siteIconUrl,
-					} ) }
-					style={ { backgroundImage: `url("${ siteIconUrl }")` } }
-					onChange={ () => {
-						// TODO
+		<>
+			{ site && editingFile && imageEditorOpen && (
+				<ImageEditor
+					className="newsletter-setup__image-editor"
+					siteId={ site.ID }
+					media={ {
+						src: editingFile,
 					} }
-				>
-					{ ! siteIconUrl ? <Icon icon={ upload } /> : <span>{ __( 'Replace' ) } </span> }
-				</FormFileUpload>
-				{ ! siteIconUrl && (
-					<FormSettingExplanation>{ __( 'Upload publication icon' ) }</FormSettingExplanation>
-				) }
-			</FormFieldset>
-
-			<FormFieldset disabled={ ! site }>
-				<FormLabel htmlFor="siteTitle">{ __( 'Publication name*' ) }</FormLabel>
-				<FormInput
-					value={ siteTitle }
-					name="siteTitle"
-					id="siteTitle"
-					isError={ !! siteTitleError }
-					onChange={ onChange }
+					allowedAspectRatios={ [ 'ASPECT_1X1' ] }
+					onDone={ ( _error: Error | null, image: Blob ) => {
+						setSelectedFile( new File( [ image ], editingFileName || 'site-logo.png' ) );
+						setSelectedFileUrl( URL.createObjectURL( image ) );
+						setImageEditorOpen( false );
+					} }
+					onCancel={ () => {
+						setEditingFile( undefined );
+						setEditingFileName( undefined );
+						setImageEditorOpen( false );
+					} }
 				/>
-				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
-			</FormFieldset>
+			) }
+			<form className="newsletter-setup__form" onSubmit={ onSubmit }>
+				<FormFieldset className="newsletter-setup__publication-icon" disabled={ isLoading }>
+					<FormFileUpload
+						className={ classNames( 'newsletter-setup__publication-button', {
+							'has-icon-or-image': selectedFile || siteIconUrl,
+						} ) }
+						accept=".jpg,.jpeg,.gif,.png"
+						onChange={ ( event ) => {
+							if ( event.target.files?.[ 0 ] ) {
+								setEditingFileName( event.target.files?.[ 0 ].name );
+								setEditingFile( URL.createObjectURL( event.target.files?.[ 0 ] ) );
+								setImageEditorOpen( true );
+								// onChange won't fire if the user picks the same file again
+								// delete the value so users can reselect the same file again
+								event.target.value = '';
+							}
+						} }
+					>
+						{ selectedFileUrl || siteIconUrl ? (
+							<img src={ selectedFileUrl || siteIconUrl } alt={ site?.name } />
+						) : (
+							<Icon icon={ upload } />
+						) }
+						<span>
+							{ selectedFileUrl || siteIconUrl ? __( 'Replace' ) : __( 'Upload publication icon' ) }
+						</span>
+					</FormFileUpload>
+				</FormFieldset>
 
-			<FormFieldset disabled={ ! site }>
-				<FormLabel htmlFor="tagline">{ __( 'Brief description' ) }</FormLabel>
-				<FormInput value={ tagline } name="tagline" id="tagline" onChange={ onChange } />
-			</FormFieldset>
-
-			<FormFieldset disabled={ ! site }>
-				<FormLabel htmlFor="accentColor">{ __( 'Accent Color' ) }</FormLabel>
-				<FormInput value={ '' } name="accentColor" id="accentColor" onChange={ onChange } />
-			</FormFieldset>
-
-			<FormFieldset disabled={ ! site }>
-				<FormLabel htmlFor="blogURL">{ __( 'Publication Address' ) }</FormLabel>
-				{ ! url ? (
-					<FormInput value={ url } disabled={ true } />
-				) : (
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore
-					<FormTextInputWithAction
-						id="blogURL"
-						className={ 'newsletter-setup__url' }
-						defaultValue={ url }
-						readOnly={ true }
-						action="Change"
-						onAction={ navigateToDomains }
+				<FormFieldset disabled={ isLoading }>
+					<FormLabel htmlFor="siteTitle">{ __( 'Publication name*' ) }</FormLabel>
+					<FormInput
+						value={ siteTitle }
+						name="siteTitle"
+						id="siteTitle"
+						isError={ !! siteTitleError }
+						onChange={ onChange }
 					/>
-				) }
-			</FormFieldset>
-			<Button className="newsletter-setup__submit-button" type="submit" primary>
-				{ __( 'Continue' ) }
-			</Button>
-		</form>
+					{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
+				</FormFieldset>
+
+				<FormFieldset disabled={ isLoading }>
+					<FormLabel htmlFor="tagline">{ __( 'Brief description' ) }</FormLabel>
+					<FormInput value={ tagline } name="tagline" id="tagline" onChange={ onChange } />
+				</FormFieldset>
+
+				<FormFieldset disabled={ isLoading }>
+					<FormLabel htmlFor="accentColor">{ __( 'Accent Color' ) }</FormLabel>
+					<FormInput value={ '' } name="accentColor" id="accentColor" onChange={ onChange } />
+				</FormFieldset>
+
+				<FormFieldset disabled={ isLoading }>
+					<FormLabel htmlFor="blogURL">{ __( 'Publication Address' ) }</FormLabel>
+					{ ! url ? (
+						<FormInput value={ url } disabled={ true } />
+					) : (
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						<FormTextInputWithAction
+							id="blogURL"
+							className={ 'newsletter-setup__url' }
+							defaultValue={ url }
+							readOnly={ true }
+							action="Change"
+							onAction={ navigateToDomains }
+						/>
+					) }
+				</FormFieldset>
+				<Button
+					disabled={ isLoading }
+					className="newsletter-setup__submit-button"
+					type="submit"
+					primary
+				>
+					{ __( 'Continue' ) }
+				</Button>
+			</form>
+		</>
 	);
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -1,0 +1,171 @@
+import { Button, FormInputValidation } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { FormFileUpload } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { Icon, upload } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import React, { FormEvent, useEffect } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormInput from 'calypso/components/forms/form-text-input';
+import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../../../../hooks/use-site';
+import type { Step } from '../../types';
+import './style.scss';
+
+const NewsletterSetup: Step = ( { navigation } ) => {
+	const { goBack, submit } = navigation;
+	const { __ } = useI18n();
+
+	const site = useSite();
+
+	const [ formTouched, setFormTouched ] = React.useState( false );
+	const [ siteIconUrl, setSiteIconUrl ] = React.useState( '' );
+	const [ siteTitle, setSiteTitle ] = React.useState( '' );
+	const [ tagline, setTagline ] = React.useState( '' );
+	const [ url, setUrl ] = React.useState( '' );
+
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
+	useEffect( () => {
+		if ( ! site ) {
+			return;
+		}
+
+		if ( formTouched ) {
+			return;
+		}
+
+		setSiteIconUrl( site.icon?.img || '' );
+		setSiteTitle( site.name || '' );
+		setTagline( site.description );
+		setUrl( new URL( site.URL ).host );
+	}, [ site, formTouched ] );
+
+	const onSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( site ) {
+			await saveSiteSettings( site.ID, {
+				blogname: siteTitle,
+				blogdescription: tagline,
+			} );
+			recordTracksEvent( 'calypso_signup_site_options_submit', {
+				has_site_title: !! siteTitle,
+				has_tagline: !! tagline,
+			} );
+
+			submit?.( { siteTitle, tagline } );
+		}
+	};
+
+	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
+		if ( site ) {
+			setFormTouched( true );
+			switch ( event.currentTarget.name ) {
+				case 'siteTitle':
+					return setSiteTitle( event.currentTarget.value );
+				case 'tagline':
+					return setTagline( event.currentTarget.value );
+			}
+		}
+	};
+
+	const navigateToDomains = () => {
+		// TODO
+	};
+
+	const siteTitleError =
+		formTouched && ! siteTitle.trim()
+			? 'Your publication needs a name so your subscribers can identify you.'
+			: '';
+
+	const stepContent = (
+		<form className="newsletter-setup__form" onSubmit={ onSubmit }>
+			<FormFieldset className="newsletter-setup__publication-icon" disabled={ ! site }>
+				<FormFileUpload
+					className={ classNames( 'newsletter-setup__publication-button', {
+						'has-icon': siteIconUrl,
+					} ) }
+					style={ { backgroundImage: `url("${ siteIconUrl }")` } }
+					onChange={ () => {
+						// TODO
+					} }
+				>
+					{ ! siteIconUrl ? <Icon icon={ upload } /> : <span>{ __( 'Replace' ) } </span> }
+				</FormFileUpload>
+				{ ! siteIconUrl && (
+					<FormSettingExplanation>{ __( 'Upload publication icon' ) }</FormSettingExplanation>
+				) }
+			</FormFieldset>
+
+			<FormFieldset disabled={ ! site }>
+				<FormLabel htmlFor="siteTitle">{ __( 'Publication name*' ) }</FormLabel>
+				<FormInput
+					value={ siteTitle }
+					name="siteTitle"
+					id="siteTitle"
+					isError={ !! siteTitleError }
+					onChange={ onChange }
+				/>
+				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
+			</FormFieldset>
+
+			<FormFieldset disabled={ ! site }>
+				<FormLabel htmlFor="tagline">{ __( 'Brief description' ) }</FormLabel>
+				<FormInput value={ tagline } name="tagline" id="tagline" onChange={ onChange } />
+			</FormFieldset>
+
+			<FormFieldset disabled={ ! site }>
+				<FormLabel htmlFor="accentColor">{ __( 'Accent Color' ) }</FormLabel>
+				<FormInput value={ '' } name="accentColor" id="accentColor" onChange={ onChange } />
+			</FormFieldset>
+
+			<FormFieldset disabled={ ! site }>
+				<FormLabel htmlFor="blogURL">{ __( 'Publication Address' ) }</FormLabel>
+				{ ! url ? (
+					<FormInput value={ url } disabled={ true } />
+				) : (
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					<FormTextInputWithAction
+						id="blogURL"
+						className={ 'newsletter-setup__url' }
+						defaultValue={ url }
+						readOnly={ true }
+						action="Change"
+						onAction={ navigateToDomains }
+					/>
+				) }
+			</FormFieldset>
+			<Button className="newsletter-setup__submit-button" type="submit" primary>
+				{ __( 'Continue' ) }
+			</Button>
+		</form>
+	);
+
+	return (
+		<StepContainer
+			stepName={ 'newsletter-setup' }
+			goBack={ goBack }
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName={ 'newsletter' }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'newsletter-setup-header' }
+					headerText={ __( 'Setup your Newsletter' ) }
+					align={ 'center' }
+				/>
+			}
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default NewsletterSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -5,7 +5,6 @@ $input-height: 44px;
 $border-radius: 4px;
 
 .newsletter-setup {
-
 	.step-container {
 		padding-top: 44px;
 	}
@@ -44,11 +43,11 @@ $border-radius: 4px;
 		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		position: relative;
 		border: 1px dashed var( --studio-gray-60 );
+		background-size: contain;
+		margin-bottom: 40px;
 
-		&.has-icon {
+		&.has-icon-or-image {
 			border: none;
-			padding: 6px 12px;
-			margin-bottom: 20px;
 		}
 
 		img {
@@ -56,13 +55,19 @@ $border-radius: 4px;
 			width: 80px;
 			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
-
+		svg {
+			width: 80px;
+			height: 80px;
+			padding: 26px;
+			box-sizing: border-box;
+		}
 		span {
 			position: absolute;
-			top: calc( 100% + 10px );
-			left: 50%;
-			transform: translateX( -50% );
-			text-decoration: underline;
+			width: 200px;
+			display: block;
+			text-align: center;
+			margin-top: 10px;
+			margin-left: -75%;
 		}
 	}
 
@@ -79,11 +84,13 @@ $border-radius: 4px;
 			width: 368px;
 		}
 
-		.form-fieldset, .newsletter-setup__submit-button {
+		.form-fieldset,
+		.newsletter-setup__submit-button {
 			width: 100%;
 		}
 
-		label, input {
+		label,
+		input {
 			font-family: $font-family;
 			font-weight: 400;
 		}
@@ -135,6 +142,17 @@ $border-radius: 4px;
 
 		.newsletter-setup__submit-button {
 			border-radius: $border-radius;
+		}
+	}
+	.newsletter-setup__image-editor {
+		position: absolute;
+		top: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 2;
+
+		use {
+			fill: white;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -1,0 +1,140 @@
+@import '../style';
+
+$font-family: 'SF Pro Text', $sans;
+$input-height: 44px;
+$border-radius: 4px;
+
+.newsletter-setup {
+
+	.step-container {
+		padding-top: 44px;
+	}
+
+	.step-container__content {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 30px;
+	}
+
+	.newsletter-setup .step-container__header {
+		margin-bottom: 32px;
+
+		h1.formatted-header__title {
+			font-size: $font-title-medium;
+
+			@include break-medium {
+				font-size: $font-headline-medium;
+			}
+		}
+	}
+
+	.newsletter-setup__publication-icon {
+		text-align: center;
+	}
+
+	.form-fieldset.newsletter-setup__publication-icon {
+		width: 80px;
+	}
+
+	.newsletter-setup__publication-button {
+		display: inline-block;
+		height: 80px;
+		width: 80px;
+		padding: 0;
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		position: relative;
+		border: 1px dashed var( --studio-gray-60 );
+
+		&.has-icon {
+			border: none;
+			padding: 6px 12px;
+			margin-bottom: 20px;
+		}
+
+		img {
+			height: 80px;
+			width: 80px;
+			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		}
+
+		span {
+			position: absolute;
+			top: calc( 100% + 10px );
+			left: 50%;
+			transform: translateX( -50% );
+			text-decoration: underline;
+		}
+	}
+
+	.newsletter-setup__form {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		position: relative;
+		padding: 0 20px;
+		width: 335px;
+
+		@include break-medium {
+			padding: 0 20px;
+			width: 368px;
+		}
+
+		.form-fieldset, .newsletter-setup__submit-button {
+			width: 100%;
+		}
+
+		label, input {
+			font-family: $font-family;
+			font-weight: 400;
+		}
+
+		label {
+			color: var( --studio-gray-60 );
+			font-size: $font-body;
+		}
+
+		input {
+			color: var( --studio-gray-100 );
+			font-size: $font-body-small;
+			padding: 12px 16px;
+			height: $input-height;
+			border-radius: $border-radius;
+		}
+
+		.newsletter-setup__url {
+			background: var( --color-neutral-0 );
+			border-radius: $border-radius;
+			height: $input-height;
+
+			input {
+				background: var( --color-neutral-0 );
+				border-color: var( --color-neutral-0 );
+				color: var( --color-neutral-20 );
+				opacity: 1;
+				-webkit-text-fill-color: var( --color-neutral-20 );
+				border: 0;
+				height: auto;
+
+				&:focus {
+					box-shadow: none;
+				}
+			}
+
+			button {
+				margin: 12px 16px;
+				padding: 0 10px;
+				height: 20px;
+				border-radius: $border-radius;
+
+				background: var( --studio-blue-5 );
+				border-color: var( --studio-blue-5 );
+
+				color: var( --studio-blue-80 );
+			}
+		}
+
+		.newsletter-setup__submit-button {
+			border-radius: $border-radius;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -27,50 +27,6 @@ $border-radius: 4px;
 		}
 	}
 
-	.newsletter-setup__publication-icon {
-		text-align: center;
-	}
-
-	.form-fieldset.newsletter-setup__publication-icon {
-		width: 80px;
-	}
-
-	.newsletter-setup__publication-button {
-		display: inline-block;
-		height: 80px;
-		width: 80px;
-		padding: 0;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		position: relative;
-		border: 1px dashed var( --studio-gray-60 );
-		background-size: contain;
-		margin-bottom: 40px;
-
-		&.has-icon-or-image {
-			border: none;
-		}
-
-		img {
-			height: 80px;
-			width: 80px;
-			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		}
-		svg {
-			width: 80px;
-			height: 80px;
-			padding: 26px;
-			box-sizing: border-box;
-		}
-		span {
-			position: absolute;
-			width: 200px;
-			display: block;
-			text-align: center;
-			margin-top: 10px;
-			margin-left: -75%;
-		}
-	}
-
 	.newsletter-setup__form {
 		display: flex;
 		flex-direction: column;
@@ -144,15 +100,27 @@ $border-radius: 4px;
 			border-radius: $border-radius;
 		}
 	}
-	.newsletter-setup__image-editor {
-		position: absolute;
-		top: 0;
-		width: 100%;
-		height: 100%;
-		z-index: 2;
 
-		use {
-			fill: white;
+	.newsletter-setup__color-picker-backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100vh;
+		height: 100vw;
+		z-index: 4;
+	}
+
+	.components-color-picker {
+		position: absolute;
+		top: 20%;
+		left: 50%;
+		transform: translateX( -50% );
+		background: white;
+		box-shadow: 0 0 20px rgb( 0 0 0 / 15% );
+		box-shadow: 0 0 20px rgb( 0 0 0 / 15% );
+
+		.components-h-stack {
+			width: unset;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/newsletters.ts
+++ b/client/landing/stepper/declarative-flow/newsletters.ts
@@ -10,7 +10,7 @@ export const newsletters: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro' ] as StepPath[];
+		return [ 'intro', 'newsletterSetup' ] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -23,7 +23,12 @@ export const newsletters: Flow = {
 		};
 
 		const goNext = () => {
-			return;
+			switch ( _currentStep ) {
+				case 'intro':
+					return navigate( 'newsletterSetup' );
+				default:
+					return navigate( 'intro' );
+			}
 		};
 
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -22,6 +22,7 @@ export { useSiteAnalysis } from './queries/use-site-analysis';
 export type { AnalysisReport } from './queries/use-site-analysis';
 export { useHasSeenWhatsNewModalQuery } from './queries/use-has-seen-whats-new-modal-query';
 export { useSiteIntent } from './queries/use-site-intent';
+export { useSiteLogoMutation } from './queries/use-site-logo-mutation';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';

--- a/packages/data-stores/src/queries/use-site-logo-mutation.ts
+++ b/packages/data-stores/src/queries/use-site-logo-mutation.ts
@@ -1,0 +1,36 @@
+import { useMutation } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export function useSiteLogoMutation( siteId: string | number | undefined ) {
+	return useMutation( async ( file: File ) => {
+		const formData = [ [ 'media[]', file ] ];
+		// first upload the image
+		const response = await wpcomRequest< {
+			media?: [
+				{
+					ID: number;
+				}
+			];
+		} >( {
+			path: `/sites/${ encodeURIComponent( siteId as string ) }/media/new`,
+			apiVersion: '1.1',
+			formData,
+			method: 'POST',
+		} );
+		// then update the site settings to the uploaded image
+		if ( response.media?.length ) {
+			const imageID = response.media[ 0 ].ID;
+			return await wpcomRequest< {
+				id: 12345;
+				url: string;
+			} >( {
+				path: `/sites/${ encodeURIComponent( siteId as string ) }/settings`,
+				apiVersion: '1.4',
+				apiNamespace: 'rest/v1.4',
+				body: { site_icon: imageID },
+				method: 'POST',
+			} );
+		}
+		throw new Error( 'No image ID returned' );
+	} );
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -102,6 +102,7 @@ export interface SiteDetails {
 	launch_status: string;
 	jetpack: boolean;
 	logo: { id: string; sizes: string[]; url: string };
+	icon?: { ico: string; img: string; media_id: number };
 	options: {
 		admin_url?: string;
 		advanced_seo_front_page_description?: string;
@@ -384,6 +385,7 @@ export enum AtomicSoftwareInstallStatus {
 	SUCCESS = 'success',
 	FAILURE = 'failure',
 }
+
 export type AtomicSoftwareInstallState = Record<
 	string,
 	{
@@ -391,6 +393,7 @@ export type AtomicSoftwareInstallState = Record<
 		error: AtomicSoftwareInstallError | undefined;
 	}
 >;
+
 export interface AtomicSoftwareInstallError {
 	name: string;
 	status: number;

--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -18,6 +18,7 @@ export interface WpcomRequestParams {
 		accessAllUsersBlogs?: boolean;
 	};
 	apiNamespace?: string;
+	formData?: ( string | File )[][];
 }
 
 export function reloadProxy(): void;


### PR DESCRIPTION
#### Proposed Changes

- This PR adds the newsletter setup step
- Implement file uploads to change the image

#### Testing Instructions
- Use the design [file](BcUdhLlhAp7UHtQHNTI4zA-fi-1865%3A18107) for reference 
- Checkout this branch
- Run `yarn && yarn start`
- Visit http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletters&siteSlug=YOUR-SITE-DOMAIN
- Compare the form with the design
- In Settings -> General (settings/general/YOUR-SITE-DOMAIN) upload site image
- Compare the form with uploaded site image
- Try to change the fields (newsletter name and description) and reload to make sure that the backend has persisted the changes.

**Form without site image**
<img width="1038" alt="Screenshot 2022-08-03 at 11 57 50" src="https://user-images.githubusercontent.com/7000684/182581003-6b1a14e0-4283-4a73-af17-4ae3222d08bb.png">
**Form with site image**
<img width="1298" alt="Screenshot 2022-08-03 at 11 57 30" src="https://user-images.githubusercontent.com/7000684/182581009-8eb0a888-9baf-457f-b3b2-636f9c151a50.png">

Related to #66215