### PR TITLE
Sites Management Page: Only show `<FilterBar>` when user has sites

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -102,7 +102,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 			</PageHeader>
 			<PageBodyWrapper>
 				<>
-					{ allSites.length > 0 ? (
+					{ allSites.length > 0 && (
 						<FilterBar>
 							<SitesSearch
 								searchIcon={ <SitesSearchIcon /> }
@@ -125,8 +125,6 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 								) ) }
 							</SelectDropdown>
 						</FilterBar>
-					) : (
-						''
 					) }
 					{ filteredSites.length > 0 ? (
 						<SitesTable sites={ filteredSites } />

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -102,28 +102,32 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 			</PageHeader>
 			<PageBodyWrapper>
 				<>
-					<FilterBar>
-						<SitesSearch
-							searchIcon={ <SitesSearchIcon /> }
-							onSearch={ ( term ) => handleQueryParamChange( 'search', term?.trim() ) }
-							isReskinned
-							placeholder={ __( 'Search by name or domain…' ) }
-							disableAutocorrect={ true }
-							defaultValue={ search }
-						/>
-						<SelectDropdown selectedText={ selectedStatus.title }>
-							{ statuses.map( ( { name, title, count } ) => (
-								<SelectDropdown.Item
-									key={ name }
-									selected={ name === selectedStatus.name }
-									count={ count }
-									onClick={ () => handleQueryParamChange( 'status', 'all' !== name ? name : '' ) }
-								>
-									{ title }
-								</SelectDropdown.Item>
-							) ) }
-						</SelectDropdown>
-					</FilterBar>
+					{ allSites.length > 0 ? (
+						<FilterBar>
+							<SitesSearch
+								searchIcon={ <SitesSearchIcon /> }
+								onSearch={ ( term ) => handleQueryParamChange( 'search', term?.trim() ) }
+								isReskinned
+								placeholder={ __( 'Search by name or domain…' ) }
+								disableAutocorrect={ true }
+								defaultValue={ search }
+							/>
+							<SelectDropdown selectedText={ selectedStatus.title }>
+								{ statuses.map( ( { name, title, count } ) => (
+									<SelectDropdown.Item
+										key={ name }
+										selected={ name === selectedStatus.name }
+										count={ count }
+										onClick={ () => handleQueryParamChange( 'status', 'all' !== name ? name : '' ) }
+									>
+										{ title }
+									</SelectDropdown.Item>
+								) ) }
+							</SelectDropdown>
+						</FilterBar>
+					) : (
+						''
+					) }
 					{ filteredSites.length > 0 ? (
 						<SitesTable sites={ filteredSites } />
 					) : (


### PR DESCRIPTION
Fixes #66210

## Proposed Changes

Only shows the `<FilterBar>` when the user has sites.

<img width="1463" alt="image" src="https://user-images.githubusercontent.com/36432/183068168-421bf14e-8a32-4745-a6e7-14f24615f504.png">


#### Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Clear out all of your sites through whichever preferred means.
3. View the page above.
