### PR TITLE
Fix site thumbnail alignment to ensure it is not cut

### DIFF
--- a/packages/components/src/site-thumbnail/style.scss
+++ b/packages/components/src/site-thumbnail/style.scss
@@ -16,6 +16,10 @@
 	height: 78px;
 }
 
+.site-thumbnail__image {
+    align-self: start;
+}
+
 .site-thumbnail__image-bg {
 	animation: fadein 1s ease-out;
 	background-position: center;


### PR DESCRIPTION
#### Proposed Changes

The site thumbnail is cut at the top. It was not visible on the list view but surfaced more after introducing the grid view with a bigger thumbnail. I fix the alignment of the screenshot.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load `/sites-dashboard` page
2. Switch to grid view
3. Locate a site that has a content starting in the top of the page and includes a thumbnail 
4. Open the site
5. Compare thumbnail with a site view and ensure that content is not cut

| Before | After |
|-------|-------|
| ![Screen Shot 2022-08-11 at 16 39 03](https://user-images.githubusercontent.com/727413/184159621-ecbef62b-199a-40f1-a4a8-e05ae803a359.png) | ![Screen Shot 2022-08-11 at 16 38 50](https://user-images.githubusercontent.com/727413/184159644-1703d689-e753-42df-942f-8b02e1fd1446.png) |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

