### PR TITLE
Fuzzy Search: Remove unnecessary default `distance`

### DIFF
--- a/packages/search/src/use-fuzzy-search.ts
+++ b/packages/search/src/use-fuzzy-search.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 
 const defaultOptions = {
 	threshold: 0.4,
-	distance: 20,
 	ignoreLocation: true,
 };
 


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/66311#discussion_r940081143

> I was reviewing https://github.com/Automattic/wp-calypso/issues/66248, and I found out that when we use `ignoreLocation`, it ignores the `distance`. In this case, it makes sense to remove `distance` to avoid confusion.