### PR TITLE
Licensing Portal: implement the unassign licenses feature

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -4,6 +4,7 @@ import { ReactElement, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import UnassignLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/unassign-license-dialog';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -27,6 +28,7 @@ export default function LicenseDetailsActions( {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
+	const [ unassignDialog, setUnassignDialog ] = useState( false );
 
 	const openRevokeDialog = useCallback( () => {
 		setRevokeDialog( true );
@@ -37,6 +39,16 @@ export default function LicenseDetailsActions( {
 		setRevokeDialog( false );
 		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_revoke_dialog_close' ) );
 	}, [ dispatch, setRevokeDialog ] );
+
+	const openUnassignDialog = useCallback( () => {
+		setUnassignDialog( true );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_unassign_dialog_open' ) );
+	}, [ dispatch, setUnassignDialog ] );
+
+	const closeUnassignDialog = useCallback( () => {
+		setUnassignDialog( false );
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_unassign_dialog_close' ) );
+	}, [ dispatch, setUnassignDialog ] );
 
 	return (
 		<div className="license-details__actions">
@@ -52,12 +64,27 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
+			{ licenseState === LicenseState.Attached && (
+				<Button onClick={ openUnassignDialog } scary>
+					{ translate( 'Unassign License' ) }
+				</Button>
+			) }
+
 			{ revokeDialog && (
 				<RevokeLicenseDialog
 					licenseKey={ licenseKey }
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
+				/>
+			) }
+
+			{ unassignDialog && (
+				<UnassignLicenseDialog
+					licenseKey={ licenseKey }
+					product={ product }
+					siteUrl={ siteUrl }
+					onClose={ closeUnassignDialog }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -59,15 +59,16 @@ export default function LicenseDetailsActions( {
 			) }
 
 			{ licenseState === LicenseState.Detached && (
-				<Button href={ addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' ) }>
+				<Button
+					className="license-details__assign-button"
+					href={ addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' ) }
+				>
 					{ translate( 'Assign License' ) }
 				</Button>
 			) }
 
 			{ licenseState === LicenseState.Attached && (
-				<Button onClick={ openUnassignDialog } scary>
-					{ translate( 'Unassign License' ) }
-				</Button>
+				<Button onClick={ openUnassignDialog }>{ translate( 'Unassign License' ) }</Button>
 			) }
 
 			{ revokeDialog && (

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -1,7 +1,6 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-$action-assign: 2;
 
 .license-details {
 	margin: 0;
@@ -69,11 +68,11 @@ $action-assign: 2;
 		display: flex;
 		flex-direction: row-reverse;
 		justify-content: space-between;
+	}
 
-		@include break-large {
-			> *:nth-child(#{$action-assign}) {
-				display: none;
-			}
+	&__assign-button {
+		@include break-xlarge {
+			display: none;
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -77,7 +77,7 @@ export default function RevokeLicenseDialog( {
 				&nbsp;
 				<a
 					className="revoke-license-dialog__learn-more"
-					href="https://github.com/Automattic/jetpack-licensing-api/tree/master/integration-docs#glossary"
+					href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/"
 					target="_blank"
 					rel="noreferrer noopener"
 				>

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -84,7 +84,7 @@ export default function UnassignLicenseDialog( {
 				&nbsp;
 				<a
 					className="unassign-license-dialog__learn-more"
-					href="https://github.com/Automattic/jetpack-licensing-api/tree/master/integration-docs#glossary"
+					href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/"
 					target="_blank"
 					rel="noreferrer noopener"
 				>

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -71,8 +71,19 @@ export default function UnassignLicenseDialog( {
 				{ translate( 'Are you sure you want to unassign this license?' ) }
 			</h2>
 			<p>
+				<strong>{ licenseKey }</strong>
+			</p>
+			<p>
+				{ translate( 'Unassigning this license means that the site' ) }
+				&nbsp;
+				{ siteUrl && <strong>{ siteUrl }</strong> }
+				&nbsp;
+				{ translate( 'will no longer have access to' ) }
+				&nbsp;
+				<strong>{ product }.</strong>
+				&nbsp;
 				{ translate(
-					'A unassigned license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
+					'Once this action is completed, you will be able to assign the license to another site. You will continue to be billed.'
 				) }
 				&nbsp;
 				<a
@@ -85,24 +96,6 @@ export default function UnassignLicenseDialog( {
 					&nbsp;
 					<Gridicon icon="external" size={ 18 } />
 				</a>
-			</p>
-			<ul>
-				{ siteUrl && (
-					<li>
-						<strong>{ translate( 'Site:' ) }</strong> { siteUrl }
-					</li>
-				) }
-				<li>
-					<strong>{ translate( 'Product:' ) }</strong> { product }
-				</li>
-				<li>
-					<strong>{ translate( 'License:' ) }</strong> <code>{ licenseKey }</code>
-				</li>
-			</ul>
-			<p className="unassign-license-dialog__warning">
-				<Gridicon icon="info-outline" size={ 18 } />
-
-				{ translate( 'Please note this action cannot be undone.' ) }
 			</p>
 		</Dialog>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -74,16 +74,12 @@ export default function UnassignLicenseDialog( {
 				<strong>{ licenseKey }</strong>
 			</p>
 			<p>
-				{ translate( 'Unassigning this license means that the site' ) }
-				&nbsp;
-				{ siteUrl && <strong>{ siteUrl }</strong> }
-				&nbsp;
-				{ translate( 'will no longer have access to' ) }
-				&nbsp;
-				<strong>{ product }.</strong>
-				&nbsp;
 				{ translate(
-					'Once this action is completed, you will be able to assign the license to another site. You will continue to be billed.'
+					'Unassigning this license means that the site {{bold}}%(siteUrl)s{{/bold}} will no longer have access to {{bold}}%(product)s{{/bold}}. Once this action is completed, you will be able to assign the license to another site. You will continue to be billed.',
+					{
+						components: { bold: <strong /> },
+						args: { siteUrl, product },
+					}
 				) }
 				&nbsp;
 				<a

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -1,0 +1,109 @@
+import { Button, Dialog, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
+import useUnassignLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-unassign-license-mutation';
+import './style.scss';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	siteUrl: string | null;
+	onClose: ( action?: string ) => void;
+}
+
+export default function UnassignLicenseDialog( {
+	licenseKey,
+	product,
+	siteUrl,
+	onClose,
+	...rest
+}: Props ): ReactElement {
+	let close = noop;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const refreshLicenceList = useRefreshLicenseList( LicenseListContext );
+	const mutation = useUnassignLicenseMutation( {
+		onSuccess: () => {
+			close();
+			dispatch( refreshLicenceList() );
+		},
+		onError: ( error: Error ) => {
+			dispatch( errorNotice( error.message ) );
+		},
+	} );
+
+	close = useCallback( () => {
+		if ( ! mutation.isLoading ) {
+			onClose();
+		}
+	}, [ onClose, mutation.isLoading ] );
+
+	const unassign = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_unassign_dialog_unassign' ) );
+		mutation.mutate( { licenseKey } );
+	}, [ licenseKey, mutation.mutate ] );
+
+	const buttons = [
+		<Button disabled={ false } onClick={ close }>
+			{ translate( 'Go back' ) }
+		</Button>,
+
+		<Button primary scary busy={ mutation.isLoading } onClick={ unassign }>
+			{ translate( 'Unassign License' ) }
+		</Button>,
+	];
+
+	return (
+		<Dialog
+			isVisible={ true }
+			buttons={ buttons }
+			additionalClassNames="unassign-license-dialog"
+			onClose={ close }
+			{ ...rest }
+		>
+			<h2 className="unassign-license-dialog__heading">
+				{ translate( 'Are you sure you want to unassign this license?' ) }
+			</h2>
+			<p>
+				{ translate(
+					'A unassigned license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
+				) }
+				&nbsp;
+				<a
+					className="unassign-license-dialog__learn-more"
+					href="https://github.com/Automattic/jetpack-licensing-api/tree/master/integration-docs#glossary"
+					target="_blank"
+					rel="noreferrer noopener"
+				>
+					{ translate( 'Learn more about unassigning licenses' ) }
+					&nbsp;
+					<Gridicon icon="external" size={ 18 } />
+				</a>
+			</p>
+			<ul>
+				{ siteUrl && (
+					<li>
+						<strong>{ translate( 'Site:' ) }</strong> { siteUrl }
+					</li>
+				) }
+				<li>
+					<strong>{ translate( 'Product:' ) }</strong> { product }
+				</li>
+				<li>
+					<strong>{ translate( 'License:' ) }</strong> <code>{ licenseKey }</code>
+				</li>
+			</ul>
+			<p className="unassign-license-dialog__warning">
+				<Gridicon icon="info-outline" size={ 18 } />
+
+				{ translate( 'Please note this action cannot be undone.' ) }
+			</p>
+		</Dialog>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
@@ -1,0 +1,67 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.unassign-license-dialog {
+	.dialog__content {
+		max-width: 628px;
+
+		&, & p {
+			font-size: 1rem;
+		}
+	}
+
+	.dialog__action-buttons {
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		background: var( --studio-gray-0 );
+		border: 0;
+
+		a {
+			margin-right: auto;
+			font-weight: 600;
+			text-decoration: underline;
+		}
+	}
+
+	&__heading {
+		margin: -16px -16px 16px;
+		padding: 9px 16px;
+		font-size: 1.125rem; /* stylelint-disable */
+		font-weight: 600;
+		line-height: 20px;
+		color: var( --studio-red-60 );
+		border-bottom: 1px solid var( --studio-gray-5 );
+
+		@include break-mobile() {
+			margin: -24px -24px 24px;
+			padding: 9px 24px;
+			line-height: 36px;
+		}
+	}
+
+	&__warning {
+		font-weight: 500;
+		color: var( --studio-red-60 );
+
+		.gridicon {
+			position: relative;
+			top: 2px;
+			margin-right: 7px;
+		}
+	}
+
+	&__learn-more {
+		text-decoration: underline;
+	}
+
+	ul {
+		margin-left: 39px;
+		font-weight: 600;
+		line-height: 30px;
+
+		code {
+			font-size: 0.875rem;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
@@ -30,24 +30,13 @@
 		font-size: 1.125rem; /* stylelint-disable */
 		font-weight: 600;
 		line-height: 20px;
-		color: var( --studio-red-60 );
+		color: var( --color-text );
 		border-bottom: 1px solid var( --studio-gray-5 );
 
 		@include break-mobile() {
 			margin: -24px -24px 24px;
 			padding: 9px 24px;
 			line-height: 36px;
-		}
-	}
-
-	&__warning {
-		font-weight: 500;
-		color: var( --studio-red-60 );
-
-		.gridicon {
-			position: relative;
-			top: 2px;
-			margin-right: 7px;
 		}
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
@@ -2,8 +2,29 @@
 @import '@wordpress/base-styles/_mixins.scss';
 
 .unassign-license-dialog {
+	&.dialog.card {
+		max-height: 100vh;
+		max-width: 100vh;
+		margin: 0;
+		align-self: stretch;
+
+
+		@include break-small {
+			max-height: 90%;
+			max-width: 90%;
+			margin: auto 0;
+			align-self: center;
+		}
+	}
+
 	.dialog__content {
 		max-width: 628px;
+		align-self: stretch;
+		height: 100%;
+
+		@include break-small {
+			align-self: center;
+		}
 
 		&, & p {
 			font-size: 1rem;
@@ -13,30 +34,65 @@
 	.dialog__action-buttons {
 		display: flex;
 		justify-content: flex-end;
-		align-items: center;
+		align-items: stretch;
 		background: var( --studio-gray-0 );
 		border: 0;
+		padding: 12px 24px;
 
 		a {
 			margin-right: auto;
 			font-weight: 600;
 			text-decoration: underline;
 		}
+
+		.button {
+			margin-bottom: 16px;
+		}
+
+		/**
+		 * .dialog__action-buttons has flex-direction to column-reverse on mobile
+		 * so with this the button on the bottom has no margin on the bottom,
+		 * but it is the first element on the tree
+		 **/
+		.button:first-child {
+			margin-bottom: 0;
+		}
+
+		@include break-mobile {
+			.button {
+				margin-bottom: 0;
+				margin-left: 10px;
+			}
+		}
+
+
+		@include break-small {
+			align-items: center;
+		}
 	}
 
 	&__heading {
 		margin: -16px -16px 16px;
-		padding: 9px 16px;
+		padding: 24px;
 		font-size: 1.125rem; /* stylelint-disable */
 		font-weight: 600;
 		line-height: 20px;
-		color: var( --color-text );
+		color: var( --studio-gray-60 );
 		border-bottom: 1px solid var( --studio-gray-5 );
 
-		@include break-mobile() {
+		@include break-mobile {
 			margin: -24px -24px 24px;
-			padding: 9px 24px;
-			line-height: 36px;
+		}
+	}
+
+	&__warning {
+		font-weight: 500;
+		color: var( --studio-red-60 );
+
+		.gridicon {
+			position: relative;
+			top: 2px;
+			margin-right: 7px;
 		}
 	}
 

--- a/client/state/partner-portal/licenses/hooks/use-unassign-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-unassign-license-mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from 'react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import { APILicense } from 'calypso/state/partner-portal/types';
+
+interface MutationUnassignLicenseVariables {
+	licenseKey: string;
+}
+
+function mutationUnassignLicense( {
+	licenseKey,
+}: MutationUnassignLicenseVariables ): Promise< APILicense > {
+	return wpcomJpl.req.post( {
+		method: 'DELETE',
+		apiNamespace: 'wpcom/v2',
+		path: `/jetpack-licensing/license/${ licenseKey }/site`,
+		body: { license_key: licenseKey },
+	} );
+}
+
+export default function useUnassignLicenseMutation< TContext = unknown >(
+	options?: UseMutationOptions< APILicense, Error, MutationUnassignLicenseVariables, TContext >
+): UseMutationResult< APILicense, Error, MutationUnassignLicenseVariables, TContext > {
+	return useMutation< APILicense, Error, MutationUnassignLicenseVariables, TContext >(
+		mutationUnassignLicense,
+		options
+	);
+}


### PR DESCRIPTION
#### Proposed Changes

* Licensing Portal: add the possibility to unassign a license from a site. Thus the users can unlinking a license from a specific site and reuse it on another site.

#### Testing Instructions

* Make sure you have a wordpress.com website.
* Open up Licensing -> Licenses.
* Issue a new license, if don't have one.
* Open some license details. If this license is not assigned to some site, please do it.
* The "Unassign License" button should appear on the bottom left corner.
* Click on the "Unassign License" button. An alert modal should appear with information about this action and ask for you to confirm that want to unassign that license from the site.

#### Screenshots
![image](https://user-images.githubusercontent.com/5550190/182459485-440f2cba-f413-4b78-805b-578d499e2e20.png)

![image](https://user-images.githubusercontent.com/5550190/182459596-5a93412e-a2c0-48aa-b1e3-ae2b241f43dd.png)


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have you sent any new strings for translation (PCYsg-1vr-p2) ASAP?

Related to #
