### PR TITLE
NewsletterFlow: integrate useSetupOnboardingSite with complete-purchase

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -1,12 +1,15 @@
 import { StepContainer } from '@automattic/onboarding';
 import { ReactElement } from 'react';
 import { useSetupOnboardingSite } from 'calypso/landing/stepper/hooks/use-setup-onboarding-site';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const Subscribers: Step = function ( { navigation } ): ReactElement | null {
 	const { submit } = navigation;
-	useSetupOnboardingSite();
+	const site = useSite();
+
+	useSetupOnboardingSite( { site } );
 
 	const handleSubmit = () => {
 		submit?.();


### PR DESCRIPTION
#### Proposed Changes

* This PR integrates the useSetupOnboardingSite with the completing purchase step.
* This allows us to clean up the code and have one central place which does the updates.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Visit http://calypso.localhost:3000/setup?flow=newsletter
- Fill in the fields in the site setup step
- When landing to the complete purchase step check if the requests for saving the site settings and logo are sent correctly

Related to #66576
