### PR TITLE
Licensing Portal: fix assign license scroll behavior on mobile

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect } from 'react';
+import { ReactElement, useEffect, useLayoutEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -17,6 +17,14 @@ export default function AssignLicense( {
 	search: string;
 } ): ReactElement {
 	const translate = useTranslate();
+
+	const scrollToTop = () => {
+		window.scrollTo( 0, 0 );
+	};
+
+	useLayoutEffect( () => {
+		scrollToTop();
+	}, [] );
 
 	useEffect( () => {
 		const layoutClass = 'layout__content--partner-portal-assign-license';


### PR DESCRIPTION
#### Proposed Changes

* On mobile, there is a bug that makes the assign license scroll remain in the same position it was on the previous page, the issue license. So, occasionally the users need to scroll up to see the page top. This PR aims to fix this.


#### Testing Instructions

* Make sure you have a wordpress.com website.
* Open up Licensing -> Licenses on the mobile version.
* Click on the "Issue New License" button.
* Scroll all the way down and check the last option on the list of products.
* With the plan checked, click on the "Select License" button.
* The "Assign License" page should appear with the top part being shown

#### Screenshots of before fixing the bug
<img src="https://user-images.githubusercontent.com/6406071/182682341-2ded70f4-ee56-4d3c-8eaf-d33f6c8588c2.png" width="400" height="656" />

<img src="https://user-images.githubusercontent.com/6406071/182687028-61f73dd9-1029-4f37-93a5-bcf97ed87bd4.png" width="400" height="656" />

#### Screenshots of after fixing the bug
<img src="https://user-images.githubusercontent.com/6406071/182682341-2ded70f4-ee56-4d3c-8eaf-d33f6c8588c2.png" width="400" height="656" />

<img src="https://user-images.githubusercontent.com/6406071/182687252-6cf1a2a3-1b0d-4088-8369-c542b09e22be.png" width="400" height="656" />


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
