### PR TITLE
Plugin Details CTA: Query purchases when the product is a marketplace product

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
@@ -24,27 +25,30 @@ export const ManagePluginMenu = ( { plugin } ) => {
 	const settingsLink = pluginOnSite?.action_links?.Settings ?? null;
 
 	return (
-		<EllipsisMenu position={ 'bottom' }>
-			{ currentPurchase?.id && (
-				<PopoverMenuItem
-					icon="credit-card"
-					href={ `/me/purchases/${ site.domain }/${ currentPurchase.id }` }
-				>
-					{ translate( 'Manage Subscription' ) }
-				</PopoverMenuItem>
-			) }
-			{ settingsLink && (
-				<PopoverMenuItem icon="cog" href={ settingsLink }>
-					{ translate( 'Settings' ) }
-				</PopoverMenuItem>
-			) }
+		<>
+			{ plugin.isMarketplaceProduct && <QueryUserPurchases /> }
+			<EllipsisMenu position={ 'bottom' }>
+				{ currentPurchase?.id && (
+					<PopoverMenuItem
+						icon="credit-card"
+						href={ `/me/purchases/${ site.domain }/${ currentPurchase.id }` }
+					>
+						{ translate( 'Manage Subscription' ) }
+					</PopoverMenuItem>
+				) }
+				{ settingsLink && (
+					<PopoverMenuItem icon="cog" href={ settingsLink }>
+						{ translate( 'Settings' ) }
+					</PopoverMenuItem>
+				) }
 
-			<PluginRemoveButton
-				plugin={ pluginOnSite }
-				site={ site }
-				menuItem
-				isMarketplaceProduct={ plugin.isMarketplaceProduct }
-			/>
-		</EllipsisMenu>
+				<PluginRemoveButton
+					plugin={ pluginOnSite }
+					site={ site }
+					menuItem
+					isMarketplaceProduct={ plugin.isMarketplaceProduct }
+				/>
+			</EllipsisMenu>
+		</>
 	);
 };


### PR DESCRIPTION
#### Testing Instructions

* Go to a paid plugins page. ex:  `/plugins/woocommerce-subscriptions` 
* Buy the plugin and go back to the plugins page (if not bought yet)
* Click on the menu on the top right of the sidebar
* Check if the **Manage purchases** option appears and redirect to the purchase page


<img width="411" alt="Screen Shot 2022-08-11 at 08 33 33" src="https://user-images.githubusercontent.com/5039531/184134284-f4e8691f-fa36-49a1-a35a-0060f74e136e.png">




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
