### PR TITLE
Use refs instead of ID for blazepress widget container

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -1,7 +1,7 @@
 // import { Button } from '@automattic/components';
 // import { createInterpolateElement } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { usePostIdParam } from 'calypso/landing/stepper/hooks/use-post-id-param';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
@@ -18,23 +18,23 @@ const Promote: React.FC< Props > = () => {
 	const postIdParam = usePostIdParam();
 	const { setStepProgress } = useDispatch( ONBOARD_STORE );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const widgetWrapperId = 'promote__widget-container';
+	const widgetWrapperRef = useRef< HTMLDivElement | null >( null );
 
 	useEffect( () => {
 		( async () => {
-			if ( siteIdParam === null || postIdParam === null ) {
+			if ( siteIdParam === null || postIdParam === null || widgetWrapperRef.current === null ) {
 				return;
 			}
-			await showDSP( siteIdParam, postIdParam, widgetWrapperId );
+			await showDSP( siteIdParam, postIdParam, widgetWrapperRef.current );
 			setIsLoading( false );
 			setStepProgress( { count: 4, progress: 1 } );
 		} )();
-	}, [] );
+	}, [ widgetWrapperRef.current ] );
 
 	return (
 		<div className="promote__content">
 			{ isLoading && <LoadingEllipsis /> }
-			<div id={ widgetWrapperId }></div>
+			<div ref={ widgetWrapperRef }></div>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/promote.tsx
@@ -33,7 +33,11 @@ const Promote: React.FC< Props > = () => {
 
 	return (
 		<div className="promote__content">
-			{ isLoading && <LoadingEllipsis /> }
+			{ isLoading && (
+				<div style={ { textAlign: 'center' } }>
+					<LoadingEllipsis />
+				</div>
+			) }
 			<div ref={ widgetWrapperRef }></div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/promote/style.scss
@@ -33,7 +33,6 @@
 
     .promote__content {
         padding: 0;
-        text-align: center;
         margin: 0 auto;
     }
 }

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -7,6 +7,7 @@ declare global {
 	interface Window {
 		BlazePress?: {
 			render: ( params: {
+				domNode?: HTMLElement;
 				domNodeId?: string;
 				stripeKey: string;
 				apiHost: string;
@@ -34,13 +35,14 @@ export async function loadDSPWidgetJS(): Promise< void > {
 export async function showDSP(
 	siteId: number | string,
 	postId: number | string,
-	domNodeId?: string
+	domNodeOrId?: HTMLElement | string
 ) {
 	await loadDSPWidgetJS();
 	return new Promise( ( resolve, reject ) => {
 		if ( window.BlazePress ) {
 			window.BlazePress.render( {
-				domNodeId: domNodeId ?? '',
+				domNode: typeof domNodeOrId !== 'string' ? domNodeOrId : undefined,
+				domNodeId: typeof domNodeOrId === 'string' ? domNodeOrId : undefined,
 				stripeKey: config( 'dsp_stripe_pub_key' ),
 				apiHost: 'https://public-api.wordpress.com',
 				apiPrefix: `/wpcom/v2/sites/${ siteId }/wordads/dsp`,


### PR DESCRIPTION
#### Proposed Changes

* Update widget stepper to use refs instead of ID (related: Picard PR 474)
* Also fixes a small styling bug that centered content

#### Testing Instructions

* This is a minor change. Widget should still work exactly the same way, e.g. https://wordpress.com/setup/promote?flow=blazepress&siteId=280895&postId=402349&flags=promote-post

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
