### PR TITLE
E2E: Use has-text selector for skip domains button

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
@@ -21,7 +21,7 @@ export class SignupDomainPage {
 	 */
 	async skipDomainSelection(): Promise< void > {
 		const locator = this.page.locator(
-			'span[role="button"]:text("Choose my domain later"):visible'
+			'span[role="button"]:has-text("Choose my domain later"):visible'
 		);
 		await locator.click();
 	}


### PR DESCRIPTION
#### Proposed Changes

* Fixes failing e2e after https://github.com/Automattic/wp-calypso/pull/66316/ 
`:has-text` should be looking also in the descendant element which in this case is another `<span />`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
