### PR TITLE
Fix incorrect visibility of privacy field in image edit form

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -81,7 +81,7 @@ class EditorMediaModalDetailFields extends Component {
 	}
 
 	isVideoPress() {
-		return this.getItemValue( 'videopress_guid' ) ? true : false;
+		return !! this.getItemValue( 'videopress_guid' );
 	}
 
 	updateChange( saveImmediately = false ) {

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -80,6 +80,10 @@ class EditorMediaModalDetailFields extends Component {
 		return getMimePrefix( this.props.item ) === prefix;
 	}
 
+	isVideoPress() {
+		return this.getItemValue( 'videopress_guid' ) ? true : false;
+	}
+
 	updateChange( saveImmediately = false ) {
 		const siteId = this.props.site?.ID;
 		const itemId = this.props.item?.ID;
@@ -170,11 +174,11 @@ class EditorMediaModalDetailFields extends Component {
 	}
 
 	renderVideoPressShortcode = () => {
-		const videopressGuid = this.getItemValue( 'videopress_guid' );
-
-		if ( ! videopressGuid ) {
+		if ( ! this.isVideoPress() ) {
 			return;
 		}
+
+		const videopressGuid = this.getItemValue( 'videopress_guid' );
 
 		return (
 			<EditorMediaModalFieldset legend={ this.props.translate( 'Shortcode' ) }>
@@ -226,6 +230,10 @@ class EditorMediaModalDetailFields extends Component {
 	};
 
 	renderPrivacySetting = () => {
+		if ( ! this.isVideoPress() ) {
+			return;
+		}
+
 		const privacySetting = this.getItemValue( 'privacy_setting' );
 		return (
 			<EditorMediaModalFieldset legend={ this.props.translate( 'Privacy' ) }>
@@ -270,9 +278,7 @@ class EditorMediaModalDetailFields extends Component {
 	};
 
 	renderAllowDownloadOption = () => {
-		// Make sure this is actually a VideoPress video
-		const videopressGuid = this.getItemValue( 'videopress_guid' );
-		if ( ! videopressGuid ) {
+		if ( ! this.isVideoPress() ) {
 			return;
 		}
 

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -8,7 +8,7 @@ import uiReducer from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
 
-jest.mock( 'calypso/post-editor/media-modal/detail/detail-fields', () =>
+jest.mock( 'calypso/components/file-picker', () =>
 	require( 'calypso/components/empty-component' )
 );
 
@@ -95,5 +95,17 @@ describe( 'EditorMediaModalDetailItem', () => {
 		);
 
 		expect( screen.queryByRole( 'button', { name: /edit/i } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should not display a Privacy field for an image', () => {
+		renderWithRedux( <DetailItem item={ DUMMY_IMAGE_MEDIA } { ...SHARED_PROPS } /> );
+
+		expect( screen.queryByRole( 'group', { name: 'Privacy' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should display a Privacy field for a video', () => {
+		renderWithRedux( <DetailItem item={ DUMMY_VIDEO_MEDIA } { ...SHARED_PROPS } /> );
+
+		expect( screen.queryByRole( 'group', { name: 'Privacy' } ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

The privacy field should be displayed only for VideoPress videos, and it should not be displayed for images.

We are fixing it by adding a condition that prevents from displaying the field if the item is not a VideoPress video.

We also perform some refactoring: extract the check to a separate method, and add tests for both states.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Image

1. Go to the site that allows for uploading video (Premium plan or higher)
2. Navigate to Media
3. Upload an image
4. Open edit form
5. Confirm that the Privacy field is not displayed

##### Video

1. Go to the site that allows for uploading video (Premium plan or higher)
2. Navigate to Media
3. Upload a video
4. Open edit form
5. Confirm that the Privacy field is displayed
6. Change the Privacy field value and save
7. Confirm that field is saved

| Image | Video |
| ----- | --------| 
| ![Screen Shot 2022-08-09 at 10 47 42](https://user-images.githubusercontent.com/727413/183606573-b865cb31-8b54-4432-a7ce-753bd453c308.png) | ![Screen Shot 2022-08-09 at 10 48 02](https://user-images.githubusercontent.com/727413/183606587-ccd2ef80-9bd6-446e-9ed6-2f5bcdbc83c8.png) |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64760
