### PR TITLE
Sites Management Dashboard: Stack display controls on smaller screens

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -13,12 +13,38 @@ export interface SitesDashboardQueryParams {
 	search?: string;
 }
 
-const FilterBar = styled.div`
-	display: flex;
-	align-items: center;
-	gap: 16px;
-	padding: 32px 0;
-`;
+const FilterBar = styled.div( {
+	display: 'flex',
+	alignItems: 'center',
+	gap: '16px',
+	padding: '32px 0',
+
+	flexDirection: 'column',
+
+	'@media screen and (min-width: 660px)': {
+		flexDirection: 'row',
+	},
+} );
+
+const DisplayControls = styled.div( {
+	gap: '16px',
+	display: 'flex',
+	alignItems: 'center',
+	alignSelf: 'stretch',
+	flex: 1,
+} );
+
+const ControlsSelectDropdown = styled( SelectDropdown )( {
+	width: '100%',
+
+	'.select-dropdown__container': {
+		width: '100%',
+
+		'@media screen and (min-width: 660px)': {
+			width: 'auto',
+		},
+	},
+} );
 
 type Statuses = ReturnType< typeof useSitesTableFiltering >[ 'statuses' ];
 
@@ -45,19 +71,21 @@ export const SitesContentControls = ( {
 				disableAutocorrect={ true }
 				defaultValue={ initialSearch }
 			/>
-			<SelectDropdown selectedText={ selectedStatus.title }>
-				{ statuses.map( ( { name, title, count } ) => (
-					<SelectDropdown.Item
-						key={ name }
-						selected={ name === selectedStatus.name }
-						count={ count }
-						onClick={ () => handleQueryParamChange( 'status', 'all' !== name ? name : '' ) }
-					>
-						{ title }
-					</SelectDropdown.Item>
-				) ) }
-			</SelectDropdown>
-			<SitesDisplayModeSwitcher />
+			<DisplayControls>
+				<ControlsSelectDropdown selectedText={ selectedStatus.title }>
+					{ statuses.map( ( { name, title, count } ) => (
+						<SelectDropdown.Item
+							key={ name }
+							selected={ name === selectedStatus.name }
+							count={ count }
+							onClick={ () => handleQueryParamChange( 'status', 'all' !== name ? name : '' ) }
+						>
+							{ title }
+						</SelectDropdown.Item>
+					) ) }
+				</ControlsSelectDropdown>
+				<SitesDisplayModeSwitcher />
+			</DisplayControls>
 		</FilterBar>
 	);
 };

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -1,10 +1,14 @@
 import Search from '@automattic/search';
 import styled from '@emotion/styled';
 
-export const SitesSearch = styled( Search )`
-	--color-surface: var( --studio-white );
-	height: 42px;
-	overflow: hidden;
-	border: 1px solid #c3c4c7;
-	flex: 0 1 390px;
-`;
+export const SitesSearch = styled( Search )( {
+	'--color-surface': 'var( --studio-white )',
+
+	height: '42px',
+	overflow: 'hidden',
+	border: '1px solid #c3c4c7',
+
+	'@media screen and (min-width: 660px)': {
+		flex: '0 1 390px',
+	},
+} );


### PR DESCRIPTION
#### Proposed Changes

With more items being added to the SMD controls, there's some fight for screen real estate, especially on smaller screens. This PR addresses that.

![image](https://user-images.githubusercontent.com/26530524/183741411-059c3d0b-56e9-47b4-a51a-e984e2f821c2.png)

#### Screen recording

https://user-images.githubusercontent.com/26530524/183741930-d5f0fb82-42f0-4539-9770-b148e8a35e5f.mov

Notice how fluid the controls are depending on the viewport.

#### Related issue

https://github.com/Automattic/wp-calypso/issues/66359.