### PR TITLE
Fix UDP jumping when switching theme filters

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -384,6 +384,9 @@
 	.responsive-toolbar-group__dropdown .responsive-toolbar-group__grouped-list {
 		justify-content: flex-start;
 	}
+	.design-picker__grid:last-child {
+		min-height: 100vh;
+	}
 	.design-picker__grid {
 		@supports ( display: grid ) {
 			@include break-medium {


### PR DESCRIPTION
The jumping is caused by the different heights of the grid container when switching theme filters because there are fewer elements.

#### Proposed Changes
 
* The height of the last grid container in the design picker has the whole viewport height to prevent the jumping
* This change introduces padding on the bottom of the page when the height of the grid container is less than the viewport height

**See the padding on the bottom** 
<img width="1724" alt="Screen Shot 2565-08-19 at 09 36 10" src="https://user-images.githubusercontent.com/1881481/185532164-6848bb19-057c-4100-a72f-01a6a3eaf3e4.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
[Recording](https://user-images.githubusercontent.com/1881481/185533146-dd1bc3bb-f793-4dd2-af72-2922f32fd3c1.mov)

- Visit [https://wordpress.com/setup/designSetup?siteSlug={site](https://wordpress.com/setup/designSetup?siteSlug=%7Bsite) slug} with no goal selection.
- On the design picker, scroll to place the theme filters on the top of the screen, then switch from `Blog` to `Sophisticated`



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66440
