### PR TITLE
Update/plugin management remove updates

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -229,20 +229,18 @@ export class PluginsListHeader extends PureComponent {
 				</ButtonGroup>
 			);
 
-			if ( ! ( isJetpackSelected && this.props.selected.length === 1 ) ) {
-				leftSideButtons.push(
-					<ButtonGroup key="plugin-list-header__buttons-remove-button">
-						<Button
-							compact
-							scary
-							disabled={ ! needsRemoveButton }
-							onClick={ this.props.removePluginNotice }
-						>
-							{ translate( 'Remove' ) }
-						</Button>
-					</ButtonGroup>
-				);
-			}
+			leftSideButtons.push(
+				<ButtonGroup key="plugin-list-header__buttons-remove-button">
+					<Button
+						compact
+						scary
+						disabled={ ! needsRemoveButton }
+						onClick={ this.props.removePluginNotice }
+					>
+						{ translate( 'Remove' ) }
+					</Button>
+				</ButtonGroup>
+			);
 
 			rightSideButtons.push(
 				<button
@@ -344,15 +342,13 @@ export class PluginsListHeader extends PureComponent {
 				</SelectDropdown.Item>
 
 				<SelectDropdown.Separator />
-				{ isJetpackOnlySelected && (
-					<SelectDropdown.Item
-						className="plugin-list-header__actions-remove-item"
-						disabled={ ! needsRemoveButton }
-						onClick={ this.props.removePluginNotice }
-					>
-						{ translate( 'Remove' ) }
-					</SelectDropdown.Item>
-				) }
+				<SelectDropdown.Item
+					className="plugin-list-header__actions-remove-item"
+					disabled={ ! needsRemoveButton }
+					onClick={ this.props.removePluginNotice }
+				>
+					{ translate( 'Remove' ) }
+				</SelectDropdown.Item>
 			</SelectDropdown>
 		);
 	}

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -111,7 +111,7 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	needsRemoveButton() {
-		return this.props.selected.length && this.canUpdatePlugins() && ! this.isJetpackSelected();
+		return this.props.selected.length && this.canUpdatePlugins();
 	}
 
 	renderCurrentActionButtons() {
@@ -228,18 +228,21 @@ export class PluginsListHeader extends PureComponent {
 					{ autoupdateButtons }
 				</ButtonGroup>
 			);
-			leftSideButtons.push(
-				<ButtonGroup key="plugin-list-header__buttons-remove-button">
-					<Button
-						compact
-						scary
-						disabled={ ! needsRemoveButton }
-						onClick={ this.props.removePluginNotice }
-					>
-						{ translate( 'Remove' ) }
-					</Button>
-				</ButtonGroup>
-			);
+
+			if ( ! ( isJetpackSelected && this.props.selected.length === 1 ) ) {
+				leftSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-remove-button">
+						<Button
+							compact
+							scary
+							disabled={ ! needsRemoveButton }
+							onClick={ this.props.removePluginNotice }
+						>
+							{ translate( 'Remove' ) }
+						</Button>
+					</ButtonGroup>
+				);
+			}
 
 			rightSideButtons.push(
 				<button
@@ -341,14 +344,15 @@ export class PluginsListHeader extends PureComponent {
 				</SelectDropdown.Item>
 
 				<SelectDropdown.Separator />
-
-				<SelectDropdown.Item
-					className="plugin-list-header__actions-remove-item"
-					disabled={ ! needsRemoveButton }
-					onClick={ this.props.removePluginNotice }
-				>
-					{ translate( 'Remove' ) }
-				</SelectDropdown.Item>
+				{ isJetpackOnlySelected && (
+					<SelectDropdown.Item
+						className="plugin-list-header__actions-remove-item"
+						disabled={ ! needsRemoveButton }
+						onClick={ this.props.removePluginNotice }
+					>
+						{ translate( 'Remove' ) }
+					</SelectDropdown.Item>
+				) }
 			</SelectDropdown>
 		);
 	}

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -232,10 +232,7 @@ export class PluginsList extends Component {
 
 	doActionOverSelected( actionName, action ) {
 		const isDeactivatingOrRemovingAndJetpackSelected = ( { slug } ) =>
-			( 'deactivating' === actionName ||
-				'activating' === actionName ||
-				'removing' === actionName ) &&
-			'jetpack' === slug;
+			[ 'deactivating', 'activating', 'removing' ].includes( actionName ) && 'jetpack' === slug;
 
 		const flattenArrays = ( full, partial ) => [ ...full, ...partial ];
 		this.removePluginStatuses();
@@ -425,13 +422,9 @@ export class PluginsList extends Component {
 			</div>
 		);
 
-		let isJetpackIncluded = false;
-
-		plugins.filter( this.isSelected ).forEach( ( plugin ) => {
-			if ( plugin.slug === 'jetpack' ) {
-				isJetpackIncluded = true;
-			}
-		} );
+		const isJetpackIncluded = plugins
+			.filter( this.isSelected )
+			.some( ( { slug } ) => slug === 'jetpack' );
 
 		acceptDialog(
 			message,

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -499,7 +499,7 @@ export class PluginsList extends Component {
 				removeJetpackNotice: false,
 			} );
 
-			this.props.warningNotice( translate( 'Jetpack cannot be removed from WordPress.com.' ) );
+			this.props.warningNotice( translate( 'Jetpack must be removed via wp-admin.' ) );
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Updating the Remove option in plugins management to no longer be disabled when Jetpack is either being disabled on its own or as part of a bulk action. Instead this option will now allow the removal to continue but display a warning indicating that Jetpack cannot be removed this way

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have a site with Jetpack connected
* Apply this PR and run `yarn start`
* Access the plugins management page at http://calypso.localhost:3000/plugins/manage/{your-site}
* Use the Edit All button to access the bulk actions menu
* Verify that removing a single plugin without Jetpack works as expected
* Verify that removing multiple plugins with Jetpack selected results in other plugins being removed and a warning notice indicating that Jetpack cannot be removed
* Verify that selecting Jetpack only does not disable the Remove button
* Verify that attempting to remove Jetpack only results in the remove modal dialog being present and the warning notice displayed after the remove is attempted

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
