### PR TITLE
Checkout: Show sublabel for DIFM extra pages

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -13,6 +13,7 @@ import {
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackProductSlug,
 	isTitanMail,
+	isDIFMProduct,
 } from '@automattic/calypso-products';
 import {
 	CheckoutModal,
@@ -22,6 +23,7 @@ import {
 	Theme,
 	LineItem as LineItemType,
 } from '@automattic/composite-checkout';
+import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren } from 'react';
@@ -645,6 +647,46 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 				} ) }
 			</>
 		);
+	}
+
+	if ( isDIFMProduct( product ) ) {
+		const numberOfExtraPages =
+			product.quantity && product.price_tier_maximum_units
+				? product.quantity - product.price_tier_maximum_units
+				: 0;
+
+		if ( numberOfExtraPages > 0 ) {
+			const costOfExtraPages = formatCurrency(
+				product.item_original_cost_integer - product.item_original_cost_for_quantity_one_integer,
+				product.currency,
+				{
+					stripZeros: true,
+					isSmallestUnit: true,
+				}
+			);
+
+			return (
+				<>
+					{ translate( 'Service: %(productCost)s one-time fee', {
+						args: {
+							productCost: product.item_original_cost_for_quantity_one_display,
+						},
+					} ) }
+					<br></br>
+					{ translate(
+						'%(numberOfExtraPages)d Extra Page: %(costOfExtraPages)s one-time fee',
+						'%(numberOfExtraPages)d Extra Pages: %(costOfExtraPages)s one-time fee',
+						{
+							args: {
+								numberOfExtraPages,
+								costOfExtraPages,
+							},
+							count: numberOfExtraPages,
+						}
+					) }
+				</>
+			);
+		}
 	}
 
 	const isDomainRegistration = product.is_domain_registration;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	isAddOn,
 	isDomainRegistration,
@@ -649,7 +650,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		);
 	}
 
-	if ( isDIFMProduct( product ) ) {
+	if ( isEnabled( 'difm/allow-extra-pages' ) && isDIFMProduct( product ) ) {
 		const numberOfExtraPages =
 			product.quantity && product.price_tier_maximum_units
 				? product.quantity - product.price_tier_maximum_units

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	isAddOn,
 	isDomainRegistration,
@@ -650,7 +649,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		);
 	}
 
