### PR TITLE
Add a margin-bottom for this specific case on Woocommerce Subscriptions.

### DIFF
--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -15,7 +15,7 @@
 	word-wrap: break-word;
 	hyphens: auto;
 
-	div div {
+	div {
 		margin-bottom: 20px;
 	}
 }

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -14,6 +14,10 @@
 	line-height: 21px;
 	word-wrap: break-word;
 	hyphens: auto;
+
+	div div {
+		margin-bottom: 20px;
+	}
 }
 
 .plugin-sections__content {


### PR DESCRIPTION
#### Proposed Changes

Add a margin-bottom for this specific case on Woocommerce products as Subscriptions and Product Add-Ons.

This change would be applied every time there is a div inside a div in `plugin-sections__content`, which shouldn't have a big negative impact on the other views.

| Before  | After |
| ------------- | ------------- |
|<img width="612" alt="Screen Shot 2022-08-17 at 17 32 00" src="https://user-images.githubusercontent.com/5039531/185248428-1363e7f5-d70d-41e7-9642-8abbd2597dc9.png">|<img width="612" alt="Screen Shot 2022-08-17 at 17 34 03" src="https://user-images.githubusercontent.com/5039531/185248453-bca8d723-213e-4e44-9fa8-76a84dad81ac.png">|


#### Testing Instructions

* Go to WooCommerce Subscriptions or Product Add-Ons WP.com page (`/plugins/woocommerce-subscriptions` or `/plugins/woocommerce-product-addons` )
* Check the piece starting with *WooCommerce Subscriptions is compatible with* is separated from the next section.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65842
Fixes #65461
