### PR TITLE
Emails: refactor using isUserOnTitanFreeTrial instead of hardcoded checking

### DIFF
--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -13,3 +13,4 @@ export { hasTitanMailWithUs } from './has-titan-mail-with-us';
 export { isDomainEligibleForTitanFreeTrial } from './is-domain-eligible-for-titan-free-trial';
 export { isTitanMonthlyProduct } from './is-titan-monthly-product';
 export { useTitanAppsUrlPrefix } from './hooks/use-titan-apps-url-prefix';
+export { isUserOnTitanFreeTrial } from './is-user-on-titan-free-trial';

--- a/client/lib/titan/is-user-on-titan-free-trial.ts
+++ b/client/lib/titan/is-user-on-titan-free-trial.ts
@@ -1,0 +1,14 @@
+import type { ResponseDomain as Domain, EmailCost } from 'calypso/lib/domains/types';
+
+export function isUserOnTitanFreeTrial( domainOrEmailCost: Domain | EmailCost ): boolean {
+	let amountOfMailboxPurchaseCost: number | undefined;
+
+	if ( 'amount' in domainOrEmailCost ) {
+		amountOfMailboxPurchaseCost = domainOrEmailCost.amount;
+	} else {
+		amountOfMailboxPurchaseCost =
+			domainOrEmailCost.titanMailSubscription?.purchaseCostPerMailbox?.amount;
+	}
+
+	return amountOfMailboxPurchaseCost === 0;
+}

--- a/client/lib/titan/test/is-user-on-titan-free-trial.ts
+++ b/client/lib/titan/test/is-user-on-titan-free-trial.ts
@@ -1,0 +1,25 @@
+import { isUserOnTitanFreeTrial } from '..';
+import {
+	exampleTrialEmailCost,
+	examplePaidEmailCost,
+	exampleTrialResponseDomain,
+	examplePaidResponseDomain,
+} from './lib/fixtures';
+
+describe( 'isUserOnTitanFreeTrial()', () => {
+	test( 'return true when EmailCost has trial data', () => {
+		expect( isUserOnTitanFreeTrial( exampleTrialEmailCost ) ).toBe( true );
+	} );
+
+	test( 'return false when EmailCost has paid data', () => {
+		expect( isUserOnTitanFreeTrial( examplePaidEmailCost ) ).toBe( false );
+	} );
+
+	test( 'return true when ResponseDomain has trial data', () => {
+		expect( isUserOnTitanFreeTrial( exampleTrialResponseDomain ) ).toBe( true );
+	} );
+
+	test( 'return false when ResponseDomain has paid data', () => {
+		expect( isUserOnTitanFreeTrial( examplePaidResponseDomain ) ).toBe( false );
+	} );
+} );

--- a/client/lib/titan/test/lib/fixtures.ts
+++ b/client/lib/titan/test/lib/fixtures.ts
@@ -1,0 +1,32 @@
+import { DOMAIN_PRIMARY } from 'calypso/state/sites/domains/test/fixture';
+import type { ResponseDomain, EmailCost } from 'calypso/lib/domains/types';
+
+export const exampleTrialEmailCost: EmailCost = {
+	amount: 0,
+	currency: 'EUR',
+	text: '€0.00',
+};
+
+export const examplePaidEmailCost: EmailCost = {
+	amount: 28.42,
+	currency: 'EUR',
+	text: '€28.42',
+};
+
+export const exampleTrialResponseDomain: ResponseDomain = {
+	...DOMAIN_PRIMARY,
+	titanMailSubscription: {
+		purchaseCostPerMailbox: {
+			...exampleTrialEmailCost,
+		},
+	},
+};
+
+export const examplePaidResponseDomain: ResponseDomain = {
+	...DOMAIN_PRIMARY,
+	titanMailSubscription: {
+		purchaseCostPerMailbox: {
+			...examplePaidEmailCost,
+		},
+	},
+};

