### PR TITLE
Import Woocommerce styles for plugin box descriptions

### DIFF
--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -79,6 +79,12 @@ const isAllowedAttr = ( tagName, attrName ) => {
 					return false;
 			}
 
+		case 'div':
+			switch ( attrName ) {
+				case 'class':
+					return true;
+			}
+
 		default:
 			return false;
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,6 +1,7 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 @import './grid-mixins.scss';
+@import './woocommerce-box.scss';
 
 .is-section-plugins .main {
 	padding-top: 35px; // Compensate for the fixed header.

--- a/client/my-sites/plugins/woocommerce-box.scss
+++ b/client/my-sites/plugins/woocommerce-box.scss
@@ -1,0 +1,183 @@
+// partially copied from https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/css/global/misc.scss
+
+// Color palette support
+$woo-lilac: #96588a;
+$woo-green: #73ae39;
+$woo-gray-background: #e6e6e6;
+$woo-gray-light: #f7f7f7;
+$woo-text-gray: #333333;
+
+// Woo colors
+$c-woocommerce-purple-0: #f7edf7 !default;
+$c-woocommerce-purple-5: #e5cfe8 !default;
+$c-woocommerce-purple-10: #d6b4e0 !default;
+$c-woocommerce-purple-20: #c792e0 !default;
+$c-woocommerce-purple-30: #af7dd1 !default;
+$c-woocommerce-purple-40: #9a69c7 !default;
+$c-woocommerce-purple-50: #7f54b3 !default;
+$c-woocommerce-purple-60: #674399 !default;
+$c-woocommerce-purple-70: #533582 !default;
+$c-woocommerce-purple-80: #3c2861 !default;
+$c-woocommerce-purple-90: #271b3d !default;
+$c-woocommerce-purple-100: #140e1f !default;
+
+// Neutral colors
+$c-white: #fff;
+$c-black: #000;
+$c-gray-0: #f6f7f7 !default;
+$c-gray-5: #dcdcde !default;
+$c-gray-10: #c3c4c7 !default;
+$c-gray-20: #a7aaad !default;
+$c-gray-30: #8c8f94 !default;
+$c-gray-40: #787c82 !default;
+$c-gray-50: #646970 !default;
+$c-gray-60: #50575e !default;
+$c-gray-70: #2c3337 !default;
+$c-gray-80: #2c3338 !default; // rgb(44, 51, 56);
+$c-gray-90: #1d2327 !default;
+$c-gray-100: #101517 !default;
+
+/* INFO BOXES & WOOCOMMERCE NOTICES */
+.woo-sc-box,
+.woocommerce-message,
+.woocommerce-info,
+.woocommerce-error,
+.post-theme-info,
+.wcpv-shortcode-registration-form-errors {
+
+	* {
+		vertical-align: baseline;
+	}
+	background: $c-woocommerce-purple-5;
+	border: 1px solid $c-woocommerce-purple-10;
+	border-left-width: 1px !important;
+	border-radius: 5px; /* stylelint-disable-line scales/radii */
+	color: $c-woocommerce-purple-90;
+	margin: 2em 0;
+	padding: 20px;
+
+	p {
+		margin: 0 0 1.618em;
+		padding: 0;
+
+		&:last-child {
+			margin: 0;
+		}
+	}
+
+	a {
+		font-weight: bold;
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.button {
+		margin: 0;
+	}
+
+	ul {
+		margin: 0.5em 0 0.8em;
+
+		li {
+			list-style: disc;
+			list-style-position: inside;
+		}
+	}
+
+	.size-thumbnail {
+		background-color: #fff;
+		border: 1px dotted #ada465 !important;
+		padding: 5px;
+	}
+
+	&.large {
+		font-size: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		padding: 25px 20px;
+	}
+
+	&.alert,
+	&.woocommerce-error,
+	&.wcpv-shortcode-registration-form-errors {
+		background: $c-woocommerce-purple-5;
+		border-color: $c-woocommerce-purple-10;
+		color: #444;
+		margin: 2em auto;
+		max-width: 1000px;
+	}
+
+	&.tick,
+	&.woocommerce-message,
+	&.woocommerce-info,
+	&.woocommerce-error {
+		background-color: #eff8e6;
+		border-color: #c9e8a9;
+		color: #424242;
+
+		a {
+			color: #424242;
+		}
+	}
+	&.woocommerce-error {
+		background: $c-woocommerce-purple-5;
+		border-color: $c-woocommerce-purple-10;
+	}
+
+	&.download {
+		background: lighten( $c-gray-70, 60% );
+		border-color: lighten( $c-gray-70, 50% );
+	}
+
+	&.note {
+		background: lighten( #f1d413, 40% );
+		border-color: lighten( #f1d413, 13% );
+
+		a {
+			color: darken( #f1d413, 20% );
+		}
+	}
+
+	&:hover {
+		box-shadow: inset 0 0 0 1px rgba( 255, 255, 255, 1 ), 0 0 10px 0 rgba( 0, 0, 0, 0.05 );
+		transition: all ease-in-out 0.2s;
+	}
+
+	&.coupon {
+		background: $woo-gray-light !important;
+		border: none;
+		border-radius: 0;
+		margin: 1.5em 0 1.758em 4em !important;
+		padding: 20px 20px 20px 12px !important;
+		position: relative;
+	}
+
+	&.coupon span.coupon-title {
+		overflow: hidden;
+		text-indent: 100%;
+		white-space: nowrap;
+	}
+
+	&.coupon p {
+		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		margin: 10px 0 10px 70px;
+	}
+
+	&.post-theme-info {
+		margin: 0 0 20px;
+		padding: 0;
+
+		.fl {
+			float: none;
+			padding: 15px 0 5px;
+			text-align: center;
+		}
+
+		.fr {
+			float: none;
+			padding: 5px 0 15px;
+			text-align: center;
+		}
+	}
+}


### PR DESCRIPTION
### Information

pdh6GB-1Tm-p2

#### Proposed Changes

* Allow classes to be kept on divs at the plugin description
* Add a Woocomerce stylesheet and import it.

#### Testing Instructions
* Checkout this branch 
* Go to the Woocommerce Subscriptions (`/plugins/woocommerce-subscriptions`), Product Add-ons(`plugins/woocommerce-product-addons`) and AutomateWoo (`/plugins/automatewoo`)
* Verify a purple box is added at the beginning of the description
* Go to other plugins pages and check if there are any regressions

| Before  | After |
| ------------- | ------------- |
|<img width="698" alt="Screen Shot 2022-08-19 at 10 42 52" src="https://user-images.githubusercontent.com/5039531/185644199-ed331450-53b7-4f84-86a1-602ad2cc0c98.png">|<img width="679" alt="Screen Shot 2022-08-19 at 10 43 10" src="https://user-images.githubusercontent.com/5039531/185644243-419459db-9fc5-4283-9bf6-24ee05ef3eb5.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65842