### PR TITLE
Stepper (NewsletterSetup): add green checkmark background for valid fields

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -5,6 +5,7 @@ import { ColorPicker } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
+import greenCheckmarkImg from 'calypso/assets/images/onboarding/green-checkmark.svg';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -32,7 +33,7 @@ function generateSwatchSVG( color: string | undefined ) {
 		! color
 			? `%3Cline x1='18' y1='4' x2='7' y2='20' stroke='%23ccc' stroke-width='1'%3E%3C/line%3E`
 			: ''
-	}%3C/svg%3E`;
+	}%3C/svg%3E")`;
 }
 const NewsletterSetup: Step = ( { navigation } ) => {
 	const { goBack, submit } = navigation;
@@ -104,6 +105,10 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 	};
 
+	const getBackgroundImage = ( fieldValue: string | undefined ) => {
+		return fieldValue && fieldValue.trim() ? `url(${ greenCheckmarkImg })` : '';
+	};
+
 	const navigateToDomains = () => {
 		// TODO
 	};
@@ -139,6 +144,9 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						value={ siteTitle }
 						name="siteTitle"
 						id="siteTitle"
+						style={ {
+							backgroundImage: getBackgroundImage( siteTitle ),
+						} }
 						isError={ !! siteTitleError }
 						onChange={ onChange }
 					/>
@@ -147,7 +155,15 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 				<FormFieldset disabled={ isLoading }>
 					<FormLabel htmlFor="tagline">{ __( 'Brief description' ) }</FormLabel>
-					<FormInput value={ tagline } name="tagline" id="tagline" onChange={ onChange } />
+					<FormInput
+						value={ tagline }
+						name="tagline"
+						id="tagline"
+						style={ {
+							backgroundImage: getBackgroundImage( tagline ),
+						} }
+						onChange={ onChange }
+					/>
 				</FormFieldset>
 
 				<FormFieldset disabled={ isLoading }>
@@ -156,7 +172,10 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						inputRef={ accentColorRef }
 						className="newsletter-setup__accent-color"
 						style={ {
-							backgroundImage: generateSwatchSVG( accentColor ),
+							backgroundImage: [
+								generateSwatchSVG( accentColor ),
+								...( accentColor ? [ getBackgroundImage( accentColor ) ] : [] ),
+							].join( ', ' ),
 						} }
 						type="text"
 						name="accentColor"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -62,11 +62,13 @@ $border-radius: 4px;
 			padding: 12px 16px;
 			height: $input-height;
 			border-radius: $border-radius;
+			background-repeat: no-repeat;
+			background-position: 95%;
 
 			&.newsletter-setup__accent-color {
-				background-size: 25px;
-				background-position: 13px center;
-				background-repeat: no-repeat;
+				background-size: 25px, auto;
+				background-position: 13px center, 95%;
+				background-repeat: no-repeat, no-repeat;
 				padding-left: 50px;
 				color: var( --studio-gray-30 );
 			}


### PR DESCRIPTION
This PR adds the missing green checkmark images for valid fields in the newsletter setup flow.

#### Proposed Changes

* added `getBackgroundImage` which based on a field value returns the background image
* integrated this style function with the applicable fields: site title, tagline, accent color. 

#### Testing Instructions
- checkout this branch
- run `yarn start`
- visit the newsletter flow: http://calypso.localhost:3000/start/newsletters
- when you arrive at the newsletter fill in value for the fields and make sure that the green checkmark is displayed according to our designs

| Before  | After |
| ------------- | ------------- |
|  <img width="907" alt="Screenshot 2022-08-10 at 18 42 59" src="https://user-images.githubusercontent.com/7000684/183966385-e706b0d1-55cd-45d9-917d-2fd0e9a645d6.png"> |  <img width="896" alt="Screenshot 2022-08-10 at 18 41 15" src="https://user-images.githubusercontent.com/7000684/183966434-116216c2-38f7-48ad-b6ea-9edc8d15d009.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
