### PR TITLE
Sites Management Page: Refactor to use `@emotion/css`

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,6 +1,5 @@
 import { Button, useSitesTableFiltering, useSitesTableSorting } from '@automattic/components';
-import { css as cssClassName } from '@emotion/css';
-import { css } from '@emotion/react';
+import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -22,61 +21,56 @@ const MAX_PAGE_WIDTH = '1280px';
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's
 // background color and border needs to be able to extend into that padding.
-const pagePadding = css`
-	padding-left: 32px;
-	padding-right: 32px;
-`;
+const pagePadding = {
+	paddingLeft: '32px',
+	paddingRight: '32px',
+};
 
-const wideCentered = css`
-	max-width: ${ MAX_PAGE_WIDTH };
-	margin: 0 auto;
-`;
+const PageHeader = styled.div( {
+	...pagePadding,
 
-const PageHeader = styled.div`
-	${ pagePadding }
+	backgroundColor: 'var( --studio-white )',
+	paddingTop: '24px',
+	paddingBottom: '24px',
+	boxShadow: 'inset 0px -1px 0px rgba( 0, 0, 0, 0.05 )',
+} );
 
-	background-color: var( --studio-white );
-	padding-top: 24px;
-	padding-bottom: 24px;
-	box-shadow: inset 0px -1px 0px rgba( 0, 0, 0, 0.05 );
-`;
+const PageBodyWrapper = styled.div( {
+	...pagePadding,
+	maxWidth: MAX_PAGE_WIDTH,
+	margin: '0 auto',
+} );
 
-const PageBodyWrapper = styled.div`
-	${ pagePadding }
-	max-width: ${ MAX_PAGE_WIDTH };
-	margin: 0 auto;
-`;
+const HeaderControls = styled.div( {
+	maxWidth: MAX_PAGE_WIDTH,
+	margin: '0 auto',
+	display: 'flex',
+	flexDirection: 'row',
+	alignItems: 'center',
+} );
 
-const HeaderControls = styled.div`
-	${ wideCentered }
+const DashboardHeading = styled.h1( {
+	fontWeight: 500,
+	fontSize: '20px',
+	lineHeight: '26px',
+	color: 'var( --studio-gray-100 )',
+	flex: 1,
+} );
 
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-`;
-
-const DashboardHeading = styled.h1`
-	font-weight: 500;
-	font-size: 20px;
-	line-height: 26px;
-	color: var( --studio-gray-100 );
-	flex: 1;
-`;
-
-const sitesMargin = cssClassName( {
+const sitesMargin = css( {
 	margin: '0 0 1.5em',
 } );
 
-const HiddenSitesMessageContainer = styled.div`
-	color: var( --color-text-subtle );
-	font-size: 14px;
-	padding: 16px 0 24px 0;
-	text-align: center;
-`;
+const HiddenSitesMessageContainer = styled.div( {
+	color: 'var( --color-text-subtle )',
+	fontSize: '14px',
+	padding: '16px 0 24px 0',
+	textAlign: 'center',
+} );
 
-const HiddenSitesMessage = styled.div`
-	margin-bottom: 1em;
-`;
+const HiddenSitesMessage = styled.div( {
+	marginBottom: '1em',
+} );
 
 export function SitesDashboard( {
 	queryParams: { search, showHidden, status = 'all' },


### PR DESCRIPTION
#### Proposed Changes

In #66459 I introduced `@emotion/css` to the `<SitesDashboard>` code. This caused a naming collision since the file already used `@emotion/react`. This PR refactors so we're only using `@emotion/css`. We don't _gotta catch 'em all_.

* Use `@emotion/css` to generate all CSS class names for `<SitesDashboard>`
* Switch style declarations from template strings to object syntax so we can share styles between components

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure `/sites-dashboard` is still styled correctly

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66459
