### PR TITLE
getPurchasedThemes: Also look for productType == "theme"

### DIFF
--- a/client/state/themes/selectors/get-purchased-themes.js
+++ b/client/state/themes/selectors/get-purchased-themes.js
@@ -13,8 +13,10 @@ import 'calypso/state/themes/init';
  */
 export function getPurchasedThemes( state, siteId ) {
 	const sitePurchases = getSitePurchases( state, siteId );
+	// TODO: productSlug check can be removed after the backend is changed to return productType
 	return sitePurchases
-		.filter( ( purchase ) => purchase?.productSlug === 'premium_theme' )
+		.filter(
+			( purchase ) => purchase?.productSlug === 'premium_theme' || purchase?.productType === 'theme'
+		)
 		.map( ( purchase ) => purchase.meta );
-	// TODO: Return getThemeNameFromMeta( purchase.meta ) after #66048 is merged
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2288,6 +2288,36 @@ describe( 'themes selectors', () => {
 			);
 			expect( purchases ).toEqual( [] );
 		} );
+
+		/*
+		Uncomment with https://github.com/Automattic/wp-calypso/pull/66285
+		test( 'given 2 purchased themes, return 2 theme names [new-style]', () => {
+			const purchases = getPurchasedThemes(
+				{
+					purchases: {
+						data: [
+							{
+								ID: 1234567,
+								blog_id: 2916284,
+								meta: 'mood',
+								product_slug: 'wp_premium_theme_mood_yearly',
+								product_type: 'theme',
+							},
+							{
+								ID: 1234568,
+								blog_id: 2916284,
+								meta: 'skivers',
+								product_slug: 'wp_premium_theme_skivers_yearly',
+								product_type: 'theme',
+							},
+						],
+					},
+				},
+				2916284
+			);
+			expect( purchases ).toEqual( [ 'mood', 'skivers' ] );
+		} );
+		*/
 	} );
 
 	describe( '#isPremiumThemeAvailable', () => {


### PR DESCRIPTION
#### Proposed Changes

* `getPurchasedThemes` will now also consider any purchase with the `productType` attribute equal to `"theme"` as a purchased theme
  * This can be rolled into #66285 or deployed as-is, right now, with small cleanup after #66285 is deployed.

#### Testing Instructions

* Test #66285 + D85381-code together: Apply both to a sandboxed site and use it to buy a premium theme subscription on a free site.
* Visit `/setup/designSetup?siteSlug=YOURSITEHERE&flags=signup/design-picker-unified` and look for the theme you bought (baxter)

**Before PR:**
![2022-08-05_13-39](https://user-images.githubusercontent.com/937354/183144904-1fbdc533-07da-4f0a-8c8d-7768094727af.png)

**After PR:**
![2022-08-05_14-09](https://user-images.githubusercontent.com/937354/183144954-911127c8-3ba0-48fc-af36-f700f63b0539.png)

