### PR TITLE
Remove isSiteUsingCoreSiteEditor selector

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -38,6 +38,7 @@ import Notice from 'calypso/components/notice';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import WpAdminAutoLogin from 'calypso/components/wpadmin-auto-login';
+import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
@@ -704,37 +705,42 @@ export class CheckoutThankYou extends Component {
 	};
 }
 
-export default connect(
-	( state, props ) => {
-		const siteId = getSelectedSiteId( state );
-		const activeTheme = getActiveTheme( state, siteId );
+export default withIsFSEActive(
+	connect(
+		( state, props ) => {
+			const siteId = getSelectedSiteId( state );
+			const activeTheme = getActiveTheme( state, siteId );
+			const { isFSEActive } = props;
 
-		return {
-			isProductsListFetching: isProductsListFetching( state ),
-			isHappychatEligible: isHappychatUserEligible( state ),
-			receipt: getReceiptById( state, props.receiptId ),
-			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
-			sitePlans: getPlansBySite( state, props.selectedSite ),
-			upgradeIntent: props.upgradeIntent || getCheckoutUpgradeIntent( state ),
-			isSimplified:
-				[ 'install_theme', 'install_plugin', 'browse_plugins' ].indexOf( props.upgradeIntent ) !==
-				-1,
-			user: getCurrentUser( state ),
-			userDate: getCurrentUserDate( state ),
-			transferComplete: transferStates.COMPLETED === getAtomicTransfer( state, siteId ).status,
-			isEmailVerified: isCurrentUserEmailVerified( state ),
-			selectedSiteSlug: getSiteSlug( state, siteId ),
-			siteHomeUrl: getSiteHomeUrl( state, siteId ),
-			customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId ),
-			site: getSite( state, siteId ),
-		};
-	},
-	{
-		fetchAtomicTransfer,
-		fetchReceipt,
-		fetchSitePlans,
-		refreshSitePlans,
-		recordStartTransferClickInThankYou,
-		requestThenActivate,
-	}
-)( localize( CheckoutThankYou ) );
+			return {
+				isProductsListFetching: isProductsListFetching( state ),
+				isHappychatEligible: isHappychatUserEligible( state ),
+				receipt: getReceiptById( state, props.receiptId ),
+				gsuiteReceipt: props.gsuiteReceiptId
+					? getReceiptById( state, props.gsuiteReceiptId )
+					: null,
+				sitePlans: getPlansBySite( state, props.selectedSite ),
+				upgradeIntent: props.upgradeIntent || getCheckoutUpgradeIntent( state ),
+				isSimplified:
+					[ 'install_theme', 'install_plugin', 'browse_plugins' ].indexOf( props.upgradeIntent ) !==
+					-1,
+				user: getCurrentUser( state ),
+				userDate: getCurrentUserDate( state ),
+				transferComplete: transferStates.COMPLETED === getAtomicTransfer( state, siteId ).status,
+				isEmailVerified: isCurrentUserEmailVerified( state ),
+				selectedSiteSlug: getSiteSlug( state, siteId ),
+				siteHomeUrl: getSiteHomeUrl( state, siteId ),
+				customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId, isFSEActive ),
+				site: getSite( state, siteId ),
+			};
+		},
+		{
+			fetchAtomicTransfer,
+			fetchReceipt,
+			fetchSitePlans,
+			refreshSitePlans,
+			recordStartTransferClickInThankYou,
+			requestThenActivate,
+		}
+	)( localize( CheckoutThankYou ) )
+);

--- a/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
 import launchedIllustration from 'calypso/assets/images/customer-home/illustration--rocket.svg';
+import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import {
 	NOTICE_CELEBRATE_SITE_LAUNCH,
 	NOTICE_CELEBRATE_SITE_SETUP_COMPLETE,
@@ -55,18 +56,22 @@ const CelebrateSiteLaunch = ( { isSiteSetupComplete, pendingSiteSetupTasks, site
 	);
 };
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const isSiteSetupComplete = isSiteChecklistComplete( state, siteId );
-	let pendingSiteSetupTasks = [];
-	if ( ! isSiteSetupComplete ) {
-		const tasks = getSiteTaskList( state, siteId ).getAll();
-		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		pendingSiteSetupTasks = tasks.filter( ( task ) => ! task.isCompleted );
-	}
-	return {
-		isSiteSetupComplete,
-		pendingSiteSetupTasks,
-		siteId,
-	};
-} )( CelebrateSiteLaunch );
+export default withIsFSEActive(
+	connect( ( state, props ) => {
+		const { isFSEActive } = props;
+		const siteId = getSelectedSiteId( state );
+		const isSiteSetupComplete = isSiteChecklistComplete( state, siteId, isFSEActive );
+
+		let pendingSiteSetupTasks = [];
+		if ( ! isSiteSetupComplete ) {
+			const tasks = getSiteTaskList( state, siteId, isFSEActive ).getAll();
+			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+			pendingSiteSetupTasks = tasks.filter( ( task ) => ! task.isCompleted );
+		}
+		return {
+			isSiteSetupComplete,
+			pendingSiteSetupTasks,
+			siteId,
+		};
+	} )( CelebrateSiteLaunch )
+);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -368,7 +368,7 @@ const ConnectedSiteSetupList = connect( ( state, props ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		tasks: taskList.getAll(),
-		taskUrls: getChecklistTaskUrls( state, siteId ),
+		taskUrls: getChecklistTaskUrls( state, siteId, isFSEActive ),
 		userEmail: user?.email,
 	};
 } )( SiteSetupList );

