### PR TITLE
Marketplace: Fix scrollToTop behavior for plugins routes

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -13,27 +13,12 @@ import {
 } from './controller';
 
 export default function () {
-	page(
-		'/plugins/setup',
-		scrollTopIfNoHash,
-		siteSelection,
-		renderProvisionPlugins,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins/setup', siteSelection, renderProvisionPlugins, makeLayout, clientRender );
 
-	page(
-		'/plugins/setup/:site',
-		scrollTopIfNoHash,
-		siteSelection,
-		renderProvisionPlugins,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins/setup/:site', siteSelection, renderProvisionPlugins, makeLayout, clientRender );
 
 	page(
 		'/plugins/browse/:category/:site?',
-		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		browsePlugins,
@@ -41,40 +26,15 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
-	page(
-		'/plugins/upload/:site_id',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		upload,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins/upload', siteSelection, sites, makeLayout, clientRender );
+	page( '/plugins/upload/:site_id', siteSelection, navigation, upload, makeLayout, clientRender );
 
-	page(
-		'/plugins',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		browsePlugins,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins', siteSelection, navigation, browsePlugins, makeLayout, clientRender );
 
-	page(
-		'/plugins/manage/:site?',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		plugins,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins/manage/:site?', siteSelection, navigation, plugins, makeLayout, clientRender );
 
 	page(
 		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
-		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		jetpackCanUpdate,
@@ -95,7 +55,6 @@ export default function () {
 
 	page(
 		'/plugins/:plugin/eligibility/:site_id',
-		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		renderPluginWarnings,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -52,7 +52,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		switch ( category ) {
 			// Scroll back to top if user is coming from "Discover".
 			case 'popular':
-			case 'featured':
 			case 'paid':
 				window.scroll( 0, 0 );
 		}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -48,6 +48,16 @@ const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) 
 };
 
 const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader } ) => {
+	useEffect( () => {
+		switch ( category ) {
+			// Scroll back to top if user is coming from "Discover".
+			case 'popular':
+			case 'featured':
+			case 'paid':
+				window.scroll( 0, 0 );
+		}
+	}, [ category ] );
+
 	const {
 		isAboveElement,
 		targetRef: searchHeaderRef,

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -7,6 +7,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import './style.scss';
 
 function pageToSearch( s ) {
+	window.scroll( 0, 0 );
 	setQueryArgs( '' !== s ? { s } : {} );
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Preserve `scrollTopIfNoHash` in:
  *  When user clicks on a plugin to browse
  * When user clicks on a plugin category to browse
* Add scroll to top for `doSearch`

Before

https://user-images.githubusercontent.com/6586048/185892942-cc072581-a6d2-4c2e-8f22-a8cefec5b764.mp4

After

https://user-images.githubusercontent.com/6586048/185893303-f83e5371-843f-4e4b-b175-92107ee42ca9.mp4

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same instructions for mobile

Case 1:
* Go to /plugins
* Scroll down to "Top free plugins"
* Click on "Browse All"
* **Validate**: should scroll back to top

Case 2:
* Go to /plugins
* Scroll down a bit
* Click on a category
* **Validate**: should not be scrolled to top
* Search for "Elementor"
* **Validate**: Should scroll back to top



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #63792 
