### PR TITLE
Stepper: add Jetpack powered

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -96,7 +96,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 								value={ progressValue * 100 }
 								total={ 100 }
 							/>
-							<SignupHeader />
+							<SignupHeader pageTitle={ flow.title } />
 							{ renderStep( path ) }
 						</div>
 					</Route>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -24,6 +24,7 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 			isLargeSkipLayout={ false }
 			stepContent={ <IntroStep flowName={ flow } goNext={ handleGetStarted } /> }
 			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -22,7 +22,7 @@ const Intro: React.FC< Props > = ( { goNext, flowName } ) => {
 				<span>{ introTitle }</span>
 			</h1>
 			<Button className="intro__button" primary onClick={ goNext }>
-				{ __( 'Get Started' ) }
+				{ __( 'Get started' ) }
 			</Button>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -36,6 +36,10 @@ $white: var( --color-surface );
 			position: absolute;
 			transform-origin: 0 0;
 		}
+
+		h1 {
+			color: var( --color-surface );
+		}
 	}
 
 	.progress-bar {
@@ -48,6 +52,10 @@ $white: var( --color-surface );
 
 			.step-container__navigation {
 				display: none;
+			}
+
+			.step-container__content {
+				min-height: 80vh;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -1,8 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@automattic/onboarding/styles/mixins';
 
-$design-button-primary-color: var( --color-primary );
-$get-started-button-primary-color: var( --studio-blue-50 );
 $white: var( --color-surface );
 
 .intro {
@@ -26,12 +24,18 @@ $white: var( --color-surface );
 	background-size: cover;
 	box-sizing: border-box;
 	padding: 60px 0 0;
+	color: $white;
+	fill: $white;
 
-	.wordpress-logo {
-		inset-block-start: 20px;
-		inset-inline-start: 20px;
-		position: absolute;
-		transform-origin: 0 0;
+	.signup-header {
+		z-index: 1;
+
+		.wordpress-logo {
+			inset-block-start: 20px;
+			inset-inline-start: 20px;
+			position: absolute;
+			transform-origin: 0 0;
+		}
 	}
 
 	.progress-bar {
@@ -46,6 +50,8 @@ $white: var( --color-surface );
 				display: none;
 			}
 		}
+
+		min-height: inherit;
 	}
 
 	.intro__content {
@@ -58,7 +64,6 @@ $white: var( --color-surface );
 
 	.intro__title {
 		@include onboarding-font-recoleta;
-		color: $white;
 		font-weight: 500;
 		line-height: 40px;
 		padding-bottom: 40px;
@@ -69,9 +74,11 @@ $white: var( --color-surface );
 	}
 
 	.intro__button {
-		color: $get-started-button-primary-color;
+		font-family: 'SF Pro Text', $sans;
+		color: var( --studio-blue-50 );
 		background-color: $white;
 		border: none;
 		font-weight: 500;
+		letter-spacing: 0.32px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -84,7 +84,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 			submit?.( { siteTitle, tagline } );
 		}
 	};
-	const steContent = (
+	const stepContent = (
 		<div className="step-container">
 			<form onSubmit={ handleSubmit }>
 				<div className="link-in-bio-setup__form">
@@ -165,7 +165,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 					align={ 'center' }
 				/>
 			}
-			stepContent={ steContent }
+			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -167,6 +167,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 			}
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -212,6 +212,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			}
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -41,6 +41,7 @@ export type UseAssertConditionsHook = () => AssertConditionResult;
 
 export type Flow = {
 	name: string;
+	title?: string;
 	classnames?: string | [ string ];
 	useSteps: UseStepHook;
 	useStepNavigation: UseStepNavigationHook;

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -6,6 +6,7 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 export const linkInBio: Flow = {
 	name: 'link-in-bio',
+	title: 'Link in Bio',
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );

--- a/client/landing/stepper/declarative-flow/newsletters.ts
+++ b/client/landing/stepper/declarative-flow/newsletters.ts
@@ -6,6 +6,7 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 export const newsletters: Flow = {
 	name: 'newsletters',
+	title: 'Newsletters',
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -1,4 +1,5 @@
 @import '@automattic/onboarding/styles/mixins';
+@import '@automattic/typography/styles/fonts';
 
 // A masterbar-like header just for
 // the signup flow.
@@ -39,8 +40,7 @@
 		color: var( --color-text );
 		top: 20px;
 		left: 56px;
-		font-size: 18;
-		font-family: 'Recoleta';
+		font-size: $font-body-large;
 	}
 
 	.signup-header__right {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -19,6 +19,7 @@ export { HappinessEngineersTray } from './happiness-engineers-tray';
 export { Spinner } from './spinner';
 export { SpinnerExample } from './spinner/example';
 export { default as WordPressLogo } from './wordpress-logo';
+export { default as JetpackLogo } from './jetpack-logo';
 export { ListTile } from './list-tile';
 export { useSitesTableFiltering } from './sites-table/use-sites-table-filtering';
 export type { SiteStatus } from './sites-table/use-sites-table-filtering';

--- a/packages/components/src/jetpack-logo/index.tsx
+++ b/packages/components/src/jetpack-logo/index.tsx
@@ -1,0 +1,98 @@
+import colorStudio from '@automattic/color-studio';
+import classNames from 'classnames';
+
+/**
+ * Module constants
+ */
+const PALETTE = colorStudio.colors;
+const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
+const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
+
+type LogoPathProps = {
+	monochrome?: boolean;
+};
+
+type JetpackLogoProps = {
+	full?: string;
+	size?: number;
+	monochrome?: boolean;
+	className?: string;
+};
+
+const LogoPathSize32: React.FunctionComponent< LogoPathProps > = ( { monochrome = false } ) => {
+	const primary = monochrome ? 'white' : COLOR_JETPACK;
+	const secondary = monochrome ? 'black' : COLOR_WHITE;
+
+	return (
+		<>
+			<path
+				className="jetpack-logo__icon-circle"
+				fill={ primary }
+				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+			/>
+			<polygon
+				className="jetpack-logo__icon-triangle"
+				fill={ secondary }
+				points="15,19 7,19 15,3 "
+			/>
+			<polygon
+				className="jetpack-logo__icon-triangle"
+				fill={ secondary }
+				points="17,29 17,13 25,13 "
+			/>
+		</>
+	);
+};
+
+const LogoPathSize32Monochrome: React.FunctionComponent< any > = () => (
+	<>
+		<mask id="jetpack-logo-mask">
+			<LogoPathSize32 monochrome />
+		</mask>
+		<path
+			className="jetpack-logo__icon-monochrome"
+			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+			mask="url( #jetpack-logo-mask )"
+		/>
+	</>
+);
+
+const JetpackLogo: React.FunctionComponent< JetpackLogoProps > = ( {
+	full = false,
+	monochrome = false,
+	size = 32,
+	className,
+	...props
+} ) => {
+	const classes = classNames( 'jetpack-logo', className );
+
+	if ( full === true ) {
+		return (
+			<svg height={ size } className={ classes } viewBox="0 0 118 32" { ...props }>
+				<title>Jetpack</title>
+				{ monochrome ? <LogoPathSize32Monochrome /> : <LogoPathSize32 /> }
+				<path
+					className="jetpack-logo__text"
+					d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z"
+				/>
+			</svg>
+		);
+	}
+
+	if ( 24 === size ) {
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<svg className={ classes } height="24" width="24" viewBox="0 0 24 24" { ...props }>
+				<path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M11,14H6l5-10V14z M13,20V10h5L13,20z" />
+			</svg>
+		);
+	}
+
+	return (
+		<svg className={ classes } height={ size } width={ size } viewBox="0 0 32 32" { ...props }>
+			{ monochrome ? <LogoPathSize32Monochrome /> : <LogoPathSize32 /> }
+		</svg>
+	);
+};
+
+export default JetpackLogo;

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -1,4 +1,4 @@
-import { WordPressLogo } from '@automattic/components';
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild, ReactElement } from 'react';
@@ -39,6 +39,7 @@ interface Props {
 	intent?: string;
 	stepProgress?: { count: number; progress: number };
 	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
+	showJetpackPowered?: boolean;
 }
 
 const StepContainer: React.FC< Props > = ( {
@@ -72,6 +73,7 @@ const StepContainer: React.FC< Props > = ( {
 	intent,
 	stepSectionName,
 	recordTracksEvent,
+	showJetpackPowered,
 } ) => {
 	const translate = useTranslate();
 
@@ -192,6 +194,11 @@ const StepContainer: React.FC< Props > = ( {
 				<div className="step-container__buttons">
 					{ isLargeSkipLayout && <hr className="step-container__skip-hr" /> }
 					{ <SkipButton /> }
+				</div>
+			) }
+			{ showJetpackPowered && (
+				<div className="step-container__jetpack-powered">
+					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
 				</div>
 			) }
 		</div>

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -244,5 +244,24 @@
 	.step-container__content {
 		margin-top: 0;
 		display: block;
+		min-height: 65vh;
+	}
+
+	/**
+	 * Jetpack Powered
+	 */
+	 .step-container__jetpack-powered {
+		display: flex;
+		justify-content: center;
+		width: 100%;
+		text-align: center;
+		font-family: 'SF Pro Text', $sans;
+		font-size: $font-body-extra-small;
+		font-weight: 400;
+		line-height: 20px;
+
+		svg {
+			margin-right: 6px;
+		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

1. Extract the Jetpack logo from ⇢ into packages
2. Add `(j) Jetpack powered` to the StepContainer controlled by prop `showJetpackPowered`
3. Added showJetpackPowered to the necessary steps
4. Extended the flow prop to include flow title
5. Added flow title to Newsletters and Link in Bio to match Figma
6. Tweaked stylings


| Newsletter | Link in Bio |
| - | - |
| <img width="712" alt="Markup 2022-08-09 at 16 43 24" src="https://user-images.githubusercontent.com/33258733/183739729-3eee70ef-069b-41f1-87e4-1ae12e5e7459.png"> | <img width="643" alt="Markup 2022-08-09 at 16 43 41" src="https://user-images.githubusercontent.com/33258733/183739669-c47b39ed-8246-4d9c-803e-9ba35b475a6d.png"> |

## Testing Instructions

1. Pull branch and `yarn start`
2. Go to: http://calypso.localhost:3000/start/link-in-bio or http://calypso.localhost:3000/start/newsletters and test the flow.
3. Jetpack powered should appear on intro and setup steps for both those flows.
4. Test other flows to make sure there is no styling bleed for example - http://calypso.localhost:3000/setup/vertical?flow=site-setup-flow

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?