### PR TITLE
Quarantine flaky e2e support-home

### DIFF
--- a/test/e2e/specs/support/support__home.ts
+++ b/test/e2e/specs/support/support__home.ts
@@ -1,5 +1,5 @@
 /**
- * @group calypso-pr
+ * @group quarantined
  */
 
 import {


### PR DESCRIPTION
#### Proposed Changes

* Quarantine flaky e2e test for support home
* The endpoint results are inconsistent causing flakiness in the e2e test. Sometimes results are returned and sometimes there is an empty result.

#### Testing Instructions
- Run the e2e