### PR TITLE
Sites Management Dashboard: Fix search input styling when navigating from Calypso home page

### DIFF
--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -4,11 +4,15 @@ import styled from '@emotion/styled';
 export const SitesSearch = styled( Search )( {
 	'--color-surface': 'var( --studio-white )',
 
-	height: '42px',
+	height: '42px !important',
+
 	overflow: 'hidden',
 	border: '1px solid #c3c4c7',
 
 	'@media screen and (min-width: 660px)': {
-		flex: '0 1 390px',
+		flex: '0 1 390px !important',
+
+		height: 'auto !important',
+		alignSelf: 'stretch',
 	},
 } );


### PR DESCRIPTION
#### Proposed Changes

When navigating from Calypso, the injected styles take precedence over the styled Search component -- `.specifity .is-awesome`. This PR "fixes" that by adding `!mportant` to the rules, and also makes the search input stretch the available height so everything lines up nicely. 

By the way, this is one HUGE pro of using CSS-in-JS: specificity isn't a problem because the styles are scoped to the component, so the styles do not affect other components throughout the page. Plus, as soon as the component is unmounted, their styles are removed from the page, preventing conflict.

#### Testing Instructions

In one tab:

1. Open Calypso home;
2. Click `Switch Site` and `All My Sites`.

In another tab:

1. Open SMD directly, without opening Calypso first (through the link).

Check that both tabs are visually consistent.

| `trunk` | This PR |
| ------- | -------- |
| ![image](https://user-images.githubusercontent.com/26530524/184430927-a07cc6fb-de03-4274-924f-4dbe1122bc46.png) | ![image](https://user-images.githubusercontent.com/26530524/184430981-e038041a-5bca-4fa0-91f0-8fcff0668d29.png) |