### PR TITLE
Marketplace on personal/premium: disable on all envs.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -101,7 +101,7 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
-		"marketplace-personal-premium": true,
+		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -76,7 +76,7 @@
 		"mailchimp": true,
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
-		"marketplace-personal-premium": true,
+		"marketplace-personal-premium": false,
 		"marketplace-jetpack-plugin-search": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,


### PR DESCRIPTION
#### Proposed Changes

* Disable buying plugins in personal / premium

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D85703-code
* Visit wpcalypso or staging
* Verify that free / personal / premium sites require business plan to buy plugins

Related to pdtkmj-io-p2#comment-532

Also, related wpcomsh 1069-gh-Automattic/wpcomsh