### PR TITLE
Stepper: Implement LIB design step customization

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -54,6 +54,7 @@ button {
 .site-setup,
 .newsletter-setup,
 .link-in-bio-setup,
+.design-setup,
 .anchor-fm {
 	position: relative;
 	padding: 60px 0 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -23,7 +23,18 @@ function makeSortCategoryToTop( slug: string ) {
 const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 
-export function getCategorizationOptions( intent: string, showAllFilter: boolean ) {
+export function getCategorizationOptions(
+	intent: string,
+	showAllFilter: boolean,
+	flow: string | null
+) {
+	if ( flow === 'link-in-bio' ) {
+		return {
+			defaultSelection: 'link-in-bio',
+			showAllFilter: false,
+			sort: () => 0,
+		};
+	}
 	const result = {
 		showAllFilter,
 		defaultSelection: null,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -389,7 +389,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			previewOnly={ newDesignEnabled }
 			hasDesignOptionHeader={ ! newDesignEnabled }
 			purchasedThemes={ purchasedThemes }
-			isMobileSizedPreview
+			isMobileSizedPreview={ flow === 'link-in-bio' }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -134,7 +134,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		} ),
 	} );
 
-	const categorizationOptions = getCategorizationOptions( intent, true );
+	const categorizationOptions = getCategorizationOptions( intent, true, flow );
 
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 
@@ -389,6 +389,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			previewOnly={ newDesignEnabled }
 			hasDesignOptionHeader={ ! newDesignEnabled }
 			purchasedThemes={ purchasedThemes }
+			isMobileSizedPreview
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -10,7 +10,7 @@ export const linkInBio: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'linkInBioSetup' ] as StepPath[];
+		return [ 'intro', 'linkInBioSetup', 'designSetup' ] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -23,7 +23,7 @@ export const linkInBio: Flow = {
 		};
 
 		const goNext = () => {
-			navigate( 'linkInBioSetup' );
+			navigate( 'designSetup' );
 			return;
 		};
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -165,7 +165,6 @@
 		&.design-picker__image-frame-no-header::after {
 			border-radius: 0; /* stylelint-disable-line scales/radii */
 		}
-
 	}
 
 	// The Aspect ratio trick: padding % is relative to width, so we use
@@ -232,7 +231,6 @@
 		text-align: left;
 		color: #50575e;
 	}
-
 
 	.design-picker__button-link.components-button.is-link {
 		text-decoration: none;
@@ -389,10 +387,22 @@
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 24px;
+
+				// mobile sized preview mode has narrow designs, so it fits more designs in one row
+				&.is-mobile-sized-preview {
+					grid-template-columns: 1fr 1fr 1fr 1fr;
+				}
+			}
+
+			@include break-large {
+				// mobile sized preview mode has narrow designs, so it fits more designs in one row
+				&.is-mobile-sized-preview {
+					grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+				}
 			}
 		}
 	}
-	
+
 	h3 {
 		font-size: $font-title-small;
 		font-weight: 600;
@@ -499,11 +509,10 @@
 	&:focus-within {
 		.design-picker__image-frame::after {
 			// `!important` is used because there is a default `background-color` with high specificity.
-			background-color: transparent !important; // to override 
+			background-color: transparent !important; // to override
 		}
 	}
 }
