### PR TITLE
Sites Management Page: Flip margins and padding when in RTL layout

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -12,7 +12,17 @@ import { SiteItemThumbnail } from './sites-site-item-thumbnail';
 import { SiteName } from './sites-site-name';
 import { SiteUrl, Truncated } from './sites-site-url';
 
-const badges = css( { display: 'flex', gap: '8px', alignItems: 'center', marginLeft: 'auto' } );
+const badges = css( {
+	display: 'flex',
+	gap: '8px',
+	alignItems: 'center',
+	'html:not( [dir="rtl"] ) &': {
+		marginLeft: 'auto',
+	},
+	'html[dir="rtl"] &': {
+		marginRight: 'auto',
+	},
+} );
 
 export const siteThumbnail = css( {
 	aspectRatio: '16 / 9',

--- a/client/sites-dashboard/components/sites-site-name.ts
+++ b/client/sites-dashboard/components/sites-site-name.ts
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
+import { marginRight } from '../utils';
 
 export const SiteName = styled.a< { fontSize?: number } >`
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	margin-right: 8px;
+	${ marginRight( '8px' ) }
 	font-weight: 500;
 	font-size: ${ ( props ) => `${ props.fontSize }px` };
 	letter-spacing: -0.4px;

--- a/client/sites-dashboard/components/sites-site-url.ts
+++ b/client/sites-dashboard/components/sites-site-url.ts
@@ -4,16 +4,13 @@ import { ExternalLink } from '@wordpress/components';
 export const SiteUrl = styled( ExternalLink )`
 	display: flex;
 	align-items: center;
+	gap: 4px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	font-size: 14px;
 	color: var( --studio-gray-60 ) !important;
 	&:hover {
 		text-decoration: underline;
-	}
-
-	.components-external-link__icon {
-		margin-left: 4px;
 	}
 `;
 

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -5,7 +5,13 @@ import { useI18n } from '@wordpress/react-i18n';
 import { memo } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
-import { displaySiteUrl, getDashboardUrl, MEDIA_QUERIES } from '../utils';
+import {
+	displaySiteUrl,
+	getDashboardUrl,
+	MEDIA_QUERIES,
+	paddingRight,
+	marginRight,
+} from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
@@ -25,7 +31,7 @@ const Row = styled.tr`
 const Column = styled.td< { mobileHidden?: boolean } >`
 	padding-top: 12px;
 	padding-bottom: 12px;
-	padding-right: 24px;
+	${ paddingRight( '24px' ) }
 	vertical-align: middle;
 	font-size: 14px;
 	line-height: 20px;
@@ -35,22 +41,21 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 
 	${ MEDIA_QUERIES.mediumOrSmaller } {
 		${ ( props ) => props.mobileHidden && 'display: none;' };
-		padding-right: 0;
-	}
+		${ paddingRight( '0' ) }
 `;
 
 const SiteListTile = styled( ListTile )`
 	line-height: initial;
-	margin-right: 0;
+	${ marginRight( '0' ) }
 
 	${ MEDIA_QUERIES.mediumOrSmaller } {
-		margin-right: 12px;
+		${ marginRight( '12px' ) }
 	}
 `;
 
 const ListTileLeading = styled.a`
 	${ MEDIA_QUERIES.mediumOrSmaller } {
-		margin-right: 12px;
+		${ marginRight( '12px' ) }
 	}
 `;
 

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -27,3 +27,17 @@ export const MEDIA_QUERIES = {
 	mediumOrLarger: '@media screen and ( min-width: 660px )',
 	large: '@media screen and ( min-width: 960px )',
 };
+
+const spaceRight = ( spaceType: 'margin' | 'padding', value: string ) => {
+	return `
+		html:not( [dir="rtl" ] ) & {
+			${ spaceType }-right: ${ value };
+		}
+		html[dir="rtl"] & {
+			${ spaceType }-left: ${ value };
+		}
+	`;
+};
+
+export const paddingRight = ( value: string ) => spaceRight( 'padding', value );
+export const marginRight = ( value: string ) => spaceRight( 'margin', value );


### PR DESCRIPTION
#### Proposed Changes

Fixes right-to-left layout. Usually, this would be done automatically by the `@automattic/webpack-rtl-plugin`. But Emotion is generating CSS rules at runtime, so the build tooling can't process them.

![grid](https://user-images.githubusercontent.com/1500769/186078480-8a0c46dd-e4c8-406b-921d-45defe3a057f.png)

![rtl table](https://user-images.githubusercontent.com/1500769/186078813-f41940af-9422-4031-8291-81d9bce18a7f.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choose a right-to-left language in your account settings, like Arabic or Hebrew
* Test `/sites-dashboard`
   * Badges should have the correct spacing
   * Long text in table cells should wrap at the correct location (it should wrap before the edge of the table cell)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


