### PR TITLE
SMP: invalidate query on window focus and on mount

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -21,3 +21,5 @@ export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'is_redirect',
 	'unmapped_url',
 ] as const;
+
+export const SITE_EXCERPT_QUERY_KEY = 'sites-dashboard-sites-data';

--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -21,5 +21,3 @@ export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'is_redirect',
 	'unmapped_url',
 ] as const;
-
-export const SITE_EXCERPT_QUERY_KEY = 'sites-dashboard-sites-data';

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
-import { useCallback, useEffect } from 'react';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { useStore } from 'react-redux';
 import { getJetpackSiteCollisions, getUnmappedUrl } from 'calypso/lib/site/utils';
 import { urlToSlug, withoutHttp } from 'calypso/lib/url';
@@ -26,24 +25,10 @@ const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	} );
 };
 
-export const useInvalidateSiteExcerptsQuery = () => {
-	const queryClient = useQueryClient();
-	return useCallback( () => {
-		queryClient.invalidateQueries( [ SITE_EXCERPT_QUERY_KEY ] );
-	}, [ queryClient ] );
-};
-
 export const useSiteExcerptsQuery = () => {
 	const store = useStore();
 
-	const invalidateSiteExcerptsQuery = useInvalidateSiteExcerptsQuery();
-
-	useEffect( () => {
-		invalidateSiteExcerptsQuery();
-	}, [ invalidateSiteExcerptsQuery ] );
-
 	return useQuery( [ SITE_EXCERPT_QUERY_KEY ], fetchSites, {
-		staleTime: 1000 * 60 * 5, // 5 minutes
 		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we
@@ -55,7 +40,6 @@ export const useSiteExcerptsQuery = () => {
 		placeholderData: {
 			sites: [],
 		},
-		refetchOnWindowFocus: 'always',
 	} );
 };
 

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -6,7 +6,6 @@ import { urlToSlug, withoutHttp } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import getSites from 'calypso/state/selectors/get-sites';
 import {
-	SITE_EXCERPT_QUERY_KEY,
 	SITE_EXCERPT_REQUEST_FIELDS,
 	SITE_EXCERPT_REQUEST_OPTIONS,
 } from './site-excerpt-constants';
@@ -28,7 +27,7 @@ const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 export const useSiteExcerptsQuery = () => {
 	const store = useStore();
 
-	return useQuery( [ SITE_EXCERPT_QUERY_KEY ], fetchSites, {
+	return useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
 		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we


### PR DESCRIPTION
#### Proposed Changes

* Clear react query cache to show most updated data, such as new sites, changed plans.

#### Testing Instructions

**Add a new site, same window**

1. Go to `/sites-dashboard`
2. I recommend filtering the sites by coming soon, and counting how many sites you currently have
3. Click on `Add new site`
4. Complete the process until you are on the new site dashboard
5. Click on `Switch site` > `All my sites` on the left menu
6. Observe your new site is already there.
7. You can filter by coming soon sites and observe you have one more site in that category.

**Add a new site, same window**

1. Open a tab (TAB1) and go to `/sites-dashboard`
2. I recommend filtering the sites by coming-soon, and counting how many sites you currently have
3. Open in a new tab and go to `/start`, or right click on `Add new site` and open it in new tab. (TAB2)
4. Complete the process until you are on the new site dashboard
5. Return to the first tab (TAB1)
6. Observe your new site is already there.
7. You can filter by coming soon sites and observe you have one more site in that category.

> **You can repeat these steps but instead of adding a new site, you can change the site's visibility, i.e. publish or unpublish a site**



#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

- Closes #66340
