### PR TITLE
Emails: Automatically move to the top and expand the Google Workspace when there is a Google Sale

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -86,12 +86,10 @@ const EmailProvidersStackedComparison = ( {
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
 
-	const shouldPromoteGoogleWorkspace = isGSuiteSupported && source === 'google-sale';
+	const shouldPromoteGoogleWorkspace = isGSuiteSupported && hasDiscount( gSuiteProduct );
 
 	const [ detailsExpanded, setDetailsExpanded ] = useState( () => {
-		const hasDiscountForGSuite = hasDiscount( gSuiteProduct );
-
-		if ( shouldPromoteGoogleWorkspace && ! selectedEmailProviderSlug && hasDiscountForGSuite ) {
+		if ( shouldPromoteGoogleWorkspace && ! selectedEmailProviderSlug ) {
 			return {
 				google: true,
 				titan: false,


### PR DESCRIPTION
#### Proposed Changes

These changes are intended to automatically expand and move to the top of the Emails Comparison page. Once there are no more sales, the card will move back again to the bottom. The change also removes the "source" check. We are not going to "force" the collapse / position anymore by setting a URL param.

#### Testing Instructions

### Scenario 1: Domain upsell - During a Google Sale period

1. Have a site and buy click on Upgrades -> Domain
2. Type any desired domain
3. Once you click on your desired domain you'll be presented with an email comparison.
4. Assert that the Google Workspace Card is at the top, and expanded.

### Scenario 2: Domain upsell - Without a Google Sale period

1. Have a site and buy click on Upgrades -> Domain
2. Type any desired domain
3. Once you click on your desired domain you'll be presented with an email comparison.
4. Assert that the Google Workspace Card is at the bottom, and collapsed.

### Scenario 3: Add an email solution to an existing domain - During a Google Sale period

1. Have a domain without an email subscription (if you don't have it, buy a domain and SKIP the email upsell (SKIP button that appears after choosing a domain)
2. Go to Upgrades -> Emails
3. If you have more than one domain click on "Add email" if not you'll be redirected to the email comparison already. 
4. Assert that the Google Workspace Card is at the top, and expanded.

### Scenario 4: Add an email solution to an existing domain - Without a Google Sale period

1. Have a domain without an email subscription (if you don't have it, buy a domain and SKIP the email upsell (SKIP button that appears after choosing a domain)
2. Go to Upgrades -> Emails
3. If you have more than one domain click on "Add email" if not you'll be redirected to the email comparison already. 
5. Assert that the Google Workspace Card is at the bottom, and collapsed.

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5689927/185936021-feab14c5-9e2f-4854-872e-7e527700337b.png) | ![image](https://user-images.githubusercontent.com/5689927/185935867-99e6c2d1-07c5-40dd-84bc-926d0b857795.png) |

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to 1200182182542585-as-1202840551030444
