### PR TITLE
Hosting Configuration: Add PHP version form setting explanation that points to docs

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -1,4 +1,5 @@
 import { Button, Card, Spinner } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect } from 'react-redux';
@@ -119,7 +120,7 @@ const WebServerSettingsCard = ( {
 							components: {
 								button: (
 									<Button
-										href="https://wordpress.com/support/php-version-switching/"
+										href={ localizeUrl( 'https://wordpress.com/support/php-version-switching/' ) }
 										borderless
 										compact
 									/>

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -112,6 +112,22 @@ const WebServerSettingsCard = ( {
 						);
 					} ) }
 				</FormSelect>
+				<FormSettingExplanation className="web-server-settings-card__php-version-explanation">
+					{ translate(
+						'The version of PHP that powers your website. See {{button}}frequently asked questions{{/button}} for more information.',
+						{
+							components: {
+								button: (
+									<Button
+										href="https://wordpress.com/support/php-version-switching/"
+										borderless
+										compact
+									/>
+								),
+							},
+						}
+					) }
+				</FormSettingExplanation>
 				{ ! isPhpVersionButtonDisabled && (
 					<Button
 						className="web-server-settings-card__php-set-version"

--- a/client/my-sites/hosting/web-server-settings-card/style.scss
+++ b/client/my-sites/hosting/web-server-settings-card/style.scss
@@ -2,3 +2,13 @@
 .web-server-settings-card__static-file-404-set-setting {
 	margin-top: 16px;
 }
+
+.web-server-settings-card__php-version-explanation a.is-compact.is-borderless {
+	text-decoration: underline;
+	color: var( --color-primary );
+	font-style: inherit;
+	font-weight: 400;
+	line-height: inherit;
+	padding: 0;
+	font-size: inherit;
+}


### PR DESCRIPTION
#### Proposed Changes

* Update PHP version setting to include a form setting explanation that points to docs with FAQ. See p7DVsv-fbI-p2

<img width="668" alt="Screen Shot 2022-08-19 at 2 43 30 PM" src="https://user-images.githubusercontent.com/1126811/185695520-f9addcd9-76ef-4420-b602-7330b3ac74a6.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Navigate to http://calypso.localhost:3000/hosting-config/$SITE_SLUG
* Ensure that you see explanation below PHP version setting and that the link is clickable

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #