### PR TITLE
Editing Toolkit: Force draft preview third party cookie issues again

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/override-preview-button-url.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/override-preview-button-url.js
@@ -1,59 +1,59 @@
-import { select, subscribe } from '@wordpress/data';
+// import { select, subscribe } from '@wordpress/data';
 
-const isEditorReady = async () =>
-	new Promise( ( resolve ) => {
-		const unsubscribe = subscribe( () => {
-			// Calypso sends the message as soon as the iframe is loaded, so we
-			// need to be sure that the editor is initialized and the core blocks
-			// registered. There is an unstable selector for that, so we use
-			// `isCleanNewPost` otherwise which is triggered when everything is
-			// initialized if the post is new.
-			const editorIsReady = select( 'core/editor' ).__unstableIsEditorReady
-				? select( 'core/editor' ).__unstableIsEditorReady()
-				: select( 'core/editor' ).isCleanNewPost();
-			if ( editorIsReady ) {
-				unsubscribe();
-				resolve();
-			}
-		} );
-	} );
+// const isEditorReady = async () =>
+// 	new Promise( ( resolve ) => {
+// 		const unsubscribe = subscribe( () => {
+// 			// Calypso sends the message as soon as the iframe is loaded, so we
+// 			// need to be sure that the editor is initialized and the core blocks
+// 			// registered. There is an unstable selector for that, so we use
+// 			// `isCleanNewPost` otherwise which is triggered when everything is
+// 			// initialized if the post is new.
+// 			const editorIsReady = select( 'core/editor' ).__unstableIsEditorReady
+// 				? select( 'core/editor' ).__unstableIsEditorReady()
+// 				: select( 'core/editor' ).isCleanNewPost();
+// 			if ( editorIsReady ) {
+// 				unsubscribe();
+// 				resolve();
+// 			}
+// 		} );
+// 	} );
 
-/**
- * The gutenberg block editor preview button opens a new window to a simple site's mapped
- * domain.
- * Adds logmein query param to editor draft post preview url to add WordPress cookies in
- * a first party context ( allowing us to avoid third party cookie issues )
- */
-async function overridePreviewButtonUrl() {
-	await isEditorReady();
+// /**
+//  * The gutenberg block editor preview button opens a new window to a simple site's mapped
+//  * domain.
+//  * Adds logmein query param to editor draft post preview url to add WordPress cookies in
+//  * a first party context ( allowing us to avoid third party cookie issues )
+//  */
+// async function overridePreviewButtonUrl() {
+// 	await isEditorReady();
 
-	// Tracks when a popover is introduced into the post editor DOM
-	const popoverSlotObserver = new window.MutationObserver( ( mutations ) => {
-		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
+// 	// Tracks when a popover is introduced into the post editor DOM
+// 	const popoverSlotObserver = new window.MutationObserver( ( mutations ) => {
+// 		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
 
-		for ( const record of mutations ) {
-			for ( const node of record.addedNodes ) {
-				if ( isComponentsPopover( node ) ) {
-					const previewButton = node.querySelector( 'a[href$="preview=true"]' );
-					// Disables default onclick behavior for the preview button and replaces
-					// it with our own window opening logic. Overriding the href directly
-					// doesn't work because the custom href we apply is overridden somewhere
-					// upstream.
+// 		for ( const record of mutations ) {
+// 			for ( const node of record.addedNodes ) {
+// 				if ( isComponentsPopover( node ) ) {
+// 					const previewButton = node.querySelector( 'a[href$="preview=true"]' );
+// 					// Disables default onclick behavior for the preview button and replaces
+// 					// it with our own window opening logic. Overriding the href directly
+// 					// doesn't work because the custom href we apply is overridden somewhere
+// 					// upstream.
 
-					if ( previewButton ) {
-						previewButton.onclick = function ( e ) {
-							e.preventDefault();
-							e.stopPropagation();
-							window.open( `${ previewButton.href }&logmein=direct` );
-						};
-					}
-				}
-			}
-		}
-	} );
+// 					if ( previewButton ) {
+// 						previewButton.onclick = function ( e ) {
+// 							e.preventDefault();
+// 							e.stopPropagation();
+// 							window.open( `${ previewButton.href }&logmein=direct` );
+// 						};
+// 					}
+// 				}
+// 			}
+// 		}
+// 	} );
 
-	const popoverSlotElem = document.querySelector( '.interface-interface-skeleton ~ .popover-slot' );
-	popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
-}
+// 	const popoverSlotElem = document.querySelector( '.interface-interface-skeleton ~ .popover-slot' );
+// 	popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
+// }
 
-overridePreviewButtonUrl();
+// overridePreviewButtonUrl();


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
