### PR TITLE
KPI Dashboard: add new build configuration for experimentation

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -35,6 +35,7 @@ object WebApp : Project({
 	buildType(PreReleaseE2ETests)
 	buildType(AuthenticationE2ETests)
 	buildType(HelpCentreE2ETests)
+	buildType(KPIDashboardTests)
 	buildType(QuarantinedE2ETests)
 })
 
@@ -863,6 +864,19 @@ object HelpCentreE2ETests : E2EBuildType(
 			withPendingChangesOnly = false
 		}
 	}
+)
+
+object KPIDashboardTests : E2EBuildType(
+	buildId = "Calypso_E2E_KPI_Dashboard",
+	buildUuid = "441efac5-721a-4557-9448-9234e89fb6b1",
+	buildName = "Test build for KPI Dashboard project",
+	buildDescription = "Test build configuration for KPI dashboard.",
+	testGroup = "kpi",
+	buildParams = {
+		param("env.VIEWPORT_NAME", "desktop")
+	},
+	buildFeatures = {
+	},
 )
 
 object QuarantinedE2ETests: E2EBuildType(


### PR DESCRIPTION
#### Proposed Changes

This PR adds a new build configuration to allow for experimentation without affecting the main E2E builds.

#### Testing Instructions

Ensure the following:
  - [x] Unit Tests
  - [x] Code Style

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66469
