### PR TITLE
Separate PluginsSearchResults page from PluginsBrowser

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -12,6 +12,7 @@ import PluginDetails from './plugin-details';
 import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
+import PluginsSearchResultPage from './plugins-search-results-page';
 
 function renderSinglePlugin( context, siteUrl ) {
 	const pluginSlug = decodeURIComponent( context.params.plugin );
@@ -56,6 +57,15 @@ function renderPluginsBrowser( context ) {
 	context.primary = createElement( PluginBrowser, {
 		path: context.path,
 		category,
+		search: searchTerm,
+	} );
+}
+
+function renderPluginsSearchPage( context ) {
+	const searchTerm = context.query.s;
+
+	context.primary = createElement( PluginsSearchResultPage, {
+		path: context.path,
 		search: searchTerm,
 	} );
 }
@@ -111,6 +121,14 @@ export function browsePluginsOrPlugin( context, next ) {
 }
 
 export function browsePlugins( context, next ) {
+	const searchTerm = context.query.s;
+
+	if ( searchTerm ) {
+		renderPluginsSearchPage( context );
+
+		return next();
+	}
+
 	renderPluginsBrowser( context );
 	next();
 }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,17 +1,21 @@
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import MainComponent from 'calypso/components/main';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import EducationFooter from 'calypso/my-sites/plugins/education-footer';
+import JetpackDisconnectedNotice from 'calypso/my-sites/plugins/jetpack-disconnected-notice';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
+import PluginsCategoryResultsPage from 'calypso/my-sites/plugins/plugins-category-results-page';
+import PluginsDiscoveryPage from 'calypso/my-sites/plugins/plugins-discovery-page';
+import PluginsNavigationHeader from 'calypso/my-sites/plugins/plugins-navigation-header';
+import PluginsPageViewTracker from 'calypso/my-sites/plugins/plugins-page-view-tracker';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -19,33 +23,9 @@ import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-s
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSitePlan, isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import {
-	getSelectedSiteId,
-	getSelectedSite,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
-import JetpackDisconnectedNotice from '../jetpack-disconnected-notice';
-import PluginsCategoryResultsPage from '../plugins-category-results-page';
-import PluginsDiscoveryPage from '../plugins-discovery-page';
-import PluginsNavigationHeader from '../plugins-navigation-header';
-import PluginsSearchResultPage from '../plugins-search-results-page';
+import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-
-const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
-	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
-	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
-
-	if ( selectedSiteId ) {
-		analyticsPath += '/:site';
-	}
-
-	if ( trackPageViews ) {
-		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
-	}
-
-	return null;
-};
 
 const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader } ) => {
 	const {
@@ -54,8 +34,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		referenceRef: navigationHeaderRef,
 	} = useScrollAboveElement();
 	const searchRef = useRef( null );
-	//  another temporary solution until phase 4 is merged
-	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
@@ -72,7 +50,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			!! selectedSite?.ID && ! canCurrentUser( state, selectedSite?.ID, 'manage_options' )
 	);
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const siteId = useSelector( getSelectedSiteId );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
 
