### PR TITLE
Marketplace: Fix the infinite loop in the Marketplace for pages with one result

### DIFF
--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -75,7 +75,9 @@ export const useWPORGInfinitePlugins = (
 				author,
 			} ),
 		{
-			select: ( data: InfiniteData< { plugins: Plugin[]; info: { page: number } } > ) => {
+			select: (
+				data: InfiniteData< { plugins: Plugin[]; info: { page: number; pages: number } } >
+			) => {
 				return {
 					...data,
 					plugins: extractPages( data.pages ),
@@ -83,6 +85,12 @@ export const useWPORGInfinitePlugins = (
 				};
 			},
 			getNextPageParam: ( lastPage ) => {
+				// When on last page, the next page is undefined, according to docs.
+				// @see: https://tanstack.com/query/v4/docs/reference/useInfiniteQuery
+				if ( lastPage.info.pages <= lastPage.info.page ) {
+					return undefined;
+				}
+
 				return ( lastPage.info.page || 0 ) + 1;
 			},
 			enabled: enabled,

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -23,6 +23,7 @@ interface WPORGResponse {
 	};
 	isLoading: boolean;
 	fetchNextPage?: () => void;
+	hasNextPage?: boolean;
 }
 
 interface WPCOMResponse {
@@ -98,6 +99,7 @@ const usePlugins = ( {
 		data: { plugins: wporgPluginsInfinite = [], pagination: wporgPaginationInfinite } = {},
 		isLoading: isFetchingWPORGInfinite,
 		fetchNextPage,
+		hasNextPage,
 	} = searchHook( wporgPluginsOptions, {
 		enabled:
 			infinite &&
@@ -157,12 +159,7 @@ const usePlugins = ( {
 	}
 
 	function fetchNextPageAndStop() {
-		if (
-			infinite &&
-			dotOrgPagination?.page &&
-			dotOrgPagination?.pages &&
-			dotOrgPagination.page >= dotOrgPagination.pages
-		) {
+		if ( ! hasNextPage ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Prevent calling fetchNextPage for Jetpack Search based on a generic flag.
* Fix useWPORGInfinitePlugins to use the proper next parameter on the last page. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link and go to Plugins > Add new plugin
* Search for `unicard` and open your browser's DevTools
* Notice that the page doesn't make an infinite number of requests to t.gif
* Repeat the steps above with the `?flags= marketplace-jetpack-plugin-search` enabled

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66864
