### PR TITLE
Update "Launched" wording to "Public"

### DIFF
--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -33,7 +33,7 @@ export const NoSitesMessage = ( { status, statusSiteCount }: SitesContainerProps
 		return <h2>{ __( 'No sites match your search.' ) }</h2>;
 	}
 
-	if ( status === 'launched' ) {
+	if ( status === 'public' ) {
 		return (
 			<NoSitesLayout
 				title={ <Title> { __( "You haven't launched a site" ) } </Title> }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -121,7 +121,7 @@ export default function SitesTableRow( { site }: SiteTableRowProps ) {
 		site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 	const isP2Site = site.options?.is_wpforteams_site;
 
-	let siteStatusLabel = __( 'Live' );
+	let siteStatusLabel = __( 'Public' );
 
 	if ( isComingSoon ) {
 		siteStatusLabel = __( 'Coming soon' );

--- a/client/sites-dashboard/components/test/no-sites-message.tsx
+++ b/client/sites-dashboard/components/test/no-sites-message.tsx
@@ -10,8 +10,8 @@ describe( '<NoSitesMessage>', () => {
 		expect( screen.getByRole( 'link' ) ).toHaveTextContent( 'Create your first site' );
 	} );
 
-	test( '"You haven\'t launched a site" message when status filter shows "launched" sites', () => {
-		render( <NoSitesMessage status="launched" statusSiteCount={ 0 } /> );
+	test( '"You haven\'t launched a site" message when status filter shows "public" sites', () => {
+		render( <NoSitesMessage status="public" statusSiteCount={ 0 } /> );
 		expect( screen.getByText( "You haven't launched a site" ) ).toBeInTheDocument();
 	} );
 

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -107,7 +107,7 @@ describe( 'useSitesTableFiltering', () => {
 				title: expect.any( String ),
 			},
 			{
-				name: 'launched',
+				name: 'public',
 				count: 2,
 				title: expect.any( String ),
 			},

--- a/packages/components/src/sites-table/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/use-sites-table-filtering.tsx
@@ -29,7 +29,7 @@ export function useSitesTableFiltering(
 	const [ statuses, filteredByStatus ] = useMemo( () => {
 		const statuses = [
 			{ name: 'all', title: __( 'All Sites' ), count: 0 },
-			{ name: 'launched', title: __( 'Launched' ), count: 0 },
+			{ name: 'public', title: __( 'Public' ), count: 0 },
 			{ name: 'private', title: __( 'Private' ), count: 0 },
 			{ name: 'coming-soon', title: __( 'Coming Soon' ), count: 0 },
 		];
@@ -61,7 +61,7 @@ function filterSites( sites: SiteExcerptData[], filterType: string ): SiteExcerp
 			site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' );
 
 		switch ( filterType ) {
-			case 'launched':
+			case 'public':
 				return ! site.is_private && ! isComingSoon;
 			case 'private':
 				return site.is_private && ! isComingSoon;


### PR DESCRIPTION
#### Proposed Changes

Currently, we use a mix of "Launched" and "Live" words for non-private/non-coming soon sites on the Sites Management Page. We change the wording to "Public" to make it consistent with other parts of the Calypso.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load Sites Management Page using `/sites-dashboard` URL
2. Confirm that the dropdown filter says "Public" and not "Launched"
3. Filter by "Public" sites and confirm that the `status` URL parameter is set to 'public'.
4. Confirm that rows show "Public" status and not "Launched"

![Screen Shot 2022-08-09 at 12 29 47](https://user-images.githubusercontent.com/727413/183627096-c03c4cf7-7b3d-4f44-8f44-98740a7ce2b4.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/66379
