### PR TITLE
BlazePress: Toggle promote-post server-side

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import { showDSP } from 'calypso/lib/promote-post';
+import { showDSP, usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 
 import './style.scss';
 
@@ -38,6 +38,12 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				setIsLoading( false );
 			} )();
 	}, [ isVisible ] );
+
+	const promoteWidgetStatus = usePromoteWidget();
+	if ( promoteWidgetStatus === PromoteWidgetStatus.DISABLED ) {
+		return <></>;
+	}
+
 	return (
 		<>
 			{ isVisible && (

--- a/client/landing/stepper/declarative-flow/blazepress-flow.ts
+++ b/client/landing/stepper/declarative-flow/blazepress-flow.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { AssertConditionResult, AssertConditionState, Flow } from './internals/types';
 import type { StepPath } from './internals/steps-repository';
 
@@ -34,16 +33,11 @@ export const blazePressFlow: Flow = {
 	},
 
 	useAssertConditions(): AssertConditionResult {
-		let result: AssertConditionResult = {
-			state: AssertConditionState.SUCCESS,
+		const result: AssertConditionResult = {
+			state: AssertConditionState.FAILURE,
+			message: 'this is not enabled yet',
 		};
 
-		if ( ! isEnabled( 'promote-post' ) ) {
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'this is not enabled yet',
-			};
-		}
 		return result;
 	},
 };

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -9,7 +8,11 @@ import FoldableCard from 'calypso/components/foldable-card';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasPaidEmailWithUs } from 'calypso/lib/emails';
-import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import {
+	recordDSPEntryPoint,
+	usePromoteWidget,
+	PromoteWidgetStatus,
+} from 'calypso/lib/promote-post';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
@@ -67,7 +70,7 @@ export const QuickLinks = ( {
 		,
 		flushDebouncedUpdateHomeQuickLinksToggleStatus,
 	] = useDebouncedCallback( updateHomeQuickLinksToggleStatus, 1000 );
-	const isPromotePostActive = config.isEnabled( 'promote-post' );
+	const isPromotePostActive = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
 	const customizerLinks =
 		isStaticHomePage && canEditPages ? (

--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -1,16 +1,20 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import megaphoneIllustration from 'calypso/assets/images/customer-home/illustration--megaphone.svg';
-import { loadDSPWidgetJS, recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import {
+	loadDSPWidgetJS,
+	recordDSPEntryPoint,
+	usePromoteWidget,
+	PromoteWidgetStatus,
+} from 'calypso/lib/promote-post';
 import { TASK_PROMOTE_POST } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const PromotePost = () => {
 	const translate = useTranslate();
-	const showPromotePost = config.isEnabled( 'promote-post' );
+	const showPromotePost = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 	const dispatch = useDispatch();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const trackDspAction = async () => {
@@ -19,7 +23,7 @@ const PromotePost = () => {
 
 	useEffect( () => {
 		loadDSPWidgetJS();
-	} );
+	}, [] );
 
 	return (
 		<>

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import classnames from 'classnames';
 import { createElement, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
@@ -62,7 +61,7 @@ const cardComponents = {
 	[ TASK_GO_MOBILE_IOS ]: GoMobile,
 	[ TASK_MARKETPLACE ]: Marketplace,
 	[ TASK_PODCASTING ]: Podcasting,
-	[ TASK_PROMOTE_POST ]: config.isEnabled( 'promote-post' ) && PromotePost,
+	[ TASK_PROMOTE_POST ]: PromotePost,
 	[ TASK_RENEW_EXPIRED_PLAN ]: Renew,
 	[ TASK_RENEW_EXPIRING_PLAN ]: Renew,
 	[ TASK_SITE_SETUP_CHECKLIST ]: SiteSetupList,

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -31,7 +31,7 @@ const cardComponents = {
 	[ EDUCATION_EARN ]: EducationEarn,
 	[ EDUCATION_STORE ]: EducationStore,
 	[ EDUCATION_WPCOURSES ]: WpCourses,
-	[ EDUCATION_PROMOTE_POST ]: config.isEnabled( 'promote-post' ) && PromotePost,
+	[ EDUCATION_PROMOTE_POST ]: PromotePost,
 	[ EDUCATION_FIND_SUCCESS ]: FindSuccess,
 	[ EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK ]: RespondToCustomerFeedback,
 	[ EDUCATION_BLOGGING_QUICK_START ]: BloggingQuickStart,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
@@ -1,26 +1,25 @@
-import config from '@automattic/calypso-config';
 import { useDispatch } from '@wordpress/data';
 import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import {
+	recordDSPEntryPoint,
+	usePromoteWidget,
+	PromoteWidgetStatus,
+} from 'calypso/lib/promote-post';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import { getPost } from 'calypso/state/posts/selectors';
 
-function PostActionsEllipsisMenuPromote( {
-	globalId,
-	postId,
-	isModuleActive,
-	bumpStatKey,
-	status,
-} ) {
+function PostActionsEllipsisMenuPromote( { globalId, postId, bumpStatKey, status } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const keyValue = globalId;
 	const { openModal } = useRouteModal( 'blazepress-widget', keyValue );
-	if ( ! isModuleActive ) {
+
+	const widgetEnabled = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+	if ( ! widgetEnabled ) {
 		return null;
 	}
 
@@ -47,7 +46,6 @@ function PostActionsEllipsisMenuPromote( {
 PostActionsEllipsisMenuPromote.propTypes = {
 	bumpStatKey: PropTypes.string,
 	globalId: PropTypes.string,
-	isModuleActive: PropTypes.bool,
 	postId: PropTypes.number,
 };
 
@@ -59,7 +57,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 
 	return {
 		type: post.type,
-		isModuleActive: config.isEnabled( 'promote-post' ),
 		postId: post.ID,
 		status: post.status,
 	};

--- a/client/my-sites/promote-post/index.js
+++ b/client/my-sites/promote-post/index.js
@@ -1,20 +1,8 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { promotedPosts } from './controller';
 
 export default () => {
-	if ( isEnabled( 'promote-post' ) ) {
-		page(
-			'/advertising/:site?',
-			siteSelection,
-			navigation,
-			promotedPosts,
-			makeLayout,
-			clientRender
-		);
-	} else {
-		page.redirect( '/' );
-	}
+	page( '/advertising/:site?', siteSelection, navigation, promotedPosts, makeLayout, clientRender );
 };

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -1,12 +1,13 @@
 import './style.scss';
-
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
+import page from 'page';
 import { useState } from 'react';
 import SitePreview from 'calypso/blocks/site-preview';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
@@ -24,6 +25,10 @@ export default function PromotedPosts() {
 		{ id: 'posts', name: translate( 'Ready to promote' ) },
 		{ id: 'campaigns', name: translate( 'Campaigns' ) },
 	];
+
+	if ( usePromoteWidget() === PromoteWidgetStatus.DISABLED ) {
+		page( '/' );
+	}
 
 	return (
 		<Main className="promote-post">

--- a/client/my-sites/stats/stats-list/action-promote.jsx
+++ b/client/my-sites/stats/stats-list/action-promote.jsx
@@ -1,9 +1,13 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
-import { recordDSPEntryPoint, showDSPWidgetModal } from 'calypso/lib/promote-post';
+import {
+	recordDSPEntryPoint,
+	showDSPWidgetModal,
+	usePromoteWidget,
+	PromoteWidgetStatus,
+} from 'calypso/lib/promote-post';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PromotePost = ( props ) => {
@@ -12,7 +16,7 @@ const PromotePost = ( props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const showPromotePost = config.isEnabled( 'promote-post' );
+	const showPromotePost = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import debugFactory from 'debug';
@@ -19,7 +18,6 @@ import Promote from './action-promote';
 import Spam from './action-spam';
 
 const debug = debugFactory( 'calypso:stats:list-item' );
-const showPromotePost = config.isEnabled( 'promote-post' );
 
 class StatsListItem extends Component {
 	static displayName = 'StatsListItem';
@@ -174,11 +172,9 @@ class StatsListItem extends Component {
 				}
 			}, this );
 
-			if ( showPromotePost ) {
-				actionItems.push(
-					<Promote postId={ data.id } key={ 'promote-post-' + data.id } moduleName={ moduleName } />
-				);
-			}
+			actionItems.push(
+				<Promote postId={ data.id } key={ 'promote-post-' + data.id } moduleName={ moduleName } />
+			);
 
 			if ( actionItems.length > 0 ) {
 				actionList = <ul className={ actionClassSet }>{ actionItems }</ul>;

--- a/config/development.json
+++ b/config/development.json
@@ -128,7 +128,6 @@
 		"plugins/plugin-details-layout": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
-		"promote-post": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -79,7 +79,6 @@
 		"plans/starter-plan": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
-		"promote-post": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,6 @@
 		"plugins/plugin-details-layout": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
-		"promote-post": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -92,7 +92,6 @@
 		"plugins/plugin-details-layout": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
-		"promote-post": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/test.json
+++ b/config/test.json
@@ -71,7 +71,6 @@
 		"plans/starter-plan": false,
 		"plugins/plugin-details-layout": false,
 		"press-this": true,
-		"promote-post": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,7 +103,6 @@
 		"plugins/plugin-details-layout": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
-		"promote-post": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,


### PR DESCRIPTION
This diff allows to control all appearances of links going to post promotion from the server. The `promote-post` feature flag is removed.

### Testing
1. Apply this diff.
2. Sandbox `public-api`.
3. Verify that everything works normally, ie: all links to Promote appear and work as expected.
4. `return false;` from the method `get_has_promote_widget` in this file: `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-me-settings-v1-1-endpoint.php` on your sandbox.
5. Reload your Calypso.
6. Verify you can't see the Promote links.
7. Make sure that cards are well tested since I couldn't make them appear (with or without this PR)