### PR TITLE
Vertical Step: Fix wrong has_vertical_images value passed to calypso_signup_site_vertical_submit 

### DIFF
--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -111,12 +111,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		inputRef.current?.focus();
 	};
 
-	const handleSuggestionsSelect = ( suggestion: {
-		name: string;
-		label: string;
-		value?: string;
-		has_vertical_images?: boolean;
-	} ) => {
+	const handleSuggestionsSelect = ( suggestion: { name: string; label: string } ) => {
 		hideSuggestions();
 		onSelect?.( suggestion as Vertical );
 	};

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -115,13 +115,15 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		name,
 		label,
 		value,
+		has_vertical_images,
 	}: {
 		name: string;
 		label: string;
 		value?: string;
+		has_vertical_images?: boolean;
 	} ) => {
 		hideSuggestions();
-		onSelect?.( { name, label, value } as Vertical );
+		onSelect?.( { name, label, value, has_vertical_images } as Vertical );
 	};
 
 	const getSuggestions = useMemo( () => {

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -111,19 +111,14 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		inputRef.current?.focus();
 	};
 
-	const handleSuggestionsSelect = ( {
-		name,
-		label,
-		value,
-		has_vertical_images,
-	}: {
+	const handleSuggestionsSelect = ( suggestion: {
 		name: string;
 		label: string;
 		value?: string;
 		has_vertical_images?: boolean;
 	} ) => {
 		hideSuggestions();
-		onSelect?.( { name, label, value, has_vertical_images } as Vertical );
+		onSelect?.( suggestion as Vertical );
 	};
 
 	const getSuggestions = useMemo( () => {


### PR DESCRIPTION
#### Proposed Changes

This diff fixes an issue where selecting a vertical from the dropdown menu doesn't pass the property `has_vertical_images`. Because of this issue, the event `calypso_signup_site_vertical_submit` will always have `has_vertical_images: false` whenever users select an option from the dropdown.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the vertical step `/setup/vertical?siteSlug=${site_slug}`
* Open up the browser DevTools → Network tab → Img 
* Select one of the featured verticals from the dropdown and click the Continue button
* Ensure that the event `calypso_signup_site_vertical_submit` is fired with  `has_vertical_images: true` 
* Head back to the vertical step, and change from one featured vertical to another featured vertical, and click the Continue button
* Ensure that the event `calypso_signup_site_vertical_submit` is fired with  `has_vertical_images: true` 
* Head back to the vertical step, and change to the vertical "Pop Music" and click the Continue button
* Ensure that the event `calypso_signup_site_vertical_submit` is fired with  `has_vertical_images: false` 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66796
