### PR TITLE
Hosting Configuration: Fetch SSH access state when component mounts

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -25,6 +25,7 @@ import {
 	requestAtomicSftpUsers,
 	createAtomicSftpUser,
 	resetAtomicSftpPassword,
+	requestAtomicSshAccess,
 	updateAtomicSftpUser,
 	enableAtomicSshAccess,
 	disableAtomicSshAccess,
@@ -53,6 +54,7 @@ export const SftpCard = ( {
 	resetSftpPassword,
 	siteHasSshFeature,
 	isSshAccessEnabled,
+	requestSshAccess,
 	enableSshAccess,
 	disableSshAccess,
 	removePasswordFromState,
@@ -111,9 +113,12 @@ export const SftpCard = ( {
 		if ( ! disabled ) {
 			setIsLoading( true );
 			requestSftpUsers( siteId );
+			if ( siteHasSshFeature ) {
+				requestSshAccess( siteId );
+			}
 		}
 		return onDestroy();
-	}, [ disabled, siteId ] );
+	}, [ disabled, siteId, siteHasSshFeature ] );
 
 	useEffect( () => {
 		if ( username === null || username || password ) {
@@ -440,6 +445,7 @@ export default connect(
 		requestSftpUsers: requestAtomicSftpUsers,
 		createSftpUser,
 		resetSftpPassword,
+		requestSshAccess: requestAtomicSshAccess,
 		enableSshAccess,
 		disableSshAccess,
 

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -186,7 +186,7 @@ export const SftpCard = ( {
 					disabled={ isLoading || isSshAccessLoading }
 					checked={ isSshAccessEnabled }
 					onChange={ () => toggleSshAccess() }
-					label={ translate( 'Enable SSH access to this site.' ) }
+					label={ translate( 'Enable SSH access for this site.' ) }
 				/>
 				{ isSshAccessEnabled && (
 					<div className="sftp-card__copy-field">

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -186,7 +186,14 @@ export const SftpCard = ( {
 					disabled={ isLoading || isSshAccessLoading }
 					checked={ isSshAccessEnabled }
 					onChange={ () => toggleSshAccess() }
-					label={ translate( 'Enable SSH access for this site.' ) }
+					label={ translate(
+						'Enable SSH access for this site. {{em}}This feature is currently in beta.{{/em}}',
+						{
+							components: {
+								em: <em />,
+							},
+						}
+					) }
 				/>
 				{ isSshAccessEnabled && (
 					<div className="sftp-card__copy-field">
@@ -274,7 +281,7 @@ export const SftpCard = ( {
 						<PanelBody title={ translate( 'What is SSH?' ) } initialOpen={ false }>
 							{ translate(
 								'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. ' +
-									'For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}}.',
+									'{{em}}This feature is currently in beta.{{/em}} For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}}.',
 								{
 									components: {
 										supportLink: (
@@ -284,6 +291,7 @@ export const SftpCard = ( {
 												href={ localizeUrl( 'https://wordpress.com/support/sftp/' ) }
 											/>
 										),
+										em: <em />,
 									},
 								}
 							) }

--- a/client/state/hosting/actions.js
+++ b/client/state/hosting/actions.js
@@ -5,6 +5,7 @@ import {
 	HOSTING_SFTP_PASSWORD_RESET,
 	HOSTING_SFTP_USER_UPDATE,
 	HOSTING_SFTP_USERS_SET,
+	HOSTING_SSH_ACCESS_REQUEST,
 	HOSTING_SSH_ACCESS_SET,
 	HOSTING_SSH_ACCESS_ENABLE,
 	HOSTING_SSH_ACCESS_DISABLE,
@@ -55,6 +56,11 @@ export const resetAtomicSftpPassword = ( siteId, sshUsername ) => ( {
 	type: HOSTING_SFTP_PASSWORD_RESET,
 	siteId,
 	sshUsername,
+} );
+
+export const requestAtomicSshAccess = ( siteId ) => ( {
+	type: HOSTING_SSH_ACCESS_REQUEST,
+	siteId,
 } );
 
 export const setAtomicSshAccess = ( siteId, status ) => ( {


### PR DESCRIPTION
From #66584 and p1660665779256229/1660660659.469349-slack-C03TP5Z3MPD

## Proposed Changes

Fetches SSH access state when the component mounts. This ensures a site with SSH enabled displays accordingly.

Also makes a minor tweak to the language:

<img width="767" alt="image" src="https://user-images.githubusercontent.com/36432/184932525-33b5dc95-29df-4d41-8b65-18cb165b21db.png">

<img width="785" alt="image" src="https://user-images.githubusercontent.com/36432/184932647-bad99206-ec21-470c-ae99-51d7b92c1654.png">

## Testing Instructions

1. Create a new Business plan site.
2. Navigate to `/hosting-config/<business-site>`.
3. Enable SSH.
4. Refresh the page and verify the SSH toggle is still enabled.