### PR TITLE
Sites Management Dashboard: Add animation to grid tile on hover 

### DIFF
--- a/client/sites-dashboard/components/sites-grid-tile.tsx
+++ b/client/sites-dashboard/components/sites-grid-tile.tsx
@@ -6,6 +6,23 @@ const container = css( {
 	width: '100%',
 	flexDirection: 'column',
 	minWidth: 0,
+	transition: 'all 0.3s ease-in-out',
+	':hover': {
+		transform: 'scale(1.07, 1.07)',
+		':after': {
+			//opacity: 1,
+		},
+	},
+	':after': {
+		content: '""',
+		position: 'absolute',
+		zIndex: -1,
+		height: '100%',
+		width: '100%',
+		opacity: 0,
+		boxShadow: '0 5px 15px rgba(0,0,0,0.1)',
+		transition: 'opacity 0.2s ease-in-out',
+	},
 } );
 
 const primaryContainer = css( {


### PR DESCRIPTION
#### Proposed Changes

* Adds more character to the tile view grid tile by applying animations when hover

#### Testing Instructions

- Go to` /sites-dashboard`
- Choose tile view and hover each tile to see animation


https://user-images.githubusercontent.com/47489215/186031908-c38f44aa-cbbb-4398-b310-6e2fa3eb6019.mov


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
