### PR TITLE
Sites Management Dashboard: Fix issue where toggle button would update on its own

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import page from 'page';
+import { ComponentPropsWithoutRef } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { SitesDisplayModeSwitcher } from './sites-display-mode-switcher';
 import { SitesSearch } from './sites-search';
@@ -48,16 +49,18 @@ const ControlsSelectDropdown = styled( SelectDropdown )( {
 
 type Statuses = ReturnType< typeof useSitesTableFiltering >[ 'statuses' ];
 
-interface SitesContentControlsProps {
+type SitesContentControlsProps = {
 	initialSearch?: string;
 	statuses: Statuses;
 	selectedStatus: Statuses[ number ];
-}
+} & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher >;
 
 export const SitesContentControls = ( {
 	initialSearch,
 	statuses,
 	selectedStatus,
+	displayMode,
+	onDisplayModeChange,
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 
@@ -84,7 +87,10 @@ export const SitesContentControls = ( {
 						</SelectDropdown.Item>
 					) ) }
 				</ControlsSelectDropdown>
-				<SitesDisplayModeSwitcher />
+				<SitesDisplayModeSwitcher
+					displayMode={ displayMode }
+					onDisplayModeChange={ onDisplayModeChange }
+				/>
 			</DisplayControls>
 		</FilterBar>
 	);

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -76,7 +76,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 
 	const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 
-	const displayMode = useSitesDisplayMode();
+	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 
 	return (
 		<main>
@@ -95,6 +95,8 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 							initialSearch={ search }
 							statuses={ statuses }
 							selectedStatus={ selectedStatus }
+							displayMode={ displayMode }
+							onDisplayModeChange={ setDisplayMode }
 						/>
 					) }
 					{ filteredSites.length > 0 || isLoading ? (

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -49,12 +49,16 @@ export const SitesDisplayModeSwitcher = () => {
 	const displayMode = useSitesDisplayMode();
 
 	return (
-		<div className={ container } role="radiogroup" aria-label={ __( 'Sites display mode' ) }>
+		<div
+			style={ { pointerEvents: isSaving ? 'none' : 'auto' } }
+			className={ container }
+			role="radiogroup"
+			aria-label={ __( 'Sites display mode' ) }
+		>
 			<Button
 				role="radio"
 				aria-label={ __( 'Tile view' ) }
 				onClick={ () => onDisplayModeChange( 'tile' ) }
-				disabled={ isSaving }
 				icon={ <Gridicon icon="grid" /> }
 				isPressed={ displayMode === 'tile' }
 			/>
@@ -62,7 +66,6 @@ export const SitesDisplayModeSwitcher = () => {
 				role="radio"
 				aria-label={ __( 'List view' ) }
 				onClick={ () => onDisplayModeChange( 'list' ) }
-				disabled={ isSaving }
 				icon={ <Gridicon icon="list-unordered" /> }
 				isPressed={ displayMode === 'list' }
 			/>

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -47,24 +47,30 @@ export const useSitesDisplayMode = () => {
 	return [ displayMode, setDisplayMode ] as const;
 };
 
-export const SitesDisplayModeSwitcher = () => {
-	const { __ } = useI18n();
+interface SitesDisplayModeSwitcherProps {
+	onDisplayModeChange( newValue: SitesDisplayMode ): void;
+	displayMode: SitesDisplayMode;
+}
 
-	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
+export const SitesDisplayModeSwitcher = ( {
+	displayMode,
+	onDisplayModeChange,
+}: SitesDisplayModeSwitcherProps ) => {
+	const { __ } = useI18n();
 
 	return (
 		<div className={ container } role="radiogroup" aria-label={ __( 'Sites display mode' ) }>
 			<Button
 				role="radio"
 				aria-label={ __( 'Tile view' ) }
-				onClick={ () => setDisplayMode( 'tile' ) }
+				onClick={ () => onDisplayModeChange( 'tile' ) }
 				icon={ <Gridicon icon="grid" /> }
 				isPressed={ displayMode === 'tile' }
 			/>
 			<Button
 				role="radio"
 				aria-label={ __( 'List view' ) }
-				onClick={ () => setDisplayMode( 'list' ) }
+				onClick={ () => onDisplayModeChange( 'list' ) }
 				icon={ <Gridicon icon="list-unordered" /> }
 				isPressed={ displayMode === 'list' }
 			/>

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -32,8 +33,17 @@ export const SitesDisplayModeSwitcher = () => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
-	const onDisplayModeChange = ( value: SitesDisplayMode ) => {
-		dispatch( savePreference( PREFERENCE_NAME, value ) );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const onDisplayModeChange = async ( value: SitesDisplayMode ) => {
+		const saveDisplayMode = savePreference( PREFERENCE_NAME, value );
+
+		try {
+			setIsSaving( true );
+			await saveDisplayMode( dispatch );
+		} finally {
+			setIsSaving( false );
+		}
 	};
 
 	const displayMode = useSitesDisplayMode();
@@ -44,6 +54,7 @@ export const SitesDisplayModeSwitcher = () => {
 				role="radio"
 				aria-label={ __( 'Tile view' ) }
 				onClick={ () => onDisplayModeChange( 'tile' ) }
+				disabled={ isSaving }
 				icon={ <Gridicon icon="grid" /> }
 				isPressed={ displayMode === 'tile' }
 			/>
@@ -51,6 +62,7 @@ export const SitesDisplayModeSwitcher = () => {
 				role="radio"
 				aria-label={ __( 'List view' ) }
 				onClick={ () => onDisplayModeChange( 'list' ) }
+				disabled={ isSaving }
 				icon={ <Gridicon icon="list-unordered" /> }
 				isPressed={ displayMode === 'list' }
 			/>


### PR DESCRIPTION
#### Proposed Changes

Fixes #66381.

In my first iteration I tried setting the `disabled` prop in the `Button` but turns out that affects the element visually for a few milliseconds. I think that disabling the pointer events while the save preference request is in progress for the radio group a better experience.

#### Testing Instructions

Try switching really quick between display modes on SMD and check that the race condition when saving the preference is gone. 
