### PR TITLE
Stepper: prefill domain search for newsletter and link in bio flows

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import type { StepPath } from './internals/steps-repository';
@@ -28,6 +28,7 @@ export const linkInBio: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const { getState } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -43,7 +44,9 @@ export const linkInBio: Flow = {
 					return navigate( 'linkInBioSetup' );
 
 				case 'linkInBioSetup':
-					return window.location.replace( '/start/link-in-bio/domains' );
+					return window.location.replace(
+						`/start/newsletter/domains?new=${ getState().siteTitle ?? '' }&search=yes`
+					);
 
 				case 'completingPurchase':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -46,7 +46,7 @@ export const linkInBio: Flow = {
 					return window.location.replace(
 						`/start/newsletter/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string
-						) }&search=yes`
+						) }&search=yes&hide_initial_query=yes`
 					);
 
 				case 'completingPurchase':

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import type { StepPath } from './internals/steps-repository';
@@ -28,7 +28,6 @@ export const linkInBio: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
-		const { getState } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -45,7 +44,9 @@ export const linkInBio: Flow = {
 
 				case 'linkInBioSetup':
 					return window.location.replace(
-						`/start/newsletter/domains?new=${ getState().siteTitle ?? '' }&search=yes`
+						`/start/newsletter/domains?new=${ encodeURIComponent(
+							providedDependencies.siteTitle as string
+						) }&search=yes`
 					);
 
 				case 'completingPurchase':

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -31,7 +31,6 @@ export const newsletter: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const siteSlug = useSiteSlug();
-		const { getState } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', _currentStep );
@@ -47,7 +46,9 @@ export const newsletter: Flow = {
 
 				case 'newsletterSetup':
 					return window.location.replace(
-						`/start/newsletter/domains?new=${ getState().siteTitle ?? '' }&search=yes`
+						`/start/newsletter/domains?new=${ encodeURIComponent(
+							providedDependencies.siteTitle as string
+						) }&search=yes`
 					);
 
 				case 'completingPurchase':

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
+import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -31,6 +31,7 @@ export const newsletter: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const siteSlug = useSiteSlug();
+		const { getState } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', _currentStep );
@@ -45,7 +46,9 @@ export const newsletter: Flow = {
 					);
 
 				case 'newsletterSetup':
-					return window.location.replace( '/start/newsletter/domains' );
+					return window.location.replace(
+						`/start/newsletter/domains?new=${ getState().siteTitle ?? '' }&search=yes`
+					);
 
 				case 'completingPurchase':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -48,7 +48,7 @@ export const newsletter: Flow = {
 					return window.location.replace(
 						`/start/newsletter/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string
-						) }&search=yes`
+						) }&search=yes&hide_initial_query=yes`
 					);
 
 				case 'completingPurchase':


### PR DESCRIPTION
#### Proposed Changes

* When newsletter and link in bio flow redirect to domains step. They need to use the available params to prefill the search field and initiate a search.
* To do this the flows read the site title from the onboarding state and use the value in the redirect.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`

**Newsletter flow**
- Visit http://calypso.localhost:3000/setup/intro?flow=newsletter
- In newsletter setup step enter a site name and submit the form
- Verify that the value is used for domain search in the next step

**Link in bio flow**
- Visit http://calypso.localhost:3000/setup/intro?flow=link-in-bio
- In link in bio setup step enter a site name and submit the form
- Verify that the value is used for domain search in the next step