@@ -83,18 +60,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {
-		if ( search ) {
-			return (
-				<PluginsSearchResultPage
-					search={ search }
-					setIsFetchingPluginsBySearchTerm={ setIsFetchingPluginsBySearchTerm }
-					siteSlug={ siteSlug }
-					siteId={ siteId }
-					sites={ sites }
-				/>
-			);
-		}
-
 		if ( category ) {
 			return (
 				<PluginsCategoryResultsPage category={ category } sites={ sites } siteSlug={ siteSlug } />
@@ -121,7 +86,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		<MainComponent wideLayout>
 			<QueryProductsList persist />
 			<QueryJetpackPlugins siteIds={ siteIds } />
-			<PageViewTrackerWrapper
+			<PluginsPageViewTracker
 				category={ category }
 				selectedSiteId={ selectedSite?.ID }
 				trackPageViews={ trackPageViews }
@@ -143,7 +108,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				popularSearchesRef={ searchHeaderRef }
 				isSticky={ isAboveElement }
 				searchTerm={ search }
-				isSearching={ isFetchingPluginsBySearchTerm }
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -15,7 +15,8 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
 
-let mockPlugins = [];
+const mockPlugins = [];
+
 jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
 	useWPORGPlugins: jest.fn( () => ( { data: { plugins: mockPlugins } } ) ),
 	useWPORGInfinitePlugins: jest.fn( () => ( {
@@ -108,22 +109,6 @@ function mountWithRedux( ui, overrideState ) {
 	);
 	return mount( <Provider store={ store }>{ ui }</Provider> );
 }
-
-describe( 'Search view', () => {
-	const myProps = {
-		search: 'searchterm',
-	};
-
-	test( 'should show NoResults when there are no results', () => {
-		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
-		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
-	} );
-	test( 'should show plugin list when there are results', () => {
-		mockPlugins = [ {} ];
-		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
-		expect( comp.find( 'PluginsBrowserList' ).length ).toBe( 1 );
-	} );
-} );
 
 describe( 'Upsell Nudge should get appropriate plan constant', () => {
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( product_slug ) => {

--- a/client/my-sites/plugins/plugins-page-view-tracker/index.jsx
+++ b/client/my-sites/plugins/plugins-page-view-tracker/index.jsx
@@ -1,0 +1,18 @@
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+const PluginsPageViewTracker = ( { category, selectedSiteId, trackPageViews } ) => {
+	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
+	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
+
+	if ( selectedSiteId ) {
+		analyticsPath += '/:site';
+	}
+
+	if ( trackPageViews ) {
+		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+	}
+
+	return null;
+};
+
+export default PluginsPageViewTracker;

--- a/client/my-sites/plugins/plugins-search-results-page/README.md
+++ b/client/my-sites/plugins/plugins-search-results-page/README.md
@@ -10,12 +10,7 @@ import PluginsSearchResultsPage from 'calypso/my-sites/plugins/plugins-search-re
 function render() {
 	return (
 		<div>
-			<PluginsSearchResultsPage
-				search={ search }
-				siteSlug={ siteSlug }
-				siteId={ siteId }
-				sites={ sites }
-			/>
+			<PluginsSearchResultsPage search={ search } />
 		</div>
 	);
 }
@@ -23,7 +18,4 @@ function render() {
 
 ## Props
 
-- `siteSlug`: a string containing the slug of the selected site
-- `sites`: a sites-list object
-- `siteId`: a number containing the current site id.
 - `search`: a string with the current search term, if exists

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -88,19 +88,19 @@ const PluginsSearchResultList = ( {
 				</>
 			);
 		}
-
-		return (
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			<div className="plugins-browser__no-results">
-				<NoResults
-					text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
-						textOnly: true,
-						components: { searchTerm: <em>{ searchTerm }</em> },
-					} ) }
-				/>
-			</div>
-		);
 	}
+
+	return (
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		<div className="plugins-browser__no-results">
+			<NoResults
+				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
+					textOnly: true,
+					components: { searchTerm: <em>{ searchTerm }</em> },
+				} ) }
+			/>
+		</div>
+	);
 };
 
 const PluginsSearchResultPage = ( { trackPageViews = true, category, search, hideHeader } ) => {

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -1,13 +1,28 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
+import MainComponent from 'calypso/components/main';
+import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import NoResults from 'calypso/my-sites/no-results';
+import JetpackDisconnectedNotice from 'calypso/my-sites/plugins/jetpack-disconnected-notice';
+import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import ClearSearchButton from 'calypso/my-sites/plugins/plugins-browser/clear-search-button';
+import PluginsNavigationHeader from 'calypso/my-sites/plugins/plugins-navigation-header';
+import PluginsPageViewTracker from 'calypso/my-sites/plugins/plugins-page-view-tracker';
+import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
+import usePlugins from 'calypso/my-sites/plugins/use-plugins';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import ClearSearchButton from '../plugins-browser/clear-search-button';
-import usePlugins from '../use-plugins';
+import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+import '../plugins-browser/style.scss';
 
 /**
  * Module variables
@@ -18,60 +33,16 @@ function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
 }
 
-const PluginsSearchResultPage = ( {
-	search: searchTerm,
+const PluginsSearchResultList = ( {
+	pluginsBySearchTerm,
+	isFetchingPluginsBySearchTerm,
+	pluginsPagination,
+	searchTerm,
 	siteSlug,
-	siteId,
 	sites,
-	categoryName,
-	setIsFetchingPluginsBySearchTerm,
+	fetchNextPage,
 } ) => {
-	const {
-		plugins: pluginsBySearchTerm = [],
-		isFetching: isFetchingPluginsBySearchTerm,
-		pagination: pluginsPagination,
-		fetchNextPage,
-	} = usePlugins( {
-		infinite: true,
-		search: searchTerm,
-		wpcomEnabled: !! searchTerm,
-		wporgEnabled: !! searchTerm,
-	} );
-
-	const dispatch = useDispatch();
-
 	const translate = useTranslate();
-
-	/*
-	 * Syncs the internal value of is fetching to share it with the search header
-	 * This is a temporary solution until phase 4 of the refactor is implemented.
-	 */
-	useEffect( () => {
-		setIsFetchingPluginsBySearchTerm( isFetchingPluginsBySearchTerm );
-	}, [ setIsFetchingPluginsBySearchTerm, isFetchingPluginsBySearchTerm ] );
-
-	useEffect( () => {
-		if ( searchTerm && pluginsPagination?.page === 1 ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_results_show', {
-					search_term: searchTerm,
-					results_count: pluginsPagination?.results,
-					blog_id: siteId,
-				} )
-			);
-		}
-
-		if ( searchTerm && pluginsPagination ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_results_page', {
-					search_term: searchTerm,
-					page: pluginsPagination.page,
-					results_count: pluginsPagination?.results,
-					blog_id: siteId,
-				} )
-			);
-		}
-	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
 
 	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
 		let title = translate( 'Search results for "%(searchTerm)s"', {
@@ -93,57 +64,136 @@ const PluginsSearchResultPage = ( {
 				}
 			);
 
-			if ( categoryName ) {
-				title = translate(
-					'Found %(total)s plugin for "%(searchTerm)s" under "%(categoryName)s"',
-					'Found %(total)s plugins for "%(searchTerm)s" under "%(categoryName)s"',
-					{
-						count: pluginsPagination.results,
-						textOnly: true,
-						args: {
-							total: pluginsPagination.results,
-							searchTerm,
-							categoryName,
-						},
-					}
-				);
-			}
+			return (
+				<>
+					<PluginsBrowserList
+						plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
+						listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
+						subtitle={
+							<>
+								{ title }
+								<ClearSearchButton />
+							</>
+						}
+						showReset={ true }
+						site={ siteSlug }
+						showPlaceholders={ isFetchingPluginsBySearchTerm }
+						currentSites={ sites }
+						variant={ PluginsBrowserListVariant.Paginated }
+						extended
+						search={ searchTerm }
+					/>
+					<InfiniteScroll nextPageMethod={ fetchNextPage } />
+				</>
+			);
 		}
 
 		return (
-			<>
-				<PluginsBrowserList
-					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
-					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
-					subtitle={
-						<>
-							{ title }
-							<ClearSearchButton />
-						</>
-					}
-					showReset={ true }
-					site={ siteSlug }
-					showPlaceholders={ isFetchingPluginsBySearchTerm }
-					currentSites={ sites }
-					variant={ PluginsBrowserListVariant.Paginated }
-					extended
-					search={ searchTerm }
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<div className="plugins-browser__no-results">
+				<NoResults
+					text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
+						textOnly: true,
+						components: { searchTerm: <em>{ searchTerm }</em> },
+					} ) }
 				/>
