### PR TITLE
ToS screenshots: Checkout page mobile view screenshot does not render correctly

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -106,7 +106,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 					type: 'jpeg',
 					quality: 20,
 				} );
-				page.setViewportSize( { width: 410, height: 820 } );
+				page.setViewportSize( { width: 410, height: 1620 } );
 				await page.screenshot( {
 					path: `tos_checkout_mobile_${ locale }.png`,
 					fullPage: true,


### PR DESCRIPTION
This PR fixes a bug that the checkout page mobile view screenshot has the "Pay" button sticking in the middle of the page:

<img src="https://user-images.githubusercontent.com/1269602/185683190-eb7cfdc7-615e-4a04-9aca-5783fe54ac08.jpeg" height=700 />

The cause of the bug is that a recent change has shipped to the checkout page mobile view which makes the "Pay" button fixed in position at the bottom of the screen. The Playwright script sets the height of the page to 820px [in this line](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/martech/tos-screenshots__checkout.ts#L109) to render the mobile view of the page, and then when it attempts a full page screenshot it scrolls through the non-visible parts of the page. However, the fixed position button element is a non-scrollable element, so it renders in the middle of the screenshot.

The fix to this problem is by setting the page height to a large enough value so that the screenshot utility does not have to scroll the scrollable parts of the page, and the whole page is visible on page load itself. This way, the fixed position element renders at the bottom of the page, and will not appear stuck in the middle.


#### Testing Instructions

The checkout page screenshot's Pay button should render at the correct position, and not appear in the middle of the screenshot as shown in the description.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

