### PR TITLE
Improve SSR cache key generation

### DIFF
--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -114,9 +114,22 @@ function compose( ...functions ) {
 }
 
 export function getNormalizedPath( pathname, query ) {
+	if ( ! pathname ) {
+		console.log( '\nNO PATH\n' );
+	}
+	// Make sure that paths like "/themes" and "/themes/" are considered the same.
+	if ( pathname.endsWith( '/' ) ) {
+		pathname = pathname.slice( 0, -1 );
+	}
+
 	if ( isEmpty( query ) ) {
 		return pathname;
 	}
 
 	return pathname + '?' + stringify( query, { sort: ( a, b ) => a.localeCompare( b ) } );
+}
+
+// Given an Express request object, return a cache key.
+export function getCacheKey( { path, query, context } ) {
+	return `${ getNormalizedPath( path, query ) }:gdpr=${ context.showGdprBanner }`;
 }

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -114,11 +114,10 @@ function compose( ...functions ) {
 }
 
 export function getNormalizedPath( pathname, query ) {
-	if ( ! pathname ) {
-		console.log( '\nNO PATH\n' );
-	}
 	// Make sure that paths like "/themes" and "/themes/" are considered the same.
-	if ( pathname.endsWith( '/' ) ) {
+	// Checks for longer lengths to avoid removing the "starting" slash for the
+	// base route.
+	if ( pathname.length > 1 && pathname.endsWith( '/' ) ) {
 		pathname = pathname.slice( 0, -1 );
 	}
 

--- a/client/server/isomorphic-routing/test/index.js
+++ b/client/server/isomorphic-routing/test/index.js
@@ -63,7 +63,7 @@ describe( 'getNormalizedPath', () => {
 		);
 	} );
 
-	test( 'should consider paths with trailing slashses the same as paths without', () => {
+	test( 'should consider paths with trailing slashes the same as paths without', () => {
 		expect( getNormalizedPath( '/hello/' ) ).toBe( getNormalizedPath( '/hello' ) );
 	} );
 } );

--- a/client/server/isomorphic-routing/test/index.js
+++ b/client/server/isomorphic-routing/test/index.js
@@ -62,4 +62,8 @@ describe( 'getNormalizedPath', () => {
 			getNormalizedPath( '/', { 'key=val': '' } )
 		);
 	} );
+
+	test( 'should consider paths with trailing slashses the same as paths without', () => {
+		expect( getNormalizedPath( '/hello/' ) ).toBe( getNormalizedPath( '/hello' ) );
+	} );
 } );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -22,7 +22,7 @@ import { login } from 'calypso/lib/paths';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
 import isSectionEnabled from 'calypso/sections-filter';
-import { serverRouter, getNormalizedPath } from 'calypso/server/isomorphic-routing';
+import { serverRouter, getCacheKey } from 'calypso/server/isomorphic-routing';
 import analytics from 'calypso/server/lib/analytics';
 import isWpMobileApp from 'calypso/server/lib/is-wp-mobile-app';
 import {
@@ -102,7 +102,11 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		response.cookie( 'country_code', geoIPCountryCode );
 	}
 
-	const cacheKey = `${ getNormalizedPath( request.path, request.query ) }:gdpr=${ showGdprBanner }`;
+	const cacheKey = getCacheKey( {
+		path: request.path,
+		query: request.query,
+		context: { showGdprBanner },
+	} );
 
 	/**
 	 * A cache object can be written for an SSR route like /themes when a request

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -56,6 +56,7 @@ jest.mock( 'calypso/login', () => {
 jest.mock( 'calypso/server/isomorphic-routing', () => ( {
 	serverRouter: jest.fn(),
 	getNormalizedPath: jest.fn(),
+	getCacheKey: jest.fn(),
 } ) );
 
 jest.mock( 'calypso/server/render', () => ( {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -14,7 +14,7 @@ import {
 	getTranslationChunkFileUrl,
 } from 'calypso/lib/i18n-utils/switch-locale';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { getNormalizedPath } from 'calypso/server/isomorphic-routing';
+import { getCacheKey } from 'calypso/server/isomorphic-routing';
 import stateCache from 'calypso/server/state-cache';
 import {
 	getDocumentHeadFormattedTitle,
@@ -219,9 +219,7 @@ export function serverRender( req, res ) {
 	attachI18n( context );
 
 	if ( shouldServerSideRender( context ) ) {
-		cacheKey = `${ getNormalizedPath( context.pathname, context.query ) }:gdpr=${
-			context.showGdprBanner
-		}`;
+		cacheKey = getCacheKey( req );
 		debug( `SSR render with cache key ${ cacheKey }.` );
 
 		context.renderedLayout = render(


### PR DESCRIPTION
### Proposed Changes
I noticed that the cache key is generated inconsistently in Calypso's SSR context. To me, I'd think that a cache access at the beginning of a request should always match the cache set at the end of a request.

In particular, to get the cache, we were using `request.path`, and to set the cache, we were using `request.context.pathname`.

Additionally, the paths "/themes/" and "/themes" did not store to the same cache item, which results in unneeded cache misses. (They were considered separate routes by the normalizer, but they're really the same)

This solves these problems by creating a `getCacheKey` function, so that the key is generated consistently all the time. It also updates the path normalizer function to make paths like "/themes/" be equivalent to "/themes".

I can't think of any edge cases for these changes, but please let me know if you can think of any! (In particular, I'm not sure why we ever used request.context where we set the cache.)

### Testing instructions
1. Checkout this branch
2. Run `DEBUG=calypso:server-render yarn start | grep "calypso:server-render"`
3. Once server is ready, open an _incognito/private window_ so that requests are logged out and SSR is used.
4. Visit these two URLs exactly without any refreshes:
5. Load http://calypso.localhost:3000/themes/. Observe that **cache miss** is printed in the console.
6. Load http://calypso.localhost:3000/themes. Observe that cache miss is _not_ printed and that the render time is extremely short.

Here's what the output looks like for me:
```sh
$ DEBUG=calypso:server-render yarn start | grep "calypso:server-render"
<i> [webpack-dev-middleware] wait until bundle finished: /version?1660696967602
# When I access /themes/ at first (cache miss):
  calypso:server-render cache access for key /themes:gdpr=true +0ms
  calypso:server-render cache miss for key /themes:gdpr=true +0ms
  calypso:server-render Server render time (ms) 53 +53ms
# When I access /themes (cache works!):
  calypso:server-render cache access for key /themes:gdpr=true +6s
  calypso:server-render Server render time (ms) 0 +0ms
```

On trunk, however, that looks like this:
```sh
$ <i> [webpack-dev-middleware] wait until bundle finished: /version?1660697201313
<i> [webpack-dev-middleware] wait until bundle finished: /version?1660697221314
<i> [webpack-dev-middleware] wait until bundle finished: /version?1660697241316
# When I access "/themes/" (cache miss)
  calypso:server-render cache access for key /themes/:gdpr=true +0ms
  calypso:server-render cache miss for key /themes/:gdpr=true +1ms
  calypso:server-render Server render time (ms) 50 +49ms
# When I access "/themes" (cache miss)
  calypso:server-render cache access for key /themes:gdpr=true +6s
  calypso:server-render cache miss for key /themes:gdpr=true +0ms
# When I access "/themes" again (cache works!)
  calypso:server-render Server render time (ms) 53 +53ms
  calypso:server-render cache access for key /themes:gdpr=true +5s
  calypso:server-render Server render time (ms) 1 +1ms
```