### PR TITLE
Add/test site credentials

### DIFF
--- a/client/components/advanced-credentials/index.tsx
+++ b/client/components/advanced-credentials/index.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { FunctionComponent, useCallback, useMemo, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import wpcomRequest from 'wpcom-proxy-request';
+import wp from 'calypso/lib/wp';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 import Main from 'calypso/components/main';
@@ -95,10 +95,9 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 
 	useEffect( () => {
 		( async () => {
-			const results: { ok: boolean } = await wpcomRequest( {
+			const results: { ok: boolean } = await wp.req.post( {
 				path: '/sites/' + siteId + '/rewind/credentials/test?role=main',
 				apiNamespace: 'wpcom/v2',
-				method: 'POST',
 			} );
 			const { ok } = results;
 			setTestCredentialsLoading( false );

--- a/client/components/advanced-credentials/index.tsx
+++ b/client/components/advanced-credentials/index.tsx
@@ -1,7 +1,8 @@
 import { Button, Card, Gridicon } from '@automattic/components';
+import { FunctionComponent, useCallback, useMemo, useState, useEffect } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { FunctionComponent, useCallback, useMemo, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
@@ -88,6 +89,18 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 
 	const { protocol } = credentials;
 	const isAtomic = hasCredentials && 'dynamic-ssh' === protocol;
+
+	const testCredentials = async () => {
+		const results: { ok: boolean } = await wpcomRequest( {
+			path: '/sites/' + siteId + '/rewind/credentials/test?role=main',
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+		} );
+		const { ok } = results;
+		return { ok };
+	};
+
+	testCredentials();
 
 	const statusState = useMemo( (): StatusState => {
 		if ( isRequestingCredentials ) {


### PR DESCRIPTION
#### Proposed Changes

* This PR seeks to fix the issue outlined in Asana task 1170120475965554-as-1202542076918872
* As explained in the Asana task, currently there is no check in place to test credentials for Jetpack connected site with Jetpack backup. WPCOM Calypso > Settings > Jetpack, as well as Cloud Jetpack > Settings shows "Connected" only if credentials have been entered. This can be problematic and provide an erroneous status if credentials have changed, causing confusion for both users and HEs alike.
* This PR makes use of a new endpoint in the public WPCOM API that will test the credentials and set the connected status accordingly

Some considerations: Every time a user navigates to Settings > Jetpack on WPCOM, or Settings on Cloud.jetpack.com, this will test the credentials. As such, I would not anticipate that this page is frequented unless a user is experiencing an issue with their credentials. Nevertheless, it's something I wanted to mention, in case this might be a concern.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new Jurassic Ninja site (or use an existing self hosted site), connect Jetpack, and add a Jetpack Backup plan
* Add server credentials at cloud.jetpack.com > Settings, or follow the steps here: https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/
* Navigate to cloud.jetpack.com > Settings, or to WPCOM > Settings > Jetpack, and confirm that it shows connected (results should match test from RWDB)
* SSH into your site and change password, then navigate back to cloud.jetpack.com > Settings or to WPCOM > Settings > Jetpack, and Calypso should show Disconnected prompting user to re-enter credentials


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202542076918872