### PR TITLE
Add feature flags and product lightbox placeholder

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -1,9 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { SVG, Path } from '@wordpress/components';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { createElement, ReactNode, useEffect, useRef } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
+import HintButton from 'calypso/my-sites/plans/jetpack-plans/product-lightbox/hint-button';
 import DisplayPrice from './display-price';
 import JetpackProductCardFeatures from './features';
 import type {
@@ -46,6 +48,7 @@ type OwnProps = {
 	showAbovePriceText?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
+	onLearnMoreClick?: React.MouseEventHandler;
 };
 
 type HeaderLevel = 1 | 2 | 3 | 4 | 5 | 6;
@@ -87,6 +90,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	aboveButtonText = null,
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
+	onLearnMoreClick,
 } ) => {
 	const isFree = item.isFree;
 
@@ -232,6 +236,9 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				) }
 				{ item.disclaimer && (
 					<span className="jetpack-product-card__disclaimer">{ item.disclaimer }</span>
+				) }
+				{ isEnabled( 'jetpack/pricing-page-product-lightbox' ) && (
+					<HintButton onClick={ onLearnMoreClick } />
 				) }
 			</div>
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	planHasFeature,
 	TERM_MONTHLY,
@@ -7,6 +8,7 @@ import {
 	JETPACK_SCAN_PRODUCTS,
 	isJetpackPlanSlug,
 } from '@automattic/calypso-products';
+import { Dialog } from '@automattic/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import * as React from 'react';
@@ -25,6 +27,7 @@ import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import PlanRenewalMessage from '../plan-renewal-message';
+import ProductLightbox from '../product-lightbox';
 import useItemPrice from '../use-item-price';
 import productAboveButtonText from './product-above-button-text';
 import productButtonLabel from './product-button-label';
@@ -209,39 +212,58 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 		buttonLabel
 	);
 
