### PR TITLE
Goals Capture: Hide DIFM goal for non-EN users.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,4 +1,5 @@
 import { Onboard } from '@automattic/data-stores';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import type { Goal } from './types';
 
@@ -9,6 +10,8 @@ const shouldDisplayGoal = ( { key }: Goal ) => ! HIDE_GOALS.includes( key );
 
 export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
+
 	const goals = [
 		{
 			key: SiteGoal.Write,
@@ -36,5 +39,13 @@ export const useGoals = ( displayAllGoals = false ): Goal[] => {
 			title: translate( 'Other' ),
 		},
 	];
-	return displayAllGoals ? goals : goals.filter( shouldDisplayGoal );
+
+	const hideDIFMGoalForNonEN = ( { key }: Goal ) => {
+		if ( key === SiteGoal.DIFM && ! isEnglishLocale ) {
+			return false;
+		}
+		return true;
+	};
+
+	return displayAllGoals ? goals.filter( hideDIFMGoalForNonEN ) : goals.filter( shouldDisplayGoal );
 };


### PR DESCRIPTION
#### Proposed Changes

* Hide DIFM goal for non-EN users.

Context: pdDOJh-Ba-p2#comment-448

#### Testing Instructions

* Change your user language settings to non-EN.
* Go to `/setup/goals?siteSlug=your_site_here.wordpress.com`.
* You should not see DIFM in the goal selection.


![image](https://user-images.githubusercontent.com/1287077/183636985-5641e57d-985f-4308-8ea7-841fa35b85df.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66399