### PR TITLE
Plugin Management: Implement multi-site(large screen) view for the plugin management

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -76,6 +76,7 @@ class SectionNav extends Component {
 
 		className = classNames( 'section-nav', this.props.className, {
 			'is-open': this.state.mobileOpen,
+			'section-nav-updated': this.props.applyUpdatedStyles,
 			'has-pinned-items': this.hasPinnedSearch || this.props.hasPinnedItems,
 		} );
 

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .section-nav-tab .count {
 	margin-left: 8px;
 }
@@ -128,4 +131,26 @@
 		flex: none;
 		width: auto;
 	}
+}
+.section-nav-updated.section-nav {
+	.is-selected.section-nav-tab .section-nav-tab__link .count {
+		color: var( --color-primary );
+	}
+	.section-nav__mobile-header {
+		.count {
+			margin-inline-start: 8px;
+		}
+		.gridicon {
+			margin-inline-start: auto;
+		}
+	}
+	.count {
+		background: var( --color-primary-5 );
+		border-radius: 3px; // stylelint-disable-line scales/radii
+		border: none;
+		font-weight: normal;
+	}
+	margin-bottom: 0;
+	background: var( --color-primary-0 );
+	box-shadow: none;
 }

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .section-nav-tab .count {
 	margin-left: 8px;
 }
@@ -148,6 +151,8 @@
 		font-weight: normal;
 	}
 	margin-bottom: 0;
