### PR TITLE
Disable wp-desktop-mac job temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
 
   wp-desktop-mac:
     macos:
-      xcode: '12.3.0'
+      xcode: '13.3.1'
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-calypso
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
 
   wp-desktop-mac:
     macos:
-      xcode: '12.5.1'
+      xcode: '12.3.0'
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-calypso
     environment:
@@ -467,15 +467,15 @@ workflows:
                 - trunk
                 - /release\/.*/
                 - /desktop\/.*/
-      - wp-desktop-mac:
-          requires:
-            - wp-desktop-assets
-          filters:
-            branches:
-              only:
-                - trunk
-                - /release\/.*/
-                - /desktop\/.*/
+#     - wp-desktop-mac:
+#         requires:
+#           - wp-desktop-assets
+#         filters:
+#           branches:
+#             only:
+#               - trunk
+#               - /release\/.*/
+#               - /desktop\/.*/
       - wp-desktop-linux:
           requires:
             - wp-desktop-assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
 
   wp-desktop-mac:
     macos:
-      xcode: '13.3.1'
+      xcode: '12.5.1'
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-calypso
     environment:


### PR DESCRIPTION
Our current used Xcode version for wp-desktop-mac is deprecated as described in:
https://circleci.com/docs/xcode-policy

After trying with both 13.3.1 and 12.5.1, we decided to temporarily disable the job until @nsakaimbo has a chance to take a closer look at the issues blocking usage of a newer version.

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
