### PR TITLE
Fix Jetpack installation UX issues

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -46,6 +46,7 @@ export class OrgCredentialsForm extends Component {
 	state = {
 		username: '',
 		password: '',
+		isUnloading: false,
 	};
 
 	handleSubmit = ( event ) => {
@@ -72,6 +73,12 @@ export class OrgCredentialsForm extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_view', {
 			url: siteToConnect,
 		} );
+
+		window.addEventListener( 'beforeunload', this.beforeUnloadHandler );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'beforeunload', this.beforeUnloadHandler );
 	}
 
 	componentDidUpdate() {
@@ -258,12 +265,15 @@ export class OrgCredentialsForm extends Component {
 
 	formFooter() {
 		const { isRemoteInstalling } = this.props;
+		const { username, password, isUnloading } = this.state;
 		return (
 			<div className="jetpack-connect__creds-form-footer">
-				{ isRemoteInstalling && <Spinner className="jetpack-connect__creds-form-spinner" /> }
+				{ ( isRemoteInstalling || isUnloading ) && (
+					<Spinner className="jetpack-connect__creds-form-spinner" />
+				) }
 				<FormButton
 					className="jetpack-connect__credentials-submit"
-					disabled={ ! this.state.username || ! this.state.password || isRemoteInstalling }
+					disabled={ ! username || ! password || isRemoteInstalling || isUnloading }
 				>
 					{ this.renderButtonLabel() }
 				</FormButton>
@@ -278,6 +288,12 @@ export class OrgCredentialsForm extends Component {
 			return;
 		}
 		page.redirect( '/jetpack/connect' );
+	};
+
+	beforeUnloadHandler = () => {
+		this.setState( {
+			isUnloading: true,
+		} );
 	};
 
 	footerLink() {

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -36,12 +36,26 @@ class JetpackConnectSiteUrlInput extends Component {
 		this.focusInput = () => formInputComponent.focus();
 	};
 
+	beforeUnloadHandler = () => {
+		this.setState( {
+			isUnloading: true,
+		} );
+	};
+
 	componentDidUpdate() {
 		if ( ! this.props.isError ) {
 			return;
 		}
 
 		this.focusInput();
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'beforeunload', this.beforeUnloadHandler );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'beforeunload', this.beforeUnloadHandler );
 	}
 
 	handleKeyPress = ( event ) => {
@@ -79,8 +93,9 @@ class JetpackConnectSiteUrlInput extends Component {
 
 	isFormSubmitBusy() {
 		const { isFetching } = this.props;
+		const { isUnloading } = this.state ?? {};
 
-		return isFetching;
+		return isFetching || isUnloading;
 	}
 
 	renderTermsOfServiceLink() {


### PR DESCRIPTION
### Proposed Changes

* Currently, a part of our jetpack-installation process makes our users feel like the UI is stuck. Waiting for a slow page transition (it takes ~9 seconds to finish) and no proper UI hints result in this experience. To fix this issue, we set the button in a busy state / display a loading spinner when the slow page transition has started.

<img width="1247" alt="slow_page_transition_jetpack_installation" src="https://user-images.githubusercontent.com/1024985/182782526-3b588290-57fb-4096-bc93-8dd153af766d.png">

### Testing Instructions

#### Case 1 - `Jetpack installation (the user is signed in to self-hosted WordPress)`

* Create a brand new self-hosted WP site using https://jurassic.ninja/create/
* Go to http://calypso.localhost:3000/setup/importerWordpress?siteSlug={SITE_SLUG}&from={HOST_CREATED_FROM_PREVIOUS_STEP}
* Click `Install Jetpack`

<img width="1152" alt="Screen Shot 2022-08-09 at 11 56 56 AM" src="https://user-images.githubusercontent.com/1024985/183561071-385ffebd-41a8-4cef-955c-8972cacd7680.png">

* During the installation process, the `continue` button should be set in a busy status

<img width="467" alt="Screen Shot 2022-08-09 at 12 02 35 PM" src="https://user-images.githubusercontent.com/1024985/183561564-e78df41e-3564-4f97-b8eb-fa389a12ab2e.png">

Screencast

Before:


https://user-images.githubusercontent.com/1024985/182780788-6aad96f9-1907-4332-83d0-ee535e77d94b.mov

After:

https://user-images.githubusercontent.com/1024985/182780908-33a23ee9-c6ad-4ccd-9dc7-799bbda60b8b.mov

#### Case 2 - `Jetpack installation (the user is not signed in to self-hosted WordPress)`

* Create a brand new self-hosted WP site using https://jurassic.ninja/create/
* Visit the dashboard of the newly created site, store the password for later user

<img width="814" alt="Screen Shot 2022-08-09 at 2 38 05 PM" src="https://user-images.githubusercontent.com/1024985/183581489-e4bb0233-8826-41fe-a31b-b2fa0e215b0f.png">

* Click `Log out` to log out of your self-hosted WordPress

<img width="291" alt="Screen Shot 2022-08-09 at 2 41 59 PM" src="https://user-images.githubusercontent.com/1024985/183581975-b788a894-7ccd-4e7f-95e8-98fc159a4759.png">

* Go to http://calypso.localhost:3000/setup/importerWordpress?siteSlug={SITE_SLUG}&from={HOST_CREATED_FROM_PREVIOUS_STEP}
* Click `Install Jetpack`

<img width="1152" alt="Screen Shot 2022-08-09 at 11 56 56 AM" src="https://user-images.githubusercontent.com/1024985/183561071-385ffebd-41a8-4cef-955c-8972cacd7680.png">

* The WordPress sign-in form should appear. Fill in the user name (demo) and password (the one you stored from the previous step) and then click the `Install Jetpack` button.

_Note: Please use this link: `http://calypso.localhost:3000/jetpack/connect/?forceInstall=1&url={SELF_HOSTED_SITE_URL}` to head to sign-in form if you're experiencing a wordpress.com redirection._



<img width="676" alt="Screen Shot 2022-08-09 at 3 29 56 PM" src="https://user-images.githubusercontent.com/1024985/183590678-cad6038b-d6d5-4db9-acf7-3b3857c182f7.png">

* A loading spinner should appear during the installation process

<img width="702" alt="Screen Shot 2022-08-09 at 3 26 53 PM" src="https://user-images.githubusercontent.com/1024985/183590109-25d9eb3d-f9a7-4de9-a854-6d8d94009301.png">

Screencast

Before:

https://user-images.githubusercontent.com/1024985/183559681-556a2829-3d71-4d10-a95c-deafd41b34a5.mov

After:

https://user-images.githubusercontent.com/1024985/183559710-b829dc48-2323-44f0-8272-36df2158b142.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65817
