### PR TITLE
WIP move ellipsis menu to the top of reader card

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import CommentButton from 'calypso/blocks/comment-button';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import PostEditButton from 'calypso/blocks/post-edit-button';
-import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowShare } from 'calypso/blocks/reader-share/helper';
 import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
@@ -22,8 +21,6 @@ const ReaderPostActions = ( props ) => {
 		onCommentClick,
 		showEdit,
 		showVisit,
-		showMenu,
-		showMenuFollow,
 		iconSize,
 		className,
 		visitUrl,
@@ -100,15 +97,6 @@ const ReaderPostActions = ( props ) => {
 					/>
 				</li>
 			) }
-			{ showMenu && (
-				<li className="reader-post-actions__item">
-					<ReaderPostOptionsMenu
-						className="ignore-click"
-						showFollow={ showMenuFollow }
-						post={ post }
-					/>
-				</li>
-			) }
 		</ul>
 	);
 	/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
@@ -120,8 +108,6 @@ ReaderPostActions.propTypes = {
 	onCommentClick: PropTypes.func,
 	showEdit: PropTypes.bool,
 	iconSize: PropTypes.number,
-	showMenu: PropTypes.bool,
-	showMenuFollow: PropTypes.bool,
 	visitUrl: PropTypes.string,
 	fullPost: PropTypes.bool,
 };
