### PR TITLE
Licensing Portal: fix Billing page design on mobile

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -113,23 +113,6 @@ export default function BillingDetails(): ReactElement {
 
 			<Card compact className="billing-details__footer">
 				<div className="billing-details__row billing-details__row--summary">
-					<span className="billing-details__total-label billing-details__cost-label">
-						{ billing.isSuccess &&
-							translate( 'Cost for {{bold}}%(date)s{{/bold}}', {
-								components: { bold: <strong /> },
-								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
-							} ) }
-
-						{ billing.isLoading && <TextPlaceholder /> }
-					</span>
-					<strong className="billing-details__cost-amount">
-						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
-
-						{ billing.isLoading && <TextPlaceholder /> }
-
-						{ billing.isError && <Gridicon icon="minus" /> }
-					</strong>
-
 					{ billing.isSuccess && ! useDailyPrices && (
 						<>
 							<span className="billing-details__total-label billing-details__line-item-meta">
@@ -151,6 +134,23 @@ export default function BillingDetails(): ReactElement {
 							</span>
 						</>
 					) }
+
+					<span className="billing-details__total-label billing-details__cost-label">
+						{ billing.isSuccess &&
+							translate( 'Cost for {{bold}}%(date)s{{/bold}}', {
+								components: { bold: <strong /> },
+								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
+							} ) }
+
+						{ billing.isLoading && <TextPlaceholder /> }
+					</span>
+					<strong className="billing-details__cost-amount">
+						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
+
+						{ billing.isLoading && <TextPlaceholder /> }
+
+						{ billing.isError && <Gridicon icon="minus" /> }
+					</strong>
 				</div>
 			</Card>
 

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
@@ -5,6 +5,8 @@
 	&__row {
 		display: grid;
 		grid-template-columns: calc( 66% - 12px ) calc( 34% - 12px );
+		direction: rtl;
+		transform: rotate( 180deg );
 		grid-template-areas:
 			'product assigned'
 			'subtotal unassigned';
@@ -13,14 +15,32 @@
 		font-size: 1.25rem;
 
 		@include break-xlarge() {
+			direction: ltr;
+			transform: rotate( 0 );
 			grid-template-columns: 1fr 150px 150px 150px;
-			grid-template-areas:
-				'product assigned unassigned subtotal';
+			grid-template-areas: 'product assigned unassigned subtotal';
 		}
 
 		&--summary {
 			grid-template-areas: none;
 			grid-gap: 8px 24px;
+		}
+
+		> * {
+			direction: ltr;
+			transform: rotate( 180deg );
+
+			@include break-xlarge() {
+				transform: rotate( 0 );
+			}
+		}
+
+		> :nth-child( even ) {
+			text-align: right;
+
+			@include break-xlarge() {
+				text-align: left;
+			}
 		}
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/style.scss
@@ -5,8 +5,6 @@
 	&__row {
 		display: grid;
 		grid-template-columns: calc( 66% - 12px ) calc( 34% - 12px );
-		direction: rtl;
-		transform: rotate( 180deg );
 		grid-template-areas:
 			'product assigned'
 			'subtotal unassigned';
@@ -15,8 +13,7 @@
 		font-size: 1.25rem;
 
 		@include break-xlarge() {
-			direction: ltr;
-			transform: rotate( 0 );
+
 			grid-template-columns: 1fr 150px 150px 150px;
 			grid-template-areas: 'product assigned unassigned subtotal';
 		}
@@ -24,15 +21,6 @@
 		&--summary {
 			grid-template-areas: none;
 			grid-gap: 8px 24px;
-		}
-
-		> * {
-			direction: ltr;
-			transform: rotate( 180deg );
-
-			@include break-xlarge() {
-				transform: rotate( 0 );
-			}
 		}
 
 		> :nth-child( even ) {

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/style.scss
@@ -3,33 +3,44 @@
 
 .billing-summary {
 	display: flex;
-	flex-wrap: wrap;
+	flex-direction: column;
 
 	@include break-xlarge() {
-		flex-wrap: nowrap;
+		flex-direction: row;
 	}
 
 	&__stat {
+		display: flex;
 		flex: 0 1 0;
+		flex-direction: row;
+		justify-content: space-between;
 		margin-bottom: 18px;
-	}
-
-	&__stat:nth-child( odd ) {
-		flex-basis: calc( 50% - 18px );
-	}
-
-	&__stat:nth-child( even ) {
-		flex-basis: calc( 50% - 1px - 18px );
-		margin-left: 18px;
-		padding-left: 18px;
-		border-left: 1px solid var( --studio-gray-5 );
 	}
 
 	&__stat:nth-last-child( -n + 2 ) {
 		margin-bottom: 0;
 	}
 
+	&__cost.billing-summary__stat {
+		display: none;
+	}
+
 	@include break-xlarge() {
+		&__stat {
+			flex-direction: column;
+		}
+
+		&__stat:nth-child( odd ) {
+			flex-basis: calc( 50% - 18px );
+		}
+
+		&__stat:nth-child( even ) {
+			flex-basis: calc( 50% - 1px - 18px );
+			margin-left: 18px;
+			padding-left: 18px;
+			border-left: 1px solid var( --studio-gray-5 );
+		}
+
 		&__stat {
 			&.billing-summary__stat {
 				flex: 1 1 0;
@@ -44,6 +55,7 @@
 		}
 
 		&__cost.billing-summary__stat {
+			display: block;
 			flex-grow: 1.25;
 			margin-left: auto;
 			border-left: 0;


### PR DESCRIPTION
The Billing Summary was too compact for scale. Also, the cost info was duplicated, appearing on the summary and on the details below.

#### Proposed Changes

* Make the Billing Summary vertical on mobile and horizontal on larger screens.
* Hide the cost info in the Billing Summary on mobile
* The Billing Details show the cost info on the bottom for mobile screens and on the top for desktops.

#### Testing Instructions

* Go to Licensing -> Billing
* The Billing Summary should be vertical on mobile and horizontal on desktop.
* The Billing Details should show the cost info as the last row on mobile and the first row on desktop.

#### Screenshot (Mobile)

![image](https://user-images.githubusercontent.com/6406071/183112031-f1765a3f-914b-47a4-98a5-0f9be8126439.png)

#### Screenshot (Desktop)

![image](https://user-images.githubusercontent.com/6406071/183112126-7d58dc8b-31e3-436f-961c-d47e24795e69.png)

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?