### PR TITLE
Fix condition that decides about displaying owner edit form

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -103,11 +103,8 @@ class EditUserForm extends Component {
 		 * On Atomic and non-Jetpack sites, if the current user is not viewing their own profile,
 		 * the user should not be able to edit the site owner's details.
 		 */
-		if (
-			( ( ! isJetpack && user.ID === siteOwner ) ||
-				( isAtomic && user.linked_user_ID === siteOwner ) ) &&
-			user.ID !== currentUser.ID
-		) {
+		const userId = user.linked_user_ID || user.ID;
+		if ( ( ! isJetpack || isAtomic ) && userId === siteOwner && userId !== currentUser.ID ) {
 			return [];
 		}
 


### PR DESCRIPTION
#### Proposed Changes

I fix the comparison that prevents editing the owner's details. It was still working incorrectly for the owner user of the Atomic site after a specific use case happened - when the external site was reconnected, which resulted in having WPCOM owner user id not in sync with the external owner user id.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a simple site with a paid plan
2. Enable hosting features to make it Atomic
3. Invite another user as an admin
4. Go through the reconnection process (P9HQHe-1ie-p2#jetpack-reconnections-tl-dr)
- Disconnect the site and simulate not existing owner, so remove the current owner from the external site and add a new account
- Setup Jetpack and Approve 
5. Navigate to site in Calypso
6. Open the owner user form when logged as an owner

Confirm that the "This user is a contractor [...]|" field and text below are displayed: 

![Screen Shot 2022-08-04 at 16 21 38](https://user-images.githubusercontent.com/727413/182873487-96d8b633-b3e5-453f-b38a-1fd37a790460.png)

Before the fix, the form below avatar was missing.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p9F6qB-9M6-p2