-				<InfiniteScroll nextPageMethod={ fetchNextPage } />
-			</>
+			</div>
 		);
 	}
+};
+
+const PluginsSearchResultPage = ( { trackPageViews = true, category, search, hideHeader } ) => {
+	const {
+		plugins: pluginsBySearchTerm = [],
+		isFetching: isFetchingPluginsBySearchTerm,
+		pagination: pluginsPagination,
+		fetchNextPage,
+	} = usePlugins( {
+		infinite: true,
+		search,
+		wpcomEnabled: !! search,
+		wporgEnabled: !! search,
+	} );
+
+	const {
+		isAboveElement,
+		targetRef: searchHeaderRef,
+		referenceRef: navigationHeaderRef,
+	} = useScrollAboveElement();
+	const searchRef = useRef( null );
+
+	const dispatch = useDispatch();
+
+	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
+	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
+	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
+
+	useEffect( () => {
+		if ( search && pluginsPagination?.page === 1 ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_show', {
+					search_term: search,
+					results_count: pluginsPagination?.results,
+					blog_id: selectedSite?.ID,
+				} )
+			);
+		}
+
+		if ( search && pluginsPagination ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_page', {
+					search_term: search,
+					page: pluginsPagination.page,
+					results_count: pluginsPagination?.results,
+					blog_id: selectedSite?.ID,
+				} )
+			);
+		}
+	}, [ search, pluginsPagination, dispatch, selectedSite ] );
 
 	return (
-		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<div className="plugins-browser__no-results">
-			<NoResults
-				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
-					textOnly: true,
-					components: { searchTerm: <em>{ searchTerm }</em> },
-				} ) }
+		<MainComponent wideLayout>
+			<QueryProductsList persist />
+			<QueryJetpackPlugins siteIds={ siteIds } />
+			<PluginsPageViewTracker
+				category={ category }
+				selectedSiteId={ selectedSite?.ID }
+				trackPageViews={ trackPageViews }
 			/>
