### PR TITLE
Domain-only sites: Add missing fallback items to the sidebar

### DIFF
--- a/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
+++ b/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
@@ -9,6 +9,7 @@ const domainOnlyFallbackMenu = ( { siteDomain }: { siteDomain: string } ) => {
 			type: 'menu-item',
 			url: `/domains/manage/${ siteDomain }/edit/${ siteDomain }`,
 		},
+		// Note: A "Manage Email" item will also be surfaced from the backend when the user has email subscriptions
 		{
 			icon: 'dashicons-cart',
 			slug: 'manage-purchases',

--- a/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
+++ b/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
@@ -1,0 +1,36 @@
+import { translate } from 'i18n-calypso';
+
+const domainOnlyFallbackMenu = ( { siteDomain }: { siteDomain: string } ) => {
+	return [
+		{
+			icon: 'dashicons-admin-settings',
+			slug: 'manage-domain',
+			title: translate( 'Manage domain' ),
+			type: 'menu-item',
+			url: `/domains/manage/${ siteDomain }/edit/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-admin-settings',
+			slug: 'manage-email',
+			title: translate( 'Manage email' ),
+			type: 'menu-item',
+			url: `/email/${ siteDomain }/manage/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-cart',
+			slug: 'manage-purchases',
+			title: translate( 'Manage purchases' ),
+			type: 'menu-item',
+			url: `/purchases/subscriptions/${ siteDomain }`,
+		},
+		{
+			icon: 'dashicons-email',
+			slug: 'inbox',
+			title: translate( 'Inbox' ),
+			type: 'menu-item',
+			url: `/inbox/${ siteDomain }`,
+		},
+	];
+};
+
+export default domainOnlyFallbackMenu;

--- a/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
+++ b/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
@@ -10,13 +10,6 @@ const domainOnlyFallbackMenu = ( { siteDomain }: { siteDomain: string } ) => {
 			url: `/domains/manage/${ siteDomain }/edit/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-admin-settings',
-			slug: 'manage-email',
-			title: translate( 'Manage email' ),
-			type: 'menu-item',
-			url: `/email/${ siteDomain }/manage/${ siteDomain }`,
-		},
-		{
 			icon: 'dashicons-cart',
 			slug: 'manage-purchases',
 			title: translate( 'Manage purchases' ),

--- a/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
+++ b/client/my-sites/sidebar/static-data/domain-only-fallback-menu.ts
@@ -5,14 +5,14 @@ const domainOnlyFallbackMenu = ( { siteDomain }: { siteDomain: string } ) => {
 		{
 			icon: 'dashicons-admin-settings',
 			slug: 'manage-domain',
-			title: translate( 'Manage domain' ),
+			title: translate( 'Manage Domain' ),
 			type: 'menu-item',
 			url: `/domains/manage/${ siteDomain }/edit/${ siteDomain }`,
 		},
 		{
 			icon: 'dashicons-cart',
 			slug: 'manage-purchases',
-			title: translate( 'Manage purchases' ),
+			title: translate( 'Manage Purchases' ),
 			type: 'menu-item',
 			url: `/purchases/subscriptions/${ siteDomain }`,
 		},

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -2,9 +2,11 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -46,6 +48,7 @@ const useSiteMenuItems = () => {
 	);
 
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, selectedSiteId ) );
+	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, selectedSiteId ) );
 
 	const shouldShowInbox = ! isP2;
 
@@ -63,6 +66,13 @@ const useSiteMenuItems = () => {
 	 */
 	if ( isJetpack && ! isAtomic && ! menuItems ) {
 		return jetpackMenu( { siteDomain } );
+	}
+
+	/**
+	 * When we have a domain-only site & we cannot retrieve the dynamic menu from that site.
+	 */
+	if ( isDomainOnly && ! menuItems ) {
+		return domainOnlyFallbackMenu( { siteDomain } );
 	}
 
 	/**


### PR DESCRIPTION
Note: The "Manage Email" menu item is no longer presented based on feedback from pbLl1t-1f6-p2#comment-1265

#### Proposed Changes

* Adds a new function to build static top menu items for the sidebar when the active site is a domain-only site
* Detects a domain-only site when the menu endpoint fails and returns the static items using the function noted above

| Before  | After  |
|---|---|
| <img width="289" alt="Screenshot 2022-08-18 at 12 57 06 PM" src="https://user-images.githubusercontent.com/277661/185389517-cd60ae4f-4448-4b5e-b7ec-df6027ad43a2.png">  | <img width="289" alt="Screenshot 2022-08-31 at 3 39 02 AM" src="https://user-images.githubusercontent.com/277661/187580494-9542f109-d968-4e53-9d58-4e4f125c94f7.png">  |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D86134-code ( to delay the menu endpoint and make the initial static items visible )
* Switch sites: Select a domain-only site.
    * If you don't have one, create one using the domain-only start flow: https://wordpress.com/domains/
    * When prompted to purchase a domain, select "Just buy a domain"
* Clear your browser cache 
* Confirm that you see following new menu items in the sidebar, and that they point at intuitive destinations
    * Manage Domain
    * Manage Purchases
    * Inbox
* Switch sites: Select each of simple ( normal ),  atomic, etc sites and confirm that you do NOT see the menu items.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D84975-code