### PR TITLE
Fix regression that prevented Jetpack Search from being purchased on an Atomic site

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -30,6 +30,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import useActOnceOnStrings from '../hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from '../hooks/use-add-products-from-url';
@@ -126,8 +127,7 @@ export default function CheckoutMain( {
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
-			// isJetpackSite already checks for isAtomicSite
-			return siteId && isJetpackSite( state, siteId );
+			return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
 		} ) || isJetpackCheckout;
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isLoadingIntroOffers = useSelector( ( state ) =>


### PR DESCRIPTION
A regression introduced in https://github.com/Automattic/wp-calypso/pull/66648 prevents Jetpack Search from being purchased on an Atomic site, since the code now tries to add a Jetpack product to the cart, which won't work on WordPress.com.

#### Proposed Changes

The correct fix is probably to change the code inside `isJetpackSite()` to correctly detect Atomic sites, since that's what https://github.com/Automattic/wp-calypso/pull/66648 was trying to make it do (the attempted check for Atomic sites perhaps needs to run earlier in the function than it currently does?) but that change has potential far-reaching consequences, so I didn't make it here. cc @manzoorwanijk

To fix the immediate regression, the simplest change is to make the checkout code go back to explicitly checking for an Atomic site like it did before (and like some other code that calls `isJetpackSite()` still seems to have done all along), and that's what this pull request does.  If `isJetpackSite()` is fixed later, then this and all other code that has redundant checks for Atomic sites could be changed at that time.

Fixes https://github.com/Automattic/jetpack/issues/25754

#### Testing Instructions

* For an Atomic site, go to Settings -> Performance in the menu, then click on "Upgrade your Jetpack Search and get the instant search experience" and make sure it adds a Jetpack Search product to your cart with no errors.  Without this pull request, it won't work.
* Repeat on a WordPress.com simple site, and a Jetpack site, and make sure those continue to work with this pull request too.

After this is deployed, it should be possible to check that the behavior is also fixed for purchases initiated from  https://jetpack.com/upgrade/search/ or https://cloud.jetpack.com/pricing too.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
