### PR TITLE
Adds tracks event for the promote post button

### DIFF
--- a/client/my-sites/stats/stats-list/action-promote.jsx
+++ b/client/my-sites/stats/stats-list/action-promote.jsx
@@ -1,16 +1,17 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
-import { showDSPWidgetModal } from 'calypso/lib/promote-post';
+import { recordDSPEntryPoint, showDSPWidgetModal } from 'calypso/lib/promote-post';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PromotePost = ( props ) => {
 	const { moduleName, postId } = props;
 
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const showPromotePost = config.isEnabled( 'promote-post' );
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -24,7 +25,7 @@ const PromotePost = ( props ) => {
 			'Clicked on Promote Post Widget Button in ' + moduleName + ' List Action Menu'
 		);
 
-		recordTracksEvent( 'calypso_mysites_stats_posts_pages_promote_posts_clicked' );
+		dispatch( recordDSPEntryPoint( 'mysites_stats_posts-and-pages_speaker-button' ) );
 	};
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Follow on from #66024 this ticket simply renames the tracks event added in that ticket for consistency with the rest of the project

#### Testing Instructions

This is a tricky one to test really as it requires having the promote posts project loaded & also that tracks events are only logged in production - so I'd just take a close look at the code here.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
