### PR TITLE
Clean unused props in DiscoveryPage

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -130,7 +130,7 @@ const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) 
 	return null;
 };
 
-const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle, hideHeader } ) => {
+const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader } ) => {
 	const {
 		isAboveElement,
 		targetRef: searchHeaderRef,
@@ -212,13 +212,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 
 		return (
 			<PluginsDiscoveryPage
-				clearSearch={ clearSearch }
-				search={ search }
-				category={ category }
-				sites={ sites }
-				searchTitle={ searchTitle }
 				siteSlug={ siteSlug }
-				siteId={ siteId }
 				jetpackNonAtomic={ jetpackNonAtomic }
 				selectedSite={ selectedSite }
 				sitePlan={ sitePlan }

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -15,7 +15,6 @@ import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import './style.scss';
 import SingleListView from '../plugins-browser/single-list-view';
 import usePlugins from '../use-plugins';
 


### PR DESCRIPTION
#### Proposed Changes

Remove unused props we are passing to the PluginsDiscoveryPage component. (example: `search` and `category`)

#### Testing Instructions

* Discovery page should show all sections.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66476 
