### PR TITLE
Agency Sign-Up: change the form fields order

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -121,21 +121,6 @@ export default function CompanyDetailsForm( {
 					{ ! showCountryFields && <TextPlaceholder /> }
 				</FormFieldset>
 
-				{ showCountryFields && stateOptions && (
-					<FormFieldset>
-						<FormLabel>{ translate( 'State' ) }</FormLabel>
-						<SelectDropdown
-							className="company-details-form__dropdown"
-							initialSelected={ addressState }
-							options={ stateOptions }
-							onSelect={ ( option: any ) => {
-								setAddressState( option.value );
-							} }
-							disabled={ isLoading }
-						/>
-					</FormFieldset>
-				) }
-
 				<FormFieldset className="company-details-form__business-address">
 					<FormLabel>{ translate( 'Business address' ) }</FormLabel>
 					<FormTextInput
@@ -157,23 +142,38 @@ export default function CompanyDetailsForm( {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel htmlFor="postalCode">{ translate( 'Postal code' ) }</FormLabel>
-					<FormTextInput
-						id="postalCode"
-						name="postalCode"
-						value={ postalCode }
-						onChange={ ( event: any ) => setPostalCode( event.target.value ) }
-						disabled={ isLoading }
-					/>
-				</FormFieldset>
-
-				<FormFieldset>
 					<FormLabel htmlFor="city">{ translate( 'City' ) }</FormLabel>
 					<FormTextInput
 						id="city"
 						name="city"
 						value={ city }
 						onChange={ ( event: any ) => setCity( event.target.value ) }
+						disabled={ isLoading }
+					/>
+				</FormFieldset>
+
+				{ showCountryFields && stateOptions && (
+					<FormFieldset>
+						<FormLabel>{ translate( 'State' ) }</FormLabel>
+						<SelectDropdown
+							className="company-details-form__dropdown"
+							initialSelected={ addressState }
+							options={ stateOptions }
+							onSelect={ ( option: any ) => {
+								setAddressState( option.value );
+							} }
+							disabled={ isLoading }
+						/>
+					</FormFieldset>
+				) }
+
+				<FormFieldset>
+					<FormLabel htmlFor="postalCode">{ translate( 'Postal code' ) }</FormLabel>
+					<FormTextInput
+						id="postalCode"
+						name="postalCode"
+						value={ postalCode }
+						onChange={ ( event: any ) => setPostalCode( event.target.value ) }
 						disabled={ isLoading }
 					/>
 				</FormFieldset>


### PR DESCRIPTION
On the agency sign-up form, the fields were in an unusual order. This PR changes the order of the form fields to improve the user's experience.

#### Proposed Changes

* Change the order of the agency sign-up form fields to the following: company name, country, business address, city, state, and postal code.

#### Testing Instructions

* With a new WP account that is not yet a partner, go to /agency/signup
* The fields should appear in the order described above

#### Screenshot before the change

![image](https://user-images.githubusercontent.com/6406071/184201765-0a8495c6-551a-41df-bd23-d79ec61b7a55.png)

#### Screenshot after the change

![image](https://user-images.githubusercontent.com/6406071/184202190-a26409b4-ab25-4224-bc0c-e9b60c4760c0.png)


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?