### PR TITLE
Fix the round corners of the design previews are cut

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.scss
@@ -84,7 +84,7 @@
 		border: 1px solid rgba( 0, 0, 0, 0.12 );
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px 6px 0 0;
-		box-sizing: border-box;
+		box-sizing: content-box;
 	}
 }
 

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -60,6 +60,7 @@
 	border: 1px solid rgba( 0, 0, 0, 0.12 );
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px 6px 0 0;
+	overflow: hidden;
 	margin: 0 auto;
 	box-sizing: border-box;
 	transition: max-width 0.2s ease-out;


### PR DESCRIPTION
#### Proposed Changes

* Fix for the duplicated border on the browser header on the design preview

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit [https://wordpress.com/setup/designSetup?siteSlug={site](https://wordpress.com/setup/designSetup?siteSlug=%7Bsite) slug} with the goal Write and publish.
- Click on a design
- Check that the border on the browser header looks like this
<img width="446" alt="Screen Shot 2565-08-18 at 09 43 00" src="https://user-images.githubusercontent.com/1881481/185284946-4d3c168f-3b6b-4333-85c7-d44c95ee9da0.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66596
