### PR TITLE
Theme/Plugin Bundling: Simplify seller stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -159,6 +159,15 @@ export const siteSetupFlow: Flow = {
 			switch ( currentStep ) {
 				case 'options': {
 					if ( intent === 'sell' ) {
+						/**
+						 * Part of the theme/plugin bundling is simplyfing the seller flow.
+						 *
+						 * Instead of having the user manually choose between "Start simple" and "More power", we let them select a theme and use the theme choice to determine which path to take.
+						 */
+						if ( isEnabled( 'themes/plugin-bundling' ) ) {
+							return navigate( 'designSetup' );
+						}
+
 						return navigate( 'storeFeatures' );
 					}
 					return navigate( 'bloggerStartingPoint' );


### PR DESCRIPTION
#### Proposed Changes

As part of the theme/plugin bundling, we're going to simplify how sellers end up going through the "Start simple" or "More power" flows.

#### Testing Instructions

**Start simple**
- Go to `http://calypso.localhost:3000/setup/goals?siteSlug=[SITESLUG]&flags=themes/plugin-bundling`
- Select "Sell online"
- Continue through the `vertical` and `options` steps
- You should land on the `designSetup` step
- Select a random free theme (eg Hari, Marl Dorna)
- You should go through the `processing` step and end up at the site dashboard

**More power**
_NOTE: You should already have a Business Plan for this site!_

- Go to `http://calypso.localhost:3000/setup/goals?siteSlug=[SITESLUG]&flags=themes/plugin-bundling`
- Select "Sell online"
- Continue through the `vertical` and `options` steps
- You should land on the `designSetup` step
- Select Baxter (currently the only theme with WooCommerce bundled)
- You should be redirected to the `plugin-bundle-flow` and end up at the `storeAddress` step

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #66815
