### PR TITLE
BlazePress widget on Blank Canvas: POC

### DIFF
--- a/client/components/blazepress/index.tsx
+++ b/client/components/blazepress/index.tsx
@@ -1,0 +1,35 @@
+import { BlankCanvas } from 'calypso/components/blank-canvas';
+// import { useEffect } from 'react';
+
+export type BlazePressPromotionProps = {
+	isVisible: boolean;
+	isLoading: boolean;
+	onClose: () => void;
+};
+
+const BlazePressPromotion = ( props: BlazePressPromotionProps ) => {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+	const { isVisible = false, isLoading = true, onClose = () => {} } = props;
+
+	// Scroll to top on initial load regardless of previous page position
+	// useEffect( () => {
+	// 	if ( isVisible ) {
+	// 		window.scrollTo( 0, 0 );
+	// 	}
+	// }, [ isVisible ] );
+
+	return (
+		<>
+			{ isVisible && (
+				<BlankCanvas className={ 'blazepress-blank-canvas' }>
+					<BlankCanvas.Content>
+						{ isLoading && <div>isLoading</div> }
+						<div id="promote__widget-container"></div>
+					</BlankCanvas.Content>
+				</BlankCanvas>
+			) }
+		</>
+	);
+};
+
+export default BlazePressPromotion;

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -40,6 +40,7 @@ export async function showDSPWidgetModal( siteId: number, postId?: number ) {
 		await loadDSPWidgetJS( async () => await showDSPWidgetModal( siteId, postId ) );
 	} else {
 		await window.BlazePress.render( {
+			domNodeId: 'promote__widget-container',
 			stripeKey: config( 'dsp_stripe_pub_key' ),
 			apiHost: 'https://public-api.wordpress.com',
 			apiPrefix: `/wpcom/v2/sites/${ siteId }/wordads/dsp`,

--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -3,7 +3,9 @@ import './style.scss';
 import { Button } from '@wordpress/components';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import BlazePressPromotion from 'calypso/components/blazepress';
 import { recordDSPEntryPoint, showDSPWidgetModal } from 'calypso/lib/promote-post';
+import { useRouteModal } from 'calypso/lib/route-modal';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 
 export type Post = {
@@ -30,12 +32,22 @@ export default function PostItem( { post }: Props ) {
 	const [ loading, setLoading ] = useState( false );
 	const dispatch = useDispatch();
 
-	const onClickPromote = async () => {
+	const keyValue = 'post-' + post.ID;
+	const { isModalOpen, value, openModal, closeModal } = useRouteModal( 'blazePress', keyValue );
+	const onClickPromote = () => {
 		setLoading( true );
-		await showDSPWidgetModal( post.site_ID, post.ID );
-		dispatch( recordDSPEntryPoint( 'promoted_posts-post_item' ) );
-		setLoading( false );
+		openModal();
+		( async () => {
+			await showDSPWidgetModal( post.site_ID, post.ID );
+			dispatch( recordDSPEntryPoint( 'promoted_posts-post_item' ) );
+			setLoading( false );
+		} )();
 	};
+
+	const onCloseWidget = () => {
+		closeModal();
+	};
+
 	return (
 		<CompactCard className="post-item__card">
 			<div className="post-item__main">
@@ -52,9 +64,16 @@ export default function PostItem( { post }: Props ) {
 					</div>
 				</div>
 			</div>
-			<Button isBusy={ loading } disabled={ loading } isLink onClick={ onClickPromote }>
-				Promote
-			</Button>
+			<div className="post-item__promote-link">
+				<BlazePressPromotion
+					isVisible={ isModalOpen && value === keyValue }
+					isLoading={ loading }
+					onClose={ onCloseWidget }
+				/>
+				<Button isBusy={ loading } disabled={ loading } isLink onClick={ onClickPromote }>
+					Promote
+				</Button>
+			</div>
 		</CompactCard>
 	);
 }


### PR DESCRIPTION
This is a different approach to embed the BlazePress widget, it uses a component called `<BlankCanvas>` in order to display the widget. The main characteristic is that it is blank, it would be up to the widget to fill the entire screen.

### Testing
1. Apply this diff.
2. Go to `http://calypso.localhost:3000/advertising/[YOUR_SITE]?flags=promote-post`.
3. Click on the `Promote` link beside any of the posts in the list.
4. Verify you see an `is loading` message and the the BlazePress widget appears:

![2022-08-12 14 46 43](https://user-images.githubusercontent.com/375980/184414808-ca6a0503-e818-4da5-aa66-3105699b4f56.gif)

Related to https://github.com/Automattic/wp-calypso/pull/66508

Closes https://github.tumblr.net/Tumblr/wordads-picard/issues/408