### PR TITLE
[TeamCity][Sentry] Add a `SENTRY_RELEASE_NAME` param to the GB source-map uploader build

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -226,7 +226,11 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					cd gutenberg
 
 					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
-					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files %SENTRY_RELEASE_NAME% upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
+					sentry-cli releases files %SENTRY_RELEASE_NAME% upload-sourcemaps . \
+							--auth-token %SENTRY_AUTH_TOKEN% \
+							--org a8c \
+							--project wpcom-gutenberg-wp-admin \
+							--url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
 				"""
 			}
 		}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -202,6 +202,16 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 			)
 		}
 
+		params {
+			text(
+				name = "SENTRY_RELEASE_NAME",
+				value = "",
+				label = "Sentry release name",
+				description = "The WPCOM Sentry release to upload the source-maps to",
+				allowEmpty = false
+			)
+		}
+
 		steps {
 			bashNodeScript {
 				name = "Upload source maps to Sentry"
@@ -216,7 +226,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					cd gutenberg
 
 					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
-					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files wpcom-test-01 upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
+					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files %SENTRY_RELEASE_NAME% upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
 				"""
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

WPCOM will soon start creating a Sentry release for each deploy (see the related section below for more contextual info). We were using a fixed `wpcom-test-01` release for testing purposes so far, and it was also used in this build to upload source-map files for the Gutenberg on WPCOM. We now need to pass the dynamic release name, and for that, we need to add a new param to the build. The consuming script* will then pass the release name in this param.

_*Right now, the consuming script is `gutenbot` that will trigger this build after installing a new version of Gutenberg on WPCOM. This is done in D85487-code_

#### Testing Instructions

* Checks should pass
* After merging, the right param should be part of the build in TC

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: 

* https://github.com/Automattic/wp-calypso/pull/63260
* https://github.com/Automattic/wp-calypso/pull/66186
* D85265-code
* D85487-code