### PR TITLE
Newsletter: set flow foundation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -36,6 +36,8 @@ export { default as intro } from './intro';
 export { default as linkInBioSetup } from './link-in-bio-setup';
 export { default as chooseADomain } from './choose-a-domain';
 export { default as launchpad } from './launchpad';
+export { default as processingFake } from './processing-fake';
+export { default as subscribers } from './subscribers';
 
 export type StepPath =
 	| 'courses'
@@ -75,4 +77,6 @@ export type StepPath =
 	| 'linkInBioSetup'
 	| 'newsletterSetup'
 	| 'intro'
-	| 'launchpad';
+	| 'launchpad'
+	| 'processingFake'
+	| 'subscribers';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -16,13 +16,13 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 	return (
 		<StepContainer
 			stepName={ 'intro' }
-			className={ cx( { 'is-newsletters': flow === 'newsletters' } ) }
+			className={ cx( { 'is-newsletter': flow === 'newsletter' } ) }
 			goBack={ goBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			isWideLayout={ true }
 			isLargeSkipLayout={ false }
-			stepContent={ <IntroStep flowName={ flow } goNext={ handleGetStarted } /> }
+			stepContent={ <IntroStep flowName={ flow as string } goNext={ handleGetStarted } /> }
 			recordTracksEvent={ recordTracksEvent }
 			showJetpackPowered
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -1,16 +1,24 @@
 import { Button } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import type { WPElement } from '@wordpress/element';
 
 interface Props {
 	goNext: () => void;
 	flowName: string;
 }
 
+interface IntroContent {
+	[ key: string ]: {
+		content: WPElement;
+		button: string;
+	};
+}
+
 const Intro: React.FC< Props > = ( { goNext, flowName } ) => {
 	const { __ } = useI18n();
 
-	const intro: any = {
+	const intro: IntroContent = {
 		newsletter: {
 			content: createInterpolateElement(
 				__( 'Your stories, right into your<br /> readers’ inbox, now!' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -4,25 +4,38 @@ import { useI18n } from '@wordpress/react-i18n';
 
 interface Props {
 	goNext: () => void;
-	flowName: string | null;
+	flowName: string;
 }
 
 const Intro: React.FC< Props > = ( { goNext, flowName } ) => {
 	const { __ } = useI18n();
 
-	const introTitle =
-		flowName === 'link-in-bio'
-			? createInterpolateElement( __( 'Let’s set up your<br />Link in Bio' ), { br: <br /> } )
-			: createInterpolateElement( __( 'Let’s set up your<br />Newsletter' ), { br: <br /> } );
+	const intro: any = {
+		newsletter: {
+			content: createInterpolateElement(
+				__( 'Your stories, right into your<br /> readers’ inbox, now!' ),
+				{ br: <br /> }
+			),
+			button: __( 'Create your newsletter' ),
+		},
+		'link-in-bio': {
+			content: createInterpolateElement(
+				__( 'Your short bio and links,<br /> accessible to your<br /> audience in minutes' ),
+				{ br: <br /> }
+			),
+			button: __( 'Create your link in bio' ),
+		},
+	};
+
+	createInterpolateElement( __( 'Let’s set up your<br />Link in Bio' ), { br: <br /> } );
 
 	return (
 		<div className="intro__content">
 			<h1 className="intro__title">
-				{ __( 'Hello!' ) }
-				<span>{ introTitle }</span>
+				<span>{ intro[ flowName ].content }</span>
 			</h1>
 			<Button className="intro__button" primary onClick={ goNext }>
-				{ __( 'Get started' ) }
+				{ intro[ flowName ].button }
 			</Button>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -10,28 +10,28 @@ interface Props {
 
 interface IntroContent {
 	[ key: string ]: {
-		content: WPElement;
-		button: string;
+		title: WPElement;
+		buttonText: string;
 	};
 }
 
 const Intro: React.FC< Props > = ( { goNext, flowName } ) => {
 	const { __ } = useI18n();
 
-	const intro: IntroContent = {
+	const introContent: IntroContent = {
 		newsletter: {
-			content: createInterpolateElement(
+			title: createInterpolateElement(
 				__( 'Your stories, right into your<br /> readers’ inbox, now!' ),
 				{ br: <br /> }
 			),
-			button: __( 'Create your newsletter' ),
+			buttonText: __( 'Create your newsletter' ),
 		},
 		'link-in-bio': {
-			content: createInterpolateElement(
+			title: createInterpolateElement(
 				__( 'Your short bio and links,<br /> accessible to your<br /> audience in minutes' ),
 				{ br: <br /> }
 			),
-			button: __( 'Create your link in bio' ),
+			buttonText: __( 'Create your link in bio' ),
 		},
 	};
 
@@ -40,10 +40,10 @@ const Intro: React.FC< Props > = ( { goNext, flowName } ) => {
 	return (
 		<div className="intro__content">
 			<h1 className="intro__title">
-				<span>{ intro[ flowName ].content }</span>
+				<span>{ introContent[ flowName ].title }</span>
 			</h1>
 			<Button className="intro__button" primary onClick={ goNext }>
-				{ intro[ flowName ].button }
+				{ introContent[ flowName ].buttonText }
 			</Button>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -7,7 +7,7 @@ $white: var( --color-surface );
 	background: url( 'calypso/assets/images/onboarding/link-in-bio-intro-background.svg' ),
 		url( 'calypso/assets/images/onboarding/link-in-bio-intro-background-noise.svg' );
 
-	&.is-newsletters {
+	&.is-newsletter {
 		background: url( 'calypso/assets/images/onboarding/paper-texture.jpg' ),
 			linear-gradient( 123deg, rgba( 7, 116, 195, 1 ) 0%, rgba( 255, 255, 255, 0 ) 100% ),
 			url( 'calypso/assets/images/onboarding/link-in-bio-intro-background-noise.svg' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -34,7 +34,7 @@ function generateSwatchSVG( color: string | undefined ) {
 	}%3C/svg%3E")`;
 }
 const NewsletterSetup: Step = ( { navigation } ) => {
-	const { goBack } = navigation;
+	const { goBack, goNext, submit } = navigation;
 	const { __ } = useI18n();
 	const accentColorRef = React.useRef< HTMLInputElement >( null );
 
@@ -72,6 +72,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
+		goNext();
 		if ( site ) {
 			setSiteDescription( tagline );
 			setSiteTitle( siteTitle );
@@ -183,7 +184,30 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						value={ accentColor || '#000000' }
 					/>
 				</FormFieldset>
-				<Button className="newsletter-setup__submit-button" type="submit" primary>
+
+				<FormFieldset disabled={ isLoading }>
+					<FormLabel htmlFor="blogURL">{ __( 'Publication Address' ) }</FormLabel>
+					{ ! url ? (
+						<FormInput value={ url } disabled={ true } />
+					) : (
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						<FormTextInputWithAction
+							id="blogURL"
+							className={ 'newsletter-setup__url' }
+							defaultValue={ url }
+							readOnly={ true }
+							action="Change"
+							onAction={ navigateToDomains }
+						/>
+					) }
+				</FormFieldset>
+				<Button
+					// disabled={ isLoading }
+					className="newsletter-setup__submit-button"
+					type="submit"
+					primary
+				>
 					{ __( 'Continue' ) }
 				</Button>
 			</form>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -34,7 +34,7 @@ function generateSwatchSVG( color: string | undefined ) {
 	}%3C/svg%3E")`;
 }
 const NewsletterSetup: Step = ( { navigation } ) => {
-	const { goBack, goNext, submit } = navigation;
+	const { goBack, goNext } = navigation;
 	const { __ } = useI18n();
 	const accentColorRef = React.useRef< HTMLInputElement >( null );
 
@@ -184,30 +184,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						value={ accentColor || '#000000' }
 					/>
 				</FormFieldset>
-
-				<FormFieldset disabled={ isLoading }>
-					<FormLabel htmlFor="blogURL">{ __( 'Publication Address' ) }</FormLabel>
-					{ ! url ? (
-						<FormInput value={ url } disabled={ true } />
-					) : (
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore
-						<FormTextInputWithAction
-							id="blogURL"
-							className={ 'newsletter-setup__url' }
-							defaultValue={ url }
-							readOnly={ true }
-							action="Change"
-							onAction={ navigateToDomains }
-						/>
-					) }
-				</FormFieldset>
-				<Button
-					// disabled={ isLoading }
-					className="newsletter-setup__submit-button"
-					type="submit"
-					primary
-				>
+				<Button className="newsletter-setup__submit-button" type="submit" primary>
 					{ __( 'Continue' ) }
 				</Button>
 			</form>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-fake/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-fake/index.tsx
@@ -1,0 +1,29 @@
+import { StepContainer } from '@automattic/onboarding';
+import { ReactElement, useEffect } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const ProcessingFake: Step = function ( { navigation } ): ReactElement | null {
+	useEffect( () => {
+		setTimeout( () => navigation.goNext(), 5000 );
+	}, [] );
+
+	return (
+		<StepContainer
+			shouldHideNavButtons={ true }
+			hideFormattedHeader={ true }
+			stepName={ 'processing-fake' }
+			flowName={ 'newsletter' }
+			isHorizontalLayout={ true }
+			stepContent={
+				<div className={ 'processing-fake' }>
+					<h1 className="processing-fake__title">This is the fake processing step</h1>
+					<p>we are pretending to do things...</p>
+				</div>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default ProcessingFake;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -1,0 +1,26 @@
+import { StepContainer } from '@automattic/onboarding';
+import { ReactElement } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const Subscribers: Step = function ( { navigation } ): ReactElement | null {
+	return (
+		<StepContainer
+			shouldHideNavButtons={ true }
+			hideFormattedHeader={ true }
+			stepName={ 'subscribers' }
+			flowName={ 'newsletter' }
+			isHorizontalLayout={ true }
+			stepContent={
+				<div className={ 'subscribers' }>
+					<h1 className="subscribers__title">This is the subscribers step</h1>
+					<p>Content here...</p>
+					<button onClick={ () => navigation.goNext() }>Go to the next step</button>
+				</div>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default Subscribers;

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,11 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
-export const newsletters: Flow = {
-	name: 'newsletters',
+export const newsletter: Flow = {
+	name: 'newsletter',
 	title: 'Newsletters',
 	useSteps() {
 		useEffect( () => {
@@ -15,11 +17,15 @@ export const newsletters: Flow = {
 		return [
 			'intro',
 			'newsletterSetup',
+			'subscribers',
+			'processingFake',
 			...( isEnabled( 'signup/launchpad' ) ? [ 'launchpad' ] : [] ),
 		] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			return providedDependencies;
 		}
@@ -31,7 +37,22 @@ export const newsletters: Flow = {
 		const goNext = () => {
 			switch ( _currentStep ) {
 				case 'intro':
-					return navigate( 'newsletterSetup' );
+					if ( userIsLoggedIn ) {
+						return navigate( 'newsletterSetup' );
+					}
+					return window.location.replace(
+						'/start/account?redirect_to=/setup/newsletterSetup?flow=newsletter'
+					);
+
+				case 'newsletterSetup':
+					return window.location.replace( '/start/newsletter/domains' );
+
+				case 'subscribers':
+					return navigate( 'processingFake' );
+
+				case 'processingFake':
+					return navigate( 'launchpad' );
+
 				default:
 					return navigate( 'intro' );
 			}

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -30,7 +30,7 @@ import { setupWpDataDebug } from '../gutenboarding/devtools';
 import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
-import { newsletters } from './declarative-flow/newsletters';
+import { newsletter } from './declarative-flow/newsletter';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
@@ -60,7 +60,7 @@ interface configurableFlows {
 }
 
 const availableFlows: Array< configurableFlows > = [
-	{ flowName: 'newsletters', pathToFlow: newsletters },
+	{ flowName: 'newsletter', pathToFlow: newsletter },
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
 ];

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -112,13 +112,10 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'newsletters',
-			steps: getAddOnsStep(
-				isEnabled( 'signup/professional-email-step' )
-					? [ 'user', 'domains', 'emails', 'plans' ]
-					: [ 'user', 'domains', 'plans' ]
-			),
-			destination: ( dependencies ) => getStepperFlowDestination( dependencies, 'newsletters' ),
+			name: 'newsletter',
+			steps: [ 'domains', 'plans' ],
+			destination: ( dependencies ) =>
+				`/setup/subscribers?flow=newsletter&siteSlug=${ dependencies.siteSlug }`,
 			description: 'Beginning of the flow to create a newsletter',
 			lastModified: '2022-07-28',
 			showRecaptcha: true,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -184,7 +184,7 @@
 		"onboarding",
 		"onboarding-with-email",
 		"with-add-ons",
-		"newsletters",
+		"newsletter",
 		"link-in-bio",
 		"setup-site",
 		"account",


### PR DESCRIPTION
## Proposed Changes

This rearranges the current Newsletter flow (still under construction) to match the Figma. Alongside the basic changes of shuffling things around this also:

1. Unifies the flow names in /start and /stepper to be `newsletter` (no 's')
2. Adjusts the current intro step with the new wording for Newsletter and Link in bio
3. Adds 2 placeholder steps `processingFake` and `subscriber`

#### This is missing the checkout loading step after purchase. I will remove this when its added.

## Testing Instructions

1. Pull branch and `yarn start`
2. Start at the beginning of the flow http://calypso.localhost:3000/setup?flow=newsletter
 * test with logged in and logged out
 * test purchase and free plan
3. Check the other /start flow to make sure there was no regression

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->