### PR TITLE
Launchpad: Add go to admin escape hatch

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,8 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSite } from '../hooks/use-site';
-import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { useSiteSlug } from '../hooks/use-site-slug';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -22,15 +21,7 @@ export const linkInBio: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		const siteSlugParam = useSiteSlugParam();
-		const site = useSite();
-
-		let siteSlug: string | null = null;
-		if ( siteSlugParam ) {
-			siteSlug = siteSlugParam;
-		} else if ( site ) {
-			siteSlug = new URL( site.URL ).host;
-		}
+		const siteSlug = useSiteSlug();
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			return providedDependencies;

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../hooks/use-site';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -20,6 +22,16 @@ export const linkInBio: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
+		const siteSlugParam = useSiteSlugParam();
+		const site = useSite();
+
+		let siteSlug: string | null = null;
+		if ( siteSlugParam ) {
+			siteSlug = siteSlugParam;
+		} else if ( site ) {
+			siteSlug = new URL( site.URL ).host;
+		}
+
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			return providedDependencies;
 		}
@@ -29,6 +41,14 @@ export const linkInBio: Flow = {
 		};
 
 		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'intro':
+					return navigate( 'linkInBioSetup' );
+
+				case 'launchpad':
+					return window.location.replace( `/view/${ siteSlug }` );
+			}
+
 			navigate( 'linkInBioSetup' );
 			return;
 		};

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -3,6 +3,8 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../hooks/use-site';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow } from './internals/types';
 
