### PR TITLE
[E2E][GB 13.9.x] Test fixes for Gutenberg

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -19,7 +19,7 @@ const selectors = {
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
-	previewButton: `${ panel } :text("Preview"):visible`,
+	previewButton: `${ panel } :text("View"):visible`,
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
 	previewPane: ( target: EditorPreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Misc test fixes, preparing for the upcoming 13.9.x release on WPCOM.

#### Testing instructions

* Tests should pass.

To be merged **after** 13.9.0 is released to production WPCOM.

Tracking issue: https://github.com/Automattic/wp-calypso/issues/66513.