### PR TITLE
Update label on button that creates a new site

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,6 +1,5 @@
 import {
 	Button,
-	Gridicon,
 	SitesTableTabPanel,
 	useSitesTableFiltering,
 	useSitesTableSorting,
@@ -106,8 +105,7 @@ export function SitesDashboard( { queryParams: { search, status } }: SitesDashbo
 				<HeaderControls>
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>
 					<Button primary href="/start?source=sites-dashboard&ref=sites-dashboard">
-						<Gridicon icon="plus" />
-						<span>{ __( 'New site' ) }</span>
+						{ __( 'Add new site' ) }
 					</Button>
 				</HeaderControls>
 			</PageHeader>


### PR DESCRIPTION
#### Proposed Changes

Updates "+ New site" button label to "Add new site"

See pdKhl6-Au-p2#comment-498

**Before**

![CleanShot 2022-08-04 at 17 36 37@2x](https://user-images.githubusercontent.com/1500769/182770755-5ae9950a-d6ed-4428-931d-7a69d8b8b75d.png)


**After**

![CleanShot 2022-08-04 at 17 36 17@2x](https://user-images.githubusercontent.com/1500769/182770770-28f2bb68-2814-438d-9567-327c18949879.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/sites-dashboard`
