### PR TITLE
Tracking: Submit site vertical in English

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -44,6 +44,7 @@ const SelectVertical: React.FC< Props > = ( {
 	const mapOneSiteVerticalsResponseToVertical = ( vertical: SiteVerticalsResponse ): Vertical => ( {
 		value: vertical.id,
 		label: vertical.title,
+		name: vertical.name,
 		category: String( translate( 'Suggestions' ) ),
 	} );
 

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -111,9 +111,17 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		inputRef.current?.focus();
 	};
 
-	const handleSuggestionsSelect = ( { label, value }: { label: string; value?: string } ) => {
+	const handleSuggestionsSelect = ( {
+		name,
+		label,
+		value,
+	}: {
+		name: string;
+		label: string;
+		value?: string;
+	} ) => {
 		hideSuggestions();
-		onSelect?.( { label, value } as Vertical );
+		onSelect?.( { name, label, value } as Vertical );
 	};
 
 	const getSuggestions = useMemo( () => {
@@ -124,6 +132,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		return suggestions.concat( [
 			{
 				value: '',
+				name: 'Something else',
 				label: String( translate( 'Something else' ) ),
 				category: 0 < suggestions.length ? '—' : '',
 			},

--- a/client/components/select-vertical/types.ts
+++ b/client/components/select-vertical/types.ts
@@ -1,5 +1,6 @@
 export interface Vertical {
 	value: string;
 	label: string;
+	name: string;
 	category?: string;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -33,7 +33,7 @@ const SiteVerticalForm: React.FC< Props > = ( {
 		// Reset the vertical selection if input field is empty.
 		// This is so users don't need to explicitly select "Something else" to clear previous selection.
 		if ( value.trim().length === 0 ) {
-			onSelect?.( { value: '', label: '' } );
+			onSelect?.( { name: '', value: '', label: '' } );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -40,7 +40,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 		event.preventDefault();
 
 		if ( site ) {
-			const { value = '', label = '' } = vertical || {};
+			const { value = '', name = '' } = vertical || {};
 
 			setIsBusy( true );
 			await saveSiteSettings( site.ID, { site_vertical_id: value } );
@@ -48,7 +48,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
 				user_input: userInput,
 				vertical_id: value,
-				vertical_title: label,
+				vertical_title: name,
 			} );
 
 			setIsBusy( false );

--- a/packages/components/src/suggestions/index.tsx
+++ b/packages/components/src/suggestions/index.tsx
@@ -12,7 +12,7 @@ import './style.scss';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-type Suggestion = { label: string; category?: string };
+type Suggestion = { name: string; label: string; category?: string };
 
 type CategorizedSuggestions = {
 	category?: string;


### PR DESCRIPTION
## Proposed Changes

- `calypso_signup_site_vertical_submit` submit vertical title in English regardless current locale
- [Update](https://github.com/Automattic/wp-calypso/blob/8992f6237a564c63a6e7060e61c7753018909cf8/client/components/select-vertical/index.tsx#L47) `mapOneSiteVerticalsResponseToVertical` to return vertical name
- [Update](https://github.com/Automattic/wp-calypso/blob/8992f6237a564c63a6e7060e61c7753018909cf8/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx#L48) vertical submit event to the new prop 
- Update type for additional prop 

## Testing Instructions
### Set up.

Open your dev tools, go to the Network tab, and clear all entries so you can monitor new network activity.
In the search/filter box on the network tab, type t.gif. This will filter network activity so you can see events.
When making some actions, click on the request and navigate to Payload tab to check all the event parameters

### Expected

- Change wpcom locale to different language other than English (eg: French)
- Head to /vertical of the onboarding
- Select vertical and click Submit button
- Confirm the `calypso_signup_site_vertical_submit` 'vertical_title' is in English

https://user-images.githubusercontent.com/10071857/182769895-3bf9147b-c6d8-400c-84a9-75232b785c4c.mp4



Related to [Issue](https://github.com/Automattic/ganon-issues/issues/102)

