### PR TITLE
Fix: Redux store doesn't cache isomorphic subtrees

### DIFF
--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -242,7 +242,7 @@ export function serverRender( req, res ) {
 
 		// And cache on the server, too.
 		if ( cacheKey ) {
-			const cacheableServerState = pick( context.store.getState(), cacheableReduxSubtrees );
+			const cacheableServerState = pick( context.store.getState(), reduxSubtrees );
 			const serverState = serialize( context.store.getCurrentReducer(), cacheableServerState );
 			stateCache.set( cacheKey, serverState.get() );
 		}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -233,7 +233,7 @@ export function serverRender( req, res ) {
 		attachHead( context );
 
 		const cacheableReduxSubtrees = [ 'documentHead' ];
-		const cacheableLoggedOutReduxSubtrees = ! context.isLoggedIn ? [ 'themes', 'ui' ] : [];
+		const cacheableLoggedOutReduxSubtrees = ! context.user ? [ 'themes', 'ui' ] : [];
 		const isomorphicSubtrees = context.section?.isomorphic ? [ 'themes', 'ui' ] : [];
 
 		const reduxSubtrees = [ ...cacheableReduxSubtrees, ...isomorphicSubtrees ];

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -233,6 +233,7 @@ export function serverRender( req, res ) {
 		attachHead( context );
 
 		const cacheableReduxSubtrees = [ 'documentHead' ];
+		const cacheableLoggedOutReduxSubtrees = ! context.isLoggedIn ? [ 'themes', 'ui' ] : [];
 		const isomorphicSubtrees = context.section?.isomorphic ? [ 'themes', 'ui' ] : [];
 
 		const reduxSubtrees = [ ...cacheableReduxSubtrees, ...isomorphicSubtrees ];
@@ -242,7 +243,10 @@ export function serverRender( req, res ) {
 
 		// And cache on the server, too.
 		if ( cacheKey ) {
-			const cacheableServerState = pick( context.store.getState(), reduxSubtrees );
+			const cacheableServerState = pick( context.store.getState(), [
+				...cacheableReduxSubtrees,
+				...cacheableLoggedOutReduxSubtrees,
+			] );
 			const serverState = serialize( context.store.getCurrentReducer(), cacheableServerState );
 			stateCache.set( cacheKey, serverState.get() );
 		}


### PR DESCRIPTION
#### Proposed Changes

This includes the defined isomorphic subtrees to the redux cache so that the /theme and /themes can cache data fetches.

#### Testing Instructions
* Log out
* Go to `/themes`
* Navigate, search and view themes
* Everything should work as before

* Repeat the steps above while logged in

