### PR TITLE
Left Align Fixed Navigation header when there's no sidebar

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -6,26 +6,31 @@ const Header = styled.header`
 	position: fixed;
 	z-index: 10;
 	top: var( --masterbar-height );
-	left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
-	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
+	left: 0;
 	padding: 0 32px;
 	box-sizing: border-box;
+	width: 100%;
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
 
-	@media ( max-width: 960px ) {
-		// Account for jetpack sites with the old sidebar.
-		left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
-		width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
-	}
+	.layout__secondary ~ .layout__primary & {
+		left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
+		width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 
-	@media ( max-width: 782px ) {
-		width: 100%;
-		left: 0;
-	}
+		@media ( max-width: 960px ) {
+			// Account for jetpack sites with the old sidebar.
+			left: calc( var( --sidebar-width-min ) + 1px ); // 1px is the sidebar border.
+			width: calc( 100% - var( --sidebar-width-min ) - 1px ); // 1px is the sidebar border.
+		}
 
-	@media ( max-width: 660px ) {
-		padding: 0 16px;
+		@media ( max-width: 782px ) {
+			width: 100%;
+			left: 0;
+		}
+
+		@media ( max-width: 660px ) {
+			padding: 0 16px;
+		}
 	}
 `;
 

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -115,13 +115,18 @@
 			position: fixed;
 			z-index: 20;
 			top: var( --masterbar-height );
-			left: calc( var( --sidebar-width-max ) + 1px );
-			width: calc( 100% - var( --sidebar-width-max ) - 1px );
+			left: 0;
+			width: 100%;
 			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
 			border-bottom: 1px solid var( --studio-gray-5 );
 			background-color: var( --studio-white );
+
+			.layout__secondary ~ .layout__primary & {
+				left: calc( var( --sidebar-width-max ) + 1px );
+				width: calc( 100% - var( --sidebar-width-max ) - 1px );
+			}
 		}
 
 	}


### PR DESCRIPTION
#### Proposed Changes

This adjusts the left-alignment of the Fixed Navigation header and the sticky Plugin search box be properly aligned if there's no sidebar (for logged-out users).

<img width="320" alt="Screenshot on 2022-08-12 at 15-35-02" src="https://user-images.githubusercontent.com/2749938/184355079-2a3ace97-18d2-46ab-9c7c-294a6f69b0b3.png">
<img width="320" alt="Screenshot on 2022-08-12 at 15-35-11" src="https://user-images.githubusercontent.com/2749938/184355077-d2acba3b-db25-4ed1-86fb-d548428c9311.png">

#### Testing Instructions

* While logged out, go to `/plugins`
* The top Navigation bar should be aligned to the left for all screen sizes
* The sticky Search Box should be center aligned

<img width="320" alt="Screenshot on 2022-08-12 at 15-39-19" src="https://user-images.githubusercontent.com/2749938/184355925-b3d527df-3d6a-4aaf-98f7-82813961e80d.png">
<img width="320" alt="Screenshot on 2022-08-12 at 15-39-32" src="https://user-images.githubusercontent.com/2749938/184355922-6d5885d1-23d4-4294-8568-41488ee38260.png">
 

* Log in and go to `/plugins`
* The position of the Fixed Navigation and the Search Box should not be affected for all screen sizes
<img width="320" alt="Screenshot on 2022-08-12 at 15-40-02" src="https://user-images.githubusercontent.com/2749938/184355895-3cc7e4d7-e2b4-426e-8de6-6a84f4cb0d8b.png">
<img width="320" alt="Screenshot on 2022-08-12 at 15-40-13" src="https://user-images.githubusercontent.com/2749938/184355898-2540f1e7-cd70-45a2-851f-467b25c087af.png">

<img width="180" alt="Screenshot on 2022-08-12 at 15-40-37" src="https://user-images.githubusercontent.com/2749938/184355890-8573ebd7-5f59-426b-8aab-3b52396b7b56.png">

