### PR TITLE
After domain only post-checkout Professional Email upsell, hide "Add email" button

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -372,7 +372,7 @@ export class CheckoutThankYou extends Component {
 	};
 
 	render() {
-		const { translate, isHappychatEligible, email } = this.props;
+		const { translate, isHappychatEligible, email, domainOnlySiteFlow } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -384,6 +384,7 @@ export class CheckoutThankYou extends Component {
 		let wasGSuiteOrGoogleWorkspace = false;
 		let wasTitanEmailOnlyProduct = false;
 		let wasTitanEmailProduct = false;
+		let wasDomainOnly = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props ).filter( ( purchase ) => ! isCredits( purchase ) );
@@ -403,6 +404,11 @@ export class CheckoutThankYou extends Component {
 			);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
 			wasTitanEmailOnlyProduct = purchases.length === 1 && purchases.some( isTitanMail );
+			wasDomainOnly =
+				domainOnlySiteFlow &&
+				purchases.every(
+					( purchase ) => isDomainMapping( purchase ) || isDomainRegistration( purchase )
+				);
 		} else if ( isStarterPlanEnabled() ) {
 			// Don't show the Happiness support until we figure out the user doesn't have a starter plan
 			showHappinessSupport = false;
@@ -483,7 +489,7 @@ export class CheckoutThankYou extends Component {
 					domain={ domainName }
 					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
-					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace }
+					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace || wasDomainOnly }
 					selectedSiteSlug={ this.props.selectedSiteSlug }
 					type={ purchaseType }
 				/>


### PR DESCRIPTION
#### Proposed Changes

In #65630, we started showing the post-checkout Professional Email upsell to domain only customers. I found a small snag in this flow where if the user clicks "Skip for now", we still nag them with another "Add email" button in the next step.

This PR hides that button in favor of a "Create a site" button.

My original intention was to include this in the previous PR, but it seems like my code there wouldn't actually produce the desired outcome (and the code was later retracted altogether).

| Before | After |
|-|-|
| ![01](https://user-images.githubusercontent.com/1101677/185885214-f7df1434-813d-4ed5-9d80-af2525b8a6ef.png) | No change |
| ![02](https://user-images.githubusercontent.com/1101677/185885296-04feffc4-19c1-4458-8d8a-bfe1b1547dd5.png) | ![03](https://user-images.githubusercontent.com/1101677/185885367-38612bd7-7fe3-4df2-b6c2-3d11f4ca287c.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/domains` to get a new domain-only site
2. Add a domain to the cart, choose "Just buy a domain", finish checkout
3. You should get a Professional Email upsell after checkout is finished. Click "Skip for now"
4. Ensure that no "Add email" button is shown in the next step

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65630
