### PR TITLE
Checkout: use formatCurrency directly in term variant picker

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -1,8 +1,8 @@
+import formatCurrency from '@automattic/format-currency';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { myFormatCurrency } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
@@ -100,9 +100,11 @@ export const ItemVariantPrice: FunctionComponent< {
 	const discountPercentage = compareToPriceForVariantTerm
 		? Math.floor( 100 - ( variant.price / compareToPriceForVariantTerm ) * 100 )
 		: 0;
-	const formattedCurrentPrice = myFormatCurrency( variant.price, variant.currency );
+	const formattedCurrentPrice = formatCurrency( variant.price, variant.currency, {
+		stripZeros: true,
+	} );
 	const formattedCompareToPriceForVariantTerm = compareToPriceForVariantTerm
-		? myFormatCurrency( compareToPriceForVariantTerm, variant.currency )
+		? formatCurrency( compareToPriceForVariantTerm, variant.currency, { stripZeros: true } )
 		: undefined;
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -13,7 +13,6 @@ import {
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
-import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useCallback } from 'react';
@@ -27,22 +26,6 @@ import type { Plan, Product } from '@automattic/calypso-products';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
-
-export function myFormatCurrency( price: number, code: string, options = {} ): string {
-	const precision = CURRENCIES[ code ].precision;
-	const EPSILON = Math.pow( 10, -precision ) - 0.000000001;
-
-	const hasCents = Math.abs( price % 1 ) >= EPSILON;
-	const formatted = formatCurrency(
-		price,
-		code,
-		hasCents ? options : { ...options, precision: 0 }
-	);
-	if ( ! formatted ) {
-		throw new Error( `Failed to format price '${ price }' in currency '${ code }'` );
-	}
-	return formatted;
-}
 
 export interface AvailableProductVariant {
 	planSlug: string;


### PR DESCRIPTION
#### Proposed Changes

The code that prints the item variant prices in the checkout term variant picker uses the `@automattic/format-currency` package. It has code that will hide the formatted price's decimal places if the decimal places are zero. However, this code is risky because it operates by overriding the configuration for the number of decimal places used by the currency.

This PR changes the term variant picker to use the `stripZeros` option instead, which should have the same effect without as much complexity.

Here's some screenshots; they should be the same before and after this change.

Variant picker without decimals:

<img width="566" alt="Screen Shot 2022-08-03 at 5 38 23 PM" src="https://user-images.githubusercontent.com/2036909/182717434-885c2bb2-2431-427d-9294-51092fbf50df.png">

Variant picker with decimals:

<img width="560" alt="Screen Shot 2022-08-03 at 5 39 53 PM" src="https://user-images.githubusercontent.com/2036909/182717454-f447f149-4870-43a2-afc4-8973a8374d14.png">


#### Testing Instructions

- Add a product that has term variants to your shopping cart (eg: any legacy plan like Premium).
- Visit checkout and verify that the term variant picker shows the prices as it did before this change.