### PR TITLE
Add a <title> for Sites Management Page

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -81,7 +81,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 
 	return (
 		<main>
-			<DocumentHead title={ __( 'Sites Management' ) } />
+			<DocumentHead title={ __( 'My Sites' ) } />
 			<PageHeader>
 				<HeaderControls>
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -2,6 +2,7 @@ import { Button, useSitesTableFiltering, useSitesTableSorting } from '@automatti
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import DocumentHead from 'calypso/components/data/document-head';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { NoSitesMessage } from './no-sites-message';
 import { SitesDashboardQueryParams, SitesContentControls } from './sites-content-controls';
@@ -80,6 +81,7 @@ export function SitesDashboard( { queryParams: { search, status = 'all' } }: Sit
 
 	return (
 		<main>
+			<DocumentHead title={ __( 'Sites Management' ) } />
 			<PageHeader>
 				<HeaderControls>
 					<DashboardHeading>{ __( 'My Sites' ) }</DashboardHeading>


### PR DESCRIPTION
#### Proposed Changes

Currently, we don't define any title in the Sites Management Page, so the browser tab and history always show "WordPress.com". In this PR, I propose to add "Sites Management" to the title, so the history entry will show "Sites Management - WordPress.com".

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. open `/sites-dashboard` page
2. Confirm that the browser tab shows "Sites Management - WordPress.com"
3. Open browsing history and confirm that entry says the same

![Screen Shot 2022-08-12 at 14 41 13](https://user-images.githubusercontent.com/727413/184355928-fe348b94-2d5b-46bf-9180-ba634621c15f.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/66525