-		</div>
+			<DocumentHead title={ translate( 'Plugins' ) } />
+
+			<PluginsAnnouncementModal />
+			{ ! hideHeader && (
+				<PluginsNavigationHeader
+					navigationHeaderRef={ navigationHeaderRef }
+					category={ category }
+					search={ search }
+				/>
+			) }
+			<JetpackDisconnectedNotice />
+			<SearchBoxHeader
+				searchRef={ searchRef }
+				popularSearchesRef={ searchHeaderRef }
+				isSticky={ isAboveElement }
+				searchTerm={ search }
+				isSearching={ isFetchingPluginsBySearchTerm }
+				title={ translate( 'Plugins you need to get your projects done' ) }
+				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
+			/>
+			<div className="plugins-browser__main-container">
+				<PluginsSearchResultList
+					pluginsBySearchTerm={ pluginsBySearchTerm }
+					isFetchingPluginsBySearchTerm={ isFetchingPluginsBySearchTerm }
+					pluginsPagination={ pluginsPagination }
+					searchTerm={ search }
+					siteSlug={ selectedSite?.slug }
+					sites={ sites }
+					fetchNextPage={ fetchNextPage }
+				/>
+			</div>
+		</MainComponent>
 	);
 };
 

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -22,6 +22,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
+// We should break this styles in a subsequent PR
 import '../plugins-browser/style.scss';
 
 /**

--- a/client/my-sites/plugins/plugins-search-results-page/test/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/test/index.jsx
@@ -1,0 +1,117 @@
+/** @jest-environment jsdom */
+
+jest.mock( 'page' );
+jest.mock( 'react-query', () => ( {
+	useQuery: () => [],
+} ) );
+jest.mock( 'calypso/lib/wporg', () => ( {
+	getWporgLocaleCode: () => 'it_US',
+	fetchPluginsList: () => Promise.resolve( [] ),
+} ) );
+jest.mock( 'calypso/lib/url-search', () => ( Component ) => ( props ) => (
+	<Component { ...props } doSearch={ jest.fn() } />
+) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
+
+let mockPlugins = [];
+jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
+	useWPORGPlugins: jest.fn( () => ( { data: { plugins: mockPlugins } } ) ),
+	useWPORGInfinitePlugins: jest.fn( () => ( {
+		data: { plugins: mockPlugins },
+		fetchNextPage: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
+	useSiteSearchPlugins: jest.fn( () => ( {
+		data: { plugins: mockPlugins },
+		fetchNextPage: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '@automattic/languages', () => [
+	{
+		value: 1,
+		langSlug: 'it',
+		name: 'Italian English',
+		wpLocale: 'it_US',
+		popular: 1,
+		territories: [ '019' ],
+	},
+] );
+
+import { PLAN_FREE } from '@automattic/calypso-products';
+import { mount } from 'enzyme';
+import { merge } from 'lodash';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import PluginsSearchResultsPage from '../';
+
+window.__i18n_text_domain__ = JSON.stringify( 'default' );
+window.IntersectionObserver = jest.fn( () => ( { observe: jest.fn(), disconnect: jest.fn() } ) );
+
+const initialReduxState = {
+	plugins: {
+		wporg: {
+			lists: {},
+			fetchingLists: {},
+		},
+		installed: {
+			isRequesting: {},
+			plugins: {},
+			status: {},
+		},
+	},
+	ui: { selectedSiteId: 1 },
+	sites: {
+		items: { 1: { ID: 1, title: 'Test Site', plan: { productSlug: PLAN_FREE } } },
+		connection: { items: { 1: true } },
+	},
+	currentUser: { capabilities: { 1: { manage_options: true } } },
+	media: {
+		queries: {
+			'[]': {
+				itemKeys: [ 1 ],
+				found: 1,
+			},
+		},
+	},
+	documentHead: {},
+	preferences: { remoteValues: {} },
+	productsList: {},
+	marketplace: {
+		billingInterval: {
+			interval: IntervalLength.MONTHLY,
+		},
+	},
+};
+
+function mountWithRedux( ui, overrideState ) {
+	const store = createStore(
+		( state ) => state,
+		merge( initialReduxState, overrideState ),
+		applyMiddleware( thunkMiddleware )
+	);
+	return mount( <Provider store={ store }>{ ui }</Provider> );
+}
+
+describe( 'Search view', () => {
+	const myProps = {
+		search: 'searchterm',
+	};
+
+	test( 'should show NoResults when there are no results', () => {
+		const comp = mountWithRedux( <PluginsSearchResultsPage { ...myProps } /> );
+		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
+	} );
+
+	test( 'should show plugin list when there are results', () => {
+		mockPlugins = [ {} ];
+		const comp = mountWithRedux( <PluginsSearchResultsPage { ...myProps } /> );
+		expect( comp.find( 'PluginsBrowserList' ).length ).toBe( 1 );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Extracts `PluginsSearchResults` page from `PluginsBrowser`.
* Creates the `PluginsPageViewTracker` component.
* Search routes now render the `PluginsSearchResults` page.
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test search and the results page
* Smoke test the rest of the views (Discovery Page, Category Results Page).
* It should return the correct results
* It should show the no results page when there are no results
* It should send the correct tracks events

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64548
Fixes #66478
