### PR TITLE
LaunchPad - enable feature flag on horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,7 @@
 		"signup/goals-step-2": true,
 		"signup/hero-flow-non-en": true,
 		"signup/inline-help": false,
-		"signup/launchpad": false,
+		"signup/launchpad": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/seller-upgrade-modal": false,


### PR DESCRIPTION
This enables the LaunchPad feature flag on horizon. This will allow for horizon testing of links-in-bio and newsletter onboarding flows to flow into the LaunchPad and sets us up for the future CFT.