### PR TITLE
i18N: Translate Logged-out Theme Showcase meta title and description

### DIFF
--- a/client/state/themes/selectors/get-theme-showcase-description.js
+++ b/client/state/themes/selectors/get-theme-showcase-description.js
@@ -1,3 +1,4 @@
+import i18n from 'i18n-calypso';
 import { get, includes } from 'lodash';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
@@ -36,8 +37,7 @@ export function getThemeShowcaseDescription( state, { filter, tier, vertical } =
 		return 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.';
 	}
 
-	return (
-		'Beautiful, responsive, free and premium WordPress themes ' +
-		'for your photography site, portfolio, magazine, business website, or blog.'
+	return i18n.translate(
+		'Beautiful, responsive, free and premium WordPress themes for your photography site, portfolio, magazine, business website, or blog.'
 	);
 }

--- a/client/state/themes/selectors/get-theme-showcase-title.js
+++ b/client/state/themes/selectors/get-theme-showcase-title.js
@@ -1,7 +1,7 @@
+import i18n from 'i18n-calypso';
 import { get, includes } from 'lodash';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
-
 import 'calypso/state/themes/init';
 
 export function getThemeShowcaseTitle( state, { filter, tier, vertical } = {} ) {
@@ -26,5 +26,5 @@ export function getThemeShowcaseTitle( state, { filter, tier, vertical } = {} ) 
 		return 'Premium WordPress Themes';
 	}
 
-	return 'WordPress Themes';
+	return i18n.translate( 'WordPress Themes' );
 }


### PR DESCRIPTION
#### Proposed Changes

* TBD

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
