### PR TITLE
Marketplace: Clean up SingleListView props

### DIFF
--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -32,17 +32,7 @@ function isNotInstalled( plugin, installedPlugins ) {
 	);
 }
 
-const SingleListView = ( {
-	category,
-	pluginsByCategoryPopular,
-	isFetchingPluginsByCategoryPopular,
-	pluginsByCategoryFeatured,
-	isFetchingPluginsByCategoryFeatured,
-	paidPlugins,
-	isFetchingPaidPlugins,
-	siteSlug,
-	sites,
-} ) => {
+const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) => {
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
@@ -54,21 +44,6 @@ const SingleListView = ( {
 	const installedPlugins = useSelector( ( state ) =>
 		getPlugins( state, siteObjectsToSiteIds( sites ) )
 	);
-
-	let plugins;
-	let isFetching;
-	if ( category === 'popular' ) {
-		plugins = pluginsByCategoryPopular;
-		isFetching = isFetchingPluginsByCategoryPopular;
-	} else if ( category === 'featured' ) {
-		plugins = pluginsByCategoryFeatured;
-		isFetching = isFetchingPluginsByCategoryFeatured;
-	} else if ( category === 'paid' ) {
-		plugins = paidPlugins;
-		isFetching = isFetchingPaidPlugins;
-	} else {
-		return null;
-	}
 
 	plugins = plugins
 		.filter( isNotBlocked )

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -107,14 +107,21 @@ const PaidPluginsSection = ( props ) => {
 		<SingleListView
 			{ ...props }
 			category="paid"
-			paidPlugins={ paidPlugins }
-			isFetchingPaidPlugins={ isFetchingPaidPlugins }
+			plugins={ paidPlugins }
+			isFetching={ isFetchingPaidPlugins }
 		/>
 	);
 };
 
 const FeaturedPluginsSection = ( props ) => {
-	return <SingleListView { ...props } category="featured" />;
+	return (
+		<SingleListView
+			{ ...props }
+			plugins={ props.pluginsByCategoryFeatured }
+			isFetching={ props.isFetchingPluginsByCategoryFeatured }
+			category="featured"
+		/>
+	);
 };
 
 const PopularPluginsSection = ( props ) => {
@@ -132,8 +139,8 @@ const PopularPluginsSection = ( props ) => {
 		<SingleListView
 			{ ...props }
 			category="popular"
-			pluginsByCategoryPopular={ pluginsByCategoryPopular }
-			isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
+			plugins={ pluginsByCategoryPopular }
+			isFetching={ isFetchingPluginsByCategoryPopular }
 		/>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* Replaces the `SingleListView` different types of plugins and isFetching into one `plugins` and `isFetching` prop.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Discovery page should show all sections.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector]~(https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~`Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66477
