### PR TITLE
VideoPress onboarding: Redirect to site editor after plan purchase

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -247,7 +247,7 @@ export function generateFlows( {
 		{
 			name: 'videopress',
 			steps: [ 'user', 'videopress-site', 'plans-premium' ],
-			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
+			destination: ( dependencies ) => `/site-editor/${ dependencies.siteSlug }`,
 			description: 'VideoPress signup flow',
 			lastModified: '2022-07-06',
 			showRecaptcha: true,


### PR DESCRIPTION
#### Proposed Changes

* Redirect to site editor after plan purchase

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply D85406-code and sandbox public-api
* go through the full checkout process.
* On succesful purchase, you are redirected to the site editor.

