### PR TITLE
Refactor: Adds SearchResultsPage to the marketplace

### DIFF
--- a/client/my-sites/plugins/plugin-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugin-search-results-page/index.jsx
@@ -26,7 +26,6 @@ const SearchResultsPage = ( {
 	categoryName,
 	setIsFetchingPluginsBySearchTerm,
 } ) => {
-
 	const {
 		plugins: pluginsBySearchTerm = [],
 		isFetching: isFetchingPluginsBySearchTerm,

--- a/client/my-sites/plugins/plugin-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugin-search-results-page/index.jsx
@@ -6,7 +6,8 @@ import NoResults from 'calypso/my-sites/no-results';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import ClearSearchButton from '../clear-search-button';
+import ClearSearchButton from '../plugins-browser/clear-search-button';
+import usePlugins from '../use-plugins';
 
 /**
  * Module variables
@@ -17,20 +18,38 @@ function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
 }
 
-const SearchListView = ( {
+const SearchResultsPage = ( {
 	search: searchTerm,
-	pluginsPagination,
-	pluginsBySearchTerm,
-	fetchNextPage,
-	isFetchingPluginsBySearchTerm,
 	siteSlug,
 	siteId,
 	sites,
 	categoryName,
+	setIsFetchingPluginsBySearchTerm,
 } ) => {
+
+	const {
+		plugins: pluginsBySearchTerm = [],
+		isFetching: isFetchingPluginsBySearchTerm,
+		pagination: pluginsPagination,
+		fetchNextPage,
+	} = usePlugins( {
+		infinite: true,
+		search: searchTerm,
+		wpcomEnabled: !! searchTerm,
+		wporgEnabled: !! searchTerm,
+	} );
+
 	const dispatch = useDispatch();
 
 	const translate = useTranslate();
+
+	/*
+	 * Syncs the internal value of is fetching to share it with the search header
+	 * This is a temporary solution until phase 4 of the refactor is implemented.
+	 */
+	useEffect( () => {
+		setIsFetchingPluginsBySearchTerm( isFetchingPluginsBySearchTerm );
+	}, [ setIsFetchingPluginsBySearchTerm, isFetchingPluginsBySearchTerm ] );
 
 	useEffect( () => {
 		if ( searchTerm && pluginsPagination?.page === 1 ) {
@@ -129,4 +148,4 @@ const SearchListView = ( {
 	);
 };
 
-export default SearchListView;
+export default SearchResultsPage;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -23,7 +23,6 @@ import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import EducationFooter from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
-import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -51,18 +50,11 @@ import {
 	getSelectedSite,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import PluginsCategoryResultsPage from '../plugins-category-results-page';
 import SearchResultsPage from '../plugin-search-results-page';
+import PluginsCategoryResultsPage from '../plugins-category-results-page';
 import PluginsDiscoveryPage from '../plugins-discovery-page';
-import usePlugins from '../use-plugins';
-import FullListView from './full-list-view';
 
 import './style.scss';
-
-/**
- * Module variables
- */
-const SHORT_LIST_LENGTH = 6;
 
 const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
 	const dispatch = useDispatch();
@@ -138,36 +130,6 @@ const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) 
 	return null;
 };
 
-/**
- * Filter the popular plugins list.
- *
- * Remove the incompatible plugins and the displayed featured
- * plugins from the popular list to avoid showing them twice.
- *
- * @param {Array} popularPlugins
- * @param {Array} featuredPlugins
- */
-function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
-	const displayedFeaturedSlugsMap = new Map(
-		featuredPlugins
-			.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
-			.map( ( plugin ) => [ plugin.slug, plugin.slug ] )
-	);
-
-	return popularPlugins.filter(
-		( plugin ) =>
-			! displayedFeaturedSlugsMap.has( plugin.slug ) && isCompatiblePlugin( plugin.slug )
-	);
-}
-
-const PluginBrowserContent = ( props ) => {
-	if ( props.category ) {
-		return <FullListView { ...props } />;
-	}
-
-	return;
-};
-
 const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle, hideHeader } ) => {
 	const {
 		isAboveElement,
@@ -185,10 +147,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
-
-	const { plugins: paidPlugins = [], isFetching: isFetchingPaidPlugins } = usePlugins( {
-		category: 'paid',
-	} );
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const jetpackNonAtomic = useSelector(
@@ -216,23 +174,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 	);
 	const hasUploadPlugins = useSelector(
 		( state ) => siteHasFeature( state, siteId, WPCOM_FEATURES_UPLOAD_PLUGINS ) || jetpackNonAtomic
-	);
-
-	const {
-		plugins: pluginsByCategoryFeatured = [],
-		isFetching: isFetchingPluginsByCategoryFeatured,
-	} = usePlugins( {
-		category: 'featured',
-	} );
-
-	const { plugins: popularPlugins = [], isFetching: isFetchingPluginsByCategoryPopular } =
-		usePlugins( {
-			category: 'popular',
-		} );
-
-	const pluginsByCategoryPopular = filterPopularPlugins(
-		popularPlugins,
-		pluginsByCategoryFeatured
 	);
 
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite?.ID ) );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -259,7 +259,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 					siteSlug={ siteSlug }
 					siteId={ siteId }
 					sites={ sites }
-					categoryName={ categoryName }
 				/>
 			);
 		}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -330,16 +330,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 			recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start' )
 		);
 
-	useEffect( () => {
-		if ( search && searchTitle ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
-					search_query: search,
-				} )
-			);
-		}
-	}, [] );
-
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ translate( 'Plugins', { textOnly: true } ) } />;
 	}


### PR DESCRIPTION
#### Proposed Changes

* Extracts `SearchResultsPage` from the `PluginsBrowser` into it's own file and folder.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the search page for regressions, everything should work as it was before the refactor.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes to #64542
