### PR TITLE
Plugin Management: Implement single-site(large screen) view for the plugin management

### DIFF
--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -1,6 +1,3 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
-
 .section-nav-tab .count {
 	margin-left: 8px;
 }

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .section-nav-tab .count {
 	margin-left: 8px;
 }

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -39,8 +39,7 @@
 
 .plugin-activate-toggle__icon {
 	flex: none;
-	margin: -1px 0 -1px 3px;
-
+	margin: auto 0 auto 3px;
 	.gridicon {
 		display: block;
 	}

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import PluginsTable from './plugins-table';
 import type { Plugin } from './types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -24,12 +24,33 @@ export default function PluginManagementV2( {
 			key: 'plugin',
 			title: translate( 'Installed Plugins' ),
 		},
-		{
-			key: 'sites',
-			title: translate( 'Sites' ),
-			smallColumn: true,
-			colSpan: 2,
-		},
+		...( selectedSite
+			? [
+					{
+						key: 'activate',
+						title: translate( 'Active' ),
+						smallColumn: true,
+					},
+					{
+						key: 'autoupdate',
+						title: translate( 'Autoupdate' ),
+						smallColumn: true,
+					},
+					{
+						key: 'last-updated',
+						title: translate( 'Last updated' ),
+						smallColumn: true,
+						colSpan: 2,
+					},
+			  ]
+			: [
+					{
+						key: 'sites',
+						title: translate( 'Sites' ),
+						smallColumn: true,
+						colSpan: 2,
+					},
+			  ] ),
 	];
 
 	if ( ! plugins.length && ! isLoading ) {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,18 +1,44 @@
 import { Gridicon, Button } from '@automattic/components';
+import { useSelector } from 'react-redux';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
+import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
+import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
+import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
 import type { Plugin } from '../types';
-import type { ReactChild, ReactElement } from 'react';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { MomentInput } from 'moment';
+import type { ReactElement, ReactChild } from 'react';
 
 import './style.scss';
 
 interface Props {
 	item: Plugin;
 	columnKey: string;
+	selectedSite: SiteData;
 }
 
-export default function PluginRowFormatter( { item, columnKey }: Props ): ReactElement | any {
+export default function PluginRowFormatter( {
+	item,
+	columnKey,
+	selectedSite,
+}: Props ): ReactElement | any {
 	const PluginDetailsButton = ( props: { className: string; children: ReactChild } ) => {
 		return <Button borderless compact href={ `/plugins/${ item.slug }` } { ...props } />;
 	};
+
+	const moment = useLocalizedMoment();
+	const state = useSelector( ( state ) => state );
+
+	const ago = ( date: MomentInput ) => {
+		return moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
+	};
+
+	const { activation: canActivate, autoupdate: canUpdate } = getAllowedPluginActions(
+		item,
+		state,
+		selectedSite
+	);
 
 	switch ( columnKey ) {
 		case 'plugin':
@@ -39,5 +65,26 @@ export default function PluginRowFormatter( { item, columnKey }: Props ): ReactE
 					{ Object.keys( item.sites ).length }
 				</PluginDetailsButton>
 			);
+		case 'activate':
+			return (
+				canActivate && <PluginActivateToggle hideLabel plugin={ item } site={ selectedSite } />
+			);
+		case 'autoupdate':
+			return (
+				canUpdate && (
+					<PluginAutoupdateToggle
+						hideLabel
+						plugin={ item }
+						site={ selectedSite }
+						wporg={ !! item.wporg }
+						isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
+					/>
+				)
+			);
+		case 'last-updated':
+			if ( item.last_updated ) {
+				return <div>{ ago( item.last_updated ) }</div>;
+			}
+			return null;
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -67,18 +67,24 @@ export default function PluginRowFormatter( {
 			);
 		case 'activate':
 			return (
-				canActivate && <PluginActivateToggle hideLabel plugin={ item } site={ selectedSite } />
+				canActivate && (
+					<div className="plugin-row-formatter__toggle">
+						<PluginActivateToggle hideLabel plugin={ item } site={ selectedSite } />
+					</div>
+				)
 			);
 		case 'autoupdate':
 			return (
 				canUpdate && (
-					<PluginAutoupdateToggle
-						hideLabel
-						plugin={ item }
-						site={ selectedSite }
-						wporg={ !! item.wporg }
-						isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
-					/>
+					<div className="plugin-row-formatter__toggle">
+						<PluginAutoupdateToggle
+							hideLabel
+							plugin={ item }
+							site={ selectedSite }
+							wporg={ !! item.wporg }
+							isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
+						/>
+					</div>
 				)
 			);
 		case 'last-updated':

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -37,3 +37,10 @@ a.button.plugin-row-formatter__plugin-name {
 		text-decoration: underline;
 	}
 }
+
+.plugin-row-formatter__toggle {
+	.plugin-action .components-toggle-control .components-base-control__field {
+		margin: auto 0;
+	}
+}
+

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
@@ -65,7 +65,13 @@ export default function PluginsTable( {
 											) }
 											key={ `table-data-${ column.key }-${ id }` }
 										>
-											{ <PluginRowFormatter columnKey={ column.key } item={ item } /> }
+											{
+												<PluginRowFormatter
+													columnKey={ column.key }
+													item={ item }
+													selectedSite={ selectedSite }
+												/>
+											}
 										</td>
 									);
 								} ) }

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/style.scss
@@ -22,15 +22,12 @@
 	td {
 		font-size: 0.875rem;
 		height: 50px;
-		width: 162px;
+		width: 175px;
 		box-sizing: border-box;
 		&:nth-child( 1 ) {
 			max-width: 200px;
 			@include break-wide() {
 				max-width: 300px;
-			}
-			@include break-huge() {
-				max-width: 350px;
 			}
 		}
 		a {
@@ -78,6 +75,12 @@ td.plugins-table__actions {
 }
 .plugins-table__small-column {
 	max-width: 100px;
+	@include break-wide() {
+		max-width: 120px;
+	}
+	@include break-huge() {
+		max-width: 150px;
+	}
 }
 .components-form-toggle.is-checked .components-form-toggle__track {
 	background-color: var( --studio-jetpack-green-50 );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -1,10 +1,18 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .update-plugin__badge {
 	font-size: 0.75rem !important;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	vertical-align: middle;
-	max-width: fit-content;
+	@include break-xlarge() {
+		max-width: 70px;
+	}
+	@include break-huge() {
+		max-width: 80px;
+	}
 }
 a.button.update-plugin__plugin-update-button {
 	color: var( --color-primary-80 );


### PR DESCRIPTION
#### Proposed Changes

This PR is built on top of https://github.com/Automattic/wp-calypso/pull/66219

This PR implements the large screen view(>1080px) for single-site plugin management. The small screen view(<1080px) will be implemented in a different PR.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/plugin-management-single-site-large-screen-view` and `yarn start-jetpack-cloud-p`
2. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
3. Click on **Switch Site** -> Select any site -> Click on **Plugins** -> Verify the plugins are shown as shown below. 

<img width="1920" alt="Screenshot 2022-08-04 at 12 31 56 PM" src="https://user-images.githubusercontent.com/10586875/182785514-6f5fdd8b-af17-47f3-846c-b95d2faf44ad.png">

4. Clicking on `Update` should redirect the user to the plugin details page.

<img width="620" alt="Screenshot 2022-08-04 at 12 40 09 PM" src="https://user-images.githubusercontent.com/10586875/182785902-cb9d44ca-549c-4a93-b49f-1a92bfb6daf8.png">

5. Verify `Active` and `Autoupdate` toggle buttons works as expected. 
6. Verify search works as expected.
7. Click on all the tabs - All, Active, Inactive & Updates and verify the plugins are shown as per the filter and the URL is changing accordingly. 
8. Verify these changes have not affected anything in Calypso Blue. 

> **_NOTE:_** The more actions icon(`...`) is just a placeholder and will be updated later in a different PR. We are reusing `<PluginActivateToggle />` and `<PluginAutoupdateToggle />` components which is being used in WP.com

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202673439327762