### PR TITLE
Fix error that occurs when not existing status filter is used

### DIFF
--- a/packages/components/src/sites-table/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/use-sites-table-filtering.tsx
@@ -47,7 +47,7 @@ export function useSitesTableFiltering(
 	}, [ allSites, __ ] );
 
 	const filteredSites = useFuzzySearch( {
-		data: filteredByStatus[ status ],
+		data: filteredByStatus[ status ] || [],
 		keys: [ 'URL', 'name', 'slug' ],
 		query: search,
 	} );


### PR DESCRIPTION
#### Proposed Changes

When we use not existing 'status' filter, e.g. 'foo', the useFuzzySearch hook receives an undefined 'data' parameter. Then it returns empty results, we check the length property of undefined, and it throws an error.

I fix it by ensuring that an empty array is passed to the hook in such a case.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load Sites Management Page using `/sites-dashboard` URL
2. Filter by any status
3. Modify `status` URL parameter to not existing value e.g.  'foo' to load the `/sites-dashboard?status=foo` URL
4. Confirm that empty results page is displayed and JS error is not thrown along with Calypso error

![Screen Shot 2022-08-09 at 12 27 21](https://user-images.githubusercontent.com/727413/183626527-f0696a7e-c783-4c84-8515-4f3a4003088d.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I found it while working on https://github.com/Automattic/wp-calypso/pull/66394