--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -1,6 +1,7 @@
 import { translate as originalTranslate, useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
+import { isUserOnTitanFreeTrial } from 'calypso/lib/titan';
 import type { EmailCost, ResponseDomain } from 'calypso/lib/domains/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import type { TranslateResult } from 'i18n-calypso';
@@ -51,7 +52,7 @@ function getPriceMessage( {
 	if ( mailboxPurchaseCost === null ) {
 		return '';
 	}
-	return mailboxPurchaseCost.amount === 0
+	return isUserOnTitanFreeTrial( mailboxPurchaseCost )
 		? translate( 'You can add new mailboxes for free until the end of your trial period.' )
 		: translate(
 				'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',
@@ -84,7 +85,7 @@ function getPriceMessageExplanation( {
 	}
 
 	// We don't need any explanation of the price at this point, because we have already handled it previously.
-	if ( mailboxPurchaseCost.amount === 0 ) {
+	if ( isUserOnTitanFreeTrial( mailboxPurchaseCost ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
#### Proposed Changes
Introduce a new function `isUserOnTitanFreeTrial`, so that now we can refactor existed codebase with using it instead of comparison `amount` with `0`,
As a result - there should be no changes in UI, behavior, etc.

#### Testing Instructions

Let's check a few scenarios.
**1) Test that nothing changed for Professional Email (FREE TRIAL)**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* If you have existed account with Professional Email (FREE TRIAL):
	* Choose your account with the Professional Email (FREE TRIAL)
* Otherwise, if you don't have existed account with the Professional Email (FREE TRIAL):
	* Click on "Add new site" at the end of the appeared list
	* Enter any domain name for test purposes
	* In the appeared list below - choose a domain with the help of the "Select" button
	* Choose any plan from the proposed with the help of the "Select" button
	* Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
	* Fill data in the "Professional Email" form to create your 3-month free email account and click on the "Add professional Email" button
	* Scroll down and click on "Complete Checkout"
	* On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
* In the body of the page, click on the "Add new mailboxes" button
* At the top part of the page body, you should see similar textual information:
![image](https://user-images.githubusercontent.com/5598437/184635715-60f7dac2-75a2-4071-b420-8e6918feae97.png)


**2) Test that nothing changed for Professional Email (PAID)**

* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
* Click on the "Renew now" button, which is located at the top part of the page body (on the right side of the text "Expires: {Date}")
* Scroll down and click on "Pay {amount} with credits"
* In the top left corner of the page, click the "My Sites" button
* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
* In the body of the page, click on the "Add new mailboxes" button
* At the top part of the page body, you should see similar textual information:
![image](https://user-images.githubusercontent.com/5598437/184635806-ddb5a0e1-0603-47a4-a8ff-8127f7740ea4.png)


**3) Test that nothing changed for Google Workspace (PAID)**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* Recommended if you have existed account with "Google Workspace" subscription:
	* Choose your account with the "Google Workspace" subscription
* Otherwise, if you don't have existed account with the "Google Workspace" subscription:
	* Click on "Add new site" at the end of the appeared list
	* Enter any domain name for test purposes
	* In the appeared list below - choose a domain with the help of the "Select" button
	* Choose any plan from the proposed with the help of the "Select" button
	* Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
	* Note, on the page "Add Professional Email" - click on the "Skip for now" button
	* On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
	* In the left sidebar menu, click on the "Inbox" item
	* At the bottom of the page is located the "Google Workspace" section, click on the "Select" button, on the right side of the section
	* Fill "Google Workspace" form and click on the "Purchase" button, below the form
	* Click on "Pay {amount} with credits"
	* Click on the "Manage email" button in the middle of the page body
	* In the left sidebar menu, click on the "Inbox" item
	* If you see the warning "Configuring mailboxes" at the top part of the page body - it means that it's necessary to wait a bit, so at the current moment, you can go to the kitchen and make a cup of coffee 🙃
	* Reload the page to check for any news regarding the configuration of your mailboxes. 
	* If it's finished, you will see the notification "Action required". So click on the "Finish setup" button under the notification and follow the instructions.
	* After finishing setup - come back to the dashboard
* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
* In the body of the page, click on the "Add new mailboxes" button
* At the top part of the page body, you should see similar textual information:
![image](https://user-images.githubusercontent.com/5598437/184636119-3d011438-7713-434b-abe8-74d95d198981.png)

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202812560566852/f