### PR TITLE
Added Checklist and ChecklistItem components for Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -1,0 +1,35 @@
+import { Button, Gridicon } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import { Task } from './types';
+
+const ChecklistItem = ( { task }: { task: Task } ) => {
+	const { id, isCompleted, actionUrl, title } = task;
+	return (
+		<li className={ `launchpad__task-${ id }` }>
+			<Button className="launchpad__checklist-item" href={ actionUrl } data-task={ id }>
+				<div className="launchpad__checklist-item-status">
+					{ task.isCompleted ? (
+						<Gridicon
+							aria-label={ translate( 'Task complete' ) }
+							className="launchpad__checklist-item-status-complete"
+							icon="checkmark"
+							size={ 18 }
+						/>
+					) : (
+						<div
+							role="img"
+							aria-label={ translate( 'Task incomplete' ) }
+							className="launchpad__checklist-item-status-pending"
+						/>
+					) }
+				</div>
+				<p className={ `launchpad__checklist-item-text ${ isCompleted && 'completed' }` }>
+					{ title }
+				</p>
+				<Gridicon className="launchpad__checklist-item-chevron" icon="chevron-right" size={ 18 } />
+			</Button>
+		</li>
+	);
+};
+
+export default ChecklistItem;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -1,0 +1,12 @@
+import ChecklistItem from './checklist-item';
+import { Task } from './types';
+
+const Checklist = ( { tasks }: { tasks: Task[] } ) => (
+	<ul className="launchpad__checklist" aria-label="Launchpad Checklist">
+		{ tasks.map( ( task ) => (
+			<ChecklistItem key={ task.id } task={ task } />
+		) ) }
+	</ul>
+);
+
+export default Checklist;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -3,19 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import Checklist from './checklist';
+import { tasks } from './tasks';
 import type { Step } from '../../types';
 import './style.scss';
-
-function PlaceHolderChecklist() {
-	return (
-		<ul style={ { textAlign: 'center' } }>
-			<li>Item 1</li>
-			<li>Item 2</li>
-			<li>Item 3</li>
-			<li>Item 4</li>
-		</ul>
-	);
-}
 
 function PlaceHolderPreview() {
 	return <div style={ { textAlign: 'center' } }>Preview here</div>;
@@ -27,7 +18,7 @@ const Launchpad: Step = ( { navigation } ) => {
 
 	const stepContent = (
 		<div className="launchpad__content">
-			<PlaceHolderChecklist />
+			<Checklist tasks={ tasks } />
 			<PlaceHolderPreview />
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -1,5 +1,69 @@
+@import '@wordpress/base-styles/mixins';
+
 .launchpad__content {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+}
+
+.launchpad__checklist {
+	list-style: none;
+	margin: 20px auto;
+	max-width: 98%;
+	padding: 0;
+	width: 500px;
+}
+
+.launchpad__checklist-item {
+	align-items: center;
+	border: none;
+	display: flex;
+	padding: 16px;
+	width: 100%;
+	margin: 0;
+	color: var( --color-text );
+}
+
+.launchpad__checklist-item-status {
+	margin-right: 8px;
+	width: 20px;
+	.gridicon {
+		top: 2px;
+	}
+}
+
+.launchpad__checklist-item-status-pending {
+	border: 1px solid var( --studio-gray-10 );
+	// stylelint-disable-next-line declaration-property-unit-allowed-list
+	border-radius: 50%;
+	box-sizing: border-box;
+	display: block;
+	height: 12px;
+	margin: 5px;
+	transition: all 0.1s;
+	width: 12px;
+}
+
+.launchpad__checklist-item-status-complete {
+	fill: var( --color-success );
+	vertical-align: text-bottom;
+}
+
+.launchpad__checklist-item-text {
+	flex-grow: 1;
+	font-size: 1rem;
+	line-height: 20px;
+	text-align: left;
+	font-weight: 600;
+	&.completed {
+		opacity: 0.8;
+		font-weight: 400;
+	}
+}
+
+.launchpad__checklist-item-chevron {
+	display: flex;
+	line-height: 20px;
+	text-align: left;
+	width: 30px;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,0 +1,23 @@
+export const tasks = [
+	{
+		id: 'setup_newsletter',
+		isCompleted: true,
+		actionUrl: '#',
+		title: 'Set up Newsletter',
+		taskType: 'blog',
+	},
+	{
+		id: 'plan_selected',
+		isCompleted: true,
+		taskType: 'blog',
+		actionUrl: '#',
+		title: 'Free Plan',
+	},
+	{
+		id: 'subscribers_added',
+		isCompleted: false,
+		actionUrl: '#',
+		title: 'Add Subscribers',
+		taskType: 'blog',
+	},
+];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -1,0 +1,7 @@
+export interface Task {
+	id: string;
+	isCompleted: boolean;
+	actionUrl: string;
+	taskType: string;
+	title: string;
+}


### PR DESCRIPTION
### Proposed Changes

This PR adds initial Checklist and ChecklistItem component for Launchpad, including associated types and styles. It also includes a tasks.tsk file that contain simple placeholder data until we can integrate with the site checklist api. 

The checklist portion of this screen should now look like this: 

<img width="1437" alt="Screenshot on 2022-08-08 at 21-14-46" src="https://user-images.githubusercontent.com/21228350/183555980-aa7a99c0-71dc-42bd-813d-bca492909219.png">

### Testing Instructions

* Check out this PR
* Navigate to the calypso repo in a terminal
* Run `yarn` and `yarn start`
* Open http://calypso.localhost:3000/setup/launchpad?flow=newsletters
* Confirm that Checklist component renders like screenshot above. 