### PR TITLE
Add default payment block plan name

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -3,7 +3,7 @@ import formatCurrency from '@automattic/format-currency';
 import { ToggleControl } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import CountedTextArea from 'calypso/components/forms/counted-textarea';
 import FormCurrencyInput from 'calypso/components/forms/form-currency-input';
@@ -172,6 +172,24 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		setEditedMarkAsDonation( true === newValue ? 'donation' : null );
 	const onNameChange = ( event ) => setEditedProductName( event.target.value );
 	const onSelectSchedule = ( event ) => setEditedSchedule( event.target.value );
+
+	const defaultNames = {
+		'false,1 month': translate( 'Monthly Subscription' ),
+		'true,1 month': translate( 'Monthly Donation' ),
+		'false,1 year': translate( 'Yearly Subscription' ),
+		'true,1 year': translate( 'Yearly Donation' ),
+		'false,one-time': translate( 'Subscription' ),
+		'true,one-time': translate( 'Donation' ),
+	};
+
+	useEffect( () => {
+		// If the user has manually entered a name that should be left as-is, don't overwrite it
+		if ( editedProductName && ! Object.values( defaultNames ).includes( editedProductName ) ) {
+			return;
+		}
+		const name = defaultNames[ [ 'donation' === editedMarkAsDonation, editedSchedule ] ] ?? '';
+		setEditedProductName( name );
+	}, [ editedMarkAsDonation, editedSchedule ] );
 
 	const onClose = ( reason ) => {
 		if ( reason === 'submit' && ! product ) {

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -173,6 +173,10 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const onNameChange = ( event ) => setEditedProductName( event.target.value );
 	const onSelectSchedule = ( event ) => setEditedSchedule( event.target.value );
 
+	// Ideally these values should be kept in sync with the Jetpack equivalents,
+	// though there's no strong technical reason to do so - nothing is going to
+	// break if they fall out of sync.
+	// https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js#L95
 	const defaultNames = {
 		'false,1 month': translate( 'Monthly Subscription' ),
 		'true,1 month': translate( 'Monthly Donation' ),


### PR DESCRIPTION
#### Proposed Changes

When adding a new payment plan for the Jetpack Payment Button block to
use, the plan name will update depending upon the payment options
selected - whether it's a donation and what the payment frequency is.

This aids users in naming their plans appropriately. Making the form
faster to fill in accurately.

If the user explicitly chooses a name that differs from one of the
possible defaults, then that is respected and not overwritten.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use the generated calypso preview link
 2. On a site with a paid plan, go to Tools -> Earn in the menu
 3. If you haven't already, follow the CTA to connect Stripe
 4. Use 'Manage Payment Button' button
 5. In the 'Manage Plans' section click 'Payment plans'
 6. Press 'Add a new payment plan'
 7. Notice that the plan name is defaulted to Monthly Subscription
 8. Notice that as you use the donation and renewal frequency controls that it updates the  plan name
 9. Enter a completely custom plan name, notice that using the donation and renewal frequency controls no longer updates the plan name

https://user-images.githubusercontent.com/93301/183400663-cc7b34f3-25af-4b80-b38c-2f89deef5b34.mp4

The below image shows the contents of the textbox with the title:
![image](https://user-images.githubusercontent.com/93301/183455817-cb7dad3b-bd35-4683-bbcf-76c392607502.png)




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/jetpack#24074, it's essentially the Calypso version of Automattic/jetpack#25397 
