### PR TITLE
Components: Change useSitesTableSorting to use generic type

### DIFF
--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -1,20 +1,21 @@
 import { useMemo } from 'react';
-// eslint-disable-next-line no-restricted-imports
-import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import type { SiteDetails } from '@automattic/data-stores';
+
+export type SiteDetailsForSorting = Partial< Pick< SiteDetails, 'options' > >;
 
 interface SitesTableSortOptions {
 	sortKey?: string;
 	sortOrder?: 'asc' | 'desc';
 }
 
-interface UseSitesTableSortingResult {
-	sortedSites: SiteExcerptData[];
+interface UseSitesTableSortingResult< T extends SiteDetailsForSorting > {
+	sortedSites: T[];
 }
 
-export function useSitesTableSorting(
-	allSites: SiteExcerptData[],
+export function useSitesTableSorting< T extends SiteDetailsForSorting >(
+	allSites: T[],
 	{ sortKey, sortOrder = 'asc' }: SitesTableSortOptions
-): UseSitesTableSortingResult {
+): UseSitesTableSortingResult< T > {
 	return useMemo( () => {
 		switch ( sortKey ) {
 			case 'updated-at':
@@ -25,7 +26,10 @@ export function useSitesTableSorting(
 	}, [ allSites, sortKey, sortOrder ] );
 }
 
-function sortSitesByLastPublish( sites: SiteExcerptData[], sortOrder: string ): SiteExcerptData[] {
+function sortSitesByLastPublish< T extends SiteDetailsForSorting >(
+	sites: T[],
+	sortOrder: string
+): T[] {
 	return [ ...sites ].sort( ( a, b ) => {
 		if ( ! a.options?.updated_at || ! b.options?.updated_at ) {
 			return 0;

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
-import type { SiteDetails } from '@automattic/data-stores';
 
-export type SiteDetailsForSorting = Partial< Pick< SiteDetails, 'options' > >;
+export interface SiteDetailsForSorting {
+	options?: {
+		updated_at?: string;
+	};
+}
 
 interface SitesTableSortOptions {
 	sortKey?: string;


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/65882, the `useSitesTableSorting()` function in the `@automattic/components` package was added with a TypeScript type (`SiteExcerptData`) imported from the `calypso` package. This creates a circular dependency.

In this PR, we modify `useSitesTableSorting()` to use a generic that only specifies the data it requires. This should allow it to continue to operate on the `SiteExcerptData` type without needing to import it directly.

#### Testing Instructions

- Load Sites Dashboard at `/sites-dashboard` URL with this PR applied.
- Compare to the version on https://horizon.wordpress.com/sites-dashboard; it should be unchanged.

As this only modifies types, it should not require very thorough testing.