### PR TITLE
Update wording for domain subscription description in purchases page

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -598,11 +598,15 @@ class ManagePurchase extends Component {
 
 		if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
 			return translate(
-				"Replaces your site's free address, %(domain)s, with the domain, " +
-					'making it easier to remember and easier to share.',
+				"When used with a paid plan, your custom domain can replace your site's free address, {{strong}}%(wpcom_url)s{{/strong}}, " +
+					'with {{strong}}%(domain)s{{/strong}}, making it easier to remember and easier to share.',
 				{
 					args: {
-						domain: purchase.domain,
+						domain: purchase.meta,
+						wpcom_url: purchase.domain,
+					},
+					components: {
+						strong: <strong />,
 					},
 				}
 			);


### PR DESCRIPTION
#### Proposed Changes

* This PR implements the wording changes from https://github.com/Automattic/wp-calypso/issues/63891, specifically in [this comment](https://github.com/Automattic/wp-calypso/issues/63891#issuecomment-1158035458)

#### Testing Instructions

* For a site where you have a domain registration or domain mapping, navigate to _Upgrades_ -> _Purchases_
* Click on a row for a domain registration or domain mapping
* Verify that the description for the subscription uses the following language:
> When used with a paid plan, your custom domain can replace your site's free address, **[wordpress.com_url]**, with **[custom_domain]**, making it easier to remember and easier to share.

##### Screenshot

<img width="1085" alt="Screenshot 2022-08-04 at 14 53 00" src="https://user-images.githubusercontent.com/3376401/182852632-139c84b8-6832-4c5d-a535-b9a474293abe.png">


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  * _I will add the string freeze label once we confirm the wording_

Related to #63891
