### PR TITLE
Help Center: Adjust Happychat endpoint in help center according to env

### DIFF
--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -22,12 +22,19 @@
 	<body>
 		<div id="wpcom" class="container"></div>
 		<script>
+			const env = new URLSearchParams( window.location.search ).get( 'env' ) || 'dev';
+			const happychat_url =
+				env === 'dev'
+					? 'https://happychat-io-staging.go-vip.co/customer'
+					: 'https://happychat.io/customer';
+			const env_id = env === 'dev' ? 'development' : 'production';
+
 			window.configData = {
-				env_id: 'development',
+				env_id,
 				i18n_default_locale_slug: 'en',
 				google_analytics_key: 'UA-10673494-15',
 				client_slug: 'browser',
-				happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
+				happychat_url,
 				site_filter: [],
 				sections: {},
 				enable_all_sections: false,

--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -3,12 +3,14 @@
  */
 import './help-center-inline-chat.scss';
 
+const env = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
+
 const InlineChat: React.FC = () => {
 	return (
 		<iframe
 			className="help-center-inline-chat__iframe"
 			title="Happychat"
-			src="https://widgets.wp.com/calypso-happychat/"
+			src={ `https://widgets.wp.com/calypso-happychat/?env=${ env }` }
 		/>
 	);
 };


### PR DESCRIPTION
### Proposed Changes

* The Happychat app in widgets.wp.com is unconfigurable and only connects to production Happychat. 
* This PR fixes that by accepting a `dev` parameter in Happychat iframe and passing that parameter from the help-center while defaulting to `dev`.

### How it works

1. The editor: the env environment variable is set in ETK, when ETK is in dev mode (locally) we'll connect to HC staging.
2. Calypso: the env environment variable is set in Calypso, when Calypso is in dev mode (locally) we'll connect to HC staging.

### Testing Instructions

Testing this comes in two stages:

#### Development

##### Calypso

1. Run Calypso. 
2. Sign in using 10% user and open page with the help center.
3. Open the Help Center.
4. Try to start a chat, if chat is not available, login to https://hud-staging.happychat.io/ and mark yourself as present.
5. Once the chat starts, inspect the iframe, the iframe src should end with `env=dev`.

##### The editor
1. Run `yarn dev --sync` in `apps/editing-toolkit`. 
2. Open the Help Center.
3. Try to start a chat, if chat is not available, login to https://hud-staging.happychat.io/ and mark yourself as present.
4. Once the chat starts, inspect the iframe, the iframe src should end with `env=dev`.

#### Production

##### Calypso
In Calypso, the calypso.live link should do. Repeat the Calypso part above, the URL should end with `env=prod`. 

##### Editor
This is somewhat tricky to test, as `NODE_ENV` will only have `production` value in production. So, I made the PR as tiny as possible to make merging it safe. Then, once you merge and deploy ETK, please repeat the steps above. The iframe URL should end with `env=prod` this time. 
