### PR TITLE
i18n: Localize EmptyContent component

### DIFF
--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -31,7 +32,6 @@ class EmptyContent extends Component {
 	};
 
 	static defaultProps = {
-		title: "You haven't created any content yet.",
 		illustration: '/calypso/images/illustrations/illustration-empty-results.svg',
 		isCompact: false,
 	};
@@ -82,6 +82,10 @@ class EmptyContent extends Component {
 	render() {
 		const action = this.props.action && this.primaryAction();
 		const secondaryAction = this.props.secondaryAction && this.secondaryAction();
+		const title =
+			this.props.title !== undefined
+				? this.props.title
+				: this.props.translate( "You haven't created any content yet." );
 		const illustration = this.props.illustration && (
 			<img
 				src={ this.props.illustration }
@@ -95,11 +99,11 @@ class EmptyContent extends Component {
 			<div
 				className={ classNames( 'empty-content', this.props.className, {
 					'is-compact': this.props.isCompact,
-					'has-title-only': this.props.title && ! this.props.line,
+					'has-title-only': title && ! this.props.line,
 				} ) }
 			>
 				{ illustration }
-				{ this.props.title ? <h2 className="empty-content__title">{ this.props.title }</h2> : null }
+				{ title ? <h2 className="empty-content__title">{ title }</h2> : null }
 				{ this.props.line ? <h3 className="empty-content__line">{ this.props.line }</h3> : null }
 				{ action }
 				{ secondaryAction }
@@ -109,4 +113,4 @@ class EmptyContent extends Component {
 	}
 }
 
-export default EmptyContent;
+export default localize( EmptyContent );


### PR DESCRIPTION
#### Proposed Changes

* Localize `EmptyContent` component and translate fallback title.

![CleanShot 2022-08-09 at 11 49 13](https://user-images.githubusercontent.com/2722412/183606830-7e277a64-8018-466a-992b-5cf6062930c3.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to a Mag-16 language.
* Checkout branch locally or use calypso.live build.
* Go to `/posts/scheduled` and confirm fallback title renders. Since it's a new string, it's likely to still be untranslated.
* Confirm `EmptyContent` component won't render the fallback title if an empty string is passed as a prop value. For example:
   * Go to `/domains/add/` and select a site.
   * Remove the value from the search field (if any) and confirm the EmptyContent component renders without the title.
* Confirm custom title prop renders as expected, e.g.`/posts/trashed/{domains}`, `/posts/scheduled/{domains}`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 472-gh-Automattic/i18n-issues
