### PR TITLE
Add a temporary check to validate if Personal and Premium plans should be upgraded before install a plugin

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -473,7 +473,6 @@ function useSiteHasFeature( selectedSite, pluginFeature ) {
 
 	if (
 		! config.isEnabled( 'marketplace-personal-premium' ) &&
-		! shouldUpgrade &&
 		( isPersonalPlan( product_slug ) || isPremiumPlan( product_slug ) )
 	) {
 		return true;

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -3,6 +3,8 @@ import {
 	isFreePlanProduct,
 	FEATURE_INSTALL_PLUGINS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
+	isPersonalPlan,
+	isPremiumPlan,
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
@@ -66,9 +68,7 @@ const PluginDetailsCTA = ( props ) => {
 		getPluginOnSite( state, selectedSite?.ID, pluginSlug )
 	);
 
-	const shouldUpgrade =
-		useSelector( ( state ) => ! siteHasFeature( state, selectedSite?.ID, pluginFeature ) ) &&
-		! isJetpackSelfHosted;
+	const shouldUpgrade = useSiteHasFeature( selectedSite, pluginFeature ) && ! isJetpackSelfHosted;
 
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, pluginSlug )
@@ -463,6 +463,23 @@ function LegacyPluginDetailsCTA( {
 			) }
 		</div>
 	);
+}
+
+function useSiteHasFeature( selectedSite, pluginFeature ) {
+	const shouldUpgrade = useSelector(
+		( state ) => ! siteHasFeature( state, selectedSite?.ID, pluginFeature )
+	);
+	const { product_slug } = selectedSite?.plan || {};
+
+	if (
+		! config.isEnabled( 'marketplace-personal-premium' ) &&
+		! shouldUpgrade &&
+		( isPersonalPlan( product_slug ) || isPremiumPlan( product_slug ) )
+	) {
+		return true;
+	}
+
+	return shouldUpgrade;
 }
 
 function PluginDetailsCTAPlaceholder() {


### PR DESCRIPTION

#### Testing Instructions

* With your proxy active
* Disable the feature flag `marketplace-personal-premium`
* Go to the paid plugin page of a site with a personal/premium subscription. Ex: `/plugins/woocommerce-bookings/{site}?flags=-marketplace-personal-premium`
* Click to purchase
* You should be redirected to the cart with the plugin and the business plan

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Fixes #66313 