### PR TITLE
Help Center: Disable the Help Center everywhere

### DIFF
--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -1,5 +1,5 @@
 import { useSupportAvailability } from '@automattic/data-stores';
-import { useHappychatAvailable } from '@automattic/happychat-connection';
+//import { useHappychatAvailable } from '@automattic/happychat-connection';
 
 type Result = {
 	render: boolean;
@@ -8,8 +8,11 @@ type Result = {
 };
 
 export function useShouldRenderChatOption(): Result {
-	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	const { available, isLoading } = useHappychatAvailable();
+	const { data: chatStatus, isLoading } = useSupportAvailability( 'CHAT' );
+	//const { available, isLoading } = useHappychatAvailable();
+	// Lock chat to unavailable until we fix the interrupted chat issue
+	// see: p1659971114434329-slack-C02T4NVL4JJ
+	const available = false;
 
 	if ( ! chatStatus?.is_user_eligible ) {
 		return {


### PR DESCRIPTION
#### Proposed Changes

* Some users are having interrupted chat sessions in the Help Center. We'll probably need to implement session continuity before being able to bring the Help Center live again.

#### Testing Instructions

1. Go to http://calypso.localhost:3000/
2. Go to Appearance section (or whatever none Home section).
3. You shouldn't see the help center. 