### PR TITLE
Create feature-flag for new pricing page and add blank component

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,0 +1,12 @@
+import type { ProductStoreProps } from './types';
+
+const ProductStore: React.FC< ProductStoreProps > = () => {
+	return (
+		<div>
+			<p>{ 'Hello there! 👋' }</p>
+			<p>{ 'Something cool coming up soon' }</p>
+		</div>
+	);
+};
+
+export default ProductStore;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,0 +1,3 @@
+export type ProductStoreProps = {
+	//coming soon
+};

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useCallback, useEffect, useState, useMemo } from 'react';
@@ -26,6 +27,7 @@ import { getPurchaseURLCallback } from './get-purchase-url-callback';
 import getViewTrackerPath from './get-view-tracker-path';
 import { getForCurrentCROIteration, Iterations } from './iterations';
 import ProductGrid from './product-grid';
+import ProductStore from './product-store';
 import type {
 	Duration,
 	ScrollCardIntoViewCallback,
@@ -213,20 +215,28 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
 				/>
 
-				{ siteId && enableUserLicensesDialog && <LicensingActivationBanner siteId={ siteId } /> }
+				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (
+					<ProductStore />
+				) : (
+					<>
+						{ siteId && enableUserLicensesDialog && (
+							<LicensingActivationBanner siteId={ siteId } />
+						) }
 
-				{ header }
+						{ header }
 
-				<ProductGrid
-					duration={ currentDuration }
-					urlQueryArgs={ urlQueryArgs }
-					planRecommendation={ planRecommendation }
-					onSelectProduct={ selectProduct }
-					onDurationChange={ trackDurationChange }
-					scrollCardIntoView={ scrollCardIntoView }
-					createButtonURL={ createProductURL }
-					isLoadingUpsellPageExperiment={ isLoadingUpsellPageExperiment }
-				/>
+						<ProductGrid
+							duration={ currentDuration }
+							urlQueryArgs={ urlQueryArgs }
+							planRecommendation={ planRecommendation }
+							onSelectProduct={ selectProduct }
+							onDurationChange={ trackDurationChange }
+							scrollCardIntoView={ scrollCardIntoView }
+							createButtonURL={ createProductURL }
+							isLoadingUpsellPageExperiment={ isLoadingUpsellPageExperiment }
+						/>
+					</>
+				) }
 
 				<QueryProductsList type="jetpack" />
 				<QueryIntroOffers siteId={ siteId ?? 'none' } />

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -43,6 +43,7 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/search-product": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -39,6 +39,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -42,6 +42,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"layout/app-banner": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -42,6 +42,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,


### PR DESCRIPTION
#### Proposed Changes

* This PR creates a feature flag named `jetpack/pricing-page-rework-v1`
* Adds a dummy component named `ProductStore`
* Renders `ProductStore` behind the new feature flag

#### Testing Instructions

- Check out the PR
- Run `yarn start-jetpack-cloud`
- Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Confirm that you see the "Hello there! 👋" text in place of the product grid
- Open the Jetpack Cloud Live link below and goto the Pricing page (`/pricing`)
- Confirm that you don't see the "Hello there! 👋" text
- Check `config/jetpack-cloud-development.json` confirm that `jetpack/pricing-page-rework-v1` is set to `true`
- Check these files to confirm that `jetpack/pricing-page-rework-v1` is set to `false`.
  - `config/jetpack-cloud-horizon.json`
  - `config/jetpack-cloud-production.json`
  - `config/jetpack-cloud-stage.json`



<img width="1302" alt="Screenshot 2022-08-18 at 1 49 08 PM" src="https://user-images.githubusercontent.com/18226415/185346957-64bce4c8-fdc6-4cbe-b3d6-66c6d2a66ac1.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664052