### PR TITLE
`JetpackHeader`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/components/jetpack-header/test/index.js
+++ b/client/components/jetpack-header/test/index.js
@@ -2,44 +2,53 @@
  * @jest-environment jsdom
  */
 
-import { shallow, mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { JetpackHeader } from '..';
+
+jest.mock( 'calypso/components/jetpack-logo', () => ( { size } ) => (
+	<div data-testid="jetpack-logo">
+		<div data-testid="jetpack-logo-size">{ size }</div>
+	</div>
+) );
+jest.mock( '../partner-logo-group', () => ( { width } ) => (
+	<div data-testid="jetpack-partner-logo-group">
+		<div data-testid="jetpack-partner-logo-group-size">{ width }</div>
+	</div>
+) );
 
 describe( 'JetpackHeader', () => {
 	test( 'renders default Jetpack logo when no partnerSlug prop', () => {
-		const wrapper = shallow( <JetpackHeader /> );
-		expect( wrapper.children() ).toHaveLength( 1 );
-		expect( wrapper.children().name() ).toEqual( 'JetpackLogo' );
-		expect( wrapper.find( 'JetpackLogo' ).props().size ).toEqual( 45 );
+		render( <JetpackHeader /> );
+		expect( screen.queryByTestId( 'jetpack-logo' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'jetpack-logo-size' ) ).toHaveTextContent( '45' );
 	} );
 
 	test( 'should render default Jetpack logo when passed empty string for partnerSlug prop', () => {
-		const wrapper = shallow( <JetpackHeader partnerSlug="" /> );
-		expect( wrapper.children() ).toHaveLength( 1 );
-		expect( wrapper.children().name() ).toEqual( 'JetpackLogo' );
-		expect( wrapper.find( 'JetpackLogo' ).props().size ).toEqual( 45 );
+		render( <JetpackHeader partnerSlug="" /> );
+		expect( screen.queryByTestId( 'jetpack-logo' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'jetpack-logo-size' ) ).toHaveTextContent( '45' );
 	} );
 
 	test( 'should render JetpackLogo when passed an unknown partner slug', () => {
-		const wrapper = shallow( <JetpackHeader partnerSlug="nonexistent" /> );
-		expect( wrapper.children() ).toHaveLength( 1 );
-		expect( wrapper.children().name() ).toEqual( 'JetpackLogo' );
-		expect( wrapper.find( 'JetpackLogo' ).props().size ).toEqual( 45 );
+		render( <JetpackHeader partnerSlug="nonexistent" /> );
+		expect( screen.queryByTestId( 'jetpack-logo' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'jetpack-logo-size' ) ).toHaveTextContent( '45' );
 	} );
 
 	test( 'should render a co-branded logo when passed a known partner slug', () => {
-		const wrapper = mount( <JetpackHeader partnerSlug="dreamhost" /> );
-		expect( wrapper.find( 'Localized(JetpackPartnerLogoGroup)' ) ).toHaveLength( 1 );
-		expect( wrapper.find( 'AsyncLoad' ) ).toHaveLength( 1 );
+		render( <JetpackHeader partnerSlug="dreamhost" /> );
+		expect( screen.queryByTestId( 'jetpack-partner-logo-group' ) ).toBeVisible();
 	} );
 
 	test( 'should override width on JetpackLogo when width provided but no partner slug', () => {
-		const wrapper = mount( <JetpackHeader width={ 60 } /> );
-		expect( wrapper.find( 'JetpackLogo' ).props().size ).toEqual( 60 );
+		render( <JetpackHeader width={ 60 } /> );
+		expect( screen.queryByTestId( 'jetpack-logo' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'jetpack-logo-size' ) ).toHaveTextContent( '60' );
 	} );
 
 	test( 'should override width on logo group when width and known partner slug provided', () => {
-		const wrapper = mount( <JetpackHeader width={ 60 } partnerSlug="dreamhost" /> );
-		expect( wrapper.find( 'Localized(JetpackPartnerLogoGroup)' ).props().width ).toEqual( 60 );
+		render( <JetpackHeader width={ 60 } partnerSlug="dreamhost" /> );
+		expect( screen.queryByTestId( 'jetpack-partner-logo-group' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'jetpack-partner-logo-group-size' ) ).toHaveTextContent( '60' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `JetpackHeader`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 
