### PR TITLE
Sites Management Page: Add 4 initial site actions to row dropdowns

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -22,4 +22,5 @@ export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'updated_at',
 	'is_redirect',
 	'unmapped_url',
+	'admin_url',
 ] as const;

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,27 +1,113 @@
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
+import { css } from '@emotion/css';
 import { useI18n } from '@wordpress/react-i18n';
-import { ComponentProps } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
-import { getDashboardUrl } from '../utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getHostingConfigUrl, getManagePluginsUrl, getPluginsUrl, getSettingsUrl } from '../utils';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
-const VisitDashboardItem = ( { site }: { site: SiteExcerptData } ) => {
+interface SitesMenuItemProps {
+	site: SiteExcerptData;
+	recordTracks: ( eventName: string, extraProps?: Record< string, any > ) => void;
+}
+
+const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 
 	return (
-		<PopoverMenuItem href={ getDashboardUrl( site.slug ) }>
-			{ __( 'Visit Dashboard' ) }
+		<PopoverMenuItem
+			href={ getSettingsUrl( site.slug ) }
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_settings_click' ) }
+		>
+			{ __( 'Settings' ) }
+		</PopoverMenuItem>
+	);
+};
+
+const ManagePluginsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+	const hasManagePluginsFeature = useSelector( ( state ) =>
+		siteHasFeature( state, site.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
+	);
+
+	// If the site can't manage plugins then go to the main plugins page instead
+	// because it shows an upsell message.
+	const [ href, label ] = hasManagePluginsFeature
+		? [ getManagePluginsUrl( site.slug ), __( 'Manage plugins' ) ]
+		: [ getPluginsUrl( site.slug ), __( 'Plugins' ) ];
+
+	return (
+		<PopoverMenuItem
+			href={ href }
+			onClick={ () =>
+				recordTracks( 'calypso_sites_dashboard_site_action_plugins_click', {
+					has_manage_plugins_feature: hasManagePluginsFeature,
+				} )
+			}
+		>
+			{ label }
+		</PopoverMenuItem>
+	);
+};
+
+const HostingConfigItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<PopoverMenuItem
+			href={ getHostingConfigUrl( site.slug ) }
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_click' ) }
+		>
+			{ __( 'Hosting configuration' ) }
+		</PopoverMenuItem>
+	);
+};
+
+const alignExternalIcon = css`
+	.gridicons-external {
+		top: 0px;
+	}
+`;
+
+const WpAdminItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<PopoverMenuItem
+			className={ alignExternalIcon }
+			href={ site.options?.admin_url }
+			isExternalLink
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_wpadmin_click' ) }
+		>
+			{ __( 'Visit WP Admin' ) }
 		</PopoverMenuItem>
 	);
 };
 
 export const SitesEllipsisMenu = ( {
 	className,
-	...props
-}: ComponentProps< typeof VisitDashboardItem > & { className?: string } ) => {
+	site,
+}: {
+	className?: string;
+	site: SiteExcerptData;
+} ) => {
+	const dispatch = useDispatch();
+	const props: SitesMenuItemProps = {
+		site,
+		recordTracks: ( eventName, extraProps = {} ) => {
+			dispatch( recordTracksEvent( eventName, extraProps ) );
+		},
+	};
+
 	return (
 		<EllipsisMenu className={ className }>
-			<VisitDashboardItem { ...props } />
+			<SettingsItem { ...props } />
+			<ManagePluginsItem { ...props } />
+			<HostingConfigItem { ...props } />
+			<WpAdminItem { ...props } />
 		</EllipsisMenu>
 	);
 };

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,5 +1,21 @@
 export const getDashboardUrl = ( slug: string ) => {
-	return '/home/' + slug;
+	return `/home/${ slug }`;
+};
+
+export const getSettingsUrl = ( slug: string ) => {
+	return `/settings/general/${ slug }`;
+};
+
+export const getPluginsUrl = ( slug: string ) => {
+	return `/plugins/${ slug }`;
+};
+
+export const getManagePluginsUrl = ( slug: string ) => {
+	return `/plugins/manage/${ slug }`;
+};
+
+export const getHostingConfigUrl = ( slug: string ) => {
+	return `/hosting-config/${ slug }`;
 };
 
 export const displaySiteUrl = ( siteUrl: string ) => {


### PR DESCRIPTION
#### Proposed Changes

Part of #65174

* Add `admin_url` to the list of site options we fetch from the server
* Add 4 menu items to the site actions menu
   * Settings
   * Manage plugins
   * Hosting configuration
   * Visit WP admin
* If the user can't manage plugins then that action links to the regular plugins page instead, which shows an upsell
* wp-admin link opens in a new tab
* Track clicks with `calypso_sites_dashboard_site_action_***_click` events

<img width="519" alt="CleanShot 2022-08-17 at 17 07 15@2x" src="https://user-images.githubusercontent.com/1500769/185039363-93a8ab3a-ee9e-4d8b-adab-08545e76dd15.png">

I don't think we can rely on a simple ```${ URL }/wp-admin``` to get to WP Admin because Jetpack sites might have something else. Perhaps they're using a multisite URL scheme that adds something else to the admin URL 🤷 

Where the user might not have access to one of the linked features I've made sure that they will land on a page that has an upsell.

I decided against refactoring the `calypso_sites_dashboard_site_action_` prefix into a shared place because from experience I've found it's much better to be able to search the codebase for tracks events names using cmd+shift+f

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try different plans
* Try Jetpack, atomic and simple sites, want to be sure the wp-admin link works for everything
* Confirm tracks events are sent on click
* Menu should look good on mobile

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

