### PR TITLE
E2E: Also check for the "Renew Annually" button in case "Renew Now" is not rendered

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -11,7 +11,8 @@ const selectors = {
 	purchasePlaceholder: '.subscriptions__list .purchase-item__placeholder',
 
 	// Purchased item actions: plans
-	renewNowCardButton: 'button:has-text("Renew Now")',
+	renewNowCardButton: 'button.card:has-text("Renew Now")',
+	renewAnnuallyCardButton: 'button.card:has-text("Renew Annually")',
 
 	cancelAndRefundButton: 'a:text("Cancel Subscription and Refund")',
 	cancelSubscriptionButton: 'button:text("Cancel Subscription")',
@@ -64,13 +65,16 @@ export class IndividualPurchasePage {
 	}
 
 	/**
-	 * Renew purchase by clicking on the "Renew Now" card button (as opposed to the inline "Renew now" button).
+	 * Renew purchase by clicking on the "Renew Now" or "Renew Annually" card button (as opposed to the inline "Renew now" button).
 	 */
 	async clickRenewNowCardButton(): Promise< void > {
 		// This triggers a real navigation to the `/checkout/<site_name>` endpoint.
 		await Promise.all( [
 			this.page.waitForNavigation( { url: /.*\/checkout.*/ } ),
-			this.page.click( selectors.renewNowCardButton ),
+			await Promise.race( [
+				this.page.click( selectors.renewNowCardButton ),
+				this.page.click( selectors.renewAnnuallyCardButton ),
+			] ),
 		] );
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the e2e scenario where the "Renew Now" is not rendered, but instead the buttons "Renew Annually" and "Renew Monthly". See screenshot for reference:

![Screen Shot 2022-08-22 at 6 19 24 PM](https://user-images.githubusercontent.com/797888/185928562-37904c10-ac9f-4d7d-a21b-e3e74733bd45.png)



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the E2E [setup guide ](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e).
* Ensure to run `yarn workspace @automattic/calypso-e2e build` first.
* Then run `yarn jest specs/plans/plans__legacy-renew.ts`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
