### PR TITLE
Jetpack Cloud Plugin Management: Update Tracks events on the plugin management related pages

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -33,7 +33,7 @@ export default ( { path } ) => {
 	);
 	const hasScan = useSelector( ( state ) => siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN ) );
 
-	const onNavigate = ( event ) => {
+	const onNavigate = ( event ) => () => {
 		dispatch( recordTracksEvent( event ) );
 
 		setNextLayoutFocus( 'content' );

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -33,8 +33,8 @@ export default ( { path } ) => {
 	);
 	const hasScan = useSelector( ( state ) => siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN ) );
 
-	const onNavigate = () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_settings_clicked' ) );
+	const onNavigate = ( event ) => {
+		dispatch( recordTracksEvent( event ) );
 
 		setNextLayoutFocus( 'content' );
 		window.scrollTo( 0, 0 );
@@ -72,7 +72,7 @@ export default ( { path } ) => {
 						comment: 'Jetpack sidebar navigation item',
 					} ) }
 					link={ pluginsPath( siteSlug ) }
-					onNavigate={ onNavigate }
+					onNavigate={ onNavigate( 'calypso_jetpack_sidebar_plugins_clicked' ) }
 					selected={ itemLinkMatches( pluginsPath( siteSlug ), path ) }
 				/>
 			) }
@@ -83,7 +83,7 @@ export default ( { path } ) => {
 						comment: 'Jetpack sidebar navigation item',
 					} ) }
 					link={ settingsPath( siteSlug ) }
-					onNavigate={ onNavigate }
+					onNavigate={ onNavigate( 'calypso_jetpack_sidebar_settings_clicked' ) }
 					selected={ itemLinkMatches( settingsPath( siteSlug ), path ) }
 				/>
 			) }
@@ -94,7 +94,7 @@ export default ( { path } ) => {
 						comment: 'Jetpack sidebar navigation item',
 					} ) }
 					link={ purchasesPath( siteSlug ) }
