### PR TITLE
Sites Management Page: Ignore match location using fuzzy search

### DIFF
--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 const defaultOptions = {
 	threshold: 0.4,
 	distance: 20,
+	ignoreLocation: true,
 };
 
 type KeysProp< T > = T extends string


### PR DESCRIPTION
Fixes #66296

## Proposed Changes

Ignores match location by default when using fuzzy search.

**Before,** a search would fail if the query didn't match within the first 8 characters of the search string:

<img width="809" alt="image" src="https://user-images.githubusercontent.com/36432/183112387-439e6a90-91ea-4b85-b351-e85b80af4d34.png">

https://user-images.githubusercontent.com/36432/183112254-ceaa2839-0b35-4535-9818-cd5ab5110f5b.mp4

**After,** a search is successful when the query falls anywhere within the search string:

<img width="887" alt="image" src="https://user-images.githubusercontent.com/36432/183112451-97560eec-d39d-4f18-81f7-b17c12eec16e.png">

https://user-images.githubusercontent.com/36432/183112067-e29ee96c-ab14-4abd-8b17-08499771bf95.mp4


## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Perform a search where your search string is in the middle of the matching string.
3. See the results you expect to see.