### PR TITLE
Optimize git cli commands for local development

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -52,20 +52,24 @@ const debug = debugFactory( 'calypso:pages' );
 
 const calypsoEnv = config( 'env_id' );
 
+let branchName;
 function getCurrentBranchName() {
-	try {
-		return execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
-	} catch ( err ) {
-		return undefined;
+	if ( ! branchName ) {
+		try {
+			branchName = execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
+		} catch ( err ) {}
 	}
+	return branchName;
 }
 
+let commitChecksum;
 function getCurrentCommitShortChecksum() {
-	try {
-		return execSync( 'git rev-parse --short HEAD' ).toString().replace( /\s/gm, '' );
-	} catch ( err ) {
-		return undefined;
+	if ( ! commitChecksum ) {
+		try {
+			commitChecksum = execSync( 'git rev-parse --short HEAD' ).toString().replace( /\s/gm, '' );
+		} catch ( err ) {}
 	}
+	return commitChecksum;
 }
 
 /*


### PR DESCRIPTION
#### Proposed Changes
In dev mode, we put the git branch and commit hash in the context of each request. This happens on every run. As a result, `execSync` blocks every request while it gets this information. In my profiling (see #66372), I noticed this taking up a relatively large amount of time compared to the rest of the code.

This improvement should cache the value so that `execSync` only needs to happen once on the first request -- and any subsequent request won't need it.

Again, this only happens in dev mode, but should be a nice little optimization :)

#### Testing Instructions
- Run `yarn start` locally and verify that calypso.localhost works as expected while navigating between pages.

