### PR TITLE
Display custom licensing prompt dialog upon connecting Jetpack

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -1,6 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -45,9 +46,13 @@ function LicensingPromptDialog( { siteId }: Props ) {
 		dispatch( recordTracksEvent( 'calypso_user_license_modal_view' ) );
 	}, [ dispatch ] );
 
-	const title = useMemo( () => {
+	let titleToRender = isEnabled( 'jetpack/pricing-page-rework-v1' )
+		? translate( 'Jetpack is successfully installed' )
+		: '';
+
+	if ( ! titleToRender ) {
 		if ( hasOneDetachedLicense ) {
-			return detachedUserLicense?.product
+			titleToRender = detachedUserLicense?.product
 				? preventWidows(
 						translate( 'Activate %(productName)s', {
 							args: {
@@ -56,9 +61,43 @@ function LicensingPromptDialog( { siteId }: Props ) {
 						} )
 				  )
 				: preventWidows( translate( 'Your product is pending activation' ) );
+		} else {
+			titleToRender = preventWidows( translate( 'Activate your new Jetpack features' ) );
 		}
-		return preventWidows( translate( 'Activate your new Jetpack features' ) );
-	}, [ detachedUserLicense, hasOneDetachedLicense, translate ] );
+	}
+
+	let instructions: React.ReactNode = preventWidows(
+		translate(
+			'Find the license key in your purchase confirmation email to activate your new Jetpack features.'
+		)
+	);
+
+	if ( isEnabled( 'jetpack/pricing-page-rework-v1' ) ) {
+		instructions = (
+			<>
+				<b>
+					{ hasOneDetachedLicense
+						? translate(
+								'You have a %(productName)s license available. You can activate it now if you want.',
+								{
+									args: {
+										productName: detachedUserLicense?.product,
+									},
+								}
+						  )
+						: translate(
+								'You have licenses available for some Jetpack features. You can activate them now if you want.'
+						  ) }
+				</b>
+				<ul>
+					<li>
+						{ translate( 'You can find the license keys in your purchase confirmation email.' ) }
+					</li>
+					<li>{ translate( 'Or in Upgrades -> Purchases -> Active Upgrades' ) }</li>
+				</ul>
+			</>
+		);
+	}
 
 	const activateProductClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_user_license_modal_activate_click' ) );
@@ -77,29 +116,21 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	return (
 		<Dialog
 			additionalClassNames="licensing-prompt-dialog"
+			additionalOverlayClassNames={
+				isEnabled( 'jetpack/pricing-page-rework-v1' ) ? 'licensing-prompt-dialog__backdrop' : ''
+			}
 			isVisible={ showLicensesDialog }
 			onClose={ closeDialog }
 			shouldCloseOnEsc
 		>
-			<h1 className="licensing-prompt-dialog__title">{ title }</h1>
+			<h1 className="licensing-prompt-dialog__title">{ titleToRender }</h1>
 			<Gridicon
 				className="licensing-prompt-dialog__close"
 				icon="cross-small"
 				size={ 24 }
 				onClick={ selectAnotherProductClick }
 			/>
-			<p className="licensing-prompt-dialog__instructions">
-				{ preventWidows(
-					translate(
-						'Find the license key in your purchase confirmation email to activate your new Jetpack features.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					)
-				) }
-			</p>
+			<div className="licensing-prompt-dialog__instructions">{ instructions }</div>
 			<div className="licensing-prompt-dialog__actions">
 				<Button
 					className="licensing-prompt-dialog__btn"
@@ -107,7 +138,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 					href={ jetpackDashboardUrl }
 					onClick={ activateProductClick }
 				>
-					{ translate( 'Activate it now' ) }
+					{ translate( 'Activate now' ) }
 				</Button>
 				<Button className="licensing-prompt-dialog__btn" onClick={ selectAnotherProductClick }>
 					{ translate( 'Select another product' ) }

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -20,6 +20,12 @@
 		padding: 24px;
 	}
 }
+.licensing-prompt-dialog {
+	// Add ".dialog__backdrop" to override the default dialog backdrop
+	&__backdrop.dialog__backdrop {
+		background-color: rgba( var( --color-neutral-100-rgb ), 0.6 );
+	}
+}
 
 .licensing-prompt-dialog .licensing-prompt-dialog__title {
 	font-size: $font-title-medium;
@@ -46,6 +52,7 @@
 
 .licensing-prompt-dialog .licensing-prompt-dialog__instructions {
 	font-size: $font-body;
+	margin-bottom: 1.5em;
 }
 
 .licensing-prompt-dialog__actions {

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,12 +1,8 @@
+import { UserLicensesDialog } from './user-licenses-dialog';
 import type { ProductStoreProps } from './types';
 
-const ProductStore: React.FC< ProductStoreProps > = () => {
-	return (
-		<div>
-			<p>{ 'Hello there! 👋' }</p>
-			<p>{ 'Something cool coming up soon' }</p>
-		</div>
-	);
+const ProductStore: React.FC< ProductStoreProps > = ( { enableUserLicensesDialog } ) => {
+	return <div>{ ( enableUserLicensesDialog || 'ok' ) && <UserLicensesDialog /> }</div>;
 };
 
 export default ProductStore;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,3 +1,6 @@
 export type ProductStoreProps = {
-	//coming soon
+	/**
+	 * Whether to show the licence activation dialog
+	 */
+	enableUserLicensesDialog?: boolean;
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
@@ -1,0 +1,19 @@
+import { useSelector } from 'react-redux';
+import LicensingActivationBanner from 'calypso/components/jetpack/licensing-activation-banner';
+import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export const UserLicensesDialog: React.FC = () => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	return (
+		<div>
+			{ siteId && (
+				<>
+					<LicensingPromptDialog siteId={ siteId } />
+					<LicensingActivationBanner siteId={ siteId } />
+				</>
+			) }
+		</div>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -199,7 +199,12 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 			{ siteId && enableUserLicensesDialog && <QueryJetpackUserLicenses /> }
 			{ siteId && enableUserLicensesDialog && <QueryJetpackUserLicensesCounts /> }
 
-			{ siteId && enableUserLicensesDialog && <LicensingPromptDialog siteId={ siteId } /> }
+			{
+				// LicensingPromptDialog has been moved to ProductStore component with jetpack/pricing-page-rework-v1
+				! isEnabled( 'jetpack/pricing-page-rework-v1' ) && siteId && enableUserLicensesDialog && (
+					<LicensingPromptDialog siteId={ siteId } />
+				)
+			}
 
 			{ nav }
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -216,7 +216,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 				/>
 
 				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (
-					<ProductStore />
+					<ProductStore enableUserLicensesDialog={ enableUserLicensesDialog } />
 				) : (
 					<>
 						{ siteId && enableUserLicensesDialog && (

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -46,7 +46,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-product-lightbox": false,
-		"jetpack/pricing-page-rework-v1": true,
+		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,


### PR DESCRIPTION
Completes: 1202796695664022-as-1202796695664096/f
Project Thread: p1HpG7-gBI-p2

This PR Updates the licensing prompt dialog to reflect the changes as given in the new Figma design

#### Proposed Changes

* Enhance `LicensingPromptDialog` and make it backward compatible.
* Create a new `UserLicensesDialog` component inside `client/my-sites/plans/jetpack-plans/product-store` and wire it up
* Hide existing dialog behind feature-flag
* Disable `jetpack/pricing-page-rework-v1` feature for the development environment as discussed here: p1661157546673919-slack-C03RCHNVC0H

#### Testing Instructions

1. Goto [https://cloud.jetpack.com/pricing](https://cloud.jetpack.com/pricing) and purchase a product e.g. Backup but do not activate it for any site
2. Boot up this PR by running `git fetch && git checkout update/licensing-prompt-dialog`
3. Run `yarn start` and open [http://calypso.localhost:3000/](http://calypso.localhost:3000/)
4. Create a JN site
5. While connecting Jetpack,  pause on the plans page i.e. `https://wordpress.com/jetpack/connect/plans/:site`
6. Copy the above URL and open it in another tab after replacing `https://wordpress.com` with `http://calypso.localhost:3000`
7. Confirm that you see the license prompt dialog on both and both look the same.
8. Now in the tab with `calypso.localhost` URL add `&flags=jetpack/pricing-page-rework-v1` to the URL and hit enter. It will enable the feature flag.
9. Confirm that you see the new licensing prompt dialog.
10. Confirm that you see the license activation banner at the top
11. Confirm that the design is as defined in Figma
12. Now again goto [https://cloud.jetpack.com/pricing](https://cloud.jetpack.com/pricing) and purchase another product e.g. Security but do not activate it for any site.
13. Reload the pages mentioned in step 4 and 5
14. Confirm the above steps for multiple pending licenses. Please note the Slack conversation (below) for that.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Figma: m0y1jHTuDpvMPkFsOJBoNP-fi-3669%3A110210
Slack conversation: p1661150917743419-slack-C03RCHNVC0H



<img width="1845" alt="Screenshot 2022-08-22 at 4 41 09 PM" src="https://user-images.githubusercontent.com/18226415/185913352-76f21edf-a0ce-457b-95e3-f3c7858e96a6.png">
<img width="1960" alt="Screenshot 2022-08-22 at 4 38 00 PM" src="https://user-images.githubusercontent.com/18226415/185913532-28afb4b7-8dd3-4ec6-8416-888ac6de4920.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664096