### PR TITLE
fixes overlay hiding end characters issue in search input

### DIFF
--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -66,7 +66,9 @@ export const WithOverlayStyling = () => {
 	return <BoxedSearch overlayStyling={ overlayStyling } />;
 };
 
-export const WithDefaultValue = () => <BoxedSearch defaultValue="a default search value" />;
+export const WithDefaultValue = () => (
+	<BoxedSearch defaultValue="a default search value overflowing the input box" />
+);
 
 export const WithCustomSearchIcon = () => {
 	const customIcon = (

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -133,7 +133,7 @@ const InnerSearch = (
 		inputLabel,
 		disableAutocorrect = false,
 		className,
-		dir = 'ltr',
+		dir,
 		fitsContainer = false,
 		searching = false,
 		compact = false,

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -133,7 +133,7 @@ const InnerSearch = (
 		inputLabel,
 		disableAutocorrect = false,
 		className,
-		dir,
+		dir = 'ltr',
 		fitsContainer = false,
 		searching = false,
 		compact = false,

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -198,23 +198,6 @@ $input-z-index: 20;
 			display: block;
 		}
 
-		// Removes the fade overlay when the search is open and focused
-		&.has-focus {
-			.search-component__input-fade {
-
-				&::before {
-					display: none;
-				}
-
-				&.ltr {
-					/*!rtl:ignore*/
-					&::before {
-						display: none;
-					}
-				}
-			}
-		}
-
 		.search-component__input-fade {
 			display: flex;
 			align-items: center;
@@ -242,6 +225,23 @@ $input-z-index: 20;
 			}
 
 			padding-left: 8px;
+		}
+
+		// Removes the fade overlay when the search is open and focused
+		&.has-focus {
+			.search-component__input-fade {
+
+				&::before {
+					display: none;
+				}
+
+				&.ltr {
+					/*!rtl:ignore*/
+					&::before {
+						display: none;
+					}
+				}
+			}
 		}
 	}
 

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -236,7 +236,6 @@ $input-z-index: 20;
 				}
 
 				&.rtl {
-					/*!rtl:ignore*/
 					&::before {
 						display: none;
 					}

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -203,13 +203,13 @@ $input-z-index: 20;
 			.search-component__input-fade {
 
 				&::before {
-					@include long-content-fade( $size: 0 );
+					display: none;
 				}
 
 				&.ltr {
 					/*!rtl:ignore*/
 					&::before {
-						@include long-content-fade( $size: 0 );
+						display: none;
 					}
 				}
 			}

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -198,6 +198,23 @@ $input-z-index: 20;
 			display: block;
 		}
 
+		// Removes the fade overlay when the search is open and focused
+		&.has-focus {
+			.search-component__input-fade {
+
+				&::before {
+					@include long-content-fade( $size: 0 );
+				}
+
+				&.ltr {
+					/*!rtl:ignore*/
+					&::before {
+						@include long-content-fade( $size: 0 );
+					}
+				}
+			}
+		}
+
 		.search-component__input-fade {
 			display: flex;
 			align-items: center;

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -235,7 +235,7 @@ $input-z-index: 20;
 					display: none;
 				}
 
-				&.ltr {
+				&.rtl {
 					/*!rtl:ignore*/
 					&::before {
 						display: none;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/66364

Fixes overlay hiding end characters issue in search input. It does so by removing the overlay when the input is in a focus state.

#### Screen recording

https://user-images.githubusercontent.com/4111723/184789322-7ed859d7-5734-4b41-8be1-b5cc588f95e8.mov

#### Testing Instructions

1. Run yarn workspace @automattic/search run storybook
2. Once running, visit http://localhost:49901/?path=/story/search--with-different-color
3. Type a lot of text into the search input box, such that it overflows the input

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
