### PR TITLE
Sites Management Page: Free site and cookie banners don't appear in thumbnails

### DIFF
--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -26,7 +26,14 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 		const updatedAt = new Date( site.options.updated_at );
 		updatedAt.setMinutes( 0 );
 		updatedAt.setSeconds( 0 );
-		siteUrl = addQueryArgs( siteUrl, { v: updatedAt.getTime() / 1000 } );
+		siteUrl = addQueryArgs( siteUrl, {
+			v: updatedAt.getTime() / 1000,
+
+			// This combination of flags stops free site headers and cookie banners from appearing.
+			iframe: true,
+			preview: true,
+			hide_banners: true,
+		} );
 	}
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Add `hide_banners` param, which hides the "Getting Started" banner shown on free sites
* Add `iframe` and `preview` params, which stops the cookie banner from appearing

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try this combination of query params on one of your sites' front ends while in incognito mode. Compare to what you get when you don't use those flags.
* Test the SMP at `/sites-dashboard` and see that the "Getting Started" banner no longer appears in the thumbnails

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes to #66627