--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -30,11 +30,11 @@ function getPageEditorUrl( state, siteId, pageId ) {
 }
 
 export default createSelector(
-	( state, siteId ) => {
+	( state, siteId, isFSEActive ) => {
 		const posts = getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY );
 		const firstPostID = get( find( posts, { type: 'post' } ), [ 0, 'ID' ] );
 		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
-		const frontPageUrl = getFrontPageEditorUrl( state, siteId );
+		const frontPageUrl = getFrontPageEditorUrl( state, siteId, isFSEActive );
 
 		return {
 			post_published: getPageEditorUrl( state, siteId, firstPostID ),
@@ -49,8 +49,8 @@ export default createSelector(
 			woocommerce_setup: getSiteUrl( state, siteId ) + '/wp-admin/admin.php?page=wc-admin',
 		};
 	},
-	( state, siteId ) => [
+	( state, siteId, isFSEActive ) => [
 		getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY ),
-		getFrontPageEditorUrl( state, siteId ),
+		getFrontPageEditorUrl( state, siteId, isFSEActive ),
 	]
 );

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -22,8 +22,7 @@ export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId, 
 	}
 
 	const shouldUseGutenberg = shouldCustomizeHomepageWithGutenberg( state, siteId );
-	const frontPageEditorUrl = getFrontPageEditorUrl( state, siteId );
-
+	const frontPageEditorUrl = getFrontPageEditorUrl( state, siteId, isFSEActive );
 	// If the theme is not active or getFrontPageEditorUrl has returned 'false', use the other function to preview customization with the theme.
 	if ( frontPageEditorUrl && shouldUseGutenberg && isThemeActive( state, themeId, siteId ) ) {
 		return frontPageEditorUrl;

--- a/client/state/selectors/get-front-page-editor-url.js
+++ b/client/state/selectors/get-front-page-editor-url.js
@@ -1,6 +1,5 @@
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 import getSiteFrontPage from 'calypso/state/sites/selectors/get-site-front-page';
 
 /**
@@ -10,14 +9,14 @@ import getSiteFrontPage from 'calypso/state/sites/selectors/get-site-front-page'
  * @param {object} siteId Site ID
  * @returns {(boolean|string)} false if there is no homepage set, the editor URL if there is one
  */
-export default function getFrontPageEditorUrl( state, siteId ) {
+export default function getFrontPageEditorUrl( state, siteId, isFSEActive ) {
 	const frontPageId = getSiteFrontPage( state, siteId );
 	// this will be zero if no homepage is set
 	if ( 0 === frontPageId ) {
 		return false;
 	}
 
-	if ( isSiteUsingCoreSiteEditor( state, siteId ) ) {
+	if ( isFSEActive ) {
 		return getSiteEditorUrl( state, siteId );
 	}
 

--- a/client/state/selectors/get-site-task-list.js
+++ b/client/state/selectors/get-site-task-list.js
@@ -10,13 +10,13 @@ import getSiteChecklist from './get-site-checklist';
  * @param  {number}  siteId Site ID
  * @returns {object}        Site settings
  */
-export default function getSiteTaskList( state, siteId ) {
+export default function getSiteTaskList( state, siteId, isFSEActive ) {
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const taskList = getTaskList( {
 		taskStatuses: get( siteChecklist, 'tasks' ),
 		siteSegment: get( siteChecklist, 'siteSegment' ),
 	} );
-	const taskUrls = getChecklistTaskUrls( state, siteId );
+	const taskUrls = getChecklistTaskUrls( state, siteId, isFSEActive );
 	taskList.removeTasksWithoutUrls( taskUrls );
 	return taskList;
 }

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -11,7 +11,7 @@ import { getSiteFrontPage } from 'calypso/state/sites/selectors';
  * @param  {number}  siteId Site ID
  * @returns {string} null if there's no data yet, false if the tasklist is incomplete, true if it's complete.
  */
-export default function isSiteChecklistComplete( state, siteId ) {
+export default function isSiteChecklistComplete( state, siteId, isFSEActive ) {
 	const siteChecklist = getSiteChecklist( state, siteId );
 
 	if (
@@ -61,6 +61,6 @@ export default function isSiteChecklistComplete( state, siteId ) {
 		return false;
 	};
 
-	const taskList = getSiteTaskList( state, siteId );
+	const taskList = getSiteTaskList( state, siteId, isFSEActive );
 	return taskList.getAll().every( isTaskComplete );
 }


### PR DESCRIPTION
#### Proposed Changes

* The `isSiteUsingCoreSiteEditor` selector is being removed because it is now deprecated. The usage of `isSiteUsingCoreSiteEditor()` has been replaced with `isFSEActive` value from the new isWithFSEActive Higher Order component.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66269