-					onNavigate={ onNavigate }
+					onNavigate={ onNavigate( 'calypso_jetpack_sidebar_purchases_clicked' ) }
 					selected={ itemLinkMatches( purchasesBasePath(), path ) }
 				/>
 			) }

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -33,17 +33,17 @@ export class PluginActivateToggle extends Component {
 
 		if ( plugin.active ) {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
-			recordEvent( 'calypso_plugin_activate_click', {
+			recordEvent( 'calypso_plugin_activate_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
-				state: 'deactivate',
+				state: 'inactive',
 			} );
 		} else {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
-			recordEvent( 'calypso_plugin_activate_click', {
+			recordEvent( 'calypso_plugin_activate_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
-				state: 'activate',
+				state: 'active',
 			} );
 		}
 	};

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -33,14 +33,14 @@ export class PluginActivateToggle extends Component {
 
 		if ( plugin.active ) {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
-			recordEvent( 'calypso_plugin_activate_toggle_click', {
+			recordEvent( 'calypso_plugin_active_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
 				state: 'inactive',
 			} );
 		} else {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
-			recordEvent( 'calypso_plugin_activate_toggle_click', {
+			recordEvent( 'calypso_plugin_active_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
 				state: 'active',

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -33,15 +33,17 @@ export class PluginActivateToggle extends Component {
 
 		if ( plugin.active ) {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
-			recordEvent( 'calypso_plugin_deactivate_click', {
+			recordEvent( 'calypso_plugin_activate_click', {
 				site: site.ID,
 				plugin: plugin.slug,
+				state: 'deactivate',
 			} );
 		} else {
 			recordGAEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
 			recordEvent( 'calypso_plugin_activate_click', {
 				site: site.ID,
 				plugin: plugin.slug,
+				state: 'activate',
 			} );
 		}
 	};

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -47,8 +47,17 @@ export class PluginActivateToggle extends Component {
 	};
 
 	trackManageConnectionLink = () => {
-		const { recordGoogleEvent: recordGAEvent } = this.props;
+		const {
+			site,
+			plugin,
+			recordGoogleEvent: recordGAEvent,
+			recordTracksEvent: recordEvent,
+		} = this.props;
 		recordGAEvent( 'Plugins', 'Clicked Manage Jetpack Connection Link', 'Plugin Name', 'jetpack' );
+		recordEvent( 'calypso_plugin_manage_connection_click', {
+			site: site.ID,
+			plugin: plugin.slug,
+		} );
 	};
 
 	manageConnectionLink() {

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -38,9 +38,10 @@ export class PluginAutoUpdateToggle extends Component {
 				'Plugin Name',
 				plugin.slug
 			);
-			recordEvent( 'calypso_plugin_autoupdate_disable_click', {
+			recordEvent( 'calypso_plugin_autoupdate_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
+				state: 'deactivate',
 			} );
 		} else {
 			recordGAEvent(
@@ -49,9 +50,10 @@ export class PluginAutoUpdateToggle extends Component {
 				'Plugin Name',
 				plugin.slug
 			);
-			recordEvent( 'calypso_plugin_autoupdate_enable_click', {
+			recordEvent( 'calypso_plugin_autoupdate_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
+				state: 'activate',
 			} );
 		}
 	};

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -41,7 +41,7 @@ export class PluginAutoUpdateToggle extends Component {
 			recordEvent( 'calypso_plugin_autoupdate_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
-				state: 'deactivate',
+				state: 'inactive',
 			} );
 		} else {
 			recordGAEvent(
@@ -53,7 +53,7 @@ export class PluginAutoUpdateToggle extends Component {
 			recordEvent( 'calypso_plugin_autoupdate_toggle_click', {
 				site: site.ID,
 				plugin: plugin.slug,
-				state: 'activate',
+				state: 'active',
 			} );
 		}
 	};

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getManageConnectionHref } from 'calypso/lib/plugins/utils';
@@ -17,11 +18,19 @@ export default function PluginManageConnection( { site, plugin }: Props ): React
 
 	const isJetpackPlugin = plugin && 'jetpack' === plugin.slug;
 
+	const trackManageConnection = () => {
+		recordTracksEvent( 'calypso_plugin_manage_connection_click', {
+			site: site.ID,
+			plugin: plugin.slug,
+		} );
+	};
+
 	return isJetpackPlugin ? (
 		<PopoverMenuItem
 			className="plugin-management-v2__actions"
 			icon="cog"
 			href={ getManageConnectionHref( site.slug ) }
+			onClick={ trackManageConnection }
 		>
 			{ translate( 'Manage Connection', {
 				comment: 'manage Jetpack connnection settings link',

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -67,6 +67,13 @@ export default function PluginRowFormatter( {
 			);
 		};
 
+	const trackPluginSiteCountButtonClick =
+		( siteId: number | undefined, pluginSlug: string ) => () => {
+			dispatch(
+				recordTracksEvent( 'calypso_plugin_site_count_click', { site: siteId, plugin: pluginSlug } )
+			);
+		};
+
 	const moment = useLocalizedMoment();
 	const state = useSelector( ( state ) => state );
 
@@ -177,7 +184,10 @@ export default function PluginRowFormatter( {
 					}
 				)
 			) : (
-				<PluginDetailsButton className="plugin-row-formatter__sites-count-button">
+				<PluginDetailsButton
+					className="plugin-row-formatter__sites-count-button"
+					onClick={ trackPluginSiteCountButtonClick( selectedSite?.ID, item.slug ) }
+				>
 					{ siteCount }
 				</PluginDetailsButton>
 			);

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement, ReactChild } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { INSTALL_PLUGIN, UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
@@ -10,6 +10,7 @@ import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggl
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 import UpdatePlugin from 'calypso/my-sites/plugins/plugin-management-v2/update-plugin';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isPluginActionInProgress,
 	getPluginOnSite,
@@ -42,8 +43,13 @@ export default function PluginRowFormatter( {
 	updatePlugin,
 }: Props ): ReactElement | any {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
-	const PluginDetailsButton = ( props: { className: string; children: ReactChild } ) => {
+	const PluginDetailsButton = ( props: {
+		className: string;
+		children: ReactChild;
+		onClick?: React.MouseEventHandler;
+	} ) => {
 		return (
 			<Button
 				borderless
@@ -53,6 +59,13 @@ export default function PluginRowFormatter( {
 			/>
 		);
 	};
+
+	const trackPluginDetailsButtonClick =
+		( siteId: number | undefined, pluginSlug: string ) => () => {
+			dispatch(
+				recordTracksEvent( 'calypso_plugin_details_click', { site: siteId, plugin: pluginSlug } )
+			);
+		};
 
 	const moment = useLocalizedMoment();
 	const state = useSelector( ( state ) => state );
@@ -107,7 +120,10 @@ export default function PluginRowFormatter( {
 		case 'plugin':
 			return isSmallScreen ? (
 				<>
-					<PluginDetailsButton className="plugin-row-formatter__plugin-name-card">
+					<PluginDetailsButton
+						className="plugin-row-formatter__plugin-name-card"
+						onClick={ trackPluginDetailsButtonClick( selectedSite?.ID, item.slug ) }
+					>
 						{ item.name }
 					</PluginDetailsButton>
 					{ pluginActionStatus }
@@ -138,7 +154,10 @@ export default function PluginRowFormatter( {
 							/>
 						) }
 						<div className="plugin-row-formatter__plugin-name-container">
-							<PluginDetailsButton className="plugin-row-formatter__plugin-name">
+							<PluginDetailsButton
+								className="plugin-row-formatter__plugin-name"
+								onClick={ trackPluginDetailsButtonClick( selectedSite?.ID, item.slug ) }
+							>
 								{ item.name }
 							</PluginDetailsButton>
 							<span className="plugin-row-formatter__overlay"></span>

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PluginCommonList from '../plugin-common/plugin-common-list';
@@ -38,6 +39,24 @@ export default function PluginsList( {
 		);
 	};
 
+	const trackManagePlugin = ( pluginSlug: string ) => () => {
+		recordTracksEvent( 'calypso_plugin_manage_click', {
+			site: selectedSite.ID,
+			plugin: pluginSlug,
+		} );
+	};
+
+	const trackRemovePlugin = ( pluginSlug: string ) => {
+		recordTracksEvent( 'calypso_plugin_remove_click', {
+			plugin: pluginSlug,
+		} );
+	};
+
+	const onRemoveClick = ( plugin: Plugin ) => () => {
+		removePluginNotice( plugin );
+		trackRemovePlugin( plugin.slug );
+	};
+
 	const renderActions = ( plugin: Plugin ) => {
 		return (
 			<>
@@ -45,6 +64,7 @@ export default function PluginsList( {
 					className="plugin-management-v2__actions"
 					icon="chevron-right"
 					href={ `/plugins/${ plugin.slug }${ selectedSite ? `/${ selectedSite.domain }` : '' }` }
+					onClick={ trackManagePlugin( plugin.slug ) }
 				>
 					{ translate( 'Manage Plugin' ) }
 				</PopoverMenuItem>
@@ -52,9 +72,9 @@ export default function PluginsList( {
 					<RemovePlugin site={ selectedSite } plugin={ plugin } />
 				) : (
 					<PopoverMenuItem
-						onClick={ () => removePluginNotice( plugin ) }
 						icon="trash"
 						className="plugin-management-v2__actions"
+						onClick={ onRemoveClick( plugin ) }
 					>
 						{ translate( 'Remove' ) }
 					</PopoverMenuItem>

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -41,7 +41,7 @@ export default function PluginsList( {
 
 	const trackManagePlugin = ( pluginSlug: string ) => () => {
 		recordTracksEvent( 'calypso_plugin_manage_click', {
-			site: selectedSite.ID,
+			site: selectedSite?.ID,
 			plugin: pluginSlug,
 		} );
 	};

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -3,10 +3,9 @@ import { Icon, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import PluginActionStatus from '../plugin-action-status';
@@ -34,7 +33,6 @@ export default function UpdatePlugin( {
 	const translate = useTranslate();
 	const allSites = useSelector( getSites );
 	const state = useSelector( ( state ) => state );
-	const dispatch = useDispatch();
 
 	const getPluginSites = ( plugin: Plugin ) => {
 		return Object.keys( plugin.sites ).map( ( siteId ) => {
@@ -44,19 +42,6 @@ export default function UpdatePlugin( {
 				...plugin.sites[ siteId ],
 			};
 		} );
-	};
-
-	const updateButtonOnClick = () => {
-		if ( updatePlugin ) {
-			updatePlugin( plugin );
-		}
-
-		dispatch(
-			recordTracksEvent( 'calypso_plugin_update_click', {
-				site: selectedSite?.ID,
-				plugin: plugin.slug,
-			} )
-		);
 	};
 
 	const sites = getPluginSites( plugin );
@@ -156,7 +141,7 @@ export default function UpdatePlugin( {
 					<Icon size={ 24 } icon={ arrowRight } />
 				</span>
 				<Button
-					onClick={ updateButtonOnClick }
+					onClick={ () => updatePlugin && updatePlugin( plugin ) }
 					className="update-plugin__new-version"
 					borderless
 					compact

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -3,9 +3,10 @@ import { Icon, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import PluginActionStatus from '../plugin-action-status';
@@ -33,6 +34,7 @@ export default function UpdatePlugin( {
 	const translate = useTranslate();
 	const allSites = useSelector( getSites );
 	const state = useSelector( ( state ) => state );
+	const dispatch = useDispatch();
 
 	const getPluginSites = ( plugin: Plugin ) => {
 		return Object.keys( plugin.sites ).map( ( siteId ) => {
@@ -42,6 +44,19 @@ export default function UpdatePlugin( {
 				...plugin.sites[ siteId ],
 			};
 		} );
+	};
+
+	const updateButtonOnClick = () => {
+		if ( updatePlugin ) {
+			updatePlugin( plugin );
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_plugin_update_click', {
+				site: selectedSite?.ID,
+				plugin: plugin.slug,
+			} )
+		);
 	};
 
 	const sites = getPluginSites( plugin );
@@ -141,7 +156,7 @@ export default function UpdatePlugin( {
 					<Icon size={ 24 } icon={ arrowRight } />
 				</span>
 				<Button
-					onClick={ () => updatePlugin && updatePlugin( plugin ) }
+					onClick={ updateButtonOnClick }
 					className="update-plugin__new-version"
 					borderless
 					compact

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -265,7 +265,7 @@ export class PluginsList extends Component {
 			','
 		);
 
-		recordTracksEvent( 'calypso_plugins_edit_action_click', {
+		recordTracksEvent( 'calypso_plugins_bulk_action_execute', {
 			action: actionName,
 			plugins: pluginSlugs,
 			sites: siteIds,
@@ -309,7 +309,7 @@ export class PluginsList extends Component {
 					} );
 			} );
 
-		recordTracksEvent( 'calypso_plugins_edit_action_click', {
+		recordTracksEvent( 'calypso_plugins_bulk_action_execute', {
 			action: 'updating',
 			plugins: [ ...updatedPlugins ].join( ',' ),
 			sites: [ ...updatedSites ].join( ',' ),
@@ -319,6 +319,7 @@ export class PluginsList extends Component {
 	updateAllPlugins = () => {
 		this.handleUpdatePlugins( this.props.plugins );
 		this.recordEvent( 'Clicked Update all Plugins', true );
+		recordTracksEvent( 'calypso_plugins_update_all_click' );
 	};
 
 	updateSelected = ( accepted ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR adds and updates Tracks events as necessary for the plugin management features in Calypso and Jetpack Cloud.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check that every action on the plugin management fires an appropriate Tracks event. These events are documented in p1HpG7-hd9-p2 and all events should be in sync with what is documented there.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202670599793009