### PR TITLE
Marketplace: Fix preinstalled premium plugins prices missing with Elasticsearch

### DIFF
--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -13,6 +13,7 @@ export type Plugin = {
 	slug: string;
 	version?: string;
 	author?: string;
+	author_name?: string;
 	author_profile?: string;
 	tested?: string;
 	rating?: number;
@@ -25,6 +26,10 @@ export type Plugin = {
 	download_link?: string;
 	icon?: string;
 	railcar: Railcar;
+	variations?: {
+		monthly: { product_slug: string };
+		yearly: { product_slug: string };
+	};
 };
 
 export type ESIndexResult = {

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -1,7 +1,10 @@
 import languages, { LanguageSlug } from '@automattic/languages';
 import { UseQueryResult, UseQueryOptions, useInfiniteQuery, InfiniteData } from 'react-query';
 import { useSelector } from 'react-redux';
-import { extractSearchInformation } from 'calypso/lib/plugins/utils';
+import {
+	extractSearchInformation,
+	getPreinstalledPremiumPluginsVariations,
+} from 'calypso/lib/plugins/utils';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { DEFAULT_PAGE_SIZE } from './constants';
 import { search } from './search-api';
@@ -62,7 +65,7 @@ const mapStarRatingToPercent = ( starRating?: number ) => ( ( starRating ?? 0 ) 
 const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 	if ( ! results ) return [];
 	return results.map( ( { fields: hit, railcar } ) => {
-		const plugin = {
+		const plugin: Plugin = {
 			name: hit.plugin.title, // TODO: add localization
 			slug: hit.slug,
 			version: hit[ 'plugin.stable_tag' ],
@@ -80,6 +83,11 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			icon: createIconUrl( hit.slug, hit.plugin.icons ),
 			railcar,
 		};
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		plugin.variations = getPreinstalledPremiumPluginsVariations( plugin );
+
 		return plugin;
 	} );
 };

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -84,8 +84,6 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			railcar,
 		};
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
 		plugin.variations = getPreinstalledPremiumPluginsVariations( plugin );
 
 		return plugin;

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -386,7 +386,7 @@ export const getManageConnectionHref = ( siteSlug ) => {
  */
 export function getPreinstalledPremiumPluginsVariations( plugin ) {
 	if ( ! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] || !! plugin.variations ) {
-		return plugin.variations;
+		return plugin?.variations;
 	}
 	const { monthly, yearly } = PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].products;
 	return {

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -184,15 +184,7 @@ export function normalizeCompatibilityList( compatibilityList ) {
 export function normalizePluginData( plugin, pluginData ) {
 	plugin = getAllowedPluginData( { ...plugin, ...pluginData } );
 
-	// Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
-	// but require a paid upgrade to function.
-	if ( !! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] && ! plugin.variations ) {
-		const { monthly, yearly } = PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].products;
-		plugin.variations = {
-			monthly: { product_slug: monthly },
-			yearly: { product_slug: yearly },
-		};
-	}
+	plugin.variations = getPreinstalledPremiumPluginsVariations( plugin );
 
 	return Object.entries( plugin ).reduce( ( returnData, [ key, item ] ) => {
 		switch ( key ) {
@@ -384,3 +376,21 @@ export const getManageConnectionHref = ( siteSlug ) => {
 		? `https://wordpress.com/settings/manage-connection/${ siteSlug }`
 		: `/settings/manage-connection/${ siteSlug }`;
 };
+
+/**
+ * Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
+ * but require a paid upgrade to function.
+ *
+ * @param {object} plugin
+ * @returns {object}
+ */
+export function getPreinstalledPremiumPluginsVariations( plugin ) {
+	if ( ! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] || !! plugin.variations ) {
+		return plugin.variations;
+	}
+	const { monthly, yearly } = PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ].products;
+	return {
+		monthly: { product_slug: monthly },
+		yearly: { product_slug: yearly },
+	};
+}

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -381,8 +381,13 @@ export const getManageConnectionHref = ( siteSlug ) => {
  * Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
  * but require a paid upgrade to function.
  *
+ * @typedef {object} PluginVariations
+ * @property {object} monthly The plugin's monthly variation
+ * @property {string} monthly.product_slug The plugin's monthly variation's product slug
+ * @property {object} yearly The plugin's yearly variation
+ * @property {string} yearly.product_slug The plugin's yearly variation's product slug
  * @param {object} plugin
- * @returns {object}
+ * @returns {PluginVariations}
  */
 export function getPreinstalledPremiumPluginsVariations( plugin ) {
 	if ( ! PREINSTALLED_PREMIUM_PLUGINS[ plugin.slug ] || !! plugin.variations ) {


### PR DESCRIPTION
#### Proposed Changes

* Add the same custom variations logic for preinstalled premium plugins (used in the regular WPORG plugins query) into the new ES query.

| Before | After |
| - | - |
| <img width="528" alt="Screenshot 2022-08-19 at 18 32 14" src="https://user-images.githubusercontent.com/2070010/185675386-33856e76-25e5-4b3f-b7d5-0fb4b9361147.png"> | <img width="525" alt="Screenshot 2022-08-19 at 18 32 06" src="https://user-images.githubusercontent.com/2070010/185675407-b64a1c06-448d-4081-8466-3c7606b7bd09.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Turn on the `marketplace-jetpack-plugin-search` feature flag in your environment of choice (currently only enabled on `wpcalypso`/`calypso.live`).
  * You can also turn it on and off in `development` and `staging` with [the `?flags` query parameter](https://github.com/Automattic/wp-calypso/blob/97e0ff657800ce21b4d31bdd42a3fb96e6c6940f/config/README.md#testing-feature-flags-via-urls).
* Open the Marketplace and search for "Jetpack Search".
  * Or just adapt this: `/plugins/{ SITE }?s=jetpack+search`.
* Make sure the price is displayed in the Jetpack Search card.
* Turn off the feature flag.
  * For example with `?flags=-marketplace-jetpack-plugin-search`.
* Try searching for "Jetpack Search" again, and make sure there are no regressions around the Marketplace.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
