### PR TITLE
increase vertical padding between designs in the UDP

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -81,20 +81,20 @@
 		.design-picker__grid {
 			display: grid;
 			grid-template-columns: 1fr;
-			row-gap: 36px;
+			row-gap: 32px;
 			margin: 0 0 30px;
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr;
 				column-gap: 24px;
-				row-gap: 32px;
+				row-gap: 28px;
 			}
 		}
 
 		.design-picker__grid-minimal {
 			display: grid;
 			grid-template-columns: 1fr;
-			row-gap: 40px;
+			row-gap: 36px;
 			margin: 0 0 30px;
 
 			@include break-medium {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -81,20 +81,20 @@
 		.design-picker__grid {
 			display: grid;
 			grid-template-columns: 1fr;
-			row-gap: 24px;
+			row-gap: 36px;
 			margin: 0 0 30px;
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr;
 				column-gap: 24px;
-				row-gap: 20px;
+				row-gap: 32px;
 			}
 		}
 
 		.design-picker__grid-minimal {
 			display: grid;
 			grid-template-columns: 1fr;
-			row-gap: 28px;
+			row-gap: 40px;
 			margin: 0 0 30px;
 
 			@include break-medium {


### PR DESCRIPTION
#### Proposed Changes
Fixes https://github.com/Automattic/wp-calypso/issues/66483

Increase vertical padding in the design picker by 8px.

I chose 8px across the board because @saygunnyc [suggested 32px total](https://github.com/Automattic/wp-calypso/pull/66200#issuecomment-1211030971) which is 8px more than what was currently used on mobile. I applied the same increase to the other screen sizes. This affects the static design picker as shown:

Static DP Mobile:
<img width="326" alt="Screen Shot 2022-08-12 at 9 20 23 am" src="https://user-images.githubusercontent.com/22446385/184258428-048ff5f3-21f2-4236-a3fb-3a20f295a6a0.png">

Unified DP Mobile:
<img width="327" alt="Screen Shot 2022-08-12 at 9 19 56 am" src="https://user-images.githubusercontent.com/22446385/184258432-e96de9e1-50bb-4e51-ac30-2e45c8b88594.png">

Static DP Desktop:
<img width="1728" alt="Screen Shot 2022-08-12 at 9 19 45 am" src="https://user-images.githubusercontent.com/22446385/184258436-b934905b-7dce-4b10-bc2f-c8f6753bb27e.png">

Unified DP Desktop:
<img width="1728" alt="Screen Shot 2022-08-12 at 9 20 43 am" src="https://user-images.githubusercontent.com/22446385/184258416-f49f22f3-8070-48dd-a44f-18c843c837f2.png">
 