### PR TITLE
Emails: remove domain warning pendingGSuiteTosAcceptanceDomains from plans page

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -237,7 +237,6 @@ class CurrentPlan extends Component {
 								'newDomainsWithPrimary',
 								'newDomains',
 								'unverifiedDomainsCanManage',
-								'pendingGSuiteTosAcceptanceDomains',
 								'unverifiedDomainsCannotManage',
 								'wrongNSMappedDomains',
 								'newTransfersWrongNS',


### PR DESCRIPTION
#### Proposed Changes
If a user bought Google Workspace subscription, but is not fully set up it (user hasn't acknowledged emails for completing sign up) then we show an unnecessary warning about it on "Upgrades > Plan" page.
We shouldn't display this email notice here in the content - it should only be displayed in the sidebar:

<img width="1355" alt="Markup 2022-08-23 at 10 09 36" src="https://user-images.githubusercontent.com/5598437/186119631-05422123-4c1d-4cc1-8cd9-caf0e121691f.png">

#### Testing Instructions
* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* Buy "Google Workspace" subscription, but it's important not to acknowledge email to complete sign-up:
    * Click on "Add new site" at the end of the appeared list
    * Enter any domain name for test purposes
    * In the appeared list below - choose a domain with the help of the "Select" button
    * Choose any plan from the proposed with the help of the "Select" button
    * Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
    * Note, on the page "Add Professional Email" - click on the "Skip for now" button
    * On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
    * In the left sidebar menu, click on the "Inbox" item
    * At the bottom of the page is located the "Google Workspace" section, click on the "Select" button, on the right side of the section
    * Fill "Google Workspace" form and click on the "Purchase" button, below the form
    * Click on "Pay {amount} with credits"
    * Click on the "Manage email" button in the middle of the page body
* In the left sidebar menu, mouse over on the "Upgrades" item and choose "Plans"
* In the page content choose "My plan" tab item

<table>
<tr>
	<td>BEFORE
	<td>AFTER
<tr>
	<td> Two warnings
	<td> Warning exists only in the left sidebar
<tr>
	<td> <img width="1000" alt="Markup 2022-08-23 at 10 09 36" src="https://user-images.githubusercontent.com/5598437/186119631-05422123-4c1d-4cc1-8cd9-caf0e121691f.png">
	<td> <img width="1000" alt="Screenshot 2022-08-23 at 09 46 23" src="https://user-images.githubusercontent.com/5598437/186118191-7b66423b-fd5d-4271-b484-73c303c170ed.png">
</table>



#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202735545987352/f