### PR TITLE
Stepper (Link in Bio, Newsletter): set site name required and update copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -65,6 +65,8 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
+		setFormTouched( true );
+
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
 
@@ -75,7 +77,10 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 				// communicate the error to the user
 			}
 		}
-		submit?.();
+
+		if ( siteTitle.trim().length ) {
+			submit?.( { siteTitle, tagline } );
+		}
 	};
 
 	const stepContent = (
@@ -107,7 +112,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 				{ siteTitleError && (
 					<FormInputValidation
 						isError
-						text={ __( 'Your site needs a name so your subscribers can identify you.' ) }
+						text={ __( `Oops. Looks like your Link in Bio doesn't have a name yet.` ) }
 					/>
 				) }
 			</FormFieldset>
@@ -144,7 +149,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id={ 'link-in-bio-setup-header' }
-					headerText={ __( 'Set up Link in Bio' ) }
+					headerText={ __( 'Pencil in a few details' ) }
 					align={ 'center' }
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -54,7 +54,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const siteTitleError =
 		formTouched && ! siteTitle.trim()
-			? __( 'Your publication needs a name so your subscribers can identify you.' )
+			? __( `Oops. Looks like your Newsletter doesn't have a name yet.` )
 			: '';
 
 	useEffect( () => {
@@ -79,7 +79,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		// setFormTouched( true );
+		setFormTouched( true );
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
@@ -93,9 +93,9 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			}
 		}
 
-		// if ( siteTitle.trim().length ) {
-		submit?.( { siteTitle, tagline } );
-		// }
+		if ( siteTitle.trim().length ) {
+			submit?.( { siteTitle, tagline } );
+		}
 	};
 
 	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
@@ -139,7 +139,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					/>
 				</Popover>
 				<FormFieldset>
-					<FormLabel htmlFor="siteTitle">{ __( 'Publication name*' ) }</FormLabel>
+					<FormLabel htmlFor="siteTitle">{ __( 'Publication name' ) }</FormLabel>
 					<FormInput
 						value={ siteTitle }
 						name="siteTitle"
@@ -201,7 +201,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			formattedHeader={
 				<FormattedHeader
 					id={ 'newsletter-setup-header' }
-					headerText={ __( 'Setup your Newsletter' ) }
+					headerText={ __( 'Pencil in a few details' ) }
 					align={ 'center' }
 				/>
 			}


### PR DESCRIPTION
| Newsletter changes | Link in bio changes |
| ------------- | ------------- |
| <img width="567" alt="Screenshot 2022-08-23 at 12 10 07" src="https://user-images.githubusercontent.com/7000684/186132810-58c0c082-ec81-4ce5-9e76-c6616a8ca337.png"> |   <img width="618" alt="Screenshot 2022-08-23 at 12 10 20" src="https://user-images.githubusercontent.com/7000684/186132707-bafe7578-06fc-4e5a-b7a4-66b33f99b158.png"> |

#### Proposed Changes

* Prevent submitting of link in bio and newsletter setup if name is not provided
* Update copy according to figma

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Visit http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter and test the name validation and verify the copy changes
- Visit http://calypso.localhost:3000/setup/linkInBioSetup?flow=link-in-bio and test the name validation and verify the copy changes