+	const [ isDialogVisible, setDialogVisible ] = React.useState( false );
+
 	return (
-		<JetpackProductCard
-			item={ item }
-			headerLevel={ 3 }
-			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
-			originalPrice={ originalPrice }
-			discountedPrice={ discountedPrice }
-			buttonLabel={ buttonLabel }
-			buttonPrimary={ ! ( isOwned || isItemPlanFeature || isSuperseded ) }
-			onButtonClick={ () => {
-				onClick( item, isUpgradeableToYearly, purchase );
-			} }
-			buttonURL={
-				createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
-			}
-			buttonDisabled={ isDisabled || buttonDisabled || isLoadingUpsellPageExperiment }
-			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
-			isFeatured={ isFeatured }
-			isOwned={ isOwned }
-			isIncludedInPlan={ isIncludedInPlan || isSuperseded }
-			isDeprecated={ isDeprecated }
-			isAligned={ isAligned }
-			displayFrom={ ! siteId && priceTierList.length > 0 }
-			tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
-			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
-			isDisabled={ isDisabled }
-			disabledMessage={ disabledMessage }
-			featuredLabel={ featuredLabel }
-			hideSavingLabel={ hideSavingLabel }
-			scrollCardIntoView={ scrollCardIntoView }
-			collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
-			pricesAreFetching={ pricesAreFetching }
-		/>
+		<>
+			{ isEnabled( 'jetpack/pricing-page-product-lightbox' ) && (
+				<Dialog
+					isVisible={ isDialogVisible }
+					buttons={ [] }
+					onClose={ () => {
+						setDialogVisible( false );
+					} }
+				>
+					<ProductLightbox product={ item } />
+				</Dialog>
+			) }
+
+			<JetpackProductCard
+				item={ item }
+				headerLevel={ 3 }
+				description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+				originalPrice={ originalPrice }
+				discountedPrice={ discountedPrice }
+				buttonLabel={ buttonLabel }
+				buttonPrimary={ ! ( isOwned || isItemPlanFeature || isSuperseded ) }
+				onButtonClick={ () => {
+					onClick( item, isUpgradeableToYearly, purchase );
+				} }
+				buttonURL={
+					createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
+				}
+				buttonDisabled={ isDisabled || buttonDisabled || isLoadingUpsellPageExperiment }
+				expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
+				isFeatured={ isFeatured }
+				isOwned={ isOwned }
+				isIncludedInPlan={ isIncludedInPlan || isSuperseded }
+				isDeprecated={ isDeprecated }
+				isAligned={ isAligned }
+				displayFrom={ ! siteId && priceTierList.length > 0 }
+				tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
+				aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
+				isDisabled={ isDisabled }
+				disabledMessage={ disabledMessage }
+				featuredLabel={ featuredLabel }
+				hideSavingLabel={ hideSavingLabel }
+				scrollCardIntoView={ scrollCardIntoView }
+				collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
+				pricesAreFetching={ pricesAreFetching }
+				onLearnMoreClick={ () => {
+					setDialogVisible( true );
+				} }
+			/>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/hint-button.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/hint-button.tsx
@@ -1,0 +1,32 @@
+// We are using this temporarily for testing purposes of the main Dialog
+
+const Icon = () => (
+	<svg
+		width="24"
+		height="24"
+		xmlns="http://www.w3.org/2000/svg"
+		fillRule="evenodd"
+		clipRule="evenodd"
+	>
+		<path d="M12 0c6.623 0 12 5.377 12 12s-5.377 12-12 12-12-5.377-12-12 5.377-12 12-12zm0 1c6.071 0 11 4.929 11 11s-4.929 11-11 11-11-4.929-11-11 4.929-11 11-11zm.053 17c.466 0 .844-.378.844-.845 0-.466-.378-.844-.844-.844-.466 0-.845.378-.845.844 0 .467.379.845.845.845zm.468-2.822h-.998c-.035-1.162.182-2.054.939-2.943.491-.57 1.607-1.479 1.945-2.058.722-1.229.077-3.177-2.271-3.177-1.439 0-2.615.877-2.928 2.507l-1.018-.102c.28-2.236 1.958-3.405 3.922-3.405 1.964 0 3.615 1.25 3.615 3.22 0 1.806-1.826 2.782-2.638 3.868-.422.563-.555 1.377-.568 2.09z" />
+	</svg>
+);
+
+type Props = {
+	onClick?: React.MouseEventHandler;
+};
+
+const HintButton: React.FC< Props > = ( { onClick } ) => {
+	return (
+		<button
+			type="button"
+			style={ { position: 'absolute', bottom: 0, right: '20px' } }
+			aria-haspopup
+			onClick={ onClick }
+		>
+			<Icon />
+		</button>
+	);
+};
+
+export default HintButton;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -1,0 +1,12 @@
+import { SelectorProduct } from '../types';
+import './style.scss';
+
+type Props = {
+	product: SelectorProduct;
+};
+
+const ProductLightbox: React.FC< Props > = ( { product } ) => {
+	return <div className="product-lightbox__main-wrapper">{ product.displayName }</div>;
+};
+
+export default ProductLightbox;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -1,0 +1,4 @@
+.product-lightbox__main-wrapper {
+    width:400px;
+    height:300px;
+}

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,6 +45,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-product-lightbox": true,
 		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,7 +45,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-product-lightbox": true,
+		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -39,6 +39,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -42,6 +42,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -42,6 +42,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,


### PR DESCRIPTION
#### Proposed Changes
- Add new Feature flag `jetpack/pricing-page-product-lightbox` for adding Learn More button to Jetpack Products and Opening new product lightbox when clicking it.
- Adding a temporary Learn More button (question mark) to Jetpack products (shown with Feature flag)
- Adding placeholder component for lightbox `product-lightbox`.

#### Testing Instructions
Feature Flag is disabled by default for every environment to avoid confusion. In order to enable it add `?flags=jetpack/pricing-page-product-lightbox` to the URL. Also important to note that elements like `hint-button` and current version of `product-lightbox` are not per designs, but more like placeholders for future development and for testing Feature Flag.

- Checkout the PR locally and start `yarn start-jetpack-cloud` OR visit Jetpack Cloud Libe link below.
- Visit `http://jetpack.cloud.localhost:3000/pricing?flags=-jetpack/pricing-page-rework-v1,jetpack/pricing-page-product-lightbox` with appropriate Feature Flags.
- Check the question mark button at the bottom-right of the product cards and confirm that Dialog opens by clicking it.
- Check that without `jetpack/pricing-page-product-lightbox` there is not hint button


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? (No tests needed yet)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
Feature Flag: 1202796695664022-as-1202796695664073/f
Lightbox placeholder: 1202796695664022-as-1202796695664078/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202796695664078
  - 0-as-1202796695664073