### PR TITLE
Fixed: Masterbar cart preserves open state after products are removed #65371

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -56,7 +56,7 @@ export function MasterbarCartButton( {
 	};
 
 	const handleRemoveProduct = ( uuid: string ) => {
-		if ( responseCart.products.length == 1 ) {
+		if ( responseCart.products.length === 1 ) {
 			setIsActive( false );
 		}
 

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -54,6 +54,16 @@ export function MasterbarCartButton( {
 			return ! active;
 		} );
 	};
+
+	const handleRemoveProduct = ( uuid: string ) => {
+		if ( responseCart.products.length == 1 ) {
+			setIsActive( false );
+		}
+
+		if ( onRemoveProduct ) {
+			onRemoveProduct( uuid );
+		}
+	};
 	const onClose = () => setIsActive( false );
 	const tooltip = String( translate( 'My shopping cart' ) );
 
@@ -81,7 +91,7 @@ export function MasterbarCartButton( {
 						cartKey={ selectedSiteId }
 						goToCheckout={ goToCheckout }
 						closeCart={ onClose }
-						onRemoveProduct={ onRemoveProduct }
+						onRemoveProduct={ handleRemoveProduct }
 						onRemoveCoupon={ onRemoveCoupon }
 					/>
 				</CheckoutErrorBoundary>


### PR DESCRIPTION
#### Proposed Changes
Updated masterbar-cart to update it's state when the last item is removed.
*

#### Testing Instructions

To reproduce:

Add a product to the cart and then manually visit /domains/add/:site.
Using the masterbar cart, remove the product from the cart.
Once the masterbar cart disappears, immediately click to add a domain to the cart.
Notice that the masterbar cart opens up on its own.
Expected behavior: the masterbar cart does not open until clicked.

*


Related to #65371
