### PR TITLE
Sites Management Page: Use sentence case for 'New site' button

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -107,7 +107,7 @@ export function SitesDashboard( { queryParams: { search, status } }: SitesDashbo
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>
 					<Button primary href="/start?source=sites-dashboard&ref=sites-dashboard">
 						<Gridicon icon="plus" />
-						<span>{ __( 'New Site' ) }</span>
+						<span>{ __( 'New site' ) }</span>
 					</Button>
 				</HeaderControls>
 			</PageHeader>


### PR DESCRIPTION
Fixes #66209

## Proposed Changes

* Uses sentence case for 'New site' button.

## Testing Instructions

1. Load `/sites-dashboard`.
2. View button.