### PR TITLE
Update the grouping of star rating mapping to make the operations more explicit

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -57,7 +57,7 @@ function buildDefaultIconUrl( pluginSlug: string ) {
 	return `https://s.w.org/plugins/geopattern-icon/${ pluginSlug }.svg`;
 }
 
-const mapStarRatingToPercent = ( starRating?: number ) => ( starRating ?? 0 / 5 ) * 100;
+const mapStarRatingToPercent = ( starRating?: number ) => ( ( starRating ?? 0 ) / 5 ) * 100;
 
 const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 	if ( ! results ) return [];


### PR DESCRIPTION
#### Proposed Changes

Update the star rating mapping to check the nullability before making the division.

According to the [Javascript Operator Precedence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table), the division (`/`) has a higher precedence than the Nullish coalescing operator(`??`). This means the parenthesis is needed to check nullability first.

#### Testing Instructions
* Go to unicard search with the flag `marketplace-jetpack-plugin-search` enabled: `/plugins?flags=marketplace-jetpack-plugin-search&s=unicard`
* Check if the star rating is shown as 1 of 5
* Go to the same page on wpcalypso: https://wpcalypso.wordpress.com/plugins?s=unicard
* See as it is 5 of 5 (which is wrong)

| Before  | After |
| ------------- | ------------- |
|<img width="1193" alt="Screen Shot 2022-08-22 at 15 57 29" src="https://user-images.githubusercontent.com/5039531/186010511-55f1fedb-ff9f-468c-8ed1-19df548bdb20.png">|<img width="1193" alt="Screen Shot 2022-08-22 at 15 57 34" src="https://user-images.githubusercontent.com/5039531/186010599-e87ddfa7-2668-4deb-9561-20f2561ce922.png">|
 
* <!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66158
