### PR TITLE
DSP Widget: add hook to test if enabled

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -1,7 +1,9 @@
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
+import { useSelector } from 'react-redux';
 import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
 declare global {
 	interface Window {
@@ -106,4 +108,31 @@ export const requestDSP = async < T >(
 		body,
 		apiNamespace: 'wpcom/v2',
 	} );
+};
+
+export enum PromoteWidgetStatus {
+	FETCHING = 'fetching',
+	ENABLED = 'enabled',
+	DISABLED = 'disabled',
+}
+
+/**
+ * Hook to verify if we should enable the promote widget.
+ *
+ * @returns bool
+ */
+export const usePromoteWidget = (): PromoteWidgetStatus => {
+	const value = useSelector( ( state ) => {
+		const settings = getUserSettings( state );
+		if ( settings ) {
+			const originalSetting = settings[ 'has_promote_widget' ];
+			if ( originalSetting !== undefined ) {
+				return originalSetting === true
+					? PromoteWidgetStatus.ENABLED
+					: PromoteWidgetStatus.DISABLED;
+			}
+		}
+		return PromoteWidgetStatus.FETCHING;
+	} );
+	return value;
 };


### PR DESCRIPTION
This diff adds a hook to test if the DSP Widget is enabled.

### Testing
While there are no visible changes it's possible to make the following modifications to verify if the hook is working.
1. Apply D86288-code if not merged.
2. Apply this PR.
3. Apply the following diff:
```diff
diff --git a/client/my-sites/promote-post/main.tsx b/client/my-sites/promote-post/main.tsx
index 1cfaefce3c..1dd567bd76 100644
--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -11,6 +11,9 @@ import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-li
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
 import PromotePostTabBar from 'calypso/my-sites/promote-post/components/promoted-post-filter';
+import { usePromoteWidget } from 'calypso/lib/promote-post';
+import page from 'page';
+import { PromoteWidgetStatus } from 'calypso/lib/promote-post';

 export type TabType = 'posts' | 'campaigns';
 export type TabOption = {
@@ -25,6 +28,11 @@ export default function PromotedPosts() {
                { id: 'campaigns', name: translate( 'Campaigns' ) },
        ];

+       const widgetStatus: PromoteWidgetStatus = usePromoteWidget();
+       if ( widgetStatus === PromoteWidgetStatus.DISABLED ) {
+               page.redirect( '/' );
+       }
+
        return (
                <Main className="promote-post">
                        { /* todo do we need those? */ }
```
4. Verify that navigating to `http://calypso.localhost:3000/advertising/[YOUR_SITE]` works as expected.
5. Modify the method `get_has_promote_widget` on `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-me-settings-v1-1-endpoint.php` file to return false.
6. Verify that navigating to `http://calypso.localhost:3000/advertising/[YOUR_SITE]` redirects to `/`.