### PR TITLE
Jetpack Agency Dashboard: Show title and subtitle on the agency dashboard for all devices >660px

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -6,19 +6,15 @@
 		padding: 0 16px;
 	}
 }
-
 .sites-overview__container {
 	padding: 16px 0;
-
 	@include break-large() {
 		padding: 6px 0;
 	}
 }
-
 .sites-overview__content-wrapper {
 	max-width: 1500px;
 	margin: auto;
-
 	@include break-large() {
 		padding: 0;
 	}
@@ -27,32 +23,25 @@
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
 	margin: 0 -32px;
-
 	padding: 0 48px;
-
-	@include break-large() {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-bottom: 1px solid var( --color-primary-5 );
 	}
 }
 .sites-overview__content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
-	margin: 0 -32px -32px;
-
+	margin: 0 -32px;
 	padding: 8px 48px;
 	min-height: 100vh;
-
-	@include break-medium() {
-		padding: 16px 48px;
-	}
-
-	@include break-large() {
+	@include breakpoint-deprecated( '>660px' ) {
+    	padding: 16px 48px;
 		background: rgba( 255, 255, 255, 0.5 );
 	}
 }
 .sites-overview__page-title-container {
 	display: none;
-	@include break-large() {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR makes changes to show the title and subtitle on the agency dashboard for all the devices >660px width

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/show-top-title-for-small-screen-in-agency-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Switch to 661px screen width using the dev tool.
4. Verify the top title & subtitle are shown below

<img width="733" alt="Screenshot 2022-08-10 at 3 00 11 PM" src="https://user-images.githubusercontent.com/10586875/183867489-1097b519-fbb6-4fb0-820b-3059e7af870f.png">

Before

<img width="713" alt="Screenshot 2022-08-10 at 3 01 46 PM" src="https://user-images.githubusercontent.com/10586875/183867861-e7124425-493f-4d20-87fe-9d61d25359da.png">

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202619025189113-as-1202735159671049