### PR TITLE
Extracts the PluginsNavigationHeader from PluginsBrowser

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,18 +1,9 @@
-import {
-	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
-	WPCOM_FEATURES_MANAGE_PLUGINS,
-	WPCOM_FEATURES_UPLOAD_PLUGINS,
-} from '@automattic/calypso-products';
-import { Button } from '@automattic/components';
-import { useBreakpoint } from '@automattic/viewport-react';
-import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
@@ -23,20 +14,11 @@ import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
-import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
-import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import {
-	getSitePlan,
-	isJetpackSite,
-	isRequestingSites,
-	getSiteAdminUrl,
-} from 'calypso/state/sites/selectors';
+import { getSitePlan, isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSiteId,
 	getSelectedSite,
@@ -45,68 +27,10 @@ import {
 import JetpackDisconnectedNotice from '../jetpack-disconnected-notice';
 import PluginsCategoryResultsPage from '../plugins-category-results-page';
 import PluginsDiscoveryPage from '../plugins-discovery-page';
+import PluginsNavigationHeader from '../plugins-navigation-header';
 import PluginsSearchResultPage from '../plugins-search-results-page';
 
 import './style.scss';
-
-const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	if ( ! hasUploadPlugins ) {
-		return null;
-	}
-
-	const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
-	const handleUploadPluginButtonClick = () => {
-		dispatch( recordTracksEvent( 'calypso_click_plugin_upload' ) );
-		dispatch( recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' ) );
-	};
-
-	return (
-		<Button
-			className="plugins-browser__button"
-			onClick={ handleUploadPluginButtonClick }
-			href={ uploadUrl }
-		>
-			<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
-			{ ! isMobile && (
-				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
-			) }
-		</Button>
-	);
-};
-
-const ManageButton = ( {
-	shouldShowManageButton,
-	siteAdminUrl,
-	siteSlug,
-	jetpackNonAtomic,
-	hasManagePlugins,
-} ) => {
-	const translate = useTranslate();
-
-	if ( ! shouldShowManageButton ) {
-		return null;
-	}
-
-	const site = siteSlug ? '/' + siteSlug : '';
-
-	// When no site is selected eg `/plugins` or when Jetpack is self hosted
-	// or if the site does not have the manage plugins feature show the
-	// Calypso Plugins Manage page.
-	// In any other case, redirect to current site WP Admin.
-	const managePluginsDestination =
-		! siteAdminUrl || jetpackNonAtomic || ! hasManagePlugins
-			? `/plugins/manage${ site }`
-			: `${ siteAdminUrl }plugins.php`;
-
-	return (
-		<Button className="plugins-browser__button" href={ managePluginsDestination }>
-			<span className="plugins-browser__button-text">{ translate( 'Installed Plugins' ) }</span>
-		</Button>
-	);
-};
 
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
 	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
@@ -133,12 +57,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
-	const breadcrumbs = useSelector( getBreadcrumbs );
-
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const jetpackNonAtomic = useSelector(
 		( state ) =>
 			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
@@ -154,26 +75,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const siteId = useSelector( getSelectedSiteId );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
-	const hasInstallPurchasedPlugins = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS )
-	);
-	const hasManagePlugins = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_MANAGE_PLUGINS )
-	);
-	const hasUploadPlugins = useSelector(
-		( state ) => siteHasFeature( state, siteId, WPCOM_FEATURES_UPLOAD_PLUGINS ) || jetpackNonAtomic
-	);
 
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite?.ID ) );
-
-	const dispatch = useDispatch();
 	const translate = useTranslate();
-
-	const isMobile = useBreakpoint( '<960px' );
-
-	const shouldShowManageButton = useMemo( () => {
-		return jetpackNonAtomic || ( isJetpack && ( hasInstallPurchasedPlugins || hasManagePlugins ) );
-	}, [ jetpackNonAtomic, isJetpack, hasInstallPurchasedPlugins, hasManagePlugins ] );
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
@@ -210,37 +113,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		);
 	};
 
-	useEffect( () => {
-		const items = [
-			{
-				label: translate( 'Plugins' ),
-				href: `/plugins/${ siteSlug || '' }`,
-				id: 'plugins',
-				helpBubble: translate(
-					'Add new functionality and integrations to your site with plugins.'
-				),
-			},
-		];
-
-		if ( category ) {
-			items.push( {
-				label: categoryName,
-				href: `/plugins/browse/${ category }/${ siteSlug || '' }`,
-				id: 'category',
-			} );
-		}
-
-		if ( search ) {
-			items.push( {
-				label: translate( 'Search Results' ),
-				href: `/plugins/${ siteSlug || '' }?s=${ search }`,
-				id: 'plugins-search',
-			} );
-		}
-
-		dispatch( updateBreadcrumbs( items ) );
-	}, [ siteSlug, search, category, categoryName, dispatch, translate ] );
-
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ translate( 'Plugins', { textOnly: true } ) } />;
 	}
