### PR TITLE
site-setup-flow: Check the current theme when ending the flow (WIP, alternate)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
@@ -4,9 +4,11 @@ import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../../stores';
 import { ANCHOR_FM_THEMES } from './anchor-fm-themes';
 import { STEP_NAME } from './constants';
@@ -18,6 +20,7 @@ const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, goToStep } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
+	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction, createSite } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -64,7 +67,9 @@ const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 				return;
 			}
 
-			return setDesignOnSite( newSite.site_slug, _selectedDesign, '' );
+			return setDesignOnSite( newSite.site_slug, _selectedDesign, '' ).then( () =>
+				reduxDispatch( requestActiveTheme( newSite.blogid ) )
+			);
 		} );
 
 		recordTracksEvent( 'calypso_signup_design_type_submit', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -18,12 +18,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef, useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useSite } from '../../../../hooks/use-site';
@@ -66,6 +67,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const reduxDispatch = useReduxDispatch();
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const siteSlug = useSiteSlugParam();
@@ -266,7 +268,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 					_selectedDesign.design_type === 'vertical' || isEnabled( 'signup/standard-theme-v13n' )
 						? siteVerticalId
 						: ''
-				)
+				).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 
 			recordTracksEvent( 'calypso_signup_select_design', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -14,12 +14,13 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useSite } from '../../../../hooks/use-site';
@@ -52,6 +53,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const reduxDispatch = useReduxDispatch();
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const siteSlug = useSiteSlugParam();
@@ -177,7 +179,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					_selectedDesign.design_type === 'vertical' || isEnabled( 'signup/standard-theme-v13n' )
 						? siteVerticalId
 						: ''
-				)
+				).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-bundled-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-bundled-plugins/index.tsx
@@ -1,9 +1,7 @@
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
-// import { StepContainer } from '@automattic/onboarding';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-// import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { useSite } from '../../../../hooks/use-site';
@@ -21,9 +19,10 @@ const GetCurrentBundledPlugins: Step = function GetCurrentBundledPluginsStep( { 
 	}
 
 	const reduxDispatch = useReduxDispatch();
-	const { goBack, goNext, submit } = navigation;
+	const { goNext } = navigation;
 	useEffect( () => {
 		reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ site?.ID ] );
 	const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
 	const currentTheme = useSelector( ( state ) =>
@@ -35,21 +34,14 @@ const GetCurrentBundledPlugins: Step = function GetCurrentBundledPluginsStep( { 
 			const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
 			if ( theme_plugin && siteSlug ) {
 				setBundledPluginSlug( siteSlug, theme_plugin[ 0 ].slug ); // only install first plugin
+				goNext();
+			} else {
+				// Current theme has no bundled plugins; they shouldn't be in this flow
+				window.location.replace( `/home/${ siteSlug }` );
 			}
-			goNext();
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ currentTheme?.id ] );
-	console.log( { currentTheme } );
 	return null;
-	/*
-	return (
-		<StepContainer
-			stepName={ 'get-current-bundled-plugins' }
-			stepContent={
-				<div>hi</div>
-			}
-		/>
-	);
-	 */
 };
 export default GetCurrentBundledPlugins;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-bundled-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-bundled-plugins/index.tsx
@@ -1,0 +1,55 @@
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+// import { StepContainer } from '@automattic/onboarding';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+// import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
+import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { useSite } from '../../../../hooks/use-site';
+import { ONBOARD_STORE } from '../../../../stores';
+import type { Step } from '../../types';
+
+const GetCurrentBundledPlugins: Step = function GetCurrentBundledPluginsStep( { navigation } ) {
+	const site = useSite();
+	const siteSlugParam = useSiteSlugParam();
+	let siteSlug: string | null = null;
+	if ( siteSlugParam ) {
+		siteSlug = siteSlugParam;
+	} else if ( site ) {
+		siteSlug = new URL( site.URL ).host;
+	}
+
+	const reduxDispatch = useReduxDispatch();
+	const { goBack, goNext, submit } = navigation;
+	useEffect( () => {
+		reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
+	}, [ site?.ID ] );
+	const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
+	const currentTheme = useSelector( ( state ) =>
+		getCanonicalTheme( state, site?.ID || -1, currentThemeId )
+	);
+	const { setBundledPluginSlug } = useDispatch( ONBOARD_STORE );
+	useEffect( () => {
+		if ( currentTheme ) {
+			const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
+			if ( theme_plugin && siteSlug ) {
+				setBundledPluginSlug( siteSlug, theme_plugin[ 0 ].slug ); // only install first plugin
+			}
+			goNext();
+		}
+	}, [ currentTheme?.id ] );
+	console.log( { currentTheme } );
+	return null;
+	/*
+	return (
+		<StepContainer
+			stepName={ 'get-current-bundled-plugins' }
+			stepContent={
+				<div>hi</div>
+			}
+		/>
+	);
+	 */
+};
+export default GetCurrentBundledPlugins;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -41,6 +41,7 @@ export { default as preLaunchpad } from './pre-launchpad';
 export { default as subscribers } from './subscribers';
 export { default as patterns } from './patterns';
 export { default as promote } from './promote';
+export { default as getCurrentBundledPlugins } from './get-current-bundled-plugins';
 
 export type StepPath =
 	| 'courses'
@@ -84,4 +85,5 @@ export type StepPath =
 	| 'intro'
 	| 'launchpad'
 	| 'subscribers'
-	| 'promote';
+	| 'promote'
+	| 'getCurrentBundledPlugins';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -23,6 +23,8 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 	const loadingMessages = useProcessingLoadingMessages();
 
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
+	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
+	const [ destinationState, setDestinationState ] = useState( {} );
 
 	useInterval( () => {
 		setCurrentMessageIndex( ( s ) => ( s + 1 ) % loadingMessages.length );
@@ -42,14 +44,31 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 			if ( typeof action === 'function' ) {
 				try {
 					const destination = await action();
-					submit?.( destination, ProcessingResult.SUCCESS );
+					// Don't call submit() directly; instead, turn on a flag that signals we should call submit() next.
+					// This allows us to call the newest submit() created. Otherwise, we would be calling a submit()
+					// that is frozen from before we called action().
+					// We can now get the most up to date values from hooks inside the flow creating submit(),
+					// including the values that were updated during the action() running.
+					setDestinationState( destination );
+					setHasActionSuccessfullyRun( true );
 				} catch ( e ) {
 					submit?.( {}, ProcessingResult.FAILURE );
 				}
-			} else submit?.( {}, ProcessingResult.NO_ACTION );
+			} else {
+				submit?.( {}, ProcessingResult.NO_ACTION );
+			}
 		} )();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ action ] );
