### PR TITLE
Update loading status for A/B test on the domains step

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
@@ -12,16 +12,18 @@ class ReskinSideExplainer extends Component {
 		super( props );
 		this.state = {
 			experiment: null,
+			isExperimentLoading: [ 'en', 'en-gb' ].includes( getLocaleSlug() ),
 		};
 	}
 	componentDidMount() {
 		this._isMounted = true;
 
-		loadExperimentAssignment( 'domain_step_cta_copy_test' ).then( ( experimentName ) => {
-			if ( this._isMounted ) {
-				this.setState( { experiment: experimentName } );
-			}
-		} );
+		[ 'en', 'en-gb' ].includes( getLocaleSlug() ) &&
+			loadExperimentAssignment( 'domain_step_cta_copy_test' ).then( ( experimentName ) => {
+				if ( this._isMounted ) {
+					this.setState( { experiment: experimentName, isExperimentLoading: false } );
+				}
+			} );
 	}
 
 	componentWillUnmount() {
@@ -68,19 +70,22 @@ class ReskinSideExplainer extends Component {
 
 				title = isPaidPlan ? paidTitle : freeTitle;
 
-				freeSubtitle =
-					this.state.experiment?.variationName === 'treatment'
-						? translate( 'You can claim your free custom domain later if you aren’t ready yet.' )
-						: translate(
-								'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
-						  );
+				freeSubtitle = (
+					<span className={ this.state.isExperimentLoading ? 'is-loading' : '' }>
+						{ this.state.experiment?.variationName === 'treatment'
+							? translate( 'You can claim your free custom domain later if you aren’t ready yet.' )
+							: translate(
+									'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
+							  ) }
+					</span>
+				);
 
 				paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
 
 				subtitle = isPaidPlan ? paidSubtitle : freeSubtitle;
 
 				subtitle2 =
-					this.state.experiment?.variationName === 'treatment'
+					this.state.isExperimentLoading || this.state.experiment?.variationName === 'treatment'
 						? null
 						: translate(
 								'We’ll pay the first year’s domain registration fees for you, simple as that!'
@@ -91,11 +96,13 @@ class ReskinSideExplainer extends Component {
 					subtitle2 = null;
 				}
 
-				ctaText =
-					this.state.experiment?.variationName === 'treatment'
-						? translate( 'View plans' )
-						: translate( 'Choose my domain later' );
-
+				ctaText = (
+					<span className={ this.state.isExperimentLoading ? 'is-loading' : '' }>
+						{ this.state.experiment?.variationName === 'treatment'
+							? translate( 'View plans' )
+							: translate( 'Choose my domain later' ) }
+					</span>
+				);
 				break;
 
 			case 'use-your-domain':

--- a/client/components/domains/reskin-side-explainer/style.scss
+++ b/client/components/domains/reskin-side-explainer/style.scss
@@ -36,4 +36,7 @@
             font-weight: 500; /* stylelint-disable-line */
         }
     }
+	.is-loading {
+		@include placeholder( --color-neutral-10 );
+	}
 }


### PR DESCRIPTION
This is a follow up proposal for https://github.com/Automattic/wp-calypso/pull/66246/ after reviewing the experiment related code.

#### Proposed Changes

* Render a placeholder (or nothing for the second subtitle) while the experiment is loading
* Stop loading the experiment and render always 'control' experience on a non-EN page. UX-wise, this will also prevent the users of other languages to see the loading placeholder

#### Testing Instructions

Same as https://github.com/Automattic/wp-calypso/pull/66246/ with these notes
* For EN locale, a placeholder will be displayed for subtitle 1 and CTA link while the experiment is loaded
* Even if a user is assigned to 'treatment', they will experience 'control' if the page is the locale is different than EN

#### Demos

* Treatment, **before** this change

https://user-images.githubusercontent.com/14192054/183133528-1e529047-00bd-4c2f-b904-0f8b8bd507aa.mov


* Treatment, **after** this change

https://user-images.githubusercontent.com/14192054/183133541-9000a61c-197d-4f56-93c5-6b134a66f86e.mov

* Control, for EN locale

https://user-images.githubusercontent.com/14192054/183133649-0224d631-a37e-40e1-b334-ad3d729a0843.mov


 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
