### PR TITLE
E2E: Update selected block CSS selector to account for inner blocks using the new block API v2

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -141,10 +141,9 @@ export class EditorGutenbergComponent {
 	 * @returns {Promise<ElementHandle>} ElementHandle of the selected block.
 	 */
 	async getSelectedBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
-		// Note the partial class match. This is to support both the block API v1 and V2.
-		// Also note that the class selector is placed before the block selector. This is to ensure that any pseudo-selector is set at the end.
+		// Note the :is() selector. This is to support both the block API v1 and V2.
 		const locator = this.editor.locator(
-			`${ editorPane } [class$="-selected"]${ blockEditorSelector }`
+			`:is(${ editorPane } ${ blockEditorSelector }.is-selected, ${ editorPane } ${ blockEditorSelector }.has-child-selected)`
 		);
 		await locator.waitFor();
 		return ( await locator.elementHandle() ) as ElementHandle;

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -142,8 +142,9 @@ export class EditorGutenbergComponent {
 	 */
 	async getSelectedBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
 		// Note the partial class match. This is to support both the block API v1 and V2.
+		// Also note that the class selector is placed before the block selector. This is to ensure that any pseudo-selector is set at the end.
 		const locator = this.editor.locator(
-			`${ editorPane } ${ blockEditorSelector }[class$="-selected"]`
+			`${ editorPane } [class$="-selected"]${ blockEditorSelector }`
 		);
 		await locator.waitFor();
 		return ( await locator.elementHandle() ) as ElementHandle;

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -141,8 +141,9 @@ export class EditorGutenbergComponent {
 	 * @returns {Promise<ElementHandle>} ElementHandle of the selected block.
 	 */
 	async getSelectedBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
+		// Note the partial class match. This is to support both the block API v1 and V2.
 		const locator = this.editor.locator(
-			`:is(${ editorPane } ${ blockEditorSelector }.is-selected, ${ editorPane } ${ blockEditorSelector }.has-child-selected)`
+			`${ editorPane } ${ blockEditorSelector }[class$="-selected"]`
 		);
 		await locator.waitFor();
 		return ( await locator.elementHandle() ) as ElementHandle;

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -141,7 +141,9 @@ export class EditorGutenbergComponent {
 	 * @returns {Promise<ElementHandle>} ElementHandle of the selected block.
 	 */
 	async getSelectedBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
-		const locator = this.editor.locator( `${ editorPane } ${ blockEditorSelector }.is-selected` );
+		const locator = this.editor.locator(
+			`:is(${ editorPane } ${ blockEditorSelector }.is-selected, ${ editorPane } ${ blockEditorSelector }.has-child-selected)`
+		);
 		await locator.waitFor();
 		return ( await locator.elementHandle() ) as ElementHandle;
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -36,9 +36,6 @@ const selectors = {
 	// Details popover
 	detailsButton: `${ panel } button[aria-label="Details"]`,
 
-	// Details popover
-	resetSearchButton: `.block-editor-inserter__content button[aria-label="Reset search"]`,
-
 	// Editor settings
 	settingsButton: ( label = settingsButtonLabel ) =>
 		`${ panel } .edit-post-header__settings .interface-pinned-items button[aria-label="${ label }"]`,

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -37,7 +37,7 @@ const selectors = {
 	detailsButton: `${ panel } button[aria-label="Details"]`,
 
 	// Details popover
-	resetSearchButton: `${ panel } button[aria-label="Reset search"]`,
+	resetSearchButton: `.block-editor-inserter__content button[aria-label="Reset search"]`,
 
 	// Editor settings
 	settingsButton: ( label = settingsButtonLabel ) =>

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -119,13 +119,11 @@ export class EditorToolbarComponent {
 	 */
 	async closeBlockInserter(): Promise< void > {
 		if ( await this.targetIsOpen( selectors.blockInserterButton ) ) {
-			// Workaround to make the block inserter dismissible after inserting a block using the block API V2.
+			// We click on the panel instead of on the block inserter button as a workaround for an issue
+			// that disables the block inserter button after inserting a block using the block API V2.
 			// See https://github.com/WordPress/gutenberg/issues/43090.
-			const resetSearchButton = this.editor.locator( selectors.resetSearchButton );
-			await resetSearchButton.click();
-
-			const blockInserterButton = this.editor.locator( selectors.blockInserterButton );
-			await blockInserterButton.click();
+			const locator = this.editor.locator( panel );
+			await locator.click();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -36,6 +36,9 @@ const selectors = {
 	// Details popover
 	detailsButton: `${ panel } button[aria-label="Details"]`,
 
+	// Details popover
+	resetSearchButton: `${ panel } button[aria-label="Reset search"]`,
+
 	// Editor settings
 	settingsButton: ( label = settingsButtonLabel ) =>
 		`${ panel } .edit-post-header__settings .interface-pinned-items button[aria-label="${ label }"]`,
@@ -116,8 +119,13 @@ export class EditorToolbarComponent {
 	 */
 	async closeBlockInserter(): Promise< void > {
 		if ( await this.targetIsOpen( selectors.blockInserterButton ) ) {
-			const locator = this.editor.locator( selectors.blockInserterButton );
-			await locator.click();
+			// Workaround to make the block inserter dismissible after inserting a block using the block API V2.
+			// See https://github.com/WordPress/gutenberg/issues/43090.
+			const resetSearchButton = this.editor.locator( selectors.resetSearchButton );
+			await resetSearchButton.click();
+
+			const blockInserterButton = this.editor.locator( selectors.blockInserterButton );
+			await blockInserterButton.click();
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

We migrated the Payment button block to the new block API v2 in https://github.com/Automattic/jetpack/pull/25384 which no longer adds the `is-selected` class to the selected block.

This PR updates the CSS selector used by the E2E to locate the selected block to also account for the `has-child-selected` class used by the block API V2 on inner blocks.

This should solve this failure for the E2E test reported in p1660001585483459-slack-CDLH4C1UZ:

```
specs/blocks/blocks__jetpack-earn.ts: Blocks: Jetpack Earn: Add and configure blocks in the editor: Payment Button:
Add the block from the sidebar
locator.waitFor: Timeout 30000ms exceeded.
=========================== logs ===========================
waiting for selector "iframe.is-loaded >> control=enter-frame >> body.block-editor-page >> div.edit-post-visual-editor__content-area [aria-label="Block: Payment Button"].is-selected" to be visible
```

#### Testing Instructions

Make sure the "Blocks: Jetpack Earn: Add and configure blocks in the editor: Payment Button" test from the Gutenberg E2E tests passes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?