### PR TITLE
Site Management Dashboard: Stick table head on scroll

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -126,7 +126,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
 			<Column mobileHidden>{ translatedStatus }</Column>
-			<Column style={ { width: '20px' } }>
+			<Column style={ { width: '24px' } }>
 				<SitesEllipsisMenu site={ site } />
 			</Column>
 		</Row>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -15,16 +15,25 @@ interface SitesTableProps {
 const Table = styled.table`
 	border-collapse: collapse;
 	table-layout: fixed;
-	@media only screen and ( max-width: 781px ) {
-		.sites-table__mobile-hidden {
-			display: none;
-		}
-	}
+	position: relative;
 `;
+
+const THead = styled.thead( {
+	'@media only screen and ( max-width: 781px )': {
+		display: 'none',
+	},
+
+	position: 'sticky',
+	zIndex: 1,
+	top: '32px',
+
+	background: '#fdfdfd',
+} );
 
 const Row = styled.tr`
 	line-height: 2em;
 	border-bottom: 1px solid #eee;
+
 	th {
 		padding-top: 12px;
 		padding-bottom: 12px;
@@ -32,7 +41,7 @@ const Row = styled.tr`
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.24px;
-		font-weight: normal;
+		font-weight: 500;
 		color: var( --studio-gray-60 );
 	}
 `;
@@ -42,7 +51,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 
 	return (
 		<Table className={ className }>
-			<thead className="sites-table__mobile-hidden">
+			<THead>
 				<Row>
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
@@ -50,7 +59,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 					<th>{ __( 'Status' ) }</th>
 					<th style={ { width: '20px' } }></th>
 				</Row>
-			</thead>
+			</THead>
 			<tbody>
 				{ isLoading &&
 					Array( N_LOADING_ROWS )

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -25,7 +25,7 @@ const THead = styled.thead< { top: number } >( ( { top } ) => ( {
 	},
 
 	position: 'sticky',
-	zIndex: 1,
+	zIndex: 3,
 	top: `${ top }px`,
 
 	background: '#fdfdfd',

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -92,7 +92,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
 					<th>{ __( 'Last Publish' ) }</th>
 					<th>{ __( 'Status' ) }</th>
-					<th style={ { width: '20px' } }></th>
+					<th style={ { width: '24px' } }></th>
 				</Row>
 			</THead>
 			<tbody>


### PR DESCRIPTION
#### Proposed Changes

A little UX improvement: as the list grows, it gets harder to distinguish the columns and their meaning. This PR attempts to to make this experience a little better by sticking the table head when scrolling.

#### Testing Instructions

**On wide screens:**
- Scroll the page and check the table head sticks below the masterbar, visible all the time.

**On wide screens with a shrunk window and a taller masterbar:**
- Scroll the page, then expand the window. Check that the table head is still sticky to the top of the page, respecting the change in the masterbar height.

![Screen Shot 2022-08-19 at 16 24 29](https://user-images.githubusercontent.com/26530524/185692441-d323ba35-1b2e-4ea9-88b0-58d3318584c6.png)

https://user-images.githubusercontent.com/26530524/185692297-d733bff3-9ae1-4946-bd5c-2a2d61ce6676.mov

