### PR TITLE
Purchases: Convert purchases assembler to TypeScript

### DIFF
--- a/client/lib/purchases/assembler.ts
+++ b/client/lib/purchases/assembler.ts
@@ -1,7 +1,8 @@
-import { camelCase } from 'lodash';
+import { snakeToCamelCase } from '@automattic/js-utils';
+import type { Purchase, RawPurchase, RawPurchaseCreditCard } from './types';
 
-function createPurchaseObject( purchase ) {
-	const object = {
+function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditCard ): Purchase {
+	const object: Purchase = {
 		id: Number( purchase.ID ),
 		active: Boolean( purchase.active ),
 		amount: Number( purchase.amount ),
@@ -26,7 +27,7 @@ function createPurchaseObject( purchase ) {
 		error: null,
 		blogCreatedDate: purchase.blog_created_date,
 		expiryDate: purchase.expiry_date,
-		expiryStatus: camelCase( purchase.expiry_status ),
+		expiryStatus: snakeToCamelCase( purchase.expiry_status ),
 		iapPurchaseManagementLink: purchase.iap_purchase_management_link,
 		includedDomain: purchase.included_domain,
 		includedDomainPurchaseAmount: purchase.included_domain_purchase_amount,
@@ -98,7 +99,7 @@ function createPurchaseObject( purchase ) {
 		isAutoRenewEnabled: purchase.auto_renew === '1',
 	};
 
-	if ( 'credit_card' === purchase.payment_type ) {
+	if ( isCreditCardPurchase( purchase ) ) {
 		object.payment.creditCard = {
 			id: Number( purchase.payment_card_id ),
 			type: purchase.payment_card_type,
@@ -115,7 +116,13 @@ function createPurchaseObject( purchase ) {
 	return object;
 }
 
-export function createPurchasesArray( dataTransferObject ) {
+function isCreditCardPurchase(
+	purchase: RawPurchase | RawPurchaseCreditCard
+): purchase is RawPurchaseCreditCard {
+	return purchase.payment_type === 'credit_card';
+}
+
+export function createPurchasesArray( dataTransferObject: undefined | RawPurchase[] ): Purchase[] {
 	if ( ! Array.isArray( dataTransferObject ) ) {
 		return [];
 	}

--- a/client/lib/purchases/assembler.ts
+++ b/client/lib/purchases/assembler.ts
@@ -122,7 +122,9 @@ function isCreditCardPurchase(
 	return purchase.payment_type === 'credit_card';
 }
 
-export function createPurchasesArray( dataTransferObject: undefined | RawPurchase[] ): Purchase[] {
+export function createPurchasesArray(
+	dataTransferObject: undefined | ( RawPurchase | RawPurchaseCreditCard )[]
+): Purchase[] {
 	if ( ! Array.isArray( dataTransferObject ) ) {
 		return [];
 	}

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -130,7 +130,7 @@ export function getDisplayName( purchase: Purchase ): ReactChild | string | unde
 
 export function getPartnerName( purchase: Purchase ): string | null {
 	if ( isPartnerPurchase( purchase ) ) {
-		return purchase.partnerName;
+		return purchase.partnerName ?? null;
 	}
 	return null;
 }
@@ -562,7 +562,7 @@ export function isRenewing( purchase: Purchase ): boolean {
 }
 
 export function isWithinIntroductoryOfferPeriod( purchase: Purchase ): boolean {
-	return purchase.introductoryOffer?.isWithinPeriod;
+	return purchase.introductoryOffer?.isWithinPeriod ?? false;
 }
 
 export function isIntroductoryOfferFreeTrial( purchase: Purchase ): boolean {

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -1,4 +1,3 @@
-// TODO: complete this type
 export interface Purchase {
 	active?: boolean;
 	amount: number;
@@ -19,22 +18,11 @@ export interface Purchase {
 	error: null;
 	expiryDate: string;
 	expiryStatus: string;
-	iapPurchaseManagementLink?: string;
+	iapPurchaseManagementLink: string | null;
 	id: number;
 	includedDomain: string;
 	includedDomainPurchaseAmount: number;
-	introductoryOffer: {
-		costPerInterval: number;
-		endDate: string;
-		intervalCount: number;
-		intervalUnit: string;
-		isWithinPeriod: boolean;
-		transitionAfterRenewalCount: number;
-		isNextRenewalUsingOffer: boolean;
-		remainingRenewalsUsingOffer: number;
-		shouldProrateWhenOfferEnds: boolean;
-		isNextRenewalProrated: boolean;
-	} | null;
+	introductoryOffer: PurchaseIntroductoryOffer | null;
 	isAutoRenewEnabled: boolean;
 	isCancelable: boolean;
 	isDomainRegistration?: boolean;
@@ -46,9 +34,9 @@ export interface Purchase {
 	isRenewal: boolean;
 	meta?: string;
 	mostRecentRenewDate?: string;
-	partnerName: string;
-	partnerSlug: string;
-	payment: PurchasePayment;
+	partnerName: string | undefined;
+	partnerSlug: string | undefined;
+	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal;
 	pendingTransfer: boolean;
 	priceText: string;
 	productDisplayPrice: string;
@@ -57,9 +45,7 @@ export interface Purchase {
 	productSlug: string;
 	purchaseRenewalQuantity: number | null;
 	refundAmount: number;
-	refundOptions:
-		| { to_product_id: number; refund_amount: number; refund_currency_symbol: string }[]
-		| null;
+	refundOptions: RefundOptions | null;
 	refundPeriodInDays: number;
 	refundText: string;
 	regularPriceText: string;
@@ -68,21 +54,170 @@ export interface Purchase {
 	siteId: number;
 	siteName: string;
 	subscribedDate: string;
-	subscriptionStatus: string;
+	subscriptionStatus: 'active' | 'inactive';
 	totalRefundAmount: number;
 	totalRefundText: string;
 	userId: number;
+	partnerKeyId: number | undefined;
+	tagLine: string;
+	taxAmount: number | string | undefined;
+	taxText: string | undefined;
+}
+
+export interface RawPurchase {
+	ID: number | string;
+	active: boolean;
+	amount: number | string;
+	attached_to_purchase_id: number | string;
+	bill_period_days: number | string;
+	bill_period_label: string;
+	most_recent_renew_date: string;
+	can_disable_auto_renew: boolean;
+	can_reenable_auto_renewal: boolean;
+	can_explicit_renew: boolean;
+	cost_to_unbundle: undefined | number | string;
+	cost_to_unbundle_display: undefined | string;
+	price_text: string;
+	currency_code: string;
+	currency_symbol: string;
+	description: string;
+	domain: string;
+	domain_registration_agreement_url: string | undefined;
+	blog_created_date: string;
+	expiry_date: string;
+	expiry_status: string;
+	iap_purchase_management_link: string | null;
+	included_domain: string;
+	included_domain_purchase_amount: number;
+	introductory_offer: RawPurchaseIntroductoryOffer | null;
+	is_cancelable: boolean;
+	is_domain_registration: boolean;
+	is_locked: boolean;
+	is_iap_purchase: boolean;
+	is_rechargable: boolean;
+	is_refundable: boolean;
+	is_renewable: boolean;
+	is_renewal: boolean;
+	meta: string | undefined;
+	partner_name: string | undefined;
+	partner_slug: string | undefined;
+	partner_key_id: number | undefined;
+	payment_name: string;
+	payment_type:
+		| 'credit_card'
+		| 'paypal_direct'
+		| 'paypal'
+		| 'emergent-paywall'
+		| 'brazil-tef'
+		| string;
+	payment_country_name: string;
+	payment_country_code: string | null;
+	stored_details_id: string | null;
+	pending_transfer: boolean;
+	product_id: number | string;
+	product_name: string;
+	product_slug: string;
+	product_display_price: string;
+	total_refund_amount: number | undefined;
+	total_refund_text: string;
+	refund_amount: number;
+	refund_text: string;
+	refund_currency_symbol: string;
+	refund_options: RefundOptions | null;
+	refund_period_in_days: number;
+	regular_price_text: string;
+	renew_date: string;
+	sale_amount: number | undefined;
+	blog_id: number | string;
+	blogname: string;
+	subscribed_date: string;
+	subscription_status: 'active' | 'inactive';
+	tag_line: string;
+	tax_amount: number | string | undefined;
+	tax_text: string | undefined;
+	renewal_price_tier_usage_quantity: number | undefined | null;
+	user_id: number | string;
+	auto_renew: '1' | '0' | null;
+	payment_card_id: number | string | undefined;
+	payment_card_type: string | undefined;
+	payment_card_processor: string | undefined;
+	payment_details: string | undefined;
+	payment_expiry: string | undefined;
+}
+
+export type RawPurchaseCreditCard = RawPurchase & {
+	payment_type: 'credit_card';
+	payment_card_type: string;
+	payment_card_processor: string;
+	payment_details: string | number;
+	payment_expiry: string;
+};
+
+export interface RefundOptions {
+	to_product_id: number;
+	refund_amount: number;
+	refund_currency_symbol: string;
+}
+
+export interface RawPurchaseIntroductoryOffer {
+	cost_per_interval: number;
+	end_date: string;
+	interval_count: number;
+	interval_unit: string;
+	is_within_period: boolean;
+	transition_after_renewal_count: number;
+	is_next_renewal_using_offer: boolean;
+	remaining_renewals_using_offer: number;
+	should_prorate_when_offer_ends: boolean;
+	is_next_renewal_prorated: boolean;
+}
+
+export interface PurchaseIntroductoryOffer {
+	costPerInterval: number;
+	endDate: string;
+	intervalCount: number;
+	intervalUnit: string;
+	isWithinPeriod: boolean;
+	transitionAfterRenewalCount: number;
+	isNextRenewalUsingOffer: boolean;
+	remainingRenewalsUsingOffer: number;
+	shouldProrateWhenOfferEnds: boolean;
+	isNextRenewalProrated: boolean;
 }
 
 export interface PurchasePayment {
 	name: string | undefined;
 	type: string | undefined;
-	countryCode: string | undefined;
+	countryCode: string | undefined | null;
 	countryName: string | undefined;
-	storedDetailsId: string | number | undefined;
-	expiryDate?: string; // Only for payment.type === 'paypal_direct'
-	creditCard?: PurchasePaymentCreditCard; // Only for payment.type === 'credit_card'
+	storedDetailsId: string | number | undefined | null;
+	expiryDate?: string;
+	creditCard?: PurchasePaymentCreditCard;
 }
+
+/**
+ * A Purchase.payment where Purchase.payment_type === 'paypal_direct'
+ */
+export type PurchasePaymentWithPayPal = PurchasePayment & {
+	name: string;
+	countryCode: string | undefined | null;
+	countryName: string | undefined;
+	storedDetailsId: string | number;
+	type: string;
+	expiryDate: string;
+};
+
+/**
+ * A Purchase.payment where Purchase.payment_type === 'credit_card'
+ */
+export type PurchasePaymentWithCreditCard = PurchasePayment & {
+	name: string;
+	countryCode: string | undefined | null;
+	countryName: string | undefined;
+	storedDetailsId: string | number;
+	type: string;
+	creditCard: PurchasePaymentCreditCard;
+};
 
 export interface PurchasePaymentCreditCard {
 	id: number;

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -15,15 +15,26 @@ export interface Purchase {
 	currencySymbol: string;
 	description: string;
 	domain: string;
-	domainRegistrationAgreementUrl: any;
-	error: any;
+	domainRegistrationAgreementUrl: string | null;
+	error: null;
 	expiryDate: string;
 	expiryStatus: string;
 	iapPurchaseManagementLink?: string;
 	id: number;
 	includedDomain: string;
 	includedDomainPurchaseAmount: number;
-	introductoryOffer: any;
+	introductoryOffer: {
+		costPerInterval: number;
+		endDate: string;
+		intervalCount: number;
+		intervalUnit: string;
+		isWithinPeriod: boolean;
+		transitionAfterRenewalCount: number;
+		isNextRenewalUsingOffer: boolean;
+		remainingRenewalsUsingOffer: number;
+		shouldProrateWhenOfferEnds: boolean;
+		isNextRenewalProrated: boolean;
+	} | null;
 	isAutoRenewEnabled: boolean;
 	isCancelable: boolean;
 	isDomainRegistration?: boolean;
@@ -44,9 +55,11 @@ export interface Purchase {
 	productId: number;
 	productName: string;
 	productSlug: string;
-	purchaseRenewalQuantity: any;
+	purchaseRenewalQuantity: number | null;
 	refundAmount: number;
-	refundOptions: any;
+	refundOptions:
+		| { to_product_id: number; refund_amount: number; refund_currency_symbol: string }[]
+		| null;
 	refundPeriodInDays: number;
 	refundText: string;
 	regularPriceText: string;

--- a/packages/js-utils/src/snake-to-camel-case.ts
+++ b/packages/js-utils/src/snake-to-camel-case.ts
@@ -3,7 +3,10 @@
  *
  * This is designed to work nearly identically to the lodash `camelCase` function.
  */
-export default function snakeToCamelCase( snakeCaseString: string ): string {
+export default function snakeToCamelCase( snakeCaseString: string | undefined ): string {
+	if ( ! snakeCaseString ) {
+		return '';
+	}
 	return snakeCaseString
 		.toLowerCase()
 		.replace( /([-_][a-z0-9])/g, ( group ) =>

--- a/packages/js-utils/src/test/snake-to-camel-case.ts
+++ b/packages/js-utils/src/test/snake-to-camel-case.ts
@@ -13,11 +13,31 @@ describe( 'snakeToCamelCase', () => {
 		expect( snakeToCamelCase( 'camel_case_1' ) ).toBe( 'camelCase1' );
 	} );
 
-	it( 'transforms snake_case to camelCase for strings with a number_followed by a capital', () => {
+	it( 'transforms snake_case to camelCase for strings with a number followed by a capital', () => {
 		expect( snakeToCamelCase( 'camel_case_1_hi' ) ).toBe( 'camelCase1Hi' );
 	} );
 
 	it( 'transforms snake_case to camelCase for strings with multiple adjacent numbers', () => {
 		expect( snakeToCamelCase( 'hello_1234_thing' ) ).toBe( 'hello1234Thing' );
+	} );
+
+	it( 'transforms kebab-case to camelCase for strings with two words', () => {
+		expect( snakeToCamelCase( 'kebab-case' ) ).toBe( 'kebabCase' );
+	} );
+
+	it( 'transforms kebab-case to camelCase for strings with four words', () => {
+		expect( snakeToCamelCase( 'kebab-case-is-fun' ) ).toBe( 'kebabCaseIsFun' );
+	} );
+
+	it( 'transforms kebab-case to camelCase for strings with a number', () => {
+		expect( snakeToCamelCase( 'kebab-case-1' ) ).toBe( 'kebabCase1' );
+	} );
+
+	it( 'transforms kebab-case to camelCase for strings with a number followed by a capital', () => {
+		expect( snakeToCamelCase( 'kebab-case-1-hi' ) ).toBe( 'kebabCase1Hi' );
+	} );
+
+	it( 'transforms kebab-case to camelCase for strings with multiple adjacent numbers', () => {
+		expect( snakeToCamelCase( 'hello-1234-thing' ) ).toBe( 'hello1234Thing' );
 	} );
 } );

--- a/packages/js-utils/src/test/snake-to-camel-case.ts
+++ b/packages/js-utils/src/test/snake-to-camel-case.ts
@@ -40,4 +40,8 @@ describe( 'snakeToCamelCase', () => {
 	it( 'transforms kebab-case to camelCase for strings with multiple adjacent numbers', () => {
 		expect( snakeToCamelCase( 'hello-1234-thing' ) ).toBe( 'hello1234Thing' );
 	} );
+
+	it( 'transforms undefined to ""', () => {
+		expect( snakeToCamelCase( undefined ) ).toBe( '' );
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/66427 which converted the functions in `lib/purchases` to TypeScript. This PR converts the `createPurchasesArray()` function to TypeScript as well. In so doing, it also completes the `Purchase` type which had been slowly filled in up until now and provides a `RawPurchase` type for the API response.

#### Testing Instructions

No testing should be required.

Apart from type changes which are always safe (as long as the type checker completes), this makes only three small changes to functional code. I will highlight each one with inline comments in this PR but one is removing lodash and the other two just provide fallbacks for undefined data. None should affect behavior.
