### PR TITLE
site-setup-flow: Check the current theme for bundled plugins when ending the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
@@ -4,9 +4,11 @@ import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../../stores';
 import { ANCHOR_FM_THEMES } from './anchor-fm-themes';
 import { STEP_NAME } from './constants';
@@ -18,6 +20,7 @@ const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, goToStep } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
+	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction, createSite } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -64,7 +67,9 @@ const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 				return;
 			}
 
-			return setDesignOnSite( newSite.site_slug, _selectedDesign, '' );
+			return setDesignOnSite( newSite.site_slug, _selectedDesign, '' ).then( () =>
+				reduxDispatch( requestActiveTheme( newSite.blogid ) )
+			);
 		} );
 
 		recordTracksEvent( 'calypso_signup_design_type_submit', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -18,12 +18,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef, useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useSite } from '../../../../hooks/use-site';
@@ -66,6 +67,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const reduxDispatch = useReduxDispatch();
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const siteSlug = useSiteSlugParam();
@@ -266,7 +268,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 					_selectedDesign.design_type === 'vertical' || isEnabled( 'signup/standard-theme-v13n' )
 						? siteVerticalId
 						: ''
-				)
+				).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 
 			recordTracksEvent( 'calypso_signup_select_design', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -14,12 +14,13 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useSite } from '../../../../hooks/use-site';
@@ -52,6 +53,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const reduxDispatch = useReduxDispatch();
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const siteSlug = useSiteSlugParam();
@@ -177,7 +179,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					_selectedDesign.design_type === 'vertical' || isEnabled( 'signup/standard-theme-v13n' )
 						? siteVerticalId
 						: ''
-				)
+				).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -23,6 +23,8 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 	const loadingMessages = useProcessingLoadingMessages();
 
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
+	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
+	const [ destinationState, setDestinationState ] = useState( {} );
 
 	useInterval( () => {
 		setCurrentMessageIndex( ( s ) => ( s + 1 ) % loadingMessages.length );
@@ -42,14 +44,31 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 			if ( typeof action === 'function' ) {
 				try {
 					const destination = await action();
-					submit?.( destination, ProcessingResult.SUCCESS );
+					// Don't call submit() directly; instead, turn on a flag that signals we should call submit() next.
+					// This allows us to call the newest submit() created. Otherwise, we would be calling a submit()
+					// that is frozen from before we called action().
+					// We can now get the most up to date values from hooks inside the flow creating submit(),
+					// including the values that were updated during the action() running.
+					setDestinationState( destination );
+					setHasActionSuccessfullyRun( true );
 				} catch ( e ) {
 					submit?.( {}, ProcessingResult.FAILURE );
 				}
-			} else submit?.( {}, ProcessingResult.NO_ACTION );
+			} else {
+				submit?.( {}, ProcessingResult.NO_ACTION );
+			}
 		} )();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ action ] );