@@ -129,9 +115,7 @@ ReaderPostActions.propTypes = {
 ReaderPostActions.defaultProps = {
 	showEdit: true,
 	showVisit: false,
-	showMenu: false,
 	iconSize: 24,
-	showMenuFollow: true,
 };
 
 export default localize( ReaderPostActions );

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import TimeSince from 'calypso/components/time-since';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
@@ -53,6 +54,8 @@ class PostByline extends Component {
 		isDiscoverPost: PropTypes.bool,
 		showSiteName: PropTypes.bool,
 		showAvatar: PropTypes.bool,
+		teams: PropTypes.array,
+		showFollow: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -69,7 +72,8 @@ class PostByline extends Component {
 	};
 
 	render() {
-		const { post, site, feed, isDiscoverPost, showSiteName, showAvatar } = this.props;
+		const { post, site, feed, isDiscoverPost, showSiteName, showAvatar, teams, showFollow } =
+			this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const siteSlug = get( site, 'slug' );
@@ -163,6 +167,12 @@ class PostByline extends Component {
 						) }
 					</div>
 				</div>
+				<ReaderPostEllipsisMenu
+					site={ site }
+					teams={ teams }
+					post={ post }
+					showFollow={ showFollow }
+				/>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-gridicon-size */

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -8,6 +8,7 @@ import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/read
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import TimeSince from 'calypso/components/time-since';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
+import FollowButton from 'calypso/reader/follow-button';
 import { getSiteName } from 'calypso/reader/get-helpers';
 import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import { getStreamUrl } from 'calypso/reader/route';
@@ -56,6 +57,8 @@ class PostByline extends Component {
 		showAvatar: PropTypes.bool,
 		teams: PropTypes.array,
 		showFollow: PropTypes.bool,
+		showPrimaryFollowButton: PropTypes.bool,
+		followSource: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -72,8 +75,19 @@ class PostByline extends Component {
 	};
 
 	render() {
-		const { post, site, feed, isDiscoverPost, showSiteName, showAvatar, teams, showFollow } =
-			this.props;
+		const {
+			post,
+			site,
+			feed,
+			isDiscoverPost,
+			showSiteName,
+			showAvatar,
+			teams,
+			showFollow,
+			showPrimaryFollowButton,
+			followSource,
+		} = this.props;
+		const followUrl = feed ? feed.feed_URL : post.site_URL;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const siteSlug = get( site, 'slug' );
@@ -167,6 +181,13 @@ class PostByline extends Component {
 						) }
 					</div>
 				</div>
+				{ showPrimaryFollowButton && followUrl && (
+					<FollowButton
+						siteUrl={ followUrl }
+						followSource={ followSource }
+						railcar={ post.railcar }
+					/>
+				) }
 				<ReaderPostEllipsisMenu
 					site={ site }
 					teams={ teams }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
-import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import AutoDirection from 'calypso/components/auto-direction';
 import FeaturedAsset from './featured-asset';
 
@@ -15,12 +14,6 @@ const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 			/>
 			<div className="reader-post-card__post-details">
 				{ postByline }
-				<ReaderPostOptionsMenu
-					className="ignore-click"
-					showFollow={ true }
-					post={ post }
-					position="bottom"
-				/>
 				<AutoDirection>
 					<h2 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -14,7 +14,6 @@ import {
 	getDiscoverBlogName,
 	getSourceFollowUrl as getDiscoverFollowUrl,
 } from 'calypso/reader/discover/helper';
-import FollowButton from 'calypso/reader/follow-button';
 import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import * as stats from 'calypso/reader/stats';
 import { expandCard as expandCardAction } from 'calypso/state/reader-ui/card-expansions/actions';
@@ -201,6 +200,8 @@ class ReaderPostCard extends Component {
 					showSiteName={ true }
 					teams={ teams }
 					showFollow={ ! isDiscover }
+					showPrimaryFollowButton={ showPrimaryFollowButton }
+					followSource={ followSource }
 				/>
 			);
 		} else {
@@ -213,6 +214,8 @@ class ReaderPostCard extends Component {
 					showAvatar={ ! compact }
 					teams={ teams }
 					showFollow={ ! isDiscover }
+					showPrimaryFollowButton={ showPrimaryFollowButton }
+					followSource={ followSource }
 				/>
 			);
 		}
@@ -271,18 +274,10 @@ class ReaderPostCard extends Component {
 			);
 		}
 
-		const followUrl = feed ? feed.feed_URL : post.site_URL;
 		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
 		return (
 			<Card className={ classes } onClick={ onClick } tagName="article">
 				{ ! compact && postByline }
-				{ showPrimaryFollowButton && followUrl && (
-					<FollowButton
-						siteUrl={ followUrl }
-						followSource={ followSource }
-						railcar={ post.railcar }
-					/>
-				) }
 				{ readerPostCard }
 				{ this.props.children }
 			</Card>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -24,12 +24,12 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 import PostByline from './byline';
 import ConversationPost from './conversation-post';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
-
 import './style.scss';
 
 const noop = () => {};
@@ -52,6 +52,7 @@ class ReaderPostCard extends Component {
 		postKey: PropTypes.object,
 		compact: PropTypes.bool,
 		isWPForTeamsItem: PropTypes.bool,
+		teams: PropTypes.array,
 		hasOrganization: PropTypes.bool,
 	};
 
@@ -132,6 +133,7 @@ class ReaderPostCard extends Component {
 			compact,
 			hasOrganization,
 			isWPForTeamsItem,
+			teams,
 		} = this.props;
 
 		let isSeen = false;
@@ -173,9 +175,7 @@ class ReaderPostCard extends Component {
 				site={ site }
 				visitUrl={ post.URL }
 				showVisit={ true }
-				showMenu={ true }
 				fullPost={ false }
-				showMenuFollow={ ! isDiscover }
 				onCommentClick={ onCommentClick }
 				showEdit={ false }
 				className="ignore-click"
@@ -195,7 +195,13 @@ class ReaderPostCard extends Component {
 				primary_tag: post.primary_tag,
 			} );
 			postByline = (
-				<PostByline post={ postForByline } site={ discoverSite } showSiteName={ true } />
+				<PostByline
+					post={ postForByline }
+					site={ discoverSite }
+					showSiteName={ true }
+					teams={ teams }
+					showFollow={ ! isDiscover }
+				/>
 			);
 		} else {
 			postByline = (
@@ -205,6 +211,8 @@ class ReaderPostCard extends Component {
 					feed={ feed }
 					showSiteName={ showSiteName || isDiscover }
 					showAvatar={ ! compact }
+					teams={ teams }
+					showFollow={ ! isDiscover }
 				/>
 			);
 		}
@@ -295,6 +303,7 @@ export default connect(
 			ownProps.postKey.blogId
 		),
 		isExpanded: isReaderCardExpanded( state, ownProps.postKey ),
+		teams: getReaderTeams( state ),
 	} ),
 	{ expandCard: expandCardAction }
 )( ReaderPostCard );

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -265,6 +265,7 @@
 .reader-post-card__byline {
 	display: flex;
 	font-size: $font-body-small;
+	align-items: space-between;
 }
 
 .reader-post-card__author::after {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -8,7 +8,7 @@
 		padding: 0;
 		height: 24px;
 		.ellipsis-menu__toggle-icon {
-			top: 0;
+			top: -1px;
 		}
 	}
 }
