### PR TITLE
Fix - the password reset email UI should not be present when adding a mailbox for Google Workspace

### DIFF
--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -317,7 +317,7 @@ const MailboxesForm = ( {
 					showCancelButton
 					submitActionText={ translate( 'Continue' ) }
 				>
-					{ hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
+					{ isTitan( provider ) && hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
 						<PasswordResetTipField tipClickHandler={ showAlternateEmailField } />
 					) }
 				</NewMailBoxList>


### PR DESCRIPTION
#### Proposed Changes

* The proposed change fixes the issue where the "change it" UI (for updating the default password reset email address) is present in the mailbox addition form for Google Workspace. The UI should not be there, as it only applies to Professional Email


#### Testing Instructions

* Have a Google Workspace subscription
* Go to the mailbox addition page: `/email/:domain/google-workspace/add-users/:site` (or navigate through **Upgrades > Emails**, select "Add new mailboxes")
* There should be **no** password reset email field (verify for adding single / multiple mailboxes)
* You should be able to add mailboxes to the cart accordingly

**Before**

<img width="1473" alt="mailbox-add-before" src="https://user-images.githubusercontent.com/104910361/182903983-c164c227-333d-413f-af68-7a81ace48a9a.png">

**After**

<img width="1477" alt="mailbox-add-after" src="https://user-images.githubusercontent.com/104910361/182904023-7a48d791-e3e1-4423-918d-e438e1deded9.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66106
