### PR TITLE
Jetpack Scan: Add Support For WordPress Core Threat Type

### DIFF
--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -26,11 +26,16 @@ const severityClassNames = ( severity: number ) => {
 // This should be temporary since this data should be coming from the api
 // and not something that we should change to accommodate the results.
 const getThreatMessage = ( threat: Threat ) => {
-	const { filename, extension = { slug: 'unknown', version: 'n/a' } } = threat;
+	const { filename, extension = { slug: 'unknown', version: 'n/a' }, version } = threat;
 	const basename = filename ? filename.replace( /.*\//, '' ) : '';
 
 	switch ( getThreatType( threat ) ) {
 		case 'core':
+			return translate( 'Vulnerable WordPress version: %s', {
+				args: [ version ],
+			} );
+
+		case 'core_file':
 			return translate( 'Infected core file: %s', {
 				args: [ basename ],
 			} );

--- a/client/components/jetpack/threat-item/types.tsx
+++ b/client/components/jetpack/threat-item/types.tsx
@@ -36,6 +36,7 @@ export interface BaseThreat {
 	context?: Record< string, unknown >;
 	severity: number;
 	source?: string;
+	version?: string;
 }
 
 export interface FixableThreat extends BaseThreat {

--- a/client/components/jetpack/threat-item/utils.ts
+++ b/client/components/jetpack/threat-item/utils.ts
@@ -25,11 +25,16 @@ export const getThreatSignatureComponents = ( threat: Threat ): SignatureCompone
 // This should be temporary since this data should be coming from the api
 // and not something that we should change to accommodate the results.
 export const getThreatMessage = ( threat: Threat ): string | TranslateResult => {
-	const { filename, extension = { slug: 'unknown', version: 'n/a' } } = threat;
+	const { filename, extension = { slug: 'unknown', version: 'n/a' }, version } = threat;
 	const basename = filename ? filename.replace( /.*\//, '' ) : '';
 
 	switch ( getThreatType( threat ) ) {
 		case 'core':
+			return translate( 'The installed version of WordPress (%s) has a known vulnerability.', {
+				args: [ version ],
+			} );
+
+		case 'core_file':
 			return translate( 'Compromised WordPress core file: %s', {
 				args: [ basename ],
 			} );
@@ -81,7 +86,7 @@ export function getThreatType( threat: Threat ): ThreatType {
 	// We can't use `hasOwnProperty` here to test these conditions because
 	// the object might contains those keys with an undefined value
 	if ( threat.diff !== undefined ) {
-		return 'core';
+		return 'core_file';
 	}
 
 	if ( threat.context !== undefined ) {
@@ -102,12 +107,17 @@ export function getThreatType( threat: Threat ): ThreatType {
 		return 'database';
 	}
 
+	if ( 'Vulnerable.WP.Core' === threat.signature ) {
+		return 'core';
+	}
+
 	return 'none';
 }
 
 export const getThreatVulnerability = ( threat: Threat ): string | TranslateResult => {
 	switch ( getThreatType( threat ) ) {
 		case 'core':
+		case 'core_file':
 			return translate( 'Vulnerability found in WordPress' );
 
 		case 'file':

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -33,6 +33,7 @@ export const formatScanThreat = ( threat ) => ( {
 	context: threat.context,
 	severity: threat.severity,
 	source: threat.source,
+	version: threat.version,
 } );
 
 /**


### PR DESCRIPTION
This PR adds support to Jetpack Scan to display the recently added "Vulnerable.WP.Core" threat type.

#### Proposed Changes

* Includes the `version` property when loading threats from the Scan API.
* Adds distinction between `core` and `core_file` threats.
* Updates threat descriptions for vulnerable WordPress core threats.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a "Vulnerable.WP.Core" threat to your test site following the instructions in jetpack-backups-3762.
* Validate the threat is displayed correctly according to the screenshots below.
* Validate that infected core file threats are not affected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshots

Before:

<img width="736" alt="Screen Shot 2022-12-18 at 11 37 41 AM" src="https://user-images.githubusercontent.com/10933065/208314477-0757b1ad-e9d5-4bee-bf09-de4e7670e6b3.png">

After:

<img width="740" alt="Screen Shot 2022-12-18 at 11 51 41 AM" src="https://user-images.githubusercontent.com/10933065/208314480-bdaf1392-9b06-48b6-ba57-ab85087b7629.png">

