### PR TITLE
Emails: update inbox textual information to encourage trial users to use more titan accounts

### DIFF
--- a/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
+++ b/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Ribbon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -47,9 +47,16 @@ const NewMailboxUpsell = ( { domains }: { domains: ResponseDomain[] } ) => {
 	return (
 		<div className="new-mailbox-upsell__container">
 			<div className="new-mailbox-upsell">
+				{ isFreeTrialNow && <Ribbon color="green">FREE</Ribbon> }
 				<div className="new-mailbox-upsell__messages">
 					<h2>{ translate( 'Need another mailbox?' ) }</h2>
-					<div>{ translate( 'Create a new one and activate it immediately.' ) }</div>
+					<div>
+						{ isFreeTrialNow
+							? translate(
+									'Create a new one for free during your trial to experience multiple mailbox efficiency.'
+							  )
+							: translate( 'Create a new one now to experience multiple mailbox efficiency.' ) }
+					</div>
 				</div>
 				<div className="new-mailbox-upsell__cta">
 					<Button

--- a/client/my-sites/email/inbox/new-mailbox-upsell/style.scss
+++ b/client/my-sites/email/inbox/new-mailbox-upsell/style.scss
@@ -16,7 +16,7 @@
 		flex-direction: column;
 		justify-content: space-between;
 		margin: 48px auto 0;
-		padding: 16px;
+		padding: 16px 40px;
 		position: relative;
 
 		@include break-medium {


### PR DESCRIPTION
#### Proposed Changes

This pull request updates the "Create new mailbox" upsell element to encourage new mailbox creation during Titan's free trial.
So the users see a ribbon with "free" text and a new description. And other users just see another new description to have consistency.

#### Testing Instructions
Let's check a few scenarios.
**1) Test appearing of the ribbon and the new description of the upsell element (*for Professional Email*)**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* If you have existed account with Professional Email (FREE TRIAL):
	* Choose your account with the Professional Email (FREE TRIAL)
* Otherwise, if you don't have existed account with the Professional Email (FREE TRIAL):
    * Click on "Add new site" at the end of the appeared list
    * Enter any domain name for test purposes
    * In the appeared list below - choose a domain with the help of the "Select" button
    * Choose any plan from the proposed with the help of the "Select" button
    * Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
    * Fill data in the "Professional Email" form to create your 3-month free email account and click on the "Add professional Email" button
    * Scroll down and click on "Complete Checkout"
    * On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
* In the left sidebar menu, click on the "Inbox" item

| BEFORE  | AFTER |
| ------------- | ------------- |
| ------------- | We can see the ribbon with "free" text and the new description|
![image](https://user-images.githubusercontent.com/5598437/184631429-00f61d46-660e-4009-b8c2-8e4ace520567.png) | ![image](https://user-images.githubusercontent.com/5598437/184631589-fc5f10cb-8b0f-4d94-9900-32a0cd86beb7.png)

**2) Test that the ribbon has disappeared for non-trial users, and the description of the upsell element has been changed (*for Professional Email*)**
* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
* Click on the "Renew now" button, which is located at the top part of the page body (on the right side of the text "Expires: {Date}")
* Scroll down and click on "Pay {amount} with credits"
* In the top left corner of the page, click the "My Sites" button
* In the left sidebar, click on the "Inbox" item

| BEFORE  | AFTER |
| ------------- | ------------- |
| ------------- | Ribbon disappeared, and now we have another new description |
![image](https://user-images.githubusercontent.com/5598437/184631429-00f61d46-660e-4009-b8c2-8e4ace520567.png) | ![image](https://user-images.githubusercontent.com/5598437/184632226-ead34980-a32d-474b-b006-cb7b1622a2ef.png)


**3) Test that in case of buying "Google Workspace" - we see only new description and we never see the ribbon**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* Recommended if you have existed account with "Google Workspace" subscription:
	* Choose your account with the "Google Workspace" subscription
* Otherwise, if you don't have existed account with the "Google Workspace" subscription:
    * Click on "Add new site" at the end of the appeared list
    * Enter any domain name for test purposes
    * In the appeared list below - choose a domain with the help of the "Select" button
    * Choose any plan from the proposed with the help of the "Select" button
    * Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
    * Note, on the page "Add Professional Email" - click on the "Skip for now" button
    * On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
    * In the left sidebar menu, click on the "Inbox" item
    * At the bottom of the page is located the "Google Workspace" section, click on the "Select" button, on the right side of the section
    * Fill "Google Workspace" form and click on the "Purchase" button, below the form
    * Click on "Pay {amount} with credits"
    * Click on the "Manage email" button in the middle of the page body
    * In the left sidebar menu, click on the "Inbox" item
    * If you see the warning "Configuring mailboxes" at the top part of the page body - it means that it's necessary to wait a bit, so at the current moment, you can go to the kitchen and make a cup of coffee 🙃
    * Reload the page to check for any news regarding the configuration of your mailboxes. 
    * If it's finished, you will see the notification "Action required". So click on the "Finish setup" button under the notification and follow the instructions.
	* After finishing setup - come back to the dashboard
* In the left sidebar, click on the "Inbox" item

| BEFORE  | AFTER |
| ------------- | ------------- |
| ------------- | We see the same result as for paid "Professional Email" |
![image](https://user-images.githubusercontent.com/5598437/184631429-00f61d46-660e-4009-b8c2-8e4ace520567.png) | ![image](https://user-images.githubusercontent.com/5598437/184632226-ead34980-a32d-474b-b006-cb7b1622a2ef.png)

#### Pre-merge Checklist
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202735679392334/f