### PR TITLE
[ Calypso ] Update flow progress bar's intial step percentage

### DIFF
--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -31,7 +31,7 @@ export function useSiteSetupFlowProgress(
 		case 'goals':
 		case 'vertical':
 		case 'intent':
-			beginningSegment = beginningSteps.indexOf( currentStep ) / MAX_STEPS;
+			beginningSegment = beginningSteps.indexOf( currentStep );
 			break;
 		case 'difmStartingPoint':
 			return { progress: 0, count: 0 };


### PR DESCRIPTION
## Proposed Changes

Update step percentage calculation on beginning steps 

## Testing Instructions
- Head to onboarding flow
- Confirm that the percentage of beginning steps's width on the onboarding is increased

1. **Goals step enabled**: enter the onboarding flow via `/setup/goals?siteSlug=${site_slug}.wordpress.com&flags=-signup/goals-step`

https://user-images.githubusercontent.com/10071857/184079448-247da246-2a78-4804-9e7a-4909a91915bb.mp4

2. **Goals step disabled**: enter the onboarding flow via `/setup/vertical?siteSlug=${site_slug}.wordpress.com&flags=-signup/goals-step`


https://user-images.githubusercontent.com/10071857/184079587-cc30c767-32c8-4873-a432-c8bbd345c14f.mp4



## Reference
Related #66486