-
 
 .generated-design-thumbnail {
 	align-items: stretch;
@@ -542,7 +551,7 @@
 		svg {
 			fill: var( --studio-gray-5 );
 		}
-    }
+	}
 
 	.generated-design-thumbnail__image {
 		position: relative;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -24,7 +24,6 @@ import {
 	sortDesigns,
 } from '../utils';
 import BadgeContainer from './badge-container';
-import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
 import ThemePreview from './theme-preview';
 import type { Categorization } from '../hooks/use-categorization';
 import type { Design } from '../types';
@@ -37,6 +36,7 @@ interface DesignPreviewImageProps {
 	locale: string;
 	highRes: boolean;
 	verticalId?: string;
+	isMobile?: boolean;
 }
 
 const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
@@ -44,9 +44,8 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	locale,
 	highRes,
 	verticalId,
+	isMobile,
 } ) => {
-	const isMobile = useViewportMatch( 'small', '<' );
-
 	return (
 		<MShotsImage
 			url={ getDesignPreviewUrl( design, {
@@ -76,6 +75,7 @@ interface DesignButtonProps {
 	hasPurchasedTheme?: boolean;
 	onCheckout?: any;
 	verticalId?: string;
+	isMobileSizedPreview?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -91,6 +91,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasPurchasedTheme = false,
 	onCheckout,
 	verticalId,
+	isMobileSizedPreview,
 } ) => {
 	const { __ } = useI18n();
 
@@ -103,6 +104,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	);
 
 	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
+
+	const isMobile = useViewportMatch( 'small', '<' );
 
 	function getPricingDescription() {
 		if ( ! isEnabled( 'signup/theme-preview-screen' ) ) {
@@ -181,7 +184,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				<span
 					className={ classnames(
 						'design-picker__image-frame',
-						'design-picker__image-frame-landscape',
+						{
+							'design-picker__image-frame-portrait': isMobileSizedPreview,
+							'design-picker__image-frame-landscape': ! isMobileSizedPreview,
+						},
 						'design-picker__scrollable',
 						{
 							'design-picker__image-frame-no-header': ! hasDesignOptionHeader,
@@ -194,6 +200,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 							locale={ locale }
 							highRes={ highRes }
 							verticalId={ verticalId }
+							isMobile={ isMobile || isMobileSizedPreview }
 						/>
 					</div>
 				</span>
@@ -265,6 +272,7 @@ interface DesignButtonContainerProps extends DesignButtonProps {
 	onPreview?: ( design: Design ) => void;
 	onUpgrade?: () => void;
 	previewOnly?: boolean;
+	isMobileSizedPreview?: boolean;
 }
 
 const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
@@ -311,6 +319,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				onSelect={ previewOnly ? onPreview : noop }
 				disabled={ ! isBlankCanvas && ! previewOnly }
+				isMobileSizedPreview={ props.isMobileSizedPreview }
 			/>
 		</div>
 	);
@@ -337,6 +346,7 @@ export interface UnifiedDesignPickerProps {
 	hasDesignOptionHeader?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
+	isMobileSizedPreview?: boolean;
 }
 
 interface StaticDesignPickerProps {
@@ -353,6 +363,7 @@ interface StaticDesignPickerProps {
 	hasDesignOptionHeader?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
+	isMobileSizedPreview?: boolean;
 }
 
 interface GeneratedDesignPickerProps {
@@ -376,8 +387,8 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 	onCheckout,
 	verticalId,
 	purchasedThemes,
+	isMobileSizedPreview,
 } ) => {
-	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
 		const result = categorization?.selection
 			? filterDesignsByCategory( designs, categorization.selection )
@@ -388,14 +399,11 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 	}, [ designs, categorization?.selection ] );
 	return (
 		<div>
-			{ categorization && hasCategories && (
-				<UnifiedDesignPickerCategoryFilter
-					categories={ categorization.categories }
-					onSelect={ categorization.onSelect }
-					selectedSlug={ categorization.selection }
-				/>
-			) }
-			<div className={ 'design-picker__grid' }>
+			<div
+				className={ classnames( 'design-picker__grid', {
+					'is-mobile-sized-preview': isMobileSizedPreview,
+				} ) }
+			>
 				{ filteredDesigns.map( ( design ) => (
 					<DesignButtonContainer
 						key={ design.slug }
@@ -414,6 +422,7 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 						onCheckout={ onCheckout }
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
+						isMobileSizedPreview={ isMobileSizedPreview }
 					/>
 				) ) }
 			</div>
@@ -474,6 +483,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	onCheckout,
 	purchasedThemes,
+	isMobileSizedPreview = false,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const translate = useTranslate();
@@ -525,6 +535,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				onCheckout={ onCheckout }
 				purchasedThemes={ purchasedThemes }
+				isMobileSizedPreview={ isMobileSizedPreview }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

* This creates the tall previews for LIB design picker. 
* It also locks the design picker to Link in Bio category when `flow === 'link-in-bio'`.

#### Testing Instructions

1. Go to http://calypso.localhost:3000/setup/linkInBioSetup?flow=link-in-bio&siteSlug=YOUR_SITE.
2. Previews should be tall, imitating a mobile screen. 
3. The design step in site setup flow shouldn't be affected at all. To see it, head to http://calypso.localhost:3000/setup/designSetup?siteSlug=YOUR_SITE. This should and behave exactly like produciton.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
