### PR TITLE
Add themes subtree back to the server-side redux cache

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -110,7 +110,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	 * request, we should not utilize the state cache for logged-in requests.
 	 * Note that in dev mode (when the user is not bootstrapped), all requests
 	 * are considered logged out. This shouldn't cause issues because only one
-	 * user is using the cache in dev mode -- so cross-pollination won't happen.
+	 * user is using the cache in dev mode -- so cross-request pollution won't happen.
 	 */
 	const cachedServerState = request.context.isLoggedIn ? {} : stateCache.get( cacheKey ) || {};
 	const getCachedState = ( reducer, storageKey ) => {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -235,11 +235,10 @@ export function serverRender( req, res ) {
 		attachHead( context );
 
 		const isomorphicSubtrees = context.section?.isomorphic ? [ 'themes', 'ui' ] : [];
-
-		const reduxSubtrees = [ 'documentHead', ...isomorphicSubtrees ];
+		const initialClientStateTrees = [ 'documentHead', ...isomorphicSubtrees ];
 
 		// Send state to client
-		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
+		context.initialReduxState = pick( context.store.getState(), initialClientStateTrees );
 
 		/**
 		 * Cache redux state to speedup future renders. For example, some network


### PR DESCRIPTION
### Proposed Changes

#### Background context:
In SSR routes in Calypso, the redux state is cached on the server to improve SSR render time. This is meant to be used in the themes section to reduce the need for network requests:

https://github.com/Automattic/wp-calypso/blob/2f17c362c3663215efc805f2cf0bcbe6dd221ba9/client/my-sites/themes/controller.jsx#L58-L64

However, in my local testing, the cache never works. I discovered that some time ago, the `themes` data was removed from the server-side cache. I do not think it was intentional for the data to never be cached. For some historical context:

- @ockham wrote a change 5 years ago [which cached the themes state](https://github.com/Automattic/wp-calypso/pull/13339) (and other parts of the redux store) on the Calypso server. At this time, the `documentHead`, `themes`, and `ui` subtrees were all cached. The point of this change was to avoid having to cache API data inline and to just have one unified cache for the redux subtrees used in SSR contexts.
- Only a few months later, another change was [merged by someone else](https://github.com/Automattic/wp-calypso/pull/18297) which subtly changed the cache so that only `documentHead` is considered a “[cacheable subtree](https://github.com/Automattic/wp-calypso/pull/18297/files#diff-da96dcbe471b47bbc5ec4aee2520997e363c827e6249d1834d4fff6f8d0df6c8R107-R127).” As a result, `themes` is no longer cached at all.
- This same behavior exists today, where only `documentHead` is considered a cacheable subtree and other sections are excluded.

I don’t know why that the second change was made which effectively reverted the original cache. My big concern for this PR is whether adding the `themes` cache back will introduce problems -- it was clearly removed on purpose, but the PR never describes why, so I can only guess.

Here's my guess: the PR removing the cache was improving locale handling. They maybe assumed that the cache would include locale-specific data and didn't want to pollute requests for a different language with that locale. So they just removed it from the cache.

If that was the case, they didn't really need to be concerned. The redux cache is **per-route**, and logged-out themes routes are always accessed under locale-specific routes. For example, `/themes` will _always_ show themes in English, and `/fr/themes` will _always_ show themes in French. As a result, when we set the themes cache in the first place, it will include the correct translations for that specific route, and when we get the cache, it will be for the locale-specific route.

As a result, at least for logged-out requests, it should be completely fine to cache the `themes` data.
 
#### This change:

We now cache the `themes` subtree in the redux state cache. This speeds up performance because network requests related to themes are skipped. 

#### Avoiding cache pollution:

I found that the redux cache is **always** read during any request, but it is only set when SSR is enabled. (E.g. only for logged-out requests.)

Unfortunately, I don't think we should keep this behavior, because it would be very easy for the logged-out cache to be used for a logged-in route. If request A to "/themes" caches the logged-out English themes data, that data would then get populated when logged-in request B to the same route occurs. Since the language is not encoded into the route if the user is logged in, that would be incorrect.

This likely doesn't cause huge problems in practice, because the client likely updates things quickly, and since SSR markup is not sent for logged-in requests.

However, the initial redux state is attached to the request even for logged-in requests, and at the very least, the `DocumentHead` component and state tree is likely used to render the initial logged-in view.

So even though the document head state has been currently cached in logged-out SSR requests, and then read from for logged-in requests, I don't know if that behavior is intentional, as it seems possible for DocumentHead to change on a per-user basis (e.g. based on user language). 

So my solution is to **never** use the redux cache if the request is logged in. (And note that the cache was only ever written to if the request was logged out, so the new behavior will at least match.)

### TODO:
- [x] Double check that this doesn't impact logged-in routes. If it does, fix it.


### Testing Instructions

1. Run `USE_SERVER_PROFILER=true yarn start`
2. Open an _incognito/private window_ so that the request is logged out
3. Visit http://calypso.localhost:3000/themes
4. A profile was saved to ./profiles/_themes. Open it and verify that the request took several hundred miliseconds
5. Visit http://calypso.localhost:3000/themes again
6. A second profile was saved. Open it and verify that the request took less than a hundred miliseconds. (In my testing, around 30ms)

Here's a video of me checking the profile times using VS Code's built-in profile viewer:

https://user-images.githubusercontent.com/6265975/185252557-9378960f-a37b-4300-8726-76679237088c.mov

If you run this same test on trunk, you should observe that while requests are somewhat faster the second time, they only go from, say, 900ms to 600ms. This is because the SSR markup cache speeds things up somewhat, but the network requests making the request take so long happen even when the markup is cached.