### PR TITLE
Disable wp-desktop-mac temporarily.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,15 +467,15 @@ workflows:
                 - trunk
                 - /release\/.*/
                 - /desktop\/.*/
-      - wp-desktop-mac:
-          requires:
-            - wp-desktop-assets
-          filters:
-            branches:
-              only:
-                - trunk
-                - /release\/.*/
-                - /desktop\/.*/
+#     - wp-desktop-mac:
+#         requires:
+#           - wp-desktop-assets
+#         filters:
+#           branches:
+#             only:
+#               - trunk
+#               - /release\/.*/
+#               - /desktop\/.*/
       - wp-desktop-linux:
           requires:
             - wp-desktop-assets


### PR DESCRIPTION
#### Proposed Changes

Disable the wp-desktop-mac build temporarily because the selected Xcode version is no longer available at circleci and there are compatibility issues with newer versions.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
