### PR TITLE
Remove encoding of ampersands in media library edit form fields

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -16,6 +16,7 @@ import { withUpdateMedia } from 'calypso/data/media/with-update-media';
 import { FormCheckbox } from 'calypso/devdocs/design/playground-scope';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
+import decodeEntities from 'calypso/lib/formatting/decode/browser';
 import { getMimePrefix, url } from 'calypso/lib/media/utils';
 import versionCompare from 'calypso/lib/version-compare';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -315,7 +316,7 @@ class EditorMediaModalDetailFields extends Component {
 					<TrackInputChanges onNewValue={ this.bumpTitleStat }>
 						<FormTextInput
 							name="title"
-							value={ this.getItemValue( 'title' ) }
+							value={ decodeEntities( this.getItemValue( 'title' ) ) }
 							onChange={ this.setFieldValue }
 						/>
 					</TrackInputChanges>
@@ -325,7 +326,7 @@ class EditorMediaModalDetailFields extends Component {
 					<TrackInputChanges onNewValue={ this.bumpCaptionStat }>
 						<FormTextarea
 							name="caption"
-							value={ this.getItemValue( 'caption' ) }
+							value={ decodeEntities( this.getItemValue( 'caption' ) ) }
 							onChange={ this.setFieldValue }
 						/>
 					</TrackInputChanges>
@@ -337,7 +338,7 @@ class EditorMediaModalDetailFields extends Component {
 					<TrackInputChanges onNewValue={ this.bumpDescriptionStat }>
 						<FormTextarea
 							name="description"
-							value={ this.getItemValue( 'description' ) }
+							value={ decodeEntities( this.getItemValue( 'description' ) ) }
 							onChange={ this.setFieldValue }
 						/>
 					</TrackInputChanges>


### PR DESCRIPTION
#### Proposed Changes

The media library item is saved as a custom post type, and the field values are saved with HTML entities encoded. Then, those encoded characters are displayed in the media library edit form.

In this PR, I propose to change that behavior to decode those characters before we display them in the form.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Media > Library
2. Upload an image.
3. Add a title, caption, alt text, and description using an ampersand
4. Save form by clicking "Done"
5. Reload the page
6. Open the form again

Confirm that there are no `&amp;` in the fields, but `&` are displayed:

![Screen Shot 2022-08-12 at 11 51 41](https://user-images.githubusercontent.com/727413/184330360-cb2a186f-d2a7-411d-97d2-04301514138a.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/66206
