### PR TITLE
Add/launchpad site preview integration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -2,24 +2,23 @@ import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import Checklist from './checklist';
+import LaunchpadSitePreview from './launchpad-site-preview';
 import { tasks } from './tasks';
 import type { Step } from '../../types';
 import './style.scss';
 
-function PlaceHolderPreview() {
-	return <div style={ { textAlign: 'center' } }>Preview here</div>;
-}
-
 const Launchpad: Step = ( { navigation } ) => {
 	const translate = useTranslate();
 	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
+	const siteSlug = useSiteSlugParam();
 
 	const stepContent = (
 		<div className="launchpad__content">
 			<Checklist tasks={ tasks } />
-			<PlaceHolderPreview />
+			<LaunchpadSitePreview siteSlug={ siteSlug } />
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -6,6 +6,7 @@ import PreviewToolbar from 'calypso/signup/steps/design-picker/preview-toolbar';
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
+	const defaultDevice = 'phone';
 
 	function formatPreviewUrl() {
 		if ( ! previewUrl ) {
@@ -36,6 +37,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 					components: { strong: <strong /> },
 				} ) }
 				translate={ translate }
+				defaultViewportDevice={ defaultDevice }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,0 +1,44 @@
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import WebPreview from 'calypso/components/web-preview/component';
+import PreviewToolbar from 'calypso/signup/steps/design-picker/preview-toolbar';
+
+const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
+	const translate = useTranslate();
+	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
+
+	function formatPreviewUrl() {
+		if ( ! previewUrl ) {
+			return null;
+		}
+
+		return addQueryArgs( previewUrl, {
+			iframe: true,
+			theme_preview: true,
+		} );
+	}
+
+	return (
+		<div className={ 'launchpad__site-preview-wrapper' }>
+			<WebPreview
+				className="launchpad__-web-preview"
+				showDeviceSwitcher={ true }
+				showPreview
+				showSEO={ true }
+				isContentOnly
+				externalUrl={ siteSlug }
+				previewUrl={ formatPreviewUrl() }
+				toolbarComponent={ PreviewToolbar }
+				showClose={ false }
+				showEdit={ false }
+				showExternal={ false }
+				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+					components: { strong: <strong /> },
+				} ) }
+				translate={ translate }
+			/>
+		</div>
+	);
+};
+
+export default LaunchpadSitePreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -1,9 +1,26 @@
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+
+.step-container.launchpad {
+	max-width: 1440px;
+    padding-inline-start: 24px;
+    padding-inline-end: 24px;
+
+	@include break-small {
+		padding-inline-start: 48px;
+    	padding-inline-end: 48px;
+	}
+	
+	.spinner-line {
+		display: none;
+	}
+}
 
 .launchpad__content {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	transform: translateY(-48px);
 }
 
 .launchpad__checklist {
@@ -66,4 +83,34 @@
 	line-height: 20px;
 	text-align: left;
 	width: 30px;
+}
+
+// Launchpad Site Preview Component
+
+.launchpad__site-preview-wrapper {
+
+	height: 600px;
+	
+	.web-preview__frame-wrapper.is-resizable {
+		margin: 0;
+		padding: 0;
+		background-color: transparent;
+	}
+
+	// Will be used to disable interaction with iframe
+	// .web-preview__frame {
+	// 	pointer-events: none;
+	// }
+
+		
+	.web-preview__frame {
+		border: 1px solid rgba( 0, 0, 0, 0.12 );
+		border-top-width: 0;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 0 0 6px 6px;
+		box-sizing: border-box;
+	}
+
+	
+
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -20,7 +20,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	transform: translateY(-48px);
+	transform: translateY( -48px );
 }
 
 .launchpad__checklist {


### PR DESCRIPTION
#### Proposed Changes

This PR adds the initial component for the Launchpad site preview.
I added a separate component for the site preview itself and updated the existing launchpad styling.

<img width="957" alt="image" src="https://user-images.githubusercontent.com/10482592/183762534-c3d4a8e9-1219-42a3-8000-54b1c8366406.png">


#### Testing Instructions

- Check out this PR
- Run yarn and yarn start 
- Open http://calypso.localhost:3000/setup/launchpad?flow=newsletters&siteSlug={siteSlugHere}
- Make sure you enter a valid site slug in the URL or the site preview will not load
- Confirm that site preview component renders like the screenshot above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66131
