### PR TITLE
DO NOT MERGE - LaunchPad - enable on other environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,7 @@
 		"signup/goals-step-2": true,
 		"signup/hero-flow-non-en": true,
 		"signup/inline-help": false,
-		"signup/launchpad": false,
+		"signup/launchpad": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/seller-upgrade-modal": false,

--- a/config/production.json
+++ b/config/production.json
@@ -121,7 +121,7 @@
 		"signup/goals-step-2": true,
 		"signup/hero-flow-non-en": true,
 		"signup/inline-help": false,
-		"signup/launchpad": false,
+		"signup/launchpad": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/seller-upgrade-modal": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -120,7 +120,7 @@
 		"signup/goals-step-2": true,
 		"signup/hero-flow-non-en": true,
 		"signup/inline-help": false,
-		"signup/launchpad": false,
+		"signup/launchpad": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/seller-upgrade-modal": false,


### PR DESCRIPTION
DO NOT MERGE

enabling LaunchPad on other environments so testing works in calypso live for shared demo.