### PR TITLE
Support: Disable Help Center as it seem to be causing degraded UX

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,
-		"calypso/help-center": true,
+		"calypso/help-center": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": false,
 		"catch-js-errors": true,


### PR DESCRIPTION
As reported on p1659971114434329-slack-C02T4NVL4JJ. We're seeing a steady stream of users coming from the Help Center that have the same issue - resending the same, original message in a loop. All with origin `gutenberg-editor` and confirmed by events' props that it's coming from Help Center.
Not sure what could be the root cause (only see https://github.com/Automattic/wp-calypso/pull/66305 that was merged on Friday related to Help Center), but seems like the best option would be to disable it for now.