### PR TITLE
Plugins: crawlable category links on logged out plugins page

### DIFF
--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -18,9 +18,11 @@ const Categories = ( { selected }: { selected?: string } ) => {
 	const dispatch = useDispatch();
 	const getCategoryUrl = useGetCategoryUrl();
 
+	// We hide these special categories from the category selector
 	const displayCategories = ALLOWED_CATEGORIES.filter(
 		( v ) => [ 'paid', 'popular', 'featured' ].indexOf( v ) < 0
 	);
+
 	const categories = Object.values( useCategories( displayCategories ) );
 	const categoryUrls = categories.map( ( { slug } ) => getCategoryUrl( slug ) );
 	const onClick = ( index: number ) => {

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,11 +1,9 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
 import page from 'page';
-import { useDispatch, useSelector } from 'react-redux';
-import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
+import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { ALLOWED_CATEGORIES, useCategories } from './use-categories';
+import { ALLOWED_REAL_CATEGORIES, useCategories } from './use-categories';
+import { useGetCategoryUrl } from './use-get-category-url';
 
 export type Category = {
 	name: string;
@@ -18,17 +16,9 @@ export type Category = {
 
 const Categories = ( { selected }: { selected?: string } ) => {
 	const dispatch = useDispatch();
-
-	const siteId = useSelector( getSelectedSiteId ) as number;
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const { localizePath } = useLocalizedPlugins();
-
-	// We hide these special categories from the category selector
-	const displayCategories = ALLOWED_CATEGORIES.filter(
-		( v ) => [ 'paid', 'popular', 'featured' ].indexOf( v ) < 0
-	);
-
-	const categories = Object.values( useCategories( displayCategories ) );
+	const getCategoryUrl = useGetCategoryUrl();
+	const categories = Object.values( useCategories( ALLOWED_REAL_CATEGORIES ) );
+	const categoryUrls = categories.map( ( { slug } ) => getCategoryUrl( slug ) );
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
 
@@ -38,27 +28,23 @@ const Categories = ( { selected }: { selected?: string } ) => {
 			} )
 		);
 
-		let url;
-		if ( category.slug !== 'discover' ) {
-			url = `/plugins/browse/${ category.slug }/${ domain || '' }`;
-		} else {
-			url = `/plugins/${ domain || '' }`;
-		}
-
-		page( localizePath( url ) );
+		page( getCategoryUrl( category.slug ) );
 	};
 
-	if ( selected && ! displayCategories.includes( selected ) ) {
+	if ( selected && ! ALLOWED_REAL_CATEGORIES.includes( selected ) ) {
 		return <div></div>;
 	}
 
 	const current = selected ? categories.findIndex( ( { slug } ) => slug === selected ) : 0;
+	const isBrowser = typeof window !== 'undefined';
 
 	return (
 		<ResponsiveToolbarGroup
 			className="categories__menu"
 			initialActiveIndex={ current }
 			onClick={ onClick }
+			hrefList={ categoryUrls }
+			forceMode={ isBrowser ? undefined : 'swipe' }
 		>
 			{ categories.map( ( category ) => (
 				<span key={ `category-${ category.slug }` }>{ category.name }</span>

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -2,7 +2,7 @@ import { ResponsiveToolbarGroup } from '@automattic/components';
 import page from 'page';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { ALLOWED_REAL_CATEGORIES, useCategories } from './use-categories';
+import { ALLOWED_CATEGORIES, useCategories } from './use-categories';
 import { useGetCategoryUrl } from './use-get-category-url';
 
 export type Category = {
@@ -17,7 +17,11 @@ export type Category = {
 const Categories = ( { selected }: { selected?: string } ) => {
 	const dispatch = useDispatch();
 	const getCategoryUrl = useGetCategoryUrl();
-	const categories = Object.values( useCategories( ALLOWED_REAL_CATEGORIES ) );
+
+	const displayCategories = ALLOWED_CATEGORIES.filter(
+		( v ) => [ 'paid', 'popular', 'featured' ].indexOf( v ) < 0
+	);
+	const categories = Object.values( useCategories( displayCategories ) );
 	const categoryUrls = categories.map( ( { slug } ) => getCategoryUrl( slug ) );
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
@@ -31,12 +35,11 @@ const Categories = ( { selected }: { selected?: string } ) => {
 		page( getCategoryUrl( category.slug ) );
 	};
 
-	if ( selected && ! ALLOWED_REAL_CATEGORIES.includes( selected ) ) {
+	if ( selected && ! displayCategories.includes( selected ) ) {
 		return <div></div>;
 	}
 
 	const current = selected ? categories.findIndex( ( { slug } ) => slug === selected ) : 0;
-	const isBrowser = typeof window !== 'undefined';
 
 	return (
 		<ResponsiveToolbarGroup
@@ -44,7 +47,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 			initialActiveIndex={ current }
 			onClick={ onClick }
 			hrefList={ categoryUrls }
-			forceMode={ isBrowser ? undefined : 'swipe' }
+			forceSwipe={ 'undefined' === typeof window }
 		>
 			{ categories.map( ( category ) => (
 				<span key={ `category-${ category.slug }` }>{ category.name }</span>

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -5,7 +5,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { Category } from '.';
 
-export const ALLOWED_REAL_CATEGORIES = [
+export const ALLOWED_CATEGORIES = [
 	'analytics',
 	'booking',
 	'customer',
@@ -25,10 +25,6 @@ export const ALLOWED_REAL_CATEGORIES = [
 	'shipping',
 	'social',
 	'widgets',
-];
-
-export const ALLOWED_CATEGORIES = [
-	...ALLOWED_REAL_CATEGORIES,
 
 	// "Top paid plugins", "Editors pick" etc aren't real categories but we
 	// treat them like they are in the UI so include them here

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -5,7 +5,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { Category } from '.';
 
-export const ALLOWED_CATEGORIES = [
+export const ALLOWED_REAL_CATEGORIES = [
 	'analytics',
 	'booking',
 	'customer',
@@ -25,6 +25,10 @@ export const ALLOWED_CATEGORIES = [
 	'shipping',
 	'social',
 	'widgets',
+];
+
+export const ALLOWED_CATEGORIES = [
+	...ALLOWED_REAL_CATEGORIES,
 
 	// "Top paid plugins", "Editors pick" etc aren't real categories but we
 	// treat them like they are in the UI so include them here

--- a/client/my-sites/plugins/categories/use-get-category-url.tsx
+++ b/client/my-sites/plugins/categories/use-get-category-url.tsx
@@ -5,7 +5,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useGetCategoryUrl() {
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) ) || '';
+	let domain = useSelector( ( state ) => getSiteDomain( state, siteId ) ) || '';
+	domain = domain.replace( /\//, '::' );
 	const { localizePath } = useLocalizedPlugins();
 
 	return ( slug: string ): string => {

--- a/client/my-sites/plugins/categories/use-get-category-url.tsx
+++ b/client/my-sites/plugins/categories/use-get-category-url.tsx
@@ -1,0 +1,18 @@
+import { useSelector } from 'react-redux';
+import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function useGetCategoryUrl() {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) ) || '';
+	const { localizePath } = useLocalizedPlugins();
+
+	return ( slug: string ): string => {
+		if ( slug !== 'discover' ) {
+			return localizePath( `/plugins/browse/${ slug }/${ domain }` );
+		}
+
+		return localizePath( `/plugins/${ domain }` );
+	};
+}

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -18,7 +18,8 @@ const selectors = {
 	browseAllFree: 'a[href^="/plugins/browse/popular"]',
 	browseAllPaid: 'a[href^="/plugins/browse/paid"]',
 	browseFirstCategory: 'button:has-text("Search Engine Optimization")',
-	categoryButton: ( section: string ) => `button:has-text("${ section }")`,
+	categoryButton: ( section: string ) =>
+		`button:has-text("${ section }"),a:has-text("${ section }")`,
 	breadcrumb: ( section: string ) => `.plugins-browser__header a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',

--- a/packages/components/src/responsive-toolbar-group/index.tsx
+++ b/packages/components/src/responsive-toolbar-group/index.tsx
@@ -6,6 +6,27 @@ import SwipeGroup from './swipe-group';
 
 import './style.scss';
 
+interface Props {
+	children: ReactChild[];
+	className?: string;
+	hideRatio?: number;
+	showRatio?: number;
+	rootMargin?: string;
+	onClick?: ( index: number ) => void;
+	initialActiveIndex?: number;
+	swipeBreakpoint?: string;
+
+	/**
+	 * List of href attributes
+	 */
+	hrefList?: string[];
+
+	/**
+	 * Rendering mode
+	 */
+	forceMode?: 'swipe' | 'dropdown';
+}
+
 const ResponsiveToolbarGroup = ( {
 	children,
 	className = '',
@@ -15,26 +36,19 @@ const ResponsiveToolbarGroup = ( {
 	onClick = () => null,
 	initialActiveIndex = -1,
 	swipeBreakpoint = '<660px',
-}: {
-	children: ReactChild[];
-	className?: string;
-	hideRatio?: number;
-	showRatio?: number;
-	rootMargin?: string;
-	onClick?: ( index: number ) => void;
-	initialActiveIndex?: number;
-	swipeBreakpoint?: string;
-} ) => {
+	hrefList = [],
+	forceMode,
+}: Props ) => {
 	const classes = classnames( 'responsive-toolbar-group', className );
-
 	const shouldSwipe = useBreakpoint( swipeBreakpoint );
 
-	if ( shouldSwipe ) {
+	if ( forceMode === 'swipe' || ( ! forceMode && shouldSwipe ) ) {
 		return (
 			<SwipeGroup
 				className={ classes }
 				initialActiveIndex={ initialActiveIndex }
 				onClick={ onClick }
+				hrefList={ hrefList }
 			>
 				{ children }
 			</SwipeGroup>

--- a/packages/components/src/responsive-toolbar-group/index.tsx
+++ b/packages/components/src/responsive-toolbar-group/index.tsx
@@ -6,7 +6,18 @@ import SwipeGroup from './swipe-group';
 
 import './style.scss';
 
-interface Props {
+const ResponsiveToolbarGroup = ( {
+	children,
+	className = '',
+	hideRatio = 0.99,
+	showRatio = 1,
+	rootMargin = '0px',
+	onClick = () => null,
+	initialActiveIndex = -1,
+	swipeBreakpoint = '<660px',
+	hrefList = [],
+	forceSwipe = false,
+}: {
 	children: ReactChild[];
 	className?: string;
 	hideRatio?: number;
@@ -24,25 +35,12 @@ interface Props {
 	/**
 	 * Rendering mode
 	 */
-	forceMode?: 'swipe' | 'dropdown';
-}
-
-const ResponsiveToolbarGroup = ( {
-	children,
-	className = '',
-	hideRatio = 0.99,
-	showRatio = 1,
-	rootMargin = '0px',
-	onClick = () => null,
-	initialActiveIndex = -1,
-	swipeBreakpoint = '<660px',
-	hrefList = [],
-	forceMode,
-}: Props ) => {
+	forceSwipe?: boolean;
+} ) => {
 	const classes = classnames( 'responsive-toolbar-group', className );
-	const shouldSwipe = useBreakpoint( swipeBreakpoint );
+	const shouldSwipe = useBreakpoint( swipeBreakpoint ) || forceSwipe;
 
-	if ( forceMode === 'swipe' || ( ! forceMode && shouldSwipe ) ) {
+	if ( shouldSwipe ) {
 		return (
 			<SwipeGroup
 				className={ classes }

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -91,7 +91,8 @@
 	}
 
 	// Remove on-focus, on-click border
-	.components-toolbar .components-button::before {
+	.components-toolbar .components-button::before,
+	.components-toolbar .components-button:focus {
 		box-shadow: none;
 	}
 }

--- a/packages/components/src/responsive-toolbar-group/swipe-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/swipe-group.tsx
@@ -1,19 +1,26 @@
-import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton as BaseToolbarButton } from '@wordpress/components';
 import classnames from 'classnames';
 import { ReactChild, useState, useRef, useEffect } from 'react';
+import type { Button } from '@wordpress/components';
 
 import './style.scss';
+
+const ToolbarButton = BaseToolbarButton as React.ComponentType<
+	( BaseToolbarButton.Props & { href?: string } ) | Button.Props
+>;
 
 export default function SwipeGroup( {
 	children,
 	className = '',
 	onClick = () => null,
 	initialActiveIndex = -1,
+	hrefList = [],
 }: {
 	children: ReactChild[];
 	className?: string;
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;
+	hrefList?: string[];
 } ) {
 	const classes = classnames( 'responsive-toolbar-group__swipe', className );
 
@@ -23,7 +30,7 @@ export default function SwipeGroup( {
 	useEffect( () => {
 		setActiveIndex( initialActiveIndex );
 	}, [ initialActiveIndex ] );
-	const ref = useRef< HTMLButtonElement | null >( null );
+	const ref = useRef< HTMLAnchorElement >( null );
 
 	// Scroll to category on load
 	useEffect( () => {
@@ -47,10 +54,15 @@ export default function SwipeGroup( {
 						key={ `button-item-${ index }` }
 						id={ `button-item-${ index }` }
 						isActive={ activeIndex === index }
+						href={ hrefList[ index ] }
 						ref={ activeIndex === index ? ref : null }
-						onClick={ () => {
+						onClick={ ( event: React.MouseEvent ) => {
 							setActiveIndex( index );
 							onClick( index );
+
+							if ( typeof hrefList[ index ] === 'string' ) {
+								event.preventDefault();
+							}
 						} }
 						className="responsive-toolbar-group__swipe-item"
 					>


### PR DESCRIPTION
#### Proposed Changes

* This PR replaces the category link buttons with anchor tags so search engines can crawl the category pages.
* This is the follow-up PR of #66225 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a logged-out user, open /plugins page disabling JavaScript with your browser.
* Regardless of the viewport size, the categories should be rendered in the swipeable toolbar and each category should be an anchor element.
  <img width="1089" alt="image" src="https://user-images.githubusercontent.com/212034/183598202-b947d6cb-fd5c-4486-8376-10ebac53ed33.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
