### PR TITLE
Bump TypeScript to 4.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
 		"stacktrace-gps": "^3.0.3",
 		"stylelint": "^13.13.1",
 		"tslib": "^2.3.0",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"webpack": "^5.68.0",
 		"webpack-bundle-analyzer": "^4.5.0",
 		"webpack-cli": "^4.9.2",

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -27,6 +27,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -40,6 +40,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -55,7 +55,7 @@
 		"semver": "^7.3.2",
 		"terser-webpack-plugin": "^5.2.4",
 		"thread-loader": "^3.0.4",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"webpack-cli": "^4.9.2"
 	},
 	"devDependencies": {

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -29,7 +29,7 @@ export default ( data: ConfigData ): ConfigData => {
 		data.features = Object.assign( data.features, features );
 	}
 	if ( window.electron && window.electron.features ) {
-		data.features = Object.assign( data.features, window.electron.features );
+		data.features = Object.assign( data.features ?? {}, window.electron.features );
 	}
 
 	return data;

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -37,7 +37,7 @@
 		"@wordpress/i18n": "^4.9.0",
 		"asana-phrase": "^0.0.8",
 		"node-fetch": "^2.6.7",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"react": "^17.0.2"

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"private": true
 }

--- a/packages/calypso-url/package.json
+++ b/packages/calypso-url/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
 		"@testing-library/react-hooks": "7.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -51,7 +51,7 @@
 		"@testing-library/react": "^12.1.3",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"react": "^17.0.2",

