### PR TITLE
Design Picker: Increase spacing between sections

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -404,6 +404,12 @@
 		cursor: pointer;
 	}
 
+	.unified-design-picker__generated-designs {
+		.design-picker__grid {
+			padding-bottom: 32px;
+		}
+	}
+
 	.unified-design-picker__subtitle {
 		color: #50575e;
 		margin-bottom: 30px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -404,12 +404,6 @@
 		cursor: pointer;
 	}
 
-	.unified-design-picker__generated-designs {
-		.design-picker__grid {
-			padding-bottom: 32px;
-		}
-	}
-
 	.unified-design-picker__subtitle {
 		color: #50575e;
 		margin-bottom: 30px;
@@ -438,6 +432,20 @@
 
 	.components-button.is-pressed:active:hover {
 		color: var( --theme-base-color );
+	}
+
+	// Customize styles for generated designs
+	.unified-design-picker__generated-designs {
+		.design-picker__grid {
+			padding-bottom: 32px;
+		}
+	}
+
+	// Customize styles for standard designs
+	.unified-design-picker__standard-designs {
+		.unified-design-picker__subtitle {
+			margin-bottom: 14px;
+		}
 	}
 }
 
@@ -548,7 +556,7 @@
 		svg {
 			fill: var( --studio-gray-5 );
 		}
-    }
+	}
 
 	.generated-design-thumbnail__image {
 		position: relative;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -490,7 +490,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 		>
 			{ heading }
 			{ generatedDesigns.length > 0 && (
-				<>
+				<div className="unified-design-picker__generated-designs">
 					<div>
 						<h3> { translate( 'Custom designs for your site' ) } </h3>
 						<p className="unified-design-picker__subtitle">
@@ -509,7 +509,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 							{ translate( 'Choose a starting theme. You can change it later.' ) }
 						</p>
 					</div>
-				</>
+				</div>
 			) }
 			<StaticDesignPicker
 				locale={ locale }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -477,6 +477,8 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const translate = useTranslate();
+	const hasGeneratedDesigns = generatedDesigns.length > 0;
+
 	return (
 		<div
 			className={ classnames(
@@ -489,7 +491,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 			) }
 		>
 			{ heading }
-			{ generatedDesigns.length > 0 && (
+			{ hasGeneratedDesigns && (
 				<div className="unified-design-picker__generated-designs">
 					<div>
 						<h3> { translate( 'Custom designs for your site' ) } </h3>
@@ -503,29 +505,33 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 						onPreview={ onPreview }
 						verticalId={ verticalId }
 					/>
+				</div>
+			) }
+			<div className="unified-design-picker__standard-designs">
+				{ hasGeneratedDesigns && (
 					<div>
 						<h3> { translate( 'Selected themes for you' ) } </h3>
 						<p className="unified-design-picker__subtitle">
 							{ translate( 'Choose a starting theme. You can change it later.' ) }
 						</p>
 					</div>
-				</div>
-			) }
-			<StaticDesignPicker
-				locale={ locale }
-				onSelect={ onSelect }
-				onPreview={ onPreview }
-				onUpgrade={ onUpgrade }
-				designs={ staticDesigns }
-				premiumBadge={ premiumBadge }
-				categorization={ categorization }
-				verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? verticalId : undefined }
-				previewOnly={ previewOnly }
-				hasDesignOptionHeader={ hasDesignOptionHeader }
-				isPremiumThemeAvailable={ isPremiumThemeAvailable }
-				onCheckout={ onCheckout }
-				purchasedThemes={ purchasedThemes }
-			/>
+				) }
+				<StaticDesignPicker
+					locale={ locale }
+					onSelect={ onSelect }
+					onPreview={ onPreview }
+					onUpgrade={ onUpgrade }
+					designs={ staticDesigns }
+					premiumBadge={ premiumBadge }
+					categorization={ categorization }
+					verticalId={ isEnabled( 'signup/standard-theme-v13n' ) ? verticalId : undefined }
+					previewOnly={ previewOnly }
+					hasDesignOptionHeader={ hasDesignOptionHeader }
+					isPremiumThemeAvailable={ isPremiumThemeAvailable }
+					onCheckout={ onCheckout }
+					purchasedThemes={ purchasedThemes }
+				/>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* According to https://github.com/Automattic/wp-calypso/pull/66515#issuecomment-1216893474, we want to increase the spacing between top and bottom sections. So, I add the following changes
  *  Put sections into div with `.unified-design-picker__generated-designs` and `unified-design-picker__standard-designs` respectively. Each section is consist of `title`, `subtitle`, and its own design picker component
  * Add the `padding-bottom` of `.design-picker__grid` inside the generated designs to increase +32px spacing.
  * Reduce the `margin-bottom` of `.unified-design-picker__subtitle` inside the standard designs by 16px.

- [x] Confirm the spacing on mobile with @saygunnyc 


**Desktop**

![image](https://user-images.githubusercontent.com/13596067/185090014-0dcce5f2-d45d-40c6-8fb8-e411efbb5371.png) 

**Mobile**

![image](https://user-images.githubusercontent.com/13596067/185091145-c98621f8-4c40-42c8-be0b-daf8aa628e44.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to setup flow: `http://calypso.localhost:3000/setup?siteSlug=<your_site>`
* When you land on the design picker, check the spacing between top and bottom sections is `72px` (40px + 32px)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/66515#issuecomment-1216893474
