### PR TITLE
Plugin Management: Implement single-site(small screen) view for the plugin management

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
@@ -31,13 +31,37 @@ export default function PluginCard( { item, selectedSite }: Props ): ReactElemen
 						<PluginRowFormatter isSmallScreen item={ item } columnKey="plugin" />
 						<span className="plugin-card__overlay"></span>
 					</div>
-					<div className="plugin-card__sites-count">
-						{ translate( 'Installed on %(count)d sites', {
-							args: {
-								count: Object.keys( item.sites ).length,
-							},
-						} ) }
-					</div>
+					{ selectedSite ? (
+						<>
+							<div className="plugin-card__site-data">
+								<PluginRowFormatter isSmallScreen columnKey="last-updated" item={ item } />
+							</div>
+							<div className="plugin-card__toggle-container">
+								<div>
+									<PluginRowFormatter
+										isSmallScreen
+										columnKey="activate"
+										item={ item }
+										selectedSite={ selectedSite }
+									/>
+								</div>
+								<div>
+									<PluginRowFormatter
+										isSmallScreen
+										columnKey="autoupdate"
+										item={ item }
+										selectedSite={ selectedSite }
+									/>
+								</div>
+							</div>
+						</>
+					) : (
+						<div className="plugin-card__site-data">
+							{ translate( 'Installed on %(count)d sites', {
+								args: { count: Object.keys( item.sites ).length },
+							} ) }
+						</div>
+					) }
 					<UpdatePlugin
 						plugin={ item }
 						selectedSite={ selectedSite }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-card/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-card/style.scss
@@ -2,6 +2,12 @@
 	display: flex;
   	flex:1;
 }
+.plugin-card__toggle-container {
+	margin-block-start: 16px;
+	& > div {
+		margin: 16px 0;
+	}
+}
 .plugin-card__left-content {
 	min-width: 32px;
 	max-width: 32px;
@@ -39,9 +45,10 @@
 	inset-block-start: 2px;
 	inset-inline-end: 0;
 }
-.plugin-card__sites-count {
+.plugin-card__site-data {
 	color: var( --studio-gray-60 );
 	font-size: 0.75rem;
+	margin: 8px 0;
 }
 .plugin-card__update-plugin {
 	margin-block-start: 16px;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,4 +1,5 @@
 import { Gridicon, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
@@ -25,6 +26,8 @@ export default function PluginRowFormatter( {
 	selectedSite,
 	isSmallScreen,
 }: Props ): ReactElement | any {
+	const translate = useTranslate();
+
 	const PluginDetailsButton = ( props: { className: string; children: ReactChild } ) => {
 		return <Button borderless compact href={ `/plugins/${ item.slug }` } { ...props } />;
 	};
@@ -78,7 +81,11 @@ export default function PluginRowFormatter( {
 			return (
 				canActivate && (
 					<div className="plugin-row-formatter__toggle">
-						<PluginActivateToggle hideLabel plugin={ item } site={ selectedSite } />
+						<PluginActivateToggle
+							hideLabel={ ! isSmallScreen }
+							plugin={ item }
+							site={ selectedSite }
+						/>
 					</div>
 				)
 			);
@@ -87,7 +94,7 @@ export default function PluginRowFormatter( {
 				canUpdate && (
 					<div className="plugin-row-formatter__toggle">
 						<PluginAutoupdateToggle
-							hideLabel
+							hideLabel={ ! isSmallScreen }
 							plugin={ item }
 							site={ selectedSite }
 							wporg={ !! item.wporg }
@@ -98,7 +105,13 @@ export default function PluginRowFormatter( {
 			);
 		case 'last-updated':
 			if ( item.last_updated ) {
-				return <div>{ ago( item.last_updated ) }</div>;
+				return isSmallScreen
+					? translate( 'Last updated %(ago)s', {
+							args: {
+								ago: ago( item.last_updated ),
+							},
+					  } )
+					: ago( item.last_updated );
 			}
 			return null;
 	}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .plugin-row-formatter__plugin-name-container {
 	position: relative;
 }
@@ -48,7 +51,18 @@ a.button.plugin-row-formatter__plugin-name-card {
 
 .plugin-row-formatter__toggle {
 	.plugin-action .components-toggle-control .components-base-control__field {
-		margin: auto 0;
+		flex-direction: row-reverse;
+		@include break-xlarge() {
+			margin: auto 0;
+			flex-direction: unset;
+		}
+	}
+	.components-form-toggle {
+		position: absolute;
+		inset-inline-start: 200px;
+		@include break-xlarge() {
+			position: relative;
+			inset-inline-start: unset;
+		}
 	}
 }
-


### PR DESCRIPTION
#### Proposed Changes

This PR implements the small screen view(<1080px) for single-site plugin management. 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/plugin-management-single-site-small-screen-view` and `yarn start-jetpack-cloud-p`
2. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
3. Switch to any width <1080px using the dev tool.
4. Click on **Switch Site** -> Select any site -> Click on **Plugins** -> Verify the plugins are shown as shown below. 

**320px**

<img width="364" alt="Screenshot 2022-08-11 at 2 52 52 PM" src="https://user-images.githubusercontent.com/10586875/184130519-3d24e1a6-aa99-476f-b1fc-d104efbb990e.png">

**768px**

<img width="800" alt="Screenshot 2022-08-11 at 2 54 42 PM" src="https://user-images.githubusercontent.com/10586875/184130700-f2b50ac3-d8f2-4eb7-a04e-ea40eeb0a702.png">

**968px**

<img width="1027" alt="Screenshot 2022-08-11 at 2 54 58 PM" src="https://user-images.githubusercontent.com/10586875/184130769-d032b6d7-d795-4cf1-846d-9ee787338a85.png">

**>1080px**

<img width="1919" alt="Screenshot 2022-08-11 at 2 55 09 PM" src="https://user-images.githubusercontent.com/10586875/184130891-d89c4819-4c0a-428c-a113-ed0089fe1bcd.png">

5. Clicking on the Plugin name & `Update` text should redirect the user to the plugin details page.
6. Verify `Active` and `Autoupdate` toggle buttons works as expected. 
7. Verify search works as expected.
8. Click on all the tabs - All, Active, Inactive & Updates and verify the plugins are shown as per the filter and the URL changes accordingly. 
9. Verify these changes have not affected anything in Calypso Blue. 

> **_NOTE:_** The more actions icon(`...`) is just a placeholder and will be updated later in a different PR. Some changes are as per the old design, and new design changes will be done in a different PR.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202673439327750