### PR TITLE
Implementing A/B test on the domains step.

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,11 +1,33 @@
 import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 class ReskinSideExplainer extends Component {
+	_isMounted = false;
+	constructor( props ) {
+		super( props );
+		this.state = {
+			experiment: null,
+		};
+	}
+	componentDidMount() {
+		this._isMounted = true;
+
+		loadExperimentAssignment( 'domain_step_cta_copy_test' ).then( ( experimentName ) => {
+			if ( this._isMounted ) {
+				this.setState( { experiment: experimentName } );
+			}
+		} );
+	}
+
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
 	getStrings() {
 		const { type, translate } = this.props;
 
@@ -74,9 +96,10 @@ class ReskinSideExplainer extends Component {
 				}
 
 				ctaText =
-					i18n.hasTranslation( 'Choose my domain later' ) || isEnLocale
-						? translate( 'Choose my domain later' )
-						: false;
+					this.state.experiment?.variationName === 'treatment'
+						? translate( 'View plans' )
+						: translate( 'Choose my domain later' );
+
 				break;
 
 			case 'use-your-domain':

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,4 +1,4 @@
-import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
@@ -36,7 +36,6 @@ class ReskinSideExplainer extends Component {
 		let paidTitle;
 		let subtitle;
 		let freeSubtitle;
-		let hasFreeSubtitle;
 		let paidSubtitle;
 		let subtitle2;
 		let ctaText;
@@ -50,8 +49,6 @@ class ReskinSideExplainer extends Component {
 			'ecommerce',
 			'domain',
 		].includes( this.props.flowName );
-
-		const isEnLocale = [ 'en', 'en-gb' ].includes( getLocaleSlug() );
 
 		switch ( type ) {
 			case 'free-domain-explainer':
@@ -71,24 +68,23 @@ class ReskinSideExplainer extends Component {
 
 				title = isPaidPlan ? paidTitle : freeTitle;
 
-				hasFreeSubtitle =
-					i18n.hasTranslation(
-						'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
-					) || isEnLocale;
-
-				freeSubtitle = hasFreeSubtitle
-					? translate(
-							'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
-					  )
-					: null;
+				freeSubtitle =
+					this.state.experiment?.variationName === 'treatment'
+						? translate( 'You can claim your free custom domain later if you aren’t ready yet.' )
+						: translate(
+								'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
+						  );
 
 				paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
 
 				subtitle = isPaidPlan ? paidSubtitle : freeSubtitle;
 
-				subtitle2 = translate(
-					'We’ll pay the first year’s domain registration fees for you, simple as that!'
-				);
+				subtitle2 =
+					this.state.experiment?.variationName === 'treatment'
+						? null
+						: translate(
+								'We’ll pay the first year’s domain registration fees for you, simple as that!'
+						  );
 
 				if ( ! subtitle ) {
 					subtitle = subtitle2;


### PR DESCRIPTION
#### Proposed Changes

* This PR implements an A/B test for the CTA and body copy in the Skip section of the Domain step. Additional context for this test is available at p58i-cJS-p2#comment-54846

Here's a screenshot of the page (with a green arrow pointing to the text that will be tested):
![CleanShot 2022-08-03 at 20 37 55@2x](https://user-images.githubusercontent.com/35781181/182738593-56107218-32d1-41ab-af73-0566eb84d11d.png)

Control body copy:
> Use the search tool on this page to find a domain you love, then select any paid annual plan.
> 
> We’ll pay the first year’s domain registration fees for you, simple as that!

Variant body copy:
> You can claim your free custom domain later if you aren’t ready yet.

Control CTA: `Choose my domain later`
Variant CTA: `View plans`


The test is implemented using Explat with the test name `domain_step_cta_copy_test`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this PR and start Calypso locally.
- Navigate to the Explat page for test name `domain_step_cta_copy_test`.
- Assign yourself to the treatment variation (click link at the top of the Bookmarklet modal and assign your main username).
- If you have public-api sandboxed, ensure it's up-to-date.
- Navigate to startup in Calypso and confirm that the CTA says `Choose my domain later`.
- Assign yourself to the control variation and confirm that the CTA says `View plans`.
- Click the link and confirm that you're brought to the plans page.
