### PR TITLE
Sites Management Dashboard: Fix Intl.Segmenter API usage

### DIFF
--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -45,16 +45,11 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 };
 
 function getFirstGrapheme( input: string ) {
-	// TODO: once we're on Typescript 4.7 we should be able to add this comment:
-	//    /// <reference lib="es2022.intl" />
-	// to the top of the file to get access to the types for Intl.Segmenter
-	// which where added in microsoft/TypeScript#48800
-	// In the mean time we need to use the `any` type to fix type errors in CI.
-
 	try {
-		const segmenter = new ( Intl as any ).Segmenter();
-		const segments = segmenter.segment( input );
-		return ( Array.from( segments )[ 0 ] as any ).segment;
+		const segmenter = new Intl.Segmenter();
+		const [ firstSegmentData ] = segmenter.segment( input );
+
+		return firstSegmentData.segment;
 	} catch {
 		// Intl.Segmenter is not available in all browsers
 		return input.charAt( 0 );

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -45,13 +45,12 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 };
 
 function getFirstGrapheme( input: string ) {
-	try {
+	if ( 'Segmenter' in Intl ) {
 		const segmenter = new Intl.Segmenter();
 		const [ firstSegmentData ] = segmenter.segment( input );
 
 		return firstSegmentData.segment;
-	} catch {
-		// Intl.Segmenter is not available in all browsers
-		return input.charAt( 0 );
 	}
+
+	return input.charAt( 0 );
 }


### PR DESCRIPTION
#### Proposed Changes

Blocked by https://github.com/Automattic/wp-calypso/pull/66472. Now that we're using the latest TS version, and one that exposes the `Intl.Segmenter` APIs, let's clean up the workarounds.

Regarding the implementation itself, I tried looking at ways to polyfill the `Segmenter` API, but adding the polyfill isn't enough since it will depend on adding languages pack with it and that might be expensive. So let's keep the fallback to `.charAt(0)` for the time being. Firefox is the only browser where the polyfill is required.

I did change the implementation to avoid catching all errors under the same block if the API is unavailable.

#### Testing Instructions

Everything should work normally, and the first-letter-as-icon fallback in the Sites Management Dashboard (`/sites-dashboard`) should produce the same output as `trunk`:

![image](https://user-images.githubusercontent.com/26530524/183752023-9669209e-603a-4232-adae-1ea56dd7efc4.png)

Related to https://github.com/Automattic/wp-calypso/pull/66061.