### PR TITLE
Add optional CPU profiler to Calypso server requests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ desktop/.yarn/*
 !.yarn/versions
 .pnp.*
 yarn-json-output.json
+
+# Profile results:
+/profiles/

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -25,7 +25,7 @@ export default function setup() {
 	app.use( userAgent.express() );
 	app.use( loggerMiddleware() );
 
-	if ( process.env.USE_PROFILER === 'true' ) {
+	if ( process.env.USE_SERVER_PROFILER === 'true' ) {
 		app.use( require( 'calypso/server/middleware/profiler' )() );
 	}
 

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -25,7 +25,7 @@ export default function setup() {
 	app.use( userAgent.express() );
 	app.use( loggerMiddleware() );
 
-	if ( process.env.USE_PROFILER ) {
+	if ( process.env.USE_PROFILER === 'true' ) {
 		app.use( require( 'calypso/server/middleware/profiler' )() );
 	}
 

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -7,6 +7,7 @@ import api from 'calypso/server/api';
 import config from 'calypso/server/config';
 import analytics from 'calypso/server/lib/analytics';
 import loggerMiddleware from 'calypso/server/middleware/logger';
+import profilerMiddleware from 'calypso/server/middleware/profiler';
 import pages from 'calypso/server/pages';
 import pwa from 'calypso/server/pwa';
 
@@ -24,6 +25,10 @@ export default function setup() {
 	app.use( cookieParser() );
 	app.use( userAgent.express() );
 	app.use( loggerMiddleware() );
+
+	if ( process.env.USE_PROFILER ) {
+		app.use( profilerMiddleware() );
+	}
 
 	if ( 'development' === process.env.NODE_ENV ) {
 		require( 'calypso/server/bundler' )( app );

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -7,7 +7,6 @@ import api from 'calypso/server/api';
 import config from 'calypso/server/config';
 import analytics from 'calypso/server/lib/analytics';
 import loggerMiddleware from 'calypso/server/middleware/logger';
-import profilerMiddleware from 'calypso/server/middleware/profiler';
 import pages from 'calypso/server/pages';
 import pwa from 'calypso/server/pwa';
 
@@ -27,7 +26,7 @@ export default function setup() {
 	app.use( loggerMiddleware() );
 
 	if ( process.env.USE_PROFILER ) {
-		app.use( profilerMiddleware() );
+		app.use( require( 'calypso/server/middleware/profiler' )() );
 	}
 
 	if ( 'development' === process.env.NODE_ENV ) {

--- a/client/server/middleware/profiler.js
+++ b/client/server/middleware/profiler.js
@@ -2,6 +2,15 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const v8Profiler = require( 'v8-profiler-next' );
 
+/**
+ * This should be dynamically imported:
+ *
+ * if ( shouldProfile ) {
+ *   app.use ( require( 'calypso/server/middleware/profiler' )() )
+ * }
+ *
+ * to avoid importing v8-profiler-next in production environments.
+ */
 module.exports = () => {
 	let IS_PROFILING = false;
 

--- a/client/server/middleware/profiler.js
+++ b/client/server/middleware/profiler.js
@@ -1,10 +1,11 @@
-import fs from 'fs';
-import path from 'path';
-import v8Profiler from 'v8-profiler-next';
+const fs = require( 'fs' );
+const path = require( 'path' );
+const v8Profiler = require( 'v8-profiler-next' );
 
-export default () => {
+module.exports = () => {
 	let IS_PROFILING = false;
 
+	// Generates a CPU profile compatible with VS Code's viewer.
 	v8Profiler.setGenerateType( 1 );
 
 	const profilesRoot = path.resolve(

--- a/client/server/middleware/profiler.js
+++ b/client/server/middleware/profiler.js
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+import v8Profiler from 'v8-profiler-next';
+
+export default () => {
+	v8Profiler.setGenerateType( 1 );
+
+	const profilesRoot = path.resolve(
+		path.join( __dirname, '../../../profiles', new Date().toISOString() )
+	);
+	try {
+		fs.accessSync( profilesRoot );
+	} catch {
+		fs.mkdirSync( profilesRoot, { recursive: true } );
+	}
+
+	return ( req, res, next ) => {
+		// Avoid profiling certain requests (like for static files).
+		if (
+			! req.originalUrl.startsWith( '/' ) ||
+			req.originalUrl.startsWith( '/calypso/' ) ||
+			req.originalUrl.startsWith( '/service-worker' ) ||
+			req.originalUrl.startsWith( '/nostats.js' ) ||
+			req.originalUrl.startsWith( '/version' )
+		) {
+			next();
+			return;
+		}
+
+		// Replace slash with underscore:
+		const profileName = req.originalUrl.replace( /\//g, '_' );
+
+		v8Profiler.startProfiling( profileName, true );
+
+		res.on( 'close', () => {
+			const profile = v8Profiler.stopProfiling( profileName );
+			profile.export( ( error, result ) => {
+				if ( error ) {
+					console.error( error );
+					return;
+				}
+				fs.writeFile( `${ profilesRoot }/${ profileName }.cpuprofile`, result, ( err ) => {
+					if ( err ) {
+						console.error( 'Something wrent wrong writing the CPU profile file.' );
+						console.log( err );
+					}
+				} );
+			} );
+			profile.delete();
+		} );
+		next();
+	};
+};

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,6 +4,23 @@
 - [Debugging React performance with React 16 and Chrome Devtools](https://building.calibreapp.com/debugging-react-performance-with-react-16-and-chrome-devtools-c90698a522ad)
 - Chrome DevTools Docs: [Analyze Runtime Performance](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/)
 
+## Server Request Profiling
+
+We've included [`v8-profiler-next`](https://www.npmjs.com/package/v8-profiler-next) which allows you to generate CPU profiles (including flamegraphs) for requests to the Calypso NodeJS server. This is helpful for finding functions which impact performance the most on a given route.
+
+To use the profiler:
+
+1. Run `USE_SERVER_PROFILER=true yarn start`.
+2. Visit a url like `calypso.localhost:3000/themes`
+3. After waiting a few extra seconds, a profile file is saved to "./profiles/$route/$route-$time.cpuprofile"
+4. This profile can be viewed with VS Code's built-in profile viewer by clicking on the profile in VS Code's file explorer. If you click the flame icon in the upper-right corner, VS Code will prompt to install a flamegraph viewer extension as well.
+
+Some notes:
+- The behavior of the dev server can differ from production, and having the profiler enabled can reduce performance. While profiles should not be treated as a source of truth for absolute production performance, they are still useful for seeing _relative_ performance. (E.g. to find a function which takes relatively more time than other functions.)
+- Any slash in the URL ("/") is changed to "_" in the filename. So when you access the base route ("/"), the profile will be saved to "./profiles/\_/\_-$datetime.cpuprofile"
+- Only one profile can be generated at a time. If you visit another route at the same time a profile is being generated for a different route, a new profile is _not_ created. However, since the CPU is a shared resource, the impact of visiting the second route at the same time will still be visible in the first route's profile.
+- Requests to various static and dev resources are not profiled.
+
 ## Bundle Analysis
 
 ### Why is X bundled?

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
 		"stylelint": "^13.13.1",
 		"tslib": "^2.3.0",
 		"typescript": "^4.7.4",
+		"v8-profiler-next": "^1.9.0",
 		"webpack": "^5.68.0",
 		"webpack-bundle-analyzer": "^4.5.0",
 		"webpack-cli": "^4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3828,6 +3828,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gar/promisify@npm:^1.0.1":
+  version: 1.1.3
+  resolution: "@gar/promisify@npm:1.1.3"
+  checksum: 0b3c9958d3cd17f4add3574975e3115ae05dc7f1298a60810414b16f6f558c137b5fb3cd3905df380bacfd955ec13f67c1e6710cbb5c246a7e8d65a8289b2bff
+  languageName: node
+  linkType: hard
+
 "@github/webauthn-json@npm:^0.4.1":
   version: 0.4.1
   resolution: "@github/webauthn-json@npm:0.4.1"
@@ -4382,6 +4389,16 @@ __metadata:
     "@nodelib/fs.scandir": 2.1.3
     fastq: ^1.6.0
   checksum: ebc8e292c5099003c78a70dddc04cde5f0316f0046eb66ba48429fba094c15e43ab93f180a14eabe06c7a29dcb91e3c008be2377a79c0fb3c9a459d075a33303
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@npmcli/fs@npm:1.1.1"
+  dependencies:
+    "@gar/promisify": ^1.0.1
+    semver: ^7.3.5
+  checksum: 4143c317a7542af9054018b71601e3c3392e6704e884561229695f099a71336cbd580df9a9ffb965d0024bf0ed593189ab58900fd1714baef1c9ee59c738c3e2
   languageName: node
   linkType: hard
 
@@ -9981,6 +9998,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xprofiler/node-pre-gyp@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "@xprofiler/node-pre-gyp@npm:1.0.9"
+  dependencies:
+    detect-libc: ^1.0.3
+    https-proxy-agent: ^5.0.0
+    make-dir: ^3.1.0
+    node-fetch: ^2.6.5
+    node-gyp: ^8.4.1
+    nopt: ^5.0.0
+    npmlog: ^5.0.1
+    rimraf: ^3.0.2
+    semver: ^7.3.5
+    tar: ^6.1.11
+  bin:
+    node-pre-gyp: bin/node-pre-gyp
+  checksum: 2545be4360db69cb8d54350b5040c6058887fccf81797b65de3f85aa20f82d640140b5ac6471a1f0ddeefc68d5cd306ac5ea1d02c5c47668866768fa877a6b65
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -10193,7 +10230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6":
+"agent-base@npm:6, agent-base@npm:^6.0.2":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
   dependencies:
@@ -10622,6 +10659,16 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 375f753c10329153c8d66dc95e8f8b6c7cc2aa66e05cb0960bd69092b10dae22900cacc7d653ad11d26b3ecbdbfe1e8bfb6ccf0265ba8077a7d979970f16b99c
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "are-we-there-yet@npm:3.0.1"
+  dependencies:
+    delegates: ^1.0.0
+    readable-stream: ^3.6.0
+  checksum: 8373f289ba42e4b5ec713bb585acdac14b5702c75f2a458dc985b9e4fa5762bc5b46b40a21b72418a3ed0cfb5e35bdc317ef1ae132f3035f633d581dd03168c3
   languageName: node
   linkType: hard
 
@@ -12243,6 +12290,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacache@npm:^15.2.0":
+  version: 15.3.0
+  resolution: "cacache@npm:15.3.0"
+  dependencies:
+    "@npmcli/fs": ^1.0.0
+    "@npmcli/move-file": ^1.0.1
+    chownr: ^2.0.0
+    fs-minipass: ^2.0.0
+    glob: ^7.1.4
+    infer-owner: ^1.0.4
+    lru-cache: ^6.0.0
+    minipass: ^3.1.1
+    minipass-collect: ^1.0.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.2
+    mkdirp: ^1.0.3
+    p-map: ^4.0.0
+    promise-inflight: ^1.0.1
+    rimraf: ^3.0.2
+    ssri: ^8.0.1
+    tar: ^6.0.2
+    unique-filename: ^1.1.1
+  checksum: 886fcc0acc4f6fd5cd142d373d8276267bc6d655d7c4ce60726fbbec10854de3395ee19bbf9e7e73308cdca9fdad0ad55060ff3bd16c6d4165c5b8d21515e1d8
+  languageName: node
+  linkType: hard
+
 "cache-base@npm:^1.0.1":
   version: 1.0.1
   resolution: "cache-base@npm:1.0.1"
@@ -13343,7 +13416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.2":
+"color-support@npm:^1.1.2, color-support@npm:^1.1.3":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
   bin:
@@ -18459,6 +18532,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gauge@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "gauge@npm:4.0.4"
+  dependencies:
+    aproba: ^1.0.3 || ^2.0.0
+    color-support: ^1.1.3
+    console-control-strings: ^1.1.0
+    has-unicode: ^2.0.1
+    signal-exit: ^3.0.7
+    string-width: ^4.2.3
+    strip-ansi: ^6.0.1
+    wide-align: ^1.1.5
+  checksum: ef10d7981113d69225135f994c9f8c4369d945e64a8fc721d655a3a38421b738c9fe899951721d1b47b73c41fdb5404ac87cc8903b2ecbed95d2800363e7e58c
+  languageName: node
+  linkType: hard
+
 "gauge@npm:~2.7.3":
   version: 2.7.4
   resolution: "gauge@npm:2.7.4"
@@ -20270,6 +20359,13 @@ __metadata:
   version: 1.1.5
   resolution: "ip@npm:1.1.5"
   checksum: 877e98d676cd8d0ca01fee8282d11b91fb97be7dd9d0b2d6d98e161db2d4277954f5b55db7cfc8556fe6841cb100d13526a74f50ab0d83d6b130fe8445040175
+  languageName: node
+  linkType: hard
+
+"ip@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ip@npm:2.0.0"
+  checksum: 8d186cc5585f57372847ae29b6eba258c68862055e18a75cc4933327232cb5c107f89800ce29715d542eef2c254fbb68b382e780a7414f9ee7caf60b7a473958
   languageName: node
   linkType: hard
 
@@ -23547,6 +23643,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-fetch-happen@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "make-fetch-happen@npm:9.1.0"
+  dependencies:
+    agentkeepalive: ^4.1.3
+    cacache: ^15.2.0
+    http-cache-semantics: ^4.1.0
+    http-proxy-agent: ^4.0.1
+    https-proxy-agent: ^5.0.0
+    is-lambda: ^1.0.1
+    lru-cache: ^6.0.0
+    minipass: ^3.1.3
+    minipass-collect: ^1.0.2
+    minipass-fetch: ^1.3.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    negotiator: ^0.6.2
+    promise-retry: ^2.0.1
+    socks-proxy-agent: ^6.0.0
+    ssri: ^8.0.0
+  checksum: 2c737faf6a7f67077679da548b5bfeeef890595bf8c4323a1f76eae355d27ebb33dcf9cf1a673f944cf2f2a7cbf4e2b09f0a0a62931737728f210d902c6be966
+  languageName: node
+  linkType: hard
+
 "makeerror@npm:1.0.x":
   version: 1.0.11
   resolution: "makeerror@npm:1.0.11"
@@ -24953,6 +25073,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.16.0":
+  version: 2.16.0
+  resolution: "nan@npm:2.16.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 95204e4ed2970c0411735d866b0a71f30625e9ce598d2f7c2dfc2145dcd4e8e48dda26fda2587657f91e96973044353d300a9a6d259079b342fa4b30548aa8fa
+  languageName: node
+  linkType: hard
+
 "nano-time@npm:1.0.0":
   version: 1.0.0
   resolution: "nano-time@npm:1.0.0"
@@ -25038,7 +25167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:0.6.3":
+"negotiator@npm:0.6.3, negotiator@npm:^0.6.2":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
@@ -25173,7 +25302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.6, node-fetch@npm:^2.6.7":
+"node-fetch@npm:2.6.7, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5, node-fetch@npm:^2.6.6, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -25232,6 +25361,26 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 2fe78d02fb152c8f5a59c9b0a558cbc5beb7f574c25646d4cfdbb62eaa36f3b43ebc585d7b53df84ef4eff5c5b4ad0a2b5a37c09816ac11f61a3bdcedd82df04
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "node-gyp@npm:8.4.1"
+  dependencies:
+    env-paths: ^2.2.0
+    glob: ^7.1.4
+    graceful-fs: ^4.2.6
+    make-fetch-happen: ^9.1.0
+    nopt: ^5.0.0
+    npmlog: ^6.0.0
+    rimraf: ^3.0.2
+    semver: ^7.3.5
+    tar: ^6.1.2
+    which: ^2.0.2
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 80ef333b3a882eb6a2695a8e08f31d618f4533eff192864e4a3a16b67ff0abc9d8c1d5fac0395550ec699326b9248c5e2b3be178492f7f4d1ccf97d2cf948021
   languageName: node
   linkType: hard
 
@@ -25540,6 +25689,18 @@ __metadata:
     gauge: ^3.0.0
     set-blocking: ^2.0.0
   checksum: 489ba519031013001135c463406f55491a17fc7da295c18a04937fe3a4d523fd65e88dd418a28b967ab743d913fdeba1e29838ce0ad8c75557057c481f7d49fa
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "npmlog@npm:6.0.2"
+  dependencies:
+    are-we-there-yet: ^3.0.0
+    console-control-strings: ^1.1.0
+    gauge: ^4.0.3
+    set-blocking: ^2.0.0
+  checksum: 0cacedfbc2f6139c746d9cd4a85f62718435ad0ca4a2d6459cd331dd33ae58206e91a0742c1558634efcde3f33f8e8e7fd3adf1bfe7978310cf00bd55cccf890
   languageName: node
   linkType: hard
 
@@ -31698,7 +31859,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"smart-buffer@npm:^4.0.2, smart-buffer@npm:^4.1.0":
+"smart-buffer@npm:^4.0.2, smart-buffer@npm:^4.1.0, smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
@@ -31807,6 +31968,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"socks-proxy-agent@npm:^6.0.0":
+  version: 6.2.1
+  resolution: "socks-proxy-agent@npm:6.2.1"
+  dependencies:
+    agent-base: ^6.0.2
+    debug: ^4.3.3
+    socks: ^2.6.2
+  checksum: d75c1cf1fdd7f8309a43a77f84409b793fc0f540742ef915154e70ac09a08b0490576fe85d4f8d68bbf80e604a62957a17ab5ef50d312fe1442b0ab6f8f6e6f6
+  languageName: node
+  linkType: hard
+
 "socks@npm:^2.3.3":
   version: 2.6.1
   resolution: "socks@npm:2.6.1"
@@ -31814,6 +31986,16 @@ resolve@^2.0.0-next.3:
     ip: ^1.1.5
     smart-buffer: ^4.1.0
   checksum: e992192c7837bfa9093251abf3e78849741f332881900f481dcb3267d18b16595e93519f63dce29f39e4135789a7ed379d210dd68e98465564a40e81ccf9082a
+  languageName: node
+  linkType: hard
+
+"socks@npm:^2.6.2":
+  version: 2.7.0
+  resolution: "socks@npm:2.7.0"
+  dependencies:
+    ip: ^2.0.0
+    smart-buffer: ^4.2.0
+  checksum: 5cc9ea8d0f1fae370d7ac319b5dd8973fa24bc58d0194a8140687fd10be53a1f348b1b02b97932ce67ddae0edf459e5da0fe4b13cd5dd22ce46ac4d1a83239ec
   languageName: node
   linkType: hard
 
@@ -32095,7 +32277,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ssri@npm:^8.0.0":
+"ssri@npm:^8.0.0, ssri@npm:^8.0.1":
   version: 8.0.1
   resolution: "ssri@npm:8.0.1"
   dependencies:
@@ -33122,6 +33304,20 @@ swiper@4.5.1:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: 6095664370f9bcedcbe6ad5958d3778804e8946da78f0e229281eb3c4a54fe8902e8d65e2f27cd59887a8fb02570ae6a0801d19a17291963d68bf536061d2b89
+  languageName: node
+  linkType: hard
+
+"tar@npm:^6.1.11":
+  version: 6.1.11
+  resolution: "tar@npm:6.1.11"
+  dependencies:
+    chownr: ^2.0.0
+    fs-minipass: ^2.0.0
+    minipass: ^3.0.0
+    minizlib: ^2.1.1
+    mkdirp: ^1.0.3
+    yallist: ^4.0.0
+  checksum: 5a016f5330f43815420797b87ade578e2ea60affd47439c988a3fc8f7bb6b36450d627c31ba6a839346fae248b4c8c12bb06bb0716211f37476838c7eff91f05
   languageName: node
   linkType: hard
 
@@ -34837,6 +35033,16 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
+"v8-profiler-next@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "v8-profiler-next@npm:1.9.0"
+  dependencies:
+    "@xprofiler/node-pre-gyp": ^1.0.9
+    nan: ^2.16.0
+  checksum: 10333bd509f6e3c19fdbfbec58a4d0b116c41b167fe900fb0689523484bf008ea2502164f062b2daf724dd1e9101b91be2202eedbd770bf730c4eb959f8aa437
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^8.1.0":
   version: 8.1.0
   resolution: "v8-to-istanbul@npm:8.1.0"
@@ -35570,7 +35776,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.0, wide-align@npm:^1.1.2":
+"wide-align@npm:^1.1.0, wide-align@npm:^1.1.2, wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:
@@ -35794,6 +36000,7 @@ swiper@4.5.1:
     stylelint: ^13.13.1
     tslib: ^2.3.0
     typescript: ^4.7.4
+    v8-profiler-next: ^1.9.0
     webpack: ^5.68.0
     webpack-bundle-analyzer: ^4.5.0
     webpack-cli: ^4.9.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -12265,32 +12265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^15.0.5":
-  version: 15.0.5
-  resolution: "cacache@npm:15.0.5"
-  dependencies:
-    "@npmcli/move-file": ^1.0.1
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    glob: ^7.1.4
-    infer-owner: ^1.0.4
-    lru-cache: ^6.0.0
-    minipass: ^3.1.1
-    minipass-collect: ^1.0.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.2
-    mkdirp: ^1.0.3
-    p-map: ^4.0.0
-    promise-inflight: ^1.0.1
-    rimraf: ^3.0.2
-    ssri: ^8.0.0
-    tar: ^6.0.2
-    unique-filename: ^1.1.1
-  checksum: cbdb1e50b5452cb0ba5d5219027c3b37e2be1ae8760683afac508db8307e55e8bc77fa90c4dc270c63a785e5553d9c32b0b668e0af07c43d3a0c2e5148cfedb7
-  languageName: node
-  linkType: hard
-
-"cacache@npm:^15.2.0":
+"cacache@npm:^15.0.5, cacache@npm:^15.2.0":
   version: 15.3.0
   resolution: "cacache@npm:15.3.0"
   dependencies:
@@ -25064,16 +25039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.12.1, nan@npm:^2.14.0":
-  version: 2.14.1
-  resolution: "nan@npm:2.14.1"
-  dependencies:
-    node-gyp: latest
-  checksum: a3ae7ce43d0aac223f58bf11952bd5ba5135df30506b55d46d0b983da83df4052631c41275fbfd5e3e749ed50c030d4561d12fb9b5bfba2083c0d66a75ee5ba1
-  languageName: node
-  linkType: hard
-
-"nan@npm:^2.16.0":
+"nan@npm:^2.12.1, nan@npm:^2.14.0, nan@npm:^2.16.0":
   version: 2.16.0
   resolution: "nan@npm:2.16.0"
   dependencies:
@@ -31859,7 +31825,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"smart-buffer@npm:^4.0.2, smart-buffer@npm:^4.1.0, smart-buffer@npm:^4.2.0":
+"smart-buffer@npm:^4.0.2, smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
@@ -31979,17 +31945,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.3.3":
-  version: 2.6.1
-  resolution: "socks@npm:2.6.1"
-  dependencies:
-    ip: ^1.1.5
-    smart-buffer: ^4.1.0
-  checksum: e992192c7837bfa9093251abf3e78849741f332881900f481dcb3267d18b16595e93519f63dce29f39e4135789a7ed379d210dd68e98465564a40e81ccf9082a
-  languageName: node
-  linkType: hard
-
-"socks@npm:^2.6.2":
+"socks@npm:^2.3.3, socks@npm:^2.6.2":
   version: 2.7.0
   resolution: "socks@npm:2.7.0"
   dependencies:
@@ -33293,21 +33249,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.2":
-  version: 6.1.10
-  resolution: "tar@npm:6.1.10"
-  dependencies:
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    minipass: ^3.0.0
-    minizlib: ^2.1.1
-    mkdirp: ^1.0.3
-    yallist: ^4.0.0
-  checksum: 6095664370f9bcedcbe6ad5958d3778804e8946da78f0e229281eb3c4a54fe8902e8d65e2f27cd59887a8fb02570ae6a0801d19a17291963d68bf536061d2b89
-  languageName: node
-  linkType: hard
-
-"tar@npm:^6.1.11":
+"tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:


### PR DESCRIPTION
#### Proposed Changes
With `USE_SERVER_PROFILER=true yarn start`, capture the CPU profile of individual routes in the Calypso server. This uses [`v8-profiler-next`](https://github.com/hyj1991/v8-profiler-next) to capture execution duration for individual JS functions.

Here's how it works:
- When the `USE_SERVER_PROFILER` environment variable exists, we add middleware to the express server which starts and stops the profiler.
- When starting the middleware, a new directory is created under `profiles` based on the current date/time. (So each execution of the server will have a different directory).
- When a request starts, the v8 profiler is also started. The profile name is set to the request URL. (with `/` replaced with `_`. So a request to `/themes` is named `_themes`)
- When the request is closed, the v8 profiler is stopped, and the profile is saved to a file with the `.cpuprofile` extension.
- Certain routes are ignored to prevent a lot of extra noise and to improve performance. (Like requests retrieving static files.)

The end result is that if you visit a single Calypso URL, a profile is saved which captures everything that happens as the server processes the request. **(Note that if you visit multiple URLs at the same time, several profiles will be saved, but each profile will contain the info from any other concurrent requests.)** So to get a one-time snapshot of a _single_ route's performance, you should _not_ have any concurrent requests.

#### Testing Instructions

1. Checkout the branch and run `yarn install`
2. Start the server with `USE_SERVER_PROFILER=true yarn start`
3. After the server boots and bundles everything, visit a calypso.localhost URL and wait for it to finish loading.
4. Inspect the `profiles` directory (in the top-level of Calypso). You should find a new directory for the date/time the server was started, and in it, you should find a file containing the profile. 
5. You should be able to open this file in VS Code to analyze the information. You can also install the extension VS Code will recommend to you to visualize the flamegraph:

<img width="1957" alt="image" src="https://user-images.githubusercontent.com/6265975/183539905-4eb25fdc-d699-48b3-9424-cd2cffa90306.png">

<img width="1957" alt="image" src="https://user-images.githubusercontent.com/6265975/183539944-c4354b4c-7199-4c10-b802-6cc2cc03a6a5.png">

