### PR TITLE
Only show the "start advertising" banner to new users

### DIFF
--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -2,16 +2,21 @@ import './style.scss';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import SitePreview from 'calypso/blocks/site-preview';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import useCampaignsQuery, {
+	Campaign,
+} from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
 import PromotePostTabBar from 'calypso/my-sites/promote-post/components/promoted-post-filter';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export type TabType = 'posts' | 'campaigns';
 export type TabOption = {
@@ -29,6 +34,12 @@ export default function PromotedPosts() {
 	if ( usePromoteWidget() === PromoteWidgetStatus.DISABLED ) {
 		page( '/' );
 	}
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const { isLoading, data } = useCampaignsQuery( selectedSiteId ?? 0 );
+	const campaigns = useMemo< Campaign[] >( () => data || [], [ data ] );
+
+	const firstCampaign = ! campaigns.length;
 
 	return (
 		<Main className="promote-post">
@@ -62,7 +73,7 @@ export default function PromotedPosts() {
 			{ selectedTab === 'campaigns' && <CampaignsList /> }
 			{ selectedTab === 'posts' && (
 				<>
-					<PostsListBanner />
+					{ ! isLoading && firstCampaign && <PostsListBanner /> }
 					<PostsList />
 				</>
 			) }


### PR DESCRIPTION
#### Proposed Changes

On the advertising homepage within calypso, there is an informative banner to explain to the user about the service.

We're removing this once they have an active campaign, making an assumption that they understand the pages core purpose.

**New Users**
![Screenshot 2022-08-22 at 16 35 39](https://user-images.githubusercontent.com/6440498/185963469-75ff9e64-ee2b-40ea-8fa3-a484f3e20fe8.png)


**Existing Users**
![Screenshot 2022-08-22 at 16 37 51](https://user-images.githubusercontent.com/6440498/185963172-0c61834a-0b0e-487b-8b66-6091ed8f12c7.png)

#### Testing Instructions

Visit the advertising page, for example `http://calypso.localhost:3000/advertising/yourdomain.com`

If you have never created a campaign before you'll see the banner, and the exact opposite should be true if you have.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
