### PR TITLE
Purchases Page: Fix Auto renew status for unbillable payment methods

### DIFF
--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -31,16 +31,6 @@ export default function PaymentInfoBlock( {
 			card.meta?.find( ( meta ) => meta.meta_key === 'is_backup' )?.meta_value
 	);
 
-	if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
-		return (
-			<PaymentInfoBlockWrapper>
-				<div className={ 'manage-purchase__no-payment-method' }>
-					<Icon icon={ warning } />
-					{ translate( 'You don’t have a supporting payment method to renew this subscription' ) }
-				</div>
-			</PaymentInfoBlockWrapper>
-		);
-	}
 	if ( isIncludedWithPlan( purchase ) ) {
 		return <PaymentInfoBlockWrapper>{ translate( 'Included with plan' ) }</PaymentInfoBlockWrapper>;
 	}
@@ -118,6 +108,16 @@ export default function PaymentInfoBlock( {
 		);
 	}
 
+	if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
+		return (
+			<PaymentInfoBlockWrapper>
+				<div className={ 'manage-purchase__no-payment-method' }>
+					<Icon icon={ warning } />
+					{ translate( 'You don’t have a payment method to renew this subscription' ) }
+				</div>
+			</PaymentInfoBlockWrapper>
+		);
+	}
 	return <PaymentInfoBlockWrapper>{ translate( 'None' ) }</PaymentInfoBlockWrapper>;
 }
 

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -108,7 +108,11 @@ export default function PaymentInfoBlock( {
 		);
 	}
 
-	if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
+	if (
+		! isRechargeable( purchase ) &&
+		hasPaymentMethod( purchase ) &&
+		purchase.isAutoRenewEnabled
+	) {
 		return (
 			<PaymentInfoBlockWrapper>
 				<div className={ 'manage-purchase__no-payment-method' }>

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -31,6 +31,16 @@ export default function PaymentInfoBlock( {
 			card.meta?.find( ( meta ) => meta.meta_key === 'is_backup' )?.meta_value
 	);
 
+	if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
+		return (
+			<PaymentInfoBlockWrapper>
+				<div className={ 'manage-purchase__no-payment-method' }>
+					<Icon icon={ warning } />
+					{ translate( 'You don’t have a supporting payment method to renew this subscription' ) }
+				</div>
+			</PaymentInfoBlockWrapper>
+		);
+	}
 	if ( isIncludedWithPlan( purchase ) ) {
 		return <PaymentInfoBlockWrapper>{ translate( 'Included with plan' ) }</PaymentInfoBlockWrapper>;
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -34,6 +34,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
+	isRechargeable,
 	isRenewing,
 	isSubscription,
 	isCloseToExpiration,
@@ -469,24 +470,40 @@ function PurchaseMetaExpiration( {
 		const subsRenewText = isAutorenewalEnabled
 			? translate( 'Auto-renew is ON' )
 			: translate( 'Auto-renew is OFF' );
-		const subsBillingText =
-			isAutorenewalEnabled && ! hideAutoRenew && hasPaymentMethod( purchase )
-				? translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
-						args: {
-							renewDate: purchase.renewDate && moment( purchase.renewDate ).format( 'LL' ),
-						},
-						components: {
-							dateSpan,
-						},
-				  } )
-				: translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
-						args: {
-							expireDate: moment( purchase.expiryDate ).format( 'LL' ),
-						},
-						components: {
-							dateSpan,
-						},
-				  } );
+		let subsBillingText;
+		if (
+			isAutorenewalEnabled &&
+			! hideAutoRenew &&
+			hasPaymentMethod( purchase ) &&
+			isRechargeable( purchase )
+		) {
+			subsBillingText = translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
+				args: {
+					renewDate: purchase.renewDate && moment( purchase.renewDate ).format( 'LL' ),
+				},
+				components: {
+					dateSpan,
+				},
+			} );
+		} else if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
+			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
+				args: {
+					expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+				},
+				components: {
+					dateSpan,
+				},
+			} );
+		} else {
+			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
+				args: {
+					expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+				},
+				components: {
+					dateSpan,
+				},
+			} );
+		}
 
 		const shouldRenderToggle = site && isProductOwner;
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -485,15 +485,6 @@ function PurchaseMetaExpiration( {
 					dateSpan,
 				},
 			} );
