### PR TITLE
Import: fix the Russian text truncated issue on the WP importer page

### DIFF
--- a/client/blocks/importer/wordpress/content-chooser/style.scss
+++ b/client/blocks/importer/wordpress/content-chooser/style.scss
@@ -3,6 +3,7 @@
 .content-chooser {
 	.formatted-header__title {
 		max-width: none;
+		word-break: break-word;
 
 		@include break-medium {
 			max-width: 390px;


### PR DESCRIPTION
#### Proposed Changes

* Use `word-break: break-word` to prevent the title text from overflowing its content box

#### Testing Instructions

* Navigate to http://calypso.localhost:3000/me/account and set your locale to `Русский`

<img width="1439" alt="Screen Shot 2022-08-10 at 4 48 13 PM" src="https://user-images.githubusercontent.com/1024985/183859310-c82faab1-8f9b-4824-9ec6-18cc20cd5234.png">

* Go to http://calypso.localhost:3000/setup/import?siteSlug={YOUR_SITE_SLUG}
* Fill in `https://coastal-night.jurassic.ninja` and then click `Продолжить`

<img width="1223" alt="Screen Shot 2022-08-10 at 5 02 12 PM" src="https://user-images.githubusercontent.com/1024985/183861215-d26833c5-d052-43e4-905d-46283fc1c8b2.png">

* Proceed to `http://calypso.localhost:3000/setup/importerWordpress?siteSlug={YOUR_SITE_SLUG}&from=https%3A%2F%2Fcoastal-night.jurassic.ninja%2F`
* The title text on the left column should not be cropped by the block on the right column

<img width="1532" alt="Screen Shot 2022-08-10 at 3 21 02 PM" src="https://user-images.githubusercontent.com/1024985/183859911-02cc45e7-b027-4cf6-841c-c2f904a2596a.png">

#### Screenshots

PC - before

<img width="1602" alt="Screen Shot 2022-08-10 at 3 21 45 PM" src="https://user-images.githubusercontent.com/1024985/183860175-c774c8ad-b934-4136-a829-1575b220ebae.png">

PC - after

<img width="1532" alt="Screen Shot 2022-08-10 at 3 21 02 PM" src="https://user-images.githubusercontent.com/1024985/183860211-6f17274e-318c-44db-9b6d-62220c2d5a0f.png">

Tablet - before

<img width="831" alt="Screen Shot 2022-08-10 at 3 22 43 PM" src="https://user-images.githubusercontent.com/1024985/183860286-f693cfec-a59c-44a4-ad55-96382a73ebc5.png">

Tablet - after

<img width="826" alt="Screen Shot 2022-08-10 at 3 22 52 PM" src="https://user-images.githubusercontent.com/1024985/183860341-7f042379-9e72-4d9b-8fae-2c79301c5e50.png">

Mobile - before

<img width="481" alt="Screen Shot 2022-08-10 at 3 23 14 PM" src="https://user-images.githubusercontent.com/1024985/183860408-b20446f6-78fa-4b1b-a874-f6b430f2934c.png">

Mobile - after

<img width="461" alt="Screen Shot 2022-08-10 at 3 23 03 PM" src="https://user-images.githubusercontent.com/1024985/183860463-5a0f79e0-c930-413e-862c-6db5b0919fb5.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66208
