### PR TITLE
(WIP) Enable the feature flag required to "Promote a Post" in stage

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,7 @@
 		"plugins/plugin-details-layout": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
-		"promote-post": false,
+		"promote-post": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_test_todo",
-	"dsp_widget_js_src": "http://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js?m=1660075754h&ver=1.0.0",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_test_todo",
-	"dsp_widget_js_src": "http://todo",
+	"dsp_widget_js_src": "http://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": false,


### PR DESCRIPTION
#### Proposed Changes

* Enable the FeatureFlag for dsp-widget

### Required changes:
- fill the dsp_widget_js_src variable with the URL to test the widget

#### Testing Instructions

- The DSP widget should open in stage env:
- Go to posts List. click in the meatball menu in a published post. 
- "Promote Post" should display. Click on it. Promote a Post should open

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Related to #
