### PR TITLE
Updated text in CTA and nudges from "Publicize" to "Jetpack Social"

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -575,7 +575,8 @@ class PostShare extends Component {
 						<div className="post-share__title">
 							<span>
 								{ translate(
-									'Share on your connected social media accounts using ' + '{{a}}Publicize{{/a}}.',
+									'Share on your connected social media accounts using ' +
+										'{{a}}Jetpack Social{{/a}}.',
 									{
 										components: {
 											a: <a href={ `/marketing/connections/${ siteSlug }` } />,

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -64,7 +64,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			}
 			{ ...( isJetpack && {
 				description: translate(
-					'Publicize makes it easy to share your new posts on your social media networks automatically. With a Jetpack Security or Complete plan, you can share content that has already been published and can also schedule posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}',
+					'Jetpack Social makes it easy to share your new posts on your social media networks automatically. With a Jetpack Security or Complete plan, you can share content that has already been published and can also schedule posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}',
 					{
 						components: {
 							ExternalLink: (

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -168,7 +168,7 @@ class PublicizeActionsList extends PureComponent {
 					status="is-info"
 					showDismiss={ false }
 					text={ translate(
-						'Did you know you can decide exactly when Publicize shares your post? You can! ' +
+						'Did you know you can decide exactly when Jetpack Social shares your post? You can! ' +
 							'Click the calendar icon next to "Share post" to schedule your social shares.'
 					) }
 				/>

--- a/client/jetpack-cloud/sections/jetpack-social/connections.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/connections.jsx
@@ -45,7 +45,7 @@ export const Connections = ( { siteId, translate } ) => {
 			/>
 			<SharingServicesGroup
 				type="publicize"
-				title={ translate( 'Jetpack Social posts {{learnMoreLink/}}', {
+				title={ translate( 'Share posts with Jetpack Social {{learnMoreLink/}}', {
 					components: { learnMoreLink },
 				} ) }
 			/>

--- a/client/jetpack-cloud/sections/jetpack-social/connections.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/connections.jsx
@@ -45,7 +45,7 @@ export const Connections = ( { siteId, translate } ) => {
 			/>
 			<SharingServicesGroup
 				type="publicize"
-				title={ translate( 'Publicize posts {{learnMoreLink/}}', {
+				title={ translate( 'Jetpack Social posts {{learnMoreLink/}}', {
 					components: { learnMoreLink },
 				} ) }
 			/>

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -536,7 +536,7 @@ export class SharingService extends Component {
 				{ 'linkedin' === this.props.service.ID && some( connections, { status: 'must_reauth' } ) && (
 					<Notice isCompact status="is-error" className="sharing-service__notice">
 						{ this.props.translate(
-							'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Publicize ' +
+							'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Jetpack Social ' +
 								'by disconnecting and reconnecting your account.'
 						) }
 					</Notice>

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -103,7 +103,7 @@ const SharingServicesGroup = ( {
 						status="is-warning"
 						showDismiss={ false }
 						text={ translate(
-							'Jetpack Social posts requires the Jetpack Social connections to be enabled'
+							'Connect to your social media accounts to enable sharing posts with Jetpack Social.'
 						) }
 					>
 						<NoticeAction onClick={ activatePublicize }>{ translate( 'Enable' ) }</NoticeAction>

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -102,7 +102,9 @@ const SharingServicesGroup = ( {
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
-						text={ translate( 'Publicize posts requires the Publicize connections to be enabled' ) }
+						text={ translate(
+							'Jetpack Social posts requires the Publicize connections to be enabled'
+						) }
 					>
 						<NoticeAction onClick={ activatePublicize }>{ translate( 'Enable' ) }</NoticeAction>
 					</Notice>

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -103,7 +103,7 @@ const SharingServicesGroup = ( {
 						status="is-warning"
 						showDismiss={ false }
 						text={ translate(
-							'Jetpack Social posts requires the Publicize connections to be enabled'
+							'Jetpack Social posts requires the Jetpack Social connections to be enabled'
 						) }
 					>
 						<NoticeAction onClick={ activatePublicize }>{ translate( 'Enable' ) }</NoticeAction>

--- a/client/my-sites/marketing/connections/services/facebook.js
+++ b/client/my-sites/marketing/connections/services/facebook.js
@@ -19,14 +19,14 @@ export class Facebook extends SharingService {
 					this.props.translate(
 						'The Facebook connection could not be made because this account does not have access to any Pages.',
 						{
-							context: 'Sharing: Publicize connection error',
+							context: 'Sharing: Jetpack Social connection error',
 						}
 					),
 					// Append temporary message to inform of Facebook API change
 					' ',
 					this.props.translate(
-						'Facebook supports Publicize connections to Facebook Pages, but not to Facebook Profiles. ' +
-							'{{a}}Learn More about Publicize for Facebook{{/a}}',
+						'Facebook supports Jetpack Social connections to Facebook Pages, but not to Facebook Profiles. ' +
+							'{{a}}Learn More about Jetpack Social for Facebook{{/a}}',
 						{
 							components: {
 								a: (

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -155,7 +155,7 @@ export const MarketingTools: FunctionComponent = () => {
 				<MarketingToolsFeature
 					title={ translate( 'Get social, and share your blog posts where the people are' ) }
 					description={ translate(
-						"Use your site's Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
+						"Use your site's Jetpack Social tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
 					) }
 					imagePath="/calypso/images/marketing/social-media-logos.svg"
 				>

--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -1896,7 +1896,7 @@ export const videosForSection = {
 			type: RESULT_VIDEO,
 			link: 'https://www.youtube.com/watch?v=NcCe0ozmqFM',
 			get title() {
-				return __( 'Connect Your Blog to Facebook Using Publicize', __i18n_text_domain__ );
+				return __( 'Connect Your Blog to Facebook Using Jetpack Social', __i18n_text_domain__ );
 			},
 			get description() {
 				return __(


### PR DESCRIPTION
#### Proposed Changes

* Updated/replacing Publicize with Jetpack Social in various strings. Ref project: pdZwE3-bt-p2#comment-568

#### Testing Instructions

* You can open the relevant pages from the sheet above, to make sure that the content flows well (as "Jetpack Social" is a longer word than "Publicize")
* Additionally, you can check the language in the diff under the files tab.
* TBD
    * One string "Post publicized"
    * Do we update the URLs (support URLs), if so we should redirect them, but also probably long-term, update them in the relevant places.     

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

@danielpost - Y'all can just ship this once approved (and when this goes live). Btw, also requires ETK deploy. 

<img width="1082" alt="Screenshot 2022-08-24 at 16 40 45@2x" src="https://user-images.githubusercontent.com/1713699/186447626-ddae9b40-6563-4b86-8456-5c15e2addeba.png">
<img width="1051" alt="Screenshot 2022-08-24 at 16 45 07@2x" src="https://user-images.githubusercontent.com/1713699/186448768-1f45d197-63f5-4a23-ab51-4ec5a81f88f1.png">
<img width="1041" alt="Screenshot 2022-08-24 at 16 46 18@2x" src="https://user-images.githubusercontent.com/1713699/186449120-a661d149-81f8-441a-90bc-b888eb69d5d3.png">
<img width="1077" alt="Screenshot 2022-08-24 at 17 01 20@2x" src="https://user-images.githubusercontent.com/1713699/186452893-8de7576a-f7e9-493d-ab80-ea8acd49125d.png">
<img width="402" alt="Screenshot 2022-08-24 at 17 02 11@2x" src="https://user-images.githubusercontent.com/1713699/186453147-2e698b99-4778-4652-b8b1-251218ee91e4.png">
<img width="1054" alt="Screenshot 2022-08-24 at 17 03 53@2x" src="https://user-images.githubusercontent.com/1713699/186453542-b4b8e0cc-fdfc-4cc8-8dfc-41c034ddf0cc.png">
<img width="1756" alt="Screenshot 2022-08-24 at 17 21 12@2x" src="https://user-images.githubusercontent.com/1713699/186457616-bedb7aa2-1dcb-4a74-8b20-795cd12742ed.png">
<img width="538" alt="Screenshot 2022-08-24 at 17 25 58@2x" src="https://user-images.githubusercontent.com/1713699/186458726-b221d131-cedd-4798-b006-1aa086a7cefe.png">
