### PR TITLE
Update PluginDetails CTA to use selectors instead of receive props

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -350,16 +350,7 @@ function PluginDetails( props ) {
 					</div>
 
 					<div className="plugin-details__actions">
-						<PluginDetailsCTA
-							plugin={ fullPlugin }
-							siteIds={ siteIds }
-							selectedSite={ selectedSite }
-							isPluginInstalledOnsite={ isPluginInstalledOnsite }
-							isPlaceholder={ showPlaceholder }
-							billingPeriod={ billingPeriod }
-							isMarketplaceProduct={ isMarketplaceProduct }
-							isSiteConnected={ isSiteConnected }
-						/>
+						<PluginDetailsCTA plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
 
 						{ ! showPlaceholder && ! requestingPluginsForSites && (
 							<PluginDetailsSidebar plugin={ fullPlugin } />
@@ -472,16 +463,7 @@ function LegacyPluginDetails( props ) {
 					</div>
 
 					<div className="plugin-details__layout-col-right">
-						<PluginDetailsCTA
-							plugin={ fullPlugin }
-							siteIds={ siteIds }
-							selectedSite={ selectedSite }
-							isPluginInstalledOnsite={ isPluginInstalledOnsite }
-							isPlaceholder={ showPlaceholder }
-							billingPeriod={ billingPeriod }
-							isMarketplaceProduct={ isMarketplaceProduct }
-							isSiteConnected={ isSiteConnected }
-						/>
+						<PluginDetailsCTA plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
 					</div>
 				</div>
 


### PR DESCRIPTION
#### Proposed Changes

Update PluginDetails CTA and CTAButton to use selectors in order to avoid prop drilling.

#### Testing Instructions

The Plugin Details page should keep working as before.

* Go to a free plugins page and try to use all the functions
* Select a business site, a free site and the multi site view

* Go to a paid plugin page and try to use all the functions
* Select a business site, a free site and the multi site view


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
