### PR TITLE
Fix - Expose password reset email field if user's email is not a valid alternate email

### DIFF
--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -231,10 +231,15 @@ const MailboxesForm = ( {
 	const userEmail = useSelector( getCurrentUserEmail );
 	const [ isAddingToCart, setIsAddingToCart ] = useState( false );
 	const [ isValidating, setIsValidating ] = useState( false );
-	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
-		FIELD_NAME,
-		FIELD_ALTERNATIVE_EMAIL,
-	] );
+
+	const isAlternateEmailValid = ! new RegExp( `@${ selectedDomainName }$` ).test( userEmail );
+	const defaultHiddenFields: HiddenFieldNames[] = [ FIELD_NAME ];
+	if ( isAlternateEmailValid ) {
+		defaultHiddenFields.push( FIELD_ALTERNATIVE_EMAIL );
+	}
+
+	const [ hiddenFieldNames, setHiddenFieldNames ] =
+		useState< HiddenFieldNames[] >( defaultHiddenFields );
 
 	const cartKey = useCartKey();
 	const cartManager = useShoppingCart( cartKey );
@@ -308,7 +313,9 @@ const MailboxesForm = ( {
 				<NewMailBoxList
 					areButtonsBusy={ isAddingToCart || isValidating }
 					hiddenFieldNames={ hiddenFieldNames }
-					initialFieldValues={ { [ FIELD_ALTERNATIVE_EMAIL ]: userEmail } }
+					initialFieldValues={ {
+						[ FIELD_ALTERNATIVE_EMAIL ]: isAlternateEmailValid ? userEmail : '',
+					} }
 					onSubmit={ onSubmit }
 					onCancel={ onCancel }
 					provider={ provider }
@@ -317,7 +324,7 @@ const MailboxesForm = ( {
 					showCancelButton
 					submitActionText={ translate( 'Continue' ) }
 				>
-					{ isTitan( provider ) && hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
+					{ hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) && (
 						<PasswordResetTipField tipClickHandler={ showAlternateEmailField } />
 					) }
 				</NewMailBoxList>


### PR DESCRIPTION
#### Proposed Changes

The mailbox addition form has been simplified to pre-populate the "Password reset email" with the user's WordPress.com account email. This becomes an issue when the user's WordPress.com account email happens to be one with the same domain as the Professional Email account that the user is making a purchasing for, since a valid alternate email must have a different domain.

This PR fixes the issue by exposing the "Password reset email" field if the user's WordPress.com account email is an invalid alternate email (has same domain as the mailbox being purchased).

#### Testing Instructions

* Have a Professional Email subscription

**Scenario 1:** Set your WordPress.com [account email](https://wordpress.com/me/account) to an email address with a different domain from your Professional Email account
* Go to `/email/:domain/manage/:site`, select "Add new mailboxes"
* **Expected Outcome**
  * The password reset email should be pre-populated with your WordPress.com account email
  * You should be able to change it using the "Change it" UI
  * You should be able to proceed to checkout without issues

<img width="1145" alt="password-reset-change-it" src="https://user-images.githubusercontent.com/104910361/183539781-106963ae-2f35-41ad-a14c-2e7e6bc69e2c.png">

**Scenario 2:** Set your WordPress.com [account email](https://wordpress.com/me/account) to an email address with the same domain as your Professional Email account
* Go to `/email/:domain/manage/:site`, select "Add new mailboxes"
* **Expected Outcome**
  * The password reset email field should be exposed
  * The field should be left empty, indicating that user needs to fill it out.
  * You should be able to proceed to checkout without issues

<img width="1082" alt="password-reset" src="https://user-images.githubusercontent.com/104910361/183539796-7b18a456-568c-42a1-9c43-175b79e98cb8.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
