### PR TITLE
Load the 'Promote' widget from a public URL

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,7 @@
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
-	"dsp_widget_js_src": "http://localhost:3004/widget.js",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js?m=1660075754h&ver=1.0.0",
 	"features": {
 		"ad-tracking": false,
 		"build/sites-dashboard": true,


### PR DESCRIPTION
#### Proposed Changes

* Set an official public URL for the promote widget. Note that this URL doesn't currently resolve.

#### Testing Instructions

* head to http://calypso.localhost:3000/advertising/goldsounds.blog?flags=promote-post (for your test blog)
* click "Promote" on a recent post
* check that it tries to load the widget from the new public URL (will 404) - https://widgets.wp.com/promote/widget.js?m=1660075754h&ver=1.0.0

#### Pre-merge Checklist

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
