### PR TITLE
Load new Promoted Posts widget once per hour

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -27,8 +27,9 @@ export async function loadDSPWidgetJS( onLoad?: () => void ) {
 		return;
 	}
 	const script = document.createElement( 'script' );
-	// cachebust once per second for now, we will reduce this rate once we're out of beta
-	script.src = config( 'dsp_widget_js_src' ) + '?ver=' + Math.round( Date.now() / 1000 );
+	// cachebust once per hour for now, we will reduce this rate once we're out of beta
+	script.src =
+		config( 'dsp_widget_js_src' ) + '?ver=' + Math.round( Date.now() / ( 1000 * 60 * 60 ) );
 	script.async = true;
 	if ( onLoad ) {
 		script.onload = onLoad;

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -27,7 +27,7 @@ export async function loadDSPWidgetJS( onLoad?: () => void ) {
 		return;
 	}
 	const script = document.createElement( 'script' );
-	// cachebust once per minute
+	// cachebust once per second for now, we will reduce this rate once we're out of beta
 	script.src = config( 'dsp_widget_js_src' ) + '?ver=' + Math.round( Date.now() / 1000 );
 	script.async = true;
 	if ( onLoad ) {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -27,7 +27,8 @@ export async function loadDSPWidgetJS( onLoad?: () => void ) {
 		return;
 	}
 	const script = document.createElement( 'script' );
-	script.src = config( 'dsp_widget_js_src' );
+	// cachebust once per minute
+	script.src = config( 'dsp_widget_js_src' ) + '?ver=' + Math.round( Date.now() / 1000 );
 	script.async = true;
 	if ( onLoad ) {
 		script.onload = onLoad;

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,7 @@
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js?m=1660075754h&ver=1.0.0",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"build/sites-dashboard": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_test_todo",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js?m=1660075754h&ver=1.0.0",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,7 +14,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_test_todo",
-	"dsp_widget_js_src": "http://todo",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"build/sites-dashboard": true,

--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -11,7 +11,8 @@ const selectors = {
 	purchasePlaceholder: '.subscriptions__list .purchase-item__placeholder',
 
 	// Purchased item actions: plans
-	renewNowCardButton: 'button.card:has-text("Renew Now")',
+	renewNowCardButton: 'button:has-text("Renew Now")',
+
 	cancelAndRefundButton: 'a:text("Cancel Subscription and Refund")',
 	cancelSubscriptionButton: 'button:text("Cancel Subscription")',
 	upgradeButton: 'a.card:text("Upgrade")',

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -53,7 +53,8 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );
 
-		it( 'Renew plan', async function () {
+		// causing failures on trunk
+		it.skip( 'Renew plan', async function () {
 			await individualPurchasesPage.clickRenewNowCardButton();
 		} );
 

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -54,6 +54,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 		} );
 
 		// causing failures on trunk
+		/* eslint-disable jest/no-disabled-tests */
 		it.skip( 'Renew plan', async function () {
 			await individualPurchasesPage.clickRenewNowCardButton();
 		} );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -53,22 +53,20 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );
 
-		// The following tests are causing failures on trunk
-		/* eslint-disable jest/no-disabled-tests */
-		it.skip( 'Renew plan', async function () {
+		it( 'Renew plan', async function () {
 			await individualPurchasesPage.clickRenewNowCardButton();
 		} );
 
-		it.skip( `${ planName } is added to cart`, async function () {
+		it( `${ planName } is added to cart`, async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
 			await cartCheckoutPage.validateCartItem( planName );
 		} );
 
-		it.skip( `Remove ${ planName } from cart`, async function () {
+		it( `Remove ${ planName } from cart`, async function () {
 			await cartCheckoutPage.removeCartItem( planName );
 		} );
 
-		it.skip( 'Automatically return to purchase page', async function () {
+		it( 'Automatically return to purchase page', async function () {
 			individualPurchasesPage = new IndividualPurchasePage( page );
 			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -53,22 +53,22 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );
 
-		// causing failures on trunk
+		// The following tests are causing failures on trunk
 		/* eslint-disable jest/no-disabled-tests */
 		it.skip( 'Renew plan', async function () {
 			await individualPurchasesPage.clickRenewNowCardButton();
 		} );
 
-		it( `${ planName } is added to cart`, async function () {
+		it.skip( `${ planName } is added to cart`, async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
 			await cartCheckoutPage.validateCartItem( planName );
 		} );
 
-		it( `Remove ${ planName } from cart`, async function () {
+		it.skip( `Remove ${ planName } from cart`, async function () {
 			await cartCheckoutPage.removeCartItem( planName );
 		} );
 
-		it( 'Automatically return to purchase page', async function () {
+		it.skip( 'Automatically return to purchase page', async function () {
 			individualPurchasesPage = new IndividualPurchasePage( page );
 			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );


### PR DESCRIPTION
#### Proposed Changes

* Add a dynamic cachebuster to the Promoted Posts "widget.js" URL so that it updates once per hour so that people see a relatively recent version.

#### Testing Instructions

* Load advertising page for your blog, e.g. http://calypso.localhost:3000/advertising/goldsounds.blog
* Click "Promote" 
* In Chrome's network inspector, look for `ver` param of the widget.js
* Reload page an hour later (or set your computer's clock forward by at least an hour)
* Click "Promote" 
* Confirm that `ver` is different (which would bust the edge cache)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
