### PR TITLE
Add Jetpack logo to Jetpack plans on sites list

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -11,6 +11,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'options',
 	'plan',
 	'jetpack',
+	'is_wpcom_atomic',
 ] as const;
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { memo } from 'react';
+import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
 import { useSiteStatus } from '../hooks/use-site-status';
 import { displaySiteUrl, getDashboardUrl } from '../utils';
@@ -64,11 +65,21 @@ const ListTileSubtitle = styled.div`
 	align-items: center;
 `;
 
+const SitePlan = styled.div`
+	display: flex;
+	line-height: 16px;
+`;
+
+const SitePlanIcon = styled.div`
+	margin-right: 6px;
+`;
+
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const { translatedStatus } = useSiteStatus( site );
 
 	const isP2Site = site.options?.is_wpforteams_site;
+	const isAtomicSite = site?.is_wpcom_atomic;
 
 	return (
 		<Row>
@@ -108,7 +119,16 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					}
 				/>
 			</Column>
-			<Column mobileHidden>{ site.plan.product_name_short }</Column>
+			<Column mobileHidden>
+				<SitePlan>
+					{ site.jetpack && ! isAtomicSite && (
+						<SitePlanIcon>
+							<JetpackLogo size={ 16 } />
+						</SitePlanIcon>
+					) }
+					{ site.plan.product_name_short }
+				</SitePlan>
+			</Column>
 			<Column mobileHidden>
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>


### PR DESCRIPTION
#### Proposed Changes

In this PR, I  propose to add a Jetpack logo to Jetpack plans on the Sites Management Page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load Sites Management Page using `/sites-dashboard` URL
2. Locate Jetpack sites and confirm that plan name is prepended with Jetpack icon
3. Locate Atomic sites and confirm that there is no icon there

![Screen Shot 2022-08-15 at 17 42 04](https://user-images.githubusercontent.com/727413/184668553-71f6658d-6a9d-4640-a0ac-49f22499a248.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/66523
