### PR TITLE
Marketplace: Add missing sites/currentSites props

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -217,6 +217,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				selectedSite={ selectedSite }
 				sitePlan={ sitePlan }
 				isVip={ isVip }
+				sites={ sites }
 			/>
 		);
 	};

--- a/client/my-sites/plugins/plugins-category-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-category-results-page/index.jsx
@@ -37,7 +37,7 @@ const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
 			title={ title }
 			site={ siteSlug }
 			showPlaceholders={ isFetching }
-			currentSites={ sites }
+			sites={ sites }
 			variant={ PluginsBrowserListVariant.InfiniteScroll }
 			fetchNextPage={ fetchNextPage }
 			extended


### PR DESCRIPTION
#### Proposed Changes

* Add a couple of missing `sites`/`currentSites` props to the Marketplace components tree.

The issue was reported internally (p1660294425003889-slack-C029JEQRVRT), and its most visible outcome was not marking installed plugins as installed.
It was caused by a couple of missing or misnamed `sites`/`currentSites` props during some recent refactors.

| Before | After |
| - | - |
| <img width="529" alt="Screenshot 2022-08-12 at 11 24 04" src="https://user-images.githubusercontent.com/2070010/184335846-6a65797b-6604-4910-b1a9-f07c263c656d.png"> | <img width="531" alt="Screenshot 2022-08-12 at 11 23 49" src="https://user-images.githubusercontent.com/2070010/184335863-55db1370-4a5f-462a-938c-fa4dda2ef698.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Dotcom Marketplace (`/plugins`) with a site capable of installing plugins.
* If needed, install a plugin and come back to the Marketplace.
* Look around for installed plugins.
* Make sure the browser card shows "Installed" instead of the price (or free).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~