### PR TITLE
Disable the Help Center everywhere

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -383,21 +383,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
 
 /**
  * Help center
- * At the moment we're showing only to 10% of the users. And to all proxied requests.
+ * At the moment we're disabling the help center.
  */
 function load_help_center() {
 	return;
-	/*
-	// enable help center for all proxied users.
-	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
-
-	$current_segment = 30; // segment of existing users that will get the help center in %.
-	$user_segment    = get_current_user_id() % 100;
-
-	if ( $is_proxied || $user_segment < $current_segment ) {
-		require_once __DIR__ . '/help-center/class-help-center.php';
-	}
-	*/
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_help_center' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,6 +386,8 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  * At the moment we're showing only to 10% of the users. And to all proxied requests.
  */
 function load_help_center() {
+	return;
+	/*
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
@@ -395,6 +397,7 @@ function load_help_center() {
 	if ( $is_proxied || $user_segment < $current_segment ) {
 		require_once __DIR__ . '/help-center/class-help-center.php';
 	}
+	*/
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_help_center' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,7 +386,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  * At the moment we're disabling the help center.
  */
 function load_help_center() {
-	return;
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_help_center' );
 

--- a/config/development.json
+++ b/config/development.json
@@ -30,7 +30,7 @@
 	"features": {
 		"ad-tracking": false,
 		"build/sites-dashboard": true,
-		"calypso/help-center": true,
+		"calypso/help-center": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"cloudflare": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,7 @@
 	"features": {
 		"ad-tracking": false,
 		"build/sites-dashboard": true,
-		"calypso/help-center": true,
+		"calypso/help-center": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": false,
 		"catch-js-errors": true,

--- a/config/production.json
+++ b/config/production.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,
-		"calypso/help-center": true,
+		"calypso/help-center": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": false,
 		"catch-js-errors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,7 @@
 	"dsp_widget_js_src": "http://todo",
 	"features": {
 		"ad-tracking": false,
-		"calypso/help-center": true,
+		"calypso/help-center": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ad-tracking": false,
 		"build/sites-dashboard": true,
-		"calypso/help-center": true,
+		"calypso/help-center": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"cloudflare": true,

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -1,5 +1,5 @@
 import { useSupportAvailability } from '@automattic/data-stores';
-//import { useHappychatAvailable } from '@automattic/happychat-connection';
+import { useHappychatAvailable } from '@automattic/happychat-connection';
 
 type Result = {
 	render: boolean;
@@ -8,11 +8,8 @@ type Result = {
 };
 
 export function useShouldRenderChatOption(): Result {
-	const { data: chatStatus, isLoading } = useSupportAvailability( 'CHAT' );
-	//const { available, isLoading } = useHappychatAvailable();
-	// Lock chat to unavailable until we fix the interrupted chat issue
-	// see: p1659971114434329-slack-C02T4NVL4JJ
-	const available = false;
+	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
+	const { available, isLoading } = useHappychatAvailable();
 
 	if ( ! chatStatus?.is_user_eligible ) {
 		return {

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -1,5 +1,5 @@
 import { useSupportAvailability } from '@automattic/data-stores';
-import { useHappychatAvailable } from '@automattic/happychat-connection';
+//import { useHappychatAvailable } from '@automattic/happychat-connection';
 
 type Result = {
 	render: boolean;
@@ -8,8 +8,11 @@ type Result = {
 };
 
 export function useShouldRenderChatOption(): Result {
-	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	const { available, isLoading } = useHappychatAvailable();
+	const { data: chatStatus, isLoading } = useSupportAvailability( 'CHAT' );
+	//const { available, isLoading } = useHappychatAvailable();
+	// Lock chat to unavailable until we fix the interrupted chat issue
+	// see: p1659971114434329-slack-C02T4NVL4JJ
+	const available = false;
 
 	if ( ! chatStatus?.is_user_eligible ) {
 		return {


### PR DESCRIPTION
#### Proposed Changes

* Some users are having interrupted chat sessions in the Help Center. We'll probably need to implement session continuity before being able to bring the Help Center live again.

#### Testing Instructions

1. Go to http://calypso.localhost:3000/
2. Go to Appearance section (or whatever none Home section).
3. You shouldn't see the help center, but you should see the FAB (the floating action button). 
4. cd into `apps/editing-tookit`.
5. run `yarn dev --sync`.
6. Sandbox a site.
7. Go to the editor of that site.
8. You shouldn't see the help center but you should see the FAB (the floating action button). 