### PR TITLE
ToS checkout screenshots: Change Pro to Business

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -19,7 +19,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
 	const blogName = 'e2eflowtestingtos1.wordpress.com';
-	const cartItemForProPlan = 'WordPress.com Pro';
+	const cartItemForBusinessPlan = 'WordPress.com Business';
 	let page: Page;
 	let plansPage: PlansPage;
 
@@ -80,13 +80,13 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			await plansPage.clickTab( 'Plans' );
 		} );
 
-		it( 'Click on "Upgrade" button for WordPress.com Premium plan', async function () {
-			await plansPage.selectPlan( 'Premium' );
+		it( 'Click on "Upgrade" button for WordPress.com Business plan', async function () {
+			await plansPage.selectPlan( 'Business' );
 		} );
 
-		it( 'WordPress.com Pro is added to cart', async function () {
+		it( 'WordPress.com Business is added to cart', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( cartItemForProPlan );
+			await cartCheckoutPage.validateCartItem( cartItemForBusinessPlan );
 		} );
 
 		it( 'Screenshot checkout page for all en and non-en locales', async function () {


### PR DESCRIPTION
#### Proposed Changes

* For the checkout page screenshot, the script used to add a Pro plan to cart so that the checkout page can open. With the deprecation of the Pro plan, this PR adds the Business plan to cart instead.

#### Testing Instructions

* Setup your local e2e instance by following the instructions in p58i-bH5-p2.
* In the test/e2e folder, run `BABEL_ENV=test yarn jest specs/martech/tos-screenshots__checkout.ts`. 
* Verify that the script completes successfully without errors, and that the checkout screenshots have been uploaded to wpcomtos.wordpress.com

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


