### PR TITLE
Update texts for LiB and newsletter flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
@@ -74,16 +74,16 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 	const completeLinkInBioFlow = () => {
 		setPendingAction( async () => {
 			setProgress( 0 );
-			setProgressTitle( __( 'Completing Purchase' ) );
+			setProgressTitle( __( 'Completing your purchase' ) );
 			await postSiteSettings();
 
 			setProgress( 0.5 );
-			setProgressTitle( __( 'Creating your Link in Bio' ) );
+			setProgressTitle( __( 'Cutting the ribbon. Popping a cork.' ) );
 
 			await wait( 1500 );
 
 			setProgress( 0.8 );
-			setProgressTitle( __( 'Preparing Next Steps' ) );
+			setProgressTitle( __( 'Flinging the doors open' ) );
 			await wait( 1500 );
 
 			await postSiteLogo();
@@ -95,7 +95,7 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 
 	const completeNewsletterFlow = () => {
 		setPendingAction( async () => {
-			setProgressTitle( __( 'Completing Purchase' ) );
+			setProgressTitle( __( 'Applying the last few stamps' ) );
 			setProgress( 0 );
 			await postSiteSettings();
 			setProgress( 0.3 );
@@ -103,6 +103,8 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 
 			await postSiteLogo();
 			setProgress( 1 );
+
+			setProgressTitle( __( 'Crisply folding your Newsletter' ) );
 			await wait( 2000 );
 			return { destination: 'subscribers' };
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -21,14 +21,14 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 	const introContent: IntroContent = {
 		newsletter: {
 			title: createInterpolateElement(
-				__( 'Your stories, right into your<br /> readers’ inbox, now!' ),
+				__( 'You’re 3 minutes away from <br /> a launch-ready Newsletter.' ),
 				{ br: <br /> }
 			),
 			buttonText: __( 'Create your newsletter' ),
 		},
 		'link-in-bio': {
 			title: createInterpolateElement(
-				__( 'Your short bio and links,<br /> accessible to your<br /> audience in minutes' ),
+				__( 'You’re 3 minutes away from <br /> a stand-out Link in Bio site.<br /> Ready? ' ),
 				{ br: <br /> }
 			),
 			buttonText: __( 'Create your link in bio' ),

--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -13,13 +13,20 @@ const useSteps = ( flowName ) => {
 	let steps = [];
 
 	switch ( flowName ) {
-		case 'newsletter':
 		case 'link-in-bio':
 			steps = [
-				{ title: __( 'Saving your preferences' ) },
-				{ title: __( 'Getting your Domain' ) },
-				{ title: __( 'Adding your Plan' ) },
-				{ title: __( 'Preparing Checkout' ) },
+				{ title: __( 'Great choices. Nearly there!' ) },
+				{ title: __( 'Shining and polishing your Bio' ) },
+				{ title: __( 'Mounting it on a marble pedestal' ) },
+				{ title: __( 'Looking good. Time for checkout!' ) },
+			];
+			break;
+		case 'newsletter':
+			steps = [
+				{ title: __( 'Excellent choices. Nearly there!' ) },
+				{ title: __( 'Smoothing down the stationery' ) },
+				{ title: __( 'Embossing all the envelopes' ) },
+				{ title: __( 'Let’s head to the checkout' ) },
 			];
 			break;
 		default:


### PR DESCRIPTION
## Proposed Changes

Add correct texts for Lib and Newsletter flows according to the new design.

NewsLetter:

<img width="735" alt="image" src="https://user-images.githubusercontent.com/2653810/186167194-da3b92c5-5ed9-4b7f-ab44-d424ae672475.png">
<img width="507" alt="image" src="https://user-images.githubusercontent.com/2653810/186167283-cf9f079e-a605-4de4-bd93-849c973a4c86.png">
<img width="502" alt="image" src="https://user-images.githubusercontent.com/2653810/186167339-c1478398-fbe9-4850-9392-73ae23b28dab.png">
<img width="456" alt="image" src="https://user-images.githubusercontent.com/2653810/186167483-961b9908-3678-4d46-83c6-3d90338c2b0d.png">




Link In Bio:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/2653810/186167578-93c73b3e-7191-4f97-89af-07fd7103eb05.png">
<img width="449" alt="image" src="https://user-images.githubusercontent.com/2653810/186167640-88f2292e-4cd5-4f81-be21-1c6bfa379d77.png">
<img width="434" alt="image" src="https://user-images.githubusercontent.com/2653810/186167680-3328e446-298d-4eee-825d-af905e105579.png">
<img width="336" alt="image" src="https://user-images.githubusercontent.com/2653810/186167739-2ec768b0-737a-4d72-90c8-015c9b7cbf9a.png">

## Testing Instructions

- Checkout this branch
- Run yarn start
- Visit the [newsletter setup](http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter) and compare the text with the designs for the site icon
- Visit the [link in bio setup](http://calypso.localhost:3000/setup/linkInBioSetup?flow=link-in-bio) and compare the text with the designs for the site icon
- Make sure that the "Replace" text is underlined after a image has been uploaded
