### PR TITLE
BlazePress widget on Stepper: POC

### DIFF
--- a/client/landing/stepper/declarative-flow/blazepress-flow.ts
+++ b/client/landing/stepper/declarative-flow/blazepress-flow.ts
@@ -1,8 +1,8 @@
 import type { StepPath } from './internals/steps-repository';
 import type { Flow } from './internals/types';
 
-export const promoteFlow: Flow = {
-	name: 'promote',
+export const blazePressFlow: Flow = {
+	name: 'blazepress',
 
 	useSteps() {
 		// useEffect( () => {

--- a/client/landing/stepper/declarative-flow/blazepress-flow.ts
+++ b/client/landing/stepper/declarative-flow/blazepress-flow.ts
@@ -1,5 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { AssertConditionResult, AssertConditionState, Flow } from './internals/types';
 import type { StepPath } from './internals/steps-repository';
-import type { Flow } from './internals/types';
 
 export const blazePressFlow: Flow = {
 	name: 'blazepress',
@@ -30,5 +31,19 @@ export const blazePressFlow: Flow = {
 		};
 
 		return { goNext, goBack, goToStep, submit };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		let result: AssertConditionResult = {
+			state: AssertConditionState.SUCCESS,
+		};
+
+		if ( ! isEnabled( 'promote-post' ) ) {
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'this is not enabled yet',
+			};
+		}
+		return result;
 	},
 };

--- a/client/landing/stepper/declarative-flow/blazepress-flow.ts
+++ b/client/landing/stepper/declarative-flow/blazepress-flow.ts
@@ -5,10 +5,6 @@ export const blazePressFlow: Flow = {
 	name: 'blazepress',
 
 	useSteps() {
-		// useEffect( () => {
-		// 	recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
-		// }, [] );
-
 		return [ 'promote' ] as StepPath[];
 	},
 
@@ -16,37 +12,17 @@ export const blazePressFlow: Flow = {
 		// function submit( providedDependencies: ProvidedDependencies = {} ) {
 		function submit() {
 			switch ( currentStep ) {
-				case 'processing':
+				case 'promote':
 					return navigate( 'promote' );
 			}
 		}
 
 		const goBack = () => {
 			return;
-			// switch ( currentStep ) {
-			// 	case 'designSetup':
-			// 		return navigate( 'podcastTitle' );
-			// 	default:
-			// 		return navigate( 'podcastTitle' );
-			// }
 		};
 
 		const goNext = () => {
 			return;
-			// const siteSlug = siteSlugParam || getNewSite()?.site_slug;
-
-			// switch ( currentStep ) {
-			// 	case 'login':
-			// 		return navigate( 'podcastTitle' );
-			// 	case 'podcastTitle':
-			// 		return navigate( 'designSetup' );
-			// 	case 'designSetup':
-			// 		return navigate( 'processing' );
-			// 	case 'processing':
-			// 		return redirect( `/page/${ siteSlug }/home` );
-			// 	default:
-			// 		return navigate( 'podcastTitle' );
-			// }
 		};
 
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -55,7 +55,8 @@ button {
 .newsletter-setup,
 .patterns,
 .link-in-bio-setup,
-.anchor-fm {
+.anchor-fm,
+.blazepress {
 	position: relative;
 	padding: 60px 0 0;
 	box-sizing: border-box;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -40,6 +40,7 @@ export { default as launchpad } from './launchpad';
 export { default as processingFake } from './processing-fake';
 export { default as subscribers } from './subscribers';
 export { default as patterns } from './patterns';
+export { default as promote } from './promote';
 
 export type StepPath =
 	| 'courses'
@@ -83,4 +84,5 @@ export type StepPath =
 	| 'intro'
 	| 'launchpad'
 	| 'processingFake'
-	| 'subscribers';
+	| 'subscribers'
+	| 'promote';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/index.tsx
@@ -1,10 +1,15 @@
+import { useTranslate } from 'i18n-calypso';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PromoteStep from './promote';
 import type { Step } from '../../types';
+import './style.scss';
 
 const Promote: Step = function Promote( { navigation, flow } ) {
 	const { goNext, goBack } = navigation;
+	const translate = useTranslate();
+	const headerText = translate( 'Promote post' );
 
 	const handleGetStarted = () => {
 		// needs to be implemented
@@ -15,6 +20,7 @@ const Promote: Step = function Promote( { navigation, flow } ) {
 			stepName={ 'promote' }
 			goBack={ goBack }
 			isHorizontalLayout={ false }
+			formattedHeader={ <FormattedHeader headerText={ headerText } align={ 'center' } /> }
 			// isWideLayout={ true }
 			// isLargeSkipLayout={ false }
 			stepContent={ <PromoteStep flowName={ flow } goNext={ handleGetStarted } /> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/index.tsx
@@ -1,0 +1,27 @@
+import { StepContainer } from 'calypso/../packages/onboarding/src';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PromoteStep from './promote';
+import type { Step } from '../../types';
+
+const Promote: Step = function Promote( { navigation, flow } ) {
+	const { goNext, goBack } = navigation;
+
+	const handleGetStarted = () => {
+		// needs to be implemented
+		goNext();
+	};
+	return (
+		<StepContainer
+			stepName={ 'promote' }
+			goBack={ goBack }
+			isHorizontalLayout={ false }
+			// isWideLayout={ true }
+			// isLargeSkipLayout={ false }
+			stepContent={ <PromoteStep flowName={ flow } goNext={ handleGetStarted } /> }
+			recordTracksEvent={ recordTracksEvent }
+			// showJetpackPowered
+		/>
+	);
+};
+
+export default Promote;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/index.tsx
@@ -15,17 +15,15 @@ const Promote: Step = function Promote( { navigation, flow } ) {
 		// needs to be implemented
 		goNext();
 	};
+
 	return (
 		<StepContainer
 			stepName={ 'promote' }
 			goBack={ goBack }
 			isHorizontalLayout={ false }
 			formattedHeader={ <FormattedHeader headerText={ headerText } align={ 'center' } /> }
-			// isWideLayout={ true }
-			// isLargeSkipLayout={ false }
 			stepContent={ <PromoteStep flowName={ flow } goNext={ handleGetStarted } /> }
 			recordTracksEvent={ recordTracksEvent }
-			// showJetpackPowered
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -1,10 +1,11 @@
 // import { Button } from '@automattic/components';
 // import { createInterpolateElement } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { showDSPWidgetModal } from 'calypso/lib/promote-post';
+import { showDSP } from 'calypso/lib/promote-post';
 
 interface Props {
 	goNext: () => void;
@@ -14,23 +15,22 @@ interface Props {
 const Promote: React.FC< Props > = () => {
 	const siteIdParam = useSiteIdParam();
 	const { setStepProgress } = useDispatch( ONBOARD_STORE );
+	const [ isLoading, setIsLoading ] = useState( true );
 
 	useEffect( () => {
 		( async () => {
 			if ( siteIdParam === null ) {
 				return;
 			}
-			await showDSPWidgetModal( siteIdParam );
-			setStepProgress( { count: 4, progress: 3 } );
+			await showDSP( siteIdParam, 200 );
+			setIsLoading( false );
+			setStepProgress( { count: 4, progress: 1 } );
 		} )();
 	}, [] );
 
-	useEffect( () => {
-		setStepProgress( { count: 4, progress: 1 } );
-	}, [] );
 	return (
 		<div className="promote__content">
-			The widget is being rendered in the div below
+			{ isLoading && <LoadingEllipsis /> }
 			<div id="promote__widget-container"></div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -1,0 +1,39 @@
+// import { Button } from '@automattic/components';
+// import { createInterpolateElement } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { showDSPWidgetModal } from 'calypso/lib/promote-post';
+
+interface Props {
+	goNext: () => void;
+	flowName: string | null;
+}
+
+const Promote: React.FC< Props > = () => {
+	const siteIdParam = useSiteIdParam();
+	const { setStepProgress } = useDispatch( ONBOARD_STORE );
+
+	useEffect( () => {
+		( async () => {
+			if ( siteIdParam === null ) {
+				return;
+			}
+			await showDSPWidgetModal( siteIdParam );
+			setStepProgress( { count: 4, progress: 3 } );
+		} )();
+	}, [] );
+
+	useEffect( () => {
+		setStepProgress( { count: 4, progress: 1 } );
+	}, [] );
+	return (
+		<div className="promote__content">
+			The widget is being rendered in the div below
+			<div id="promote__widget-container"></div>
+		</div>
+	);
+};
+
+export default Promote;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -22,7 +22,7 @@ const Promote: React.FC< Props > = () => {
 
 	useEffect( () => {
 		( async () => {
-			if ( siteIdParam === null ) {
+			if ( siteIdParam === null || postIdParam === null ) {
 				return;
 			}
 			await showDSP( siteIdParam, postIdParam, widgetWrapperId );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -16,13 +16,14 @@ const Promote: React.FC< Props > = () => {
 	const siteIdParam = useSiteIdParam();
 	const { setStepProgress } = useDispatch( ONBOARD_STORE );
 	const [ isLoading, setIsLoading ] = useState( true );
+	const widgetWrapperId = 'promote__widget-container';
 
 	useEffect( () => {
 		( async () => {
 			if ( siteIdParam === null ) {
 				return;
 			}
-			await showDSP( siteIdParam, 200 );
+			await showDSP( siteIdParam, 200, widgetWrapperId );
 			setIsLoading( false );
 			setStepProgress( { count: 4, progress: 1 } );
 		} )();
@@ -31,7 +32,7 @@ const Promote: React.FC< Props > = () => {
 	return (
 		<div className="promote__content">
 			{ isLoading && <LoadingEllipsis /> }
-			<div id="promote__widget-container"></div>
+			<div id={ widgetWrapperId }></div>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -3,6 +3,7 @@
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { usePostIdParam } from 'calypso/landing/stepper/hooks/use-post-id-param';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { showDSP } from 'calypso/lib/promote-post';
@@ -14,6 +15,7 @@ interface Props {
 
 const Promote: React.FC< Props > = () => {
 	const siteIdParam = useSiteIdParam();
+	const postIdParam = usePostIdParam();
 	const { setStepProgress } = useDispatch( ONBOARD_STORE );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const widgetWrapperId = 'promote__widget-container';
@@ -23,7 +25,7 @@ const Promote: React.FC< Props > = () => {
 			if ( siteIdParam === null ) {
 				return;
 			}
-			await showDSP( siteIdParam, 200, widgetWrapperId );
+			await showDSP( siteIdParam, postIdParam, widgetWrapperId );
 			setIsLoading( false );
 			setStepProgress( { count: 4, progress: 1 } );
 		} )();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
@@ -1,0 +1,33 @@
+@import '@wordpress/components/build-style/style';
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.promote {
+    .step-container__header {
+        margin-top: 40px;
+
+        .formatted-header {
+            margin-top: 0;
+            .formatted-header__title {
+                @include onboarding-font-recoleta;
+                color: #101517;
+                font-size: 1.5rem;
+                font-weight: 400;
+                letter-spacing: -0.4px;
+                letter-spacing: 0.2px;
+                margin: 0;
+
+                @media ( min-width: 1080px ) {
+                    padding: 0;
+                }
+            }
+        }
+
+        @include break-mobile {
+            margin: 16px 0 24px;
+            transform: translateY( -14px );
+            min-height: 42px;
+        }
+    }
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
@@ -32,9 +32,8 @@
     }
 
     .promote__content {
-        padding: 1em;
-        max-width: 540px;
+        padding: 0;
         text-align: center;
-        margin: 16vh auto 0;
+        margin: 0 auto;
     }
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
@@ -26,7 +26,7 @@
 
         @include break-mobile {
             margin: 16px 0 24px;
-            transform: translateY( -14px );
+            transform: translateY( -54px );
             min-height: 42px;
         }
     }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
@@ -30,4 +30,11 @@
             min-height: 42px;
         }
     }
+
+    .promote__content {
+        padding: 1em;
+        max-width: 540px;
+        text-align: center;
+        margin: 16vh auto 0;
+    }
 }

--- a/client/landing/stepper/declarative-flow/promote-flow.ts
+++ b/client/landing/stepper/declarative-flow/promote-flow.ts
@@ -1,0 +1,58 @@
+import type { StepPath } from './internals/steps-repository';
+import type { Flow } from './internals/types';
+
+export const promoteFlow: Flow = {
+	name: 'promote',
+
+	useSteps() {
+		// useEffect( () => {
+		// 	recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+		// }, [] );
+
+		return [ 'promote' ] as StepPath[];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		// function submit( providedDependencies: ProvidedDependencies = {} ) {
+		function submit() {
+			switch ( currentStep ) {
+				case 'processing':
+					return navigate( 'promote' );
+			}
+		}
+
+		const goBack = () => {
+			return;
+			// switch ( currentStep ) {
+			// 	case 'designSetup':
+			// 		return navigate( 'podcastTitle' );
+			// 	default:
+			// 		return navigate( 'podcastTitle' );
+			// }
+		};
+
+		const goNext = () => {
+			return;
+			// const siteSlug = siteSlugParam || getNewSite()?.site_slug;
+
+			// switch ( currentStep ) {
+			// 	case 'login':
+			// 		return navigate( 'podcastTitle' );
+			// 	case 'podcastTitle':
+			// 		return navigate( 'designSetup' );
+			// 	case 'designSetup':
+			// 		return navigate( 'processing' );
+			// 	case 'processing':
+			// 		return redirect( `/page/${ siteSlug }/home` );
+			// 	default:
+			// 		return navigate( 'podcastTitle' );
+			// }
+		};
+
+		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/hooks/use-post-id-param.ts
+++ b/client/landing/stepper/hooks/use-post-id-param.ts
@@ -1,0 +1,5 @@
+import { useQuery } from './use-query';
+
+export function usePostIdParam(): string | null {
+	return useQuery().get( 'postId' );
+}

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -28,11 +28,11 @@ import { requestSites } from 'calypso/state/sites/actions';
 import { WindowLocaleEffectManager } from '../gutenboarding/components/window-locale-effect-manager';
 import { setupWpDataDebug } from '../gutenboarding/devtools';
 import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
+import { blazePressFlow } from './declarative-flow/blazepress-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
 import { newsletter } from './declarative-flow/newsletter';
 import { podcasts } from './declarative-flow/podcasts';
-import { promoteFlow } from './declarative-flow/promote-flow';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
 import { useAnchorFmParams } from './hooks/use-anchor-fm-params';
@@ -64,7 +64,7 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'newsletter', pathToFlow: newsletter },
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
-	{ flowName: 'promote', pathToFlow: promoteFlow },
+	{ flowName: 'blazepress', pathToFlow: blazePressFlow },
 ];
 
 const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -32,6 +32,7 @@ import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
 import { newsletter } from './declarative-flow/newsletter';
 import { podcasts } from './declarative-flow/podcasts';
+import { promoteFlow } from './declarative-flow/promote-flow';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
 import { useAnchorFmParams } from './hooks/use-anchor-fm-params';
@@ -63,6 +64,7 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'newsletter', pathToFlow: newsletter },
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
+	{ flowName: 'promote', pathToFlow: promoteFlow },
 ];
 
 const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -37,11 +37,12 @@ export async function loadDSPWidgetJS( onLoad?: () => void ) {
 	document.body.appendChild( script );
 }
 
-export async function showDSPWidgetModal( siteId: number, postId?: number ) {
+export async function showDSPWidgetModal( siteId: number | string, postId?: number ) {
 	if ( ! window.BlazePress ) {
 		await loadDSPWidgetJS( async () => await showDSPWidgetModal( siteId, postId ) );
 	} else {
 		await window.BlazePress.render( {
+			domNodeId: 'promote__widget-container',
 			stripeKey: config( 'dsp_stripe_pub_key' ),
 			apiHost: 'https://public-api.wordpress.com',
 			apiPrefix: `/wpcom/v2/sites/${ siteId }/wordads/dsp`,

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -32,12 +32,12 @@ function loadDSP() {
 	} );
 }
 
-export async function showDSP( siteId: number | string, postId?: number ) {
+export async function showDSP( siteId: number | string, postId?: number, domNodeId?: string ) {
 	await loadDSP();
 	return new Promise( ( resolve, reject ) => {
 		if ( window.BlazePress ) {
 			window.BlazePress.render( {
-				domNodeId: 'promote__widget-container',
+				domNodeId: domNodeId ?? '',
 				stripeKey: config( 'dsp_stripe_pub_key' ),
 				apiHost: 'https://public-api.wordpress.com',
 				apiPrefix: `/wpcom/v2/sites/${ siteId }/wordads/dsp`,
@@ -72,12 +72,11 @@ export async function loadDSPWidgetJS( onLoad?: () => void ) {
 	document.body.appendChild( script );
 }
 
-export async function showDSPWidgetModal( siteId: number | string, postId?: number ) {
+export async function showDSPWidgetModal( siteId: number, postId?: number ) {
 	if ( ! window.BlazePress ) {
 		await loadDSPWidgetJS( async () => await showDSPWidgetModal( siteId, postId ) );
 	} else {
 		await window.BlazePress.render( {
-			domNodeId: 'promote__widget-container',
 			stripeKey: config( 'dsp_stripe_pub_key' ),
 			apiHost: 'https://public-api.wordpress.com',
 			apiPrefix: `/wpcom/v2/sites/${ siteId }/wordads/dsp`,

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -34,7 +34,7 @@ function loadDSP() {
 
 export async function showDSP(
 	siteId: number | string,
-	postId?: number | string,
+	postId: number | string,
 	domNodeId?: string
 ) {
 	await loadDSP();

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -32,7 +32,11 @@ function loadDSP() {
 	} );
 }
 
-export async function showDSP( siteId: number | string, postId?: number, domNodeId?: string ) {
+export async function showDSP(
+	siteId: number | string,
+	postId?: number | string,
+	domNodeId?: string
+) {
 	await loadDSP();
 	return new Promise( ( resolve, reject ) => {
 		if ( window.BlazePress ) {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -14,6 +14,7 @@ declare global {
 				template: string;
 				urn: string;
 				onLoaded?: () => void;
+				showDialog?: boolean;
 			} ) => void;
 		};
 	}
@@ -88,6 +89,7 @@ export async function showDSPWidgetModal( siteId: number, postId?: number ) {
 			authToken: 'wpcom-proxy-request',
 			template: 'article',
 			urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
+			showDialog: true, // for now
 		} );
 	}
 }


### PR DESCRIPTION
Adds a step and a flow in stepper to load the BlazePress Widget. 

One thing to note is that the progress indicator changed to a horizontal bar on the top of the screen instead of `X out of Y`.
<img width="844" alt="image" src="https://user-images.githubusercontent.com/375980/184221540-9cdacd36-271c-4328-876d-54e9412a9d9e.png">

### Testing
1. Apply this PR.
2. Navigate to http://calypso.localhost:3000/setup/promote?flow=blazepress&siteId=[YOUR_SITE_ID]&postId=[YOUR_POST_ID]&flags=promote-post.
3. Verify the BlazePress widget is loading inside the Stepper.
![2022-08-17 15 04 03](https://user-images.githubusercontent.com/375980/185211218-198cbe64-109f-44be-a4e4-876f6e02f975.gif)

Closes https://github.tumblr.net/Tumblr/wordads-picard/issues/408