### PR TITLE
Sites Management Page: Change '+ New site' to 'Add new site'

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,9 +1,4 @@
-import {
-	Button,
-	Gridicon,
-	useSitesTableFiltering,
-	useSitesTableSorting,
-} from '@automattic/components';
+import { Button, useSitesTableFiltering, useSitesTableSorting } from '@automattic/components';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
@@ -106,8 +101,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 				<HeaderControls>
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>
 					<Button primary href="/start?source=sites-dashboard&ref=sites-dashboard">
-						<Gridicon icon="plus" />
-						<span>{ __( 'New site' ) }</span>
+						<span>{ __( 'Add new site' ) }</span>
 					</Button>
 				</HeaderControls>
 			</PageHeader>


### PR DESCRIPTION
## Proposed Changes

Changes the '+ New site' button to 'Add new site'.

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/36432/182849054-d15206b9-55d8-41d2-897f-b9c721dd524a.png">

See pdKhl6-Au-p2#comment-498

Previously #66250

## Testing Instructions

1. Navigate to `/sites-dashboard`
2. View button as 'Add new site'