### PR TITLE
UDP: Remove space on the left of category select

### DIFF
--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -61,7 +61,7 @@
 	width: 100%;
 
 	.responsive-toolbar-group__swipe-list {
-		padding: 0 8px;
+		padding: 0;
 		display: flex;
 		flex-wrap: nowrap;
 		overflow-x: scroll;
@@ -77,6 +77,10 @@
 
 		.responsive-toolbar-group__swipe-item {
 			font-size: 0.875rem;
+
+			&:first-of-type {
+				margin-left: -8px;
+			}
 		}
 
 		// Core override - prevent buttons from wordwrapping content

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -61,7 +61,7 @@
 	width: 100%;
 
 	.responsive-toolbar-group__swipe-list {
-		margin-left: -8px;
+		padding: 0 8px;
 		display: flex;
 		flex-wrap: nowrap;
 		overflow-x: scroll;

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -61,7 +61,7 @@
 	width: 100%;
 
 	.responsive-toolbar-group__swipe-list {
-		padding: 0;
+		margin-left: -8px;
 		display: flex;
 		flex-wrap: nowrap;
 		overflow-x: scroll;
@@ -77,10 +77,6 @@
 
 		.responsive-toolbar-group__swipe-item {
 			font-size: 0.875rem;
-
-			&:first-of-type {
-				margin-left: -8px;
-			}
 		}
 
 		// Core override - prevent buttons from wordwrapping content

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -441,8 +441,27 @@
 .design-picker--has-categories {
 	.responsive-toolbar-group__swipe {
 		.responsive-toolbar-group__swipe-list {
-			padding: 0;
-			margin-left: -8px;
+			padding: 0 0 24px;
+
+			>div:first-of-type {
+				button {
+					padding-left: 8px;
+
+					&::before {
+						left: 0;
+					}
+				}
+			}
+		
+			>div:last-of-type {
+				button {
+					padding-right: 8px;
+
+					&::before {
+						right: 0;
+					}
+				}
+			}
 		}
 	}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -439,6 +439,13 @@
 
 // layout with categories
 .design-picker--has-categories {
+	.responsive-toolbar-group__swipe {
+		.responsive-toolbar-group__swipe-list {
+			padding: 0;
+			margin-left: -8px;
+		}
+	}
+
 	@supports ( display: grid ) {
 		.design-picker__grid {
 			@include break-medium {


### PR DESCRIPTION
## Proposed Changes

- Update `.responsive-toolbar-group__swipe-list` stylesheet

## Testing Instructions

- Heading to /designSetup step of onboarding flow
- Switch to mobile viewport
- Confirm that the left space of the category select is in good shape

https://user-images.githubusercontent.com/10071857/183034535-8aea1f32-ed3a-47e2-ac61-0273c8e45e67.mp4



Related to #66284
