### PR TITLE
Media: Only show free images button when displaying images in media selector

### DIFF
--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -77,7 +77,8 @@ class MediaLibraryListNoContent extends Component {
 		const showFreeLibraryButton =
 			config.isEnabled( 'external-media/free-photo-library' ) &&
 			userCan( 'upload_files', this.props.site ) &&
-			! this.props.source;
+			! this.props.source &&
+			( 'images' === this.props.filter || 'undefined' === typeof this.props.filter ); // Filter to where we would allow selecting an image.
 
 		if ( userCan( 'upload_files', this.props.site ) && ! this.props.source ) {
 			line = this.props.translate( 'Would you like to upload something?' );


### PR DESCRIPTION
#### Proposed Changes

* Limits showing the "Browse Free Images" button to only when the user has the potential to add images.

See p1659934624276799-slack-C029GN3KD


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Go to `calypso.localhost:3000/post/$site_slug`
* Insert `file` block
* Click through filters
* Ensure that you only see the "Browse Free images" button when on the `All` or `Images` filter

Of note there is some differences in how CSS for the action buttons in the file picker is handled that results in the action buttons touching. This appears to happen on `trunk` as is not related to the changes in this PR, so I was choosing to defer investigating that. But, if you feel strongly, then leave a comment.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->