### PR TITLE
Theme/Plugin Bundling: The themes/plugin-bundling feature flag also enables the UpgradeModal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -202,7 +202,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	function upgradePlan() {
-		if ( ! isEnabled( 'signup/seller-upgrade-modal' ) ) {
+		if ( ! isEnabled( 'signup/seller-upgrade-modal' ) && ! isEnabled( 'themes/plugin-bundling' ) ) {
 			return goToCheckout();
 		}
 
@@ -217,7 +217,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			return null;
 		}
 
-		if ( isEnabled( 'signup/seller-upgrade-modal' ) ) {
+		if ( isEnabled( 'signup/seller-upgrade-modal' ) || isEnabled( 'themes/plugin-bundling' ) ) {
 			recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
 				theme: selectedDesign?.slug,
 			} );


### PR DESCRIPTION
#### Proposed Changes

The unified design picker previously only displayed the UpgradeModal when the signup/seller-upgrade-modal flag was enabled. However that flag was primarily being used for the theme subscription work that's on hold.

This lets us leverage the upgrade modal for the theme/plugin bundling.

#### Testing Instructions

##### Testing the original behavior
- Go to `http://calypso.localhost:3000/setup/designSetup?siteSlug=mbb0819a.wordpress.com&flags=-themes/plugin-bundling`
- Take any flow that takes you to the design picker (eg "Write & Publish" or "Sell -> Start simple")
- Select a premium theme and click "Unlock theme"
- You should be taken to the checkout screen

##### Testing the new behavior

- Go to `http://calypso.localhost:3000/setup/designSetup?siteSlug=mbb0819a.wordpress.com&flags=themes/plugin-bundling`
- Take any flow that takes you to the design picker (eg "Write & Publish" or "Sell -> Start simple")
- Select a premium theme and click "Unlock theme"
- You should see the upgrade model pictured below

![image](https://user-images.githubusercontent.com/917632/185682681-f655952d-36d6-427a-a344-6aa0aa46b875.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66760
