### PR TITLE
Don't set default theme on atomic sites as it may not work

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -132,8 +132,7 @@ export const siteSetupFlow: Flow = {
 					if ( goalsStepEnabled ) {
 						pendingActions.push( setGoalsOnSite( siteSlug, goals ) );
 					}
-
-					if ( intent === SiteIntent.Write && ! selectedDesign ) {
+					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
 						pendingActions.push( setThemeOnSite( siteSlug, WRITE_INTENT_DEFAULT_THEME ) );
 					}
 


### PR DESCRIPTION
Originally reported by @arinoch in testing for the unified design picker CFT pdtkmj-h8-p2#comment-519

If a user is able to enter the `/setup` flow with an atomic site, and then selects the `write` goal, it will attempt to set a default `livro` theme. 

However, when setting the theme, the API call will fail with the error "Theme not found". Strangely, if the atomic site has previously installed the livro theme from the theme showcase, setting the theme will succeed. 

I haven't been able to work out why this is and in the interest of time, I think we should just disable setting the default theme for atomic sites in this flow.

Note that the user should not be guided to the `/setup` flow for an Atomic site under normal circumstances, they would have to manually enter the URL or be sent there due to a bug

https://user-images.githubusercontent.com/22446385/183574770-930e8de9-4345-49de-8e86-2ae683a68091.mov


#### Testing instructions

Open the /setup flow for an existing atomic site e.g.
`/setup/goals?siteSlug=$atomic_site.wpcomstaging.com`
select the `write & publish` goal.
select `draft your first post` or `choose a design`