### PR TITLE
Vertical Step: Track whether submitted vertical is eligible for design verticalization

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -46,7 +46,7 @@ const SelectVertical: React.FC< Props > = ( {
 		label: vertical.title,
 		name: vertical.name,
 		category: String( translate( 'Suggestions' ) ),
-		has_verticalizable_images: !! vertical.has_verticalizable_images,
+		has_vertical_images: !! vertical.has_vertical_images,
 	} );
 
 	const mapManySiteVerticalsResponseToVertical = (

--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -46,6 +46,7 @@ const SelectVertical: React.FC< Props > = ( {
 		label: vertical.title,
 		name: vertical.name,
 		category: String( translate( 'Suggestions' ) ),
+		has_verticalizable_images: !! vertical.has_verticalizable_images,
 	} );
 
 	const mapManySiteVerticalsResponseToVertical = (

--- a/client/components/select-vertical/types.ts
+++ b/client/components/select-vertical/types.ts
@@ -3,4 +3,5 @@ export interface Vertical {
 	label: string;
 	name: string;
 	category?: string;
+	has_verticalizable_images?: boolean;
 }

--- a/client/components/select-vertical/types.ts
+++ b/client/components/select-vertical/types.ts
@@ -3,5 +3,5 @@ export interface Vertical {
 	label: string;
 	name: string;
 	category?: string;
-	has_verticalizable_images?: boolean;
+	has_vertical_images?: boolean;
 }

--- a/client/data/site-verticals/types.ts
+++ b/client/data/site-verticals/types.ts
@@ -2,7 +2,7 @@ export interface SiteVerticalsResponse {
 	id: string;
 	name: string;
 	title: string;
-	has_verticalizable_images?: boolean;
+	has_vertical_images?: boolean;
 }
 
 export interface SiteVerticalQueryByIdParams {

--- a/client/data/site-verticals/types.ts
+++ b/client/data/site-verticals/types.ts
@@ -2,6 +2,7 @@ export interface SiteVerticalsResponse {
 	id: string;
 	name: string;
 	title: string;
+	has_verticalizable_images?: boolean;
 }
 
 export interface SiteVerticalQueryByIdParams {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -40,7 +40,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 		event.preventDefault();
 
 		if ( site ) {
-			const { value = '', name = '', has_verticalizable_images = false } = vertical || {};
+			const { value = '', name = '', has_vertical_images = false } = vertical || {};
 
 			setIsBusy( true );
 			await saveSiteSettings( site.ID, { site_vertical_id: value } );
@@ -49,7 +49,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 				user_input: userInput,
 				vertical_id: value,
 				vertical_title: name,
-				has_verticalizable_images,
+				has_vertical_images,
 			} );
 
 			setIsBusy( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -40,7 +40,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 		event.preventDefault();
 
 		if ( site ) {
-			const { value = '', name = '' } = vertical || {};
+			const { value = '', name = '', has_verticalizable_images = false } = vertical || {};
 
 			setIsBusy( true );
 			await saveSiteSettings( site.ID, { site_vertical_id: value } );
@@ -49,6 +49,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 				user_input: userInput,
 				vertical_id: value,
 				vertical_title: name,
+				has_verticalizable_images,
 			} );
 
 			setIsBusy( false );


### PR DESCRIPTION
#### Proposed Changes

This PR adds the property `has_vertical_images` to the `calypso_signup_site_vertical_submit` tracks event. The property `has_vertical_images` indicates whether the submitted vertical is eligible for design verticalization in the design picker step.

**Note: This PR depends on D85535-code.**

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the vertical question step `/setup/vertical?siteSluge=${site_slug}`
* Open up your browser's developer tools, and switch to the "Network" tab, then the "Img" filter.
  * Consider filtering by `t.gif` as well.
* Select one of the verticals from the featured vertical list (they are all eligible).
* Submit the vertical by clicking the "Continue" button.
* Ensure that the `calypso_signup_site_vertical_submit` event tracks `has_vertical_images` as `true`.
* Repeat the previous steps, this time selecting an eligible vertical such as "Pop Music" or "Something else"
* Submit the vertical by clicking the "Continue" button.
* Ensure that the `calypso_signup_site_vertical_submit` event tracks `has_vertical_images` as `false`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

