### PR TITLE
Design Setup: Remove references to monthly subscriptions from upgrade modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -2,9 +2,6 @@ import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/componen
 import { useSelect } from '@wordpress/data';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormRadio from 'calypso/components/forms/form-radio';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
 import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
@@ -22,29 +19,15 @@ interface UpgradeModalProps {
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
 	const theme = useThemeDetails( slug );
-	const [ subInterval, setSubInterval ] = useState( 'yearly' );
 	const features = theme.data && theme.data.taxonomies.features;
 	const featuresHeading = translate( 'Theme features' ) as string;
 	const themeYearlyProduct = useSelect(
 		( select ) => select( PRODUCTS_LIST_STORE ).getProductBySlug( 'pro-plan' ) //Pass combination of `slug` and `subInterval` to selector to get theme price
 	);
-	const themeMonthlyProduct = useSelect(
-		( select ) => select( PRODUCTS_LIST_STORE ).getProductBySlug( 'pro-plan-monthly' ) //Pass combination of `slug` and `subInterval` to selector to get theme price
-	);
-	const themePrice =
-		subInterval === 'yearly'
-			? themeYearlyProduct?.combined_cost_display
-			: themeMonthlyProduct?.combined_cost_display;
-
-	let savings = 0;
-	if ( themeMonthlyProduct?.cost && themeYearlyProduct?.cost ) {
-		savings = Math.floor(
-			( 1 - themeYearlyProduct?.cost / ( themeMonthlyProduct?.cost * 12 ) ) * 100
-		);
-	}
+	const themePrice = themeYearlyProduct?.combined_cost_display;
 
 	//Wait until we have theme and product data to show content
-	const isLoading = ! themeYearlyProduct?.cost || ! themeMonthlyProduct?.cost || ! theme.data;
+	const isLoading = ! themeYearlyProduct?.cost || ! theme.data;
 
 	return (
 		<Dialog
@@ -64,40 +47,14 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 							) }
 						</p>
 						<div className="upgrade-modal__theme-price">
-							<span>{ themePrice }</span>
-							{ subInterval === 'yearly' ? translate( 'per year' ) : translate( 'per month' ) }
-						</div>
-						<div className="upgrade-modal__subscription-interval">
-							<FormLabel>
-								<FormRadio
-									id="subscription-interval-monthly"
-									name="subscription-interval"
-									label={ translate( 'Monthly' ) }
-									className="upgrade-modal__radio"
-									value="monthly"
-									checked={ 'monthly' === subInterval }
-									onChange={ () => setSubInterval( 'monthly' ) }
-								/>
-							</FormLabel>
-							<FormLabel>
-								{ /* @TODO: Calculate savings based on annual/monthly price difference */ }
-								<FormRadio
-									id="subscription-interval-yearly"
-									name="subscription-interval"
-									className="upgrade-modal__radio"
-									label={ translate( 'Annually {{span}}(Save %(savings)s%){{/span}}', {
-										args: {
-											savings,
-										},
-										components: {
-											span: <span className="upgrade-modal__subscription-savings" />,
-										},
-									} ) }
-									value="yearly"
-									checked={ 'yearly' === subInterval }
-									onChange={ () => setSubInterval( 'yearly' ) }
-								/>
-							</FormLabel>
+							{ translate( '{{span}}%(themePrice)s{{/span}} per year', {
+								components: {
+									span: <span />,
+								},
+								args: {
+									themePrice,
+								},
+							} ) }
 						</div>
 						<div className="upgrade-modal__actions">
 							<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -21,8 +21,9 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const theme = useThemeDetails( slug );
 	const features = theme.data && theme.data.taxonomies.features;
 	const featuresHeading = translate( 'Theme features' ) as string;
-	const themeYearlyProduct = useSelect(
-		( select ) => select( PRODUCTS_LIST_STORE ).getProductBySlug( 'pro-plan' ) //Pass combination of `slug` and `subInterval` to selector to get theme price
+	//@TODO This is a placeholder until we have theme products to choose from
+	const themeYearlyProduct = useSelect( ( select ) =>
+		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'value_bundle' )
 	);
 	const themePrice = themeYearlyProduct?.combined_cost_display;
 


### PR DESCRIPTION
#### Proposed Changes

* We won't be offering themes for monthly subscriptions, so I've removed that information from the modal.

**Before**

<img width="817" alt="Screen Shot 2022-08-08 at 1 00 47 PM" src="https://user-images.githubusercontent.com/2124984/183473007-e08f0535-8780-4332-82c9-6690cecef536.png">




**After**

<img width="804" alt="Screen Shot 2022-08-08 at 12 53 05 PM" src="https://user-images.githubusercontent.com/2124984/183471900-9f44c280-4a6d-44b2-a6d5-c6a2abf1bec1.png">


#### Testing Instructions

* Switch to this PR, navigate to `/setup/?siteSlug=yourtestsite.wordpress.com&flags=signup/seller-upgrade-modal`
* Choose a Premium design from the design selection step
* Click "upgrade" in the upper right corner
* You should see the above modal instead of being forwarded to checkout.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