@@ -258,28 +130,12 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 
 			<PluginsAnnouncementModal />
 			{ ! hideHeader && (
-				<FixedNavigationHeader
-					className="plugins-browser__header"
-					navigationItems={ breadcrumbs }
-					compactBreadcrumb={ isMobile }
-					ref={ navigationHeaderRef }
-				>
-					<div className="plugins-browser__main-buttons">
-						<ManageButton
-							shouldShowManageButton={ shouldShowManageButton }
-							siteAdminUrl={ siteAdminUrl }
-							siteSlug={ siteSlug }
-							jetpackNonAtomic={ jetpackNonAtomic }
-							hasManagePlugins={ hasManagePlugins }
-						/>
-
-						<UploadPluginButton
-							isMobile={ isMobile }
-							siteSlug={ siteSlug }
-							hasUploadPlugins={ hasUploadPlugins }
-						/>
-					</div>
-				</FixedNavigationHeader>
+				<PluginsNavigationHeader
+					navigationHeaderRef={ navigationHeaderRef }
+					categoryName={ categoryName }
+					category={ category }
+					search={ search }
+				/>
 			) }
 			<JetpackDisconnectedNotice />
 			<SearchBoxHeader

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -1,0 +1,172 @@
+import {
+	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
+	WPCOM_FEATURES_MANAGE_PLUGINS,
+	WPCOM_FEATURES_UPLOAD_PLUGINS,
+} from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
+import { Icon, upload } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	if ( ! hasUploadPlugins ) {
+		return null;
+	}
+
+	const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
+	const handleUploadPluginButtonClick = () => {
+		dispatch( recordTracksEvent( 'calypso_click_plugin_upload' ) );
+		dispatch( recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' ) );
+	};
+
+	return (
+		<Button
+			className="plugins-browser__button"
+			onClick={ handleUploadPluginButtonClick }
+			href={ uploadUrl }
+		>
+			<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
+			{ ! isMobile && (
+				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
+			) }
+		</Button>
+	);
+};
+
+const ManageButton = ( {
+	shouldShowManageButton,
+	siteAdminUrl,
+	siteSlug,
+	jetpackNonAtomic,
+	hasManagePlugins,
+} ) => {
+	const translate = useTranslate();
+
+	if ( ! shouldShowManageButton ) {
+		return null;
+	}
+
+	const site = siteSlug ? '/' + siteSlug : '';
+
+	// When no site is selected eg `/plugins` or when Jetpack is self hosted
+	// or if the site does not have the manage plugins feature show the
+	// Calypso Plugins Manage page.
+	// In any other case, redirect to current site WP Admin.
+	const managePluginsDestination =
+		! siteAdminUrl || jetpackNonAtomic || ! hasManagePlugins
+			? `/plugins/manage${ site }`
+			: `${ siteAdminUrl }plugins.php`;
+
+	return (
+		<Button className="plugins-browser__button" href={ managePluginsDestination }>
+			<span className="plugins-browser__button-text">{ translate( 'Installed Plugins' ) }</span>
+		</Button>
+	);
+};
+
+const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category, search } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
+
+	const jetpackNonAtomic = useSelector(
+		( state ) =>
+			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
+	);
+
+	const hasUploadPlugins = useSelector(
+		( state ) =>
+			siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_UPLOAD_PLUGINS ) || jetpackNonAtomic
+	);
+
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite?.ID ) );
+
+	const breadcrumbs = useSelector( getBreadcrumbs );
+
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
+
+	const isMobile = useBreakpoint( '<960px' );
+
+	const hasInstallPurchasedPlugins = useSelector( ( state ) =>
+		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS )
+	);
+	const hasManagePlugins = useSelector( ( state ) =>
+		siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
+	);
+
+	const shouldShowManageButton = useMemo( () => {
+		return jetpackNonAtomic || ( isJetpack && ( hasInstallPurchasedPlugins || hasManagePlugins ) );
+	}, [ jetpackNonAtomic, isJetpack, hasInstallPurchasedPlugins, hasManagePlugins ] );
+
+	useEffect( () => {
+		const items = [
+			{
+				label: translate( 'Plugins' ),
+				href: `/plugins/${ selectedSite?.slug || '' }`,
+				id: 'plugins',
+				helpBubble: translate(
+					'Add new functionality and integrations to your site with plugins.'
+				),
+			},
+		];
+
+		if ( category ) {
+			items.push( {
+				label: categoryName,
+				href: `/plugins/browse/${ category }/${ selectedSite?.slug || '' }`,
+				id: 'category',
+			} );
+		}
+
+		if ( search ) {
+			items.push( {
+				label: translate( 'Search Results' ),
+				href: `/plugins/${ selectedSite?.slug || '' }?s=${ search }`,
+				id: 'plugins-search',
+			} );
+		}
+
+		dispatch( updateBreadcrumbs( items ) );
+	}, [ selectedSite?.slug, search, category, categoryName, dispatch, translate ] );
+
+	return (
+		<FixedNavigationHeader
+			className="plugins-browser__header"
+			navigationItems={ breadcrumbs }
+			compactBreadcrumb={ isMobile }
+			ref={ navigationHeaderRef }
+		>
+			<div className="plugins-browser__main-buttons">
+				<ManageButton
+					shouldShowManageButton={ shouldShowManageButton }
+					siteAdminUrl={ siteAdminUrl }
+					siteSlug={ selectedSite?.slug }
+					jetpackNonAtomic={ jetpackNonAtomic }
+					hasManagePlugins={ hasManagePlugins }
+				/>
+
+				<UploadPluginButton
+					isMobile={ isMobile }
+					siteSlug={ selectedSite?.slug }
+					hasUploadPlugins={ hasUploadPlugins }
+				/>
+			</div>
+		</FixedNavigationHeader>
+	);
+};
+
+export default PluginsNavigationHeader;


### PR DESCRIPTION
#### Proposed Changes

* Extracts out the logic behind the navigation header from the `PluginsBrowser`.
* Creates the `PluginsNavigationHeader`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate into the plugins marketplace
* Check that the breadcrumbs are working fine by navigating through search and categories.
* Check that the "Install Plugins" and "Installed Plugins" buttons are visible in Atomic and Self-Hosted sites.
* Check that the "Install Plugins" and "Installed Plugins" buttons are not visible in simple sites.
* Check that the "Install Plugins" and "Installed Plugins" buttons are not visible when there is no site selected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- ~[ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- ~[ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64545 
