### PR TITLE
Sites Dashboard: forwardRef Image to FastAverageColor the site logo

### DIFF
--- a/client/components/image/index.js
+++ b/client/components/image/index.js
@@ -1,13 +1,15 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 const hideImageOnError = ( event ) => {
 	event.target.style.display = 'none';
 };
 
-export default function Image( { alt, className, src, ...restProps } ) {
+const Image = React.forwardRef( ( { alt, className, src, ...restProps }, ref ) => {
 	return (
 		<img
+			ref={ ref }
 			src={ src }
 			onError={ hideImageOnError }
 			className={ classnames( className, 'image' ) }
@@ -15,10 +17,12 @@ export default function Image( { alt, className, src, ...restProps } ) {
 			{ ...restProps }
 		/>
 	);
-}
+} );
 
 Image.propTypes = {
 	alt: PropTypes.string,
 	className: PropTypes.string,
 	src: PropTypes.string,
 };
+
+export default Image;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -2,6 +2,7 @@ import { ListTile, SiteThumbnail } from '@automattic/components';
 import { ClassNames, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { useRef } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import Image from 'calypso/components/image';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -119,6 +120,8 @@ const VisitDashboardItem = ( { site }: { site: SiteExcerptData } ) => {
 export default function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 
+	const logoRef = useRef< HTMLImageElement >( null );
+
 	const isComingSoon =
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 	const isP2Site = site.options?.is_wpforteams_site;
@@ -143,9 +146,11 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 										mShotsUrl={ setmShotsUrl ? site.URL : undefined }
 										alt={ site.name }
 										bgColorImgUrl={ site.icon?.img }
+										logoRef={ logoRef }
 									>
 										{ site.icon ? (
 											<Image
+												ref={ logoRef }
 												src={ site.icon.img }
 												alt={ site.name }
 												style={ { height: '50px', width: '50px' } }

--- a/packages/components/src/site-thumbnail/use-dominant-color.tsx
+++ b/packages/components/src/site-thumbnail/use-dominant-color.tsx
@@ -18,12 +18,12 @@ export default function useDominantColor(
 				],
 				width: 50,
 				height: 50,
+				crossOrigin: 'Anonymous',
 			} );
 			setColor( color );
 		}
-
 		//get the dominant color of image from url
-		if ( url && url.length > 0 ) {
+		else if ( url && url.length > 0 ) {
 			fac
 				.getColorAsync( url, {
 					ignoredColor: [


### PR DESCRIPTION
#### Proposed Changes

Example of using ForwardRef to calculate the Logo FastAverageColor.
This PR doesn't fix the CORS issue, so it shouldn't be merged.

Instead of refactoring `Image`, we could also use `img` directly.

Related to #66061
