### PR TITLE
Masterbar cart: Fix open state after products are removed

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -38,6 +38,8 @@ export function MasterbarCartButton( {
 	useEffect( () => {
 		if ( shouldShowCart ) {
 			reduxDispatch( recordTracksEvent( 'calypso_masterbar_cart_shown' ) );
+		} else {
+			setIsActive( false );
 		}
 	}, [ shouldShowCart, reduxDispatch ] );
 


### PR DESCRIPTION
## Description:

Upon adding a product to cart from the addons page, followed by removing it
from the masterbar cart on top, When we follow this immediately with adding 
a domain to the cart, we see that the masterbar cart pops up even though we
did not focus on it.

In this diff, we change the state of the masterbar cart in a way that sets it to not
show the popup when there are no items in the cart.  The issue here was that the
state for showing the popup was set to true even though the masterbar cart wasn't
clicked on. Through the useEffect hook, I am setting it to false when there are no items
in the cart.

![](https://d.pr/i/mjHlDR+)

## Testing Instructions:

1. Add a product to the cart and then manually visit /domains/add/:site.
2. Using the masterbar cart, remove the product from the cart.
3. Once the masterbar cart disappears, immediately click to add a domain to the cart.
4. Notice that the masterbar cart does not open up on its own.

## Screencast:

![](https://d.pr/i/CqDBu5+)

#### Proposed Changes

* Set setIsActive to false when no items in the cart via useEffect

* Fixes # #65371



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