@@ -277,6 +277,7 @@
 .reader__content .reader-post-card__tag-link {
 	color: var( --color-text-subtle );
 	margin-top: 2px;
+	white-space: nowrap;
 	cursor: pointer;
 	&:hover {
 		color: var( --color-primary );
@@ -292,6 +293,7 @@
 .reader-post-card__byline-details {
 	color: var( --color-primary );
 	width: 100%;
+	overflow: hidden;
 }
 
 // Fix for IE11 unable to handle nested flexbox min-height.
@@ -335,9 +337,9 @@
 	flex-direction: row;
 	height: 20px;
 	margin-left: 10px;
+	margin-right: 12px;
 	overflow: hidden;
 	position: relative;
-	width: calc( 100% - 140px );
 
 	@include breakpoint-deprecated( '<480px' ) {
 		max-width: 500px;
@@ -538,14 +540,6 @@
 		margin-top: 0;
 	}
 
-	.like-button .gridicon {
-		top: 5px;
-	}
-
-	.like-button__label {
-		margin: -3px 0 0 -5px;
-	}
-
 	.comment-button {
 		align-items: flex-start;
 	}
@@ -553,6 +547,19 @@
 	.comment-button .gridicon {
 		top: 4px;
 		margin-right: 2px;
+	}
+
+	.like-button {
+		display: inline-block;
+		padding: 4px 0 4px 4px;
+		text-align: left;
+		vertical-align: top;
+		.like-button__like-icons {
+			height: 18px;
+			width: 18px;
+			display: inline-block;
+			vertical-align: top;
+		}
 	}
 
 	.reader-share__button-label,
@@ -570,13 +577,10 @@
 
 // Follow button for stream cards
 .reader-post-card.card .follow-button {
-	border: 0;
-	border-radius: 0;
-	float: right;
-	padding: 0;
-	position: absolute;
-	right: 0;
-	top: 16px;
+	flex-shrink: 0;
+	align-self: flex-start;
+	margin-right: 20px;
+	margin-top: -1px;
 
 	.gridicon {
 		fill: var( --color-primary );

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -3,6 +3,16 @@
 	border-top: 1px solid var( --color-neutral-10 );
 }
 
+.reader-post-options-menu__ellipsis-menu {
+	.ellipsis-menu__toggle {
+		padding: 0;
+		height: 24px;
+		.ellipsis-menu__toggle-icon {
+			top: 0;
+		}
+	}
+}
+
 .reader-post-card.card {
 	border-bottom: 1px solid var( --color-neutral-10 );
 	box-shadow: none;
@@ -381,7 +391,7 @@
 	.site-icon {
 		width: 32px !important;
 		height: 32px !important;
-		/* stylelint-disable-next-line scales/font-size */
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 32px !important;
 		line-height: 32px !important;
 	}

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -1,48 +1,19 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { size, map } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import * as DiscoverHelper from 'calypso/reader/discover/helper';
-import FollowButton from 'calypso/reader/follow-button';
-import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
-import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
-import * as stats from 'calypso/reader/stats';
-import * as PostUtils from 'calypso/state/posts/utils';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import { hasReaderFollowOrganization } from 'calypso/state/reader/follows/selectors';
-import {
-	requestMarkAsSeen,
-	requestMarkAsUnseen,
-	requestMarkAsSeenBlog,
-	requestMarkAsUnseenBlog,
-} from 'calypso/state/reader/seen-posts/actions';
-import { blockSite } from 'calypso/state/reader/site-blocks/actions';
 import { getSite } from 'calypso/state/reader/sites/selectors';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
-
 import './style.scss';
-
-const noop = () => {};
+import ReaderPostEllipsisMenu from './reader-post-ellipsis-menu';
 
 class ReaderPostOptionsMenu extends Component {
 	static propTypes = {
-		currentRoute: PropTypes.string,
 		post: PropTypes.object,
 		feed: PropTypes.object,
 		onBlock: PropTypes.func,
@@ -54,193 +25,7 @@ class ReaderPostOptionsMenu extends Component {
 		showReportSite: PropTypes.bool,
 		position: PropTypes.string,
 		posts: PropTypes.array,
-		isWPForTeamsItem: PropTypes.bool,
 		teams: PropTypes.array,
-	};
-
-	static defaultProps = {
-		onBlock: noop,
-		position: 'top left',
-		showFollow: true,
-		showVisitPost: true,
-		showEditPost: true,
-		showConversationFollow: true,
-		showReportPost: true,
-		showReportSite: false,
-		posts: [],
-	};
-
-	blockSite = () => {
-		stats.recordAction( 'blocked_blog' );
-		stats.recordGaEvent( 'Clicked Block Site' );
-		stats.recordTrackForPost( 'calypso_reader_block_site', this.props.post );
-		this.props.blockSite( this.props.post.site_ID );
-		this.props.onBlock();
-	};
-
-	reportPost = () => {
-		if ( ! this.props.post || ! this.props.post.URL ) {
-			return;
-		}
-
-		stats.recordAction( 'report_post' );
-		stats.recordGaEvent( 'Clicked Report Post', 'post_options' );
-		stats.recordTrackForPost( 'calypso_reader_post_reported', this.props.post );
-
-		window.open(
-			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ),
-			'_blank'
-		);
-	};
-
-	reportSite = () => {
-		if ( ! this.props.site || ! this.props.site.URL ) {
-			return;
-		}
-
-		stats.recordAction( 'report_site' );
-		stats.recordGaEvent( 'Clicked Report Site', 'post_options' );
-		stats.recordTrackForPost( 'calypso_reader_site_reported', this.props.site );
-
-		window.open(
-			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.site.URL ),
-			'_blank'
-		);
-	};
-
-	getFollowUrl = () => {
-		return this.props.feed
-			? this.props.feed.feed_URL
-			: this.props.post.feed_URL || this.props.post.site_URL;
-	};
-
-	onMenuToggle = ( isMenuVisible ) => {
-		stats.recordAction( isMenuVisible ? 'open_post_options_menu' : 'close_post_options_menu' );
-		stats.recordGaEvent( isMenuVisible ? 'Open Post Options Menu' : 'Close Post Options Menu' );
-		stats.recordTrackForPost(
-			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
-			this.props.post
-		);
-	};
-
-	editPost = () => {
-		const { post, site } = this.props;
-		let editUrl = '//wordpress.com/post/' + post.site_ID + '/' + post.ID + '/';
-
-		if ( site && site.slug ) {
-			editUrl = PostUtils.getEditURL( post, site );
-		}
-
-		stats.recordAction( 'edit_post' );
-		stats.recordGaEvent( 'Clicked Edit Post', 'post_options' );
-		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', this.props.post );
-
-		setTimeout( function () {
-			// give the analytics a chance to escape
-			if ( editUrl.indexOf( '//' ) === 0 ) {
-				window.location.href = editUrl;
-			} else {
-				page( editUrl );
-			}
-		}, 100 );
-	};
-
-	visitPost = () => {
-		const post = this.props.post;
-
-		if ( ! post || ! post.URL ) {
-			return;
-		}
-
-		stats.recordAction( 'visit_post' );
-		stats.recordGaEvent( 'Clicked Visit Post', 'post_options' );
-		stats.recordTrackForPost( 'calypso_reader_visit_post_clicked', post );
-
-		window.open( post.URL, '_blank' );
-	};
-
-	markAsSeen = () => {
-		const { post, posts } = this.props;
-
-		if ( ! post ) {
-			return;
-		}
-
-		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_seen_clicked' );
-
-		const feedId = post.feed_ID;
-		let postIds = [ post.ID ];
-		let feedItemIds = [ post.feed_item_ID ];
-		let globalIds = [ post.global_ID ];
-
-		if ( size( posts ) ) {
-			postIds = map( posts, 'ID' );
-			feedItemIds = map( posts, 'feed_item_ID' );
-			globalIds = map( posts, 'global_ID' );
-		}
-
-		if ( post.feed_item_ID ) {
-			// is feed
-			this.props.requestMarkAsSeen( {
-				feedId,
-				feedUrl: post.feed_URL,
-				feedItemIds,
-				globalIds,
-			} );
-		} else {
-			// is blog
-			this.props.requestMarkAsSeenBlog( {
-				feedId,
-				feedUrl: post.feed_URL,
-				blogId: post.site_ID,
-				postIds,
-				globalIds,
-			} );
-		}
-
-		this.onMenuToggle();
-	};
-
-	markAsUnSeen = () => {
-		const { post, posts } = this.props;
-
-		if ( ! post ) {
-			return;
-		}
-
-		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_unseen_clicked' );
-
-		const feedId = post.feed_ID;
-		let postIds = [ post.ID ];
-		let feedItemIds = [ post.feed_item_ID ];
-		let globalIds = [ post.global_ID ];
-
-		if ( size( posts ) ) {
-			postIds = map( posts, 'ID' );
-			feedItemIds = map( posts, 'feed_item_ID' );
-			globalIds = map( posts, 'global_ID' );
-		}
-
-		if ( post.feed_item_ID ) {
-			// is feed
-			this.props.requestMarkAsUnseen( {
-				feedId,
-				feedUrl: post.feed_URL,
-				feedItemIds,
-				globalIds,
-			} );
-		} else {
-			// is blog
-			this.props.requestMarkAsUnseenBlog( {
-				feedId,
-				feedUrl: post.feed_URL,
-				blogId: post.site_ID,
-				postIds,
-				globalIds,
-			} );
-		}
-
-		this.onMenuToggle();
 	};
 
 	render() {
@@ -252,33 +37,17 @@ class ReaderPostOptionsMenu extends Component {
 			translate,
 			position,
 			posts,
-			isWPForTeamsItem,
-			currentRoute,
-			hasOrganization,
+			onBlock,
+			showVisitPost,
+			showReportPost,
+			showReportSite,
+			showEditPost,
+			showFollow,
+			showConversationFollow,
 		} = this.props;
 
 		if ( ! post ) {
 			return null;
-		}
-
-		const { ID: postId, site_ID: siteId } = post;
-		const isEditPossible = PostUtils.userCan( 'edit_post', post );
-		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
-		const followUrl = this.getFollowUrl();
-		const isTeamMember = isAutomatticTeamMember( teams );
-		const showConversationFollowButton =
-			this.props.showConversationFollow && shouldShowConversationFollowButton( post );
-
-		let isBlockPossible = false;
-
-		// Should we show the 'block' option?
-		if (
-			post.site_ID &&
-			( ! post.is_external || post.is_jetpack ) &&
-			! isEditPossible &&
-			! isDiscoverPost
-		) {
-			isBlockPossible = true;
 		}
 
 		const classes = classnames( 'reader-post-options-menu', this.props.className );
@@ -290,116 +59,31 @@ class ReaderPostOptionsMenu extends Component {
 					<QueryReaderSite siteId={ +post.site_ID } />
 				) }
 				{ ! teams && <QueryReaderTeams /> }
-				<EllipsisMenu
-					className="reader-post-options-menu__ellipsis-menu"
-					popoverClassName="reader-post-options-menu__popover ignore-click"
-					onToggle={ this.onMenuToggle }
+				<ReaderPostEllipsisMenu
+					site={ site }
+					teams={ teams }
+					translate={ translate }
 					position={ position }
-				>
-					{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers blogId={ +site.ID } /> }
-
-					{ this.props.showFollow && (
-						<FollowButton
-							tagName={ PopoverMenuItem }
-							siteUrl={ followUrl }
-							followLabel={ showConversationFollowButton ? translate( 'Follow site' ) : null }
-							followingLabel={ showConversationFollowButton ? translate( 'Following site' ) : null }
-						/>
-					) }
-
-					{ showConversationFollowButton && (
-						<ConversationFollowButton
-							tagName={ PopoverMenuItem }
-							siteId={ siteId }
-							postId={ postId }
-							post={ post }
-							followSource={ READER_POST_OPTIONS_MENU }
-						/>
-					) }
-
-					{ isEligibleForUnseen( { isWPForTeamsItem, currentRoute, hasOrganization } ) &&
-						canBeMarkedAsSeen( { post, posts } ) &&
-						post.is_seen && (
-							<PopoverMenuItem
-								onClick={ this.markAsUnSeen }
-								icon="not-visible"
-								itemComponent={ 'a' }
-							>
-								{ size( posts ) > 0 && translate( 'Mark all as unseen' ) }
-								{ size( posts ) === 0 && translate( 'Mark as unseen' ) }
-							</PopoverMenuItem>
-						) }
-
-					{ isEligibleForUnseen( { isWPForTeamsItem, currentRoute, hasOrganization } ) &&
-						canBeMarkedAsSeen( { post, posts } ) &&
-						! post.is_seen && (
-							<PopoverMenuItem onClick={ this.markAsSeen } icon="visible">
-								{ size( posts ) > 0 && translate( 'Mark all as seen' ) }
-								{ size( posts ) === 0 && translate( 'Mark as seen' ) }
-							</PopoverMenuItem>
-						) }
-
-					{ this.props.showVisitPost && post.URL && (
-						<PopoverMenuItem onClick={ this.visitPost } icon="external">
-							{ translate( 'Visit post' ) }
-						</PopoverMenuItem>
-					) }
-
-					{ this.props.showEditPost && isEditPossible && (
-						<PopoverMenuItem onClick={ this.editPost } icon="pencil">
-							{ translate( 'Edit post' ) }
-						</PopoverMenuItem>
-					) }
-
-					{ ( this.props.showFollow || isEditPossible || post.URL ) &&
-						( isBlockPossible || isDiscoverPost ) && (
-							<hr className="reader-post-options-menu__hr" />
-						) }
-
-					{ isBlockPossible && (
-						<PopoverMenuItem onClick={ this.blockSite }>
-							{ translate( 'Block site' ) }
-						</PopoverMenuItem>
-					) }
-
-					{ ( ( this.props.showReportPost && isBlockPossible ) || isDiscoverPost ) && (
-						<PopoverMenuItem onClick={ this.reportPost }>
-							{ translate( 'Report this post' ) }
-						</PopoverMenuItem>
-					) }
-
-					{ this.props.showReportSite && site && isBlockPossible && (
-						<PopoverMenuItem onClick={ this.reportSite }>
-							{ translate( 'Report this site' ) }
-						</PopoverMenuItem>
-					) }
-				</EllipsisMenu>
+					post={ post }
+					posts={ posts }
+					onBlock={ onBlock }
+					showVisitPost={ showVisitPost }
+					showReportPost={ showReportPost }
+					showReportSite={ showReportSite }
+					showEditPost={ showEditPost }
+					showFollow={ showFollow }
+					showConversationFollow={ showConversationFollow }
+				/>
 			</span>
 		);
 	}
 }
 
-export default connect(
-	( state, { post: { feed_ID: feedId, is_external, site_ID } = {} } ) => {
-		const siteId = is_external ? null : site_ID;
-
-		return Object.assign(
-			{ currentRoute: getCurrentRoute( state ) },
-			{ isWPForTeamsItem: isSiteWPForTeams( state, siteId ) || isFeedWPForTeams( state, feedId ) },
-			{
-				hasOrganization: hasReaderFollowOrganization( state, feedId, siteId ),
-			},
-			{ teams: getReaderTeams( state ) },
-			feedId > 0 && { feed: getFeed( state, feedId ) },
-			siteId > 0 && { site: getSite( state, siteId ) }
-		);
-	},
-	{
-		blockSite,
-		requestMarkAsSeen,
-		requestMarkAsUnseen,
-		requestMarkAsSeenBlog,
-		requestMarkAsUnseenBlog,
-		recordReaderTracksEvent,
-	}
-)( localize( ReaderPostOptionsMenu ) );
+export default connect( ( state, { post: { feed_ID: feedId, is_external, site_ID } = {} } ) => {
+	const siteId = is_external ? null : site_ID;
+	return Object.assign(
+		{ teams: getReaderTeams( state ) },
+		feedId > 0 && { feed: getFeed( state, feedId ) },
+		siteId > 0 && { site: getSite( state, siteId ) }
+	);
+} )( localize( ReaderPostOptionsMenu ) );

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -1,0 +1,372 @@
+import { localize } from 'i18n-calypso';
+import { size, map } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
+import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import * as DiscoverHelper from 'calypso/reader/discover/helper';
+import FollowButton from 'calypso/reader/follow-button';
+import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
+import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import * as stats from 'calypso/reader/stats';
+import * as PostUtils from 'calypso/state/posts/utils';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { hasReaderFollowOrganization } from 'calypso/state/reader/follows/selectors';
+import {
+	requestMarkAsSeen,
+	requestMarkAsUnseen,
+	requestMarkAsSeenBlog,
+	requestMarkAsUnseenBlog,
+} from 'calypso/state/reader/seen-posts/actions';
+import { blockSite } from 'calypso/state/reader/site-blocks/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
+
+const noop = () => {};
+
+class ReaderPostEllipsisMenu extends Component {
+	static propTypes = {
+		post: PropTypes.object,
+		feed: PropTypes.object,
+		onBlock: PropTypes.func,
+		showFollow: PropTypes.bool,
+		showVisitPost: PropTypes.bool,
+		showEditPost: PropTypes.bool,
+		showConversationFollow: PropTypes.bool,
+		showReportPost: PropTypes.bool,
+		showReportSite: PropTypes.bool,
+		position: PropTypes.string,
+		posts: PropTypes.array,
+		teams: PropTypes.array,
+	};
+
+	static defaultProps = {
+		onBlock: noop,
+		position: 'top left',
+		showFollow: true,
+		showVisitPost: true,
+		showEditPost: true,
+		showConversationFollow: true,
+		showReportPost: true,
+		showReportSite: false,
+		posts: [],
+	};
+
+	blockSite = () => {
+		stats.recordAction( 'blocked_blog' );
+		stats.recordGaEvent( 'Clicked Block Site' );
+		stats.recordTrackForPost( 'calypso_reader_block_site', this.props.post );
+		this.props.blockSite( this.props.post.site_ID );
+		this.props.onBlock();
+	};
+
+	visitPost = () => {
+		const post = this.props.post;
+
+		if ( ! post || ! post.URL ) {
+			return;
+		}
+
+		stats.recordAction( 'visit_post' );
+		stats.recordGaEvent( 'Clicked Visit Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_visit_post_clicked', post );
+
+		window.open( post.URL, '_blank' );
+	};
+
+	reportPost = () => {
+		if ( ! this.props.post || ! this.props.post.URL ) {
+			return;
+		}
+
+		stats.recordAction( 'report_post' );
+		stats.recordGaEvent( 'Clicked Report Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_post_reported', this.props.post );
+
+		window.open(
+			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ),
+			'_blank'
+		);
+	};
+
+	reportSite = () => {
+		if ( ! this.props.site || ! this.props.site.URL ) {
+			return;
+		}
+
+		stats.recordAction( 'report_site' );
+		stats.recordGaEvent( 'Clicked Report Site', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_site_reported', this.props.site );
+
+		window.open(
+			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.site.URL ),
+			'_blank'
+		);
+	};
+
+	getFollowUrl = () => {
+		return this.props.feed
+			? this.props.feed.feed_URL
+			: this.props.post.feed_URL || this.props.post.site_URL;
+	};
+
+	onMenuToggle = ( isMenuVisible ) => {
+		stats.recordAction( isMenuVisible ? 'open_post_options_menu' : 'close_post_options_menu' );
+		stats.recordGaEvent( isMenuVisible ? 'Open Post Options Menu' : 'Close Post Options Menu' );
+		stats.recordTrackForPost(
+			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
+			this.props.post
+		);
+	};
+
+	editPost = () => {
+		const { post, site } = this.props;
+		let editUrl = '//wordpress.com/post/' + post.site_ID + '/' + post.ID + '/';
+
+		if ( site && site.slug ) {
+			editUrl = PostUtils.getEditURL( post, site );
+		}
+
+		stats.recordAction( 'edit_post' );
+		stats.recordGaEvent( 'Clicked Edit Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', this.props.post );
+
+		setTimeout( function () {
+			// give the analytics a chance to escape
+			if ( editUrl.indexOf( '//' ) === 0 ) {
+				window.location.href = editUrl;
+			} else {
+				page( editUrl );
+			}
+		}, 100 );
+	};
+
+	markAsSeen = () => {
+		const { post, posts } = this.props;
+
+		if ( ! post ) {
+			return;
+		}
+
+		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_seen_clicked' );
+
+		const feedId = post.feed_ID;
+		let postIds = [ post.ID ];
+		let feedItemIds = [ post.feed_item_ID ];
+		let globalIds = [ post.global_ID ];
+
+		if ( size( posts ) ) {
+			postIds = map( posts, 'ID' );
+			feedItemIds = map( posts, 'feed_item_ID' );
+			globalIds = map( posts, 'global_ID' );
+		}
+
+		if ( post.feed_item_ID ) {
+			// is feed
+			this.props.requestMarkAsSeen( {
+				feedId,
+				feedUrl: post.feed_URL,
+				feedItemIds,
+				globalIds,
+			} );
+		} else {
+			// is blog
+			this.props.requestMarkAsSeenBlog( {
+				feedId,
+				feedUrl: post.feed_URL,
+				blogId: post.site_ID,
+				postIds,
+				globalIds,
+			} );
+		}
+
+		this.onMenuToggle();
+	};
+
+	markAsUnSeen = () => {
+		const { post, posts } = this.props;
+
+		if ( ! post ) {
+			return;
+		}
+
+		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_unseen_clicked' );
+
+		const feedId = post.feed_ID;
+		let postIds = [ post.ID ];
+		let feedItemIds = [ post.feed_item_ID ];
+		let globalIds = [ post.global_ID ];
+
+		if ( size( posts ) ) {
+			postIds = map( posts, 'ID' );
+			feedItemIds = map( posts, 'feed_item_ID' );
+			globalIds = map( posts, 'global_ID' );
+		}
+
+		if ( post.feed_item_ID ) {
+			// is feed
+			this.props.requestMarkAsUnseen( {
+				feedId,
+				feedUrl: post.feed_URL,
+				feedItemIds,
+				globalIds,
+			} );
+		} else {
+			// is blog
+			this.props.requestMarkAsUnseenBlog( {
+				feedId,
+				feedUrl: post.feed_URL,
+				blogId: post.site_ID,
+				postIds,
+				globalIds,
+			} );
+		}
+
+		this.onMenuToggle();
+	};
+
+	render() {
+		const {
+			post,
+			site,
+			teams,
+			translate,
+			position,
+			posts,
+			isWPForTeamsItem,
+			currentRoute,
+			hasOrganization,
+		} = this.props;
+
+		const { ID: postId, site_ID: siteId } = post;
+
+		const isEditPossible = PostUtils.userCan( 'edit_post', post );
+		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
+
+		let isBlockPossible = false;
+
+		// Should we show the 'block' option?
+		if (
+			post.site_ID &&
+			( ! post.is_external || post.is_jetpack ) &&
+			! isEditPossible &&
+			! isDiscoverPost
+		) {
+			isBlockPossible = true;
+		}
+
+		const followUrl = this.getFollowUrl();
+		const isTeamMember = isAutomatticTeamMember( teams );
+		const showConversationFollowButton =
+			this.props.showConversationFollow && shouldShowConversationFollowButton( post );
+
+		return (
+			<EllipsisMenu
+				className="reader-post-options-menu__ellipsis-menu"
+				popoverClassName="reader-post-options-menu__popover ignore-click"
+				onToggle={ this.onMenuToggle }
+				position={ position }
+			>
+				{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers blogId={ +site.ID } /> }
+
+				{ this.props.showFollow && (
+					<FollowButton
+						tagName={ PopoverMenuItem }
+						siteUrl={ followUrl }
+						followLabel={ showConversationFollowButton ? translate( 'Follow site' ) : null }
+						followingLabel={ showConversationFollowButton ? translate( 'Following site' ) : null }
+					/>
+				) }
+
+				{ showConversationFollowButton && (
+					<ConversationFollowButton
+						tagName={ PopoverMenuItem }
+						siteId={ siteId }
+						postId={ postId }
+						post={ post }
+						followSource={ READER_POST_OPTIONS_MENU }
+					/>
+				) }
+
+				{ isEligibleForUnseen( { isWPForTeamsItem, currentRoute, hasOrganization } ) &&
+					canBeMarkedAsSeen( { post, posts } ) &&
+					post.is_seen && (
+						<PopoverMenuItem onClick={ this.markAsUnSeen } icon="not-visible" itemComponent={ 'a' }>
+							{ size( posts ) > 0 && translate( 'Mark all as unseen' ) }
+							{ size( posts ) === 0 && translate( 'Mark as unseen' ) }
+						</PopoverMenuItem>
+					) }
+
+				{ isEligibleForUnseen( { isWPForTeamsItem, currentRoute, hasOrganization } ) &&
+					canBeMarkedAsSeen( { post, posts } ) &&
+					! post.is_seen && (
+						<PopoverMenuItem onClick={ this.markAsSeen } icon="visible">
+							{ size( posts ) > 0 && translate( 'Mark all as seen' ) }
+							{ size( posts ) === 0 && translate( 'Mark as seen' ) }
+						</PopoverMenuItem>
+					) }
+
+				{ this.props.showVisitPost && post.URL && (
+					<PopoverMenuItem onClick={ this.visitPost } icon="external">
+						{ translate( 'Visit post' ) }
+					</PopoverMenuItem>
+				) }
+
+				{ this.props.showEditPost && isEditPossible && (
+					<PopoverMenuItem onClick={ this.editPost } icon="pencil">
+						{ translate( 'Edit post' ) }
+					</PopoverMenuItem>
+				) }
+
+				{ ( this.props.showFollow || isEditPossible || post.URL ) &&
+					( isBlockPossible || isDiscoverPost ) && <hr className="reader-post-options-menu__hr" /> }
+
+				{ isBlockPossible && (
+					<PopoverMenuItem onClick={ this.blockSite }>
+						{ translate( 'Block site' ) }
+					</PopoverMenuItem>
+				) }
+
+				{ ( ( this.props.showReportPost && isBlockPossible ) || isDiscoverPost ) && (
+					<PopoverMenuItem onClick={ this.reportPost }>
+						{ translate( 'Report this post' ) }
+					</PopoverMenuItem>
+				) }
+
+				{ this.props.showReportSite && site && isBlockPossible && (
+					<PopoverMenuItem onClick={ this.reportSite }>
+						{ translate( 'Report this site' ) }
+					</PopoverMenuItem>
+				) }
+			</EllipsisMenu>
+		);
+	}
+}
+export default connect(
+	( state, { post: { feed_ID: feedId, is_external, site_ID } = {} } ) => {
+		const siteId = is_external ? null : site_ID;
+
+		return Object.assign(
+			{ currentRoute: getCurrentRoute( state ) },
+			{ isWPForTeamsItem: isSiteWPForTeams( state, siteId ) || isFeedWPForTeams( state, feedId ) },
+			{
+				hasOrganization: hasReaderFollowOrganization( state, feedId, siteId ),
+			}
+		);
+	},
+	{
+		blockSite,
+		requestMarkAsSeen,
+		requestMarkAsUnseen,
+		requestMarkAsSeenBlog,
+		requestMarkAsUnseenBlog,
+		recordReaderTracksEvent,
+	}
+)( localize( ReaderPostEllipsisMenu ) );


### PR DESCRIPTION
### Proposed Changes

Implements https://github.com/Automattic/wp-calypso/issues/66624 and moves the ellipsis menu to the top of the card.

In order to accomodate this and keep things aligned, I had to make changes to the follow button and the likes button.

<img width="966" alt="Screen Shot 2022-08-23 at 5 55 07 pm" src="https://user-images.githubusercontent.com/22446385/186110778-8aa3adef-5fb3-44ff-9d65-4f2408e4703c.png">

Working towards figma designs posted here pe7F0s-90-p2


#### Testing Instructions
* [ ] test the normal `reader-post-card` under `/read`
* [ ] test the "combined" card `reader-combined-card`. You can see instances of this card when searching for tags e.g. `/tag/interview`. I have intentionally left this card as it is because we are thinking of removing it. But its hamburger menu should still work.
* [ ] test the "compact" card on the `/read/conversations` page
* [ ] test that changes have not affected other places that components may have been used such as the post page