### PR TITLE
Add prop intent to calypso_signup_{step_start, generated_design_picker_view}

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -62,8 +62,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	}, [ location ] );
 
 	useEffect( () => {
-		recordStepStart( flow.name, kebabCase( currentRoute ) );
-	}, [ flow.name, currentRoute ] );
+		recordStepStart( flow.name, kebabCase( currentRoute ), { intent } );
+	}, [ flow.name, currentRoute, intent ] );
 
 	const assertCondition = flow.useAssertConditions?.() ?? { state: AssertConditionState.SUCCESS };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -161,6 +161,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		if ( showGeneratedDesigns && ! hasTrackedView.current ) {
 			hasTrackedView.current = true;
 			recordTracksEvent( 'calypso_signup_generated_design_picker_view', {
+				intent,
 				vertical_id: siteVerticalId,
 				generated_designs: generatedDesigns?.map( ( design ) => design.slug ).join( ',' ),
 			} );


### PR DESCRIPTION
#### Proposed Changes

This PR adds the prop `intent` to the Tracks events `calypso_signup_step_start` and `calypso_signup_generated_design_picker_view` for analytics purposes.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing `calypso_signup_generated_design_picker_view`:
* Head to `/setup/goals?siteSlug=${site_slug}&flags=-signup/design-picker-unified` and select either Write ("Write & Publish") or Build ("Promote myself or business") flow. 
* Select any vertical from the featured verticals list and click on the "Continue" button.
* Ensure that you land on the v13n design picker, and verify via browser developer tools that the event `calypso_signup_generated_design_picker_view` is being fired with the prop `intent` set to the correct value.

Testing `calypso_signup_step_start`:
* Head to `/setup/goals?siteSlug=${site_slug}`
* Ensure that each onboarding step fires the event `calypso_signup_step_start` with the prop `intent` set to the correct value.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66346
