### PR TITLE
NewsletterSetup: enable editing when there is no siteSlug

### DIFF
--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -3,7 +3,7 @@ import { FormFileUpload } from '@wordpress/components';
 import { Icon, upload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ImageEditor from 'calypso/blocks/image-editor';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import './style.scss';
@@ -14,6 +14,7 @@ export type SiteIconWithPickerProps = {
 	site: SiteDetails | null;
 	imageEditorClassName?: string;
 	uploadFieldClassName?: string;
+	disabled: boolean;
 };
 export function SiteIconWithPicker( {
 	selectedFile,
@@ -21,6 +22,7 @@ export function SiteIconWithPicker( {
 	site,
 	imageEditorClassName,
 	uploadFieldClassName,
+	disabled,
 }: SiteIconWithPickerProps ) {
 	const { __ } = useI18n();
 
@@ -28,8 +30,15 @@ export function SiteIconWithPicker( {
 	const [ editingFileName, setEditingFileName ] = React.useState< string >();
 	const [ editingFile, setEditingFile ] = React.useState< string >();
 	const [ imageEditorOpen, setImageEditorOpen ] = React.useState< boolean >( false );
-	const isLoading = ! site;
 	const siteIconUrl = site?.icon?.img;
+
+	useEffect( () => {
+		if ( ! site && editingFile ) {
+			onSelect( new File( [ editingFile ], editingFileName || 'site-logo.png' ) );
+			setSelectedFileUrl( editingFile );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ editingFile ] );
 
 	return (
 		<>
@@ -55,7 +64,7 @@ export function SiteIconWithPicker( {
 			) }
 			<FormFieldset
 				className={ classNames( 'site-icon-with-picker__site-icon', uploadFieldClassName ) }
-				disabled={ isLoading }
+				disabled={ disabled }
 			>
 				<FormFileUpload
 					className={ classNames( 'site-icon-with-picker__upload-button', {

--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -14,7 +14,7 @@ export type SiteIconWithPickerProps = {
 	site: SiteDetails | null;
 	imageEditorClassName?: string;
 	uploadFieldClassName?: string;
-	disabled: boolean;
+	disabled?: boolean;
 };
 export function SiteIconWithPicker( {
 	selectedFile,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -10,6 +10,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
@@ -39,6 +40,8 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const accentColorRef = React.useRef< HTMLInputElement >( null );
 
 	const site = useSite();
+	const usesSite = !! useSiteSlugParam();
+
 	const { setSiteTitle, setSiteAccentColor, setSiteDescription, setSiteLogo } =
 		useDispatch( ONBOARD_STORE );
 
@@ -73,35 +76,32 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 		goNext();
-		if ( site ) {
-			setSiteDescription( tagline );
-			setSiteTitle( siteTitle );
-			setSiteAccentColor( accentColor );
 
-			if ( selectedFile && base64Image ) {
-				try {
-					setSiteLogo( base64Image );
-					// this should be moved to the loader step
-					// await setSiteLogo( new File( [ base64ImageToBlob( base64Image ) ], 'site-logo.png' ) );
-				} catch ( _error ) {
-					// communicate the error to the user
-				}
+		setSiteDescription( tagline );
+		setSiteTitle( siteTitle );
+		setSiteAccentColor( accentColor );
+
+		if ( selectedFile && base64Image ) {
+			try {
+				setSiteLogo( base64Image );
+				// this should be moved to the loader step
+				// await setSiteLogo( new File( [ base64ImageToBlob( base64Image ) ], 'site-logo.png' ) );
+			} catch ( _error ) {
+				// communicate the error to the user
 			}
-			// submit?.( { siteTitle, tagline } );
 		}
+		// submit?.( { siteTitle, tagline } );
 	};
 
 	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
-		if ( site ) {
-			setFormTouched( true );
-			switch ( event.currentTarget.name ) {
-				case 'siteTitle':
-					return setComponentSiteTitle( event.currentTarget.value );
-				case 'tagline':
-					return setTagline( event.currentTarget.value );
-				case 'accentColor':
-					return setAccentColor( event.currentTarget.value );
-			}
+		setFormTouched( true );
+		switch ( event.currentTarget.name ) {
+			case 'siteTitle':
+				return setComponentSiteTitle( event.currentTarget.value );
+			case 'tagline':
+				return setTagline( event.currentTarget.value );
+			case 'accentColor':
+				return setAccentColor( event.currentTarget.value );
 		}
 	};
 
@@ -119,6 +119,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			<form className="newsletter-setup__form" onSubmit={ onSubmit }>
 				<SiteIconWithPicker
 					site={ site }
+					disabled={ usesSite ? ! site : false }
 					onSelect={ ( file ) => {
 						setSelectedFile( file );
 						imageFileToBase64( file );


### PR DESCRIPTION
#### Proposed Changes

* Enable fields to be edited when there is no site slug parameter present

<img width="1182" alt="Screenshot 2022-08-16 at 12 05 23" src="https://user-images.githubusercontent.com/7000684/184853824-00bc0a61-1e42-4306-a815-bf781ce38048.png">


#### Testing Instructions
- Check out this branch 
- run `yarn start`

**Testing with siteSlug**z
- visit http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter&siteSlug=YOURSITE
- make sure you can edit the fields

**Testing without siteSlug**
- visit http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter
- make sure you can edit the fields
