### PR TITLE
Unified Design Picker: Theme Preview recognizes individual premium theme purchases

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -14,10 +14,13 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -27,6 +30,7 @@ import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import PreviewToolbar from './preview-toolbar';
 import UpgradeModal from './upgrade-modal';
+import getThemeIdFromDesign from './util/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
 import type { Design } from '@automattic/design-picker';
@@ -74,6 +78,15 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			( select ) =>
 				site && select( SITE_STORE ).siteHasFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
 		)
+	);
+
+	useQuerySitePurchases( site ? site.ID : -1 );
+
+	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
+	const didPurchaseSelectedTheme = useSelector( ( state ) =>
+		site && selectedDesignThemeId
+			? isThemePurchased( state, selectedDesignThemeId, site.ID )
+			: false
 	);
 
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
@@ -258,7 +271,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		const headerDesignTitle = (
 			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
 		);
-		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
+		const shouldUpgrade =
+			selectedDesign.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme;
 		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview
 		const shouldCustomizeText = intent === SiteIntent.Write || intent === SiteIntent.Sell;
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/util/get-theme-id-from-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/util/get-theme-id-from-design.tsx
@@ -1,0 +1,13 @@
+import type { Design } from '@automattic/design-picker';
+
+const getThemeIdFromDesign = ( design: Design ) => {
+	const stylesheet = design?.recipe?.stylesheet;
+	if ( stylesheet ) {
+		// Transform stylesheet "premium/skivers" into themeId "skivers"
+		const slashIndex = stylesheet.lastIndexOf( '/' );
+		const themeId = stylesheet.substring( slashIndex + 1 );
+		return themeId;
+	}
+	return null;
+};
+export default getThemeIdFromDesign;


### PR DESCRIPTION
#### Proposed Changes

* When using the Unified Design Picker and previewing an individual premium theme, check to see if that theme has been purchased when deciding to display the "Unlock <ThemeName>" button

**Current behavior**
![2022-08-03_16-06](https://user-images.githubusercontent.com/937354/182713672-c255bcfb-8ac9-49a0-aa2e-135c6b9665d2.png)

**With this PR**
![2022-08-03_16-11](https://user-images.githubusercontent.com/937354/182713716-c87f7a07-bcd1-447b-b8ed-1461456ed712.png)


#### Testing Instructions

* Have a free site with an individual premium theme purchased
* Go to `/setup/designSetup?siteSlug=<SITE_SLUG>&flags=signup/seller-upgrade-modal` (note the flag)
* Find a Premium theme you have purchased, and click on it to preview
* The top right button should say "Start with ThemeName" and not "Unlock"
* Click back, and this time click on a Premium theme you have not purchased
* The top right button should continue to say "Unlock"


Related to #65857 #66187
