### PR TITLE
Theme/Plugin Bundling: Stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
@@ -1,0 +1,5 @@
+const pluginBundleSteps = {
+	woocommerce: [ 'storeAddress', 'businessInfo', 'wooConfirm', 'processing' ],
+};
+
+export default pluginBundleSteps;

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -20,6 +20,7 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from './internals/types';
+import pluginBundleSteps from './plugin-bundle-data';
 import type { StepPath } from './internals/steps-repository';
 
 const WRITE_INTENT_DEFAULT_THEME = 'livro';
@@ -33,14 +34,10 @@ export const pluginBundleFlow: Flow = {
 			return [];
 		}
 
-		return [
-			'storeAddress',
-			'businessInfo',
-			'wooConfirm',
-			'processing',
-			'error',
-			// 'wooInstallPlugins', // TODO - Do we need this?
-		] as StepPath[];
+		// TODO - This needs to come from somewhere else eventually
+		const pluginSlug = 'woocommerce';
+
+		return pluginBundleSteps[ pluginSlug ] as StepPath[];
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -1,0 +1,257 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Onboard } from '@automattic/data-stores';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { useSite } from '../hooks/use-site';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { redirect } from './internals/steps-repository/import/util';
+import { ProcessingResult } from './internals/steps-repository/processing-step';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
+import type { StepPath } from './internals/steps-repository';
+
+const WRITE_INTENT_DEFAULT_THEME = 'livro';
+const SiteIntent = Onboard.SiteIntent;
+
+export const pluginBundleFlow: Flow = {
+	name: 'plugin-bundle',
+
+	useSteps() {
+		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
+			return [];
+		}
+
+		return [
+			'storeAddress',
+			'businessInfo',
+			'wooConfirm',
+			'processing',
+			'error',
+			// 'wooInstallPlugins', // TODO - Do we need this?
+		] as StepPath[];
+	},
+	useStepNavigation( currentStep, navigate ) {
+		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+		const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
+		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+		const startingPoint = useSelect( ( select ) => select( ONBOARD_STORE ).getStartingPoint() );
+		const siteSlugParam = useSiteSlugParam();
+		const site = useSite();
+		const currentUser = useSelector( getCurrentUser );
+		const isEnglishLocale = useIsEnglishLocale();
+		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
+
+		let siteSlug: string | null = null;
+		if ( siteSlugParam ) {
+			siteSlug = siteSlugParam;
+		} else if ( site ) {
+			siteSlug = new URL( site.URL ).host;
+		}
+
+		const adminUrl = useSelect(
+			( select ) => site && select( SITE_STORE ).getSiteOption( site.ID, 'admin_url' )
+		);
+		const isAtomic = useSelect(
+			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
+		);
+		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
+		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
+			useDispatch( ONBOARD_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
+		const dispatch = reduxDispatch();
+		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
+
+		// Since we're mimicking a subset of the site-setup-flow, we're safe to use the siteSetupProgress.
+		const flowProgress = useSiteSetupFlowProgress( currentStep, intent, storeType );
+
+		if ( flowProgress ) {
+			setStepProgress( flowProgress );
+		}
+
+		const exitFlow = ( to: string ) => {
+			setPendingAction( () => {
+				/**
+				 * This implementation seems very hacky.
+				 * The new Promise returned is never resolved or rejected.
+				 *
+				 * If we were to resolve the promise when all pending actions complete,
+				 * I found out this results in setIntentOnSite and setGoalsOnSite being called multiple times
+				 * because the exitFlow itself is called more than once on actual flow exits.
+				 */
+				return new Promise( () => {
+					if ( ! siteSlug ) return;
+
+					const pendingActions = [ setIntentOnSite( siteSlug, intent ) ];
+
+					if ( goalsStepEnabled ) {
+						pendingActions.push( setGoalsOnSite( siteSlug, goals ) );
+					}
+					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
+						pendingActions.push( setThemeOnSite( siteSlug, WRITE_INTENT_DEFAULT_THEME ) );
+					}
+
+					Promise.all( pendingActions ).then( () => window.location.replace( to ) );
+				} );
+			} );
+
+			navigate( 'processing' );
+
+			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
+			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction' ] );
+		};
+
+		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+			recordSubmitStep( providedDependencies, intent, currentStep );
+
+			switch ( currentStep ) {
+				case 'storeAddress':
+					return navigate( 'businessInfo' );
+
+				case 'businessInfo': {
+					if ( isAtomic ) {
+						return navigate( 'wooInstallPlugins' );
+					}
+					return navigate( 'wooConfirm' );
+				}
+
+				case 'wooConfirm': {
+					const [ checkoutUrl ] = params;
+
+					if ( checkoutUrl ) {
+						window.location.replace( checkoutUrl.toString() );
+					}
+
+					return navigate( 'wooTransfer' );
+				}
+				case 'processing': {
+					const processingResult = params[ 0 ] as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					// If the user skips starting point, redirect them to the post editor
+					if ( intent === 'write' && startingPoint !== 'skip-to-my-home' ) {
+						if ( startingPoint !== 'write' ) {
+							window.sessionStorage.setItem( 'wpcom_signup_complete_show_draft_post_modal', '1' );
+						}
+
+						return exitFlow( `/post/${ siteSlug }` );
+					}
+
+					// End of woo flow
+					if ( intent === 'sell' && storeType === 'power' ) {
+						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
+
+						if (
+							isEnabled( 'signup/woo-verify-email' ) &&
+							currentUser &&
+							! currentUser.email_verified
+						) {
+							return navigate( 'wooVerifyEmail' );
+						}
+						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
+					}
+
+					return exitFlow( `/home/${ siteSlug }` );
+				}
+
+				// TODO - Do we need this?
+				case 'wooInstallPlugins':
+					return navigate( 'processing' );
+			}
+		}
+
+		const goBack = () => {
+			switch ( currentStep ) {
+				case 'storeAddress':
+					return navigate( 'storeFeatures' );
+
+				case 'businessInfo':
+					return navigate( 'storeAddress' );
+
+				case 'wooConfirm':
+					return navigate( 'businessInfo' );
+
+				default:
+					return navigate( 'storeAddress' );
+			}
+		};
+
+		const goNext = () => {
+			switch ( currentStep ) {
+				// TODO - Do we need anything here?
+				default:
+					return navigate( 'storeAddress' );
+			}
+		};
+
+		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit, exitFlow };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const siteSlug = useSiteSlugParam();
+		const siteId = useSiteIdParam();
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const fetchingSiteError = useSelect( ( select ) =>
+			select( SITE_STORE ).getFetchingSiteError()
+		);
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! userIsLoggedIn ) {
+			redirect( '/start' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'site-setup requires a logged in user',
+			};
+		}
+
+		if ( ! siteSlug && ! siteId ) {
+			redirect( '/' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'site-setup did not provide the site slug or site id it is configured to.',
+			};
+		}
+
+		if ( fetchingSiteError ) {
+			redirect( '/' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: fetchingSiteError.message,
+			};
+		}
+
+		const canManageOptions = useCanUserManageOptions();
+		if ( canManageOptions === 'requesting' ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+			};
+		} else if ( canManageOptions === false ) {
+			redirect( '/start' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message:
+					'site-setup the user needs to have the manage_options capability to go through the flow.',
+			};
+		}
+
+		return result;
+	},
+};

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -31,11 +31,17 @@ export const pluginBundleFlow: Flow = {
 
 	useSteps() {
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
+			// TODO - Need to handle this better
 			return [];
 		}
 
-		// TODO - This needs to come from somewhere else eventually
+		// TODO - This needs to come from somewhere else eventually. Maybe a query string parameter but data-store might be better
 		const pluginSlug = 'woocommerce';
+
+		if ( ! pluginSlug || ! pluginBundleSteps.hasOwnProperty( pluginSlug ) ) {
+			// TODO - Need to handle this better
+			return [];
+		}
 
 		return pluginBundleSteps[ pluginSlug ] as StepPath[];
 	},

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -66,8 +66,10 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
 	{ flowName: 'blazepress', pathToFlow: blazePressFlow },
