### PR TITLE
Change Remove subscription button wording in /earn

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -440,6 +440,12 @@ class MembershipsSection extends Component {
 		}
 	}
 	renderSubscriberActions( subscriber ) {
+		let buttonText;
+		if ( subscriber.plan.renew_interval === 'one-time' ) {
+			buttonText = this.props.translate( 'Remove' );
+		} else {
+			buttonText = this.props.translate( 'Cancel Subscription' );
+		}
 		return (
 			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
 				<PopoverMenuItem
@@ -452,7 +458,7 @@ class MembershipsSection extends Component {
 				</PopoverMenuItem>
 				<PopoverMenuItem onClick={ () => this.setState( { cancelledSubscriber: subscriber } ) }>
 					<Gridicon size={ 18 } icon={ 'cross' } />
-					{ this.props.translate( 'Cancel Subscription' ) }
+					{ buttonText }
 				</PopoverMenuItem>
 			</EllipsisMenu>
 		);

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -162,7 +162,7 @@ class MembershipsSection extends Component {
 			this.props.requestSubscriptionStop(
 				this.props.siteId,
 				this.state.cancelledSubscriber,
-				this.getWording( this.state.cancelledSubscriber ).success
+				this.getIntervalDependantWording( this.state.cancelledSubscriber ).success
 			);
 		}
 		this.setState( { cancelledSubscriber: null } );
@@ -218,7 +218,7 @@ class MembershipsSection extends Component {
 	}
 
 	renderSubscriberList() {
-		const wording = this.getWording( this.state.cancelledSubscriber );
+		const wording = this.getIntervalDependantWording( this.state.cancelledSubscriber );
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Customers and Subscribers' ) } />
@@ -286,7 +286,7 @@ class MembershipsSection extends Component {
 		);
 	}
 
-	getWording( subscriber ) {
+	getIntervalDependantWording( subscriber ) {
 		const subscriber_email = subscriber?.user.user_email ?? '';
 		const plan_name = subscriber?.plan.title ?? '';
 
@@ -467,7 +467,7 @@ class MembershipsSection extends Component {
 				</PopoverMenuItem>
 				<PopoverMenuItem onClick={ () => this.setState( { cancelledSubscriber: subscriber } ) }>
 					<Gridicon size={ 18 } icon={ 'cross' } />
-					{ this.getWording( subscriber ).button }
+					{ this.getIntervalDependantWording( subscriber ).button }
 				</PopoverMenuItem>
 			</EllipsisMenu>
 		);

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -287,59 +287,33 @@ class MembershipsSection extends Component {
 	}
 
 	getWording( subscriber ) {
-		const isOneTime = subscriber?.plan?.renew_interval === 'one-time';
 		const subscriber_email = subscriber?.user.user_email ?? '';
-		const wording = {
-			donation: {
-				button: isOneTime
-					? this.props.translate( 'Remove' )
-					: this.props.translate( 'Cancel Donation' ),
-				confirmation_subheading: this.props.translate( 'Do you want to remove this donation?' ),
-				confirmation_info:
-					this.props.translate(
-						'Removing this donation means that the user %(subscriber_email)s will no longer have access to any service granted by this plan, such as restricted premium content or digital subscription.',
-						{ args: { subscriber_email: subscriber_email } }
-					) +
-					' ' +
-					( isOneTime
-						? this.props.translate( 'The donation will not be refunded.' )
-						: this.props.translate(
-								'Donations already made will not be refunded to the user but any scheduled future donations will not be made.'
-						  ) ),
-				success: this.props.translate( 'Donation cancelled for %(subscriber_email)s.', {
-					args: { subscriber_email: subscriber_email },
-				} ),
-			},
-			purchase: {
-				button: isOneTime
-					? this.props.translate( 'Remove' )
-					: this.props.translate( 'Cancel Subscription' ),
-				confirmation_subheading: this.props.translate( 'Do you want to remove this purchase?' ),
-				confirmation_info:
-					this.props.translate(
-						'Removing this purchase means that the user %(subscriber_email)s will no longer have access to any service granted by this plan, such as restricted premium content or digital subscription.',
-						{ args: { subscriber_email: subscriber?.user.user_email ?? '' } }
-					) +
-					' ' +
-					( isOneTime
-						? this.props.translate( 'The purchase will not be refunded.' )
-						: this.props.translate(
-								'Payments already made will not be refunded to the user but any scheduled future payments will not be made.'
-						  ) ),
-				success: this.props.translate( 'Subscription cancelled for %(subscriber_email)s.', {
-					args: { subscriber_email: subscriber_email },
-				} ),
-			},
-		};
+		const plan_name = subscriber?.plan.title ?? '';
 
-		// plan.type is null for non-donations, it's not known what they are, so they're called purchase here.
-		// That is also used as the fallback in case other plan types are added in the future without updating
-		// this function.
-		let productType = subscriber?.plan?.type ?? 'purchase';
-		if ( ! ( productType in wording ) ) {
-			productType = 'purchase';
+		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
+			return {
+				button: this.props.translate( 'Remove payment' ),
+				confirmation_subheading: this.props.translate( 'Do you want to remove this payment?' ),
+				confirmation_info: this.props.translate(
+					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
+					{ args: { subscriber_email, plan_name } }
+				),
+				success: this.props.translate( 'Payment removed for %(subscriber_email)s.', {
+					args: { subscriber_email },
+				} ),
+			};
 		}
-		return wording[ productType ];
+		return {
+			button: this.props.translate( 'Cancel payment' ),
+			confirmation_subheading: this.props.translate( 'Do you want to cancel this payment?' ),
+			confirmation_info: this.props.translate(
+				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
+				{ args: { subscriber_email, plan_name } }
+			),
+			success: this.props.translate( 'Payment cancelled for %(subscriber_email)s.', {
+				args: { subscriber_email },
+			} ),
+		};
 	}
 
 	renderManagePlans() {


### PR DESCRIPTION
#### Proposed Changes

The Remove Subscription button flow on the earn page is confusing for
subscriptions which were purchased by one-off donations & payments. The
user is able to access paywalled areas of the site associated with that
payment plan, but don't have an ongoing financial commitment.

This change modifies a lot of the wording in the Remove Subscription
flow, including the button, the confirmation dialog and the result
to depend on the type and frequency of the plan being removed. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Apply this diff to your sandbox / local calypso
 2. Sandbox a simple site with a Premium or Business plan
 2. [Enable the sandbox store](PCYsg-IA-p2)
 2. Add a new post on the sandboxed site
 2. Insert a Donations block
 2. Insert a Payment button block with a one-time plan
 3. Insert a Payment button with a recurring payment plan
 4. Publish the post
 5. Visit the post
 6. Use both the payment buttons to purchase
 7. Use the donations block to purchase a one-time and recurring donation
 8. Go to /earn/payments
 9. You should see four subscribers - one for each of the purchases just made
 10. Use the three dots menu to cancel each of them in turn, carefully taking note that the wording each time is appropriate.

Here's a screencast showing the cancellation process

https://user-images.githubusercontent.com/93301/185603889-bb40aa59-e0fa-4ade-8a70-d39e9f4a49a0.mp4

 Caption | Image
-------|------
one-time payment dialog | ![image](https://user-images.githubusercontent.com/93301/185604052-68a6fdd5-515e-425b-9263-ba67e11606d7.png)
recurring payment dialog | ![image](https://user-images.githubusercontent.com/93301/185604230-2e9288b2-4701-470d-8301-ddc2f08336a0.png)
recurring payment confirmation | ![image](https://user-images.githubusercontent.com/93301/185604334-babced83-f886-432c-8d7d-d0694a11368f.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64600 