### PR TITLE
unified-design-picker: Flatten text conditional

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -109,55 +109,52 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			return null;
 		}
 
-		let text: any = __( 'Free' );
-
-		if ( design.is_premium ) {
-			if ( shouldUpgrade ) {
-				// Premium, needs upgrade
-				text =
-					( ! isEnabled( 'signup/seller-upgrade-modal' ) && (
-						<Button
-							isLink={ true }
-							className="design-picker__button-link"
-							onClick={ ( e: any ) => {
-								e.stopPropagation();
-								onCheckout?.();
-							} }
-						>
-							{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
-								? __( 'Included in WordPress.com Premium' )
-								: __( 'Upgrade to Premium' ) }
-						</Button>
-					) ) ||
-					createInterpolateElement(
-						sprintf(
-							/* translators: %(price)s - the price of the theme */
-							__( '%(price)s per year or <button>included in WordPress.com Premium</button>' ),
-							{
-								price: design.price,
-							}
-						),
+		let text: React.ReactNode = null;
+		if ( design.is_premium && shouldUpgrade ) {
+			if ( isEnabled( 'signup/seller-upgrade-modal' ) ) {
+				text = createInterpolateElement(
+					sprintf(
+						/* translators: %(price)s - the price of the theme */
+						__( '%(price)s per year or <button>included in WordPress.com Premium</button>' ),
 						{
-							button: (
-								<Button
-									isLink={ true }
-									className="design-picker__button-link"
-									onClick={ ( e: any ) => {
-										e.stopPropagation();
-										onCheckout?.();
-									} }
-								/>
-							),
+							price: design.price,
 						}
-					);
-			} else if ( hasPurchasedTheme ) {
-				// Premium, does not need upgrade
-				// TODO: How to figure out if it's annual or monthly?
-				text = __( 'Purchased on an annual subscription' );
+					),
+					{
+						button: (
+							<Button
+								isLink={ true }
+								className="design-picker__button-link"
+								onClick={ ( e: any ) => {
+									e.stopPropagation();
+									onCheckout?.();
+								} }
+							/>
+						),
+					}
+				);
 			} else {
-				// ! shouldUpgrade && ! hasPurchasedTheme
-				text = __( 'Included in your plan' );
+				text = (
+					<Button
+						isLink={ true }
+						className="design-picker__button-link"
+						onClick={ ( e: any ) => {
+							e.stopPropagation();
+							onCheckout?.();
+						} }
+					>
+						{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
+							? __( 'Included in WordPress.com Premium' )
+							: __( 'Upgrade to Premium' ) }
+					</Button>
+				);
 			}
+		} else if ( design.is_premium && ! shouldUpgrade && hasPurchasedTheme ) {
+			text = __( 'Purchased on an annual subscription' );
+		} else if ( design.is_premium && ! shouldUpgrade && ! hasPurchasedTheme ) {
+			text = __( 'Included in your plan' );
+		} else if ( ! design.is_premium ) {
+			text = __( 'Free' );
 		}
 
 		return <div className="design-picker__pricing-description">{ text }</div>;


### PR DESCRIPTION
#### Proposed Changes

* In the unified-design-picker, flatten some nested ifs to try to make them easier to understand
  * It's not 100% flat since there's still a flag check
  * No functional changes; code should behave the same before and after
  * Making the same sorts of changes from #66279 (Site Setup Design Picker) and applying to the Unified Design Picker

#### Testing Instructions


* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=testsitemmrfree100.wordpress.com&flags=signup/design-picker-unified,signup/seller-upgrade-modal`
* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=testsitemmrfree100.wordpress.com&flags=signup/design-picker-unified,-signup/seller-upgrade-modal`
* Check that the upsell and purchase text still works (free theme, premium theme + purchased, premium theme + premium plan, premium theme needs upgrade)

![2022-08-05_15-13_1](https://user-images.githubusercontent.com/937354/183156176-9e9ede1c-844d-466a-9b7a-edb6092d085f.png)
![2022-08-05_15-13](https://user-images.githubusercontent.com/937354/183156193-bbe0c88a-c546-4840-b1b7-28a95d1d026a.png)

