### PR TITLE
Update Plugin details breakpoints

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -13,15 +13,15 @@ $mobile-icon-height: 175px;
 .plugin-details-header__main-info {
 	margin-top: 16px;
 	display: flex;
-	flex-direction: column;
-	align-items: center;
 	flex-wrap: wrap;
 	justify-content: center;
+	text-align: center;
 
 	@include break-mobile {
 		flex-wrap: nowrap;
 		align-items: flex-start;
 		justify-content: flex-start;
+		text-align: initial;
 	}
 	
 	.plugin-details-header__icon {
@@ -36,6 +36,10 @@ $mobile-icon-height: 175px;
 		width: $mobile-icon-height;
 		height: $mobile-icon-height;
 	}
+}
+
+.legacy .plugin-details-header__main-info {
+	text-align: initial;
 }
 
 .plugin-details-header__title-container {

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -13,6 +13,8 @@ $mobile-icon-height: 175px;
 .plugin-details-header__main-info {
 	margin-top: 16px;
 	display: flex;
+	flex-direction: column;
+	align-items: center;
 	flex-wrap: wrap;
 	justify-content: center;
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -2,8 +2,6 @@
 @import '@wordpress/base-styles/_mixins.scss';
 @import './grid-mixins.scss';
 
-$mobile-layout-grid: repeat( 3, minmax( 0, 1fr ) );
-
 .is-section-plugins .main {
 	padding-top: 35px; // Compensate for the fixed header.
 
@@ -86,7 +84,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	display: flex;
 	align-items: center;
 
-	@media screen and ( max-width: 1040px ) {
+	@media screen and ( max-width: 1280px ) {
 		.plugins__button {
 			border: none;
 		}
@@ -124,23 +122,18 @@ body.is-section-plugins.theme-default.color-scheme {
 .plugin-details__layout {
 	padding-top: 54px;
 
-	@include breakpoint-deprecated( '<1040px' ) {
-		padding-top: 0;
-	}
-
 	@include display-grid;
-	grid-template-columns: $mobile-layout-grid;
-	@include break-mobile {
-		grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) 350px;
-	}
+	grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) 350px;
 	grid-column-gap: 60px;
 	grid-template-areas: 'header header actions'
 						'content content actions';
 
-	@include breakpoint-deprecated( '<1040px' ) {
+	@include breakpoint-deprecated( '<1280px' ) {
 		grid-template-areas: 'header header header'
 							'actions actions actions'
 							'content content content';
+		grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
+		padding-top: 0;
 	}
 
 	.plugin-details__header {
@@ -158,7 +151,7 @@ body.is-section-plugins.theme-default.color-scheme {
 		padding: 40px;
 		height: fit-content;
 
-		@include breakpoint-deprecated( '<1040px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			margin-top: 40px;
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -84,7 +84,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	display: flex;
 	align-items: center;
 
-	@media screen and ( max-width: 960px ) {
+	@media screen and ( max-width: 1040px ) {
 		.plugins__button {
 			border: none;
 		}
@@ -122,7 +122,7 @@ body.is-section-plugins.theme-default.color-scheme {
 .plugin-details__layout {
 	padding-top: 54px;
 
-	@include breakpoint-deprecated( '<960px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		padding-top: 0;
 	}
 
@@ -132,7 +132,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	grid-template-areas: 'header header actions'
 						'content content actions';
 
-	@include breakpoint-deprecated( '<960px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		grid-template-areas: 'header header header'
 							'actions actions actions'
 							'content content content';
@@ -153,7 +153,7 @@ body.is-section-plugins.theme-default.color-scheme {
 		padding: 40px;
 		height: fit-content;
 
-		@include breakpoint-deprecated( '<960px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			margin-top: 40px;
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -2,6 +2,8 @@
 @import '@wordpress/base-styles/_mixins.scss';
 @import './grid-mixins.scss';
 
+$mobile-layout-grid: repeat( 3, minmax( 0, 1fr ) );
+
 .is-section-plugins .main {
 	padding-top: 35px; // Compensate for the fixed header.
 
@@ -127,7 +129,10 @@ body.is-section-plugins.theme-default.color-scheme {
 	}
 
 	@include display-grid;
-	grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) 350px;
+	grid-template-columns: $mobile-layout-grid;
+	@include break-mobile {
+		grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr ) 350px;
+	}
 	grid-column-gap: 60px;
 	grid-template-areas: 'header header actions'
 						'content content actions';


### PR DESCRIPTION
#### Proposed Changes

Update of the breakpoints for the Plugin Details page: 
* Smaller screens
* Mobile screens

Smaller width before first breakpoint: 
| Before  | After |
| ------------- | ------------- |
|<img width="250" alt="Screen Shot 2022-08-12 at 08 43 04" src="https://user-images.githubusercontent.com/5039531/184363990-6c1dcf5d-edee-4c6c-a356-abd9976f6fc4.png">|<img width="280" alt="Screen Shot 2022-08-12 at 08 42 26" src="https://user-images.githubusercontent.com/5039531/184364100-1c319d96-ed84-45d8-8045-8a1ae70a9a7d.png">|

Mobile view:
| Before  | After |
| ------------- | ------------- |
|<img width="240" alt="Screen Shot 2022-08-12 at 09 24 17" src="https://user-images.githubusercontent.com/5039531/184364284-e3599d5c-8b3c-42f6-9f8f-c1ae845ffaa6.png">|<img width="240" alt="Screen Shot 2022-08-12 at 09 23 41" src="https://user-images.githubusercontent.com/5039531/184364330-8d1dc7d9-afcb-4d15-92f6-1f615f1e3488.png">|


#### Testing Instructions
* Go to the plugin details page
* Open the browser dev tools on the responsive layout tool
* Resize the screen for extra large, large, medium, small and mobile layouts
* Check if the layout adapts well

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
