### PR TITLE
Update the classnames on PluginDetailsCTA to comply with the new BEM rules

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -95,8 +95,8 @@ export default function CTAButton( {
 				closeDialog={ () => setShowAddCustomDomain( false ) }
 			/>
 			<Dialog
-				additionalClassNames={ 'plugin-details-CTA__dialog-content' }
-				additionalOverlayClassNames={ 'plugin-details-CTA__modal-overlay' }
+				additionalClassNames={ 'plugin-details-cta__dialog-content' }
+				additionalOverlayClassNames={ 'plugin-details-cta__modal-overlay' }
 				isVisible={ showEligibility }
 				title={ translate( 'Eligibility' ) }
 				onClose={ () => setShowEligibility( false ) }
@@ -119,7 +119,7 @@ export default function CTAButton( {
 				/>
 			</Dialog>
 			<Button
-				className="plugin-details-CTA__install-button"
+				className="plugin-details-cta__install-button"
 				primary
 				onClick={ () => {
 					if ( pluginRequiresCustomPrimaryDomain ) {
@@ -154,8 +154,8 @@ export default function CTAButton( {
 				}
 			</Button>
 			{ isJetpackSelfHosted && isMarketplaceProduct && (
-				<div className="plugin-details-CTA__not-available">
-					<p className="plugin-details-CTA__not-available-text">
+				<div className="plugin-details-cta__not-available">
+					<p className="plugin-details-cta__not-available-text">
 						{ translate( 'Thanks for your interest. ' ) }
 						{ translate(
 							'Paid plugins are not yet available for Jetpack Sites but we can notify you when they are ready.'
@@ -163,7 +163,7 @@ export default function CTAButton( {
 					</p>
 					{ hasPreferences && (
 						<ToggleControl
-							className="plugin-details-CTA__follow-toggle"
+							className="plugin-details-cta__follow-toggle"
 							label={ translate( 'Keep me updated' ) }
 							checked={ keepMeUpdatedPreference }
 							onChange={ updatedKeepMeUpdatedPreference }

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -113,9 +113,9 @@ const PluginDetailsCTA = ( props ) => {
 	// If we cannot retrieve plugin status through jetpack ( ! isJetpack ) and plugin is preinstalled.
 	if ( ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug ) ) {
 		return (
-			<div className="plugin-details-CTA__container">
-				<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
-				<span className="plugin-details-CTA__preinstalled">
+			<div className="plugin-details-cta__container">
+				<div className="plugin-details-cta__price">{ translate( 'Free' ) }</div>
+				<span className="plugin-details-cta__preinstalled">
 					{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }
 				</span>
 			</div>
@@ -126,7 +126,7 @@ const PluginDetailsCTA = ( props ) => {
 	// but require a paid upgrade to function.
 	if ( isPreinstalledPremiumPlugin ) {
 		return (
-			<div className="plugin-details-CTA__container">
+			<div className="plugin-details-cta__container">
 				<PluginDetailsCTAPreinstalledPremiumPlugins
 					isPluginInstalledOnsite={ isPluginInstalledOnsite }
 					plugin={ plugin }
@@ -147,27 +147,27 @@ const PluginDetailsCTA = ( props ) => {
 		// Check if already instlaled on the site
 		const activeText = translate( '{{span}}active{{/span}}', {
 			components: {
-				span: <span className="plugin-details-CTA__installed-text-active"></span>,
+				span: <span className="plugin-details-cta__installed-text-active"></span>,
 			},
 		} );
 		const inactiveText = translate( '{{span}}deactivated{{/span}}', {
 			components: {
-				span: <span className="plugin-details-CTA__installed-text-inactive"></span>,
+				span: <span className="plugin-details-cta__installed-text-inactive"></span>,
 			},
 		} );
 		const { active } = sitePlugin;
 
 		return (
-			<div className="plugin-details-CTA__container">
-				<div className="plugin-details-CTA__container-header">
-					<div className="plugin-details-CTA__installed-text">
+			<div className="plugin-details-cta__container">
+				<div className="plugin-details-cta__container-header">
+					<div className="plugin-details-cta__installed-text">
 						{ translate( 'Installed and {{activation /}}', {
 							components: {
 								activation: active ? activeText : inactiveText,
 							},
 						} ) }
 					</div>
-					<div className="plugin-details-CTA__manage-plugin-menu">
+					<div className="plugin-details-cta__manage-plugin-menu">
 						<ManagePluginMenu plugin={ plugin } />
 					</div>
 				</div>
@@ -178,12 +178,12 @@ const PluginDetailsCTA = ( props ) => {
 					site={ selectedSite }
 					plugin={ sitePlugin }
 					label={
-						<span className="plugin-details-CTA__autoupdate-text">
-							<span className="plugin-details-CTA__autoupdate-text-main">
+						<span className="plugin-details-cta__autoupdate-text">
+							<span className="plugin-details-cta__autoupdate-text-main">
 								{ translate( 'Enable autoupdates.' ) }
 							</span>
 							{ sitePlugin.version && (
-								<span className="plugin-details-CTA__autoupdate-text-version">
+								<span className="plugin-details-cta__autoupdate-text-version">
 									{ translate( ' Currently %(version)s', {
 										args: { version: sitePlugin.version },
 									} ) }
@@ -201,13 +201,13 @@ const PluginDetailsCTA = ( props ) => {
 	if ( ! selectedSite ) {
 		// Check if there is no site selected
 		return (
-			<div className="plugin-details-CTA__container">
+			<div className="plugin-details-cta__container">
 				<ManageSitePluginsDialog
 					plugin={ plugin }
 					isVisible={ displayManageSitePluginsModal }
 					onClose={ () => setDisplayManageSitePluginsModal( false ) }
 				/>
-				<div className="plugin-details-CTA__installed-text">
+				<div className="plugin-details-cta__installed-text">
 					{ !! installedOnSitesQuantity &&
 						translate(
 							'Installed on {{span}}%d site{{/span}}',
@@ -216,7 +216,7 @@ const PluginDetailsCTA = ( props ) => {
 								args: [ installedOnSitesQuantity ],
 								installedOnSitesQuantity,
 								components: {
-									span: <span className="plugin-details-CTA__installed-text-quantity"></span>,
+									span: <span className="plugin-details-cta__installed-text-quantity"></span>,
 								},
 								count: installedOnSitesQuantity,
 							}
@@ -230,18 +230,18 @@ const PluginDetailsCTA = ( props ) => {
 	}
 
 	return (
-		<div className="plugin-details-CTA__container">
-			<div className="plugin-details-CTA__price">
+		<div className="plugin-details-cta__container">
+			<div className="plugin-details-cta__price">
 				<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 					{ ( { isFetching, price, period } ) =>
 						isFetching ? (
-							<div className="plugin-details-CTA__price-placeholder">...</div>
+							<div className="plugin-details-cta__price-placeholder">...</div>
 						) : (
 							<>
 								{ price ? (
 									<>
 										{ price + ' ' }
-										<span className="plugin-details-CTA__period">{ period }</span>
+										<span className="plugin-details-cta__period">{ period }</span>
 									</>
 								) : (
 									translate( 'Free' )
@@ -258,7 +258,7 @@ const PluginDetailsCTA = ( props ) => {
 					plugin={ plugin }
 				/>
 			) }
-			<div className="plugin-details-CTA__install">
+			<div className="plugin-details-cta__install">
 				<CTAButton
 					plugin={ plugin }
 					isPluginInstalledOnsite={ isPluginInstalledOnsite }
@@ -273,7 +273,7 @@ const PluginDetailsCTA = ( props ) => {
 				/>
 			</div>
 			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
-				<div className="plugin-details-CTA__t-and-c">
+				<div className="plugin-details-cta__t-and-c">
 					{ translate(
 						'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
 						{
@@ -294,13 +294,13 @@ const PluginDetailsCTA = ( props ) => {
 				</div>
 			) }
 			{ shouldUpgrade && (
-				<div className="plugin-details-CTA__upgrade-required">
-					<span className="plugin-details-CTA__upgrade-required-icon">
+				<div className="plugin-details-cta__upgrade-required">
+					<span className="plugin-details-cta__upgrade-required-icon">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						<Gridicon icon="notice-outline" size={ 20 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 					</span>
-					<span className="plugin-details-CTA__upgrade-required-text">
+					<span className="plugin-details-cta__upgrade-required-text">
 						{ translate( 'You need to upgrade your plan to install plugins.' ) }
 					</span>
 				</div>
@@ -376,22 +376,22 @@ function LegacyPluginDetailsCTA( {
 	if ( ! selectedSite || ! userCan( 'manage_options', selectedSite ) ) {
 		if ( isMarketplaceProduct ) {
 			return (
-				<div className="plugin-details-CTA__container">
-					<div className="plugin-details-CTA__price align-right">
+				<div className="plugin-details-cta__container">
+					<div className="plugin-details-cta__price align-right">
 						<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 							{ ( { isFetching, price, period } ) =>
 								isFetching ? (
-									<div className="plugin-details-CTA__price-placeholder">...</div>
+									<div className="plugin-details-cta__price-placeholder">...</div>
 								) : (
 									<>
 										{ price + ' ' }
-										<span className="plugin-details-CTA__period">{ period }</span>
+										<span className="plugin-details-cta__period">{ period }</span>
 									</>
 								)
 							}
 						</PluginPrice>
 						{ selectedSite && shouldUpgrade && (
-							<span className="plugin-details-CTA__uprade-required">
+							<span className="plugin-details-cta__uprade-required">
 								{ translate( 'Plan upgrade required' ) }
 							</span>
 						) }
@@ -408,24 +408,24 @@ function LegacyPluginDetailsCTA( {
 	}
 
 	return (
-		<div className="plugin-details-CTA__container">
-			<div className="plugin-details-CTA__price">
+		<div className="plugin-details-cta__container">
+			<div className="plugin-details-cta__price">
 				<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 					{ ( { isFetching, price, period } ) =>
 						isFetching ? (
-							<div className="plugin-details-CTA__price-placeholder">...</div>
+							<div className="plugin-details-cta__price-placeholder">...</div>
 						) : (
 							<>
 								{ price ? (
 									<>
 										{ price + ' ' }
-										<span className="plugin-details-CTA__period">{ period }</span>
+										<span className="plugin-details-cta__period">{ period }</span>
 									</>
 								) : (
 									translate( 'Free' )
 								) }
 								{ shouldUpgrade && (
-									<span className="plugin-details-CTA__uprade-required">
+									<span className="plugin-details-cta__uprade-required">
 										{ translate( 'Plan upgrade required' ) }
 									</span>
 								) }
@@ -434,7 +434,7 @@ function LegacyPluginDetailsCTA( {
 					}
 				</PluginPrice>
 			</div>
-			<div className="plugin-details-CTA__install">
+			<div className="plugin-details-cta__install">
 				<CTAButton
 					plugin={ plugin }
 					isPluginInstalledOnsite={ isPluginInstalledOnsite }
@@ -448,7 +448,7 @@ function LegacyPluginDetailsCTA( {
 				/>
 			</div>
 			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
-				<div className="plugin-details-CTA__t-and-c">
+				<div className="plugin-details-cta__t-and-c">
 					{ translate(
 						'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
 						{
@@ -483,10 +483,10 @@ function LegacyPluginDetailsCTA( {
 
 function PluginDetailsCTAPlaceholder() {
 	return (
-		<div className="plugin-details-CTA__container is-placeholder">
-			<div className="plugin-details-CTA__price">...</div>
-			<div className="plugin-details-CTA__install">...</div>
-			<div className="plugin-details-CTA__t-and-c">...</div>
+		<div className="plugin-details-cta__container is-placeholder">
+			<div className="plugin-details-cta__price">...</div>
+			<div className="plugin-details-cta__install">...</div>
+			<div className="plugin-details-cta__t-and-c">...</div>
 		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -42,20 +42,20 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		usePreinstalledPremiumPlugin( plugin.slug );
 
 	const managedPluginMessage = (
-		<span className="plugin-details-CTA__preinstalled">
+		<span className="plugin-details-cta__preinstalled">
 			{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }
 		</span>
 	);
 	const pluginPrice = (
 		<>
-			<div className="plugin-details-CTA__price">
+			<div className="plugin-details-cta__price">
 				<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 					{ ( { isFetching, price, period } ) =>
 						isFetching ? (
-							<div className="plugin-details-CTA__price-placeholder">...</div>
+							<div className="plugin-details-cta__price-placeholder">...</div>
 						) : (
 							<PreinstalledPremiumPluginPriceDisplay
-								className="plugin-details-CTA__period"
+								className="plugin-details-cta__period"
 								period={ period }
 								pluginSlug={ plugin.slug }
 								price={ price }
@@ -75,9 +75,9 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 	);
 
 	const upgradeButton = (
-		<div className="plugin-details-CTA__install">
+		<div className="plugin-details-cta__install">
 			<Button
-				className="plugin-details-CTA__install-button"
+				className="plugin-details-cta__install-button"
 				href={ `/checkout/${ selectedSiteSlug }/${ preinstalledPremiumPluginProduct }` }
 				primary
 			>
@@ -86,7 +86,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		</div>
 	);
 	const activateButton = (
-		<div className="plugin-details-CTA__install">
+		<div className="plugin-details-cta__install">
 			<CTAButton
 				billingPeriod={ billingPeriod }
 				isJetpackSelfHosted={ isJetpackSelfHosted }

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -1,18 +1,18 @@
 @use '../variables';
 
-.plugin-details-CTA__container {
+.plugin-details-cta__container {
 	@extend %plugin-header;
 }
 
-.legacy .plugin-details-CTA__container {
+.legacy .plugin-details-cta__container {
 	padding-bottom: 0;
 }
 
-.plugin-details-CTA__modal-overlay.dialog__backdrop {
+.plugin-details-cta__modal-overlay.dialog__backdrop {
 	background-color: rgba( var( --color-neutral-100-rgb ), 0.7 );
 }
 
-.plugin-details-CTA__dialog-content {
+.plugin-details-cta__dialog-content {
 	.eligibility-warnings {
 		margin: 0;
 
@@ -22,7 +22,7 @@
 	}
 }
 
-.plugin-details-CTA__price {
+.plugin-details-cta__price {
 	font-family: $brand-serif;
 	font-size: $font-title-large;
 	color: var( --studio-gray-100 );
@@ -37,125 +37,125 @@
 	}
 }
 
-.plugin-details-CTA__price-placeholder {
+.plugin-details-cta__price-placeholder {
 	width: 100%;
 
 	@extend %placeholder;
 }
 
-.plugin-details-CTA__period {
+.plugin-details-cta__period {
 	font-family: $sans;
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
 	padding-left: 3px;
 }
 
-.plugin-details-CTA__uprade-required {
+.plugin-details-cta__uprade-required {
 	width: 100%;
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
 }
 
-.plugin-details-CTA__preinstalled {
+.plugin-details-cta__preinstalled {
 	width: 100%;
 	margin-bottom: 20px;
 }
 
-.plugin-details-CTA__install {
+.plugin-details-cta__install {
 	margin-bottom: 20px;
 
-	.plugin-details-CTA__install-button {
+	.plugin-details-cta__install-button {
 		width: 100%;
 		padding: 12px 16px;
 	}
 }
 
-.plugin-details-CTA__t-and-c {
+.plugin-details-cta__t-and-c {
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-50 );
 	margin-bottom: 16px;
 }
 
-.plugin-details-CTA__not-available {
-	.plugin-details-CTA__not-available-text {
+.plugin-details-cta__not-available {
+	.plugin-details-cta__not-available-text {
 		color: var( --studio-gray-60 );
 		margin: 16px 0;
 		font-size: $font-body-small;
 	}
 
-	.plugin-details-CTA__follow-toggle label {
+	.plugin-details-cta__follow-toggle label {
 		color: var( --studio-gray-80 );
 	}
 }
 
-.plugin-details-CTA__upgrade-required {
+.plugin-details-cta__upgrade-required {
 	display: flex;
 
-	.plugin-details-CTA__upgrade-required-icon {
+	.plugin-details-cta__upgrade-required-icon {
 		color: var( --studio-orange-40 );
 		padding-top: 3px;
 	}
 
-	.plugin-details-CTA__upgrade-required-text {
+	.plugin-details-cta__upgrade-required-text {
 		color: var( --studio-gray-80 );
 		font-size: $font-body-small;
 		margin-left: 16px;
 	}
 }
 
-.plugin-details-CTA__container-header {
+.plugin-details-cta__container-header {
 	display: flex;
 	justify-content: space-between;
 }
 
-.plugin-details-CTA__manage-plugin-menu {
+.plugin-details-cta__manage-plugin-menu {
 	margin-top: -12px;
 }
 
-.plugin-details-CTA__installed-text {
+.plugin-details-cta__installed-text {
 	color: var( --studio-gray-100 );
 	font-size: $font-body;
 	height: 40px;
 
-	.plugin-details-CTA__installed-text-quantity {
+	.plugin-details-cta__installed-text-quantity {
 		color: var( --studio-green-50 );
 	}
 
-	.plugin-details-CTA__installed-text-active {
+	.plugin-details-cta__installed-text-active {
 		color: var( --studio-green-60 );
 	}
 
-	.plugin-details-CTA__installed-text-inactive {
+	.plugin-details-cta__installed-text-inactive {
 		color: var( --studio-red-60 );
 	}
 }
 
-.plugin-details-CTA__autoupdate-text {
+.plugin-details-cta__autoupdate-text {
 	font-size: $font-body-extra-small;
 
-	.plugin-details-CTA__autoupdate-text-main {
+	.plugin-details-cta__autoupdate-text-main {
 		color: var( --studio-gray-100 );
 	}
 
-	.plugin-details-CTA__autoupdate-text-version {
+	.plugin-details-cta__autoupdate-text-version {
 		color: var( --studio-gray-60 );
 	}
 }
 
 .legacy {
-	.plugin-details-CTA__t-and-c {
+	.plugin-details-cta__t-and-c {
 		margin-bottom: 0;
 	}
 
-	.plugin-details-CTA__period {
+	.plugin-details-cta__period {
 		padding-left: 0;
 	}
 }
 
 .is-placeholder {
-	.plugin-details-CTA__price,
-	.plugin-details-CTA__install,
-	.plugin-details-CTA__t-and-c {
+	.plugin-details-cta__price,
+	.plugin-details-cta__install,
+	.plugin-details-cta__t-and-c {
 		@extend %placeholder;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

Update the classnames on PluginDetailsCTA to comply with the new BEM rules. There shouldn't be any visual or function behaviour change by their PR.

#### Testing Instructions
* Checkout this branch
* Go to the plugin details page 
* The CTA area of the Plugins page should looks the same as the one in production (WordPress.com)
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
