### PR TITLE
Signup: Always use Lettre for newsletter flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -113,7 +113,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'newsletter',
-			steps: [ 'domains', 'plans' ],
+			steps: [ 'domains', 'plans-newsletter' ],
 			destination: ( dependencies, localeSlug, goesThroughCheckout ) => {
 				return goesThroughCheckout
 					? `/setup/completingPurchase?flow=newsletter&siteSlug=${ dependencies.siteSlug }`

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -30,6 +30,7 @@ const stepNameToModuleName = {
 	'plans-starter': 'plans',
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
+	'plans-newsletter': 'plans',
 	'plans-personal': 'plans',
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -211,6 +211,15 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
+		// the only unique thing about plans-newsletter is that it provides themeSlugWithRepo dependency
+		'plans-newsletter': {
+			stepName: 'plans',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			optionalDependencies: [ 'emailItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isPlanFulfilled,
+		},
 
 		'plans-new': {
 			stepName: 'plans',

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -102,6 +102,13 @@ export class PlansStep extends Component {
 					this.props.goToNextStep();
 				}
 			);
+		} else if ( flowName === 'newsletter' ) {
+			// newsletter flow always uses pub/lettre
+			this.props.submitSignupStep( step, {
+				cartItem,
+				themeSlugWithRepo: 'pub/lettre',
+			} );
+			this.props.goToNextStep();
 		} else {
 			this.props.submitSignupStep( step, {
 				cartItem,

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -39,6 +39,7 @@
 	margin-top: 25px;
 }
 
+.signup__step.is-plans-newsletter .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans-launch .formatted-header__subtitle .button.is-borderless {
 	padding: 0;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -783,6 +783,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 	.signup__step.is-domains,
 	.signup__step.is-emails,
+	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans {
 		.formatted-header {
 			.formatted-header__title {
@@ -820,6 +821,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
+	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans {
 		.formatted-header__title {
 			font-weight: 500; /* stylelint-disable-line */
@@ -870,6 +872,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
  * and the current back button is redundent.
 */
 body.is-section-signup.is-white-signup {
+	.signup__step.is-plans-newsletter .step-wrapper__navigation,
 	.signup__step.is-plans .step-wrapper__navigation,
 	.signup__step.is-domains .step-wrapper__navigation {
 		@include breakpoint-deprecated( '<660px' ) {


### PR DESCRIPTION
#### Proposed Changes

* This sets `pub/lettre` theme to all sites created with `newsletter` flow.

#### Testing Instructions

1. Checkout this branch and run calypso.
2. Go to /setup?flow=newsletter.
3. Create a site.
4. It should have Lettre theme.