-	background: var( --color-primary-0 );
-	box-shadow: none;
+	@include break-large() {
+		background: var( --color-primary-0 );
+		box-shadow: none;
+	}
 }

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -1,6 +1,3 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
-
 .section-nav-tab .count {
 	margin-left: 8px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -140,6 +140,7 @@ export default function SitesOverview(): ReactElement {
 							</div>
 						</div>
 						<SectionNav
+							applyUpdatedStyles
 							selectedText={
 								<span>
 									{ selectedItem.label }
@@ -148,7 +149,6 @@ export default function SitesOverview(): ReactElement {
 							}
 							selectedCount={ selectedItem.count }
 							className={ classNames(
-								'sites-overview__section-nav',
 								isMobile &&
 									highlightTab &&
 									selectedItem.key === 'favorites' &&

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -254,30 +254,6 @@
 .sites-overview__status-warning {
 	border-color: var( --studio-yellow-20 );
 }
-.sites-overview__section-nav.section-nav {
-	.is-selected.section-nav-tab .section-nav-tab__link .count {
-		color: var( --color-primary );
-	}
-	.section-nav__mobile-header {
-		.count {
-			margin-inline-start: 8px;
-		}
-		.gridicon {
-			margin-inline-start: auto;
-		}
-	}
-	.count {
-		background: var( --color-primary-5 );
-		border-radius: 3px; // stylelint-disable-line scales/radii
-		border: none;
-		font-weight: normal;
-	}
-	margin-bottom: 0;
-	@include break-large() {
-		background: unset;
-		box-shadow: none;
-	}
-}
 @keyframes highlight-tab-animation {
 	0% {
 		background: var( --color-neutral-70 );

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
@@ -1,5 +1,5 @@
 .plugins-overview__container {
-	padding: 0 16px;
+	padding: 6px 0;
 }
 .plugins-overview__logo {
 	fill: var( --color-neutral-10 );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -428,7 +428,7 @@ export class PluginsMain extends Component {
 				attr.count = this.props.pluginUpdateCount;
 			}
 			if ( 'all' === filterItem.id ) {
-				attr.count = this.props.currentPlugins.length;
+				attr.count = this.props.allPluginsCount;
 			}
 			return <NavItem { ...attr }>{ filterItem.title }</NavItem>;
 		} );
@@ -540,6 +540,7 @@ export default flow(
 			const visibleSiteIds = siteObjectsToSiteIds( getVisibleSites( sites ) ) ?? [];
 			const siteIds = siteObjectsToSiteIds( sites ) ?? [];
 			const pluginsWithUpdates = getPlugins( state, siteIds, 'updates' );
+			const allPlugins = getPlugins( state, siteIds, 'all' );
 			const jetpackNonAtomic =
 				isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId );
 			const hasManagePlugins =
@@ -565,6 +566,7 @@ export default flow(
 				currentPlugins: getPlugins( state, siteIds, filter ),
 				currentPluginsOnVisibleSites: getPlugins( state, visibleSiteIds, filter ),
 				pluginUpdateCount: pluginsWithUpdates && pluginsWithUpdates.length,
+				allPluginsCount: allPlugins && allPlugins.length,
 				requestingPluginsForSites: isRequestingForSites( state, siteIds ),
 				updateableJetpackSites: getUpdateableJetpackSites( state ),
 				userCanManagePlugins: selectedSiteId

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -470,7 +470,7 @@ export class PluginsMain extends Component {
 													selectedSite: this.props.selectedSite.domain,
 												},
 										  } )
-										: this.props.translate( 'All sites' ) }
+										: this.props.translate( 'Manage plugins installed on all sites' ) }
 								</div>
 							</div>
 						) }

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -501,17 +501,9 @@ export class PluginsMain extends Component {
 						</div>
 					</div>
 				</div>
-				<div
-					className={ classNames( {
-						'plugins__main-content': isJetpackCloud,
-					} ) }
-				>
-					<div
-						className={ classNames( {
-							'plugins__content-wrapper': isJetpackCloud,
-						} ) }
-					>
-						{ isJetpackCloud && (
+				{ isJetpackCloud ? (
+					<div className="plugins__main-content">
+						<div className="plugins__content-wrapper">
 							<div className="plugins__search">
 								<Search
 									hideFocus
@@ -524,10 +516,12 @@ export class PluginsMain extends Component {
 									placeholder={ this.props.translate( 'Search plugins' ) }
 								/>
 							</div>
-						) }
-						{ this.renderPluginsContent() }
+							{ this.renderPluginsContent() }
+						</div>
 					</div>
-				</div>
+				) : (
+					this.renderPluginsContent()
+				) }
 			</>
 		);
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -140,8 +140,10 @@ export class PluginsMain extends Component {
 	}
 
 	getFilters() {
-		const { translate } = this.props;
-		const siteFilter = this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '';
+		const { translate, search } = this.props;
+		const siteFilter = `${ this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' }${
+			search ? '?s=' + search : ''
+		}`;
 
 		return [
 			{

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -2,13 +2,14 @@ import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import PluginsTable from './plugins-table';
 import type { Plugin } from './types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 import './style.scss';
 
 interface Props {
 	plugins: Array< Plugin >;
 	isLoading: boolean;
-	selectedSite: any;
+	selectedSite: SiteData;
 	searchTerm: string;
 }
 export default function PluginManagementV2( {

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,0 +1,52 @@
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
+import PluginsTable from './plugins-table';
+import type { Plugin } from './types';
+
+import './style.scss';
+
+interface Props {
+	plugins: Array< Plugin >;
+	isLoading: boolean;
+	selectedSite: any;
+	searchTerm: string;
+}
+export default function PluginManagementV2( {
+	plugins,
+	isLoading,
+	selectedSite,
+	searchTerm,
+}: Props ): ReactElement {
+	const translate = useTranslate();
+	const columns = [
+		{
+			key: 'plugin',
+			title: translate( 'Installed Plugins' ),
+		},
+		{
+			key: 'sites',
+			title: translate( 'Sites' ),
+			smallColumn: true,
+			colSpan: 2,
+		},
+	];
+
+	if ( ! plugins.length && ! isLoading ) {
+		let emptyStateMessage = translate( 'No plugins found' );
+		if ( searchTerm ) {
+			emptyStateMessage = translate( 'No results found. Please try refining your search.' );
+		}
+		return <div className="plugin-management-v2__no-sites">{ emptyStateMessage }</div>;
+	}
+
+	return (
+		<div className="plugin-management-v2__main-content-container">
+			<PluginsTable
+				items={ plugins }
+				columns={ columns }
+				isLoading={ isLoading }
+				selectedSite={ selectedSite }
+			/>
+		</div>
+	);
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Button } from '@automattic/components';
 import { ReactElement } from 'react';
 import type { Plugin } from '../types';
 
@@ -28,6 +28,15 @@ export default function PluginRowFormatter( { item, columnKey }: Props ): ReactE
 				</span>
 			);
 		case 'sites':
-			return Object.keys( item.sites ).length;
+			return (
+				<Button
+					className="plugin-row-formatter__sites-count-button"
+					borderless
+					compact
+					href={ `/plugins/${ item.slug }` }
+				>
+					{ Object.keys( item.sites ).length }
+				</Button>
+			);
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,0 +1,33 @@
+import { Gridicon } from '@automattic/components';
+import { ReactElement } from 'react';
+import type { Plugin } from '../types';
+
+import './style.scss';
+
+interface Props {
+	item: Plugin;
+	columnKey: string;
+}
+
+export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | any {
+	switch ( columnKey ) {
+		case 'plugin':
+			return (
+				<span className="plugin-row-formatter__plugin-name-container">
+					{ item.icon ? (
+						<img
+							className="plugin-row-formatter__plugin-icon"
+							src={ item.icon }
+							alt={ item.name }
+						/>
+					) : (
+						<Gridicon className="plugin-row-formatter__plugin-icon has-opacity" icon="plugins" />
+					) }
+					<span className="plugin-row-formatter__plugin-name">{ item.name }</span>
+					<span className="plugin-row-formatter__overlay"></span>
+				</span>
+			);
+		case 'sites':
+			return Object.keys( item.sites ).length;
+	}
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 	columnKey: string;
 }
 
-export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | null {
+export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | any {
 	switch ( columnKey ) {
 		case 'plugin':
 			return (

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 	columnKey: string;
 }
 
-export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | any {
+export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | null {
 	switch ( columnKey ) {
 		case 'plugin':
 			return (

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,6 +1,6 @@
 import { Gridicon, Button } from '@automattic/components';
-import { ReactElement } from 'react';
 import type { Plugin } from '../types';
+import type { ReactChild, ReactElement } from 'react';
 
 import './style.scss';
 
@@ -10,6 +10,10 @@ interface Props {
 }
 
 export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | any {
+	const PluginDetailsButton = ( props: { className: string; children: ReactChild } ) => {
+		return <Button borderless compact href={ `/plugins/${ item.slug }` } { ...props } />;
+	};
+
 	switch ( columnKey ) {
 		case 'plugin':
 			return (
@@ -23,20 +27,17 @@ export default function PluginRowFormatter( { item, columnKey }: Props ): ReactE
 					) : (
 						<Gridicon className="plugin-row-formatter__plugin-icon has-opacity" icon="plugins" />
 					) }
-					<span className="plugin-row-formatter__plugin-name">{ item.name }</span>
+					<PluginDetailsButton className="plugin-row-formatter__plugin-name">
+						{ item.name }
+					</PluginDetailsButton>
 					<span className="plugin-row-formatter__overlay"></span>
 				</span>
 			);
 		case 'sites':
 			return (
-				<Button
-					className="plugin-row-formatter__sites-count-button"
-					borderless
-					compact
-					href={ `/plugins/${ item.slug }` }
-				>
+				<PluginDetailsButton className="plugin-row-formatter__sites-count-button">
 					{ Object.keys( item.sites ).length }
-				</Button>
+				</PluginDetailsButton>
 			);
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -7,7 +7,7 @@
 	vertical-align: middle;
 	margin-inline-end: 16px;
 }
-.plugin-row-formatter__plugin-name {
+a.button.plugin-row-formatter__plugin-name {
 	display: inline-block;
 	font-weight: 500;
 	white-space: nowrap;
@@ -17,6 +17,7 @@
 	color: var( --studio-gray-100 );
 	width: calc( 100% - 55px );
 	font-size: 0.875rem;
+	text-align: left;
 }
 .plugin-row-formatter__overlay {
 	display: block;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -1,0 +1,33 @@
+.plugin-row-formatter__plugin-name-container {
+	position: relative;
+}
+.plugin-row-formatter__plugin-icon {
+	width: 24px;
+	height: 24px;
+	vertical-align: middle;
+	margin-inline-end: 16px;
+}
+.plugin-row-formatter__plugin-name {
+	display: inline-block;
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: clip;
+	vertical-align: middle;
+	color: var( --studio-gray-100 );
+	width: calc( 100% - 55px );
+	font-size: 0.875rem;
+}
+.plugin-row-formatter__overlay {
+	display: block;
+	position: absolute;
+	height: 48px;
+	width: 20px;
+	background: linear-gradient(
+		to right,
+		rgba( 255, 255, 255, 0.8 ) 30%,
+		rgba( 255, 255, 255, 1 ) 100%
+	);
+	inset-block-start: -14px;
+	inset-inline-end: 0;
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -31,3 +31,8 @@
 	inset-block-start: -14px;
 	inset-inline-end: 0;
 }
+.plugin-row-formatter__sites-count-button {
+	&:hover {
+		text-decoration: underline;
+	}
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
@@ -1,0 +1,92 @@
+import { Gridicon, Button } from '@automattic/components';
+import classNames from 'classnames';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import PluginRowFormatter from '../plugin-row-formatter';
+import UpdatePlugin from '../update-plugin';
+import type { PluginColumns, Plugin } from '../types';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+interface Props {
+	isLoading: boolean;
+	columns: PluginColumns;
+	items: Array< Plugin >;
+	selectedSite: any;
+}
+
+export default function PluginsTable( {
+	isLoading,
+	columns,
+	items,
+	selectedSite,
+}: Props ): ReactElement {
+	return (
+		<table className="plugins-table__table">
+			<thead>
+				<tr>
+					{ columns.map( ( column ) => (
+						<th colSpan={ column.colSpan || 1 } key={ column.key }>
+							{ column.title }
+						</th>
+					) ) }
+					<th></th>
+				</tr>
+			</thead>
+			<tbody>
+				{ isLoading ? (
+					<tr>
+						{ columns.map( ( column ) => (
+							<td key={ column.key }>
+								{ column.key === 'plugin' && (
+									<Gridicon className="plugins-table__plugin-icon is-loading" icon="plugins" />
+								) }
+								<TextPlaceholder />
+							</td>
+						) ) }
+						<td>
+							<TextPlaceholder />
+						</td>
+						<td>
+							<TextPlaceholder />
+						</td>
+					</tr>
+				) : (
+					items.map( ( item ) => {
+						const id = item.id;
+						return (
+							<tr key={ `table-row-${ id }` } className="plugins-table__table-row">
+								{ columns.map( ( column ) => {
+									return (
+										<td
+											className={ classNames(
+												column.smallColumn && 'plugins-table__small-column'
+											) }
+											key={ `table-data-${ column.key }-${ id }` }
+										>
+											{ <PluginRowFormatter columnKey={ column.key } item={ item } /> }
+										</td>
+									);
+								} ) }
+								<td>
+									<UpdatePlugin plugin={ item } selectedSite={ selectedSite } />
+								</td>
+								{
+									<td className={ classNames( 'plugins-table__actions' ) }>
+										<Button borderless compact>
+											<Gridicon
+												icon="ellipsis"
+												size={ 18 }
+												className="plugins-table__all-actions"
+											/>
+										</Button>
+									</td>
+								}
+							</tr>
+						);
+					} )
+				) }
+			</tbody>
+		</table>
+	);
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
@@ -4,6 +4,7 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import PluginRowFormatter from '../plugin-row-formatter';
 import UpdatePlugin from '../update-plugin';
 import type { PluginColumns, Plugin } from '../types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { ReactElement } from 'react';
 
 import './style.scss';
@@ -12,7 +13,7 @@ interface Props {
 	isLoading: boolean;
 	columns: PluginColumns;
 	items: Array< Plugin >;
-	selectedSite: any;
+	selectedSite: SiteData;
 }
 
 export default function PluginsTable( {

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/style.scss
@@ -59,7 +59,7 @@ td.plugins-table__actions {
 	padding: 0;
 	width: 50px;
 	text-align: right;
-    padding-right: 16px;
+	padding-right: 16px;
 }
 .plugins-table__table-row {
 	&:hover {

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/style.scss
@@ -1,0 +1,90 @@
+
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.plugins-table__table {
+	display: none;
+	@include break-xlarge() {
+		display: table;
+	}
+	border: 1px solid var( --studio-gray-5 );
+	border-collapse: collapse;
+	tr {
+		height: 1px;
+		background: var( --studio-white );
+	}
+	th {
+		font-size: 0.75rem;
+		color: var( --studio-gray-50 );
+		font-weight: 400;
+		height: 50px;
+	}
+	td {
+		font-size: 0.875rem;
+		height: 50px;
+		width: 162px;
+		box-sizing: border-box;
+		&:nth-child( 1 ) {
+			max-width: 200px;
+			@include break-wide() {
+				max-width: 300px;
+			}
+			@include break-huge() {
+				max-width: 350px;
+			}
+		}
+		a {
+			display: flex;
+		}
+	}
+	td, th {
+		border-bottom: 1px solid var( --studio-gray-5 );
+		text-align: left;
+		border-collapse: collapse;
+		vertical-align: middle;
+		@include break-xlarge() {
+			padding: 0 8px;
+		}
+		@include break-wide() {
+			padding: 0 16px;
+		}
+	}
+	.partner-portal-text-placeholder {
+		display: inline-flex;
+		min-width: 50%;
+		vertical-align: middle;
+	}
+}
+td.plugins-table__actions {
+	padding: 0;
+	width: 50px;
+	text-align: right;
+    padding-right: 16px;
+}
+.plugins-table__table-row {
+	&:hover {
+		background: var( --studio-gray-0 );
+		.plugin-row-formatter__overlay {
+			background: linear-gradient( to right, rgba( 246, 247, 247, 0.8 ) 30%, rgba( 246, 247, 247, 1 ) 100% );
+		}
+	}
+}
+.plugins-table__all-actions {
+	vertical-align: middle;
+	display: inline-flex;
+	color: var( --studio-gray-40 );
+	margin: 0 0.1em;
+	height: 100%;
+}
+.plugins-table__small-column {
+	max-width: 100px;
+}
+.components-form-toggle.is-checked .components-form-toggle__track {
+	background-color: var( --studio-jetpack-green-50 );
+}
+.plugins-table__plugin-icon {
+	width: 24px;
+	height: 24px;
+	vertical-align: middle;
+	margin-inline-end: 16px;
+}

--- a/client/my-sites/plugins/plugin-management-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/style.scss
@@ -1,0 +1,15 @@
+.has-opacity {
+	opacity: 0.3;
+}
+.is-loading {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	opacity: 0.3;
+}
+.plugin-management-v2__main-content-container {
+	margin-top: 8px;
+}
+.plugin-management-v2__no-sites {
+	text-align: center;
+	font-size: 1.5rem;
+	margin-top: 16px;
+}

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -1,0 +1,22 @@
+import type { MomentInput } from 'moment';
+import type { ReactChild } from 'react';
+
+export type PluginColumns = Array< {
+	key: string;
+	title: ReactChild;
+	smallColumn?: boolean;
+	colSpan?: number;
+} >;
+
+export type PluginSite = { ID: string | number; canUpdateFiles: any };
+
+export interface Plugin {
+	id: number;
+	last_updated: MomentInput;
+	sites: Array< PluginSite >;
+	icon: string;
+	name: string;
+	pluginsOnSites: Array< any >;
+	slug: string;
+	wporg: string;
+}

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -8,12 +8,12 @@ export type PluginColumns = Array< {
 	colSpan?: number;
 } >;
 
-export type PluginSite = { ID: string | number; canUpdateFiles: any };
+export type PluginSite = { [ key: string ]: { ID: number; canUpdateFiles: boolean } };
 
 export interface Plugin {
 	id: number;
 	last_updated: MomentInput;
-	sites: Array< PluginSite >;
+	sites: PluginSite;
 	icon: string;
 	name: string;
 	pluginsOnSites: Array< any >;

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import Badge from 'calypso/components/badge';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
+import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
+import type { PluginSite, Plugin } from '../types';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+interface Props {
+	plugin: Plugin;
+	selectedSite: any;
+	className?: string;
+}
+
+export default function UpdatePlugin( {
+	plugin,
+	selectedSite,
+	className,
+}: Props ): ReactElement | null {
+	const translate = useTranslate();
+	const allSites = useSelector( getSites );
+	const state = useSelector( ( state ) => state );
+
+	const getPluginSites = ( plugin: Plugin ) => {
+		return Object.keys( plugin.sites ).map( ( siteId: any ) => {
+			const site = allSites.find( ( s ) => s?.ID === parseInt( siteId ) );
+			return {
+				...site,
+				...plugin.sites[ siteId ],
+			};
+		} );
+	};
+
+	const sites = getPluginSites( plugin );
+	const siteIds = siteObjectsToSiteIds( sites );
+	const pluginsOnSites: any = getPluginOnSites( state, siteIds, plugin?.slug );
+
+	const updated_versions = sites
+		.map( ( site: PluginSite ) => {
+			const sitePlugin = pluginsOnSites?.sites[ site.ID ];
+			return sitePlugin?.update?.new_version;
+		} )
+		.filter( ( version ) => version );
+
+	const hasUpdate = sites.some( ( site ) => {
+		const sitePlugin = pluginsOnSites?.sites[ site.ID ];
+		return sitePlugin?.update && site.canUpdateFiles;
+	} );
+
+	const allowedActions = getAllowedPluginActions( plugin, state, selectedSite );
+
+	let content;
+
+	if ( ! allowedActions.autoupdate ) {
+		content = <div>{ translate( 'Auto-managed on this site' ) }</div>;
+	} else if ( hasUpdate ) {
+		content = (
+			<>
+				<Badge className="update-plugin__badge" type="warning">
+					{ updated_versions[ 0 ] } { translate( 'Available' ) }
+				</Badge>
+				<Button
+					className="update-plugin__plugin-update-button"
+					borderless
+					compact
+					href={ `/plugins/${ plugin.slug }` }
+				>
+					{ translate( 'Update' ) }
+				</Button>
+			</>
+		);
+	}
+	return content ? <div className={ classNames( className ) }>{ content }</div> : null;
+}

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -7,14 +7,15 @@ import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
-import type { PluginSite, Plugin } from '../types';
+import type { Plugin } from '../types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import type { ReactElement } from 'react';
 
 import './style.scss';
 
 interface Props {
 	plugin: Plugin;
-	selectedSite: any;
+	selectedSite: SiteData;
 	className?: string;
 }
 
@@ -28,7 +29,7 @@ export default function UpdatePlugin( {
 	const state = useSelector( ( state ) => state );
 
 	const getPluginSites = ( plugin: Plugin ) => {
-		return Object.keys( plugin.sites ).map( ( siteId: any ) => {
+		return Object.keys( plugin.sites ).map( ( siteId ) => {
 			const site = allSites.find( ( s ) => s?.ID === parseInt( siteId ) );
 			return {
 				...site,
@@ -42,7 +43,7 @@ export default function UpdatePlugin( {
 	const pluginsOnSites: any = getPluginOnSites( state, siteIds, plugin?.slug );
 
 	const updated_versions = sites
-		.map( ( site: PluginSite ) => {
+		.map( ( site ) => {
 			const sitePlugin = pluginsOnSites?.sites[ site.ID ];
 			return sitePlugin?.update?.new_version;
 		} )

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -1,0 +1,14 @@
+.update-plugin__badge {
+	font-size: 0.75rem !important;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	vertical-align: middle;
+	max-width: fit-content;
+}
+a.button.update-plugin__plugin-update-button {
+	color: var( --color-primary-80 );
+	margin-left: 10px;
+	text-decoration: underline;
+	display: inline-flex;
+}

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
@@ -3,8 +3,14 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { Plugin } from '../types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { AppState } from 'calypso/types';
 
-export const getAllowedPluginActions = ( plugin: Plugin, state, selectedSite ) => {
+export const getAllowedPluginActions = (
+	plugin: Plugin,
+	state: AppState,
+	selectedSite: SiteData
+) => {
 	const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
 	const siteIsAtomic = isSiteAutomatedTransfer( state, selectedSite?.ID );
 	const siteIsJetpack = isJetpackSite( state, selectedSite?.ID );

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
@@ -1,0 +1,20 @@
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import type { Plugin } from '../types';
+
+export const getAllowedPluginActions = ( plugin: Plugin, state, selectedSite ) => {
+	const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
+	const siteIsAtomic = isSiteAutomatedTransfer( state, selectedSite?.ID );
+	const siteIsJetpack = isJetpackSite( state, selectedSite?.ID );
+	const hasManagePlugins = siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+	const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
+	const canManagePlugins =
+		! selectedSite || ( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
+
+	return {
+		autoupdate: ! isManagedPlugin && canManagePlugins,
+		activation: ! isManagedPlugin && canManagePlugins,
+	};
+};

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -32,6 +32,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import PluginManagementV2 from '../plugin-management-v2';
 
 import './style.scss';
 
@@ -79,6 +80,10 @@ export class PluginsList extends Component {
 		}
 
 		if ( this.props.isPlaceholder !== nextProps.isPlaceholder ) {
+			return true;
+		}
+
+		if ( this.props.searchTerm !== nextProps.searchTerm ) {
 			return true;
 		}
 
@@ -468,7 +473,7 @@ export class PluginsList extends Component {
 
 		const selectedSiteSlug = this.props.selectedSiteSlug ? this.props.selectedSiteSlug : '';
 
-		if ( this.props.isPlaceholder ) {
+		if ( this.props.isPlaceholder && ! this.props.isJetpackCloud ) {
 			return (
 				<div className="plugins-list">
 					<SectionHeader
@@ -481,7 +486,7 @@ export class PluginsList extends Component {
 			);
 		}
 
-		if ( isEmpty( this.props.plugins ) ) {
+		if ( isEmpty( this.props.plugins ) && ! this.props.isJetpackCloud ) {
 			return null;
 		}
 
@@ -489,34 +494,47 @@ export class PluginsList extends Component {
 			<div className="plugins-list">
 				<QueryProductsList />
 				<PluginNotices sites={ this.getPluginsSites() } plugins={ this.props.plugins } />
-				<PluginsListHeader
-					label={ this.props.header }
-					isBulkManagementActive={ this.state.bulkManagementActive }
-					selectedSiteSlug={ selectedSiteSlug }
-					plugins={ this.props.plugins }
-					selected={ this.getSelected() }
-					toggleBulkManagement={ this.toggleBulkManagement }
-					updateAllPlugins={ this.updateAllPlugins }
-					updateSelected={ this.updateSelected }
-					pluginUpdateCount={ this.props.pluginUpdateCount }
-					activateSelected={ this.activateSelected }
-					deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
-					deactivateSelected={ this.deactivateSelected }
-					setAutoupdateSelected={ this.setAutoupdateSelected }
-					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
-					removePluginNotice={ this.removePluginDialog }
-					setSelectionState={ this.setBulkSelectionState }
-					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
-					haveInactiveSelected={ this.props.plugins.some(
-						this.filterSelection.inactive.bind( this )
-					) }
-					haveUpdatesSelected={ this.props.plugins.some(
-						this.filterSelection.updates.bind( this )
-					) }
-				/>
-				<Card className={ itemListClasses }>
-					{ this.orderPluginsByUpdates( this.props.plugins ).map( this.renderPlugin ) }
-				</Card>
+				{ this.props.isJetpackCloud ? (
+					<PluginManagementV2
+						plugins={ this.props.plugins }
+						isLoading={ this.props.isLoading }
+						selectedSite={ this.props.selectedSite }
+						searchTerm={ this.props.searchTerm }
+					/>
+				) : (
+					<>
+						<PluginsListHeader
+							label={ this.props.header }
+							isBulkManagementActive={ this.state.bulkManagementActive }
+							selectedSiteSlug={ selectedSiteSlug }
+							plugins={ this.props.plugins }
+							selected={ this.getSelected() }
+							toggleBulkManagement={ this.toggleBulkManagement }
+							updateAllPlugins={ this.updateAllPlugins }
+							updateSelected={ this.updateSelected }
+							pluginUpdateCount={ this.props.pluginUpdateCount }
+							activateSelected={ this.activateSelected }
+							deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
+							deactivateSelected={ this.deactivateSelected }
+							setAutoupdateSelected={ this.setAutoupdateSelected }
+							unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
+							removePluginNotice={ this.removePluginDialog }
+							setSelectionState={ this.setBulkSelectionState }
+							haveActiveSelected={ this.props.plugins.some(
+								this.filterSelection.active.bind( this )
+							) }
+							haveInactiveSelected={ this.props.plugins.some(
+								this.filterSelection.inactive.bind( this )
+							) }
+							haveUpdatesSelected={ this.props.plugins.some(
+								this.filterSelection.updates.bind( this )
+							) }
+						/>
+						<Card className={ itemListClasses }>
+							{ this.orderPluginsByUpdates( this.props.plugins ).map( this.renderPlugin ) }
+						</Card>
+					</>
+				) }
 			</div>
 		);
 	}
@@ -583,7 +601,6 @@ export class PluginsList extends Component {
 export default connect(
 	( state, { plugins } ) => {
 		const selectedSite = getSelectedSite( state );
-
 		return {
 			allSites: getSites( state ),
 			pluginsOnSites: getPluginsOnSites( state, plugins ),

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -346,7 +346,7 @@ body.is-section-plugins header .select-dropdown__item {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
 	margin: 0 -32px -32px;
-	padding: 8px 48px;
+	padding: 16px 48px;
 	min-height: 100vh;
 	background: rgba( 255, 255, 255, 0.5 );
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -315,3 +315,45 @@ body.is-section-plugins header .select-dropdown__item {
 		}
 	}
 }
+.plugins__page-title {
+	color: var( --studio-gray-80 );
+	font-weight: 400;
+}
+.plugins__page-subtitle {
+	font-size: 0.875rem;
+	color: var( --studio-gray-60 );
+	margin-bottom: 8px;
+}
+.plugins__jetpack-cloud {
+	.plugins__main-header .section-nav {
+		border-width: 0;
+	}
+	.plugins__main-header {
+		margin: 0;
+	}
+}
+.plugins__top-container {
+	margin: 0 -32px;
+	padding: 0 48px;
+	border-bottom: 1px solid var( --color-primary-5 );
+}
+.plugins__content-wrapper {
+	max-width: 1500px;
+	margin: auto;
+	padding: 0;
+}
+.plugins__main-content {
+	// We need these negative margin values because we want to make the container full-width,
+	// but our element is inside a limited-width parent.
+	margin: 0 -32px -32px;
+	padding: 8px 48px;
+	min-height: 100vh;
+	background: rgba( 255, 255, 255, 0.5 );
+}
+.plugins__search {
+	height: 52px;
+	box-shadow: 0 0 0 1px var( --color-neutral-5 );
+	.search.is-open {
+		box-shadow: none;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

This PR implements the large screen view(>1080px) for multi-site plugin management. The small screen view(<1080px) will be implemented in a different PR

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/plugin-management-multi-site-large-screen-view` and `yarn start-jetpack-cloud-p`
2. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
3. Click on **Plugins** in the sidebar -> Verify that the new UI for the plugin is shown as below.

<img width="1920" alt="Screenshot 2022-08-03 at 3 21 20 PM" src="https://user-images.githubusercontent.com/10586875/182580829-c8a4d65c-b9b4-4313-829e-731ef2eab146.png">

<img width="1654" alt="Screenshot 2022-08-03 at 3 21 01 PM" src="https://user-images.githubusercontent.com/10586875/182580723-a090807a-640d-46eb-a9cb-65be9dd8797b.png">

4. Clicking on Sites count, Plugin name & `Update` text should redirect the user to the plugin details page.

<img width="560" alt="Screenshot 2022-08-03 at 3 28 23 PM" src="https://user-images.githubusercontent.com/10586875/182590008-0e9408cb-3b67-47de-b732-f96b0c746da4.png">

5. Verify search works as expected.
6. Click on all the tabs - All, Active, Inactive & Updates and verify the plugins are shown as per the filter, and the URL is changing accordingly. 
7. Verify these changes have not affected anything in Calypso Blue. 

> **_NOTE:_** The more actions icon(`...`) is just a placeholder and will be updated later in a different PR, and the single-site view will be implemented in the upcoming PR. 

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202698250096202, 1202518759611394-as-1202672925908038 & 1202518759611394-as-1202672925908026