### PR TITLE
Update strings from Paid plugins to Premium plugins

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -134,7 +134,7 @@ export default function MarketplaceTest() {
 				<PluginsBrowserList
 					plugins={ data }
 					listName={ 'paid' }
-					title={ 'Paid Plugins' }
+					title={ 'Premium Plugins' }
 					site={ selectedSiteSlug }
 					showPlaceholders={ isFetching }
 					currentSites={ null }

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -53,7 +53,7 @@ export function useCategories(
 
 	const categories = {
 		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
-		paid: { name: __( 'Top paid plugins' ), slug: 'paid', tags: [] },
+		paid: { name: __( 'Top premium plugins' ), slug: 'paid', tags: [] },
 		popular: { name: __( 'Top free plugins' ), slug: 'popular', tags: [] },
 		featured: { name: __( 'Editor’s pick' ), slug: 'featured', tags: [] },
 		seo: {

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit();
 		} );
 
-		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
+		it.each( [ 'Top premium plugins', 'Editor’s pick', 'Top free plugins' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );
@@ -48,20 +48,20 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Top paid plugins' );
+			await pluginsPage.validateHasSection( 'Top premium plugins' );
 		} );
-		it( 'Can browse all paid plugins', async function () {
+		it( 'Can browse all premium plugins', async function () {
 			await pluginsPage.clickBrowseAllPaidPlugins();
-			await pluginsPage.validateHasSubtitle( 'Top paid plugins' );
+			await pluginsPage.validateHasSubtitle( 'Top premium plugins' );
 		} );
 
-		it( 'Can return via breadcrumb from paid plugins', async function () {
+		it( 'Can return via breadcrumb from premium plugins', async function () {
 			if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 				await pluginsPage.clickPluginsBreadcrumb();
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Top paid plugins' );
+			await pluginsPage.validateHasSection( 'Top premium plugins' );
 		} );
 
 		it.each( [
@@ -96,7 +96,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit( credentials.testSites?.primary.url as string );
 		} );
 
-		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
+		it.each( [ 'Top premium plugins', 'Editor’s pick', 'Top free plugins' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );

--- a/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
+++ b/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
@@ -39,6 +39,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 
 	// We don't support marketplace plugin purchases on self hosted sites. (Source code download restrictions)
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
-		await pluginsPage.validateNotHasSection( 'Top paid plugins' );
+		await pluginsPage.validateNotHasSection( 'Top premium plugins' );
 	} );
 } );


### PR DESCRIPTION
#### Testing Instructions
* Go to the live version of Calypso plugins page (`wordpress.com/plugins`)
* Check the first section is called `Top paid plugins`
* Check out this branch and go to the Plugins page
* Check the first section is called `Top premium plugins`

| Before  | After |
| ------------- | ------------- |
|<img width="1161" alt="Screen Shot 2022-08-15 at 18 27 33" src="https://user-images.githubusercontent.com/5039531/184730868-414a9c2f-c980-46ff-85da-3522e7470bac.png">|<img width="1161" alt="Screen Shot 2022-08-15 at 18 26 07" src="https://user-images.githubusercontent.com/5039531/184731279-be3391be-2d17-411b-8355-d2bcbe2d2b7b.png">|

#### Not included
* URL changes
* Code mentions to paid plugins

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65487