### PR TITLE
Add props to hide url bar and choose devices in DesignPickerPreviewToolbar component

### DIFF
--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -19,9 +19,9 @@ const DesignPickerPreviewToolbar = ( {
 	filterDevicesToShow,
 } ) => {
 	const devices = React.useRef( {
-		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 24 },
+		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 36 },
 		tablet: { title: translate( 'Tablet' ), icon: tablet, iconSize: 24 },
-		phone: { title: translate( 'Phone' ), icon: phone, iconSize: 18 },
+		phone: { title: translate( 'Phone' ), icon: phone, iconSize: 24 },
 	} );
 
 	function filterDevices( selectedDevices ) {

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -15,18 +15,37 @@ const DesignPickerPreviewToolbar = ( {
 	showDeviceSwitcher,
 	setDeviceViewport,
 	translate,
+	showSiteAddressBar,
+	filterDevicesToShow,
 } ) => {
 	const devices = React.useRef( {
-		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 36 },
+		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 24 },
 		tablet: { title: translate( 'Tablet' ), icon: tablet, iconSize: 24 },
-		phone: { title: translate( 'Phone' ), icon: phone, iconSize: 24 },
+		phone: { title: translate( 'Phone' ), icon: phone, iconSize: 18 },
 	} );
+
+	function filterDevices( selectedDevices ) {
+		// If invalid input, display all possible devices
+		// If valid input, Will filter out any devices that do not exist in the 'possibleDevices' array above
+		if ( Array.isArray( selectedDevices ) && selectedDevices.length > 0 ) {
+			const filteredPossibleDevices = selectedDevices.filter( ( device ) => {
+				return possibleDevices.includes( device );
+			} );
+
+			return filteredPossibleDevices;
+		}
+		return possibleDevices;
+	}
+
+	const filteredPossibleDevices = filterDevicesToShow
+		? filterDevices( filterDevicesToShow )
+		: possibleDevices;
 
 	return (
 		<div className="preview-toolbar__toolbar">
 			{ showDeviceSwitcher && (
 				<div className="preview-toolbar__devices">
-					{ possibleDevices.map( ( device ) => (
+					{ filteredPossibleDevices.map( ( device ) => (
 						<Button
 							key={ device }
 							borderless
@@ -44,16 +63,18 @@ const DesignPickerPreviewToolbar = ( {
 					) ) }
 				</div>
 			) }
-			<div className="preview-toolbar__browser-header">
-				<svg width="40" height="8">
-					<g>
-						<rect width="8" height="8" rx="4" />
-						<rect x="16" width="8" height="8" rx="4" />
-						<rect x="32" width="8" height="8" rx="4" />
-					</g>
-				</svg>
-				{ externalUrl && <span className="preview-toolbar__browser-url">{ externalUrl }</span> }
-			</div>
+			{ showSiteAddressBar && (
+				<div className="preview-toolbar__browser-header">
+					<svg width="40" height="8">
+						<g>
+							<rect width="8" height="8" rx="4" />
+							<rect x="16" width="8" height="8" rx="4" />
+							<rect x="32" width="8" height="8" rx="4" />
+						</g>
+					</svg>
+					{ externalUrl && <span className="preview-toolbar__browser-url">{ externalUrl }</span> }
+				</div>
+			) }
 		</div>
 	);
 };
@@ -67,6 +88,14 @@ DesignPickerPreviewToolbar.propTypes = {
 	showDeviceSwitcher: PropTypes.bool,
 	// Called when a device button is clicked
 	setDeviceViewport: PropTypes.func,
+	// Show iframe site address bar
+	showSiteAddressBar: PropTypes.bool,
+	// Filter devices to show in device switcher
+	filterDevicesToShow: PropTypes.array,
+};
+
+DesignPickerPreviewToolbar.defaultProps = {
+	showSiteAddressBar: true,
 };
 
 export default localize( DesignPickerPreviewToolbar );

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -16,7 +16,7 @@ const DesignPickerPreviewToolbar = ( {
 	setDeviceViewport,
 	translate,
 	showSiteAddressBar,
-	filterDevicesToShow,
+	devicesToShow,
 } ) => {
 	const devices = React.useRef( {
 		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 36 },
@@ -25,21 +25,18 @@ const DesignPickerPreviewToolbar = ( {
 	} );
 
 	function filterDevices( selectedDevices ) {
-		// If invalid input, display all possible devices
-		// If valid input, Will filter out any devices that do not exist in the 'possibleDevices' array above
+		// If invalid inputs, display all possible devices
+		// If at least one valid input, Will filter out any devices that do not exist in the 'possibleDevices' array above
+		let filteredPossibleDevices = [];
 		if ( Array.isArray( selectedDevices ) && selectedDevices.length > 0 ) {
-			const filteredPossibleDevices = selectedDevices.filter( ( device ) => {
+			filteredPossibleDevices = selectedDevices.filter( ( device ) => {
 				return possibleDevices.includes( device );
 			} );
-
-			return filteredPossibleDevices;
 		}
-		return possibleDevices;
+		return filteredPossibleDevices.length === 0 ? possibleDevices : filteredPossibleDevices;
 	}
 
-	const filteredPossibleDevices = filterDevicesToShow
-		? filterDevices( filterDevicesToShow )
-		: possibleDevices;
+	const filteredPossibleDevices = filterDevices( devicesToShow );
 
 	return (
 		<div className="preview-toolbar__toolbar">
@@ -91,7 +88,7 @@ DesignPickerPreviewToolbar.propTypes = {
 	// Show iframe site address bar
 	showSiteAddressBar: PropTypes.bool,
 	// Filter devices to show in device switcher
-	filterDevicesToShow: PropTypes.array,
+	devicesToShow: PropTypes.array,
 };
 
 DesignPickerPreviewToolbar.defaultProps = {

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -15,7 +15,7 @@ const DesignPickerPreviewToolbar = ( {
 	showDeviceSwitcher,
 	setDeviceViewport,
 	translate,
-	showSiteAddressBar,
+	showSiteAddressBar = true,
 	devicesToShow,
 } ) => {
 	const devices = React.useRef( {
@@ -89,10 +89,6 @@ DesignPickerPreviewToolbar.propTypes = {
 	showSiteAddressBar: PropTypes.bool,
 	// Filter devices to show in device switcher
 	devicesToShow: PropTypes.array,
-};
-
-DesignPickerPreviewToolbar.defaultProps = {
-	showSiteAddressBar: true,
 };
 
 export default localize( DesignPickerPreviewToolbar );


### PR DESCRIPTION
#### Proposed Changes

* Added `showSiteAddressBar` prop to `<WebPreview />` component that will be used inside the `DesignPickerPreviewToolbar` component to show/hide the iframe URL address bar. 

* Added `devicesToShow` prop to `<WebPreview />` component that will be used inside the `DesignPickerPreviewToolbar` component to control which devices we want to display in the device switcher. This prop will accept an array with 3 possible values: 'desktop', 'tablet', 'phone'. (Any other value will be filtered out)

---

This is how the web preview should look like **without** the `showSiteAddressBar` and `devicesToShow` props added.

![image](https://user-images.githubusercontent.com/10482592/184684561-a51ef9f9-bca9-4fe7-bfa3-cb11064dd7d2.png)

This is how the web preview should look like **with** the `showSiteAddressBar` and `devicesToShow` props added.

![image](https://user-images.githubusercontent.com/10482592/184684588-d49f5045-2d55-4caa-bcca-df52c1abd026.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Load a page with an existing `<WebPreview />` component such as "http://calypso.localhost:3000/setup/designSetup?siteSlug=SITE_SLUG_HERE" and ensure the web preview component includes a device switcher and iframe with an address bar. 

You can navigate to this page from the 'calypso.localhost:3000/start' flow if the direct url does not work.
Steps:
> 1. calypso.localhost:3000/start
> 2. Select a domain (You can choose a free domain)
> 3. Click "continue" until you reach the design picker page (`/setup/designSetup?...`)
> 4. Select a random design and you will be navigated to page with the web preview/site preview.

* To test the props, add`showSiteAddressBar={false}` prop and `devicesToShow={['desktop']}` prop (you can use any combination of the 3 devices, `phone`, `desktop`, `tablet` in this array) to the web preview component inside `launchpad-site-preview.tsx`.
* Navigate to "http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=SITE_SLUG_HERE"
* You should no longer see the URL address bar and the device switcher should only display the devices you specified in the `devicesToShow` prop.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66571 & #66572
