### PR TITLE
Fix GlobalNotices position on mobile

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -4,15 +4,14 @@
 
 	z-index: z-index( 'root', '.global-notices' );
 	position: fixed;
-	top: auto;
+	top: var( --masterbar-height );
 	right: 0;
-	bottom: 0;
+	bottom: auto;
 	left: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		top: calc( var( --masterbar-height ) + 16px );
 		right: 16px;
-		bottom: auto;
 		left: auto;
 		max-width: calc( 100% - 32px );
 	}


### PR DESCRIPTION
The GlobalNotices component on mobile used to appear fixed at the bottom of the screen. This behavior was making it overlay some buttons.

#### Proposed Changes

* This PR moves GlobalNotices to the top of the page below the main header on mobile

#### Testing Instructions

* Make sure you have a wordpress.com website.
* Open up Licensing -> Licenses.
* You need to get an error message error to show GlobalNotices. You can follow these steps to get one error message.
    * Issue a license, if you don't have one.
    * Assign this license to a site.
    * Try to create a license of the same product as the previous license and assign it to the same site. 
    * You should see an error message like this: "The site already has the same product".
* The GlobalNotices component should appear on the top of the screen below the main header

#### Screenshots

![image](https://user-images.githubusercontent.com/6406071/182713041-0f531e09-ef06-4626-8244-52a3bf689e68.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
