### PR TITLE
Update some copy for cancellation offers

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx
@@ -197,7 +197,7 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 				<p>{ renewalCopy }</p>
 				<p className="jetpack-cancellation-offer__tos">
 					{ translate(
-						'Getting this discount means you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
+						'Getting this discount means you agree to our {{tosLink}}Terms of Service{{/tosLink}}. If you currently have automatic renewal enabled, you authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
 						{
 							components: {
 								tosLink: (


### PR DESCRIPTION
#### Proposed Changes

* Updates some language in the cancellation flow for the offer step.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the test plan for #65000 and confirm that the copy on the offer step is updated to read

"Getting this discount means you agree to our Terms of Service. If you currently have automatic renewal enabled, you authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand how your subscription works and how to cancel."

![Screen Shot 2022-08-10 at 9 47 46 AM](https://user-images.githubusercontent.com/18016357/183918799-9d463618-9db7-4f90-a203-68cd076f7972.png)
