### PR TITLE
Add link to Privacy Policy on Login and Registration screens

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -598,12 +598,21 @@ export class LoginForm extends Component {
 					<p className="login__form-terms">
 						{ this.props.translate(
 							// To make any changes to this copy please speak to the legal team
-							'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+							'By continuing, ' +
+								'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and' +
+								' acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 							{
 								components: {
 									tosLink: (
 										<a
 											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									privacyLink: (
+										<a
+											href={ localizeUrl( 'https://automattic.com/privacy/' ) }
 											target="_blank"
 											rel="noopener noreferrer"
 										/>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -154,16 +154,16 @@ class SocialLoginForm extends Component {
 			redirectTo.includes( 'jetpack/connect' ) &&
 			config.isEnabled( 'jetpack/magic-link-signup' );
 
-		const privacyLink = (
+		const tosLink = (
 			<a
-				href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+				href={ localizeUrl( 'https://wordpress.com/tos/' ) }
 				target="_blank"
 				rel="noopener noreferrer"
 			/>
 		);
-		const tosLink = (
+		const privacyLink = (
 			<a
-				href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+				href={ localizeUrl( 'https://automattic.com/privacy/' ) }
 				target="_blank"
 				rel="noopener noreferrer"
 			/>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -153,6 +153,22 @@ class SocialLoginForm extends Component {
 			redirectTo &&
 			redirectTo.includes( 'jetpack/connect' ) &&
 			config.isEnabled( 'jetpack/magic-link-signup' );
+
+		const privacyLink = (
+			<a
+				href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		);
+		const tosLink = (
+			<a
+				href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		);
+
 		if ( isJetpackMagicLinkSignUpFlow ) {
 			return (
 				<>
@@ -163,20 +179,8 @@ class SocialLoginForm extends Component {
 								' {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 							{
 								components: {
-									tosLink: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									privacyLink: (
-										<a
-											href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
+									tosLink,
+									privacyLink,
 								},
 							}
 						) }
@@ -199,20 +203,8 @@ class SocialLoginForm extends Component {
 						' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 					{
 						components: {
-							tosLink: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							privacyLink: (
-								<a
-									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+							tosLink,
+							privacyLink,
 						},
 					}
 				) }

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -157,17 +157,29 @@ class SocialLoginForm extends Component {
 			return (
 				<>
 					<p className="login__social-tos">
-						{ translate( 'By continuing, you agree to our {{a}}Terms of Service{{/a}}.', {
-							components: {
-								a: (
-									<a
-										href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						} ) }
+						{ translate(
+							'By continuing, you agree to our {{tosLink}}Terms of' +
+								' Service{{/tosLink}} and acknowledge that you have read our' +
+								' {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+							{
+								components: {
+									tosLink: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									privacyLink: (
+										<a
+											href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
 					</p>
 					<p className="login__social-tos">
 						{ translate(
@@ -182,13 +194,21 @@ class SocialLoginForm extends Component {
 			<p className="login__social-tos">
 				{ translate(
 					"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-						' are creating an account and you agree to our' +
-						' {{a}}Terms of Service{{/a}}.',
+						' are creating an account, you agree to our' +
+						' {{tosLink}}Terms of Service{{/tosLink}}, and acknowledge that you have' +
+						' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 					{
 						components: {
-							a: (
+							tosLink: (
 								<a
 									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							privacyLink: (
+								<a
+									href={ localizeUrl( 'https://automattic.com/privacy/' ) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -128,6 +128,7 @@
 		margin-bottom: 5px;
 	}
 
+	input.form-text-input,
 	input {
 		margin-bottom: 20px;
 		transition: none;

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -779,11 +779,11 @@ class SignupForm extends Component {
 		);
 	}
 
-	handleOnClickTos = () => {
+	handleTosClick = () => {
 		recordTracksEvent( 'calypso_signup_tos_link_click' );
 	};
 
-	handleOnClickPrivacy = () => {
+	handlePrivacyClick = () => {
 		recordTracksEvent( 'calypso_signup_privacy_link_click' );
 	};
 
@@ -796,7 +796,7 @@ class SignupForm extends Component {
 					tosLink: (
 						<a
 							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-							onClick={ this.handleOnClickTos }
+							onClick={ this.handleTosClick }
 							target="_blank"
 							rel="noopener noreferrer"
 						/>
@@ -804,7 +804,7 @@ class SignupForm extends Component {
 					privacyLink: (
 						<a
 							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-							onClick={ this.handleOnClickPrivacy }
+							onClick={ this.handlePrivacyClick }
 							target="_blank"
 							rel="noopener noreferrer"
 						/>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -783,42 +783,35 @@ class SignupForm extends Component {
 		recordTracksEvent( 'calypso_signup_tos_link_click' );
 	};
 
-	getTermsOfServiceUrl() {
-		return localizeUrl( 'https://wordpress.com/tos/' );
-	}
+	handleOnClickPrivacy = () => {
+		recordTracksEvent( 'calypso_signup_privacy_link_click' );
+	};
 
 	termsOfServiceLink = () => {
-		const tosLink = (
-			<a
-				href={ this.getTermsOfServiceUrl() }
-				onClick={ this.handleOnClickTos }
-				target="_blank"
-				rel="noopener noreferrer"
-			/>
-		);
 		const tosText = this.props.translate(
-			'By creating an account you agree to our {{a}}Terms of Service{{/a}}.',
+			'By creating an account you agree to our {{tosLink}}Terms of Service{{/tosLink}} and' +
+				' acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			{
 				components: {
-					a: tosLink,
+					tosLink: (
+						<a
+							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+							onClick={ this.handleOnClickTos }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					privacyLink: (
+						<a
+							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+							onClick={ this.handleOnClickPrivacy }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
 				},
 			}
 		);
-
-		if ( this.props.isSocialSignupEnabled ) {
-			return (
-				<p className="signup-form__terms-of-service-link">
-					{ this.props.translate(
-						'By creating an account, you agree to our {{a}}Terms of Service{{/a}}.',
-						{
-							components: {
-								a: tosLink,
-							},
-						}
-					) }
-				</p>
-			);
-		}
 
 		return <p className="signup-form__terms-of-service-link">{ tosText }</p>;
 	};

--- a/client/blocks/signup-form/social-signup-tos.jsx
+++ b/client/blocks/signup-form/social-signup-tos.jsx
@@ -6,13 +6,21 @@ function SocialSignupToS( props ) {
 		<p className="signup-form__social-buttons-tos">
 			{ props.translate(
 				"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-					' are creating an account and you agree to our' +
-					' {{a}}Terms of Service{{/a}}.',
+					' are creating an account, you agree to our' +
+					' {{tosLink}}Terms of Service{{/tosLink}}, and acknowledge that you have' +
+					' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				{
 					components: {
-						a: (
+						tosLink: (
 							<a
 								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						privacyLink: (
+							<a
+								href={ localizeUrl( 'https://automattic.com/privacy/' ) }
 								target="_blank"
 								rel="noopener noreferrer"
 							/>

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -879,7 +879,7 @@
 		font-size: $woo-font-size-small;
 		line-height: 28px;
 		color: $woo-gray-40;
-		margin: 25px 8px 8px;
+		margin: 0 8px 12px;
 		a {
 			font-size: inherit;
 		}


### PR DESCRIPTION
#### Proposed Changes

There was a request  p6JqRr-6Yz-p2#comment-14399 to add text “and acknowledge that you have read our Privacy Policy” to the TOS acceptance lines for both Login and Registration screens.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On WooCommerce.test click login
- Replace _https://wordpress.com/_ with _http://calypso.localhost:3000/_ in the URL and check if texts mentioning Terms of Service contain a link to Privacy Policy too
- Go to the registration screen (click "Create an Account" link) and check if texts mentioning Terms of Service contain a link to Privacy Policy too
- Go to the regular login screen http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F and check if texts mentioning Terms of Service contain a link to Privacy Policy too
- Click on the "Create a new account" link and check if texts mentioning Terms of Service contain a link to Privacy Policy too
- Please test around this issue

#### Screenshots

![image](https://user-images.githubusercontent.com/4765119/182578595-3341dc6e-8e55-477c-9152-4cf3fb08f6e9.png)

![image](https://user-images.githubusercontent.com/4765119/182578677-c164925e-8790-4aa6-b619-24cf5945da70.png)

http://calypso.localhost:3000/log-in/new/en-gb?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fstart%2Fdomains%3Fuser_email%3D&signup_url=%2Fstart%2Fuser%3Fuser_email%3D
![image](https://user-images.githubusercontent.com/4765119/182578743-f17e0ec6-fe13-4cf7-8289-d11124ddc4a6.png)

http://calypso.localhost:3000/start/user?user_email=
![image](https://user-images.githubusercontent.com/4765119/182578823-32e5298a-26d8-4e3c-ae58-7c942709c7cc.png)

http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F
![image](https://user-images.githubusercontent.com/4765119/182578879-96466919-681f-45b9-ab1c-d466e3815886.png)