### PR TITLE
Pricing page rework: Add Jetpack Free component

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,11 +1,22 @@
+import { useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { JetpackFree } from './jetpack-free';
 import { UserLicensesDialog } from './user-licenses-dialog';
 import type { ProductStoreProps } from './types';
 
-const ProductStore: React.FC< ProductStoreProps > = ( { enableUserLicensesDialog } ) => {
+import './style.scss';
+
+const ProductStore: React.FC< ProductStoreProps > = ( {
+	enableUserLicensesDialog,
+	urlQueryArgs,
+} ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
 	return (
-		<div>
-			{ enableUserLicensesDialog && <UserLicensesDialog /> }
+		<div className="jetpack-product-store">
+			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
+			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 			<StoreFooter />
 		</div>
 	);

--- a/client/my-sites/plans/jetpack-plans/product-store/jetpack-free.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/jetpack-free.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import useJetpackFreeButtonProps from '../jetpack-free-card/use-jetpack-free-button-props';
+import { JetpackFreeProps } from './types';
+
+export const JetpackFree: React.FC< JetpackFreeProps > = ( { urlQueryArgs, siteId } ) => {
+	const translate = useTranslate();
+
+	const { href, onClick } = useJetpackFreeButtonProps( siteId, urlQueryArgs );
+
+	return (
+		<div className="jetpack-product-store__jetpack-free">
+			<h3 className="jetpack-product-store__jetpack-free--headline">
+				{ translate( 'Still not sure?' ) }
+			</h3>
+			<p className="jetpack-product-store__jetpack-free--info">
+				{ translate( 'Start with the free version and try out the premium plugins later.' ) }
+			</p>
+			<Button onClick={ onClick } href={ href }>
+				{ translate( 'Start with %(productName)s', {
+					args: {
+						productName: translate( 'Jetpack Free' ),
+					},
+				} ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -13,6 +13,7 @@
         }
     }
     .button {
+        color: var( --color-neutral-100 );
         border: 1px solid var( --color-neutral-100 );
         font-weight: 600;
     }

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -3,6 +3,8 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        margin: 3em 0;
+        padding: 0 1.5em;
 
         &--headline {
             font-size: $font-title-large;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -4,7 +4,6 @@
         flex-direction: column;
         align-items: center;
         margin: 3em 0;
-        padding: 0 1.5em;
 
         &--headline {
             font-size: $font-title-large;
@@ -12,6 +11,7 @@
         }
         &--info {
             font-size: $font-body-small;
+            text-align: center;
         }
     }
     .button {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -1,0 +1,19 @@
+.jetpack-product-store {
+    &__jetpack-free {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+
+        &--headline {
+            font-size: $font-title-large;
+            margin-bottom: 1em;
+        }
+        &--info {
+            font-size: $font-body-small;
+        }
+    }
+    .button {
+        border: 1px solid var( --color-neutral-100 );
+        font-weight: 600;
+    }
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,6 +1,14 @@
-export type ProductStoreProps = {
+import { BasePageProps } from '../types';
+
+export interface ProductStoreBaseProps {
+	siteId: number | null;
+}
+
+export interface ProductStoreProps extends Pick< BasePageProps, 'urlQueryArgs' > {
 	/**
 	 * Whether to show the licence activation dialog
 	 */
 	enableUserLicensesDialog?: boolean;
-};
+}
+
+export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;

--- a/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
@@ -1,11 +1,8 @@
-import { useSelector } from 'react-redux';
 import LicensingActivationBanner from 'calypso/components/jetpack/licensing-activation-banner';
 import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { ProductStoreBaseProps } from './types';
 
-export const UserLicensesDialog: React.FC = () => {
-	const siteId = useSelector( getSelectedSiteId );
-
+export const UserLicensesDialog: React.FC< ProductStoreBaseProps > = ( { siteId } ) => {
 	return (
 		<div>
 			{ siteId && (

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -221,7 +221,10 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 				/>
 
 				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (
-					<ProductStore enableUserLicensesDialog={ enableUserLicensesDialog } />
+					<ProductStore
+						enableUserLicensesDialog={ enableUserLicensesDialog }
+						urlQueryArgs={ urlQueryArgs }
+					/>
 				) : (
 					<>
 						{ siteId && enableUserLicensesDialog && (

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -26,7 +26,7 @@ export type PurchaseURLCallback = (
 export type DurationChangeCallback = ( arg0: Duration ) => void;
 export type ScrollCardIntoViewCallback = ( arg0: HTMLDivElement, arg1: string ) => void;
 
-interface BasePageProps {
+export interface BasePageProps {
 	rootUrl: string;
 	urlQueryArgs: QueryArgs;
 	nav?: ReactNode;


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a new `JetpackFree` component inside `ProductStore`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR 
    * Run `git fetch && git checkout add/jetpack-free-component`
    * Run `yarn start-jetpack-cloud`
    * Goto [http://jetpack.cloud.localhost:3001/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3001/pricing?flags=jetpack/pricing-page-rework-v1)
* Or click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* Confirm that you see the Jetpack Free component
* Confirm that the design matches the Figma design

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<img width="1226" alt="Screenshot 2022-08-23 at 2 48 08 PM" src="https://user-images.githubusercontent.com/18226415/186121445-727578d0-cf12-4aac-a729-713e6b92995c.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/18226415/186141517-47331f1f-5d6a-41fb-af3e-6b08e58df350.png">



Completes: 1202796695664022-as-1202796695664061/f
Figma: m0y1jHTuDpvMPkFsOJBoNP-fi-3715%3A132855

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664061