### PR TITLE
Editor Iframe: remove unnecessary check that site editor is enabled

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -10,7 +10,6 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
 import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
@@ -193,10 +192,9 @@ export const redirect = async ( context, next ) => {
 	if ( ! shouldLoadGutenframe( state, siteId, postType ) ) {
 		const postId = getPostID( context );
 
-		const url =
-			postType || ! isSiteUsingCoreSiteEditor( state, siteId )
-				? getEditorUrl( state, siteId, postId, postType )
-				: getSiteEditorUrl( state, siteId );
+		const url = postType
+			? getEditorUrl( state, siteId, postId, postType )
+			: getSiteEditorUrl( state, siteId );
 		// pass along parameters, for example press-this
 		return window.location.replace( addQueryArgs( context.query, url ) );
 	}


### PR DESCRIPTION
#### Proposed Changes

Removes a deprecated check for the Site editor being enabled, when the editor iframe is loading, but needs to redirect to wp-admin.

The Site editor is now enabled for all block themes, so there is no need for this check, and it seems to be [causing a bug](https://github.com/Automattic/wp-calypso/issues/63262) when combined with the latest Gutenberg plugin release. (Context: paYE8P-1Pu-p2)

#### Testing Instructions

First, reproduce this on an Atomic site, with a block theme activated:

- Go to the Posts list and use the View panel to go to the Classic view

<img width="409" alt="image" src="https://user-images.githubusercontent.com/1699996/182896636-84c180e5-65df-41c7-8aba-f797422a83a9.png">

- Navigate back to a Calypso rendered page, such as "Home" (wp-admin should _not_ be in the url)
- Click on Appearance > Editor (beta)
- You should be redirected to `/wp-admin/post-new.php`

Then load Calypso from this branch and retest. You should end up at the Site editor in wp-admin, rather than `post-new.php`. **(Make sure you go back to the Calypso dev environment when coming back to Calypso, and not wordpress.com)**

**Check for regressions**

- Simple sites also load the Site editor correctly for both "Default" (Calypso iframe) and "Classic" (wp-admin) views
- Classic themes can load the post editor correctly for both "Default" (Calypso iframe) and "Classic" (wp-admin) views
- Check that for both classic and block themes, you can visit /post/{site}/{post_id} and you either load the Post editor in the Calypso iframe or are redirected to wp-admin, based on the most recent "View" preference you've set.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- n/a Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- n/a Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Fixes #63262