### PR TITLE
Launchpad: Add simple checklist

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -33,6 +33,7 @@ export { default as difmStartingPoint } from './difm-starting-point';
 export { default as letsGetStarted } from './lets-get-started';
 export { default as intro } from './intro';
 export { default as chooseADomain } from './choose-a-domain';
+export { default as launchpad } from './launchpad';
 
 export type StepPath =
 	| 'courses'
@@ -69,4 +70,5 @@ export type StepPath =
 	| 'difmStartingPoint'
 	| 'letsGetStarted'
 	| 'chooseADomain'
-	| 'intro';
+	| 'intro'
+	| 'launchpad';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,0 +1,58 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+// import './style.scss';
+
+function PlaceHolderChecklist() {
+	return (
+		<ul style={ { textAlign: 'center' } }>
+			<li>Item 1</li>
+			<li>Item 2</li>
+			<li>Item 3</li>
+			<li>Item 4</li>
+		</ul>
+	);
+}
+
+function PlaceHolderPreview() {
+	return <div style={ { textAlign: 'center' } }>Preview here</div>;
+}
+
+const Launchpad: Step = ( { navigation } ) => {
+	const translate = useTranslate();
+	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
+
+	// TODO: Replace inline styling with classname and scss styling
+	const stepContent = (
+		<div style={ { display: 'flex', flexDirection: 'column', justifyContent: 'center' } }>
+			<PlaceHolderChecklist />
+			<PlaceHolderPreview />
+		</div>
+	);
+
+	return (
+		<>
+			<DocumentHead title={ almostReadyToLaunchText } />
+			<StepContainer
+				stepName={ 'launchpad' }
+				goNext={ navigation.goNext }
+				skipLabelText={ translate( 'Go to Admin' ) }
+				skipButtonAlign={ 'top' }
+				hideBack={ true }
+				stepContent={ stepContent }
+				formattedHeader={
+					<FormattedHeader
+						id={ 'launchpad-header' }
+						headerText={ <>{ almostReadyToLaunchText }</> }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default Launchpad;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -3,33 +3,41 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import LaunchpadList from './list';
+import LaunchpadPreview from './preview';
 import type { Step } from '../../types';
-// import './style.scss';
 
-function PlaceHolderChecklist() {
-	return (
-		<ul style={ { textAlign: 'center' } }>
-			<li>Item 1</li>
-			<li>Item 2</li>
-			<li>Item 3</li>
-			<li>Item 4</li>
-		</ul>
-	);
-}
+import './style.scss';
 
-function PlaceHolderPreview() {
-	return <div style={ { textAlign: 'center' } }>Preview here</div>;
-}
+const tasks = [
+	{
+		id: 101,
+		isCompleted: true,
+		linkTo: '#',
+		title: 'Free Plan',
+	},
+	{
+		id: 102,
+		isCompleted: true,
+		linkTo: '#',
+		title: 'Set up Newsletter',
+	},
+	{
+		id: 103,
+		isCompleted: false,
+		linkTo: '#',
+		title: 'Add Subscribers',
+	},
+];
 
 const Launchpad: Step = ( { navigation } ) => {
 	const translate = useTranslate();
-	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
+	const almostReadyToLaunchText = translate( 'Voilà! Your Newsletter is up and running' );
 
-	// TODO: Replace inline styling with classname and scss styling
 	const stepContent = (
-		<div style={ { display: 'flex', flexDirection: 'column', justifyContent: 'center' } }>
-			<PlaceHolderChecklist />
-			<PlaceHolderPreview />
+		<div className="launchpad">
+			<LaunchpadList tasks={ tasks } />
+			<LaunchpadPreview />
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/list-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/list-item.tsx
@@ -1,0 +1,40 @@
+import { Gridicon } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+
+interface Props {
+	isCompleted: boolean;
+	linkTo: string;
+	id: number;
+	title: string;
+}
+
+const LaunchpadListItem = ( { isCompleted, id, linkTo, title }: Props ) => (
+	<li className={ `launchpad__task-${ id }` }>
+		<button
+			className="launchpad__list-item"
+			onClick={ () => console.log( `navigate to ${ linkTo }` ) } // eslint-disable-line
+			data-task={ id }
+		>
+			<div className="launchpad__list-item-status">
+				{ isCompleted ? (
+					<Gridicon
+						aria-label={ translate( 'Task complete' ) }
+						className="launchpad__list-item-status-complete"
+						icon="checkmark"
+						size={ 18 }
+					/>
+				) : (
+					<div
+						role="img"
+						aria-label={ translate( 'Task incomplete' ) }
+						className="launchpad__list-item-status-pending"
+					/>
+				) }
+			</div>
+			<p className={ `launchpad__list-item-text ${ isCompleted && 'completed' }` }>{ title }</p>
+			<Gridicon className="launchpad__list-item-chevron" icon="chevron-right" size={ 18 } />
+		</button>
+	</li>
+);
+
+export default LaunchpadListItem;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/list.tsx
@@ -1,0 +1,33 @@
+import LaunchpadListItem from './list-item';
+
+type Task = {
+	id: number;
+	isCompleted: boolean;
+	linkTo: string;
+	title: string;
+};
+
+interface Props {
+	tasks: Task[];
+}
+
+const LaunchpadList = ( { tasks }: Props ) => (
+	<ul
+		className="launchpad__list"
+		role="tablist"
+		aria-label="Launchpad Checklist"
+		aria-orientation="vertical"
+	>
+		{ tasks.map( ( task ) => (
+			<LaunchpadListItem
+				key={ task.id }
+				id={ task.id }
+				title={ task.title }
+				isCompleted={ task.isCompleted }
+				linkTo={ task.linkTo }
+			/>
+		) ) }
+	</ul>
+);
+
+export default LaunchpadList;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/preview.tsx
@@ -1,0 +1,3 @@
+const LaunchpadPreview = () => <div className="launchpad__preview">Preview here</div>;
+
+export default LaunchpadPreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -1,0 +1,87 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.launchpad {
+	display: 'flex';
+	flex-direction: 'column';
+	justify-content: 'center';
+}
+
+.launchpad__list {
+	list-style: none;
+	margin: 20px auto;
+	max-width: 98%;
+	padding: 0;
+	width: 500px;
+	li {
+		border-bottom: 1px solid var( --color-border-subtle );
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+}
+
+.launchpad__list-item {
+	align-items: center;
+	display: flex;
+	padding: 16px;
+	transition: all 0.1s;
+	cursor: pointer;
+	width: 100%;
+	margin: 0;
+	color: var( --color-text );
+
+	@include breakpoint-deprecated( '>660px' ) {
+		padding: 16px 24px;
+	}
+
+	&:focus-visible {
+		box-shadow: inset 0 0 0 2px var( --color-primary );
+	}
+}
+
+.launchpad__list-item-status {
+	margin-right: 8px;
+	width: 20px;
+}
+
+.launchpad__list-item-status-pending {
+	border: 1px solid var( --studio-gray-10 );
+	// Using percentage because we're drawing a circle in CSS
+	// stylelint-disable-next-line declaration-property-unit-allowed-list
+	border-radius: 50%;
+	box-sizing: border-box;
+	display: block;
+	height: 12px;
+	margin: 5px;
+	transition: all 0.1s;
+	width: 12px;
+}
+
+.launchpad__list-item-status-complete {
+	fill: var( --color-success );
+	vertical-align: text-bottom;
+}
+
+.launchpad__list-item-text {
+	display: flex;
+	flex-grow: 1;
+	font-size: 1rem;
+	line-height: 20px;
+	text-align: left;
+	font-weight: 600;
+	&.completed {
+		font-weight: 400;
+	}
+}
+
+.launchpad__list-item-chevron {
+	display: flex;
+	line-height: 20px;
+	text-align: left;
+	width: 30px;
+}
+
+.launchpad__preview {
+	text-align: center;
+}

--- a/client/landing/stepper/declarative-flow/newsletters.ts
+++ b/client/landing/stepper/declarative-flow/newsletters.ts
@@ -10,7 +10,7 @@ export const newsletters: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro' ] as StepPath[];
+		return [ 'intro', 'launchpad' ] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -37,6 +37,7 @@ export const siteSetupFlow: Flow = {
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 
 		return [
+			'launchpad',
 			...( isEnabled( 'signup/goals-step' ) && isEnabledFTM ? [ 'goals' ] : [] ),
 			...( isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM ? [ 'vertical' ] : [] ),
 			'intent',

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -37,7 +37,6 @@ export const siteSetupFlow: Flow = {
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 
 		return [
-			'launchpad',
 			...( isEnabled( 'signup/goals-step' ) && isEnabledFTM ? [ 'goals' ] : [] ),
 			...( isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM ? [ 'vertical' ] : [] ),
 			'intent',


### PR DESCRIPTION
### Proposed Changes

Note: This is an experimental draft. 

Forked from trial branch that sets up full screen Launchpad within stepper (https://github.com/Automattic/wp-calypso/pull/66194). Added a simple checklist component with checklist items. Current state looks like this. 

<img width="1451" alt="Screenshot on 2022-08-03 at 16-40-32" src="https://user-images.githubusercontent.com/21228350/182724686-2e85a399-8e2c-41c6-b989-74492737dee2.png">

### Testing Instructions

* Check out this PR
* Navigate to the calypso repo in a terminal
* Run `yarn` and `yarn start`
* Open http://calypso.localhost:3000/setup/launchpad?flow=newsletters