### PR TITLE
Add header and pricing banner in the new pricing page.

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -25,7 +25,7 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 			title={
 				isEnabled( 'jetpack/pricing-page-rework-v1' )
 					? translate( 'Best-in-class products for your WordPress site' )
-					: undefined
+					: translate( 'Security, performance, and marketing tools made for WordPress' )
 			}
 		/>
 	);

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import { hideMasterbar } from 'calypso/state/ui/actions';
@@ -17,7 +19,16 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 
 	context.store.dispatch( hideMasterbar() );
 	context.nav = <JetpackComMasterbar pathname={ lang ? path.replace( `/${ lang }`, '' ) : path } />;
-	context.header = <Header urlQueryArgs={ urlQueryArgs } />;
+	context.header = (
+		<Header
+			urlQueryArgs={ urlQueryArgs }
+			title={
+				isEnabled( 'jetpack/pricing-page-rework-v1' )
+					? translate( 'Best-in-class products for your WordPress site' )
+					: undefined
+			}
+		/>
+	);
 	context.footer = <JetpackComFooter />;
 	next();
 }

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -5,7 +5,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
-const Header: React.FC< Props > = () => {
+const Header: React.FC< Props > = ( { title }: Props ) => {
 	const translate = useTranslate();
 
 	return (
@@ -14,7 +14,7 @@ const Header: React.FC< Props > = () => {
 				<FormattedHeader
 					className="header__main-title"
 					headerText={ preventWidows(
-						translate( 'Security, performance, and marketing tools made for WordPress' )
+						title ?? translate( 'Security, performance, and marketing tools made for WordPress' )
 					) }
 					align="center"
 				/>
@@ -25,6 +25,7 @@ const Header: React.FC< Props > = () => {
 
 type Props = {
 	urlQueryArgs: { [ key: string ]: string };
+	title?: string;
 };
 
 export default Header;

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -5,7 +5,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
-const Header: React.FC< Props > = ( { title }: Props ) => {
+const Header: React.FC< Props > = ( { title } ) => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-slugs.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-slugs.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { getSitePlan } from 'calypso/state/sites/selectors';
+import { getPlansToDisplay, getProductsToDisplay } from '../../product-grid/utils';
+import { Duration } from '../../types';
+import useGetPlansGridProducts from '../../use-get-plans-grid-products';
+
+const useProductSlugs = ( siteId: number | null, duration: Duration ): string[] => {
+	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const currentPlanSlug = currentPlan?.product_slug || null;
+	const { availableProducts, purchasedProducts, includedInPlanProducts } =
+		useGetPlansGridProducts( siteId );
+
+	return useMemo(
+		() =>
+			[
+				...getProductsToDisplay( {
+					duration,
+					availableProducts,
+					purchasedProducts,
+					includedInPlanProducts,
+				} ),
+				...getPlansToDisplay( { duration, currentPlanSlug } ),
+			].map( ( { productSlug } ) => productSlug ),
+		[ duration, availableProducts, purchasedProducts, includedInPlanProducts, currentPlanSlug ]
+	);
+};
+
+export default useProductSlugs;

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-slugs.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-slugs.ts
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getPlansToDisplay, getProductsToDisplay } from '../../product-grid/utils';
-import { Duration } from '../../types';
 import useGetPlansGridProducts from '../../use-get-plans-grid-products';
+import { ProductSlugsProps } from '../types';
 
-const useProductSlugs = ( siteId: number | null, duration: Duration ): string[] => {
+const useProductSlugs = ( { siteId, duration }: ProductSlugsProps ): string[] => {
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const currentPlanSlug = currentPlan?.product_slug || null;
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -40,7 +40,6 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	return (
 		<div className="jetpack-product-store">
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
-			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 
 			<div className="jetpack-product-store__pricing-banner">
 				<IntroPricingBanner
@@ -48,6 +47,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 					siteId={ siteId ?? 'none' }
 				/>
 			</div>
+
+			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 
 			<Recommendations />
 

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,6 +1,11 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
+import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getPlansToDisplay, getProductsToDisplay } from '../product-grid/utils';
+import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import { JetpackFree } from './jetpack-free';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
@@ -11,14 +16,41 @@ import './style.scss';
 const ProductStore: React.FC< ProductStoreProps > = ( {
 	enableUserLicensesDialog,
 	urlQueryArgs,
+	duration,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
+	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const currentPlanSlug = currentPlan?.product_slug || null;
+	const { availableProducts, purchasedProducts, includedInPlanProducts } =
+		useGetPlansGridProducts( siteId );
+
+	const allItems = useMemo(
+		() => [
+			...getProductsToDisplay( {
+				duration,
+				availableProducts,
+				purchasedProducts,
+				includedInPlanProducts,
+			} ),
+			...getPlansToDisplay( { duration, currentPlanSlug } ),
+		],
+		[ duration, availableProducts, purchasedProducts, includedInPlanProducts, currentPlanSlug ]
+	);
 
 	return (
 		<div className="jetpack-product-store">
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
+
+			<div className="jetpack-product-store__pricing-banner">
+				<IntroPricingBanner
+					productSlugs={ allItems.map( ( { productSlug } ) => productSlug ) }
+					siteId={ siteId ?? 'none' }
+				/>
+			</div>
+
 			<Recommendations />
+
 			<StoreFooter />
 		</div>
 	);

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -16,7 +16,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	duration,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
-	const productSlugs = useProductSlugs( siteId, duration );
+	const productSlugs = useProductSlugs( { siteId, duration } );
 
 	return (
 		<div className="jetpack-product-store">

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,11 +1,8 @@
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
-import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getPlansToDisplay, getProductsToDisplay } from '../product-grid/utils';
-import useGetPlansGridProducts from '../use-get-plans-grid-products';
+import useProductSlugs from './hooks/use-product-slugs';
 import { JetpackFree } from './jetpack-free';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
@@ -19,24 +16,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	duration,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
-	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
-	const currentPlanSlug = currentPlan?.product_slug || null;
-	const { availableProducts, purchasedProducts, includedInPlanProducts } =
-		useGetPlansGridProducts( siteId );
-
-	const productSlugs = useMemo(
-		() =>
-			[
-				...getProductsToDisplay( {
-					duration,
-					availableProducts,
-					purchasedProducts,
-					includedInPlanProducts,
-				} ),
-				...getPlansToDisplay( { duration, currentPlanSlug } ),
-			].map( ( { productSlug } ) => productSlug ),
-		[ duration, availableProducts, purchasedProducts, includedInPlanProducts, currentPlanSlug ]
-	);
+	const productSlugs = useProductSlugs( siteId, duration );
 
 	return (
 		<div className="jetpack-product-store">

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -24,16 +24,17 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =
 		useGetPlansGridProducts( siteId );
 
-	const allItems = useMemo(
-		() => [
-			...getProductsToDisplay( {
-				duration,
-				availableProducts,
-				purchasedProducts,
-				includedInPlanProducts,
-			} ),
-			...getPlansToDisplay( { duration, currentPlanSlug } ),
-		],
+	const productSlugs = useMemo(
+		() =>
+			[
+				...getProductsToDisplay( {
+					duration,
+					availableProducts,
+					purchasedProducts,
+					includedInPlanProducts,
+				} ),
+				...getPlansToDisplay( { duration, currentPlanSlug } ),
+			].map( ( { productSlug } ) => productSlug ),
 		[ duration, availableProducts, purchasedProducts, includedInPlanProducts, currentPlanSlug ]
 	);
 
@@ -42,10 +43,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
 
 			<div className="jetpack-product-store__pricing-banner">
-				<IntroPricingBanner
-					productSlugs={ allItems.map( ( { productSlug } ) => productSlug ) }
-					siteId={ siteId ?? 'none' }
-				/>
+				<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
 			</div>
 
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -45,21 +45,10 @@
 	height: 120px;
 
 	margin-bottom: 1.25rem;
-    display: flex;
-    justify-content: center;
 
 	@include break-large {
 		height: 54px;
 
 		margin-bottom: 0;
 	}
-
-    .intro-pricing-banner, .intro-pricing-banner__sticky, .intro-pricing-banner__loading {
-        align-items: flex-start;
-
-        img {
-            min-width: 2em;
-            margin-inline-end: 0.5em;
-        }
-    }
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -45,10 +45,21 @@
 	height: 120px;
 
 	margin-bottom: 1.25rem;
+    display: flex;
+    justify-content: center;
 
 	@include break-large {
 		height: 54px;
 
 		margin-bottom: 0;
 	}
+
+    .intro-pricing-banner, .intro-pricing-banner__sticky, .intro-pricing-banner__loading {
+        align-items: flex-start;
+
+        img {
+            min-width: 2em;
+            margin-inline-end: 0.5em;
+        }
+    }
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .jetpack-product-store {
     &__jetpack-free {
         display: flex;
@@ -36,4 +39,16 @@
         border: 1px solid var( --color-neutral-100 );
         font-weight: 600;
     }
+}
+
+.jetpack-product-store__pricing-banner {
+	height: 120px;
+
+	margin-bottom: 1.25rem;
+
+	@include break-large {
+		height: 54px;
+
+		margin-bottom: 0;
+	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -13,3 +13,5 @@ export interface ProductStoreProps extends Pick< BasePageProps, 'urlQueryArgs' >
 }
 
 export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;
+
+export type ProductSlugProps = Pick< ProductStoreProps, 'duration' > & ProductStoreBaseProps;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -14,4 +14,4 @@ export interface ProductStoreProps extends Pick< BasePageProps, 'urlQueryArgs' >
 
 export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;
 
-export type ProductSlugProps = Pick< ProductStoreProps, 'duration' > & ProductStoreBaseProps;
+export type ProductSlugsProps = Pick< ProductStoreProps, 'duration' > & ProductStoreBaseProps;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,4 +1,4 @@
-import { BasePageProps } from '../types';
+import { BasePageProps, Duration } from '../types';
 
 export interface ProductStoreBaseProps {
 	siteId: number | null;
@@ -9,6 +9,7 @@ export interface ProductStoreProps extends Pick< BasePageProps, 'urlQueryArgs' >
 	 * Whether to show the licence activation dialog
 	 */
 	enableUserLicensesDialog?: boolean;
+	duration: Duration;
 }
 
 export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'calypso/../packages/i18n-calypso';
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
@@ -16,7 +15,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import LicensingActivationBanner from 'calypso/components/jetpack/licensing-activation-banner';
 import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
 import Main from 'calypso/components/main';
-import PricingHeader from 'calypso/jetpack-cloud/sections/pricing/header';
 import { MAIN_CONTENT_ID } from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useExperiment } from 'calypso/lib/explat';
@@ -61,7 +59,6 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const viewTrackerPath = getViewTrackerPath( rootUrl, siteSlugProp );
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 	const legacyPlan = planRecommendation ? planRecommendation[ 0 ] : null;
-	const translate = useTranslate();
 
 	const [ isLoadingUpsellPageExperiment, experimentAssignment ] = useExperiment(
 		'calypso_jetpack_upsell_page_2022_06'
@@ -225,10 +222,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 
 				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (
 					<>
-						<PricingHeader
-							urlQueryArgs={ urlQueryArgs }
-							title={ translate( 'Best-in-class products for your WordPress site' ) }
-						/>
+						{ header }
 
 						<ProductStore
 							enableUserLicensesDialog={ enableUserLicensesDialog }

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -233,6 +233,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 						<ProductStore
 							enableUserLicensesDialog={ enableUserLicensesDialog }
 							urlQueryArgs={ urlQueryArgs }
+							duration={ currentDuration }
 						/>
 					</>
 				) : (

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTranslate } from 'calypso/../packages/i18n-calypso';
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryJetpackUserLicenses from 'calypso/components/data/query-jetpack-user-licenses';
@@ -15,6 +16,7 @@ import QuerySites from 'calypso/components/data/query-sites';
 import LicensingActivationBanner from 'calypso/components/jetpack/licensing-activation-banner';
 import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
 import Main from 'calypso/components/main';
+import PricingHeader from 'calypso/jetpack-cloud/sections/pricing/header';
 import { MAIN_CONTENT_ID } from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useExperiment } from 'calypso/lib/explat';
@@ -59,6 +61,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const viewTrackerPath = getViewTrackerPath( rootUrl, siteSlugProp );
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 	const legacyPlan = planRecommendation ? planRecommendation[ 0 ] : null;
+	const translate = useTranslate();
 
 	const [ isLoadingUpsellPageExperiment, experimentAssignment ] = useExperiment(
 		'calypso_jetpack_upsell_page_2022_06'
@@ -221,10 +224,17 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 				/>
 
 				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (
-					<ProductStore
-						enableUserLicensesDialog={ enableUserLicensesDialog }
-						urlQueryArgs={ urlQueryArgs }
-					/>
+					<>
+						<PricingHeader
+							urlQueryArgs={ urlQueryArgs }
+							title={ translate( 'Best-in-class products for your WordPress site' ) }
+						/>
+
+						<ProductStore
+							enableUserLicensesDialog={ enableUserLicensesDialog }
+							urlQueryArgs={ urlQueryArgs }
+						/>
+					</>
 				) : (
 					<>
 						{ siteId && enableUserLicensesDialog && (


### PR DESCRIPTION
#### Proposed Changes

* Add an optional `title` property to the Jetpack cloud pricing `Header` component to override the existing header text. This allows us to be selective in how we render the header without changing existing components that use it.

* Render `Header` and `ProductStore` in the selector with the new title text.

* Display the `IntroPricingBanner` component in the `ProductStore`. This is mostly copy/paste to the existing implementation in the ProductGrid component. I did not make a re-usable component out of it so as to not complicate the current `ProductGrid` implementation.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Boot up this PR
   * Run `git fetch && git checkout add/pricing-page-header-and-banner`
   * Run yarn start-jetpack-cloud
   * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Or click on Jetpack Cloud live link below
   * Goto /pricing?flags=jetpack/pricing-page-rework-v1
 * Confirm that the Header text is visible with the correct text
 * Confirm that the pricing banner is visible
 
<img width="1282" alt="Screen Shot 2022-08-23 at 6 31 13 PM" src="https://user-images.githubusercontent.com/56598660/186136556-b2c447a3-eaa3-43d7-8baa-7d739a4fbac0.png">

 * Load the page without the new pricing page by going to http://jetpack.cloud.localhost:3000/pricing or via the Jetpack cloud live link below and goto `/pricing`.
    * Make sure that the header text is correct and did not load the new text.
    * Make sure that the pricing banner is loading properly.

 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202838239202323

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202838239202323