### PR TITLE
Launchpad: Update site url above checklist

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,27 +1,35 @@
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import Checklist from './checklist';
 import { tasks } from './tasks';
 
-const Sidebar = () => (
-	<div className="launchpad__sidebar">
-		<div className="launchpad__sidebar-header">
-			<WordPressLogo className="launchpad__sidebar-header-logo" size={ 24 } />
-			<span className="launchpad__sidebar-header-flow-name">Newsletter</span>
-		</div>
-		<div className="launchpad__sidebar-content-container">
-			<div className="launchpad__progress-bar-container">
-				<span className="launchpad__progress-value">33%</span>
-				<div className="launchpad__progress-bar">
-					<div className="launchpad__progress-bar-completed" />
-				</div>
+const Sidebar = () => {
+	const site = useSite();
+	const url = site?.URL?.replace( /^https?:\/\//, '' );
+
+	return (
+		<div className="launchpad__sidebar">
+			<div className="launchpad__sidebar-header">
+				<WordPressLogo className="launchpad__sidebar-header-logo" size={ 24 } />
+				<span className="launchpad__sidebar-header-flow-name">Newsletter</span>
 			</div>
-			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }
-			<h1 className="launchpad__sidebar-h1">Voilà! Your Newsletter is up and running!</h1>
-			<p className="launchpad__sidebar-description">Keep up the momentum with these next steps.</p>
-			<div className="launchpad__url-box">lorcaletters.blog</div>
-			<Checklist tasks={ tasks } />
+			<div className="launchpad__sidebar-content-container">
+				<div className="launchpad__progress-bar-container">
+					<span className="launchpad__progress-value">33%</span>
+					<div className="launchpad__progress-bar">
+						<div className="launchpad__progress-bar-completed" />
+					</div>
+				</div>
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }
+				<h1 className="launchpad__sidebar-h1">Voilà! Your Newsletter is up and running!</h1>
+				<p className="launchpad__sidebar-description">
+					Keep up the momentum with these next steps.
+				</p>
+				<div className="launchpad__url-box">{ url }</div>
+				<Checklist tasks={ tasks } />
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default Sidebar;


### PR DESCRIPTION
## Proposed Changes

* Add a site url for the current site being onboarded above the launchpad checklist

## Screenshots and GIFs

<img width="1496" alt="Screen Shot 2022-08-18 at 7 41 36 PM" src="https://user-images.githubusercontent.com/5414230/185531439-1c1133cf-fa72-4f13-8218-29740d118ecf.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* `yarn start`
* Navigate to the launchpad view http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=YOUR_SITE_SLUG_HERE
* Note that the site slug is displayed above the checklist

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66705
