### PR TITLE
Fix Marketplace Plugins Breadcrumb 2x Click Issue

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -1,6 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { Key } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 
@@ -114,6 +115,12 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		);
 	}
 
+	function gotoLink( href: string | undefined ) {
+		if ( href !== undefined ) {
+			page( href );
+		}
+	}
+
 	if ( items.length > 1 ) {
 		return (
 			<StyledUl>
@@ -121,7 +128,13 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 					<StyledLi key={ index }>
 						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 14 } /> }
 						{ item.href && index !== items.length - 1 ? (
-							<a href={ item.href }>{ item.label }</a>
+							<button
+								tabIndex={ 0 }
+								style={ { cursor: 'pointer' } }
+								onClick={ () => gotoLink( item.href ) }
+							>
+								{ item.label }
+							</button>
 						) : (
 							<span>{ item.label }</span>
 						) }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -19,7 +19,7 @@ const selectors = {
 	browseAllPaid: 'a[href^="/plugins/browse/paid"]',
 	browseFirstCategory: 'button:has-text("Search Engine Optimization")',
 	categoryButton: ( section: string ) => `button:has-text("${ section }")`,
-	breadcrumb: ( section: string ) => `.plugins-browser__header a:text("${ section }") `,
+	breadcrumb: ( section: string ) => `.plugins-browser__header button:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',


### PR DESCRIPTION
#### Proposed Changes

P2: pdh6GB-1QJ-p2

Before this PR, on the Plugin details page, it took 2 clicks on the breadcrumb links before the linked page would load.

After this PR, it takes only 1 click.

![before-2-clicks](https://user-images.githubusercontent.com/140841/186030039-f0ab16db-8a3b-4090-bdca-ccced8f3f3ee.png)

This PR solves the 2-click problem by replacing the anchor tag with a `<button>` with an onClick event that calls the `page()` function.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Visit the plugin details page for any plugin
For example: http://calypso.localhost:3000/plugins/woocommerce-table-rate-shipping/{your-test-site}
* Click on "Plugins" in the breadcrumb links. It should only take 1 click to load.
* Test around this issue.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66795