### PR TITLE
Stepper: set site intent with the tailored flow name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
@@ -15,7 +15,7 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 	const { setPendingAction, setProgressTitle, setProgress } = useDispatch( ONBOARD_STORE );
 	const site = useSite();
 
-	const siteSetup = useSetupOnboardingSite( { ignoreUrl: true, site } );
+	const siteSetup = useSetupOnboardingSite( { ignoreUrl: true, site, flow } );
 
 	const completeLinkInBioFlow = () => {
 		setPendingAction( async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -5,11 +5,11 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
-const Subscribers: Step = function ( { navigation } ): ReactElement | null {
+const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null {
 	const { submit } = navigation;
 	const site = useSite();
 
-	useSetupOnboardingSite( { site } );
+	useSetupOnboardingSite( { site, flow } );
 
 	const handleSubmit = () => {
 		submit?.();


### PR DESCRIPTION
#### Proposed Changes

* This sets the intent site option with `newsletter` or `link-in-bio` depending on the flow. 

#### Testing steps

This only works for link-in-bio in the meantime because newsletter flow doesn't go through `completingPurchase` step. It'l become clear when the subscribers step is done. 

1. Go to /setup?flow=link-in-bio
2. Open DevTools > Network. Filter requests by `intent`.
3. Go through the flow, a `site-intent` request will pop up.
4. See that it's successful. 

