### PR TITLE
Social Auth: Remove Google API migration feature flag and obsolete code

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -48,17 +48,9 @@ class SocialLoginForm extends Component {
 		} );
 	};
 
-	handleGoogleResponse = ( response, triggeredByUser = true ) => {
+	handleGoogleResponse = ( tokens, triggeredByUser = true ) => {
 		const { onSuccess, socialService } = this.props;
 		let redirectTo = this.props.redirectTo;
-
-		const tokens = config.isEnabled( 'migration/sign-in-with-google' )
-			? response // The `response` object itself holds the tokens, no need for any other method calls.
-			: response.getAuthResponse?.();
-
-		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
-			return;
-		}
 
 		// ignore response if the user did not click on the google button
 		// and did not follow the redirect flow

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -37,15 +37,7 @@ class SocialSignupForm extends Component {
 		this.props.handleResponse( 'apple', null, response.id_token, extraUserData );
 	};
 
-	handleGoogleResponse = ( response, triggeredByUser = true ) => {
-		const tokens = config.isEnabled( 'migration/sign-in-with-google' )
-			? response // The `response` object itself holds the tokens, no need for any other method calls.
-			: response.getAuthResponse?.();
-
-		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
-			return;
-		}
-
+	handleGoogleResponse = ( tokens, triggeredByUser = true ) => {
 		if ( ! triggeredByUser && this.props.socialService !== 'google' ) {
 			return;
 		}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -34,9 +34,7 @@ class GoogleSocialButton extends Component {
 	};
 
 	static defaultProps = {
-		scope: config.isEnabled( 'migration/sign-in-with-google' )
-			? 'openid profile email'
-			: 'https://www.googleapis.com/auth/userinfo.profile',
+		scope: 'openid profile email',
 		fetchBasicProfile: true,
 		onClick: noop,
 	};
@@ -58,20 +56,14 @@ class GoogleSocialButton extends Component {
 	}
 
 	componentDidMount() {
-		if ( config.isEnabled( 'migration/sign-in-with-google' ) ) {
-			if ( this.props.authCodeFromRedirect ) {
-				this.handleAuthorizationCode( {
-					auth_code: this.props.authCodeFromRedirect,
-					redirect_uri: this.props.redirectUri,
-				} );
-			}
-
-			this.initializeGoogleSignIn();
-
-			return;
+		if ( this.props.authCodeFromRedirect ) {
+			this.handleAuthorizationCode( {
+				auth_code: this.props.authCodeFromRedirect,
+				redirect_uri: this.props.redirectUri,
+			} );
 		}
 
-		this.initialize();
+		this.initializeGoogleSignIn();
 	}
 
 	async initializeGoogleSignIn() {
@@ -171,25 +163,7 @@ class GoogleSocialButton extends Component {
 			return;
 		}
 
-		if ( config.isEnabled( 'migration/sign-in-with-google' ) ) {
-			this.client.requestCode();
-			return;
-		}
-
-		const { responseHandler } = this.props;
-
-		// Options are documented here:
-		// https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2signinoptions
-		window.gapi.auth2
-			.getAuthInstance()
-			.signIn( { prompt: 'select_account' } )
-			.then( responseHandler, ( error ) => {
-				this.props.recordTracksEvent( 'calypso_social_button_failure', {
-					social_account_type: 'google',
-					starting_point: this.props.startingPoint,
-					error_code: error.error,
-				} );
-			} );
+		this.client.requestCode();
 	}
 
 	showError( event ) {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { loadScript } from '@automattic/load-script';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -14,8 +13,6 @@ import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
-
-let auth2InitDone = false;
 
 import './style.scss';
 
@@ -54,8 +51,6 @@ class GoogleSocialButton extends Component {
 
 	constructor( props ) {
 		super( props );
-
-		this.initialized = null;
 
 		this.handleClick = this.handleClick.bind( this );
 		this.showError = this.showError.bind( this );
@@ -111,86 +106,6 @@ class GoogleSocialButton extends Component {
 		}
 
 		return window.google.accounts.oauth2;
-	}
-
-	async loadDependency() {
-		if ( ! window.gapi ) {
-			await loadScript( 'https://apis.google.com/js/platform.js' );
-		}
-
-		return window.gapi;
-	}
-
-	async initializeAuth2( gapi ) {
-		if ( auth2InitDone ) {
-			return;
-		}
-
-		await gapi.auth2.init( {
-			fetch_basic_profile: this.props.fetchBasicProfile,
-			client_id: this.props.clientId,
-			scope: this.props.scope,
-			ux_mode: this.props.uxMode,
-			redirect_uri: this.props.redirectUri,
-		} );
-		auth2InitDone = true;
-	}
-
-	initialize() {
-		if ( this.initialized ) {
-			return this.initialized;
-		}
-
-		this.setState( { error: '' } );
-
-		const { translate } = this.props;
-
-		this.initialized = this.loadDependency()
-			.then( ( gapi ) =>
-				new Promise( ( resolve ) => gapi.load( 'auth2', resolve ) ).then( () => gapi )
-			)
-			.then( ( gapi ) =>
-				this.initializeAuth2( gapi ).then( () => {
-					this.setState( { isDisabled: false } );
-
-					const googleAuth = gapi.auth2.getAuthInstance();
-					const currentUser = googleAuth.currentUser.get();
-
-					// handle social authentication response from a redirect-based oauth2 flow
-					if ( currentUser && this.props.uxMode === 'redirect' ) {
-						this.props.responseHandler( currentUser, false );
-					}
-
-					return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
-				} )
-			)
-			.catch( ( error ) => {
-				this.initialized = null;
-
-				if ( 'idpiframe_initialization_failed' === error.error ) {
-					// This error is caused by 3rd party cookies being blocked.
-					this.setState( {
-						error: translate(
-							'Please enable "third-party cookies" to connect your Google account. To learn how to do this, {{learnMoreLink}}click here{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: (
-										<a
-											target="_blank"
-											rel="noreferrer"
-											href={ localizeUrl( 'https://wordpress.com/support/third-party-cookies/' ) }
-										/>
-									),
-								},
-							}
-						),
-					} );
-				}
-
-				return Promise.reject( error );
-			} );
-
-		return this.initialized;
 	}
 
 	async handleAuthorizationCode( { auth_code, redirect_uri } ) {

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -74,20 +74,12 @@ class SocialLoginActionButton extends Component {
 		};
 
 		if ( service === 'google' ) {
-			const tokens = config.isEnabled( 'migration/sign-in-with-google' )
-				? response // The `response` object itself holds the tokens, no need for any other method calls.
-				: response.getAuthResponse?.();
-
-			if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
-				return;
-			}
-
 			this.recordLoginSuccess( service );
 
 			socialInfo = {
 				...socialInfo,
-				access_token: tokens.access_token,
-				id_token: tokens.id_token,
+				access_token: response.access_token,
+				id_token: response.id_token,
 			};
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -104,7 +104,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"marketplace-personal-premium": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/import-light-url-screen": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -54,7 +54,6 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -48,7 +48,6 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": true,
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -50,7 +50,6 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -51,7 +51,6 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
-		"migration/sign-in-with-google": true,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"p2/p2-plus": true,
 		"plans/starter-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -80,7 +80,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"p2/p2-plus": true,
 		"page/export": true,

--- a/config/test.json
+++ b/config/test.json
@@ -62,7 +62,6 @@
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"plans/starter-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -81,7 +81,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration/sign-in-with-google": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/difm": true,


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/64791. Fixes https://github.com/Automattic/wp-calypso/issues/64538.

After a few weeks of having the `migration/sign-in-with-google` flag enabled in production, we did not notice any substantial reduction in conversions. This is backed by data: 2d132-pb.

#### Testing Instructions

The same as https://github.com/Automattic/wp-calypso/pull/64957, except for the need to activate the `migration/sign-in-with-google` flag (which is now the default).

#### Pre-merge Checklist

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?