### PR TITLE
PluginsBrowser Refactor: Renames the SearchResultsPage to follow naming standard

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -50,9 +50,9 @@ import {
 	getSelectedSite,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import SearchResultsPage from '../plugin-search-results-page';
 import PluginsCategoryResultsPage from '../plugins-category-results-page';
 import PluginsDiscoveryPage from '../plugins-discovery-page';
+import PluginsSearchResultPage from '../plugins-search-results-page';
 
 import './style.scss';
 
@@ -194,7 +194,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 	const renderList = () => {
 		if ( search ) {
 			return (
-				<SearchResultsPage
+				<PluginsSearchResultPage
 					search={ search }
 					setIsFetchingPluginsBySearchTerm={ setIsFetchingPluginsBySearchTerm }
 					siteSlug={ siteSlug }

--- a/client/my-sites/plugins/plugins-search-results-page/README.md
+++ b/client/my-sites/plugins/plugins-search-results-page/README.md
@@ -1,0 +1,29 @@
+# Plugins Search Results Page
+
+This component renders the plugins searcha results page.
+
+## How to use
+
+```js
+import PluginsSearchResultsPage from 'calypso/my-sites/plugins/plugins-search-results-page';
+
+function render() {
+	return (
+		<div>
+			<PluginsSearchResultsPage
+				search={ search }
+				siteSlug={ siteSlug }
+				siteId={ siteId }
+				sites={ sites }
+			/>
+		</div>
+	);
+}
+```
+
+## Props
+
+- `siteSlug`: a string containing the slug of the selected site
+- `sites`: a sites-list object
+- `siteId`: a number containing the current site id.
+- `search`: a string with the current search term, if exists

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -18,7 +18,7 @@ function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
 }
 
-const SearchResultsPage = ( {
+const PluginsSearchResultPage = ( {
 	search: searchTerm,
 	siteSlug,
 	siteId,
@@ -147,4 +147,4 @@ const SearchResultsPage = ( {
 	);
 };
 
-export default SearchResultsPage;
+export default PluginsSearchResultPage;


### PR DESCRIPTION
#### Proposed Changes

*  Changes the name of `SearchResultsPage` to `PluginsSearchResultPage`.
* Adds `Readme.md` file

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test that search is working correctly

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66423