-		} else if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
-			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
-				args: {
-					expireDate: moment( purchase.expiryDate ).format( 'LL' ),
-				},
-				components: {
-					dateSpan,
-				},
-			} );
 		} else {
 			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
 				args: {

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -64,7 +64,12 @@ describe( 'PaymentInfoBlock', () => {
 		} );
 
 		describe( 'when the purchase a non-rechargable payment method', () => {
-			const purchase = { expiryStatus, payment: { type: 'ideal' }, isRechargeable: false };
+			const purchase = {
+				expiryStatus,
+				payment: { type: 'ideal' },
+				isRechargeable: false,
+				isAutoRenewEnabled: true,
+			};
 
 			it( 'renders "You don’t have a payment method to renew this subscription"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -66,9 +66,11 @@ describe( 'PaymentInfoBlock', () => {
 		describe( 'when the purchase a non-rechargable payment method', () => {
 			const purchase = { expiryStatus, payment: { type: 'ideal' }, isRechargeable: false };
 
-			it( 'renders "None"', () => {
+			it( 'renders "You don’t have a payment method to renew this subscription"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
-				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
+				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
+					'You don’t have a payment method to renew this subscription'
+				);
 			} );
 
 			it( 'does not render "will not be billed"', () => {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -22,6 +22,7 @@ import {
 	getDisplayName,
 	isExpired,
 	isExpiring,
+	isRechargeable,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPartnerPurchase,
@@ -409,6 +410,15 @@ class PurchaseItem extends Component {
 		const { purchase, translate } = this.props;
 
 		if ( purchase.isAutoRenewEnabled && ! hasPaymentMethod( purchase ) ) {
+			return (
+				<div className={ 'purchase-item__no-payment-method' }>
+					<Icon icon={ warningIcon } />
+					<span>{ translate( 'You don’t have a payment method to renew this subscription' ) }</span>
+				</div>
+			);
+		}
+
+		if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
 			return (
 				<div className={ 'purchase-item__no-payment-method' }>
 					<Icon icon={ warningIcon } />

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -418,7 +418,11 @@ class PurchaseItem extends Component {
 			);
 		}
 
-		if ( ! isRechargeable( purchase ) && hasPaymentMethod( purchase ) ) {
+		if (
+			! isRechargeable( purchase ) &&
+			hasPaymentMethod( purchase ) &&
+			purchase.isAutoRenewEnabled
+		) {
 			return (
 				<div className={ 'purchase-item__no-payment-method' }>
 					<Icon icon={ warningIcon } />


### PR DESCRIPTION
#### Description:

On the individual purchase management page when the initial payment was done with a payment method that does not support renewal like ideal, then we see a message `None` this could be replaced with a text that makes more sense like `You don't have a payment gateway to renew this subscription`.  Similarly the subscription renewal component before that says `You will be billed on` without any date information.



#### Proposed Changes

We are seeing the below on the purchase page which seems broken:

![](https://d.pr/i/RL3ea9+)

Suggested Solution includes expiry date and a notice that makes sense:

![](https://d.pr/i/Bc2I2Y+)


#### Testing Instructions

1. Add a renewable addon product to cart like `Removable ads` from /add-ons/:site
2. Ensure to have currency as Euro and country as Netherlands
3. This will provide a gateway like Ideal which will not allow renewal
4. Complete Payment with ideal gateway
5. Now visit /purchases/subscriptions/:site/
6. Click on the exact purchase from active upgrades tab
7. Now, you should see the above suggestion under the `Subscription
   renewal` and `Payment method` columns



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #1058
