### PR TITLE
plugin-bundle-flow: Use wooTransfer and wooInstallPlugins steps for woocommerce

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
@@ -1,5 +1,12 @@
 const pluginBundleSteps = {
-	woocommerce: [ 'storeAddress', 'businessInfo', 'wooConfirm', 'processing' ],
+	woocommerce: [
+		'storeAddress',
+		'businessInfo',
+		'wooConfirm',
+		'wooTransfer',
+		'wooInstallPlugins',
+		'processing',
+	],
 };
 
 export type BundledPlugin = keyof typeof pluginBundleSteps;

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -172,7 +172,8 @@ export const pluginBundleFlow: Flow = {
 					return exitFlow( `/home/${ siteSlug }` );
 				}
 
-				// TODO - Do we need this?
+				case 'wooTransfer':
+					return navigate( 'processing' );
 				case 'wooInstallPlugins':
 					return navigate( 'processing' );
 			}


### PR DESCRIPTION
#### Proposed Changes

* In the plugin-bundle flow in stepper, reuse the `wooTransfer` step to initiate an atomic transfer and the `wooInstallPlugins` step to install the woo software set.

#### Testing Instructions

* Have a simple site with a business plan.
* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE&notice=purchase-success`
* Choose baxter and click the "Start with Baxter" button in the top right
* You should be sent to the plugin-bundle flow.
  * There seem to be CSS issues? The progress bar at the top looks odd.
* Progress through the steps and when you end, you should have an atomic site with woocommerce installed.

Related to #65100
