### PR TITLE
DIFM Step: Show loader when saving preferences

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -244,6 +244,8 @@ export default function DIFMLanding( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const hasPriceDataLoaded = productCost && currencyCode;
 
+	const [ isLoading, setIsLoading ] = useState( true );
+
 	const displayCost = hasPriceDataLoaded
 		? formatCurrency( productCost, currencyCode, { stripZeros: true } )
 		: '';
@@ -266,7 +268,8 @@ export default function DIFMLanding( {
 	useEffect( () => {
 		( async () => {
 			await dispatch( incrementCounter( 'VIEWED_DIFM_LANDING' ) );
-			dispatch( requestProductsList( { type: 'all' } ) );
+			await dispatch( requestProductsList( { type: 'all' } ) );
+			setIsLoading( false );
 		} )();
 	}, [ dispatch ] );
 
@@ -278,7 +281,7 @@ export default function DIFMLanding( {
 		'Hire a professional to set up your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
 		{
 			components: {
-				PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
+				PriceWrapper: isLoading ? <Placeholder /> : <span />,
 				sup: <sup />,
 			},
 			args: {

--- a/client/my-sites/marketing/do-it-for-me/site-build-showcase.tsx
+++ b/client/my-sites/marketing/do-it-for-me/site-build-showcase.tsx
@@ -33,16 +33,16 @@ const Container = styled.div`
 		opacity: 0;
 	}
 
-	> div:nth-child( 2 ) {
+	> div:nth-of-type( 2 ) {
 		animation-delay: 8s;
 	}
-	> div:nth-child( 3 ) {
+	> div:nth-of-type( 3 ) {
 		animation-delay: 16s;
 	}
-	> div:nth-child( 4 ) {
+	> div:nth-of-type( 4 ) {
 		animation-delay: 24s;
 	}
-	> div:nth-child( 5 ) {
+	> div:nth-of-type( 5 ) {
 		animation-delay: 32s;
 	}
 `;


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to #66080. The loading placeholder is not shown if the product prices are already cached in browser storage. However, on this page, we need to fetch the latest prices from the backend and show the updated prices on this page. The loading placeholder should also be shown while the network request to update Calypso preferences completes. `incrementCounter()` internally updates Calypso preferences.

This PR adds a new state slice `saving` to the `preferences` store. This will be set to `true` when a network request is sent to save preferences and will be set to `false` when the request completes or fails.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/difmStartingPoint?siteSlug=<site slug>`.
* Confirm that the placeholder is shown till both requests (`/preferences` and `/products`) are complete.


https://user-images.githubusercontent.com/5436027/183037806-4ca03efa-5a57-4cbb-bdd2-5d38f8863c0f.mp4



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? - NA
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) - NA
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - NA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#978