### PR TITLE
Theme/Plugin Bundling: Rework bundled plugin data store

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -31,8 +31,9 @@ export const pluginBundleFlow: Flow = {
 	name: 'plugin-bundle',
 
 	useSteps() {
+		const siteSlugParam = useSiteSlugParam();
 		const pluginSlug = useSelect( ( select ) =>
-			select( ONBOARD_STORE ).getBundledPluginSlug()
+			select( ONBOARD_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -303,9 +303,10 @@ export const setEditEmail = ( email: string ) => ( {
 	email,
 } );
 
-export const setBundledPluginSlug = ( slug: string ) => ( {
+export const setBundledPluginSlug = ( siteSlug: string, pluginSlug: string ) => ( {
 	type: 'SET_BUNDLED_PLUGIN_SLUG' as const,
-	slug,
+	siteSlug,
+	pluginSlug,
 } );
 
 export type OnboardAction = ReturnType<

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -27,6 +27,7 @@ export function register(): typeof STORE_KEY {
 			'anchorPodcastId',
 			'anchorEpisodeId',
 			'anchorSpotifyUrl',
+			'bundledPluginSlug',
 			'domain',
 			'domainSearch',
 			'goals',

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -354,12 +354,18 @@ const editEmail: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
-const bundledPluginSlug: Reducer< string, OnboardAction > = ( state = '', action ) => {
+const bundledPluginSlug: Reducer< { [ key: string ]: string | undefined }, OnboardAction > = (
+	state = {},
+	action
+) => {
 	if ( action.type === 'SET_BUNDLED_PLUGIN_SLUG' ) {
-		return action.slug;
+		return {
+			...state,
+			[ action.siteSlug ]: action.pluginSlug,
+		};
 	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return '';
+		return {};
 	}
 	return state;
 };

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -49,4 +49,5 @@ export const hasSelectedDesignWithoutFonts = ( state: State ) =>
 
 export const getEditEmail = ( state: State ) => state.editEmail;
 
-export const getBundledPluginSlug = ( state: State ) => state.bundledPluginSlug;
+export const getBundledPluginSlug = ( state: State, siteSlug: string ) =>
+	state.bundledPluginSlug[ siteSlug ];

--- a/packages/data-stores/src/onboard/test/actions.ts
+++ b/packages/data-stores/src/onboard/test/actions.ts
@@ -4,15 +4,17 @@
 
 import { setBundledPluginSlug } from '../actions';
 
-const slug = 'woocommerce';
+const siteSlug = 'test.wordpress.com';
+const pluginSlug = 'woocommerce';
 
 describe( 'Onboard Actions', () => {
 	it( 'should return a SET_BUNDLED_PLUGIN_SLUG Action', () => {
 		const expected = {
 			type: 'SET_BUNDLED_PLUGIN_SLUG',
-			slug,
+			siteSlug,
+			pluginSlug,
 		};
 
-		expect( setBundledPluginSlug( slug ) ).toEqual( expected );
+		expect( setBundledPluginSlug( siteSlug, pluginSlug ) ).toEqual( expected );
 	} );
 } );

--- a/packages/data-stores/src/onboard/test/selectors.ts
+++ b/packages/data-stores/src/onboard/test/selectors.ts
@@ -7,12 +7,15 @@ import type { State } from '../reducer';
 
 describe( 'getBundledPluginSlug', () => {
 	it( 'retrieves the bundled plugin slug from the store', () => {
-		const slug = 'woocommerce';
+		const siteSlug = 'test.wordpress.com';
+		const pluginSlug = 'woocommerce';
 
 		const state: State = {
-			bundledPluginSlug: slug,
+			bundledPluginSlug: {
+				[ siteSlug ]: pluginSlug,
+			},
 		};
 
-		expect( getBundledPluginSlug( state ) ).toEqual( slug );
+		expect( getBundledPluginSlug( state, siteSlug ) ).toEqual( pluginSlug );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

Instead of storing a single plugin slug as a string, `bundledPluginSlug` is now an object that's keyed off `siteSlug`. This allows people to potentially interact with multiple sites with bundled plugins.

#### Testing Instructions

```
yarn run test-packages packages/data-stores/src/onboard/test/
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
