### PR TITLE
Show Plugin details CTA button for pages for logged-out users

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import config from '@automattic/calypso-config';
 import {
 	isFreePlanProduct,
@@ -5,6 +6,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -14,6 +16,7 @@ import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-pl
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import {
 	isRequestingForSites,
@@ -66,6 +69,7 @@ const PluginDetailsCTA = ( props ) => {
 		: FEATURE_INSTALL_PLUGINS;
 	const incompatiblePlugin = ! isJetpackSelfHosted && ! isCompatiblePlugin( pluginSlug );
 	const userCantManageTheSite = ! userCan( 'manage_options', selectedSite );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const sitePlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSite?.ID, pluginSlug )
 	);
@@ -198,7 +202,7 @@ const PluginDetailsCTA = ( props ) => {
 		);
 	}
 
-	if ( ! selectedSite ) {
+	if ( ! selectedSite && isLoggedIn ) {
 		// Check if there is no site selected
 		return (
 			<div className="plugin-details-CTA__container">
@@ -259,18 +263,29 @@ const PluginDetailsCTA = ( props ) => {
 				/>
 			) }
 			<div className="plugin-details-CTA__install">
-				<CTAButton
-					plugin={ plugin }
-					isPluginInstalledOnsite={ isPluginInstalledOnsite }
-					isJetpackSelfHosted={ isJetpackSelfHosted }
-					selectedSite={ selectedSite }
-					hasEligibilityMessages={ hasEligibilityMessages }
-					isMarketplaceProduct={ isMarketplaceProduct }
-					billingPeriod={ billingPeriod }
-					shouldUpgrade={ shouldUpgrade }
-					isSiteConnected={ isSiteConnected }
-					disabled={ incompatiblePlugin || userCantManageTheSite }
-				/>
+				{ isLoggedIn ? (
+					<CTAButton
+						plugin={ plugin }
+						isPluginInstalledOnsite={ isPluginInstalledOnsite }
+						isJetpackSelfHosted={ isJetpackSelfHosted }
+						selectedSite={ selectedSite }
+						hasEligibilityMessages={ hasEligibilityMessages }
+						isMarketplaceProduct={ isMarketplaceProduct }
+						billingPeriod={ billingPeriod }
+						shouldUpgrade={ shouldUpgrade }
+						isSiteConnected={ isSiteConnected }
+						disabled={ incompatiblePlugin || userCantManageTheSite }
+					/>
+				) : (
+					<Button
+						type="a"
+						className="plugin-details-CTA__install-button"
+						primary
+						href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
+					>
+						{ translate( 'View plans' ) }
+					</Button>
+				) }
 			</div>
 			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 				<div className="plugin-details-CTA__t-and-c">
@@ -293,7 +308,7 @@ const PluginDetailsCTA = ( props ) => {
 					) }
 				</div>
 			) }
-			{ shouldUpgrade && (
+			{ shouldUpgrade && isLoggedIn && (
 				<div className="plugin-details-CTA__upgrade-required">
 					<span className="plugin-details-CTA__upgrade-required-icon">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }


### PR DESCRIPTION
#### Proposed Changes

More info: pau2Xa-4j7-p2

This shows a `View plans` CTA button on the Plugin details page pointing to the [/pricing](https://wordpress.com/pricing/) page.

#### Testing Instructions

* Log out
* Go to `/plugins/wordpress-seo-premium` and `/plugins/mailpoet`
* There should be a `VIew plan` CTA button which points to https://wordpress.com/pricing

<img width="320" alt="Screenshot on 2022-08-15 at 16-22-09" src="https://user-images.githubusercontent.com/2749938/184643306-b7504b3e-f600-4cf9-8351-5d0ef918c4b3.png">
<img width="320" alt="Screenshot on 2022-08-15 at 16-21-55" src="https://user-images.githubusercontent.com/2749938/184643296-01febdd3-b389-405b-835b-a5243b55a02d.png">


* The page should be unaffected if logged in
