### PR TITLE
Bug: Hide the password reset field for Professional Email only

### DIFF
--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -234,7 +234,7 @@ const MailboxesForm = ( {
 
 	const isAlternateEmailValid = ! new RegExp( `@${ selectedDomainName }$` ).test( userEmail );
 	const defaultHiddenFields: HiddenFieldNames[] = [ FIELD_NAME ];
-	if ( isAlternateEmailValid ) {
+	if ( isAlternateEmailValid && isTitan( provider ) ) {
 		defaultHiddenFields.push( FIELD_ALTERNATIVE_EMAIL );
 	}
 


### PR DESCRIPTION
This bug fixes a regression that arose from #66373 where the password reset field is hidden for all email providers, rather than Professional Email alone.

#### Proposed Changes

* A constraint that ensures this operation only works for Professional Email is introduced.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Test 1

* Have a Professional Email subscription
* Go to `/email/:domain/manage/:site`, select "Add new mailboxes"
* Confirm that the password reset email should be pre-populated with your WordPress.com account email and you should be able to change it using the "Change it" UI

<img width="900" alt="password-reset-change-it" src="https://user-images.githubusercontent.com/104910361/183539781-106963ae-2f35-41ad-a14c-2e7e6bc69e2c.png">

#### Test 2

* Have a Google Workspace subscription
* Go to `/email/:domain/manage/:site`, select "Add new mailboxes"
* Confirm that both the password reset field and the "Change it" UI are not available

<img width="900" alt="Screenshot 2022-08-19 at 7 29 03 PM" src="https://user-images.githubusercontent.com/277661/185684003-dd283f2f-3f41-4adb-831b-66fabaa56ee8.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66373