@@ -27,6 +29,15 @@ export const newsletter: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const siteSlugParam = useSiteSlugParam();
+		const site = useSite();
+
+		let siteSlug: string | null = null;
+		if ( siteSlugParam ) {
+			siteSlug = siteSlugParam;
+		} else if ( site ) {
+			siteSlug = new URL( site.URL ).host;
+		}
 
 		function submit() {
 			switch ( _currentStep ) {
@@ -57,6 +68,10 @@ export const newsletter: Flow = {
 
 				case 'processingFake':
 					return navigate( 'launchpad' );
+
+				case 'launchpad':
+					// TODO: Handle null case
+					return window.location.replace( `/home/${ siteSlug }` );
 
 				default:
 					return navigate( 'intro' );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import { useSite } from '../hooks/use-site';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import type { StepPath } from './internals/steps-repository';
@@ -39,6 +40,20 @@ export const newsletter: Flow = {
 			siteSlug = new URL( site.URL ).host;
 		}
 
+		const exitLaunchpad = async ( siteSlug: string | null ) => {
+			// TODO: Handle null case for site slug
+			try {
+				await wpcom.req.post( `/sites/${ siteSlug }/settings`, {
+					apiVersion: '1.1',
+					launchpad_screen: 'off',
+				} );
+
+				window.location.replace( `/home/${ siteSlug }` );
+			} catch ( err: any ) {
+				// TODO: Add error handling
+			}
+		};
+
 		function submit() {
 			switch ( _currentStep ) {
 				case 'completingPurchase':
@@ -70,8 +85,8 @@ export const newsletter: Flow = {
 					return navigate( 'launchpad' );
 
 				case 'launchpad':
-					// TODO: Handle null case
-					return window.location.replace( `/home/${ siteSlug }` );
+					navigate( 'processingFake' );
+					return exitLaunchpad( siteSlug );
 
 				default:
 					return navigate( 'intro' );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -3,8 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSite } from '../hooks/use-site';
-import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { useSiteSlug } from '../hooks/use-site-slug';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow } from './internals/types';
 
@@ -29,15 +28,7 @@ export const newsletter: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
-		const siteSlugParam = useSiteSlugParam();
-		const site = useSite();
-
-		let siteSlug: string | null = null;
-		if ( siteSlugParam ) {
-			siteSlug = siteSlugParam;
-		} else if ( site ) {
-			siteSlug = new URL( site.URL ).host;
-		}
+		const siteSlug = useSiteSlug();
 
 		function submit() {
 			switch ( _currentStep ) {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -3,7 +3,6 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import wpcom from 'calypso/lib/wp';
 import { useSite } from '../hooks/use-site';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import type { StepPath } from './internals/steps-repository';
@@ -40,20 +39,6 @@ export const newsletter: Flow = {
 			siteSlug = new URL( site.URL ).host;
 		}
 
-		const exitLaunchpad = async ( siteSlug: string | null ) => {
-			// TODO: Handle null case for site slug
-			try {
-				await wpcom.req.post( `/sites/${ siteSlug }/settings`, {
-					apiVersion: '1.1',
-					launchpad_screen: 'off',
-				} );
-
-				window.location.replace( `/home/${ siteSlug }` );
-			} catch ( err: any ) {
-				// TODO: Add error handling
-			}
-		};
-
 		function submit() {
 			switch ( _currentStep ) {
 				case 'completingPurchase':
@@ -85,8 +70,7 @@ export const newsletter: Flow = {
 					return navigate( 'launchpad' );
 
 				case 'launchpad':
-					navigate( 'processingFake' );
-					return exitLaunchpad( siteSlug );
+					return window.location.replace( `/view/${ siteSlug }` );
 
 				default:
 					return navigate( 'intro' );

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../hooks/use-site';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -18,7 +20,17 @@ export const podcasts: Flow = {
 		] as StepPath[];
 	},
 
-	useStepNavigation( currentStep, navigate ) {
+	useStepNavigation( _currentStep, navigate ) {
+		const siteSlugParam = useSiteSlugParam();
+		const site = useSite();
+
+		let siteSlug: string | null = null;
+		if ( siteSlugParam ) {
+			siteSlug = siteSlugParam;
+		} else if ( site ) {
+			siteSlug = new URL( site.URL ).host;
+		}
+
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			return providedDependencies;
 		}
@@ -28,8 +40,13 @@ export const podcasts: Flow = {
 		};
 
 		const goNext = () => {
-			navigate( 'chooseADomain' );
-			return;
+			switch ( _currentStep ) {
+				case 'letsGetStarted':
+					return navigate( 'chooseADomain' );
+
+				case 'launchpad':
+					return window.location.replace( `/view/${ siteSlug }` );
+			}
 		};
 
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -1,8 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSite } from '../hooks/use-site';
-import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { useSiteSlug } from '../hooks/use-site-slug';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -21,15 +20,7 @@ export const podcasts: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		const siteSlugParam = useSiteSlugParam();
-		const site = useSite();
-
-		let siteSlug: string | null = null;
-		if ( siteSlugParam ) {
-			siteSlug = siteSlugParam;
-		} else if ( site ) {
-			siteSlug = new URL( site.URL ).host;
-		}
+		const siteSlug = useSiteSlug();
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			return providedDependencies;

--- a/client/landing/stepper/hooks/use-site-slug.ts
+++ b/client/landing/stepper/hooks/use-site-slug.ts
@@ -1,0 +1,16 @@
+import { useSite } from './use-site';
+import { useSiteSlugParam } from './use-site-slug-param';
+
+export function useSiteSlug() {
+	const siteSlugParam = useSiteSlugParam();
+	const site = useSite();
+
+	let siteSlug: string | null = null;
+	if ( siteSlugParam ) {
+		siteSlug = siteSlugParam;
+	} else if ( site ) {
+		siteSlug = new URL( site.URL ).host;
+	}
+
+	return siteSlug;
+}


### PR DESCRIPTION
## Context
Develop an 'escape hatch' for the full-screen LaunchPad mode. In designs we can see this as a "Skip to Admin" button. More context and designs - paYE8P-1Ot-p2

![2022-08-15 11 14 12](https://user-images.githubusercontent.com/5414230/184691967-be298f17-60c7-41b5-9ab4-6b06b491a623.gif)

## Proposed Changes
* User is navigated to the WordPress view page when escape hatch is used

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* `yarn start`
* Navigate to the launchpad screen for different flows
  * `http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=[YOUR_SITE_SLUG_HERE]`
  *  `http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=[YOUR_SITE_SLUG_HERE]`
  *  `http://calypso.localhost:3000/setup/launchpad?flow=podcasts&siteSlug=[YOUR_SITE_SLUG_HERE]`
* Click on the `Go to Admin` button in the bottom of the left-hand sidebar
* The user should be redirected to the WordPress view page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66120