### PR TITLE
Ability to define JITM image via an image path

### DIFF
--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -36,6 +36,18 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 		}
 	}
 
+	// Colour scheme for Google Workspace sale JITM
+	&.modal--google_workspace_engagement_customers {
+		.modal__sidebar {
+			background: var( --color-surface );
+			margin-right: 20px;
+		}
+
+		.components-button:hover svg {
+			fill: var( --color-neutral-20 );
+		}
+	}
+
 	.components-modal__header {
 		display: flex;
 		position: absolute;

--- a/client/blocks/jitm/templates/modal.jsx
+++ b/client/blocks/jitm/templates/modal.jsx
@@ -12,7 +12,6 @@ export default function ModalTemplate( {
 	featureClass,
 	icon,
 	iconPath,
-	iconBgColour,
 	message,
 	onClick,
 	onDismiss,
@@ -48,7 +47,7 @@ export default function ModalTemplate( {
 		}
 	};
 
-	const getModalClassName = () => {
+	const getModalImageClassName = () => {
 		switch ( icon ) {
 			case 'embedded-inbox':
 				return 'modal__embedded-inbox';
@@ -57,9 +56,13 @@ export default function ModalTemplate( {
 		}
 	};
 
+	const getModalClassName = () => {
+		return `modal__main modal--${ featureClass }`;
+	};
+
 	return isDismissed.includes( featureClass ) ? null : (
 		<Guide
-			className="modal__main"
+			className={ getModalClassName() }
 			contentLabel={ message }
 			onFinish={ () => {
 				onDismiss();
@@ -92,9 +95,9 @@ export default function ModalTemplate( {
 									<p className="modal__disclaimer">{ line }</p>
 								) ) }
 							</div>
-							<div className="modal__sidebar" style={ { backgroundColor: iconBgColour } }>
+							<div className="modal__sidebar">
 								<img
-									className={ getModalClassName() }
+									className={ getModalImageClassName() }
 									src={ getModalImage() }
 									alt={ getModalAltText() }
 								/>

--- a/client/blocks/jitm/templates/modal.jsx
+++ b/client/blocks/jitm/templates/modal.jsx
@@ -11,6 +11,8 @@ export default function ModalTemplate( {
 	disclaimer,
 	featureClass,
 	icon,
+	iconPath,
+	iconBgColour,
 	message,
 	onClick,
 	onDismiss,
@@ -22,6 +24,11 @@ export default function ModalTemplate( {
 	const translate = useTranslate();
 
 	const getModalImage = () => {
+		// If a direct path is provided, use the referenced image as the JITM artwork.
+		if ( iconPath ) {
+			return iconPath;
+		}
+
 		switch ( icon ) {
 			case 'embedded-inbox':
 				return Inbox;
@@ -85,7 +92,7 @@ export default function ModalTemplate( {
 									<p className="modal__disclaimer">{ line }</p>
 								) ) }
 							</div>
-							<div className="modal__sidebar">
+							<div className="modal__sidebar" style={ { backgroundColor: iconBgColour } }>
 								<img
 									className={ getModalClassName() }
 									src={ getModalImage() }

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -33,6 +33,7 @@ const transformApiRequest = ( { data: jitms } ) =>
 		classes: unescapeDecimalEntities( jitm.content.classes || '' ),
 		icon: unescapeDecimalEntities( jitm.content.icon || '' ),
 		iconPath: unescapeDecimalEntities( jitm.content.iconPath || '' ),
+		iconBgColour: unescapeDecimalEntities( jitm.content.iconBgColour || '' ),
 		featureClass: jitm.feature_class,
 		CTA: {
 			message: unescapeDecimalEntities( jitm.CTA.message ),

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -33,7 +33,6 @@ const transformApiRequest = ( { data: jitms } ) =>
 		classes: unescapeDecimalEntities( jitm.content.classes || '' ),
 		icon: unescapeDecimalEntities( jitm.content.icon || '' ),
 		iconPath: unescapeDecimalEntities( jitm.content.iconPath || '' ),
-		iconBgColour: unescapeDecimalEntities( jitm.content.iconBgColour || '' ),
 		featureClass: jitm.feature_class,
 		CTA: {
 			message: unescapeDecimalEntities( jitm.CTA.message ),


### PR DESCRIPTION
#### Proposed Changes

The proposed change enables:
* A JITM image to be configured using an image path `iconPath`
* Custom style to be applied to the JITM based on the class name `modal--{featureClass}`

#### Testing Instructions

This needs to be tested with D85911-code. Please follow the test instructions in outlined in that patch.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #