### PR TITLE
Sites Management Page: Tweak sites managment page styles

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -25,7 +25,7 @@ interface SitesDashboardQueryParams {
 	search?: string;
 }
 
-const MAX_PAGE_WIDTH = '1184px';
+const MAX_PAGE_WIDTH = '1280px';
 
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -46,7 +46,7 @@ const SiteName = styled.a`
 	white-space: nowrap;
 	margin-right: 8px;
 	font-weight: 500;
-	font-size: 16px;
+	font-size: 14px;
 	letter-spacing: -0.4px;
 
 	&:hover {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -21,13 +21,14 @@ const Table = styled.table`
 const Row = styled.tr`
 	line-height: 2em;
 	border-bottom: 1px solid #eee;
-	td {
+	th {
 		padding-top: 12px;
 		padding-bottom: 12px;
 		vertical-align: middle;
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.24px;
+		font-weight: normal;
 		color: var( --studio-gray-60 );
 	}
 `;

--- a/packages/components/src/sites-table/sites-count-badge.tsx
+++ b/packages/components/src/sites-table/sites-count-badge.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled';
 
 export const SitesCountBadge = styled.span`
 	font-size: 12px;
-	font-weight: 500;
-	color: var( --studio-gray-80 );
-	background-color: var( --studio-gray-5 );
+	color: var( --studio-gray-60 );
+	background-color: var( --studio-gray-0 );
 	padding: 0px 10px;
 	margin-left: 10px;
 	border-radius: 4px;


### PR DESCRIPTION
#### Proposed Changes

Part of @SaxonF's design changes proposed in https://github.com/Automattic/wp-calypso/pull/65871

Tweaks to the table styles

* Makes the table a little wider
* Reduce font size of site title
* Lighten up the column headings a bit
* Lighten up the site counts a bit

![CleanShot 2022-08-03 at 22 23 58@2x](https://user-images.githubusercontent.com/1500769/182586020-680e138e-0cd8-43bb-9279-50149fcc17c6.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the dashboard locally
* Bask in its beauty
* Make sure mobile layout still looks good

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65871
