### PR TITLE
Jetpack Agency Dashboard: Update plugin details manage connection link

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -13,6 +13,7 @@ import {
 } from '@automattic/calypso-products';
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { PREINSTALLED_PREMIUM_PLUGINS } from 'calypso/my-sites/plugins/constants';
 import { sanitizeSectionContent } from './sanitize-section-content';
@@ -371,3 +372,15 @@ export function marketplacePlanToAdd( currentPlan, pluginBillingPeriod ) {
 				: PLAN_BUSINESS_MONTHLY;
 	}
 }
+
+/**
+ * Determines the URL to use for managing a connection.
+ *
+ * @param {string} siteSlug The site slug to use in the URL.
+ * @returns The URL to use for managing a connection.
+ */
+export const getManageConnectionHref = ( siteSlug ) => {
+	return isJetpackCloud()
+		? `https://wordpress.com/settings/manage-connection/${ siteSlug }`
+		: `/settings/manage-connection/${ siteSlug }`;
+};

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { ACTIVATE_PLUGIN, DEACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
+import { getManageConnectionHref } from 'calypso/lib/plugins/utils';
 import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { togglePluginActivation } from 'calypso/state/plugins/installed/actions';
@@ -72,14 +73,14 @@ export class PluginActivateToggle extends Component {
 				<a
 					className="plugin-activate-toggle__icon"
 					onClick={ this.trackManageConnectionLink }
-					href={ '/settings/manage-connection/' + site.slug }
+					href={ getManageConnectionHref( site.slug ) }
 				>
 					<Gridicon icon="cog" size={ 18 } />
 				</a>
 				<a
 					className="plugin-activate-toggle__label"
 					onClick={ this.trackManageConnectionLink }
-					href={ '/settings/manage-connection/' + site.slug }
+					href={ getManageConnectionHref( site.slug ) }
 				>
 					{ translate( 'Manage Connection', {
 						comment: 'manage Jetpack connnection settings link',


### PR DESCRIPTION
… Cloud redirects to WordPress.com

#### Proposed Changes

This PR updates the "manage connections" button on the plugin details page so that Jetpack Cloud sends users to wordpress.com. This is done because the `/settings/manage-connection` page is not available on Jetpack Cloud.

<img width="808" alt="image" src="https://user-images.githubusercontent.com/42627630/182661268-fa25206c-2fcc-463b-9a68-c4a4e4221e14.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/plugins/jetpack` on Jetpack Cloud. Click the "manage connection" button and verify that you are taken to wordpress.com.
2. Visit `/plugins/jetpack` on wordpress.com. Again click the "manage connection" button and verify that you are still taken to wordpress.com.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202674050443461