### PR TITLE
Fix Jetpack standalone only sites visible on wpcom site selector

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -30,6 +30,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import useActOnceOnStrings from '../hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from '../hooks/use-add-products-from-url';
@@ -126,8 +127,7 @@ export default function CheckoutMain( {
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
-			// isJetpackSite already checks for isAtomicSite
-			return isJetpackSite( state, siteId );
+			return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
 		} ) || isJetpackCheckout;
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isLoadingIntroOffers = useSelector( ( state ) =>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -30,7 +30,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import useActOnceOnStrings from '../hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from '../hooks/use-add-products-from-url';
@@ -127,7 +126,8 @@ export default function CheckoutMain( {
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
-			return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
+			// isJetpackSite already checks for isAtomicSite
+			return isJetpackSite( state, siteId );
 		} ) || isJetpackCheckout;
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isLoadingIntroOffers = useSelector( ( state ) =>

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -4,9 +4,20 @@ import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import CloseOnEscape from 'calypso/components/close-on-escape';
 import SiteSelector from 'calypso/components/site-selector';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { hasTouch } from 'calypso/lib/touch-detect';
+import { isJetpackSitePred } from 'calypso/state/sites/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+
+/**
+ * In order to decide whether to show the site in site selector,
+ * we need to know if the site has full Jetpack plugin installed,
+ * or if we are on Jetpack Cloud and the site has a Jetpack Standalone plugin installed.
+ */
+const isJetpackSiteOrJetpackCloud = isJetpackSitePred( {
+	considerStandaloneProducts: isJetpackCloud(),
+} );
 
 const noop = () => {};
 
@@ -92,6 +103,7 @@ class SitePicker extends Component {
 					autoFocus={ this.state.isAutoFocused }
 					onClose={ this.onClose }
 					groups={ true }
+					filter={ isJetpackSiteOrJetpackCloud }
 				/>
 			</div>
 		);

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -6,7 +6,7 @@ import CloseOnEscape from 'calypso/components/close-on-escape';
 import SiteSelector from 'calypso/components/site-selector';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { hasTouch } from 'calypso/lib/touch-detect';
-import { isJetpackSitePred } from 'calypso/state/sites/selectors';
+import { getJetpackActivePlugins, isJetpackSitePred } from 'calypso/state/sites/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 
@@ -88,6 +88,12 @@ class SitePicker extends Component {
 		this.closePicker( null );
 	};
 
+	filterSites = ( site ) => {
+		// Filter out the sites on WPCOM that don't have full Jetpack plugin installed
+		// Such sites should work fine on Jetpack Cloud
+		return getJetpackActivePlugins( site ) ? isJetpackSiteOrJetpackCloud( site ) : true;
+	};
+
 	render() {
 		return (
 			<div>
@@ -103,7 +109,7 @@ class SitePicker extends Component {
 					autoFocus={ this.state.isAutoFocused }
 					onClose={ this.onClose }
 					groups={ true }
-					filter={ isJetpackSiteOrJetpackCloud }
+					filter={ this.filterSites }
 				/>
 			</div>
 		);

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -8,7 +8,7 @@ import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isJetpackSitePred } from 'calypso/state/sites/selectors';
+import { getJetpackActivePlugins, isJetpackSitePred } from 'calypso/state/sites/selectors';
 
 /**
  * In order to decide whether to show the site in site selector,
@@ -38,8 +38,9 @@ class Sites extends Component {
 	}
 
 	filterSites = ( site ) => {
-		// only show Jetpack sites with the full plugin or Jetpack Cloud with the standalone plugin
-		if ( ! isJetpackSiteOrJetpackCloud( site ) ) {
+		// Filter out the sites on WPCOM that don't have full Jetpack plugin installed
+		// Such sites should work fine on Jetpack Cloud
+		if ( getJetpackActivePlugins( site ) && ! isJetpackSiteOrJetpackCloud( site ) ) {
 			return false;
 		}
 		const path = this.props.siteBasePath;

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -7,6 +7,17 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { isJetpackSitePred } from 'calypso/state/sites/selectors';
+
+/**
+ * In order to decide whether to show the site in site selector,
+ * we need to know if the site has full Jetpack plugin installed,
+ * or if we are on Jetpack Cloud and the site has a Jetpack Standalone plugin installed.
+ */
+const isJetpackSiteOrJetpackCloud = isJetpackSitePred( {
+	considerStandaloneProducts: isJetpackCloud(),
+} );
 
 import './style.scss';
 
@@ -27,6 +38,10 @@ class Sites extends Component {
 	}
 
 	filterSites = ( site ) => {
+		// only show Jetpack sites with the full plugin or Jetpack Cloud with the standalone plugin
+		if ( ! isJetpackSiteOrJetpackCloud( site ) ) {
+			return false;
+		}
 		const path = this.props.siteBasePath;
 
 		// Domains can be managed on Simple and Atomic sites.

--- a/client/state/sites/selectors/get-jetpack-active-plugins.ts
+++ b/client/state/sites/selectors/get-jetpack-active-plugins.ts
@@ -1,0 +1,8 @@
+import type { SiteDetails } from '@automattic/data-stores';
+
+/**
+ * Get the list of active Jetpack plugins for a site.
+ */
+export default function getJetpackActivePlugins( site: SiteDetails | null ) {
+	return site?.options?.jetpack_connection_active_plugins;
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -8,6 +8,7 @@ export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';
 export { default as canJetpackSiteUpdateFiles } from './can-jetpack-site-update-files';
 export { default as getCustomizerUrl } from './get-customizer-url';
+export { default as getJetpackActivePlugins } from './get-jetpack-active-plugins';
 export { default as getJetpackCheckoutRedirectUrl } from './get-jetpack-checkout-redirect-url';
 export { default as getJetpackComputedAttributes } from './get-jetpack-computed-attributes';
 export { default as getSeoTitle } from './get-seo-title';

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -49,6 +49,7 @@ export { default as isJetpackConnectionPluginActive } from './is-jetpack-connect
 export { default as isJetpackMinimumVersion } from './is-jetpack-minimum-version';
 export { default as isJetpackModuleActive } from './is-jetpack-module-active';
 export { default as isJetpackSite } from './is-jetpack-site';
+export { default as isJetpackSitePred } from './is-jetpack-site-pred';
 export { default as isJetpackSiteMainNetworkSite } from './is-jetpack-site-main-network-site';
 export { default as isJetpackSiteMultiSite } from './is-jetpack-site-multi-site';
 export { default as isJetpackSiteSecondaryNetworkSite } from './is-jetpack-site-secondary-network-site';

--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -1,0 +1,43 @@
+import type { SiteDetails } from '@automattic/data-stores';
+
+export type IsJetpackSitePredOptions = {
+	considerStandaloneProducts?: boolean;
+};
+
+const DEFAULT_OPTIONS: IsJetpackSitePredOptions = {
+	considerStandaloneProducts: true,
+};
+
+/**
+ * A function that returns a predicate which when passed a site
+ * returns true if site is a Jetpack site, false if the site is hosted on
+ * WordPress.com, or null if the site is unknown.
+ *
+ * When options.considerStandaloneProducts is true (the default), sites with
+ * Jetpack standalone plugins will also be considered Jetpack sites for the
+ * purposes of this function.
+ *
+ * CAUTION: It does not consider whether the site is an Atomic site.
+ */
+export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) {
+	return function isJetpackSite( site: SiteDetails | null ): boolean | null {
+		if ( ! site ) {
+			return null;
+		}
+
+		// Sites with full Jetpack plugin have a boolean `jetpack` property.
+		if ( site.jetpack ) {
+			return true;
+		}
+
+		// Merge default options with options.
+		const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
+
+		// If we should not consider standalone products
+		if ( ! mergedOptions.considerStandaloneProducts ) {
+			return false;
+		}
+
+		return Boolean( site.options?.jetpack_connection_active_plugins?.length );
+	};
+}

--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -1,11 +1,19 @@
 import type { SiteDetails } from '@automattic/data-stores';
 
 export type IsJetpackSitePredOptions = {
+	/**
+	 * When true, the sites with Jetpack standalone plugins will also be considered Jetpack sites
+	 */
 	considerStandaloneProducts?: boolean;
+	/**
+	 * When true, the Atomic site will also be considered as Jetpack site
+	 */
+	treatAtomicAsJetpackSite?: boolean;
 };
 
 const DEFAULT_OPTIONS: IsJetpackSitePredOptions = {
 	considerStandaloneProducts: true,
+	treatAtomicAsJetpackSite: false,
 };
 
 /**
@@ -16,8 +24,6 @@ const DEFAULT_OPTIONS: IsJetpackSitePredOptions = {
  * When options.considerStandaloneProducts is true (the default), sites with
  * Jetpack standalone plugins will also be considered Jetpack sites for the
  * purposes of this function.
- *
- * CAUTION: It does not consider whether the site is an Atomic site.
  */
 export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) {
 	return function isJetpackSite( site: SiteDetails | null ): boolean | null {
@@ -25,13 +31,18 @@ export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) 
 			return null;
 		}
 
+		// Merge default options with options.
+		const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
+
+		// If the site is an Atomic site, but we should not treat it as Jetpack site, return false.
+		if ( ! mergedOptions.treatAtomicAsJetpackSite && site.options?.is_wpcom_atomic ) {
+			return false;
+		}
+
 		// Sites with full Jetpack plugin have a boolean `jetpack` property.
 		if ( site.jetpack ) {
 			return true;
 		}
-
-		// Merge default options with options.
-		const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
 
 		// If we should not consider standalone products
 		if ( ! mergedOptions.considerStandaloneProducts ) {

--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -13,7 +13,7 @@ export type IsJetpackSitePredOptions = {
 
 const DEFAULT_OPTIONS: IsJetpackSitePredOptions = {
 	considerStandaloneProducts: true,
-	treatAtomicAsJetpackSite: false,
+	treatAtomicAsJetpackSite: true,
 };
 
 /**

--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -24,6 +24,9 @@ const DEFAULT_OPTIONS: IsJetpackSitePredOptions = {
  * When options.considerStandaloneProducts is true (the default), sites with
  * Jetpack standalone plugins will also be considered Jetpack sites for the
  * purposes of this function.
+ *
+ * When options.treatAtomicAsJetpackSite is true (the default), Atomic sites with
+ * Jetpack will also be considered Jetpack sites for the purposes of this function.
  */
 export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) {
 	return function isJetpackSite( site: SiteDetails | null ): boolean | null {

--- a/client/state/sites/selectors/is-jetpack-site.ts
+++ b/client/state/sites/selectors/is-jetpack-site.ts
@@ -1,10 +1,7 @@
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isJetpackSitePred, { IsJetpackSitePredOptions } from './is-jetpack-site-pred';
 import type { AppState } from 'calypso/types';
-
-const defaultOptions = {
-	considerStandaloneProducts: true,
-};
 
 /**
  * Returns true if site is a Jetpack site, false if the site is hosted on
@@ -17,23 +14,10 @@ const defaultOptions = {
 export default function isJetpackSite(
 	state: AppState,
 	siteId: number | undefined | null,
-	options?: Partial< typeof defaultOptions >
+	options?: IsJetpackSitePredOptions
 ): boolean | null {
 	if ( ! siteId ) {
 		return null;
-	}
-
-	// Merge default options with options.
-	options = options ? { ...defaultOptions, ...options } : defaultOptions;
-
-	const site = getRawSite( state, siteId );
-	if ( ! site ) {
-		return null;
-	}
-
-	// Sites with full Jetpack plugin have a boolean `jetpack` property.
-	if ( site.jetpack ) {
-		return true;
 	}
 
 	// if it's an atomic site, return false
@@ -41,10 +25,7 @@ export default function isJetpackSite(
 		return false;
 	}
 
-	// If we should not consider standalone products
-	if ( ! options.considerStandaloneProducts ) {
-		return false;
-	}
+	const site = getRawSite( state, siteId );
 
-	return Boolean( site.options?.jetpack_connection_active_plugins?.length );
+	return isJetpackSitePred( options )( site );
 }

--- a/client/state/sites/selectors/is-jetpack-site.ts
+++ b/client/state/sites/selectors/is-jetpack-site.ts
@@ -1,5 +1,4 @@
 import getRawSite from 'calypso/state/selectors/get-raw-site';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isJetpackSitePred, { IsJetpackSitePredOptions } from './is-jetpack-site-pred';
 import type { AppState } from 'calypso/types';
 
@@ -18,11 +17,6 @@ export default function isJetpackSite(
 ): boolean | null {
 	if ( ! siteId ) {
 		return null;
-	}
-
-	// if it's an atomic site, return false
-	if ( isAtomicSite( state, siteId ) ) {
-		return false;
 	}
 
 	const site = getRawSite( state, siteId );

--- a/client/state/sites/selectors/is-jetpack-site.ts
+++ b/client/state/sites/selectors/is-jetpack-site.ts
@@ -9,6 +9,9 @@ import type { AppState } from 'calypso/types';
  * When options.considerStandaloneProducts is true (the default), sites with
  * Jetpack standalone plugins will also be considered Jetpack sites for the
  * purposes of this function.
+ *
+ * When options.treatAtomicAsJetpackSite is true (the default), Atomic sites with
+ * Jetpack will also be considered Jetpack sites for the purposes of this function.
  */
 export default function isJetpackSite(
 	state: AppState,

--- a/client/state/sites/test/is-jetpack-site.ts
+++ b/client/state/sites/test/is-jetpack-site.ts
@@ -20,17 +20,45 @@ describe( 'isJetpackSite', () => {
 		expect( isJetpackSite( getSiteState(), siteId + 1 ) ).toEqual( null );
 	} );
 
-	test( 'should return false if the site is hosted on WordPress.com, even if a product plugin is installed', () => {
-		expect( isJetpackSite( getSiteState( { jetpack: false } ), siteId ) ).toEqual( false );
+	test( 'should return true for Atomic sites with Jetpack by default', () => {
 		expect(
 			isJetpackSite(
 				getSiteState( {
+					jetpack: true,
 					options: {
-						is_automated_transfer: true,
-						jetpack_connection_active_plugins: [ 'jetpack-backup' ],
+						is_wpcom_atomic: true,
 					},
 				} ),
 				siteId
+			)
+		).toEqual( true );
+	} );
+
+	test( 'should return false for Atomic sites without Jetpack', () => {
+		expect(
+			isJetpackSite(
+				getSiteState( {
+					jetpack: false,
+					options: {
+						is_wpcom_atomic: true,
+					},
+				} ),
+				siteId
+			)
+		).toEqual( false );
+	} );
+
+	test( 'should return false for Atomic sites when treatAtomicAsJetpackSite is set to false', () => {
+		expect(
+			isJetpackSite(
+				getSiteState( {
+					jetpack: true,
+					options: {
+						is_wpcom_atomic: true,
+					},
+				} ),
+				siteId,
+				{ treatAtomicAsJetpackSite: false }
 			)
 		).toEqual( false );
 	} );
@@ -40,6 +68,9 @@ describe( 'isJetpackSite', () => {
 			isJetpackSite(
 				getSiteState( {
 					jetpack: true,
+					options: {
+						is_wpcom_atomic: true,
+					},
 				} ),
 				siteId
 			)
@@ -72,6 +103,20 @@ describe( 'isJetpackSite', () => {
 				siteId
 			)
 		).toEqual( true );
+	} );
+
+	test( 'should return false if the site has neither the full Jetpack plugin nor a standalone one', () => {
+		expect(
+			isJetpackSite(
+				getSiteState( {
+					jetpack: false,
+					options: {
+						jetpack_connection_active_plugins: [],
+					},
+				} ),
+				siteId
+			)
+		).toEqual( false );
 	} );
 
 	test( 'should return false if the site has a standalone Jetpack plugin installed, but not the full plugin with considerStandaloneProducts set to false', () => {


### PR DESCRIPTION
Sites with Jetpack standalone sites do not work well in WPCOM because WPCOM expects REST API to be available for the site which is possible only via the full Jetpack plugin. Thus, many UI sections on WPCOM for sites with standalone Jetpack plugins break e.g. Users and Stats section for a site with Standalone Backup, Search or Boost.

#### Proposed Changes

* This PR filters out the sites with Jetpack standalone plugins from WPCOM site selector
* It retains those sites in site selector for Jetpack Cloud
* It extracts `isJetpackSitePred` predicate from `isJetpackSite` selector to make it re-usable when we already have a site object.

#### Testing Instructions

- Create a site (JN site) with only a standalone Jetpack plugin, e.g., Backup, Search, Boost, etc.
- Boot up this PR and run `yarn start` and also `start-jetpack-cloud-p` in another terminal window/tab
- Connect Jetpack on the site with an appropriate plan
- If you see errors during connection, then replace `https://wordpress` with `http://calypso.localhost:3000` in the connection URL.
- Goto [http://calypso.localhost:3000/sites](http://calypso.localhost:3000/sites)
- Confirm that the JN site with only standalone Jetpack plugin IS NOT available in the selector
- Goto [http://jetpack.cloud.localhost:3001/landing](http://jetpack.cloud.localhost:3001/landing)
- Confirm that the site with only standalone Jetpack plugin IS available in the selector
- Select the site
- Confirm that everything works fine

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes 1164141197617539-as-1202835600809449/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202835600809449