### PR TITLE
Sites Management Page: Hide 'Hidden' sites by default

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -5,6 +5,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'URL',
 	'is_coming_soon',
 	'is_private',
+	'visible',
 	'launch_status',
 	'icon',
 	'name',

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -10,8 +10,9 @@ import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
 
 export interface SitesDashboardQueryParams {
-	status: FilterableSiteLaunchStatuses;
 	search?: string;
+	showHidden?: boolean;
+	status: FilterableSiteLaunchStatuses;
 }
 
 const FilterBar = styled.div( {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,9 +1,9 @@
 import { Button, useSitesTableFiltering, useSitesTableSorting } from '@automattic/components';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { NoSitesMessage } from './no-sites-message';
@@ -62,26 +62,21 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
-const HiddenSitesMessage = styled.span`
+const HiddenSitesMessageContainer = styled.div`
 	color: var( --color-text-subtle );
-	display: block;
 	font-size: 14px;
-	padding: 16px 16px 24px;
+	padding: 16px 0 24px 0;
+	text-align: center;
 `;
 
-const HiddenSitesMessageLink = styled.a`
-	text-decoration: underline;
-
-	&:hover {
-		text-decoration: none;
-	}
+const HiddenSitesMessage = styled.div`
+	margin-bottom: 1em;
 `;
 
 export function SitesDashboard( {
 	queryParams: { search, showHidden, status = 'all' },
 }: SitesDashboardProps ) {
-	const { __ } = useI18n();
-	const translate = useTranslate();
+	const { __, _n } = useI18n();
 
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 
@@ -131,26 +126,24 @@ export function SitesDashboard( {
 								<SitesGrid isLoading={ isLoading } sites={ filteredSites } />
 							) }
 							{ selectedStatus.hiddenCount > 0 && (
-								<HiddenSitesMessage>
-									{ translate(
-										'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
-										'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
-										{
-											count: selectedStatus.hiddenCount,
-											args: {
+								<HiddenSitesMessageContainer>
+									<HiddenSitesMessage>
+										{ sprintf(
+											/* translators: the `hiddenSitesCount` field will be a number greater than 0 */
+											_n(
+												'%(hiddenSitesCount)d more hidden site. Use search to access it.',
+												'%(hiddenSitesCount)d more hidden sites. Use search to access them.',
+												selectedStatus.hiddenCount
+											),
+											{
 												hiddenSitesCount: selectedStatus.hiddenCount,
-											},
-											components: {
-												br: <br />,
-												a: (
-													<HiddenSitesMessageLink
-														href={ addQueryArgs( window.location.href, { 'show-hidden': 'true' } ) }
-													/>
-												),
-											},
-										}
-									) }
-								</HiddenSitesMessage>
+											}
+										) }
+									</HiddenSitesMessage>
+									<Button href={ addQueryArgs( window.location.href, { 'show-hidden': 'true' } ) }>
+										Show all
+									</Button>
+								</HiddenSitesMessageContainer>
 							) }
 						</>
 					) : (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -144,8 +144,8 @@ export function SitesDashboard( {
 										{ sprintf(
 											/* translators: the `hiddenSitesCount` field will be a number greater than 0 */
 											_n(
-												'%(hiddenSitesCount)d more hidden site. Use search to access it.',
-												'%(hiddenSitesCount)d more hidden sites. Use search to access them.',
+												'%(hiddenSitesCount)d site is hidden from the list. Use search to access it.',
+												'%(hiddenSitesCount)d sites are hidden from the list. Use search to access them.',
 												selectedStatus.hiddenCount
 											),
 											{

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,4 +1,5 @@
 import { Button, useSitesTableFiltering, useSitesTableSorting } from '@automattic/components';
+import { css as cssClassName } from '@emotion/css';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
@@ -62,6 +63,10 @@ const DashboardHeading = styled.h1`
 	flex: 1;
 `;
 
+const sitesMargin = cssClassName( {
+	margin: '0 0 1.5em',
+} );
+
 const HiddenSitesMessageContainer = styled.div`
 	color: var( --color-text-subtle );
 	font-size: 14px;
@@ -120,10 +125,18 @@ export function SitesDashboard( {
 					{ filteredSites.length > 0 || isLoading ? (
 						<>
 							{ displayMode === 'list' && (
-								<SitesTable isLoading={ isLoading } sites={ filteredSites } />
+								<SitesTable
+									isLoading={ isLoading }
+									sites={ filteredSites }
+									className={ sitesMargin }
+								/>
 							) }
 							{ displayMode === 'tile' && (
-								<SitesGrid isLoading={ isLoading } sites={ filteredSites } />
+								<SitesGrid
+									isLoading={ isLoading }
+									sites={ filteredSites }
+									className={ sitesMargin }
+								/>
 							) }
 							{ selectedStatus.hiddenCount > 0 && (
 								<HiddenSitesMessageContainer>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,6 +1,5 @@
 import { Button, useSitesTableFiltering, useSitesTableSorting } from '@automattic/components';
-import { css as cssClassName } from '@emotion/css';
-import { css } from '@emotion/react';
+import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -22,61 +21,56 @@ const MAX_PAGE_WIDTH = '1280px';
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's
 // background color and border needs to be able to extend into that padding.
-const pagePadding = css`
-	padding-left: 32px;
-	padding-right: 32px;
-`;
+const pagePadding = {
+	paddingLeft: '32px',
+	paddingRight: '32px',
+};
 
-const wideCentered = css`
-	max-width: ${ MAX_PAGE_WIDTH };
-	margin: 0 auto;
-`;
+const PageHeader = styled.div( {
+	...pagePadding,
 
-const PageHeader = styled.div`
-	${ pagePadding }
+	backgroundColor: 'var( --studio-white )',
+	paddingTop: '24px',
+	paddingBottom: '24px',
+	boxShadow: 'inset 0px -1px 0px rgba( 0, 0, 0, 0.05 )',
+} );
 
-	background-color: var( --studio-white );
-	padding-top: 24px;
-	padding-bottom: 24px;
-	box-shadow: inset 0px -1px 0px rgba( 0, 0, 0, 0.05 );
-`;
+const PageBodyWrapper = styled.div( {
+	...pagePadding,
+	maxWidth: MAX_PAGE_WIDTH,
+	margin: '0 auto',
+} );
 
-const PageBodyWrapper = styled.div`
-	${ pagePadding }
-	max-width: ${ MAX_PAGE_WIDTH };
-	margin: 0 auto;
-`;
+const HeaderControls = styled.div( {
+	maxWidth: MAX_PAGE_WIDTH,
+	margin: '0 auto',
+	display: 'flex',
+	flexDirection: 'row',
+	alignItems: 'center',
+} );
 
-const HeaderControls = styled.div`
-	${ wideCentered }
+const DashboardHeading = styled.h1( {
+	fontWeight: 500,
+	fontSize: '20px',
+	lineHeight: '26px',
+	color: 'var( --studio-gray-100 )',
+	flex: 1,
+} );
 
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-`;
-
-const DashboardHeading = styled.h1`
-	font-weight: 500;
-	font-size: 20px;
-	line-height: 26px;
-	color: var( --studio-gray-100 );
-	flex: 1;
-`;
-
-const sitesMargin = cssClassName( {
+const sitesMargin = css( {
 	margin: '0 0 1.5em',
 } );
 
-const HiddenSitesMessageContainer = styled.div`
-	color: var( --color-text-subtle );
-	font-size: 14px;
-	padding: 16px 0 24px 0;
-	text-align: center;
-`;
+const HiddenSitesMessageContainer = styled.div( {
+	color: 'var( --color-text-subtle )',
+	fontSize: '14px',
+	padding: '16px 0 24px 0',
+	textAlign: 'center',
+} );
 
-const HiddenSitesMessage = styled.div`
-	margin-bottom: 1em;
-`;
+const HiddenSitesMessage = styled.div( {
+	marginBottom: '1em',
+} );
 
 export function SitesDashboard( {
 	queryParams: { search, showHidden, status = 'all' },

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -67,13 +67,13 @@ const HiddenSitesMessage = styled.span`
 	display: block;
 	font-size: 14px;
 	padding: 16px 16px 24px;
+`;
 
-	a {
-		text-decoration: underline;
+const HiddenSitesMessageLink = styled.a`
+	text-decoration: underline;
 
-		&:hover {
-			text-decoration: none;
-		}
+	&:hover {
+		text-decoration: none;
 	}
 `;
 
@@ -143,7 +143,7 @@ export function SitesDashboard( {
 											components: {
 												br: <br />,
 												a: (
-													<a
+													<HiddenSitesMessageLink
 														href={ addQueryArgs( window.location.href, { 'show-hidden': 'true' } ) }
 													/>
 												),

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -130,7 +130,7 @@ export function SitesDashboard( {
 							{ displayMode === 'tile' && (
 								<SitesGrid isLoading={ isLoading } sites={ filteredSites } />
 							) }
-							{ selectedStatus.hiddenCount && (
+							{ selectedStatus.hiddenCount > 0 && (
 								<HiddenSitesMessage>
 									{ translate(
 										'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -100,8 +100,6 @@ export function SitesDashboard( {
 
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 
-	const currentUrlWithShowHidden = addQueryArgs( window.location.href, { 'show-hidden': 'true' } );
-
 	return (
 		<main>
 			<DocumentHead title={ __( 'My Sites' ) } />
@@ -144,7 +142,11 @@ export function SitesDashboard( {
 											},
 											components: {
 												br: <br />,
-												a: <a href={ currentUrlWithShowHidden } />,
+												a: (
+													<a
+														href={ addQueryArgs( window.location.href, { 'show-hidden': 'true' } ) }
+													/>
+												),
 											},
 										}
 									) }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -154,7 +154,7 @@ export function SitesDashboard( {
 										) }
 									</HiddenSitesMessage>
 									<Button href={ addQueryArgs( window.location.href, { 'show-hidden': 'true' } ) }>
-										Show all
+										{ __( 'Show all' ) }
 									</Button>
 								</HiddenSitesMessageContainer>
 							) }

--- a/client/sites-dashboard/components/sites-grid.tsx
+++ b/client/sites-dashboard/components/sites-grid.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import classnames from 'classnames';
 import { SitesGridItem } from './sites-grid-item';
 import { SitesGridItemLoading } from './sites-grid-item-loading';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -21,13 +22,14 @@ const container = css( {
 } );
 
 interface SitesGridProps {
-	sites: SiteExcerptData[];
+	className?: string;
 	isLoading: boolean;
+	sites: SiteExcerptData[];
 }
 
-export const SitesGrid = ( { sites, isLoading }: SitesGridProps ) => {
+export const SitesGrid = ( { sites, isLoading, className }: SitesGridProps ) => {
 	return (
-		<div className={ container }>
+		<div className={ classnames( container, className ) }>
 			{ isLoading
 				? Array( N_LOADING_ROWS )
 						.fill( null )

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -61,7 +61,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			<SitesDashboard
 				queryParams={ {
 					search: context.query.search,
-					showHidden: context.query[ 'show-hidden' ],
+					showHidden: context.query[ 'show-hidden' ] === 'true',
 					status: context.query.status,
 				} }
 			/>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -61,6 +61,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			<SitesDashboard
 				queryParams={ {
 					search: context.query.search,
+					showHidden: context.query[ 'show-hidden' ],
 					status: context.query.status,
 				} }
 			/>

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -17,6 +17,7 @@ export interface SiteData {
 	is_wpcom_atomic?: boolean;
 	is_private?: boolean;
 	is_coming_soon?: boolean;
+	visible?: boolean;
 	launch_status?: string;
 	// TODO: fill out the rest of this
 }

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -10,12 +10,14 @@ function createMockSite( {
 	URL,
 	is_private = false,
 	is_coming_soon = false,
+	visible = true,
 }: {
 	ID?: number;
 	name?: string;
 	URL?: string;
 	is_private?: boolean;
 	is_coming_soon?: boolean;
+	visible?: boolean;
 } = {} ) {
 	return {
 		name: name ?? `site ${ ID }`,
@@ -23,6 +25,7 @@ function createMockSite( {
 		slug: `site${ ID }.io`,
 		is_private,
 		is_coming_soon,
+		visible,
 	};
 }
 
@@ -84,7 +87,7 @@ describe( 'useSitesTableFiltering', () => {
 		const public1 = createMockSite( { is_private: false } );
 		const public2 = createMockSite( { is_private: false } );
 		const private1 = createMockSite( { is_private: true } );
-		const private2 = createMockSite( { is_private: true } );
+		const private2 = createMockSite( { is_private: true, visible: false } );
 		const comingSoon = createMockSite( { is_private: true, is_coming_soon: true } );
 
 		const { result } = renderHook( () =>
@@ -99,21 +102,25 @@ describe( 'useSitesTableFiltering', () => {
 				name: 'all',
 				count: 5,
 				title: expect.any( String ),
+				hiddenCount: 1,
 			},
 			{
 				name: 'public',
 				count: 2,
 				title: expect.any( String ),
+				hiddenCount: 0,
 			},
 			{
 				name: 'private',
 				count: 2,
 				title: expect.any( String ),
+				hiddenCount: 1,
 			},
 			{
 				name: 'coming-soon',
 				count: 1,
 				title: expect.any( String ),
+				hiddenCount: 0,
 			},
 		] );
 	} );

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -83,6 +83,28 @@ describe( 'useSitesTableFiltering', () => {
 		expect( result.current.filteredSites ).toEqual( [ private1, private2 ] );
 	} );
 
+	test( 'does not return hidden sites by default', () => {
+		const visible = createMockSite( { visible: true } );
+		const hidden = createMockSite( { visible: false } );
+
+		const { result } = renderHook( () =>
+			useSitesTableFiltering( [ visible, hidden ], { status } )
+		);
+
+		expect( result.current.filteredSites ).toEqual( [ visible ] );
+	} );
+
+	test( 'returns hidden sites when asked', () => {
+		const visible = createMockSite( { visible: true } );
+		const hidden = createMockSite( { visible: false } );
+
+		const { result } = renderHook( () =>
+			useSitesTableFiltering( [ visible, hidden ], { status, showHidden: true } )
+		);
+
+		expect( result.current.filteredSites ).toEqual( [ visible, hidden ] );
+	} );
+
 	test( 'returns counts for each status type', () => {
 		const public1 = createMockSite( { is_private: false } );
 		const public2 = createMockSite( { is_private: false } );
@@ -100,7 +122,7 @@ describe( 'useSitesTableFiltering', () => {
 		expect( result.current.statuses ).toEqual( [
 			{
 				name: 'all',
-				count: 5,
+				count: 4, // hidden site not included in count
 				title: expect.any( String ),
 				hiddenCount: 1,
 			},
@@ -112,9 +134,52 @@ describe( 'useSitesTableFiltering', () => {
 			},
 			{
 				name: 'private',
-				count: 2,
+				count: 1, // hidden site not included in count
 				title: expect.any( String ),
 				hiddenCount: 1,
+			},
+			{
+				name: 'coming-soon',
+				count: 1,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
+		] );
+	} );
+
+	test( 'showHidden option includes hidden sites in `count`, but not `hiddenCount`', () => {
+		const public1 = createMockSite( { is_private: false } );
+		const public2 = createMockSite( { is_private: false, visible: false } );
+		const private1 = createMockSite( { is_private: true } );
+		const private2 = createMockSite( { is_private: true, visible: false } );
+		const comingSoon = createMockSite( { is_private: true, is_coming_soon: true } );
+
+		const { result } = renderHook( () =>
+			useSitesTableFiltering( [ public1, public2, private1, private2, comingSoon ], {
+				search: '',
+				showHidden: true,
+				status,
+			} )
+		);
+
+		expect( result.current.statuses ).toEqual( [
+			{
+				name: 'all',
+				count: 5,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
+			{
+				name: 'public',
+				count: 2,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
+			{
+				name: 'private',
+				count: 2,
+				title: expect.any( String ),
+				hiddenCount: 0,
 			},
 			{
 				name: 'coming-soon',


### PR DESCRIPTION
Fixes #66380

## Proposed Changes

Hides 'Hidden' sites from the List and Tile view by default, and adds a message indicating such at the bottom:

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/36432/184878599-d347aa14-720d-4a8d-84ff-180a116751bc.png">

'Hidden' sites appear as soon as you start searching. If you click on the link in the message, `?show-hidden=true` is appended to the URL and 'Hidden' sites will always appear (with or without searching).

## Testing Instructions

1. Switch to the branch and allow the application to rebuild.
2. Clear your `calypso_store` in LocalStorage. Calypso will need to re-request site excerpts to load the `visible` property.
3. Navigate to `/sites-dashboard`
4. Observe your 'Hidden' sites aren't displayed in the list.
5. Start searching for a 'Hidden' site.
6. Observe the site appear in the search results.
7. Clear out your search.
8. Navigate to the bottom of the page.
9. Observe the message about hidden sites.
10. Click on the link within the hidden sites message.
11. Observe all of your sites appear, regardless of whether they're hidden.