### PR TITLE
Design Picker: Enable signup/design-picker-unified flag

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -117,7 +117,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
-		"signup/design-picker-unified": false,
+		"signup/design-picker-unified": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,7 +117,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
-		"signup/design-picker-unified": false,
+		"signup/design-picker-unified": true,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,
 		"signup/inline-help": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,7 +125,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
-		"signup/design-picker-unified": false,
+		"signup/design-picker-unified": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,


### PR DESCRIPTION
#### Proposed Changes

* Enable `signup/design-picker-unified` flag to ship the UDP to production

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup`
* Select one of the following intents
  * Write & Publish
  * Promote myself or business
  * Sell online
  * Other
* Select any vertical
* When you land on the design picker, you have to see the Unified Design Picker and everything works as expected.

See pdtkmj-h8-p2 for more details

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64998