### PR TITLE
Search: fade input on RTL mode

### DIFF
--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -102,3 +102,5 @@ export const WithDifferentColor = () => (
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 	<BoxedSearch className="stories__search--with-different-color" />
 );
+
+export const RTLMode = () => <BoxedSearch dir="rtl" />;

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -208,15 +208,14 @@ $input-z-index: 20;
 			font-size: $font-body;
 
 			&::before {
-				@include long-content-fade( $size: 32px, $z-index: $input-z-index + 2, $color: var( --color-surface ) );
+				@include long-content-fade( $direction: right, $size: 32px, $z-index: $input-z-index + 2, $color: var( --color-surface ) );
 				border-radius: inherit;
 			}
 
-			&.ltr {
-				/*!rtl:ignore*/
+			&.rtl {
 				&::before {
 					@include long-content-fade(
-						$direction: right,
+						$direction: left,
 						$size: 32px,
 						$z-index: $input-z-index + 2,
 						$color: var( --color-surface )


### PR DESCRIPTION
#### Proposed Changes

`trunk` version of RTL mode input fade is broken: the fade is applied to the right of the input instead of fading out the characters on the left (which is the end in RTL).

This PR corrects the issue.

#### Testing Instructions

1. Run `yarn workspace @automattic/search run storybook`;
2. Open the `RTL mode` story;
3. Type a lot of characters.

Check that the fade is applied to the left (end) of the input instead of to the right (start).

| This PR | `trunk` |
| --------| ------- |
| ![image](https://user-images.githubusercontent.com/26530524/185212598-09026808-816f-448b-a3dd-815433ce26a6.png) | ![image](https://user-images.githubusercontent.com/26530524/185212720-5e334ac8-5267-409e-af0f-40cc643550aa.png) |
