### PR TITLE
Sites Management Page: Show "Launch site" action in dropdown

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -6,6 +6,7 @@ import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 import { getHostingConfigUrl, getManagePluginsUrl, getPluginsUrl, getSettingsUrl } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -13,6 +14,22 @@ interface SitesMenuItemProps {
 	site: SiteExcerptData;
 	recordTracks: ( eventName: string, extraProps?: Record< string, any > ) => void;
 }
+
+const LaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+
+	return (
+		<PopoverMenuItem
+			onClick={ () => {
+				dispatch( launchSiteOrRedirectToLaunchSignupFlow( site.ID, 'sites-dashboard' ) );
+				recordTracks( 'calypso_sites_dashboard_site_action_launch_click' );
+			} }
+		>
+			{ __( 'Launch site' ) }
+		</PopoverMenuItem>
+	);
+};
 
 const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
@@ -104,6 +121,7 @@ export const SitesEllipsisMenu = ( {
 
 	return (
 		<EllipsisMenu className={ className }>
+			{ site.launch_status === 'unlaunched' && <LaunchItem { ...props } /> }
 			<SettingsItem { ...props } />
 			<ManagePluginsItem { ...props } />
 			<HostingConfigItem { ...props } />

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -16,6 +16,10 @@ export const launchSite = ( siteId ) => ( {
 	},
 } );
 
+/**
+ * @param {number} siteId
+ * @param {string?} source
+ */
 export const launchSiteOrRedirectToLaunchSignupFlow =
 	( siteId, source = null ) =>
 	( dispatch, getState ) => {


### PR DESCRIPTION
#### Proposed Changes

Depends on #66641

* Add "Launch site" action for unlaunched sites
* If the site already has a plan and domain the site launches immediately, otherwise it goes through the launch flow
* Fires `calypso_sites_dashboard_site_action_launch_click` tracks event
* Add JSDoc types for `launchSiteOrRedirectToLaunchSignupFlow` action (otherwise I got TypeScript errors)


<img width="359" alt="CleanShot 2022-08-17 at 17 41 01@2x" src="https://user-images.githubusercontent.com/1500769/185043178-7860b5ec-3005-4405-8fa7-e714ab365ff0.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch action should only appear for unlaunched sites
   * "launching" is a one-off thing i.e. if you flip a launched site into coming soon mode, it still counts as a launched site
   * uses the same logic for showing the action that the general settings page does i.e. https://github.com/Automattic/wp-calypso/blob/e1e8a5fc8c734f533c809909b959d6bd5ab2016e/client/state/selectors/is-unlaunched-site.js#L10
* If you enter the launch flow, the "Back to My Sites" button will take you back to the SMP

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65174
