### PR TITLE
Sites Management Page: Fix hiding columns on mobile

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -29,12 +29,7 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	color: var( --studio-gray-60 );
 
 	@media only screen and ( max-width: 781px ) {
-		${ ( props ) =>
-			props.mobileHidden &&
-			css`
-				display: none;
-			` };
-
+		${ ( props ) => props.mobileHidden && 'display: none;' };
 		padding-right: 0;
 	}
 `;


### PR DESCRIPTION
Introduced in #65756

From p1659722893729439-slack-C0347E545HR

## Proposed Changes

Restores hiding columns on mobile.

**Before**

<img width="635" alt="image" src="https://user-images.githubusercontent.com/36432/183139854-a2b8e834-d639-4e24-8d53-4b6763836131.png">

**After**

<img width="547" alt="image" src="https://user-images.githubusercontent.com/36432/183139760-24ffbbd1-b52e-43b6-973b-2a520e2b6e0b.png">


## Testing Instructions

1. Visit `/sites-dashboard` on mobile.