### PR TITLE
Remove the restriction of transferring a primary domain on an atomic site

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -62,12 +62,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const {
 		currentRoute,
 		domains,
-		isAtomic,
 		isDomainInfoLoading,
 		isDomainLocked,
 		isDomainOnly,
 		isMapping,
-		isPrimaryDomain,
 		isSupportSession,
 		selectedDomainName,
 		selectedSite,
@@ -142,30 +140,28 @@ const TransferPage = ( props: TransferPageProps ) => {
 			);
 		}
 
-		if ( ! ( isPrimaryDomain && isAtomic ) ) {
-			if ( options.length > 0 ) {
-				options.push( <div key="separator" className="transfer-page__item-separator"></div> );
-			}
-			const mainText = isMapping
-				? __( 'Transfer this domain connection to any site you are an administrator on' )
-				: __( 'Transfer this domain to any site you are an administrator on' );
-
-			options.push(
-				<ActionCard
-					key="transfer-to-another-site"
-					buttonHref={ domainManagementTransferToOtherSite(
-						selectedSite.slug,
-						selectedDomainName,
-						currentRoute
-					) }
-					// translators: Continue is a verb
-					buttonText={ __( 'Continue' ) }
-					// translators: Transfer a domain to another WordPress.com site
-					headerText={ __( 'To another WordPress.com site' ) }
-					mainText={ mainText }
-				/>
-			);
+		if ( options.length > 0 ) {
+			options.push( <div key="separator" className="transfer-page__item-separator"></div> );
 		}
+		const mainText = isMapping
+			? __( 'Transfer this domain connection to any site you are an administrator on' )
+			: __( 'Transfer this domain to any site you are an administrator on' );
+
+		options.push(
+			<ActionCard
+				key="transfer-to-another-site"
+				buttonHref={ domainManagementTransferToOtherSite(
+					selectedSite.slug,
+					selectedDomainName,
+					currentRoute
+				) }
+				// translators: Continue is a verb
+				buttonText={ __( 'Continue' ) }
+				// translators: Transfer a domain to another WordPress.com site
+				headerText={ __( 'To another WordPress.com site' ) }
+				mainText={ mainText }
+			/>
+		);
 
 		return options.length > 0 ? <Card>{ options }</Card> : null;
 	};


### PR DESCRIPTION
#### Proposed Changes

This PR removes the restriction of transferring a primary domain on an atomic site to another site since this option now works fine on the back end and it's no longer necessary to prevent this action.

#### Testing Instructions
With an atomic site selected, make sure that the option to transfer the primary domain for the site to another site shows up on the domains/manage transfer page.

<img width="1149" alt="Domains_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/185679024-38de99fe-ea63-4269-bf12-b1e60edf6d37.png">

Try moving a primary domain on an atomic site to a different site.  Make sure that this works as expected.