### PR TITLE
SMP: Tile/Table mode comes from regular component state but changes are persisted

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -4,7 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import page from 'page';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import { SitesDisplayModeSwitcher } from './sites-display-mode-switcher';
+import { SitesDisplayModeSwitcher, SitesDisplayMode } from './sites-display-mode-switcher';
 import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
 
@@ -52,12 +52,16 @@ interface SitesContentControlsProps {
 	initialSearch?: string;
 	statuses: Statuses;
 	selectedStatus: Statuses[ number ];
+	displayMode: SitesDisplayMode;
+	onDisplayModeChange: ( newMode: SitesDisplayMode ) => void;
 }
 
 export const SitesContentControls = ( {
 	initialSearch,
 	statuses,
 	selectedStatus,
+	displayMode,
+	onDisplayModeChange,
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 
@@ -84,7 +88,10 @@ export const SitesContentControls = ( {
 						</SelectDropdown.Item>
 					) ) }
 				</ControlsSelectDropdown>
-				<SitesDisplayModeSwitcher />
+				<SitesDisplayModeSwitcher
+					displayMode={ displayMode }
+					onDisplayModeChange={ onDisplayModeChange }
+				/>
 			</DisplayControls>
 		</FilterBar>
 	);

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -76,7 +76,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 
 	const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 
-	const displayMode = useSitesDisplayMode();
+	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 
 	return (
 		<main>
@@ -95,6 +95,8 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 							initialSearch={ search }
 							statuses={ statuses }
 							selectedStatus={ selectedStatus }
+							displayMode={ displayMode }
+							onDisplayModeChange={ setDisplayMode }
 						/>
 					) }
 					{ filteredSites.length > 0 || isLoading ? (


### PR DESCRIPTION
#### Proposed Changes

Alternative to https://github.com/Automattic/wp-calypso/pull/66473 which uses regular component state to store the current tile/table mode. However it does still use the preferences store to save it for subsequent sessions.

That way we're ignoring the response back from the preferences saving API.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
