### PR TITLE
[Calypso] Update 'Something else' vertical tracking vertical_id

### DIFF
--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -131,7 +131,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 
 		return suggestions.concat( [
 			{
-				value: '',
+				value: '-1',
 				name: 'Something else',
 				label: String( translate( 'Something else' ) ),
 				category: 0 < suggestions.length ? '—' : '',

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -131,7 +131,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 
 		return suggestions.concat( [
 			{
-				value: '-1',
+				value: '',
 				name: 'Something else',
 				label: String( translate( 'Something else' ) ),
 				category: 0 < suggestions.length ? '—' : '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -47,7 +47,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 
 			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
 				user_input: userInput,
-				vertical_id: value,
+				vertical_id: name === 'Something else' ? -1 : name,
 				vertical_title: name,
 			} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -47,7 +47,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 
 			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
 				user_input: userInput,
-				vertical_id: name === 'Something else' ? -1 : name,
+				vertical_id: name === 'Something else' ? -1 : value,
 				vertical_title: name,
 			} );
 


### PR DESCRIPTION
## Proposed Changes

- Update 'Something else' vertical tracking id 

## Testing Instructions
### Set up.

Open your dev tools, go to the Network tab, and clear all entries so you can monitor new network activity.
In the search/filter box on the network tab, type t.gif. This will filter network activity so you can see events.
When making some actions, click on the request and navigate to Payload tab to check all the event parameters

## Expected

Head to /vertical of the onboarding
Select 'Something else' and click Submit button
Confirm the calypso_signup_site_vertical_submit 'vertical_id' is -1

<img width="710" alt="Screenshot%20on%202022-08-08%20at%2008-11-02" src="https://user-images.githubusercontent.com/10071857/183320253-bdbcaea0-a45a-4303-a5f1-5d2887c8ba15.png">

## References
Related to #66306
