### PR TITLE
Plugins: Use <a> tags for the search keywords links

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,5 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -30,12 +29,34 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef, isSearching 
 	);
 };
 
+const SearchLink = ( { searchTerm, currentTerm, onSelect } ) => {
+	const classes = [ 'search-box-header__recommended-searches-list-item' ];
+
+	if ( searchTerm === currentTerm ) {
+		classes.push( 'search-box-header__recommended-searches-list-item-selected' );
+
+		return <span className={ classes.join( ' ' ) }>{ searchTerm }</span>;
+	}
+
+	return (
+		<a
+			href={ `/plugins?s=${ searchTerm }` }
+			className={ classes.join( ' ' ) }
+			onClick={ onSelect }
+			onKeyPress={ onSelect }
+		>
+			{ searchTerm }
+		</a>
+	);
+};
+
 const PopularSearches = ( props ) => {
 	const { searchTerms, doSearch, searchedTerm, popularSearchesRef } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const clickHandler = ( searchTerm ) => ( event ) => {
+		event.preventDefault();
 
-	const onClick = ( searchTerm ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_plugins_popular_searches_click', {
 				search_term: searchTerm,
@@ -53,28 +74,12 @@ const PopularSearches = ( props ) => {
 
 			<div className="search-box-header__recommended-searches-list">
 				{ searchTerms.map( ( searchTerm, n ) => (
-					<Fragment key={ 'search-box-item' + n }>
-						{ searchTerm === searchedTerm ? (
-							<span
-								className="search-box-header__recommended-searches-list-item search-box-header__recommended-searches-list-item-selected"
-								key={ 'recommended-search-item-' + n }
-							>
-								{ searchTerm }
-							</span>
-						) : (
-							<span
-								onClick={ () => onClick( searchTerm ) }
-								onKeyPress={ () => onClick( searchTerm ) }
-								role="link"
-								tabIndex={ 0 }
-								className="search-box-header__recommended-searches-list-item"
-								key={ 'recommended-search-item-' + n }
-							>
-								{ searchTerm }
-							</span>
-						) }
-						{ n !== searchTerms.length - 1 && <>,&nbsp;</> }
-					</Fragment>
+					<SearchLink
+						key={ 'search-box-item' + n }
+						onSelect={ clickHandler( searchTerm ) }
+						searchTerm={ searchTerm }
+						currentTerm={ searchedTerm }
+					/>
 				) ) }
 			</div>
 		</div>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,7 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
+import { useCurrentRoute } from 'calypso/components/route';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
@@ -31,6 +32,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef, isSearching 
 
 const SearchLink = ( { searchTerm, currentTerm, onSelect } ) => {
 	const classes = [ 'search-box-header__recommended-searches-list-item' ];
+	const route = useCurrentRoute();
 
 	if ( searchTerm === currentTerm ) {
 		classes.push( 'search-box-header__recommended-searches-list-item-selected' );
@@ -40,7 +42,7 @@ const SearchLink = ( { searchTerm, currentTerm, onSelect } ) => {
 
 	return (
 		<a
-			href={ `/plugins?s=${ searchTerm }` }
+			href={ `${ route.currentRoute }?s=${ searchTerm }` }
 			className={ classes.join( ' ' ) }
 			onClick={ onSelect }
 			onKeyPress={ onSelect }

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -76,6 +76,16 @@
 			text-align: center;
 
 			.search-box-header__recommended-searches-list-item {
+				&::after {
+					content: ',';
+					display: inline-block;
+					width: 0;
+					margin-right: 0.5em;
+				}
+				&:last-child::after {
+					content: none;
+				}
+
 				&:hover:not( .search-box-header__recommended-searches-list-item-selected ) {
 					color: var( --color-link );
 					cursor: pointer;


### PR DESCRIPTION
#### Proposed Changes

* This PR replaces the search keywords with anchor tags so search engines can crawl the search result pages.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a logged-out user, open `/plugins` page.
* The popular keywords should be anchor tags.
  <img width="695" alt="Plugins_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/182600103-0014f6ca-1b58-4a41-977a-e23e4e0597e6.png">
* Make sure it directs you to the search result page when clicked.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#](998-gh-Automattic/martech)