-	{ flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow },
-];
+	config.isEnabled( 'themes/plugin-bundling' )
+		? { flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow }
+		: null,
+].filter( ( item ) => item !== null ) as Array< configurableFlows >;
 
 const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {
 	const { anchorFmPodcastId } = useAnchorFmParams();

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -32,7 +32,6 @@ import { blazePressFlow } from './declarative-flow/blazepress-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
 import { newsletter } from './declarative-flow/newsletter';
-import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -32,6 +32,7 @@ import { blazePressFlow } from './declarative-flow/blazepress-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
 import { newsletter } from './declarative-flow/newsletter';
+import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
@@ -65,6 +66,7 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
 	{ flowName: 'blazepress', pathToFlow: blazePressFlow },
+	{ flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow },
 ];
 
 const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {
@@ -72,8 +74,6 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { 
 	const flowName = useQuery().get( 'flow' );
 
 	let flow = siteSetupFlow;
-
-	// TODO - We need some mechanism to tell if we're using the pluginBundleFlow. Maybe a query string param or something from the data store?
 
 	if ( anchorFmPodcastId ) {
 		flow = anchorFmFlow;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -32,6 +32,7 @@ import { blazePressFlow } from './declarative-flow/blazepress-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
 import { newsletter } from './declarative-flow/newsletter';
+import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
@@ -72,6 +73,8 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { 
 	const flowName = useQuery().get( 'flow' );
 
 	let flow = siteSetupFlow;
+
+	// TODO - We need some mechanism to tell if we're using the pluginBundleFlow. Maybe a query string param or something from the data store?
 
 	if ( anchorFmPodcastId ) {
 		flow = anchorFmFlow;


### PR DESCRIPTION
#### Proposed Changes

This adds a new Stepper flow for installing plugins that come bundled with certain themes. Currently geared heavily towards WooCommerce since that's the only plugin that will be bundled as part of the MVP

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/setup/?siteSlug=__SITEHERE__&flow=plugin-bundle&flags=themes/plugin-bundling`

After visiting the above link, you should begin at the `storeAddress` step and continue through `businessInfo`, `wooConfirm` (if necessary), and `processing`.

NOTE: No plugins will actually be installed at this point.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65557
