### PR TITLE
format-currency: Export named formatCurrency from format-currency package

### DIFF
--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -2,7 +2,14 @@
 
 A library for formatting currency.
 
-Exports two functions:
+Exports two functions, `formatCurrency` and `getCurrencyObject`.
+
+`formatCurrency` is also the default export so either of these imports will work:
+
+```
+import { formatCurrency } from '@automattic/format-currency';`
+import formatCurrency from '@automattic/format-currency';`
+```
 
 ## formatCurrency()
 

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -37,7 +37,7 @@ export * from './types';
  * @param      {FormatCurrencyOptions}    options    options object
  * @returns    {?string}                  A formatted string.
  */
-export default function formatCurrency(
+export function formatCurrency(
 	number: number,
 	code: string,
 	options: FormatCurrencyOptions = {}
@@ -150,3 +150,5 @@ function convertPriceForSmallestUnit( price: number, precision: number ): number
 function getSmallestUnitDivisor( precision: number ): number {
 	return 10 ** precision;
 }
+
+export default formatCurrency;


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/66175 which improved the documentation for the `@automattic/format-currency` package. In that documentation we mention two of the functions exported by the package. However, it's not clear that one is a named export and one is a default export. In this PR we export both functions by name so that they can both be used more easily.

#### Testing Instructions

None should be needed.