### PR TITLE
Plugin Management: Implement multi-site(small screen) view for the plugin management

### DIFF
--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -151,8 +151,24 @@
 		font-weight: normal;
 	}
 	margin-bottom: 0;
-	@include break-large() {
+	@include breakpoint-deprecated( '>660px' ) {
 		background: var( --color-primary-0 );
 		box-shadow: none;
+	}
+}
+.is-jetpack-cloud {
+	@include breakpoint-deprecated( '>660px' ) {
+		.section-nav-tabs.is-dropdown {
+			margin: 8px 0;
+			z-index: 99;
+			.select-dropdown__header .count {
+				top: unset;
+				margin-inline-end: 20px;
+			}
+			.select-dropdown__item-count .count {
+				position: static;
+				color: var( --color-primary );
+			}
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
@@ -1,5 +1,10 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .plugins-overview__container {
-	padding: 6px 0;
+	.current-section {
+		padding: 0 16px;
+	}
 }
 .plugins-overview__logo {
 	fill: var( --color-neutral-10 );

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,4 +1,7 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import PluginCard from './plugin-card';
 import PluginsTable from './plugins-table';
 import type { Plugin } from './types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
@@ -69,6 +72,22 @@ export default function PluginManagementV2( {
 				isLoading={ isLoading }
 				selectedSite={ selectedSite }
 			/>
+			<div className="plugin-management-v2__mobile-view">
+				<>
+					<Card className="plugin-management-v2__content-header">
+						<div>{ translate( 'Installed Plugins' ) }</div>
+					</Card>
+					{ isLoading ? (
+						<Card>
+							<TextPlaceholder />
+						</Card>
+					) : (
+						plugins.map( ( item ) => (
+							<PluginCard key={ item.id } item={ item } selectedSite={ selectedSite } />
+						) )
+					) }
+				</>
+			</div>
 		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
@@ -1,0 +1,55 @@
+import { Gridicon, Card, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import PluginRowFormatter from '../plugin-row-formatter';
+import UpdatePlugin from '../update-plugin';
+import type { Plugin } from '../types';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+interface Props {
+	item: Plugin;
+	selectedSite: SiteData;
+}
+
+export default function PluginCard( { item, selectedSite }: Props ): ReactElement {
+	const translate = useTranslate();
+
+	return (
+		<Card className="plugin-card__card" compact>
+			<div className="plugin-card__columns">
+				<div className="plugin-card__left-content">
+					{ item.icon ? (
+						<img className="plugin-card__plugin-icon" src={ item.icon } alt={ item.name } />
+					) : (
+						<Gridicon className="plugin-card__plugin-icon has-opacity" icon="plugins" />
+					) }
+				</div>
+				<div className="plugin-card__main-content">
+					<div>
+						<PluginRowFormatter isSmallScreen item={ item } columnKey="plugin" />
+						<span className="plugin-card__overlay"></span>
+					</div>
+					<div className="plugin-card__sites-count">
+						{ translate( 'Installed on %(count)d sites', {
+							args: {
+								count: Object.keys( item.sites ).length,
+							},
+						} ) }
+					</div>
+					<UpdatePlugin
+						plugin={ item }
+						selectedSite={ selectedSite }
+						className="plugin-card__update-plugin"
+					/>
+				</div>
+				<div className="plugin-card__right-content">
+					<Button borderless compact>
+						<Gridicon icon="ellipsis" size={ 18 } className="plugin-card__all-actions" />
+					</Button>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-card/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-card/style.scss
@@ -1,0 +1,48 @@
+.plugin-card__columns {
+	display: flex;
+  	flex:1;
+}
+.plugin-card__left-content {
+	min-width: 32px;
+	max-width: 32px;
+  	order: 1;
+}
+.plugin-card__main-content {
+	flex: 1;
+	order: 2;
+	position: relative;
+	padding: 0 0 0 16px;
+	width: 70%;
+}
+.plugin-card__right-content {
+	width: 20px;
+	order: 3;
+}
+.plugin-card__plugin-icon {
+	width: 32px;
+	height: 32px;
+}
+.plugin-card__all-actions {
+	color: var( --studio-gray-40 );
+	margin: 0 0.1em;
+}
+.plugin-card__overlay {
+	display: block;
+	position: absolute;
+	height: 20px;
+	width: 20px;
+	background: linear-gradient(
+		to right,
+		rgba( 255, 255, 255, 0.8 ) 30%,
+		rgba( 255, 255, 255, 1 ) 100%
+	);
+	inset-block-start: 2px;
+	inset-inline-end: 0;
+}
+.plugin-card__sites-count {
+	color: var( --studio-gray-60 );
+	font-size: 0.75rem;
+}
+.plugin-card__update-plugin {
+	margin-block-start: 16px;
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -15,13 +15,15 @@ import './style.scss';
 interface Props {
 	item: Plugin;
 	columnKey: string;
-	selectedSite: SiteData;
+	selectedSite?: SiteData;
+	isSmallScreen?: boolean;
 }
 
 export default function PluginRowFormatter( {
 	item,
 	columnKey,
 	selectedSite,
+	isSmallScreen,
 }: Props ): ReactElement | any {
 	const PluginDetailsButton = ( props: { className: string; children: ReactChild } ) => {
 		return <Button borderless compact href={ `/plugins/${ item.slug }` } { ...props } />;
@@ -34,15 +36,22 @@ export default function PluginRowFormatter( {
 		return moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
 	};
 
-	const { activation: canActivate, autoupdate: canUpdate } = getAllowedPluginActions(
-		item,
-		state,
-		selectedSite
-	);
+	let canActivate;
+	let canUpdate;
+
+	if ( selectedSite ) {
+		const { activation, autoupdate } = getAllowedPluginActions( item, state, selectedSite );
+		canActivate = activation;
+		canUpdate = autoupdate;
+	}
 
 	switch ( columnKey ) {
 		case 'plugin':
-			return (
+			return isSmallScreen ? (
+				<PluginDetailsButton className="plugin-row-formatter__plugin-name-card">
+					{ item.name }
+				</PluginDetailsButton>
+			) : (
 				<span className="plugin-row-formatter__plugin-name-container">
 					{ item.icon ? (
 						<img

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -7,7 +7,7 @@
 	vertical-align: middle;
 	margin-inline-end: 16px;
 }
-a.button.plugin-row-formatter__plugin-name {
+.plugin-name {
 	display: inline-block;
 	font-weight: 500;
 	white-space: nowrap;
@@ -15,9 +15,17 @@ a.button.plugin-row-formatter__plugin-name {
 	text-overflow: clip;
 	vertical-align: middle;
 	color: var( --studio-gray-100 );
-	width: calc( 100% - 55px );
 	font-size: 0.875rem;
 	text-align: left;
+}
+
+a.button.plugin-row-formatter__plugin-name {
+	@extend .plugin-name;
+	width: calc( 100% - 55px );
+}
+a.button.plugin-row-formatter__plugin-name-card {
+	@extend .plugin-name;
+	width: calc( 100% - 10px );
 }
 .plugin-row-formatter__overlay {
 	display: block;

--- a/client/my-sites/plugins/plugin-management-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/style.scss
@@ -1,3 +1,15 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.plugin-management-v2__mobile-view {
+	margin: 0 -16px;
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: unset;
+	}
+	@include break-xlarge() {
+		display: none;
+	}
+}
 .has-opacity {
 	opacity: 0.3;
 }
@@ -12,4 +24,15 @@
 	text-align: center;
 	font-size: 1.5rem;
 	margin-top: 16px;
+}
+.plugin-management-v2__content-header {
+	margin-block-end: 0;
+	height: 50px;
+	> div {
+		color: var( --color-text );
+		font-size: 0.75rem;
+		display: flex;
+		align-items: center;
+		height: 100%;
+	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
 @import './grid-mixins.scss';
 
 .is-section-plugins .main {
@@ -324,35 +326,62 @@ body.is-section-plugins header .select-dropdown__item {
 	color: var( --studio-gray-60 );
 	margin-bottom: 8px;
 }
+.plugins__page-title-container {
+	display: none;
+	@include breakpoint-deprecated( '>660px' ) {
+		display: block;
+	}
+}
 .plugins__jetpack-cloud {
 	.plugins__main-header .section-nav {
-		border-width: 0;
+		border-width: 1px;
+		@include breakpoint-deprecated( '>660px' ) {
+			border-width: 0;
+		}
 	}
 	.plugins__main-header {
-		margin: 0;
+		margin: 9px 0;
+		@include breakpoint-deprecated( '>660px' ) {
+			margin: 0;
+		}
 	}
 }
 .plugins__top-container {
 	margin: 0 -32px;
-	padding: 0 48px;
-	border-bottom: 1px solid var( --color-primary-5 );
+	padding: 8px 48px 0;
+	@include breakpoint-deprecated( '>660px' ) {
+		padding: 16px 48px 0;
+		border-bottom: 1px solid var( --color-primary-5 );
+	}
+	@include break-large() {
+		padding: 6px 48px 0;
+	}
 }
 .plugins__content-wrapper {
 	max-width: 1500px;
 	margin: auto;
-	padding: 0;
+	@include break-large() {
+		padding: 0;
+	}
 }
 .plugins__main-content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
-	margin: 0 -32px -32px;
-	padding: 16px 48px;
+	margin: 0 -32px;
+	padding: 0 48px;
 	min-height: 100vh;
-	background: rgba( 255, 255, 255, 0.5 );
+	@include breakpoint-deprecated( '>660px' ) {
+    	padding: 16px 48px;
+		background: rgba( 255, 255, 255, 0.5 );
+	}
 }
 .plugins__search {
 	height: 52px;
 	box-shadow: 0 0 0 1px var( --color-neutral-5 );
+	margin-block-end: 8px;
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-block-end: 0;
+	}
 	.search.is-open {
 		box-shadow: none;
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR implements the small screen view(<1080px) for multi-site plugin management. 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/plugin-management-multi-site-small-screen-view` and `yarn start-jetpack-cloud-p`
2. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
3. Switch to any width <1080px using the dev tool.
4. Click on **Plugins** in the sidebar -> Verify that the new card UI for the plugin is shown as below.

**320px**

<img width="386" alt="Screenshot 2022-08-10 at 3 22 34 PM" src="https://user-images.githubusercontent.com/10586875/183874110-650a5995-253b-4ef6-982b-604eaa6244fe.png">

**768px**

<img width="830" alt="Screenshot 2022-08-10 at 3 22 46 PM" src="https://user-images.githubusercontent.com/10586875/183874362-0d539ef2-463b-4e66-8556-b102205368b4.png">

**<1080px**

<img width="1129" alt="Screenshot 2022-08-10 at 3 23 18 PM" src="https://user-images.githubusercontent.com/10586875/183874579-25f77f76-9bd1-471d-8f6d-3005d5069f5c.png">

5. Clicking on the Plugin name & `Update` text should redirect the user to the plugin details page.
6. Verify search works as expected.
7. Click on all the tabs - All, Active, Inactive & Updates and verify the plugins are shown as per the filter and the URL changes accordingly. 
8. Verify these changes have not affected anything in Calypso Blue. 

> **_NOTE:_** The more actions icon(`...`) is just a placeholder and will be updated later in a different PR, and the single-site card view will be implemented in the upcoming PR. 

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202673439327767