### PR TITLE
Revert "Help Center: Adjust Happychat endpoint in help center according to env"

### DIFF
--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -22,19 +22,12 @@
 	<body>
 		<div id="wpcom" class="container"></div>
 		<script>
-			const env = new URLSearchParams( window.location.search ).get( 'env' ) || 'dev';
-			const happychat_url =
-				env === 'dev'
-					? 'https://happychat-io-staging.go-vip.co/customer'
-					: 'https://happychat.io/customer';
-			const env_id = env === 'dev' ? 'development' : 'production';
-
 			window.configData = {
-				env_id,
+				env_id: 'development',
 				i18n_default_locale_slug: 'en',
 				google_analytics_key: 'UA-10673494-15',
 				client_slug: 'browser',
-				happychat_url,
+				happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
 				site_filter: [],
 				sections: {},
 				enable_all_sections: false,

--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -3,14 +3,12 @@
  */
 import './help-center-inline-chat.scss';
 
-const env = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
-
 const InlineChat: React.FC = () => {
 	return (
 		<iframe
 			className="help-center-inline-chat__iframe"
 			title="Happychat"
-			src={ `https://widgets.wp.com/calypso-happychat/?env=${ env }` }
+			src="https://widgets.wp.com/calypso-happychat/"
 		/>
 	);
 };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#66305

As reported on p1659971114434329-slack-C02T4NVL4JJ. We're seeing a steady stream of users coming from the Help Center that have the same issue - resending the same, original message in a loop. All with origin gutenberg-editor and confirmed by events' props that it's coming from Help Center.
Not sure what could be the root cause (only see https://github.com/Automattic/wp-calypso/pull/66305 that was merged on Friday related to Help Center), but seems like the best option would be to revert it.