### PR TITLE
Sites Management Page: Fix sites thumbnail loader

### DIFF
--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -42,8 +42,7 @@ export const SiteThumbnail = ( {
 		`site-thumbnail__size-${ size }`
 	);
 
-	const loader = mShotsUrl && ! isError ? 'site-thumbnail-loader' : '';
-	const removeMshotsDefaultLoader = isLoading ? 'site-thumbnail__image' : '';
+	const showLoader = mShotsUrl && ! isError;
 
 	return (
 		<div className={ classes } style={ { backgroundColor, color } }>
@@ -55,22 +54,16 @@ export const SiteThumbnail = ( {
 			) }
 			{ isLoading && (
 				<div
-					className={ loader }
-					style={ {
-						position: 'absolute',
-						width: '100%',
-						height: '100%',
-						alignItems: 'center',
-						justifyContent: 'center',
-						display: 'flex',
-					} }
+					className={ classnames( { 'site-thumbnail-loader': showLoader }, 'site-thumbnail-icon' ) }
 				>
 					{ children }
 				</div>
 			) }
 			{ src && ! isError && (
 				<img
-					className={ removeMshotsDefaultLoader }
+					className={ classnames( 'site-thumbnail__image', {
+						'site-thumbnail__mshot_default_hidden': isLoading,
+					} ) }
 					ref={ imgRef }
 					src={ src }
 					alt={ alt }

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -43,6 +43,7 @@ export const SiteThumbnail = ( {
 	);
 
 	const loader = mShotsUrl && ! isError ? 'site-thumbnail-loader' : '';
+	const removeMshotsDefaultLoader = isLoading ? 'site-thumbnail__image' : '';
 
 	return (
 		<div className={ classes } style={ { backgroundColor, color } }>
@@ -57,6 +58,11 @@ export const SiteThumbnail = ( {
 					className={ loader }
 					style={ {
 						position: 'absolute',
+						width: '100%',
+						height: '100%',
+						alignItems: 'center',
+						justifyContent: 'center',
+						display: 'flex',
 					} }
 				>
 					{ children }
@@ -64,7 +70,7 @@ export const SiteThumbnail = ( {
 			) }
 			{ src && ! isError && (
 				<img
-					className="site-thumbnail__image"
+					className={ removeMshotsDefaultLoader }
 					ref={ imgRef }
 					src={ src }
 					alt={ alt }

--- a/packages/components/src/site-thumbnail/style.scss
+++ b/packages/components/src/site-thumbnail/style.scss
@@ -47,10 +47,8 @@
 	animation: fadein 1.5s;
 }
 
-.site-thumbnail__image {
-	width: 0;
+.site-thumbnail__mshot_default_hidden {
 	height: 0;
-	opacity: 0;
 	visibility: hidden;
 }
 
@@ -70,6 +68,16 @@
 	top: 0;
 	z-index: 1;
 	display: inline-table;
+}
+
+.site-thumbnail-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	z-index: 2;
 }
 
 

--- a/packages/components/src/site-thumbnail/style.scss
+++ b/packages/components/src/site-thumbnail/style.scss
@@ -47,7 +47,7 @@
 	animation: fadein 1.5s;
 }
 
-.site-thumbnail-loading .site-thumbnail__image {
+.site-thumbnail__image {
 	width: 0;
 	height: 0;
 	opacity: 0;

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -38,7 +38,7 @@ export const useMshotsImg = (
 		[ src, options, retryCount ]
 	);
 	const imgRef = useRef< HTMLImageElement >( null );
-	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isError, setIsError ] = useState( false );
 
 	useEffect( () => {
@@ -51,7 +51,11 @@ export const useMshotsImg = (
 					imgRef?.current?.naturalWidth === 400 && imgRef?.current.naturalHeight === 300;
 				if ( ! hasLoadingImgDimensions ) {
 					setIsLoading( false );
-				} else if ( retryCount < MAXTRIES ) {
+				} else {
+					setIsLoading( true );
+				}
+
+				if ( retryCount < MAXTRIES ) {
 					// Only refresh 10 times
 					timeout = setTimeout(
 						() => setRetryCount( ( retryCount ) => retryCount + 1 ),

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -38,7 +38,7 @@ export const useMshotsImg = (
 		[ src, options, retryCount ]
 	);
 	const imgRef = useRef< HTMLImageElement >( null );
-	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isError, setIsError ] = useState( false );
 
 	useEffect( () => {
@@ -47,15 +47,12 @@ export const useMshotsImg = (
 			imgRef.current.onload = () => {
 				// MShot Loading image is 400x300px.
 				// MShot 404 image is 748×561px
+				setIsLoading( true );
 				const hasLoadingImgDimensions =
 					imgRef?.current?.naturalWidth === 400 && imgRef?.current.naturalHeight === 300;
 				if ( ! hasLoadingImgDimensions ) {
 					setIsLoading( false );
-				} else {
-					setIsLoading( true );
-				}
-
-				if ( retryCount < MAXTRIES ) {
+				} else if ( retryCount < MAXTRIES ) {
 					// Only refresh 10 times
 					timeout = setTimeout(
 						() => setRetryCount( ( retryCount ) => retryCount + 1 ),


### PR DESCRIPTION
#### Proposed Changes

* This PR fix loader so that it takes up the entire thumbnail instead of only the site icon
* This PR fix loader to remove the mshots default loader when site is updated and new screen shot is loaded without a page refresh.

**Bad Loader**

https://user-images.githubusercontent.com/47489215/184968326-b00208f5-9e46-490b-8883-e189986089f5.mov

https://user-images.githubusercontent.com/47489215/184968608-af911c34-03c8-459d-83f8-e820aaf1a57b.mov

**Fixed Loader**

https://user-images.githubusercontent.com/47489215/184969092-6d692b6d-0d67-409a-8815-168fdc162498.mov

#### Testing Instructions

1. Go to `/sites-dashboard`
2. Throttle internet speed using chrome network tab to simulate slower speed (clear cache)
3. Test mshots loader is not shown for thumbnail view by following instructions [here](https://github.com/Automattic/wp-calypso/pull/66534) to modify a site and see it updated in sites-dashboard without refreshing
4. Verify the loaders are shown as in the fixed videos above

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66616