-	if ( isEnabled( 'difm/allow-extra-pages' ) && isDIFMProduct( product ) ) {
+	if ( isDIFMProduct( product ) ) {
 		const numberOfExtraPages =
 			product.quantity && product.price_tier_maximum_units
 				? product.quantity - product.price_tier_maximum_units

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -1,7 +1,8 @@
 import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { LineItemSublabelAndPrice } from '../src/checkout-line-items';
+import '@testing-library/jest-dom/extend-expect';
 
 describe( 'LineItemSublabelAndPrice', () => {
 	describe( 'DIFM product', () => {
@@ -40,35 +41,35 @@ describe( 'LineItemSublabelAndPrice', () => {
 			item_original_cost_for_quantity_one_display: '$499',
 		};
 
-		test( 'should return null if product does not support tiered pricing', () => {
-			const wrapper = shallow(
+		test( 'should return null if product does not support tiered pricing', async () => {
+			const { container } = render(
 				<LineItemSublabelAndPrice product={ difmProductWithoutTieredPricing } />
 			);
-			expect( wrapper.html() ).toEqual( '' );
+			expect( container.innerHTML ).toEqual( '' );
 		} );
 
-		test( 'should return empty fragment if the number of selected pages is less than the tier maximum', () => {
-			const wrapper = shallow(
+		test( 'should return empty fragment if the number of selected pages is less than the tier maximum', async () => {
+			const { container } = render(
 				<LineItemSublabelAndPrice product={ difmProductWithLessThanFiveExtraPages } />
 			);
-			expect( wrapper.html() ).toEqual( '' );
+			expect( container.innerHTML ).toEqual( '' );
 		} );
 
-		test( 'should return the sublabel if the number of selected pages is more than the tier maximum (singular)', () => {
-			const wrapper = shallow(
+		test( 'should return the sublabel if the number of selected pages is more than the tier maximum (singular)', async () => {
+			render(
 				<LineItemSublabelAndPrice product={ difmProductWithMoreThanFiveExtraPagesSingular } />
 			);
-			expect( wrapper.html() ).toEqual(
-				'Service: $499 one-time fee<br/>1 Extra Page: $69 one-time fee'
+			expect( screen.getByText( /Service/i ) ).toHaveTextContent(
+				'Service: $499 one-time fee1 Extra Page: $69 one-time fee' // The <br> tag is ignored here
 			);
 		} );
 
-		test( 'should return the sublabel if the number of selected pages is more than the tier maximum (plural)', () => {
-			const wrapper = shallow(
+		test( 'should return the sublabel if the number of selected pages is more than the tier maximum (plural)', async () => {
+			render(
 				<LineItemSublabelAndPrice product={ difmProductWithMoreThanFiveExtraPagesPlural } />
 			);
-			expect( wrapper.html() ).toEqual(
-				'Service: $499 one-time fee<br/>2 Extra Pages: $138 one-time fee'
+			expect( screen.getByText( /Service/i ) ).toHaveTextContent(
+				'Service: $499 one-time fee2 Extra Pages: $138 one-time fee' // The <br> tag is ignored here
 			);
 		} );
 	} );

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -4,6 +4,14 @@ import React from 'react';
 import { LineItemSublabelAndPrice } from '../src/checkout-line-items';
 import '@testing-library/jest-dom/extend-expect';
 
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => true,
+	__esModule: true,
+	default: function config( key: string ) {
+		return key;
+	},
+} ) );
+
 describe( 'LineItemSublabelAndPrice', () => {
 	describe( 'DIFM product', () => {
 		const emptyDIFMProduct = {

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -4,14 +4,6 @@ import React from 'react';
 import { LineItemSublabelAndPrice } from '../src/checkout-line-items';
 import '@testing-library/jest-dom/extend-expect';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: () => true,
-	__esModule: true,
-	default: function config( key: string ) {
-		return key;
-	},
-} ) );
-
 describe( 'LineItemSublabelAndPrice', () => {
 	describe( 'DIFM product', () => {
 		const emptyDIFMProduct = {

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -1,0 +1,75 @@
+import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { LineItemSublabelAndPrice } from '../src/checkout-line-items';
+
+describe( 'LineItemSublabelAndPrice', () => {
+	describe( 'DIFM product', () => {
+		const emptyDIFMProduct = {
+			...getEmptyResponseCartProduct(),
+			product_slug: 'wp_difm_lite',
+			bill_period: '-1',
+		};
+		const difmProductWithoutTieredPricing = {
+			...emptyDIFMProduct,
+			price_tier_maximum_units: null,
+			quantity: null,
+		};
+
+		const difmProductWithLessThanFiveExtraPages = {
+			...emptyDIFMProduct,
+			price_tier_maximum_units: 5,
+			quantity: 4,
+		};
+
+		const difmProductWithMoreThanFiveExtraPagesSingular = {
+			...emptyDIFMProduct,
+			price_tier_maximum_units: 5,
+			quantity: 6,
+			item_original_cost_integer: 49900 + ( 6 - 5 ) * 6900,
+			item_original_cost_for_quantity_one_integer: 49900,
+			item_original_cost_for_quantity_one_display: '$499',
+		};
+
+		const difmProductWithMoreThanFiveExtraPagesPlural = {
+			...emptyDIFMProduct,
+			price_tier_maximum_units: 5,
+			quantity: 7,
+			item_original_cost_integer: 49900 + ( 7 - 5 ) * 6900,
+			item_original_cost_for_quantity_one_integer: 49900,
+			item_original_cost_for_quantity_one_display: '$499',
+		};
+
+		test( 'should return null if product does not support tiered pricing', () => {
+			const wrapper = shallow(
+				<LineItemSublabelAndPrice product={ difmProductWithoutTieredPricing } />
+			);
+			expect( wrapper.html() ).toEqual( '' );
+		} );
+
+		test( 'should return empty fragment if the number of selected pages is less than the tier maximum', () => {
+			const wrapper = shallow(
+				<LineItemSublabelAndPrice product={ difmProductWithLessThanFiveExtraPages } />
+			);
+			expect( wrapper.html() ).toEqual( '' );
+		} );
+
+		test( 'should return the sublabel if the number of selected pages is more than the tier maximum (singular)', () => {
+			const wrapper = shallow(
+				<LineItemSublabelAndPrice product={ difmProductWithMoreThanFiveExtraPagesSingular } />
+			);
+			expect( wrapper.html() ).toEqual(
+				'Service: $499 one-time fee<br/>1 Extra Page: $69 one-time fee'
+			);
+		} );
+
+		test( 'should return the sublabel if the number of selected pages is more than the tier maximum (plural)', () => {
+			const wrapper = shallow(
+				<LineItemSublabelAndPrice product={ difmProductWithMoreThanFiveExtraPagesPlural } />
+			);
+			expect( wrapper.html() ).toEqual(
+				'Service: $499 one-time fee<br/>2 Extra Pages: $138 one-time fee'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

PT: pdh1Xd-Oi-p2
GH: 969-gh-Automattic/martech

The DIFM service currently includes 5 pages for the site build. We are in the process of shifting to a tiered pricing model for DIFM so that the user can purchase extra pages. If more than 5 pages are selected, this change adds a sublabel to the DIFM product on the checkout screen. 

The backend changes are in D85709-code. If tiered pricing is available, the `price_tier_maximum_units` field on the `product` object denotes the number of included pages (currently 5), and the `quantity` field denotes the number of pages selected by the user.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Without the tiered pricing change**
* Go to `/start/do-it-for-me`, and complete the flow till you reach checkout. There should be no sublabel visible.
<img width="599" alt="Screenshot 2022-08-23 at 6 13 23 PM" src="https://user-images.githubusercontent.com/5436027/186183424-263d0c7a-67cb-4838-9282-72c121290b95.png">

**With the tiered pricing change**
* Apply D85709-code
* Go to `/start/do-it-for-me?flags=difm/allow-extra-pages`. On the page picker step, select **less** than 5 pages. There should be no sublabel visible on checkout.
<img width="599" alt="Screenshot 2022-08-23 at 6 13 23 PM" src="https://user-images.githubusercontent.com/5436027/186183424-263d0c7a-67cb-4838-9282-72c121290b95.png">

* Go to `/start/do-it-for-me?flags=difm/allow-extra-pages`. On the page picker step, select **exactly** 6 pages. The sublabel should be visible at the checkout screen and the text should be in the singular form (1 Extra Page)
<img width="599" alt="Screenshot 2022-08-23 at 6 12 35 PM" src="https://user-images.githubusercontent.com/5436027/186184441-6a5019f4-6609-492e-b756-570a6250968f.png">

* Go to `/start/do-it-for-me?flags=difm/allow-extra-pages`. On the page picker step, select **more** than 6 pages. The sublabel should be visible at the checkout screen and the text should be in the plural form (7 Extra Pages)
<img width="598" alt="Screenshot 2022-08-23 at 5 51 47 PM" src="https://user-images.githubusercontent.com/5436027/186184832-da0136f1-e4a8-4367-a5fd-790caa88f5e0.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - Not required since the product is available only for EN.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#969