### PR TITLE
WooCommerce.com login - fix line-height of ToS

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -644,6 +644,7 @@
 
 			a {
 				font-size: inherit;
+				line-height: inherit;
 			}
 		}
 
@@ -877,11 +878,13 @@
 	.login__form-terms {
 		font-weight: 400;
 		font-size: $woo-font-size-small;
-		line-height: 28px;
+		line-height: 20px;
 		color: $woo-gray-40;
-		margin: 0 8px 12px;
+		margin: 4px 8px 16px;
+
 		a {
 			font-size: inherit;
+			line-height: inherit;
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

The `line-height` of links inside ToS acceptance lines was too big. This caused the lines to have different heights:
![image](https://user-images.githubusercontent.com/4765119/183043542-525db5f6-728f-4bd3-b4b2-483abd4c8238.png). This PR ensures that links inside ToS acceptance lines have proper `line-height`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On WooCommerce.test click login
- Replace _https://wordpress.com/_ with _http://calypso.localhost:3000/_ in the URL and if texts regarding Terms of Service acceptance are displayed properly ![image](https://user-images.githubusercontent.com/4765119/183043464-8df97c85-e716-4f9a-8cf3-f11eff0ac44c.png)
- Please test around this issue
