### PR TITLE
i18n: Fix media unsupported file type article link localization

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -174,7 +174,7 @@ export class MediaLibraryContent extends Component {
 						i18nOptions
 					);
 					actionText = translate( 'See supported file types' );
-					actionLink = localizeUrl( 'https://support.wordpress.com/accepted-filetypes' );
+					actionLink = localizeUrl( 'https://wordpress.com/support/accepted-filetypes' );
 					externalAction = true;
 					break;
 				case MediaValidationErrors.UPLOAD_VIA_URL_404:


### PR DESCRIPTION
#### Proposed Changes

* Update link to support article in Media unsupported file types validation rule to match the URL mapping for support sites in `localizeUrl`.

#### Testing Instructions

* Checkout diff locally or use calypso.live build.
* Change UI to Mag-16 language.
* Go to `/media` and attempt to upload unsupported file type (e.g. `zip`, `csv, `xml`, etc.).
* Confirm the error link is localized.

![CleanShot 2022-08-09 at 16 45 59](https://user-images.githubusercontent.com/2722412/183665472-e8140339-2c10-4f72-bc32-2aeb68a437c9.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 475-gh-Automattic/i18n-issues
