### PR TITLE
E2E: use force parameter for navtab interaction in PlansPage.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -88,18 +88,7 @@ export async function clickNavTab(
 
 	// Click on the intended item and wait for navigation to finish.
 	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
-	try {
-		await Promise.all( [ page.waitForNavigation( { timeout: 10 * 1000 } ), navTabItem.click() ] );
-	} catch {
-		// In case the initial click fails, try again but this time with the force parameter set.
-		// This is acceptable as typically we are not testing whether the navtab is responsive to clicks.
-		// Failure to click on navtabs will trigger the entire build to fail and is often detrimental to
-		// the overall confidence in test suites.
-		await Promise.all( [
-			page.waitForNavigation( { timeout: 10 * 1000 } ),
-			page.dispatchEvent( selectors.navTabItem( { name: name } ), 'click' ),
-		] );
-	}
+	await Promise.all( [ page.waitForNavigation( { timeout: 10 * 1000 } ), navTabItem.click() ] );
 
 	// Final verification.
 	const newSelectedTabLocator = page.locator(

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -112,18 +112,14 @@ export class PlansPage {
 	 * @param {PlansPageTab} targetTab Name of the tab.
 	 */
 	async clickTab( targetTab: PlansPageTab ): Promise< void > {
-		// On mobile viewports, the way PlansPage loads its contents
-		// causes an event to fire which closes all open panes.
-		// As a last resort workaround, forcibly click on the target selector
-		// even if the pane is closed.
+		// The way PlansPage loads its contents is particularly prone to
+		// flakiness outside the control of Playwright auto-retry mechanism.
+		// To work around this, forcibly click on the target selector.
+		// This affects primarily Mobile viewports but also can also occur
+		// on Desktop viewports.
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// await this.page.dispatchEvent( targetTab, 'click' );
-			await clickNavTab( this.page, targetTab, { force: true } );
-		} else {
-			await clickNavTab( this.page, targetTab );
-		}
+		await clickNavTab( this.page, targetTab, { force: true } );
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

This PR changes the navtab interaction in the PlansPage to use the `force` flag by default.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66465.
