### PR TITLE
Sites Management Page: Disable autocorrect in search input

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -120,6 +120,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 								onSearch={ ( term ) => handleQueryParamChange( 'search', term?.trim() ) }
 								isReskinned
 								placeholder={ __( 'Search by name or domain…' ) }
+								disableAutocorrect={ true }
 								defaultValue={ search }
 							/>
 						</SearchWrapper>


### PR DESCRIPTION
## Proposed Changes

Before:

<img width="684" alt="image" src="https://user-images.githubusercontent.com/36432/182839990-804db846-3571-42a2-b76b-fa1e514717f2.png">

After:

<img width="710" alt="image" src="https://user-images.githubusercontent.com/36432/182839802-4dee1f41-906c-42a4-b831-ef4a8f12736d.png">

## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Enter 'daniel' in search input.
3. Enter 'dani' in search input.
4. Observe your first search isn't suggested.