### PR TITLE
SearchBoxHeader Cleanup

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -7,7 +7,7 @@ import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -17,7 +17,6 @@ import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { setQueryArgs } from 'calypso/lib/query-args';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
@@ -139,9 +138,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const searchRef = useRef( null );
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
-	const clearSearch = useCallback( () => {
-		searchRef?.current?.setKeyword( '' );
-	}, [ searchRef ] );
 
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
@@ -221,12 +217,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			/>
 		);
 	};
-
-	useEffect( () => {
-		if ( ! search ) {
-			clearSearch();
-		}
-	}, [ clearSearch, search ] );
 
 	useEffect( () => {
 		const items = [
@@ -328,7 +318,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				searchRef={ searchRef }
 				popularSearchesRef={ searchHeaderRef }
 				isSticky={ isAboveElement }
-				doSearch={ ( searchTerm ) => setQueryArgs( '' !== searchTerm ? { s: searchTerm } : {} ) }
 				searchTerm={ search }
 				isSearching={ isFetchingPluginsBySearchTerm }
 				title={ translate( 'Plugins you need to get your projects done' ) }

--- a/client/my-sites/plugins/search-box-header/README.md
+++ b/client/my-sites/plugins/search-box-header/README.md
@@ -8,7 +8,6 @@ This component is used to render the heading of the plugin marketplace, a search
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 
 <SearchBoxHeader
-	doSearch={ doSearch }
 	searchTerm={ search }
 	siteSlug={ siteSlug }
 	title={ translate( 'Plugins you need to get your projects done' ) }
@@ -18,7 +17,6 @@ import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 
 ## Props
 
-- `doSearch`: A function used to execute the search.
 - `searchTerm`: The string used as a term to search the plugins.
 - `siteSlug`: A string representing the url of the current selected site, it can be optional.
 - `title`: A string that is rendered in the heading.

--- a/client/my-sites/plugins/search-box-header/README.md
+++ b/client/my-sites/plugins/search-box-header/README.md
@@ -1,4 +1,4 @@
-# Plugins List
+# Search Box Header
 
 This component is used to render the heading of the plugin marketplace, a search bar and a list of recommended searches.
 

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,11 +1,12 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment } from 'react';
+import { Fragment, useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { setQueryArgs } from 'calypso/lib/query-args';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
-const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef, isSearching } ) => {
+const SearchBox = ( { isMobile, searchTerm, doSearch, searchBoxRef, isSearching } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -82,22 +83,28 @@ const PopularSearches = ( props ) => {
 };
 
 const SearchBoxHeader = ( props ) => {
-	const {
-		doSearch,
-		searchTerm,
-		title,
-		searchTerms,
-		isSticky,
-		popularSearchesRef,
-		isSearching,
-		searchRef,
-	} = props;
+	const { searchTerm, title, searchTerms, isSticky, popularSearchesRef, isSearching, searchRef } =
+		props;
+
+	const doSearch = useCallback( ( receivedSearch ) => {
+		setQueryArgs( '' !== receivedSearch ? { s: receivedSearch } : {} );
+	}, [] );
 
 	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
 	const updateSearchBox = ( keyword ) => {
 		searchRef.current.setKeyword( keyword );
 		doSearch( keyword );
 	};
+
+	const clearSearch = useCallback( () => {
+		setQueryArgs( {} );
+	}, [] );
+
+	useEffect( () => {
+		if ( ! searchTerm ) {
+			clearSearch();
+		}
+	}, [ clearSearch, searchTerm ] );
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>


### PR DESCRIPTION
Extracting out search logic from the `PluginsBrowser` component into the `SearchBoxHeader`. Since most of this logic is just updating the url, it is okay that they live inside the `SearchBoxHeader` this way we can remove more responsibilities from the `PluginsBrowser`.

#### Proposed Changes

* Moves doSearch inside the SearchBoxHeader component.
* Moves clearSearch inside the SearchBoxHeader component.

#### Testing Instructions

* Go to the plugins page
* Test that search and clearing search through the x button is working fine

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes~?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64544
