### PR TITLE
Remove help center icon

### DIFF
--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -62,6 +62,8 @@ export function shouldLoadInlineHelp( sectionName: string, currentRoute: string 
 		'/start/p2',
 		'/start/videopress',
 		'/start/setup-site',
+		'/start/newsletter',
+		'/start/link-in-bio',
 		'/plugins/domain',
 		'/plugins/marketplace/setup',
 	];


### PR DESCRIPTION
## Proposed Changes

Hide the blue help icon from Tailored flows ( Newsletter and LiB )
<img width="64" alt="image" src="https://user-images.githubusercontent.com/2653810/186127282-0c92186a-f3ca-4a38-8cd8-99941e77a5fc.png">

## Testing Instructions

- Pull this branch and yarn start from the root folder
- Start at the beginning of the flow http://calypso.localhost:3000/setup/intro?flow=newsletter or http://calypso.localhost:3000/setup/intro?flow=link-in-bio
- Navigate on the flow until the domain step
- The Blue Question mark button should not be visible.
