### PR TITLE
Theme Showcase: Improve cursor style consistency

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -158,6 +158,12 @@ $theme-info-height: 54px;
 	text-align: center;
 }
 
+.card.is-clickable {
+	.theme__upsell-popover {
+		cursor: pointer;
+	}
+}
+
 .theme__upsell-cta {
 	margin-top: 10px;
 }


### PR DESCRIPTION
#### Proposed Changes

* Minor change to mouse cursor CSS while mousing over the premium theme star in the theme showcase with the `signup/seller-upgrade-modal` flag on.
* The card belonging to the theme is clickable and changes your mouse cursor to a pointer.
  * The SVG of the premium theme icon also changes your mouse cursor to a pointer.
  * However, there's a "dead zone" just outside the SVG that turns your mouse cursor to default.
  * If you mouse over the card, your cursor turns to a pointer. Then as you approach the premium theme star, your cursor turns to default when it's really close, then it turns back to a pointer when you're over the star.
  * This PR changes it so there is no 'dead zone', your cursor is always a pointer.

**Before this PR: Mouse cursor changes when you are close to, but not over the star**

https://user-images.githubusercontent.com/937354/182721690-704fbf56-b326-4895-bbe0-a44836b565ce.mp4



**After this PR: Mouse cursor stays consistent inside the card**  


https://user-images.githubusercontent.com/937354/182721716-80735714-5f87-4db0-aaca-67668fd89694.mp4



#### Testing Instructions



* Visit `http://calypso.localhost:3000/themes/premium/SITENAME?flags=signup/seller-upgrade-modal`
* Mouse over the card and premium theme star and verify this is an improvement
* Also ensure I didn't break anything while the flag is off (or maybe in other contexts)
