### PR TITLE
Flaky E2E: correct expected outcome after selecting a design and landing at home dashboard.

### DIFF
--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -175,8 +175,9 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 		} );
 
 		it( 'Land in Home dashboard', async function () {
-			const myHomePage = new MyHomePage( page );
-			await myHomePage.validateTaskHeadingMessage( "Update your site's design" );
+			await page.waitForURL(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
 		} );
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the incorrect assumption for a test step which expects the message "Update your site's design" to always appear after selecting a design then landing at `/home` endpoint.

#### Testing Instructions

Ensure the following:
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66228
