### PR TITLE
Blazepress widget: add as modal

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -20,6 +20,13 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 
+	// Scroll to top on initial load regardless of previous page position
+	useEffect( () => {
+		if ( isVisible ) {
+			window.scrollTo( 0, 0 );
+		}
+	}, [ isVisible ] );
+
 	useEffect( () => {
 		isVisible &&
 			( async () => {

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -1,0 +1,65 @@
+import { Gridicon } from '@automattic/components';
+import { useEffect, useRef, useState } from 'react';
+import { BlankCanvas } from 'calypso/components/blank-canvas';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import WordPressLogo from 'calypso/components/wordpress-logo';
+import { showDSP } from 'calypso/lib/promote-post';
+
+import './style.scss';
+
+export type BlazePressPromotionProps = {
+	isVisible: boolean;
+	siteId: string | number;
+	postId: string | number;
+	onClose: () => void;
+};
+
+const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+	const { isVisible = false, onClose = () => {} } = props;
+	const [ isLoading, setIsLoading ] = useState( true );
+	const widgetContainer = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		isVisible &&
+			( async () => {
+				if ( props.siteId === null || props.postId === null ) {
+					return;
+				}
+
+				await showDSP( props.siteId, props.postId, widgetContainer.current );
+				setIsLoading( false );
+			} )();
+	}, [ isVisible ] );
+	return (
+		<>
+			{ isVisible && (
+				<BlankCanvas className={ 'blazepress-widget' }>
+					<div className={ 'blazepress-widget__header-bar' }>
+						<WordPressLogo />
+						<h2>Promote</h2>
+						<span
+							role="button"
+							className={ 'blazepress-widget__cross' }
+							onKeyDown={ onClose }
+							tabIndex={ 0 }
+							onClick={ onClose }
+						>
+							<Gridicon icon="cross" size={ 24 } />
+						</span>
+					</div>
+					<div
+						className={
+							isLoading ? 'blazepress-widget__content loading' : 'blazepress-widget__content'
+						}
+					>
+						{ isLoading && <LoadingEllipsis /> }
+						<div ref={ widgetContainer }></div>
+					</div>
+				</BlankCanvas>
+			) }
+		</>
+	);
+};
+
+export default BlazePressWidget;

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -1,0 +1,43 @@
+@import '@automattic/typography/styles/variables';
+@import '@automattic/onboarding/styles/mixins.scss';
+
+.blazepress-widget {
+    display: flex;
+    flex-direction: column;
+
+    .blazepress-widget__header-bar {
+        align-items: center;
+        display: flex;
+        justify-content: space-between;
+        min-height: 72px;
+        padding: 0 20px;
+
+        h2 {
+            @include onboarding-font-recoleta;
+            font-size: $font-title-small;
+            letter-spacing: 0;
+            flex: 1;
+        }
+
+        .wordpress-logo {
+            width: 1.5rem;
+            height: 1.5rem;
+            fill: var( --color-text );
+            margin: 0 1.5rem 0 0;
+        }
+
+        .blazepress-widget__cross {
+            height: 24px;
+            cursor: pointer;
+        }
+    }
+    .blazepress-widget__content {
+        display: flex;
+        flex-direction: column;
+    }
+    .blazepress-widget__content.loading {
+        justify-content: center;
+        align-items: center;
+        flex: auto;
+    }
+}

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -4,6 +4,7 @@
 .blazepress-widget {
     display: flex;
     flex-direction: column;
+    z-index: 1001;
 
     .blazepress-widget__header-bar {
         align-items: center;

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -7,7 +7,7 @@ declare global {
 	interface Window {
 		BlazePress?: {
 			render: ( params: {
-				domNode?: HTMLElement;
+				domNode?: HTMLElement | null;
 				domNodeId?: string;
 				stripeKey: string;
 				apiHost: string;
@@ -35,7 +35,7 @@ export async function loadDSPWidgetJS(): Promise< void > {
 export async function showDSP(
 	siteId: number | string,
 	postId: number | string,
-	domNodeOrId?: HTMLElement | string
+	domNodeOrId?: HTMLElement | string | null
 ) {
 	await loadDSPWidgetJS();
 	return new Promise( ( resolve, reject ) => {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -41,6 +41,7 @@ import { setPreviewUrl } from 'calypso/state/ui/preview/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { statsLinkForPage } from '../helpers';
 import PageCardInfo from '../page-card-info';
+import PageEllipsisMenuWrapper from './page-ellipsis-menu-wrapper';
 
 const recordEvent = ( event ) => recordGoogleEvent( 'Pages', event );
 const noop = () => {};
@@ -446,19 +447,7 @@ class Page extends Component {
 
 	undoPostStatus = () => this.updatePostStatus( this.props.shadowStatus.undo );
 
-	render() {
-		const {
-			editorUrl,
-			page,
-			shadowStatus,
-			showPublishedStatus,
-			siteId,
-			translate,
-			isPostsPage: latestPostsPage,
-		} = this.props;
-		const title = page.title || translate( 'Untitled' );
-		const canEdit = userCan( 'edit_post', page ) && ! latestPostsPage;
-		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
+	createEllipsisMenu = () => {
 		const viewItem = this.getViewItem();
 		const promoteItem = this.getPromoteItem();
 		const publishItem = this.getPublishItem();
@@ -484,27 +473,48 @@ class Page extends Component {
 			moreInfoItem ||
 			exportItem;
 
-		const ellipsisMenu = hasMenuItems && (
-			<EllipsisMenu
-				className="page__actions-toggle"
-				position="bottom left"
-				onToggle={ this.handleMenuToggle }
-			>
-				{ editItem }
-				{ publishItem }
-				{ viewItem }
-				{ promoteItem }
-				{ statsItem }
-				{ copyPageItem }
-				{ copyLinkItem }
-				{ restoreItem }
-				{ frontPageItem }
-				{ postsPageItem }
-				{ exportItem }
-				{ sendToTrashItem }
-				{ moreInfoItem }
-			</EllipsisMenu>
+		return (
+			hasMenuItems && (
+				<PageEllipsisMenuWrapper globalId={ this.props.page.global_ID }>
+					<EllipsisMenu
+						className="page__actions-toggle"
+						position="bottom left"
+						onToggle={ this.handleMenuToggle }
+					>
+						{ editItem }
+						{ publishItem }
+						{ viewItem }
+						{ promoteItem }
+						{ statsItem }
+						{ copyPageItem }
+						{ copyLinkItem }
+						{ restoreItem }
+						{ frontPageItem }
+						{ postsPageItem }
+						{ exportItem }
+						{ sendToTrashItem }
+						{ moreInfoItem }
+					</EllipsisMenu>
+				</PageEllipsisMenuWrapper>
+			)
 		);
+	};
+
+	render() {
+		const {
+			editorUrl,
+			page,
+			shadowStatus,
+			showPublishedStatus,
+			siteId,
+			translate,
+			isPostsPage: latestPostsPage,
+		} = this.props;
+		const title = page.title || translate( 'Untitled' );
+		const canEdit = userCan( 'edit_post', page ) && ! latestPostsPage;
+		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
+
+		const ellipsisMenu = this.createEllipsisMenu();
 
 		const isTrashed = page.status === 'trash';
 

--- a/client/my-sites/pages/page/page-ellipsis-menu-wrapper.js
+++ b/client/my-sites/pages/page/page-ellipsis-menu-wrapper.js
@@ -1,0 +1,26 @@
+import { useSelector } from 'react-redux';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import { getPost } from 'calypso/state/posts/selectors';
+
+const PageEllipsisMenuWrapper = ( { children, globalId } ) => {
+	const keyValue = globalId;
+	const { isModalOpen, value, closeModal } = useRouteModal( 'blazepress-widget', keyValue );
+	const post = useSelector( ( state ) => getPost( state, globalId ) );
+
+	return (
+		<>
+			{ post && (
+				<BlazePressWidget
+					isVisible={ isModalOpen && value === keyValue }
+					siteId={ post.site_ID }
+					postId={ post.ID }
+					onClose={ () => closeModal() }
+				/>
+			) }
+			{ children }
+		</>
+	);
+};
+
+export default PageEllipsisMenuWrapper;

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -1,7 +1,11 @@
 import PropTypes from 'prop-types';
 import { Children, cloneElement } from 'react';
+import { useSelector } from 'react-redux';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import { getPost } from 'calypso/state/posts/selectors';
 import PostActionsEllipsisMenuComments from './comments';
 import PostActionsEllipsisMenuCopyLink from './copy-link';
 import PostActionsEllipsisMenuDuplicate from './duplicate';
@@ -17,6 +21,10 @@ import './style.scss';
 
 export default function PostActionsEllipsisMenu( { globalId, includeDefaultActions, children } ) {
 	let actions = [];
+
+	const keyValue = globalId;
+	const { isModalOpen, value, closeModal } = useRouteModal( 'blazepress-widget', keyValue );
+	const post = useSelector( ( state ) => getPost( state, globalId ) );
 
 	if ( includeDefaultActions ) {
 		actions.push(
@@ -45,6 +53,14 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 
 	return (
 		<div className="post-actions-ellipsis-menu">
+			{ post && (
+				<BlazePressWidget
+					isVisible={ isModalOpen && value === keyValue }
+					siteId={ post.site_ID }
+					postId={ post.ID }
+					onClose={ () => closeModal() }
+				/>
+			) }
 			<EllipsisMenu position="bottom left" disabled={ ! globalId }>
 				{ actions.map( ( action ) => cloneElement( action, { globalId } ) ) }
 			</EllipsisMenu>

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
@@ -2,22 +2,24 @@ import config from '@automattic/calypso-config';
 import { useDispatch } from '@wordpress/data';
 import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { loadDSPWidgetJS, recordDSPEntryPoint, showDSPWidgetModal } from 'calypso/lib/promote-post';
+import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import { useRouteModal } from 'calypso/lib/route-modal';
 import { getPost } from 'calypso/state/posts/selectors';
 
-function PostActionsEllipsisMenuPromote( { siteId, postId, isModuleActive, bumpStatKey, status } ) {
+function PostActionsEllipsisMenuPromote( {
+	globalId,
+	postId,
+	isModuleActive,
+	bumpStatKey,
+	status,
+} ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	useEffect( () => {
-		if ( isModuleActive ) {
-			loadDSPWidgetJS();
-		}
-	} );
-
+	const keyValue = globalId;
+	const { openModal } = useRouteModal( 'blazepress-widget', keyValue );
 	if ( ! isModuleActive ) {
 		return null;
 	}
@@ -30,9 +32,9 @@ function PostActionsEllipsisMenuPromote( { siteId, postId, isModuleActive, bumpS
 		return null;
 	}
 
-	const showDSPWidget = async () => {
+	const showDSPWidget = () => {
 		dispatch( recordDSPEntryPoint( bumpStatKey ) );
-		await showDSPWidgetModal( siteId, postId );
+		openModal();
 	};
 
 	return (
@@ -47,7 +49,6 @@ PostActionsEllipsisMenuPromote.propTypes = {
 	globalId: PropTypes.string,
 	isModuleActive: PropTypes.bool,
 	postId: PropTypes.number,
-	siteId: PropTypes.number,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -60,7 +61,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 		type: post.type,
 		isModuleActive: config.isEnabled( 'promote-post' ),
 		postId: post.ID,
-		siteId: post.site_ID,
 		status: post.status,
 	};
 };

--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -3,7 +3,9 @@ import './style.scss';
 import { Button } from '@wordpress/components';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { recordDSPEntryPoint, showDSPWidgetModal } from 'calypso/lib/promote-post';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
+import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import { useRouteModal } from 'calypso/lib/route-modal';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 
 export type Post = {
@@ -29,13 +31,22 @@ type Props = {
 export default function PostItem( { post }: Props ) {
 	const [ loading, setLoading ] = useState( false );
 	const dispatch = useDispatch();
+	const keyValue = 'post-' + post.ID;
+	const { isModalOpen, value, openModal, closeModal } = useRouteModal(
+		'blazepress-widget',
+		keyValue
+	);
+
+	const onCloseWidget = () => {
+		setLoading( false );
+		closeModal();
+	};
 
 	const onClickPromote = async () => {
-		setLoading( true );
-		await showDSPWidgetModal( post.site_ID, post.ID );
+		openModal();
 		dispatch( recordDSPEntryPoint( 'promoted_posts-post_item' ) );
-		setLoading( false );
 	};
+
 	return (
 		<CompactCard className="post-item__card">
 			<div className="post-item__main">
@@ -52,9 +63,17 @@ export default function PostItem( { post }: Props ) {
 					</div>
 				</div>
 			</div>
-			<Button isBusy={ loading } disabled={ loading } isLink onClick={ onClickPromote }>
-				Promote
-			</Button>
+			<div className="post-item__promote-link">
+				<BlazePressWidget
+					isVisible={ isModalOpen && value === keyValue }
+					siteId={ post.site_ID }
+					postId={ post.ID }
+					onClose={ onCloseWidget }
+				/>
+				<Button isBusy={ loading } disabled={ loading } isLink onClick={ onClickPromote }>
+					Promote
+				</Button>
+			</div>
 		</CompactCard>
 	);
 }


### PR DESCRIPTION
This diff includes the BlazePress widget as a modal to allow a smoother user experience.

### Testing
1. Apply this diff.
2. Go to `http://calypso.localhost:3000/pages/[YOUR_SITE]` and verify you can open the modal from the Ellipsis Menu > Promote Post. Also verify that the post/page info is loaded correctly.
3. Go to `http://calypso.localhost:3000/posts/[YOUR_SITE]` and verify you can open the modal from the Ellipsis Menu > Promote Post. Also verify that the post/page info is loaded correctly.
4. Go to `http://calypso.localhost:3000/advertising/[YOUR_SITE]` and verify you can open the modal by clicking on the Promote link beside the post.


What to expect:
![2022-08-18 17 00 36](https://user-images.githubusercontent.com/375980/185484567-724a248e-2fb8-4745-a4a7-b3b88043527f.gif)

