### PR TITLE
Site Management Dashboard: Display slug if there is no site title

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -65,9 +65,13 @@ function getSiteSlug( site: SiteExcerptNetworkData, conflictingSites: number[] =
 function computeFields( allSites: SiteExcerptNetworkData[] ) {
 	const conflictingSites = getJetpackSiteCollisions( allSites );
 	return function computeFieldsSite( data: SiteExcerptNetworkData ): SiteExcerptData {
+		const trimmedName = data.name?.trim() ?? '';
+		const slug = getSiteSlug( data, conflictingSites );
+
 		return {
 			...data,
-			slug: getSiteSlug( data, conflictingSites ),
+			name: trimmedName.length > 0 ? trimmedName : slug,
+			slug,
 		};
 	};
 }

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -57,7 +57,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 			primary={
 				<>
 					<SiteName fontSize={ 16 } { ...siteDashboardUrlProps }>
-						{ site.name ? site.name : __( '(No Site Title)' ) }
+						{ site.name }
 					</SiteName>
 
 					<div className={ badges }>

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -8,6 +8,8 @@ import { useSiteStatus } from '../hooks/use-site-status';
 
 const NoIcon = styled.div( {
 	fontSize: 'xx-large',
+	textTransform: 'uppercase',
+	userSelect: 'none',
 } );
 
 interface SiteItemThumbnailProps extends ComponentProps< typeof SiteThumbnail > {

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -88,7 +88,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					title={
 						<ListTileTitle>
 							<SiteName href={ getDashboardUrl( site.slug ) } title={ __( 'Visit Dashboard' ) }>
-								{ site.name ? site.name : __( '(No Site Title)' ) }
+								{ site.name }
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 						</ListTileTitle>


### PR DESCRIPTION
#### Proposed Changes

In the main Calypso sidebar, we fall back to showing the site's domain when there's no title. It's repetitive, but it matches what the user sees elsewhere.

#### Testing Instructions

Remove the title for a site and check that we're displaying the slug instead of the `(No Site Title)` placeholder.

| `trunk` | This branch |
| -------- | --------------- |
| ![image](https://user-images.githubusercontent.com/26530524/183749309-274d8263-935a-4be0-a609-1e3e98f47a8c.png) | ![image](https://user-images.githubusercontent.com/26530524/183749220-2f6fe1be-c0e8-42bb-963a-db6cd368259a.png) |

Related to https://github.com/Automattic/wp-calypso/pull/66325#discussion_r941567703.