### PR TITLE
Sites Managment Page: Boost filtering performance by taking advantage site data object equality

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -2,6 +2,7 @@ import { ListTile, SiteThumbnail } from '@automattic/components';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { memo } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import Image from 'calypso/components/image';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -114,7 +115,7 @@ const VisitDashboardItem = ( { site }: { site: SiteExcerptData } ) => {
 	);
 };
 
-export default function SitesTableRow( { site }: SiteTableRowProps ) {
+export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 
 	const isComingSoon =
@@ -190,7 +191,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 			</Column>
 		</Row>
 	);
-}
+} );
 
 function getFirstGrapheme( input: string ) {
 	// TODO: once we're on Typescript 4.7 we should be able to add this comment:

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -123,4 +123,27 @@ describe( 'useSitesTableFiltering', () => {
 			},
 		] );
 	} );
+
+	test( 'filtering maintains object equality', () => {
+		// Object equality is important for memoizing the site table row
+
+		const mockSite = createMockSite( { name: 'site title 1' } );
+
+		const { result, rerender } = renderHook(
+			( { search } ) => useSitesTableFiltering( [ mockSite ], { search, status: 'all' } ),
+			{ initialProps: { search: 'titl' } }
+		);
+
+		expect( result.current.filteredSites ).toHaveLength( 1 );
+		expect( result.current.filteredSites[ 0 ] ).toBe( mockSite );
+
+		rerender( { search: 'does not match' } );
+
+		expect( result.current.filteredSites ).toHaveLength( 0 );
+
+		rerender( { search: 'title' } );
+
+		expect( result.current.filteredSites ).toHaveLength( 1 );
+		expect( result.current.filteredSites[ 0 ] ).toBe( mockSite );
+	} );
 } );

--- a/packages/components/src/sites-table/test/use-sites-table-sorting.jsx
+++ b/packages/components/src/sites-table/test/use-sites-table-sorting.jsx
@@ -68,4 +68,26 @@ describe( 'useSitesTableSorting', () => {
 		expect( result.current.sortedSites[ 1 ].ID ).toBe( 3 );
 		expect( result.current.sortedSites[ 2 ].ID ).toBe( 2 );
 	} );
+
+	test( 'sorting maintains object equality', () => {
+		// Object equality is important for memoizing the site table row
+
+		const { result, rerender } = renderHook(
+			( { sortOrder } ) =>
+				useSitesTableSorting( filteredSites, { sortKey: 'updated-at', sortOrder } ),
+			{ initialProps: { sortOrder: 'asc' } }
+		);
+
+		expect( result.current.sortedSites ).toHaveLength( 3 );
+		expect( result.current.sortedSites[ 0 ] ).toBe( filteredSites[ 0 ] );
+		expect( result.current.sortedSites[ 1 ] ).toBe( filteredSites[ 2 ] );
+		expect( result.current.sortedSites[ 2 ] ).toBe( filteredSites[ 1 ] );
+
+		rerender( { sortOrder: 'desc' } );
+
+		expect( result.current.sortedSites ).toHaveLength( 3 );
+		expect( result.current.sortedSites[ 0 ] ).toBe( filteredSites[ 1 ] );
+		expect( result.current.sortedSites[ 1 ] ).toBe( filteredSites[ 2 ] );
+		expect( result.current.sortedSites[ 2 ] ).toBe( filteredSites[ 0 ] );
+	} );
 } );

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -26,7 +26,7 @@ export function useSitesTableSorting(
 }
 
 function sortSitesByLastPublish( sites: SiteExcerptData[], sortOrder: string ): SiteExcerptData[] {
-	return sites.sort( ( a, b ) => {
+	return [ ...sites ].sort( ( a, b ) => {
 		if ( ! a.options?.updated_at || ! b.options?.updated_at ) {
 			return 0;
 		}


### PR DESCRIPTION

Re-rendering after typing the first character can take quite a long time. Especially when you have hundreds of sites.

This flame graph represents the render after typing a single character into the input box. It took about 400ms and involved a lot of JavaScript.
![before](https://user-images.githubusercontent.com/1500769/183612621-6456aa86-de5c-48e5-afcf-4baa678b416c.png)

This flame graph is after the changes in this PR are applied. Now it's about 200ms and most of it is in styling and layout (so the CSS after JS has run).

![after](https://user-images.githubusercontent.com/1500769/183613422-66be499c-d7c0-44bc-bb9a-e9ce18a4d4e0.png)

It might be possible to improve some of the CSS performance too.

Caveat: this was all measured in a debug build. I'll measure again on calypso.live

#### Proposed Changes

* I wrote some tests while debugging to double check that filtering and sorting didn't mess with object equality (they never should have)
* Fixed up an issue where the sorting hook was mutating its input, this seemed to be breaking row memoisation, but it's a React no-no in general since object and array references are used so frequently in hook dependency lists
* Wrapped `<SiteTableRow>` in a call to `React.memo()`. This tells React that it can skip rendering a row if it's props haven't changed

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66295
