### PR TITLE
Remove unnecessary step and timers

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -1,31 +1,14 @@
 import { StepContainer } from '@automattic/onboarding';
-import { useDispatch } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
 import { useSetupOnboardingSite } from 'calypso/landing/stepper/hooks/use-setup-onboarding-site';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
-const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
-
 const Subscribers: Step = function ( { navigation } ): ReactElement | null {
 	const { submit } = navigation;
-	const { __ } = useI18n();
-	const { setPendingAction, setProgressTitle, setProgress } = useDispatch( ONBOARD_STORE );
 	useSetupOnboardingSite();
 
 	const handleSubmit = () => {
-		setPendingAction( async () => {
-			setProgressTitle( __( 'Creating your Newsletter' ) );
-			setProgress( 0.3 );
-			await wait( 1500 );
-			setProgress( 1 );
-			setProgressTitle( __( 'Preparing Next Steps' ) );
-			await wait( 2000 );
-			return { destination: 'launchpad' };
-		} );
-
 		submit?.();
 	};
 

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -55,7 +55,7 @@ export const newsletter: Flow = {
 				}
 
 				case 'subscribers':
-					return navigate( 'processing' );
+					return navigate( 'launchpad' );
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

Remove unnecessary processing screen and fake timers from subscribers step.

## Testing Instructions

- Pull this branch and yarn start from the root folder
- Start at the beginning of the flow http://calypso.localhost:3000/setup/intro?flow=newsletter
- You should not see any processing step after subscribers step.
- After subscribers, you should see the launchpad.
