### PR TITLE
[Calypso] Fix generated design progress bar not sticky 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -83,6 +83,11 @@ button {
 		height: 8px;
 		background-color: transparent;
 
+		&.is-fixed {
+            position: fixed;
+            background-color: #fff;
+        }
+
 		.progress-bar__progress {
 			background-color: $onboarding-accent-blue;
 			border-radius: 0;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -83,10 +83,12 @@ button {
 		height: 8px;
 		background-color: transparent;
 
-		&.is-fixed {
-            position: fixed;
-            background-color: #fff;
-        }
+		@include break-small {
+			&.is-fixed {
+				position: fixed;
+				background-color: #fff;
+			}
+		}
 
 		.progress-bar__progress {
 			background-color: $onboarding-accent-blue;

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -69,9 +69,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 	const progressValue = stepProgress ? stepProgress.progress / stepProgress.count : 0;
-	const isGeneratedDesignsView = useSelect( ( select ) =>
-		select( ONBOARD_STORE ).getIsGeneratedDesignsView()
-	);
 
 	const renderStep = ( path: StepPath ) => {
 		switch ( assertCondition.state ) {
@@ -96,7 +93,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 							<ProgressBar
 								// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 								className={ classnames( 'flow-progress', {
-									'is-fixed': isGeneratedDesignsView && path === 'designSetup',
+									'is-fixed': stepData?.isGeneratedDesignsView && path === 'designSetup',
 								} ) }
 								value={ progressValue * 100 }
 								total={ 100 }

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -69,6 +69,9 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 	const progressValue = stepProgress ? stepProgress.progress / stepProgress.count : 0;
+	const isGeneratedDesignsView = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getIsGeneratedDesignsView()
+	);
 
 	const renderStep = ( path: StepPath ) => {
 		switch ( assertCondition.state ) {
@@ -92,7 +95,9 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 						<div className={ classnames( flow.name, flow.classnames, kebabCase( path ) ) }>
 							<ProgressBar
 								// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-								className="flow-progress"
+								className={ classnames( 'flow-progress', {
+									'is-fixed': isGeneratedDesignsView && path === 'designSetup',
+								} ) }
 								value={ progressValue * 100 }
 								total={ 100 }
 							/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -170,7 +170,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 
 		setStepData( {
 			...stepData,
-			isGeneratedDesignsView: showGeneratedDesigns && ! isMobile,
+			isGeneratedDesignsView: showGeneratedDesigns,
 		} );
 	}, [ showGeneratedDesigns, hasTrackedView, generatedDesigns ] );
 
@@ -369,7 +369,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 
 		setStepData( {
 			...stepData,
-			isGeneratedDesignsView: showGeneratedDesigns && ! isMobile,
+			isGeneratedDesignsView: showGeneratedDesigns,
 		} );
 		goBack();
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -64,7 +64,8 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const site = useSite();
-	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setPendingAction, setIsGeneratedDesignsView } =
+		useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
@@ -165,6 +166,8 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 				generated_designs: generatedDesigns?.map( ( design ) => design.slug ).join( ',' ),
 			} );
 		}
+
+		setIsGeneratedDesignsView( showGeneratedDesigns );
 	}, [ showGeneratedDesigns, hasTrackedView, generatedDesigns ] );
 
 	function headerText() {
@@ -295,6 +298,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		recordTracksEvent( 'calypso_signup_design_view_more_select' );
 
 		setSelectedDesign( undefined );
+		setIsGeneratedDesignsView( showGeneratedDesigns );
 		setIsPreviewingDesign( false );
 		setIsForceStaticDesigns( true );
 	}
@@ -360,6 +364,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			return;
 		}
 
+		setIsGeneratedDesignsView( showGeneratedDesigns );
 		goBack();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -30,7 +30,7 @@ import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import useTrackScrollPageFromTop from '../../../../hooks/use-track-scroll-page-from-top';
-import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import { ONBOARD_STORE, SITE_STORE, STEPPER_INTERNAL_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
@@ -64,10 +64,11 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const site = useSite();
-	const { setSelectedDesign, setPendingAction, setIsGeneratedDesignsView } =
-		useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setStepData } = useDispatch( STEPPER_INTERNAL_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() ) || {};
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
@@ -167,7 +168,10 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			} );
 		}
 
-		setIsGeneratedDesignsView( showGeneratedDesigns );
+		setStepData( {
+			...stepData,
+			isGeneratedDesignsView: showGeneratedDesigns && ! isMobile,
+		} );
 	}, [ showGeneratedDesigns, hasTrackedView, generatedDesigns ] );
 
 	function headerText() {
@@ -298,7 +302,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		recordTracksEvent( 'calypso_signup_design_view_more_select' );
 
 		setSelectedDesign( undefined );
-		setIsGeneratedDesignsView( showGeneratedDesigns );
+		setStepData( showGeneratedDesigns );
 		setIsPreviewingDesign( false );
 		setIsForceStaticDesigns( true );
 	}
@@ -364,7 +368,10 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			return;
 		}
 
-		setIsGeneratedDesignsView( showGeneratedDesigns );
+		setStepData( {
+			...stepData,
+			isGeneratedDesignsView: showGeneratedDesigns && ! isMobile,
+		} );
 		goBack();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -302,7 +302,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		recordTracksEvent( 'calypso_signup_design_view_more_select' );
 
 		setSelectedDesign( undefined );
-		setStepData( showGeneratedDesigns );
 		setIsPreviewingDesign( false );
 		setIsForceStaticDesigns( true );
 	}

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -233,7 +233,7 @@
 			}
 
 			&.has-sticky-nav-buttons-padding {
-				padding-bottom: 48px;
+				padding-bottom: 40px;
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

*   Update flow progress bar to fixed position when user views the generated designs (in the legacy `SiteSetupDesignPicker` )
*   Update ONBOARD store for the new action `setIsGeneratedDesignsView` and selector `getIsGeneratedDesignsView`  

## Testing Instructions

*   Running the onboarding flow to access the /designSetup step `/setup/designSetup?siteSlug=${site_slug}&flags=-signup/design-picker-unified` 
*   Confirm the progress bar is sticked on top when scrolling on the generated designs view  
     

https://user-images.githubusercontent.com/10071857/183558258-d6ba06c6-7598-45c3-bf3f-8149cc51c1c3.mp4



## Reference

Related to #66332