### PR TITLE
fixes nudge positioning issue, added top padding to the container

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -18,6 +18,8 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import SingleListView from '../plugins-browser/single-list-view';
 import usePlugins from '../use-plugins';
 
+import './style.scss';
+
 /**
  * Module variables
  */

--- a/client/my-sites/plugins/plugins-discovery-page/style.scss
+++ b/client/my-sites/plugins/plugins-discovery-page/style.scss
@@ -1,0 +1,3 @@
+.plugins-discovery-page__upgrade-banner {
+    padding-top: 2px;
+}


### PR DESCRIPTION
Fixes Issue https://github.com/Automattic/wp-calypso/issues/66484

#### Proposed Changes

* Upgrade Nudge in plugins was overlapping with the border, this PR fixes it by adding top padding to the container.

### Before
<img width="1033" alt="Screenshot 2022-08-14 at 11 00 06 PM" src="https://user-images.githubusercontent.com/4111723/184548308-0f138ae5-ca14-4b3c-b853-415256ddaaae.png">

### After
<img width="1009" alt="Screenshot 2022-08-14 at 10 58 32 PM" src="https://user-images.githubusercontent.com/4111723/184548322-f4c129a7-20cf-4279-a166-c2d6b4fdd7a4.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
