### PR TITLE
Enable cancellation offers in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,7 +15,7 @@
 		"build/sites-dashboard": true,
 		"calypso/help-center": false,
 		"calypsoify/plugins": true,
-		"cancellation-offers": false,
+		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"cloudflare": true,
 		"composite-checkout-testing": true,

--- a/config/production.json
+++ b/config/production.json
@@ -20,7 +20,7 @@
 		"bilmur-script": true,
 		"calypso/help-center": false,
 		"calypsoify/plugins": true,
-		"cancellation-offers": false,
+		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,6 +20,7 @@
 		"build/sites-dashboard": true,
 		"calypso/help-center": false,
 		"calypsoify/plugins": true,
+		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR enables the Jetpack cancellation offers in all environments.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Generally, N/A since this is just a feature flag change.
* You can check that the offers are available in Calypso live by following the test plan for #65000 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
