### PR TITLE
VideosUI: Allow to override text in header

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,9 +20,9 @@ const VideosUi = ( {
 	FooterBar,
 	areVideosTranslated = true,
 	intent = undefined,
-	title,
-	subtitle,
-	options,
+	title = false,
+	subtitle = false,
+	options = false,
 } ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -9,6 +9,7 @@ import {
 	useCourseData,
 	useUpdateUserCourseProgressionMutation,
 } from 'calypso/data/courses';
+import { COURSE_DETAILS } from 'calypso/data/courses/constants';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import VideoChapters from './video-chapters';
 import VideoPlayer from './video-player';
@@ -97,23 +98,6 @@ const VideosUi = ( {
 		}
 	}, [ course ] );
 
-	let headerTitle;
-	let headerSubtitle;
-	let headerSummary;
-
-	switch ( courseSlug ) {
-		case COURSE_SLUGS.BLOGGING_QUICK_START:
-			headerTitle = translate( 'Watch five videos.' );
-			headerSubtitle = translate( 'Save yourself hours.' );
-			headerSummary = [
-				translate( 'Learn the basics of blogging' ),
-				translate( 'Familiarize yourself with WordPress' ),
-				translate( 'Upskill and save hours' ),
-				translate( 'Set yourself up for blogging success' ),
-			];
-			break;
-	}
-
 	return (
 		<div className="videos-ui">
 			<div className="videos-ui__header">
@@ -135,12 +119,12 @@ const VideosUi = ( {
 				) }
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
-						<h2>{ headerTitle }</h2>
-						<h2>{ headerSubtitle }</h2>
+						<h2>{ COURSE_DETAILS[ courseSlug ].headerTitle }</h2>
+						<h2>{ COURSE_DETAILS[ courseSlug ].headerSubtitle }</h2>
 					</div>
 					<div className="videos-ui__summary">
 						<ul>
-							{ headerSummary.map( ( text ) => {
+							{ COURSE_DETAILS[ courseSlug ].headerSummary.map( ( text ) => {
 								return (
 									<li>
 										<Gridicon icon="checkmark" size={ 18 } /> { text }

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,6 +20,9 @@ const VideosUi = ( {
 	FooterBar,
 	areVideosTranslated = true,
 	intent = undefined,
+	title,
+	subtitle,
+	options,
 } ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
@@ -118,26 +121,39 @@ const VideosUi = ( {
 				) }
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
-						<h2>{ translate( 'Watch five videos.' ) }</h2>
-						<h2>{ translate( 'Save yourself hours.' ) }</h2>
+						<h2>{ title ? title : translate( 'Watch five videos.' ) }</h2>
+						<h2>{ subtitle ? subtitle : translate( 'Save yourself hours.' ) }</h2>
 					</div>
 					<div className="videos-ui__summary">
 						<ul>
-							<li>
-								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-								{ translate( 'Learn the basics of blogging' ) }
-							</li>
-							<li>
-								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-								{ translate( 'Familiarize yourself with WordPress' ) }
-							</li>
-							<li>
-								<Gridicon icon="checkmark" size={ 18 } /> { translate( 'Upskill and save hours' ) }
-							</li>
-							<li>
-								<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-								{ translate( 'Set yourself up for blogging success' ) }
-							</li>
+							{ ( ! options || options[ 0 ] ) && (
+								<li>
+									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+									{ options[ 0 ] ? options[ 0 ] : translate( 'Learn the basics of blogging' ) }
+								</li>
+							) }
+							{ ( ! options || options[ 1 ] ) && (
+								<li>
+									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+									{ options[ 1 ]
+										? options[ 1 ]
+										: translate( 'Familiarize yourself with WordPress' ) }
+								</li>
+							) }
+							{ ( ! options || options[ 2 ] ) && (
+								<li>
+									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+									{ options[ 2 ] ? options[ 2 ] : translate( 'Upskill and save hours' ) }
+								</li>
+							) }
+							{ ( ! options || options[ 3 ] ) && (
+								<li>
+									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
+									{ options[ 3 ]
+										? options[ 3 ]
+										: translate( 'Set yourself up for blogging success' ) }
+								</li>
+							) }
 						</ul>
 					</div>
 				</div>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,9 +20,6 @@ const VideosUi = ( {
 	FooterBar,
 	areVideosTranslated = true,
 	intent = undefined,
-	headerTitle = false,
-	headerSubtitle = false,
-	headerOptionsList = [],
 } ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
@@ -38,14 +35,6 @@ const VideosUi = ( {
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
 	const currentVideo = course?.videos?.[ currentVideoKey || 0 ];
-	const headerOptions = headerOptionsList.length
-		? headerOptionsList
-		: [
-				translate( 'Learn the basics of blogging' ),
-				translate( 'Familiarize yourself with WordPress' ),
-				translate( 'Upskill and save hours' ),
-				translate( 'Set yourself up for blogging success' ),
-		  ];
 
 	const onVideoPlayClick = ( videoSlug ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
@@ -108,6 +97,33 @@ const VideosUi = ( {
 		}
 	}, [ course ] );
 
+	let headerTitle;
+	let headerSubtitle;
+	let headerSummary;
+
+	switch ( courseSlug ) {
+		case COURSE_SLUGS.BLOGGING_QUICK_START:
+			headerTitle = translate( 'Watch five videos.' );
+			headerSubtitle = translate( 'Save yourself hours.' );
+			headerSummary = [
+				translate( 'Learn the basics of blogging' ),
+				translate( 'Familiarize yourself with WordPress' ),
+				translate( 'Upskill and save hours' ),
+				translate( 'Set yourself up for blogging success' ),
+			];
+			break;
+		case COURSE_SLUGS.PAYMENTS_FEATURES:
+			headerTitle = translate( 'Add Payments Features' );
+			headerSubtitle = translate( 'Make Money on Your Website' );
+			headerSummary = [
+				translate( 'Making Money with Payments Features' ),
+				translate( 'Premium Membership Blog' ),
+				translate( 'Paid Subscription Newsletter' ),
+				translate( 'Run a Crowdfunding Campaign' ),
+			];
+			break;
+	}
+
 	return (
 		<div className="videos-ui">
 			<div className="videos-ui__header">
@@ -134,7 +150,7 @@ const VideosUi = ( {
 					</div>
 					<div className="videos-ui__summary">
 						<ul>
-							{ headerOptions.map( ( text ) => {
+							{ headerSummary.map( ( text ) => {
 								return (
 									<li>
 										<Gridicon icon="checkmark" size={ 18 } /> { text }

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -145,8 +145,8 @@ const VideosUi = ( {
 				) }
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
-						<h2>{ headerTitle ? headerTitle : translate( 'Watch five videos.' ) }</h2>
-						<h2>{ headerSubtitle ? headerSubtitle : translate( 'Save yourself hours.' ) }</h2>
+						<h2>{ headerTitle }</h2>
+						<h2>{ headerSubtitle }</h2>
 					</div>
 					<div className="videos-ui__summary">
 						<ul>

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -112,16 +112,6 @@ const VideosUi = ( {
 				translate( 'Set yourself up for blogging success' ),
 			];
 			break;
-		case COURSE_SLUGS.PAYMENTS_FEATURES:
-			headerTitle = translate( 'Add Payments Features' );
-			headerSubtitle = translate( 'Make Money on Your Website' );
-			headerSummary = [
-				translate( 'Making Money with Payments Features' ),
-				translate( 'Premium Membership Blog' ),
-				translate( 'Paid Subscription Newsletter' ),
-				translate( 'Run a Crowdfunding Campaign' ),
-			];
-			break;
 	}
 
 	return (

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -22,7 +22,7 @@ const VideosUi = ( {
 	intent = undefined,
 	headerTitle = false,
 	headerSubtitle = false,
-	headerOptionsList = false,
+	headerOptionsList = [],
 } ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
@@ -38,7 +38,7 @@ const VideosUi = ( {
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
 	const currentVideo = course?.videos?.[ currentVideoKey || 0 ];
-	const headerOptions = headerOptionsList
+	const headerOptions = headerOptionsList.length
 		? headerOptionsList
 		: [
 				translate( 'Learn the basics of blogging' ),
@@ -134,7 +134,7 @@ const VideosUi = ( {
 					</div>
 					<div className="videos-ui__summary">
 						<ul>
-							{ headerOptions.map( function ( text ) {
+							{ headerOptions.map( ( text ) => {
 								return (
 									<li>
 										<Gridicon icon="checkmark" size={ 18 } /> { text }

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -43,7 +43,7 @@ const VideosUi = ( {
 		: [
 				translate( 'Learn the basics of blogging' ),
 				translate( 'Familiarize yourself with WordPress' ),
-				translate( 'Familiarize yourself with WordPress' ),
+				translate( 'Upskill and save hours' ),
 				translate( 'Set yourself up for blogging success' ),
 		  ];
 

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -20,9 +20,9 @@ const VideosUi = ( {
 	FooterBar,
 	areVideosTranslated = true,
 	intent = undefined,
-	title = false,
-	subtitle = false,
-	options = false,
+	headerTitle = false,
+	headerSubtitle = false,
+	headerOptionsList = false,
 } ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
@@ -38,6 +38,14 @@ const VideosUi = ( {
 	const [ currentVideoKey, setCurrentVideoKey ] = useState( null );
 	const [ isPlaying, setIsPlaying ] = useState( false );
 	const currentVideo = course?.videos?.[ currentVideoKey || 0 ];
+	const headerOptions = headerOptionsList
+		? headerOptionsList
+		: [
+				translate( 'Learn the basics of blogging' ),
+				translate( 'Familiarize yourself with WordPress' ),
+				translate( 'Familiarize yourself with WordPress' ),
+				translate( 'Set yourself up for blogging success' ),
+		  ];
 
 	const onVideoPlayClick = ( videoSlug ) => {
 		recordTracksEvent( 'calypso_courses_play_click', {
@@ -121,39 +129,18 @@ const VideosUi = ( {
 				) }
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
-						<h2>{ title ? title : translate( 'Watch five videos.' ) }</h2>
-						<h2>{ subtitle ? subtitle : translate( 'Save yourself hours.' ) }</h2>
+						<h2>{ headerTitle ? headerTitle : translate( 'Watch five videos.' ) }</h2>
+						<h2>{ headerSubtitle ? headerSubtitle : translate( 'Save yourself hours.' ) }</h2>
 					</div>
 					<div className="videos-ui__summary">
 						<ul>
-							{ ( ! options || options[ 0 ] ) && (
-								<li>
-									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-									{ options[ 0 ] ? options[ 0 ] : translate( 'Learn the basics of blogging' ) }
-								</li>
-							) }
-							{ ( ! options || options[ 1 ] ) && (
-								<li>
-									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-									{ options[ 1 ]
-										? options[ 1 ]
-										: translate( 'Familiarize yourself with WordPress' ) }
-								</li>
-							) }
-							{ ( ! options || options[ 2 ] ) && (
-								<li>
-									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-									{ options[ 2 ] ? options[ 2 ] : translate( 'Upskill and save hours' ) }
-								</li>
-							) }
-							{ ( ! options || options[ 3 ] ) && (
-								<li>
-									<Gridicon icon="checkmark" size={ 18 } />{ ' ' }
-									{ options[ 3 ]
-										? options[ 3 ]
-										: translate( 'Set yourself up for blogging success' ) }
-								</li>
-							) }
+							{ headerOptions.map( function ( text ) {
+								return (
+									<li>
+										<Gridicon icon="checkmark" size={ 18 } /> { text }
+									</li>
+								);
+							} ) }
 						</ul>
 					</div>
 				</div>

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,6 +1,19 @@
+import i18n from 'i18n-calypso';
 import type { CourseSlug } from './types';
 
 export const COURSE_SLUGS: { [ key: string ]: CourseSlug } = Object.freeze( {
 	BLOGGING_QUICK_START: 'blogging-quick-start',
-	PAYMENTS_FEATURES: 'payments-features',
 } );
+
+export const COURSE_DETAILS = {
+	[ COURSE_SLUGS.BLOGGING_QUICK_START ]: {
+		headerTitle: i18n.translate( 'Watch five videos.' ),
+		headerSubtitle: i18n.translate( 'Save yourself hours.' ),
+		headerSummary: [
+			i18n.translate( 'Learn the basics of blogging' ),
+			i18n.translate( 'Familiarize yourself with WordPress' ),
+			i18n.translate( 'Upskill and save hours' ),
+			i18n.translate( 'Set yourself up for blogging success' ),
+		],
+	},
+};

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -2,4 +2,5 @@ import type { CourseSlug } from './types';
 
 export const COURSE_SLUGS: { [ key: string ]: CourseSlug } = Object.freeze( {
 	BLOGGING_QUICK_START: 'blogging-quick-start',
+	PAYMENTS_FEATURES: 'payments-features',
 } );


### PR DESCRIPTION
This PR allow to overwrite texts in header by component params. 

Before all text there was hardcoded and was about blogging start guide - default curse. This component was used till now only once and only for course "". VideosUI allow to show new courses but with hardcoded description. 

#### Proposed Changes

* added new params into VideosUI component: title, subtitle, option
* keep default texts if no params passed to VideosUI to keep backward compatibility

#### Testing Instructions

https://user-images.githubusercontent.com/82798599/185570106-f17caf24-585e-42b7-85ad-269d5c266873.mp4

* Select your site
* Go to dashboard
* find "Blog like an expert from day one"
* Click on "Start learning"
* Video component should load and you should see in the header text "Watch five videos.", "Save yourself hours." and list with 4 elements on the right.
* close modal with video
Then on your calypso localhost:
* go to BloggingQuickStartModal https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/customer-home/cards/education/blogging-quick-start/blogging-quick-start-modal.jsx
at line 33, in VideosUi component add 3 params in separate lines: 
```
title={ "My title" }
subtitle={ "My subtitle" }
options={ [ 'first option', 'second option' ] }
```
* reload page and click again "Start learning"
* you should see texts in header the same as params above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65447