+
+	// When the hasActionSuccessfullyRun flag turns on, run submit().
+	useEffect( () => {
+		if ( hasActionSuccessfullyRun ) {
+			submit?.( destinationState, ProcessingResult.SUCCESS );
+		}
+		// A change in submit() doesn't cause this effect to rerun.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ hasActionSuccessfullyRun ] );
 
 	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
 	const [ simulatedProgress, setSimulatedProgress ] = useState( 0 );

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -36,7 +36,7 @@ export const pluginBundleFlow: Flow = {
 			select( ONBOARD_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
-		console.log( { pluginSlug } );
+		console.log( { siteSlugParam, pluginSlug } );
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			// TODO - Need to handle this better
 			return [];

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -38,27 +38,17 @@ export const pluginBundleFlow: Flow = {
 
 		const steps: StepPath[] = [ 'getCurrentBundledPlugins' ];
 		let bundlePluginSteps: StepPath[] = [];
+
 		// Temp for testing baxter
 		if ( pluginSlug === 'test-plugin' ) {
 			pluginSlug = 'woocommerce';
 		}
+
 		if ( pluginSlug ) {
 			bundlePluginSteps = pluginBundleSteps[ pluginSlug ] as StepPath[];
 		}
-		console.log( { siteSlugParam, pluginSlug, bundlePluginSteps } );
+
 		return steps.concat( bundlePluginSteps );
-		return [ 'getCurrentBundledPlugins' ];
-		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
-			// TODO - Need to handle this better
-			return [];
-		}
-
-		if ( ! pluginSlug || ! pluginBundleSteps.hasOwnProperty( pluginSlug ) ) {
-			// TODO - Need to handle this better
-			return [];
-		}
-
-		return pluginBundleSteps[ pluginSlug ] as StepPath[];
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -32,11 +32,22 @@ export const pluginBundleFlow: Flow = {
 
 	useSteps() {
 		const siteSlugParam = useSiteSlugParam();
-		const pluginSlug = useSelect( ( select ) =>
+		let pluginSlug = useSelect( ( select ) =>
 			select( ONBOARD_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
-		console.log( { siteSlugParam, pluginSlug } );
+		const steps: StepPath[] = [ 'getCurrentBundledPlugins' ];
+		let bundlePluginSteps: StepPath[] = [];
+		// Temp for testing baxter
+		if ( pluginSlug === 'test-plugin' ) {
+			pluginSlug = 'woocommerce';
+		}
+		if ( pluginSlug ) {
+			bundlePluginSteps = pluginBundleSteps[ pluginSlug ] as StepPath[];
+		}
+		console.log( { siteSlugParam, pluginSlug, bundlePluginSteps } );
+		return steps.concat( bundlePluginSteps );
+		return [ 'getCurrentBundledPlugins' ];
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			// TODO - Need to handle this better
 			return [];

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -36,6 +36,7 @@ export const pluginBundleFlow: Flow = {
 			select( ONBOARD_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
+		console.log( { pluginSlug } );
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			// TODO - Need to handle this better
 			return [];

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -8,6 +8,7 @@ import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -83,6 +84,11 @@ export const siteSetupFlow: Flow = {
 		const siteSlugParam = useSiteSlugParam();
 		const site = useSite();
 		const currentUser = useSelector( getCurrentUser );
+		const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
+		const currentTheme = useSelector( ( state ) =>
+			getCanonicalTheme( state, site?.ID || -1, currentThemeId )
+		);
+
 		const isEnglishLocale = useIsEnglishLocale();
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 		const urlQueryParams = useQuery();
@@ -189,6 +195,14 @@ export const siteSetupFlow: Flow = {
 						}
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
+
+					// Check current theme
+					// Does it have a plugin bundled?
+					// If so, send them to the plugin-bundle flow
+					console.log( 'submit() sees the currentTheme: ', currentTheme );
+					// debugger()
+					// if ( theme has plugin bundled ) { send to plugin-bundle }
+					// TODO: The currentTheme doesn't have the taxonomy information available
 
 					return exitFlow( `/home/${ siteSlug }` );
 				}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -108,12 +108,8 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const {
-			setPendingAction,
-			setStepProgress,
-			resetOnboardStoreWithSkipFlags,
-			setBundledPluginSlug,
-		} = useDispatch( ONBOARD_STORE );
+		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
+			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
@@ -203,20 +199,11 @@ export const siteSetupFlow: Flow = {
 
 					// Check current theme: Does it have a plugin bundled?
 					// If so, send them to the plugin-bundle flow.
-					console.log( 'Checking for plugin bundle' );
 					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
 					if ( isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0 ) {
-						setBundledPluginSlug( siteSlug || '', theme_plugin[ 0 ].slug ); // only install first plugin
-						console.log( 'setting bundled plugin slug:', {
-							siteSlug,
-							bundledPluginSlug: theme_plugin[ 0 ].slug,
-						} );
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
-						//return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
-						// return exitFlow( getStepUrl( 'plugin-bundle', false, false, false ) );
 					}
 
-					// Possibly clear setBundledPluginSlug here?
 					return exitFlow( `/home/${ siteSlug }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -212,6 +212,7 @@ export const siteSetupFlow: Flow = {
 							bundledPluginSlug: theme_plugin[ 0 ].slug,
 						} );
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
+						//return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 						// return exitFlow( getStepUrl( 'plugin-bundle', false, false, false ) );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -201,18 +201,21 @@ export const siteSetupFlow: Flow = {
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 
-					// Check current theme
-					// Does it have a plugin bundled?
+					// Check current theme: Does it have a plugin bundled?
+					// If so, send them to the plugin-bundle flow.
 					console.log( 'Checking for plugin bundle' );
 					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
 					if ( isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0 ) {
-						setBundledPluginSlug( theme_plugin[ 0 ].slug ); // only install first plugin
-						console.log( 'setting bundled plugin slug to ', theme_plugin[ 0 ].slug );
-						// TODO: Should we remove this and set plugin-bundle to check currentTheme?.taxonomies?.theme_plugin directly?
+						setBundledPluginSlug( siteSlug | '', theme_plugin[ 0 ].slug ); // only install first plugin
+						console.log( 'setting bundled plugin slug:', {
+							siteSlug,
+							bundledPluginSlug: theme_plugin[ 0 ].slug,
+						} );
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 						// return exitFlow( getStepUrl( 'plugin-bundle', false, false, false ) );
 					}
 
+					// Possibly clear setBundledPluginSlug here?
 					return exitFlow( `/home/${ siteSlug }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -206,7 +206,7 @@ export const siteSetupFlow: Flow = {
 					console.log( 'Checking for plugin bundle' );
 					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
 					if ( isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0 ) {
-						setBundledPluginSlug( siteSlug | '', theme_plugin[ 0 ].slug ); // only install first plugin
+						setBundledPluginSlug( siteSlug || '', theme_plugin[ 0 ].slug ); // only install first plugin
 						console.log( 'setting bundled plugin slug:', {
 							siteSlug,
 							bundledPluginSlug: theme_plugin[ 0 ].slug,

--- a/client/types.ts
+++ b/client/types.ts
@@ -45,6 +45,7 @@ export interface Theme {
 	tags: string[];
 	taxonomies?: {
 		theme_feature?: ThemeFeature[];
+		theme_plugin?: ThemePlugin[];
 	};
 	template: string;
 	theme_uri: string;
@@ -59,6 +60,12 @@ interface ThemeCost {
 }
 
 interface ThemeFeature {
+	name: string;
+	slug: string;
+	term_id: string;
+}
+
+interface ThemePlugin {
 	name: string;
 	slug: string;
 	term_id: string;


### PR DESCRIPTION
#### Proposed Changes

* When site-setup-flow ends, check the current theme to see if it has a plugin bundled. If so, send them along to the next theme.
  * This is not working yet.
  * Next step is to determine why currentTheme does not have the taxonomy information, even though it is included in the API.

#### Testing Instructions


* Uncomment the debugger line in the pr
* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE&notice=purchase-success`
* Choose baxter
* Click the button in the top right to "start with baxter"
* Examine the console log
* You should see the baxter theme details logged
* UP NEXT: The baxter details should include the new plugin theme taxonomy information added in #65553
* Eventually: Choosing a theme with a plugin bundled should send you to another flow instead of /home



Related to #65555