+
+	// When the hasActionSuccessfullyRun flag turns on, run submit().
+	useEffect( () => {
+		if ( hasActionSuccessfullyRun ) {
+			submit?.( destinationState, ProcessingResult.SUCCESS );
+		}
+		// A change in submit() doesn't cause this effect to rerun.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ hasActionSuccessfullyRun ] );
 
 	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
 	const [ simulatedProgress, setSimulatedProgress ] = useState( 0 );

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -36,7 +36,7 @@ export const pluginBundleFlow: Flow = {
 			select( SITE_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
-		console.log( { pluginSlug } );
+		console.log( { siteSlugParam, pluginSlug } );
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			// TODO - Need to handle this better
 			return [];

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -38,15 +38,14 @@ export const pluginBundleFlow: Flow = {
 
 		console.log( { siteSlugParam, pluginSlug } );
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
-			// TODO - Need to handle this better
-			return [];
+			window.location.replace( `/home/${ siteSlugParam }` );
 		}
 
 		if ( ! pluginSlug || ! pluginBundleSteps.hasOwnProperty( pluginSlug ) ) {
-			// TODO - Need to handle this better
-			return [];
+			window.location.replace( `/home/${ siteSlugParam }` );
 		}
 
+		console.log( 'plugin bundle steps', pluginBundleSteps[ pluginSlug ] );
 		return pluginBundleSteps[ pluginSlug ] as StepPath[];
 	},
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -36,7 +36,6 @@ export const pluginBundleFlow: Flow = {
 			select( SITE_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
-		console.log( { siteSlugParam, pluginSlug } );
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			window.location.replace( `/home/${ siteSlugParam }` );
 		}
@@ -45,7 +44,6 @@ export const pluginBundleFlow: Flow = {
 			window.location.replace( `/home/${ siteSlugParam }` );
 		}
 
-		console.log( 'plugin bundle steps', pluginBundleSteps[ pluginSlug ] );
 		return pluginBundleSteps[ pluginSlug ] as StepPath[];
 	},
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -36,6 +36,7 @@ export const pluginBundleFlow: Flow = {
 			select( SITE_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
+		console.log( { pluginSlug } );
 		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
 			// TODO - Need to handle this better
 			return [];

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -8,6 +8,7 @@ import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -83,6 +84,11 @@ export const siteSetupFlow: Flow = {
 		const siteSlugParam = useSiteSlugParam();
 		const site = useSite();
 		const currentUser = useSelector( getCurrentUser );
+		const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
+		const currentTheme = useSelector( ( state ) =>
+			getCanonicalTheme( state, site?.ID || -1, currentThemeId )
+		);
+
 		const isEnglishLocale = useIsEnglishLocale();
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 		const urlQueryParams = useQuery();
@@ -189,6 +195,14 @@ export const siteSetupFlow: Flow = {
 						}
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
+
+					// Check current theme
+					// Does it have a plugin bundled?
+					// If so, send them to the plugin-bundle flow
+					console.log( 'submit() sees the currentTheme: ', currentTheme );
+					// debugger()
+					// if ( theme has plugin bundled ) { send to plugin-bundle }
+					// TODO: The currentTheme doesn't have the taxonomy information available
 
 					return exitFlow( `/home/${ siteSlug }` );
 				}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -201,18 +201,21 @@ export const siteSetupFlow: Flow = {
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 
-					// Check current theme
-					// Does it have a plugin bundled?
+					// Check current theme: Does it have a plugin bundled?
+					// If so, send them to the plugin-bundle flow.
 					console.log( 'Checking for plugin bundle' );
 					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
 					if ( isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0 ) {
-						setBundledPluginSlug( theme_plugin[ 0 ].slug ); // only install first plugin
-						console.log( 'setting bundled plugin slug to ', theme_plugin[ 0 ].slug );
-						// TODO: Should we remove this and set plugin-bundle to check currentTheme?.taxonomies?.theme_plugin directly?
+						setBundledPluginSlug( siteSlug | '', theme_plugin[ 0 ].slug ); // only install first plugin
+						console.log( 'setting bundled plugin slug:', {
+							siteSlug,
+							bundledPluginSlug: theme_plugin[ 0 ].slug,
+						} );
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 						// return exitFlow( getStepUrl( 'plugin-bundle', false, false, false ) );
 					}
 
+					// Possibly clear setBundledPluginSlug here?
 					return exitFlow( `/home/${ siteSlug }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -24,7 +24,6 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from './internals/types';
-//import { getStepUrl } from 'calypso/signup/utils';
 import type { StepPath } from './internals/steps-repository';
 
 const WRITE_INTENT_DEFAULT_THEME = 'livro';
@@ -209,7 +208,6 @@ export const siteSetupFlow: Flow = {
 					) {
 						setBundledPluginSlug( siteSlug, theme_plugin[ 0 ].slug ); // only install first plugin
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
-						// return exitFlow( getStepUrl( 'plugin-bundle', false, false, false ) );
 					}
 
 					// We know this theme doesn't have a plugin bundled, so clear it in the store

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -200,19 +200,23 @@ export const siteSetupFlow: Flow = {
 
 					// Check current theme: Does it have a plugin bundled?
 					// If so, send them to the plugin-bundle flow.
-					console.log( 'Checking for plugin bundle' );
 					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
-					if ( isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0 ) {
-						setBundledPluginSlug( siteSlug || '', theme_plugin[ 0 ].slug ); // only install first plugin
-						console.log( 'setting bundled plugin slug:', {
-							siteSlug,
-							bundledPluginSlug: theme_plugin[ 0 ].slug,
-						} );
+					if (
+						isEnabled( 'themes/plugin-bundling' ) &&
+						theme_plugin &&
+						theme_plugin.length > 0 &&
+						siteSlug
+					) {
+						setBundledPluginSlug( siteSlug, theme_plugin[ 0 ].slug ); // only install first plugin
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 						// return exitFlow( getStepUrl( 'plugin-bundle', false, false, false ) );
 					}
 
-					// Possibly clear setBundledPluginSlug here?
+					// We know this theme doesn't have a plugin bundled, so clear it in the store
+					if ( siteSlug ) {
+						setBundledPluginSlug( siteSlug, '' );
+					}
+
 					return exitFlow( `/home/${ siteSlug }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -108,12 +108,9 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const {
-			setPendingAction,
-			setStepProgress,
-			resetOnboardStoreWithSkipFlags,
-			setBundledPluginSlug,
-		} = useDispatch( ONBOARD_STORE );
+		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
+			useDispatch( ONBOARD_STORE );
+		const { setBundledPluginSlug } = useDispatch( SITE_STORE );
 		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -109,8 +109,8 @@ export const siteSetupFlow: Flow = {
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
-		const { setBundledPluginSlug } = useDispatch( SITE_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, setBundledPluginSlug } =
+			useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -206,7 +206,7 @@ export const siteSetupFlow: Flow = {
 					console.log( 'Checking for plugin bundle' );
 					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
 					if ( isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0 ) {
-						setBundledPluginSlug( siteSlug | '', theme_plugin[ 0 ].slug ); // only install first plugin
+						setBundledPluginSlug( siteSlug || '', theme_plugin[ 0 ].slug ); // only install first plugin
 						console.log( 'setting bundled plugin slug:', {
 							siteSlug,
 							bundledPluginSlug: theme_plugin[ 0 ].slug,

--- a/client/types.ts
+++ b/client/types.ts
@@ -45,6 +45,7 @@ export interface Theme {
 	tags: string[];
 	taxonomies?: {
 		theme_feature?: ThemeFeature[];
+		theme_plugin?: ThemePlugin[];
 	};
 	template: string;
 	theme_uri: string;
@@ -59,6 +60,12 @@ interface ThemeCost {
 }
 
 interface ThemeFeature {
+	name: string;
+	slug: string;
+	term_id: string;
+}
+
+interface ThemePlugin {
 	name: string;
 	slug: string;
 	term_id: string;


### PR DESCRIPTION
#### Proposed Changes

* When site-setup-flow ends, check the current theme to see if it has a plugin bundled. If so, send them along to the plugin-bundle flow.
  *  The three places that call the design picker in stepper (anchor-fm-design-picker.tsx, site-setup-design-picker.tsx, unified-design-picker.tsx) wait for a design to be picked, then call requestActiveTheme after
    * I was not able to build this into the `setDesignOnSite()` itself because this request uses a different store and a different data layer (@wordpress/data vs redux)
  * The very last part of siteSetupFlow checks the currentTheme?.taxonomies?.theme_plugin info, and if it finds bundled themes and a certain flag set, it saves that theme with `setBundledPluginSlug()` and passes them along to the plugin-bundle flow
* Changed the implementation of stepper running the `submit()` function
  * `processing-step/index.tsx` runs pending actions, and then calls submit(). [Old Version.](https://github.com/Automattic/wp-calypso/blob/46421d78b315acbe90b7e4eff065b77175d51d23/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx#L44-L45) [New Version](https://github.com/Automattic/wp-calypso/blob/8564eecbdd107be10768991ea40297c4122a9272/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx#L46-L53).
    * With this PR, the pending actions include fetching information about the current theme, which the submit() function needs access to, in order to decide if the user goes home or to the plugin bundle flow.
    * When the theme fetch inside the pending actions resolves, a new version of submit() with the correct closure is created and passed to `processing-step/index.tsx`.
    * However, `processing-step` wasn't using this, it was always using the version of submit() passed before the pending actions ran, and ignored all updates.
    * I slightly changed the mechanism to allow it to use the latest version of submit() created.

#### Testing Instructions

* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE&notice=purchase-success`
* Choose baxter
* Click the button in the top right to "start with baxter"
* You should be moved to the plugin-bundle-flow (you'll see a screen about putting in your address)


Related to #65555