--- a/packages/create-calypso-config/package.json
+++ b/packages/create-calypso-config/package.json
@@ -36,6 +36,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -57,7 +57,7 @@
 		"jest-fetch-mock": "^3.0.3",
 		"nock": "^12.0.3",
 		"node-fetch": "^2.6.6",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"wait-for-expect": "^3.0.2",
 		"wpcom-proxy-request": "workspace:^"
 	}

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -52,7 +52,7 @@
 		"react-dom": "^17.0.2",
 		"reakit-utils": "^0.15.1",
 		"redux": "^4.1.2",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"webpack": "^5.68.0"
 	},
 	"peerDependencies": {

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -52,7 +52,7 @@
 		"@testing-library/react": "^12.1.3",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^6.7.0",

--- a/packages/domain-utils/package.json
+++ b/packages/domain-utils/package.json
@@ -30,6 +30,6 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -35,6 +35,6 @@
 		"@testing-library/react": "^12.1.3",
 		"@testing-library/react-hooks": "^7.0.2",
 		"react-dom": ">=16.8 <18",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -30,6 +30,6 @@
 	"devDependencies": {
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"files": [
 		"dist",

--- a/packages/happychat-connection/package.json
+++ b/packages/happychat-connection/package.json
@@ -35,7 +35,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"peerDependencies": {

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -54,7 +54,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/addon-backgrounds": "^6.4.19",
 		"@storybook/react": "^6.4.19",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^6.1.5",

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -43,6 +43,6 @@
 		"@types/react": "^17.0.39",
 		"react-dom": "^17.0.2",
 		"react-test-renderer": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -32,6 +32,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -49,6 +49,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -40,7 +40,7 @@
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"redux": "^4.1.2",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"webpack": "^5.68.0"
 	}
 }

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -43,7 +43,7 @@
 		"classnames": "^2.3.1",
 		"react-router-dom": "^5.1.2",
 		"tslib": "^2.3.0",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"use-debounce": "^3.1.0"
 	},
 	"devDependencies": {
@@ -54,7 +54,7 @@
 		"copyfiles": "^2.3.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^6.7.0",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -52,7 +52,7 @@
 		"@testing-library/react": "^12.1.3",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -52,7 +52,7 @@
 		"redux": "^4.1.2",
 		"sass-loader": "^10.1.1",
 		"style-loader": "^1.2.1",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"webpack": "^5.63.0"
 	},
 	"peerDependencies": {

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -44,7 +44,7 @@
 		"jest": "^27.3.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^6.7.0",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -48,7 +48,7 @@
 		"@automattic/typography": "workspace:^",
 		"@wordpress/base-styles": "^4.5.0",
 		"prop-types": "^15.7.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^6.7.0",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -59,7 +59,7 @@
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"reakit-utils": "^0.15.1",
-		"typescript": "^4.5.5",
+		"typescript": "^4.7.4",
 		"webpack": "^5.68.0"
 	},
 	"scripts": {

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -45,6 +45,6 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/site-picker/package.json
+++ b/packages/site-picker/package.json
@@ -40,7 +40,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/state-utils/package.json
+++ b/packages/state-utils/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -51,7 +51,7 @@
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/react": "^6.4.18",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^6.1.5",

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -38,6 +38,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -30,6 +30,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -54,7 +54,7 @@
 		"@testing-library/react": "^12.1.3",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"typescript": "^4.5.5"
+		"typescript": "^4.7.4"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34056,23 +34056,23 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.5.5":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
+"typescript@npm:^4.5.5, typescript@npm:^4.7.4":
+  version: 4.7.4
+  resolution: "typescript@npm:4.7.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 53e8bcf00abde8ecb2002d1f1e15160b21cb62b2dd0ff71bad2ef55fa96141f76316fce649a415758d3f17bd8e0c5676d8f017c34ec3e38b585812d4717a712c
+  checksum: 8c1c4007b6ce5b24c49f0e89173ab9e82687cc6ae54418d1140bb63b82d6598d085ac0f993fe3d3d1fbf87a2c76f1f81d394dc76315bc72c7a9f8561c5d8d205
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>":
-  version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=493e53"
+"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
+  version: 4.7.4
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d06fdd5852d0fe86f44b56507d37a3458812a1dff11c0fedaeedbe163e81646643669a5bc0dcc3500c72128267b384cda7567c53c568f94e7c753ac6b4cfbce3
+  checksum: 9648156f08ecb48f34d5223d890147a59a66d4c03a419032c9e8a31befaa00497623b544569a8efc434f9ad845495871d3d4bda67dae3ee6d479d711e4ff5309
   languageName: node
   linkType: hard
 
@@ -35810,7 +35810,7 @@ swiper@4.5.1:
     stacktrace-gps: ^3.0.3
     stylelint: ^13.13.1
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     webpack: ^5.68.0
     webpack-bundle-analyzer: ^4.5.0
     webpack-cli: ^4.9.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,7 @@ __metadata:
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -87,7 +87,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -103,7 +103,7 @@ __metadata:
     hash.js: ^1.1.7
     lodash: ^4.17.21
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -178,7 +178,7 @@ __metadata:
     semver: ^7.3.2
     terser-webpack-plugin: ^5.2.4
     thread-loader: ^3.0.4
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     webpack-cli: ^4.9.2
   peerDependencies:
     postcss: ^8.4.5
@@ -213,7 +213,7 @@ __metadata:
     "@types/node": ^16.11.26
     cookie: ^0.4.1
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -251,7 +251,7 @@ __metadata:
     node-fetch: ^2.6.7
     playwright: ^1.23
     totp-generator: ^0.0.12
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -312,7 +312,7 @@ __metadata:
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     i18n-calypso: "workspace:^"
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     react: ^17.0.2
   languageName: unknown
@@ -350,7 +350,7 @@ __metadata:
     debug: ^4.3.3
     react: ^17.0.2
     react-dom: ^17.0.2
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -366,7 +366,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     photon: "workspace:^"
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -401,7 +401,7 @@ __metadata:
     lodash: ^4.17.21
     prop-types: ^15.7.2
     react-modal: ^3.14.3
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     utility-types: ^3.10.0
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -428,7 +428,7 @@ __metadata:
     prop-types: ^15.7.2
     react: ^17.0.2
     react-dom: ^17.0.2
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -442,7 +442,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     cookie: ^0.4.1
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -467,7 +467,7 @@ __metadata:
     qs: ^6.9.1
     redux: ^4.1.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     use-debounce: ^3.1.0
     utility-types: ^3.10.0
     validator: ^13.5.2
@@ -503,7 +503,7 @@ __metadata:
     reakit-utils: ^0.15.1
     redux: ^4.1.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     utility-types: ^3.10.0
     webpack: ^5.68.0
   peerDependencies:
@@ -541,7 +541,7 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     use-debounce: ^3.1.0
     uuid: ^8.3.2
   peerDependencies:
@@ -558,7 +558,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/domain-utils@workspace:packages/domain-utils"
   dependencies:
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -603,7 +603,7 @@ __metadata:
     react: ">=16.8 <18"
     react-dom: ">=16.8 <18"
     tslib: ">=2.3.0"
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -614,7 +614,7 @@ __metadata:
     "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -624,7 +624,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -674,7 +674,7 @@ __metadata:
     react: ^17.0.2
     react-query: ^3.32.1
     socket.io-client: 2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     react: ^17.0.2
@@ -706,7 +706,7 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     react-draggable: ^4.4.4
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@wordpress/data": ^6.1.5
     "@wordpress/element": ^4.5.0
@@ -734,7 +734,7 @@ __metadata:
     react-dom: ^17.0.2
     react-test-renderer: ^17.0.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -789,7 +789,7 @@ __metadata:
   resolution: "@automattic/js-utils@workspace:packages/js-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -805,7 +805,7 @@ __metadata:
     "@wordpress/components": ^19.15.0
     "@wordpress/i18n": ^4.9.0
     "@wordpress/react-i18n": ^3.7.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@wordpress/data": ^6.7.0
     react: ^17.0.2
@@ -829,7 +829,7 @@ __metadata:
     react-dom: ^17.0.2
     redux: ^4.1.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     webpack: ^5.68.0
   languageName: unknown
   linkType: soft
@@ -869,7 +869,7 @@ __metadata:
     react-dom: ^17.0.2
     react-router-dom: ^5.1.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     use-debounce: ^3.1.0
   peerDependencies:
     "@wordpress/data": ^6.7.0
@@ -915,7 +915,7 @@ __metadata:
     debug: ^4.3.3
     react: ^17.0.2
     react-dom: ^17.0.2
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^4.1.2
@@ -1051,7 +1051,7 @@ __metadata:
     sass-loader: ^10.1.1
     style-loader: ^1.2.1
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     webpack: ^5.63.0
   peerDependencies:
     "@wordpress/i18n": ^4.7.0
@@ -1079,7 +1079,7 @@ __metadata:
     lodash: ^4.17.21
     react: ^17.0.2
     react-dom: ^17.0.2
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@wordpress/data": ^6.7.0
     react: ^17.0.2
@@ -1108,7 +1108,7 @@ __metadata:
     lodash: ^4.17.21
     prop-types: ^15.7.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     uuid: ^8.3.2
   peerDependencies:
     "@wordpress/data": ^6.7.0
@@ -1184,7 +1184,7 @@ __metadata:
     reakit-utils: ^0.15.1
     redux: ^4.1.2
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
     webpack: ^5.68.0
   peerDependencies:
     react: ^17.0.2
@@ -1200,7 +1200,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     debug: ^4.3.3
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -1219,7 +1219,7 @@ __metadata:
     "@wordpress/i18n": ^4.9.0
     "@wordpress/icons": ^9.0.0
     classnames: ^2.3.1
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@wordpress/data": ^6.1.5
     react: ^17.0.2
@@ -1265,7 +1265,7 @@ __metadata:
     redux: ^4.1.2
     redux-thunk: ^2.3.0
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -1292,7 +1292,7 @@ __metadata:
     classnames: ^2.3.1
     debug: ^4.3.4
     react-popper: ^2.2.5
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@wordpress/data": ^6.1.5
     react: ^17.0.2
@@ -1308,7 +1308,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: ^2.3.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -1338,7 +1338,7 @@ __metadata:
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -1508,7 +1508,7 @@ __metadata:
     prop-types: ^15.7.2
     react: ^17.0.2
     react-dom: ^17.0.2
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^4.1.2
@@ -26688,7 +26688,7 @@ __metadata:
     crc32: ^0.2.2
     debug: ^4.3.3
     seed-random: ^2.2.0
-    typescript: ^4.5.5
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -34056,7 +34056,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.5.5, typescript@npm:^4.7.4":
+"typescript@npm:^4.7.4":
   version: 4.7.4
   resolution: "typescript@npm:4.7.4"
   bin:
@@ -34066,7 +34066,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
   version: 4.7.4
   resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=493e53"
   bin:


### PR DESCRIPTION
#### Proposed Changes

This PR bumps Typescript from 4.6.3 to the next latest minor version: 4.7.4.

There are no breaking changes and Calypso still compiles, so it's safe to merge. I've had to null-coalesce `data.features` in `calypso-config/src/desktop.ts` as TS now requires the first argument to `Object.assign` to be an object (it was more flexible before and accepted anything, now this type is fixed. Good for us!)

The reason to do this is that we want to use newer APIs that were not exposed before `v4.7`: https://github.com/Automattic/wp-calypso/pull/66422.

#### Testing Instructions

Nothing should change. The app should compile and run normally.