### PR TITLE
Fix breadcrumbs when switching selected site on plugin details

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -31,7 +31,7 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
-import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
+import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
@@ -210,29 +210,27 @@ function PluginDetails( props ) {
 	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( fullPlugin.slug );
 
 	useEffect( () => {
-		if ( breadcrumbs.length === 0 ) {
-			dispatch(
-				appendBreadcrumb( {
-					label: translate( 'Plugins' ),
-					href: `/plugins/${ selectedSite?.slug || '' }`,
-					id: 'plugins',
-					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins.'
-					),
-				} )
-			);
-		}
+		const items = [
+			{
+				label: translate( 'Plugins' ),
+				href: `/plugins/${ selectedSite?.slug || '' }`,
+				id: 'plugins',
+				helpBubble: translate(
+					'Add new functionality and integrations to your site with plugins.'
+				),
+			},
+		];
 
 		if ( fullPlugin.name && props.pluginSlug ) {
-			dispatch(
-				appendBreadcrumb( {
-					label: fullPlugin.name,
-					href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
-					id: `plugin-${ props.pluginSlug }`,
-				} )
-			);
+			items.push( {
+				label: fullPlugin.name,
+				href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
+				id: `plugin-${ props.pluginSlug }`,
+			} );
 		}
-	}, [ fullPlugin.name, props.pluginSlug, selectedSite ] );
+
+		dispatch( updateBreadcrumbs( items ) );
+	}, [ fullPlugin.name, props.pluginSlug, selectedSite?.slug, dispatch, translate ] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {


### PR DESCRIPTION
Fixes #66666

The breadcrumbs were not updating unless the length of the breadcrumbs changed. Switching site maintains the same breadcrumb length. Replaced it with a more direct approach copied from the browser page that does the same thing.

#### Proposed Changes

* Replaces breadcrumb push logic with set logic.

#### Testing Instructions

* View a single plugin page e.g. http://calypso.localhost:3000/plugins/woocommerce-subscriptions/test1578673.wpcomstaging.com
* Switch sites to another site
* Hover over the breadcrumb root: Plugins
* You should see the correct and updated site in the url of the link
