### PR TITLE
Fix plugin page links in category results

### DIFF
--- a/client/my-sites/plugins/plugins-browser/full-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/full-list-view/index.jsx
@@ -15,7 +15,7 @@ const FullListView = ( props ) => {
 						<ClearSearchButton />
 					</>
 				}
-				site={ props.siteSlug }
+				site={ props.site }
 				showPlaceholders={ props.isFetching }
 				currentSites={ props.sites }
 				variant={ PluginsBrowserListVariant.InfiniteScroll }


### PR DESCRIPTION
#### Proposed Changes

* Fix plugin page links in category results when there is a selected site

#### Testing Instructions

* http://calypso.localhost:3000/plugins/browse/seo
* Plugin links should not include a site slug at the end of urls
* http://calypso.localhost:3000/plugins/browse/seo/test441068760.wordpress.com
* Plugin links should include a site slug at the end of urls

Before
![Screenshot_2022-08-17_10-51-47](https://user-images.githubusercontent.com/811776/185009991-c8028334-2fff-4b44-9ca9-ee00e9b841f3.png)


After
![Screenshot_2022-08-17_10-51-07](https://user-images.githubusercontent.com/811776/185009934-1a7eb9fd-87e1-4368-b344-ced52195159d.png)



Fixes https://github.com/Automattic/wp-calypso/issues/66634#top
