### PR TITLE
Stepper: Implement color picker popover for newsletter accent color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -18,10 +18,26 @@ import type { Step } from '../../types';
 
 import './style.scss';
 
+/**
+ * Generates an inline SVG for the color picker swatch
+ *
+ * @param color the color in HEX
+ * @returns a value for background-image
+ */
+function generateSwatchSVG( color: string | undefined ) {
+	return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='10' stroke='%23ccc' stroke-width='1' fill='${ encodeURIComponent(
+		color || '#fff'
+	) }'%3E%3C/circle%3E${
+		// render a line when a color isn't selected
+		! color
+			? `%3Cline x1='18' y1='4' x2='7' y2='20' stroke='%23ccc' stroke-width='1'%3E%3C/line%3E`
+			: ''
+	}%3C/svg%3E`;
+}
 const NewsletterSetup: Step = ( { navigation } ) => {
 	const { goBack, submit } = navigation;
 	const { __ } = useI18n();
-	const colorAccentRef = React.useRef< HTMLInputElement >( null );
+	const accentColorRef = React.useRef< HTMLInputElement >( null );
 
 	const site = useSite();
 
@@ -29,7 +45,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
-	const [ colorAccent, setAccentColor ] = React.useState( '#000000' );
+	const [ accentColor, setAccentColor ] = React.useState< string | undefined >();
 	const [ url, setUrl ] = React.useState( '' );
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const { mutateAsync: setSiteLogo, isLoading: isUploadingIcon } = useSiteLogoMutation( site?.ID );
@@ -107,13 +123,13 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 				/>
 				<Popover
 					isVisible={ colorPickerOpen }
-					context={ colorAccentRef.current }
+					context={ accentColorRef.current }
 					position="top left"
 					onClose={ () => setColorPickerOpen( false ) }
 				>
 					<ColorPicker
 						disableAlpha
-						color={ colorAccent }
+						color={ accentColor || '#000000' }
 						onChangeComplete={ ( value ) => setAccentColor( value.hex ) }
 					/>
 				</Popover>
@@ -137,14 +153,17 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 				<FormFieldset disabled={ isLoading }>
 					<FormLabel htmlFor="accentColor">{ __( 'Accent Color' ) }</FormLabel>
 					<FormInput
-						inputRef={ colorAccentRef }
+						inputRef={ accentColorRef }
 						className="newsletter-setup__accent-color"
+						style={ {
+							backgroundImage: generateSwatchSVG( accentColor ),
+						} }
 						type="text"
 						name="accentColor"
 						id="accentColor"
 						onFocus={ () => setColorPickerOpen( ! colorPickerOpen ) }
 						readOnly
-						value={ colorAccent }
+						value={ accentColor || '#000000' }
 					/>
 				</FormFieldset>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormInputValidation } from '@automattic/components';
+import { Button, FormInputValidation, Popover } from '@automattic/components';
 import { useSiteLogoMutation } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { ColorPicker } from '@wordpress/components';
@@ -10,7 +10,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
-import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -22,6 +21,7 @@ import './style.scss';
 const NewsletterSetup: Step = ( { navigation } ) => {
 	const { goBack, submit } = navigation;
 	const { __ } = useI18n();
+	const colorAccentRef = React.useRef< HTMLInputElement >( null );
 
 	const site = useSite();
 
@@ -105,16 +105,18 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					onSelect={ setSelectedFile }
 					selectedFile={ selectedFile }
 				/>
-				{ colorPickerOpen && (
-					<div className="newsletter-setup__color-picker-backdrop">
-						<ColorPicker
-							disableAlpha
-							color={ colorAccent }
-							onChangeComplete={ ( value ) => setAccentColor( value.hex ) }
-						/>
-					</div>
-				) }
-
+				<Popover
+					isVisible={ colorPickerOpen }
+					context={ colorAccentRef.current }
+					position="top left"
+					onClose={ () => setColorPickerOpen( false ) }
+				>
+					<ColorPicker
+						disableAlpha
+						color={ colorAccent }
+						onChangeComplete={ ( value ) => setAccentColor( value.hex ) }
+					/>
+				</Popover>
 				<FormFieldset disabled={ isLoading }>
 					<FormLabel htmlFor="siteTitle">{ __( 'Publication name*' ) }</FormLabel>
 					<FormInput
@@ -134,16 +136,15 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 				<FormFieldset disabled={ isLoading }>
 					<FormLabel htmlFor="accentColor">{ __( 'Accent Color' ) }</FormLabel>
-					<FormTextInputWithAffixes
-						style={ { backgroundColor: colorAccent } }
-						prefix={
-							<span className="newsletter-setup__accent-color-prefix">{ colorAccent }</span>
-						}
+					<FormInput
+						inputRef={ colorAccentRef }
+						className="newsletter-setup__accent-color"
 						type="text"
 						name="accentColor"
 						id="accentColor"
 						onFocus={ () => setColorPickerOpen( ! colorPickerOpen ) }
 						readOnly
+						value={ colorAccent }
 					/>
 				</FormFieldset>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -62,12 +62,22 @@ $border-radius: 4px;
 			padding: 12px 16px;
 			height: $input-height;
 			border-radius: $border-radius;
+
+			&.newsletter-setup__accent-color {
+				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='10' stroke='%23ccc' stroke-width='1' fill='none' %3E%3C/circle%3E%3Cline x1='18' y1='4' x2='7' y2='20' stroke='%23ccc' stroke-width='1'%3E%3C/line%3E%3C/svg%3E" );
+				background-size: 25px;
+				background-position: 13px center;
+				background-repeat: no-repeat;
+				padding-left: 50px;
+				color: var( --studio-gray-30 );
+			}
 		}
 
 		.newsletter-setup__url {
 			background: var( --color-neutral-0 );
 			border-radius: $border-radius;
 			height: $input-height;
+			border: none;
 
 			input {
 				background: var( --color-neutral-0 );
@@ -100,27 +110,10 @@ $border-radius: 4px;
 			border-radius: $border-radius;
 		}
 	}
+}
 
-	.newsletter-setup__color-picker-backdrop {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100vh;
-		height: 100vw;
-		z-index: 4;
-	}
-
-	.components-color-picker {
-		position: absolute;
-		top: 20%;
-		left: 50%;
-		transform: translateX( -50% );
-		background: white;
-		box-shadow: 0 0 20px rgb( 0 0 0 / 15% );
-		box-shadow: 0 0 20px rgb( 0 0 0 / 15% );
-
-		.components-h-stack {
-			width: unset;
-		}
+.components-color-picker {
+	.components-h-stack {
+		width: unset !important;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -64,7 +64,6 @@ $border-radius: 4px;
 			border-radius: $border-radius;
 
 			&.newsletter-setup__accent-color {
-				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='10' stroke='%23ccc' stroke-width='1' fill='none' %3E%3C/circle%3E%3Cline x1='18' y1='4' x2='7' y2='20' stroke='%23ccc' stroke-width='1'%3E%3C/line%3E%3C/svg%3E" );
 				background-size: 25px;
 				background-position: 13px center;
 				background-repeat: no-repeat;


### PR DESCRIPTION
#### Proposed Changes

* Uses `ColorPicker` from `@wordpress/components` to add a color picker to the newsletter setup page. 
* Uses `Popover` form `@automattic/components` to hover the color picker nicely on mobile and desktop. 
* Implements the swatch next to the color field.

#### Testing Instructions

1. Go to http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletters&siteSlug=YOUR_SITE
2. Play with the color picker, everything should work as expected.
3. Try on simulated mobile in DevTools.

