### PR TITLE
Stepper (Link in Bio, Newsletter): update placeholder text, minor sty…

### DIFF
--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -15,6 +15,7 @@ export type SiteIconWithPickerProps = {
 	imageEditorClassName?: string;
 	uploadFieldClassName?: string;
 	disabled?: boolean;
+	placeholderText?: string;
 };
 export function SiteIconWithPicker( {
 	selectedFile,
@@ -23,6 +24,7 @@ export function SiteIconWithPicker( {
 	imageEditorClassName,
 	uploadFieldClassName,
 	disabled,
+	placeholderText,
 }: SiteIconWithPickerProps ) {
 	const { __ } = useI18n();
 
@@ -80,7 +82,9 @@ export function SiteIconWithPicker( {
 						<Icon icon={ upload } />
 					) }
 					<span>
-						{ selectedFileUrl || siteIconUrl ? __( 'Replace' ) : __( 'Upload publication icon' ) }
+						{ selectedFileUrl || siteIconUrl
+							? __( 'Replace' )
+							: placeholderText || __( 'Add a site icon' ) }
 					</span>
 				</FormFileUpload>
 			</FormFieldset>

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -29,6 +29,11 @@ button.components-button.site-icon-with-picker__upload-button {
 
 	&.has-icon-or-image {
 		border: none;
+
+		span {
+			text-decoration: underline;
+			text-underline-position: under;
+		}
 	}
 
 	img {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -87,6 +87,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 		<form className="link-in-bio-setup__form" onSubmit={ handleSubmit }>
 			<SiteIconWithPicker
 				site={ site }
+				placeholderText={ __( 'Upload a profile image' ) }
 				onSelect={ ( file ) => {
 					setSelectedFile( file );
 					imageFileToBase64( file );


### PR DESCRIPTION
| Newsletter Setup  | Link in bio Setup |
| ------------- | ------------- |
|  <img width="444" alt="Screenshot 2022-08-23 at 13 44 54" src="https://user-images.githubusercontent.com/7000684/186149910-3bdce6c4-cac8-4798-86c7-2d14e7597451.png"> |  <img width="510" alt="Screenshot 2022-08-23 at 13 45 00" src="https://user-images.githubusercontent.com/7000684/186149961-19afc983-7595-42c0-9255-85d6255565c6.png"> |

#### Proposed Changes

* This PR update the placeholder text for the site icon, for the newsletter flow and link in bio flow.
* Also this updates the styling of the "Replace" text to be underlined.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Visit the [newsletter setup](http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter) and compare the text with the designs for the site icon
- Visit the [link in bio setup](http://calypso.localhost:3000/setup/linkInBioSetup?flow=link-in-bio) and compare the text with the designs for the site icon
- Make sure that the "Replace" text is underlined after a image has been uploaded