### PR TITLE
Site Setup Design Picker: Recognize individual theme purchases

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -18,10 +18,14 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef, useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
+import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -34,6 +38,7 @@ import GeneratedDesignPickerWebPreview from './generated-design-picker-web-previ
 import PreviewToolbar from './preview-toolbar';
 import StickyPositioner from './sticky-positioner';
 import UpgradeModal from './upgrade-modal';
+import getThemeIdFromDesign from './util/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
 import type { Design } from '@automattic/design-picker';
@@ -91,6 +96,17 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			( select ) =>
 				site && select( SITE_STORE ).siteHasFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
 		)
+	);
+	useQuerySitePurchases( site ? site.ID : -1 );
+
+	const purchasedThemes = useSelector( ( state ) =>
+		site ? getPurchasedThemes( state, site.ID ) : []
+	);
+	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
+	const didPurchaseSelectedTheme = useSelector( ( state ) =>
+		site && selectedDesignThemeId
+			? isThemePurchased( state, selectedDesignThemeId, site.ID )
+			: false
 	);
 
 	const { data: themeDesigns = [] } = useDesignsBySite( site );
@@ -376,7 +392,8 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
 		);
 
-		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
+		const shouldUpgrade =
+			selectedDesign.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme;
 		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview
 		const shouldCustomizeText = intent === SiteIntent.Write || intent === SiteIntent.Sell;
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {
@@ -554,6 +571,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			previewOnly={ newDesignEnabled }
 			hasDesignOptionHeader={ ! newDesignEnabled }
 			verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? siteVerticalId : undefined }
+			purchasedThemes={ purchasedThemes }
 		/>
 	);
 

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -123,32 +123,29 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			return null;
 		}
 
-		let text: any = __( 'Free' );
+		let text: React.ReactNode = null;
 
-		if ( design.is_premium ) {
-			if ( shouldUpgrade ) {
-				text = (
-					<Button
-						isLink={ true }
-						className="design-picker__button-link"
-						onClick={ ( e: any ) => {
-							e.stopPropagation();
-							onCheckout?.();
-						} }
-					>
-						{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
-							? __( 'Included in WordPress.com Premium' )
-							: __( 'Upgrade to Premium' ) }
-					</Button>
-				);
-			} else if ( hasPurchasedTheme ) {
-				// Premium, does not need upgrade
-				// TODO: How to figure out if it's annual or monthly?
-				text = __( 'Purchased on an annual subscription' );
-			} else {
-				// ! shouldUpgrade && ! hasPurchasedTheme
-				text = __( 'Included in your plan' );
-			}
+		if ( design.is_premium && shouldUpgrade ) {
+			text = (
+				<Button
+					isLink={ true }
+					className="design-picker__button-link"
+					onClick={ ( e: any ) => {
+						e.stopPropagation();
+						onCheckout?.();
+					} }
+				>
+					{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
+						? __( 'Included in WordPress.com Premium' )
+						: __( 'Upgrade to Premium' ) }
+				</Button>
+			);
+		} else if ( design.is_premium && ! shouldUpgrade && hasPurchasedTheme ) {
+			text = __( 'Purchased on an annual subscription' );
+		} else if ( design.is_premium && ! shouldUpgrade && ! hasPurchasedTheme ) {
+			text = __( 'Included in your plan' );
+		} else if ( ! design.is_premium ) {
+			text = __( 'Free' );
 		}
 
 		return <div className="design-picker__pricing-description">{ text }</div>;


### PR DESCRIPTION
#### Proposed Changes

* Site Setup Design Picker: Recognize individual theme purchases
  * PRs #66187 and #66239 implemented this for the Unified Design Picker. This does it for the Site Setup Design Picker (what you see if the unified one is off).

Premium themes can be acquired by purchasing a plan that provides all premium themes, or by buying an individual premium theme directly.  The design picker isn't aware of individual purchases yet, this PR adds it.

For example, I have a free plan site where I have purchased the premium theme skivers.

**Before PR:**
![2022-08-04_14-10](https://user-images.githubusercontent.com/937354/182936341-dbcbc285-967a-48cf-be74-a3f75a213fdb.png)
![2022-08-04_14-11](https://user-images.githubusercontent.com/937354/182936360-4b306db4-8403-416c-b8fe-3f36af0caa65.png)

**After PR:**
![2022-08-04_14-09](https://user-images.githubusercontent.com/937354/182936392-76b6f085-9dcd-4f29-9444-846de709c6a5.png)
![2022-08-04_14-09_1](https://user-images.githubusercontent.com/937354/182936418-9bfb8edc-f447-40b1-a23f-16b144b3640b.png)


#### Note: Interaction with other changes

This will need further update once #66048 + D84731-code is merged.

I'll have to change the format of `purchasedThemes`. It's currently an array of theme names, `[ 'skivers', 'payton' ]`, but it will need to contain both the name and the period.  Maybe `[ {name: 'skivers', period: 'yearly'}, ... ]` ?


#### Note: Duplication of wasThemePurchased()

I tried putting this in `client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils`, and importing it from the design-picker, but an eslint rule was triggered saying I shouldn't import from there (no-restricted-imports). I guess there has to be one copy in the design picker package, and one in stepper, unless I'm missing something.
 

#### Testing Instructions

**Part 1**

* Have a free site with an individual premium theme purchased
* Go to `http://calypso.localhost:3000/setup/designSetup?siteSlug=SITE_SLUG_HERE&flags=-signup/design-picker-unified` (note turning the flag off)
* Find Premium themes you have and have not purchased, and note the pricing information below the theme's name.

**Part 2**

* Find a Premium theme you have purchased, and click on it to preview
* The top right button should say "Start with ThemeName" and not "Unlock"
* Click back, and this time click on a Premium theme you have not purchased
* The top right button should continue to say "Unlock"



Related to #65704 #65857
