### PR TITLE
Revert "Editing Toolkit: Refactor block-editor preview button url override"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -246,12 +246,8 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_disable_hei
 /**
  * Overrides the block editor preview button url with one that accounts for third party cookie
  * blocking.
- *
- * @param object $response WordPress rest response object.
- * @return object $response WordPress rest response object with updated links.
  */
-function override_preview_button_url( $response ) {
-	// We're not seeing custom domain cookie problems for atomic sites, so avoid running the script.
+function enqueue_override_preview_button_url() {
 	if ( ! function_exists( 'is_blog_atomic' ) ) {
 		return;
 	};
@@ -262,15 +258,13 @@ function override_preview_button_url( $response ) {
 		return;
 	}
 
-	if ( empty( $response->data ) || empty( $response->data['link'] ) ) {
-		return $response;
-	}
-
-	// logmein is a special URL that logs users into their custom mapped domain and sets up
-	// their log in cookie in a first-party context.
-	$response->data['link'] = add_query_arg( 'logmein', 'direct', $response->data['link'] );
-	return $response;
+	wp_enqueue_script(
+		'a8c_override_preview_button_url',
+		plugins_url( 'dist/override-preview-button-url.min.js', __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . 'dist/override-preview-button-url.min.js' ),
+		true
+	);
 }
 
-add_filter( 'rest_prepare_post', __NAMESPACE__ . '\override_preview_button_url', 10, 1 );
-add_filter( 'rest_prepare_page', __NAMESPACE__ . '\override_preview_button_url', 10, 1 );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_override_preview_button_url' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/override-preview-button-url.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/override-preview-button-url.js
@@ -1,0 +1,59 @@
+import { select, subscribe } from '@wordpress/data';
+
+const isEditorReady = async () =>
+	new Promise( ( resolve ) => {
+		const unsubscribe = subscribe( () => {
+			// Calypso sends the message as soon as the iframe is loaded, so we
+			// need to be sure that the editor is initialized and the core blocks
+			// registered. There is an unstable selector for that, so we use
+			// `isCleanNewPost` otherwise which is triggered when everything is
+			// initialized if the post is new.
+			const editorIsReady = select( 'core/editor' ).__unstableIsEditorReady
+				? select( 'core/editor' ).__unstableIsEditorReady()
+				: select( 'core/editor' ).isCleanNewPost();
+			if ( editorIsReady ) {
+				unsubscribe();
+				resolve();
+			}
+		} );
+	} );
+
+/**
+ * The gutenberg block editor preview button opens a new window to a simple site's mapped
+ * domain.
+ * Adds logmein query param to editor draft post preview url to add WordPress cookies in
+ * a first party context ( allowing us to avoid third party cookie issues )
+ */
+async function overridePreviewButtonUrl() {
+	await isEditorReady();
+
+	// Tracks when a popover is introduced into the post editor DOM
+	const popoverSlotObserver = new window.MutationObserver( ( mutations ) => {
+		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
+
+		for ( const record of mutations ) {
+			for ( const node of record.addedNodes ) {
+				if ( isComponentsPopover( node ) ) {
+					const previewButton = node.querySelector( 'a[href$="preview=true"]' );
+					// Disables default onclick behavior for the preview button and replaces
+					// it with our own window opening logic. Overriding the href directly
+					// doesn't work because the custom href we apply is overridden somewhere
+					// upstream.
+
+					if ( previewButton ) {
+						previewButton.onclick = function ( e ) {
+							e.preventDefault();
+							e.stopPropagation();
+							window.open( `${ previewButton.href }&logmein=direct` );
+						};
+					}
+				}
+			}
+		}
+	} );
+
+	const popoverSlotElem = document.querySelector( '.interface-interface-skeleton ~ .popover-slot' );
+	popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
+}
+
+overridePreviewButtonUrl();

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"build": "NODE_ENV=production yarn dev",
 		"build:block-inserter-modifications": "calypso-build --env source='block-inserter-modifications/contextual-tips'",
-		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images'",
+		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url'",
 		"build:error-reporting": "calypso-build --env source='error-reporting'",
 		"build:event-countdown-block": "calypso-build --env source='event-countdown-block'",
 		"build:global-styles": "calypso-build --env source='global-styles'",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#66370