### PR TITLE
Checkout: explicitly ignore rejected promises when applying coupons

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-coupon-field-state.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { ApplyCouponToCart } from '@automattic/shopping-cart';
 
 export type CouponFieldStateProps = {
 	couponFieldValue: string;
@@ -12,7 +13,7 @@ export type CouponFieldStateProps = {
 };
 
 export default function useCouponFieldState(
-	applyCoupon: ( couponId: string ) => void
+	applyCoupon: ApplyCouponToCart
 ): CouponFieldStateProps {
 	const reduxDispatch = useDispatch();
 	const [ couponFieldValue, setCouponFieldValue ] = useState< string >( '' );
@@ -41,7 +42,9 @@ export default function useCouponFieldState(
 				} )
 			);
 
-			applyCoupon( trimmedValue );
+			applyCoupon( trimmedValue ).catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 
 			return;
 		}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -607,7 +607,10 @@ export class PlanFeatures extends Component {
 				] )
 				.then( () => {
 					if ( withDiscount && this.isMounted ) {
-						return shoppingCartManager.applyCoupon( withDiscount );
+						return shoppingCartManager.applyCoupon( withDiscount ).catch( () => {
+							// If the coupon does not apply, let's continue to checkout anyway.
+							return Promise.resolve();
+						} );
 					}
 				} )
 				.then( () => {
@@ -630,7 +633,10 @@ export class PlanFeatures extends Component {
 				] )
 				.then( () => {
 					if ( withDiscount && this.isMounted ) {
-						return shoppingCartManager.applyCoupon( withDiscount );
+						return shoppingCartManager.applyCoupon( withDiscount ).catch( () => {
+							// If the coupon does not apply, let's continue to the next page anyway.
+							return Promise.resolve();
+						} );
 					}
 				} )
 				.then( () => {


### PR DESCRIPTION
#### Proposed Changes

All of the shopping cart operations performed by the `@automattic/shopping-cart` package return a Promise which is resolved when operation completes (well, actually when the cart next becomes valid but it's usually the same thing). At the same time, in calypso, the `CartMessages` component watches for errors on cart operations and displays them to the user. When attempting to apply a coupon, it's fairly common for the coupon to be invalid and for the user to receive an error message. Because the error is handled by `CartMessages`, we ignore the Promise rejection from the `applyCoupon()` call. However, this causes the rejection to bubble up to the browser console (and to our error logs).

This PR handles these rejections by making them a noop instead.

Note that these functions used to not reject on errors until https://github.com/Automattic/wp-calypso/pull/58834

#### Screenshots

The error displayed by `CartMessages`:

<img width="721" alt="Screen Shot 2022-08-12 at 3 44 38 PM" src="https://user-images.githubusercontent.com/2036909/184431986-211b3764-e5aa-4b62-b9e6-cee78b790fb8.png">

The console error this PR prevents:

<img width="687" alt="Screen Shot 2022-08-12 at 3 45 04 PM" src="https://user-images.githubusercontent.com/2036909/184432016-427b1237-2706-47d5-b108-e1a8167f087a.png">


#### Testing Instructions

- Add a product to your cart and visit checkout on this branch.
- Open the browser's JS console.
- Click "Add a coupon code".
- Try to add an invalid coupon code (just type anything in the coupon field and press "Apply").
- Verify that you see an error message displayed on the page.
- Verify that you see no "Unhandled Promise rejection" in the console.