### PR TITLE
Jetpack Cloud: Close sidebar on mobile by clicking the Jetpack Logo 

### DIFF
--- a/client/components/jetpack/masterbar/index.tsx
+++ b/client/components/jetpack/masterbar/index.tsx
@@ -1,22 +1,36 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import ProfileDropdown from 'calypso/components/jetpack/profile-dropdown';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 
 import './style.scss';
 
 const JetpackCloudMasterBar: React.FC = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const headerTitle = useSelector( getDocumentHeadTitle );
 	const currentRoute = useSelector( getCurrentRoute );
 	const isNarrow = useBreakpoint( '<660px' );
+	const currentLayoutFocus = useSelector( getCurrentLayoutFocus );
 	const isExteriorPage = /^\/(?:backup|scan)\/[^/]*$/.test( currentRoute );
+
+	const handleLogoClick = React.useCallback(
+		( e ) => {
+			if ( isNarrow && 'sidebar' === currentLayoutFocus ) {
+				e.preventDefault();
+				dispatch( setLayoutFocus( 'content' ) );
+			}
+		},
+		[ dispatch, setLayoutFocus, isNarrow, currentLayoutFocus ]
+	);
 
 	return (
 		<Masterbar
@@ -25,6 +39,7 @@ const JetpackCloudMasterBar: React.FC = () => {
 			<a
 				className="masterbar__item-home"
 				href="/"
+				onClick={ handleLogoClick }
 				title={
 					translate( 'Jetpack Cloud Dashboard', {
 						comment: 'Jetpack Cloud top navigation bar item',


### PR DESCRIPTION
#### Proposed Changes

* Context 👉🏻  1201801459945917-as-1201871814935661/f

Clicking on the Jetpack Logo when on a mobile view with the sidebar open will close the sidebar;
Clicking on the Jetpack Logo when on a mobile view with the sidebar closed will do the default link click event;
Clicking on the Jetpack Logo when on desktop view will do the default link click event;

> This behavior was mimic'ed from wordpress.com

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open [Jetpack Cloud](https://jetpack.cloud.localhost:3000)
* Shrink the width of your window or use the device simulator to have a narrow width view
* Open the sidebar
* Click on the Jetpack Logo (this should close the sidebar)
* Click on the Jetpack Logo again (this should navigate to the root path, and then be redirected to `/dashboard`, which is the default redirect for logged in users)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
