### PR TITLE
Theme/Plugin Bundling: Retrieve the bundled plugin slug from the ONBOARD_STORE

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
@@ -2,4 +2,6 @@ const pluginBundleSteps = {
 	woocommerce: [ 'storeAddress', 'businessInfo', 'wooConfirm', 'processing' ],
 };
 
+export type BundledPlugin = keyof typeof pluginBundleSteps;
+
 export default pluginBundleSteps;

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -22,6 +22,7 @@ import {
 } from './internals/types';
 import pluginBundleSteps from './plugin-bundle-data';
 import type { StepPath } from './internals/steps-repository';
+import type { BundledPlugin } from './plugin-bundle-data';
 
 const WRITE_INTENT_DEFAULT_THEME = 'livro';
 const SiteIntent = Onboard.SiteIntent;
@@ -30,13 +31,14 @@ export const pluginBundleFlow: Flow = {
 	name: 'plugin-bundle',
 
 	useSteps() {
+		const pluginSlug = useSelect( ( select ) =>
+			select( ONBOARD_STORE ).getBundledPluginSlug()
+		) as BundledPlugin;
+
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			// TODO - Need to handle this better
 			return [];
 		}
-
-		// TODO - This needs to come from somewhere else eventually. Maybe a query string parameter but data-store might be better
-		const pluginSlug = 'woocommerce';
 
 		if ( ! pluginSlug || ! pluginBundleSteps.hasOwnProperty( pluginSlug ) ) {
 			// TODO - Need to handle this better

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -303,6 +303,11 @@ export const setEditEmail = ( email: string ) => ( {
 	email,
 } );
 
+export const setBundledPluginSlug = ( slug: string ) => ( {
+	type: 'SET_BUNDLED_PLUGIN_SLUG' as const,
+	slug,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -345,4 +350,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteDescription
 	| typeof setSiteLogo
 	| typeof setSiteAccentColor
+	| typeof setBundledPluginSlug
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -354,10 +354,21 @@ const editEmail: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
+const bundledPluginSlug: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_BUNDLED_PLUGIN_SLUG' ) {
+		return action.slug;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
 	anchorSpotifyUrl,
+	bundledPluginSlug,
 	domain,
 	domainSearch,
 	domainCategory,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -48,3 +48,5 @@ export const hasSelectedDesignWithoutFonts = ( state: State ) =>
 	hasSelectedDesign( state ) && ! state.selectedFonts;
 
 export const getEditEmail = ( state: State ) => state.editEmail;
+
+export const getBundledPluginSlug = ( state: State ) => state.bundledPluginSlug;

--- a/packages/data-stores/src/onboard/test/actions.ts
+++ b/packages/data-stores/src/onboard/test/actions.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { setBundledPluginSlug } from '../actions';
+
+const slug = 'woocommerce';
+
+describe( 'Onboard Actions', () => {
+	it( 'should return a SET_BUNDLED_PLUGIN_SLUG Action', () => {
+		const expected = {
+			type: 'SET_BUNDLED_PLUGIN_SLUG',
+			slug,
+		};
+
+		expect( setBundledPluginSlug( slug ) ).toEqual( expected );
+	} );
+} );

--- a/packages/data-stores/src/onboard/test/selectors.ts
+++ b/packages/data-stores/src/onboard/test/selectors.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getBundledPluginSlug } from '../selectors';
+import type { State } from '../reducer';
+
+describe( 'getBundledPluginSlug', () => {
+	it( 'retrieves the bundled plugin slug from the store', () => {
+		const slug = 'woocommerce';
+
+		const state: State = {
+			bundledPluginSlug: slug,
+		};
+
+		expect( getBundledPluginSlug( state ) ).toEqual( slug );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

This adds a new item to the `ONBOARD_STORE` which contains a bundled plugin slug.

The new `pluginBundleFlow` will retrieve the slug of the plugin from the store and use it to determine which steps to take the user through.

#### Testing Instructions

```
yarn run test-packages packages/data-stores/src/onboard/test
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
