### PR TITLE
Sites Management Dashboard: Add visibility distinction

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -11,7 +11,7 @@ import { SitesSearchIcon } from './sites-search-icon';
 
 export interface SitesDashboardQueryParams {
 	search?: string;
-	showHidden?: boolean;
+	showHidden: boolean;
 	status: FilterableSiteLaunchStatuses;
 }
 

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -54,6 +54,7 @@ type SitesContentControlsProps = {
 	initialSearch?: string;
 	statuses: Statuses;
 	selectedStatus: Statuses[ number ];
+	includeHiddenOnSiteCount: boolean;
 } & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher >;
 
 export const SitesContentControls = ( {
@@ -62,6 +63,7 @@ export const SitesContentControls = ( {
 	selectedStatus,
 	displayMode,
 	onDisplayModeChange,
+	includeHiddenOnSiteCount,
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 
@@ -77,11 +79,11 @@ export const SitesContentControls = ( {
 			/>
 			<DisplayControls>
 				<ControlsSelectDropdown selectedText={ selectedStatus.title }>
-					{ statuses.map( ( { name, title, count } ) => (
+					{ statuses.map( ( { name, title, visibleCount, hiddenCount } ) => (
 						<SelectDropdown.Item
 							key={ name }
 							selected={ name === selectedStatus.name }
-							count={ count }
+							count={ includeHiddenOnSiteCount ? visibleCount + hiddenCount : visibleCount }
 							onClick={ () => handleQueryParamChange( 'status', 'all' !== name ? name : '' ) }
 						>
 							{ title }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -129,6 +129,7 @@ export function SitesDashboard( {
 							{ displayMode === 'list' && (
 								<>
 									<SitesTable
+										showVisibilityColumn={ showHidden }
 										isLoading={ isLoading }
 										sites={ sitesList }
 										className={ sitesMargin }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -139,6 +139,7 @@ export function SitesDashboard( {
 							{ displayMode === 'tile' && (
 								<>
 									<SitesGrid
+										showVisibilityIndicator={ showHidden }
 										isLoading={ isLoading }
 										sites={ sitesList }
 										className={ sitesMargin }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -94,8 +94,6 @@ export function SitesDashboard( {
 
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 
-	const hasSites = filteredSites.hidden.length > 0 || filteredSites.visible.length > 0;
-
 	const sitesList = useMemo( () => {
 		return showHidden
 			? [ ...filteredSites.visible, ...filteredSites.hidden ]
@@ -117,6 +115,7 @@ export function SitesDashboard( {
 				<>
 					{ ( allSites.length > 0 || isLoading ) && (
 						<SitesContentControls
+							includeHiddenOnSiteCount={ showHidden }
 							initialSearch={ search }
 							statuses={ statuses }
 							selectedStatus={ selectedStatus }
@@ -124,7 +123,7 @@ export function SitesDashboard( {
 							onDisplayModeChange={ setDisplayMode }
 						/>
 					) }
-					{ hasSites || isLoading ? (
+					{ sitesList.length > 0 || isLoading ? (
 						<>
 							{ displayMode === 'list' && (
 								<>
@@ -170,7 +169,11 @@ export function SitesDashboard( {
 					) : (
 						<NoSitesMessage
 							status={ selectedStatus.name }
-							statusSiteCount={ selectedStatus.count }
+							statusSiteCount={
+								showHidden
+									? selectedStatus.visibleCount + selectedStatus.hiddenCount
+									: selectedStatus.visibleCount
+							}
 						/>
 					) }
 				</>

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,4 +1,4 @@
-import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/components';
+import { useSiteLaunchStatusLabel, getSiteLaunchStatus, Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import { useI18n } from '@wordpress/react-i18n';
 import { AnchorHTMLAttributes, memo } from 'react';
@@ -34,9 +34,10 @@ const ellipsis = css( {
 
 interface SitesGridItemProps {
 	site: SiteExcerptData;
+	showVisibilityIndicator: boolean;
 }
 
-export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
+export const SitesGridItem = memo( ( { site, showVisibilityIndicator }: SitesGridItemProps ) => {
 	const { __ } = useI18n();
 
 	const isP2Site = site.options?.is_wpforteams_site;
@@ -61,6 +62,13 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 					</SiteName>
 
 					<div className={ badges }>
+						{ showVisibilityIndicator && (
+							<Gridicon
+								size={ 16 }
+								title={ site.visible ? __( 'Visible' ) : __( 'Hidden' ) }
+								icon={ site.visible ? 'visible' : 'not-visible' }
+							/>
+						) }
 						{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 						{ getSiteLaunchStatus( site ) !== 'public' && (
 							<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>

--- a/client/sites-dashboard/components/sites-grid.tsx
+++ b/client/sites-dashboard/components/sites-grid.tsx
@@ -25,16 +25,28 @@ interface SitesGridProps {
 	className?: string;
 	isLoading: boolean;
 	sites: SiteExcerptData[];
+	showVisibilityIndicator: boolean;
 }
 
-export const SitesGrid = ( { sites, isLoading, className }: SitesGridProps ) => {
+export const SitesGrid = ( {
+	sites,
+	isLoading,
+	className,
+	showVisibilityIndicator,
+}: SitesGridProps ) => {
 	return (
 		<div className={ classnames( container, className ) }>
 			{ isLoading
 				? Array( N_LOADING_ROWS )
 						.fill( null )
 						.map( ( _, i ) => <SitesGridItemLoading key={ i } delayMS={ i * 150 } /> )
-				: sites.map( ( site ) => <SitesGridItem site={ site } key={ site.ID } /> ) }
+				: sites.map( ( site ) => (
+						<SitesGridItem
+							site={ site }
+							key={ site.ID }
+							showVisibilityIndicator={ showVisibilityIndicator }
+						/>
+				  ) ) }
 		</div>
 	);
 };

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -15,6 +15,7 @@ import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 interface SiteTableRowProps {
 	site: SiteExcerptData;
+	displayVisibility: boolean;
 }
 
 const Row = styled.tr`
@@ -73,7 +74,7 @@ const SitePlanIcon = styled.div`
 	margin-right: 6px;
 `;
 
-export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
+export default memo( function SitesTableRow( { site, displayVisibility }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 
@@ -126,6 +127,9 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
 			<Column mobileHidden>{ translatedStatus }</Column>
+			{ displayVisibility && (
+				<Column mobileHidden>{ site.visible ? __( 'Visible' ) : __( 'Hidden' ) }</Column>
+			) }
 			<Column style={ { width: '20px' } }>
 				<SitesEllipsisMenu site={ site } />
 			</Column>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -15,16 +15,25 @@ interface SitesTableProps {
 const Table = styled.table`
 	border-collapse: collapse;
 	table-layout: fixed;
-	@media only screen and ( max-width: 781px ) {
-		.sites-table__mobile-hidden {
-			display: none;
-		}
-	}
+	position: relative;
 `;
+
+const THead = styled.thead( {
+	'@media only screen and ( max-width: 781px )': {
+		display: 'none',
+	},
+
+	position: 'sticky',
+	zIndex: 1,
+	top: '32px',
+
+	background: '#fdfdfd',
+} );
 
 const Row = styled.tr`
 	line-height: 2em;
 	border-bottom: 1px solid #eee;
+
 	th {
 		padding-top: 12px;
 		padding-bottom: 12px;
@@ -32,7 +41,7 @@ const Row = styled.tr`
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.24px;
-		font-weight: normal;
+		font-weight: 500;
 		color: var( --studio-gray-60 );
 	}
 `;
@@ -42,7 +51,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 
 	return (
 		<Table className={ className }>
-			<thead className="sites-table__mobile-hidden">
+			<THead>
 				<Row>
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
@@ -50,7 +59,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 					<th>{ __( 'Status' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>
-			</thead>
+			</THead>
 			<tbody>
 				{ isLoading &&
 					Array( N_LOADING_ROWS )

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -10,6 +10,7 @@ interface SitesTableProps {
 	className?: string;
 	sites: SiteExcerptData[];
 	isLoading?: boolean;
+	showVisibilityColumn: boolean;
 }
 
 const Table = styled.table`
@@ -46,7 +47,12 @@ const Row = styled.tr`
 	}
 `;
 
-export function SitesTable( { className, sites, isLoading = false }: SitesTableProps ) {
+export function SitesTable( {
+	className,
+	sites,
+	isLoading = false,
+	showVisibilityColumn,
+}: SitesTableProps ) {
 	const { __ } = useI18n();
 
 	return (
@@ -57,6 +63,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
 					<th>{ __( 'Last Publish' ) }</th>
 					<th>{ __( 'Status' ) }</th>
+					{ showVisibilityColumn && <th>{ __( 'Visibility' ) }</th> }
 					<th style={ { width: '20px' } }></th>
 				</Row>
 			</THead>
@@ -67,13 +74,13 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 						.map( ( _, i ) => (
 							<SitesTableRowLoading
 								key={ i }
-								columns={ 5 }
+								columns={ showVisibilityColumn ? 6 : 5 }
 								delayMS={ i * 150 }
 								logoProps={ { width: 108, height: 78 } }
 							/>
 						) ) }
 				{ sites.map( ( site ) => (
-					<SitesTableRow site={ site } key={ site.ID }></SitesTableRow>
+					<SitesTableRow site={ site } key={ site.ID } displayVisibility={ showVisibilityColumn } />
 				) ) }
 			</tbody>
 		</Table>

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -34,7 +34,8 @@ const status = 'all';
 describe( 'useSitesTableFiltering', () => {
 	test( 'no sites to filter', () => {
 		const { result } = renderHook( () => useSitesTableFiltering( [], { search: '', status } ) );
-		expect( result.current.filteredSites ).toEqual( [] );
+		expect( result.current.filteredSites.visible ).toEqual( [] );
+		expect( result.current.filteredSites.hidden ).toEqual( [] );
 	} );
 
 	test( 'empty search query returns the same list', () => {
@@ -42,7 +43,8 @@ describe( 'useSitesTableFiltering', () => {
 
 		const { result } = renderHook( () => useSitesTableFiltering( sites, { search: '', status } ) );
 
-		expect( result.current.filteredSites ).toEqual( sites );
+		expect( result.current.filteredSites.visible ).toEqual( sites );
+		expect( result.current.filteredSites.hidden ).toEqual( [] );
 	} );
 
 	test( 'search by query matches site name', () => {
@@ -53,7 +55,8 @@ describe( 'useSitesTableFiltering', () => {
 			useSitesTableFiltering( [ catSite, dogSite ], { search: 'c', status } )
 		);
 
-		expect( result.current.filteredSites ).toEqual( [ catSite ] );
+		expect( result.current.filteredSites.visible ).toEqual( [ catSite ] );
+		expect( result.current.filteredSites.hidden ).toEqual( [] );
 	} );
 
 	test( 'search by query matches site URL', () => {
@@ -64,7 +67,8 @@ describe( 'useSitesTableFiltering', () => {
 			useSitesTableFiltering( [ catSite, dogSite ], { search: 'c', status } )
 		);
 
-		expect( result.current.filteredSites ).toEqual( [ catSite ] );
+		expect( result.current.filteredSites.visible ).toEqual( [ catSite ] );
+		expect( result.current.filteredSites.hidden ).toEqual( [] );
 	} );
 
 	test( 'filter by "private"', () => {
@@ -80,7 +84,8 @@ describe( 'useSitesTableFiltering', () => {
 			} )
 		);
 
-		expect( result.current.filteredSites ).toEqual( [ private1, private2 ] );
+		expect( result.current.filteredSites.visible ).toEqual( [ private1, private2 ] );
+		expect( result.current.filteredSites.hidden ).toEqual( [] );
 	} );
 
 	test( 'returns counts for each status type', () => {
@@ -100,26 +105,26 @@ describe( 'useSitesTableFiltering', () => {
 		expect( result.current.statuses ).toEqual( [
 			{
 				name: 'all',
-				count: 4, // hidden site not included in count
 				title: expect.any( String ),
+				visibleCount: 4,
 				hiddenCount: 1,
 			},
 			{
 				name: 'public',
-				count: 2,
 				title: expect.any( String ),
+				visibleCount: 2,
 				hiddenCount: 0,
 			},
 			{
 				name: 'private',
-				count: 1, // hidden site not included in count
 				title: expect.any( String ),
+				visibleCount: 1,
 				hiddenCount: 1,
 			},
 			{
 				name: 'coming-soon',
-				count: 1,
 				title: expect.any( String ),
+				visibleCount: 1,
 				hiddenCount: 0,
 			},
 		] );
@@ -135,16 +140,19 @@ describe( 'useSitesTableFiltering', () => {
 			{ initialProps: { search: 'titl' } }
 		);
 
-		expect( result.current.filteredSites ).toHaveLength( 1 );
-		expect( result.current.filteredSites[ 0 ] ).toBe( mockSite );
+		expect( result.current.filteredSites.visible ).toHaveLength( 1 );
+		expect( result.current.filteredSites.visible[ 0 ] ).toBe( mockSite );
+		expect( result.current.filteredSites.hidden ).toHaveLength( 0 );
 
 		rerender( { search: 'does not match' } );
 
-		expect( result.current.filteredSites ).toHaveLength( 0 );
+		expect( result.current.filteredSites.visible ).toHaveLength( 0 );
+		expect( result.current.filteredSites.hidden ).toHaveLength( 0 );
 
 		rerender( { search: 'title' } );
 
-		expect( result.current.filteredSites ).toHaveLength( 1 );
-		expect( result.current.filteredSites[ 0 ] ).toBe( mockSite );
+		expect( result.current.filteredSites.visible ).toHaveLength( 1 );
+		expect( result.current.filteredSites.visible[ 0 ] ).toBe( mockSite );
+		expect( result.current.filteredSites.hidden ).toHaveLength( 0 );
 	} );
 } );

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -83,28 +83,6 @@ describe( 'useSitesTableFiltering', () => {
 		expect( result.current.filteredSites ).toEqual( [ private1, private2 ] );
 	} );
 
-	test( 'does not return hidden sites by default', () => {
-		const visible = createMockSite( { visible: true } );
-		const hidden = createMockSite( { visible: false } );
-
-		const { result } = renderHook( () =>
-			useSitesTableFiltering( [ visible, hidden ], { status } )
-		);
-
-		expect( result.current.filteredSites ).toEqual( [ visible ] );
-	} );
-
-	test( 'returns hidden sites when asked', () => {
-		const visible = createMockSite( { visible: true } );
-		const hidden = createMockSite( { visible: false } );
-
-		const { result } = renderHook( () =>
-			useSitesTableFiltering( [ visible, hidden ], { status, showHidden: true } )
-		);
-
-		expect( result.current.filteredSites ).toEqual( [ visible, hidden ] );
-	} );
-
 	test( 'returns counts for each status type', () => {
 		const public1 = createMockSite( { is_private: false } );
 		const public2 = createMockSite( { is_private: false } );
@@ -137,49 +115,6 @@ describe( 'useSitesTableFiltering', () => {
 				count: 1, // hidden site not included in count
 				title: expect.any( String ),
 				hiddenCount: 1,
-			},
-			{
-				name: 'coming-soon',
-				count: 1,
-				title: expect.any( String ),
-				hiddenCount: 0,
-			},
-		] );
-	} );
-
-	test( 'showHidden option includes hidden sites in `count`, but not `hiddenCount`', () => {
-		const public1 = createMockSite( { is_private: false } );
-		const public2 = createMockSite( { is_private: false, visible: false } );
-		const private1 = createMockSite( { is_private: true } );
-		const private2 = createMockSite( { is_private: true, visible: false } );
-		const comingSoon = createMockSite( { is_private: true, is_coming_soon: true } );
-
-		const { result } = renderHook( () =>
-			useSitesTableFiltering( [ public1, public2, private1, private2, comingSoon ], {
-				search: '',
-				showHidden: true,
-				status,
-			} )
-		);
-
-		expect( result.current.statuses ).toEqual( [
-			{
-				name: 'all',
-				count: 5,
-				title: expect.any( String ),
-				hiddenCount: 0,
-			},
-			{
-				name: 'public',
-				count: 2,
-				title: expect.any( String ),
-				hiddenCount: 0,
-			},
-			{
-				name: 'private',
-				count: 2,
-				title: expect.any( String ),
-				hiddenCount: 0,
 			},
 			{
 				name: 'coming-soon',

--- a/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-filtering.tsx
@@ -88,6 +88,20 @@ describe( 'useSitesTableFiltering', () => {
 		expect( result.current.filteredSites.hidden ).toEqual( [] );
 	} );
 
+	test( 'splits by visibility status', () => {
+		const private1 = createMockSite( { is_private: true } );
+		const hidden1 = createMockSite( { is_private: true, visible: false } );
+
+		const { result } = renderHook( () =>
+			useSitesTableFiltering( [ private1, hidden1 ], {
+				status: 'private',
+			} )
+		);
+
+		expect( result.current.filteredSites.visible ).toEqual( [ private1 ] );
+		expect( result.current.filteredSites.hidden ).toEqual( [ hidden1 ] );
+	} );
+
 	test( 'returns counts for each status type', () => {
 		const public1 = createMockSite( { is_private: false } );
 		const public2 = createMockSite( { is_private: false } );

--- a/packages/components/src/sites-table/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/use-sites-table-filtering.tsx
@@ -30,7 +30,8 @@ interface SitesTableFilterOptions {
 interface Status {
 	title: React.ReactChild;
 	name: FilterableSiteLaunchStatuses;
-	count: number;
+	visibleCount: number;
+	hiddenCount: number;
 }
 
 interface UseSitesTableFilteringResult< T > {
@@ -60,12 +61,6 @@ export function useSitesTableFiltering< T extends SiteObjectWithBasicInfo >(
 	}, [ __, translatedSiteLaunchStatuses ] );
 
 	const [ statuses, groupedByStatus ] = useMemo( () => {
-		const statuses: Status[] = siteLaunchStatusFilterValues.map( ( name ) => ( {
-			name,
-			title: filterableSiteLaunchStatuses[ name ],
-			count: 0,
-		} ) );
-
 		const groupedByStatus = allSites.reduce< {
 			[ K in Status[ 'name' ] ]: SitesByVisibility< T >;
 		} >(
@@ -87,11 +82,12 @@ export function useSitesTableFiltering< T extends SiteObjectWithBasicInfo >(
 			}
 		);
 
-		for ( const status of statuses ) {
-			status.count =
-				groupedByStatus[ status.name ].visible.length +
-				groupedByStatus[ status.name ].hidden.length;
-		}
+		const statuses: Status[] = siteLaunchStatusFilterValues.map( ( name ) => ( {
+			name,
+			title: filterableSiteLaunchStatuses[ name ],
+			visibleCount: groupedByStatus[ name ].visible.length,
+			hiddenCount: groupedByStatus[ name ].hidden.length,
+		} ) );
 
 		return [ statuses, groupedByStatus ];
 	}, [ allSites, filterableSiteLaunchStatuses ] );


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/66597.

### Proposed Changes

This PR aims to improve the perception of visibility status for the user. It adds a new column to the sites table and an icon to the sites grid.

The order of the list is now preserved by adding the exposed hidden sites to the bottom of it.

The visibility column only shows up when the hidden sites are exposed. The same thing happens in tile mode, but with an icon indicating the visibility.

I've also included a little UX improvement: stick the table head at the top. It improves understanding of the columns as the list grows longer.

### Testing Instructions

#### Sticky table headings

![image](https://user-images.githubusercontent.com/26530524/185236092-2fdd9b8c-5522-453a-9a71-5a4c27043d44.png)

#### Table mode (appended to the bottom of the list)

![Screen Shot 2022-08-17 at 17 25 40](https://user-images.githubusercontent.com/26530524/185236395-05faf262-1476-4e16-b76a-1e3672667b3f.png)

#### Tile mode

![Screen Shot 2022-08-17 at 17 27 59](https://user-images.githubusercontent.com/26530524/185236775-2df84970-5170-47fb-9876-859973e99c2f.png)