### PR TITLE
Help Center: Calypso-related style and support fixes

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -48,6 +48,7 @@
 				padding: 15.5px !important;
 				border: 1px solid var( --studio-gray-10 ) !important;
 				border-radius: 4px !important;
+				box-sizing: border-box;
 			}
 		}
 	}
@@ -64,6 +65,7 @@
 	border-radius: 4px;
 	width: 100%;
 	display: block;
+	box-sizing: border-box;
 
 	&:focus {
 		box-shadow: none;

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -93,7 +93,7 @@
 					font-weight: normal;
 					line-height: 1.4;
 					display: flex;
-					
+
 					span {
 						flex-grow: 2;
 					}
@@ -316,6 +316,7 @@
 			h3 {
 				font-size: $font-body;
 				font-weight: 500;
+				margin: 1em 0;
 			}
 		}
 
@@ -326,6 +327,7 @@
 
 			a {
 				text-decoration: none;
+				color: #1d2327;
 			}
 
 			&.is-reversed {

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -1,18 +1,20 @@
 /* eslint-disable no-restricted-imports */
 import { useHas3PC, useSupportAvailability } from '@automattic/data-stores';
+import { shouldTargetWpcom } from '@automattic/help-center';
 import { useSelector } from 'react-redux';
 import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 
 export function useStillNeedHelpURL() {
 	const { hasCookies } = useHas3PC();
 	const isSimpleSite: boolean = useSelector( ( state ) => getIsSimpleSite( state ) );
-	const { data: supportAvailability } = useSupportAvailability( 'OTHER', isSimpleSite );
+	const canUseWpcomApis = Boolean( shouldTargetWpcom( isSimpleSite ) );
+	const { data: supportAvailability } = useSupportAvailability( 'OTHER', canUseWpcomApis );
 
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
 
-	if ( ! isSimpleSite ) {
+	if ( ! canUseWpcomApis ) {
 		return 'https://wordpress.com/help/contact';
 	}
 

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-imports */
 import { useHas3PC, useSupportAvailability } from '@automattic/data-stores';
-import { shouldTargetWpcom } from '@automattic/help-center';
 import { useSelector } from 'react-redux';
 import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
+import { shouldTargetWpcom } from '../utils';
 
 export function useStillNeedHelpURL() {
 	const { hasCookies } = useHas3PC();

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -255,6 +255,7 @@ $head-foot-height: 50px;
 		font-size: $font-body-small;
 		font-weight: 500;
 		color: var( --studio-gray-100 );
+		margin: 1em 0;
 	}
 
 	.help-center-sibyl-articles__container {

--- a/packages/site-picker/src/hooks.tsx
+++ b/packages/site-picker/src/hooks.tsx
@@ -2,6 +2,7 @@ import { focus } from '@wordpress/dom';
 import { useCallback, useEffect } from 'react';
 
 export const useArrowNavigation = (
+	enabled: boolean,
 	element: HTMLElement | null,
 	open: boolean,
 	onOpen: () => void
@@ -38,10 +39,12 @@ export const useArrowNavigation = (
 	);
 
 	useEffect( () => {
-		document.addEventListener( 'keydown', handleTrapFocus );
+		if ( enabled ) {
+			document.addEventListener( 'keydown', handleTrapFocus );
+		}
 
 		return () => {
 			document.removeEventListener( 'keydown', handleTrapFocus );
 		};
-	}, [ handleTrapFocus ] );
+	}, [ handleTrapFocus, enabled ] );
 };

--- a/packages/site-picker/src/index.tsx
+++ b/packages/site-picker/src/index.tsx
@@ -90,7 +90,7 @@ export const SitePickerDropDown: FC< Props > = ( {
 	const [ open, setOpen ] = useState( false );
 
 	useFocusTrap( { current: ref } );
-	useArrowNavigation( ref, open, () => setOpen( true ) );
+	useArrowNavigation( enabled, ref, open, () => setOpen( true ) );
 
 	const selectedSite = options.find( ( s ) => s?.ID === siteId ) || options[ 0 ];
 


### PR DESCRIPTION
### Proposed Changes

#### Fixes

* It seems the help center has some CSS issues in Calypso
	- The input fields are too wide in the contact form.
	- The headings are half no margins and had to be manually margined.
* It seems [`useStillNeedHelpUrl`](https://github.com/Automattic/wp-calypso/blob/trunk/packages/help-center/src/hooks/use-still-need-help-url.tsx#L6) still used to check if the site is Atomic before checking for support options, even though this is irrelevant in Calypso. This uses `shouldTargetWpcom` instead of `isSimpleSites`. 
* The site-picker still opened if you press the down arrow even when its read only. 

#### Testing Instructions

1. Using the 10% user, please login to WordPress.
2. Select an Atomic site (eg: go to http://calypso.localhost:3000/themes/testsite10percent2022.wpcomstaging.com).
3. The help-center should work.
4. Clicking "Still need help" should offer support options (not open a new tab).
5. Contact form should look perfect.
6. To verify `useStillNeedHelpUrl` still does its job, please upload the build to an Atomic site and the Help Center in the editor, “Still need help” should open a new tab.

