### PR TITLE
Add tracks event for skip and change display text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -4,8 +4,8 @@ import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
 import type { Step } from '../../types';
 
 import './style.scss';
-
-const DIFMStartingPoint: Step = function ( { navigation } ) {
+const STEP_NAME = 'difmStartingPoint';
+const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
 
 	const onSubmit = () => {
@@ -13,12 +13,17 @@ const DIFMStartingPoint: Step = function ( { navigation } ) {
 	};
 
 	const onSkip = () => {
+		recordTracksEvent( 'calypso_signup_skip_step', {
+			flow,
+			step: STEP_NAME,
+		} );
+
 		goNext?.();
 	};
 
 	return (
 		<StepContainer
-			stepName={ 'difmStartingPoint' }
+			stepName={ STEP_NAME }
 			goBack={ goBack }
 			goNext={ goNext }
 			isHorizontalLayout={ true }

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -356,7 +356,7 @@ export default function DIFMLanding( {
 						</NextButton>
 						{ isInOnboarding && (
 							<SkipButton isLink={ true } onClick={ onSkip }>
-								{ translate( 'Skip for now' ) }
+								{ translate( "I'll do it myself" ) }
 							</SkipButton>
 						) }
 					</CTASectionWrapper>


### PR DESCRIPTION
#### Proposed Changes

* Adds a manual tracks event to track the skipping of DIFM in the landing page.
* Adds the text `I'll do it myself` instead of skip for now - 1003-gh-Automattic/martech

#### Testing Instructions
- Create a new site (free site is ok) by going through `/start`
- After creating the site in the goals step select `hire a professional`
- In the DIFM starting point landing page check whether `I'll do it myself` is shown on the skip button
<img width="1403" alt="image" src="https://user-images.githubusercontent.com/3422709/185586927-1ea5aba2-401c-4266-b5e4-6a667fe72558.png">

- Set localStorage.setItem('debug', 'calypso:analytics*'); in browser console
- Clear the console to make sure it's easier to identify more logs
- Click on  `I'll do it myself` 
- Make sure the skip test event is visible
<img width="852" alt="image" src="https://user-images.githubusercontent.com/3422709/185590993-09977e71-2628-49af-a17b-cba9c3b2463c.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
Fixes 1003-gh-Automattic/martech