### PR TITLE
 Fix Marketplace Plugins Breadcrumb 2x Click Issue

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -20,7 +20,6 @@ const SearchBox = ( { isMobile, searchTerm, doSearch, searchBoxRef, isSearching 
 				pinned={ isMobile }
 				fitsContainer={ isMobile }
 				onSearch={ doSearch }
-				onSearchClose={ () => setQueryArgs( {} ) }
 				defaultValue={ searchTerm }
 				searchMode="on-enter"
 				placeholder={ translate( 'Try searching "ecommerce"' ) }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -36,7 +36,7 @@ const SearchBox = ( { isMobile, searchTerm, searchBoxRef, isSearching } ) => {
 };
 
 const PopularSearches = ( props ) => {
-	const { searchTerms, searchedTerm, searchRef, popularSearchesRef } = props;
+	const { searchTerms, searchedTerm, searchBoxRef, popularSearchesRef } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -49,7 +49,7 @@ const PopularSearches = ( props ) => {
 
 		// When loading a search via click instead of interacting with the search
 		// box input directly we need to set the search term separately.
-		searchRef?.current?.setKeyword( searchTerm );
+		searchBoxRef?.current?.setKeyword( searchTerm );
 		pageToSearch( searchTerm );
 	};
 
@@ -114,8 +114,8 @@ const SearchBoxHeader = ( props ) => {
 				/>
 			</div>
 			<PopularSearches
-				searchedTerm={ searchTerm }
 				searchBoxRef={ searchRef }
+				searchedTerm={ searchTerm }
 				searchTerms={ searchTerms }
 				popularSearchesRef={ popularSearchesRef }
 			/>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useCallback, useEffect } from 'react';
+import { Fragment, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -20,6 +20,7 @@ const SearchBox = ( { isMobile, searchTerm, doSearch, searchBoxRef, isSearching 
 				pinned={ isMobile }
 				fitsContainer={ isMobile }
 				onSearch={ doSearch }
+				onSearchClose={ () => setQueryArgs( {} ) }
 				defaultValue={ searchTerm }
 				searchMode="on-enter"
 				placeholder={ translate( 'Try searching "ecommerce"' ) }
@@ -95,16 +96,6 @@ const SearchBoxHeader = ( props ) => {
 		searchRef.current.setKeyword( keyword );
 		doSearch( keyword );
 	};
-
-	const clearSearch = useCallback( () => {
-		setQueryArgs( {} );
-	}, [] );
-
-	useEffect( () => {
-		if ( ! searchTerm ) {
-			clearSearch();
-		}
-	}, [ clearSearch, searchTerm ] );
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,12 +1,16 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useCallback } from 'react';
+import { Fragment, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
-const SearchBox = ( { isMobile, searchTerm, doSearch, searchBoxRef, isSearching } ) => {
+function pageToSearch( s ) {
+	setQueryArgs( '' !== s ? { s } : {} );
+}
+
+const SearchBox = ( { isMobile, searchTerm, searchBoxRef, isSearching } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -19,7 +23,7 @@ const SearchBox = ( { isMobile, searchTerm, doSearch, searchBoxRef, isSearching 
 				ref={ searchBoxRef }
 				pinned={ isMobile }
 				fitsContainer={ isMobile }
-				onSearch={ doSearch }
+				onSearch={ pageToSearch }
 				defaultValue={ searchTerm }
 				searchMode="on-enter"
 				placeholder={ translate( 'Try searching "ecommerce"' ) }
@@ -32,7 +36,7 @@ const SearchBox = ( { isMobile, searchTerm, doSearch, searchBoxRef, isSearching 
 };
 
 const PopularSearches = ( props ) => {
-	const { searchTerms, doSearch, searchedTerm, popularSearchesRef } = props;
+	const { searchTerms, searchedTerm, searchRef, popularSearchesRef } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -43,7 +47,10 @@ const PopularSearches = ( props ) => {
 			} )
 		);
 
-		doSearch( searchTerm );
+		// When loading a search via click instead of interacting with the search
+		// box input directly we need to set the search term separately.
+		searchRef?.current?.setKeyword( searchTerm );
+		pageToSearch( searchTerm );
 	};
 
 	return (
@@ -86,30 +93,29 @@ const SearchBoxHeader = ( props ) => {
 	const { searchTerm, title, searchTerms, isSticky, popularSearchesRef, isSearching, searchRef } =
 		props;
 
-	const doSearch = useCallback( ( receivedSearch ) => {
-		setQueryArgs( '' !== receivedSearch ? { s: receivedSearch } : {} );
-	}, [] );
-
-	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
-	const updateSearchBox = ( keyword ) => {
-		searchRef.current.setKeyword( keyword );
-		doSearch( keyword );
-	};
+	// Clear the keyword in search box on PluginsBrowser load if required.
+	// Required when navigating to a new plugins browser location
+	// without using close search ("X") to clear. e.g. When clicking
+	// clear in the search results header.
+	useEffect( () => {
+		if ( ! searchTerm ) {
+			searchRef?.current?.setKeyword( '' );
+		}
+	}, [ searchRef, searchTerm ] );
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>
 			<div className="search-box-header__header">{ title }</div>
 			<div className="search-box-header__search">
 				<SearchBox
-					doSearch={ doSearch }
 					searchTerm={ searchTerm }
 					searchBoxRef={ searchRef }
 					isSearching={ isSearching }
 				/>
 			</div>
 			<PopularSearches
-				doSearch={ updateSearchBox }
 				searchedTerm={ searchTerm }
+				searchBoxRef={ searchRef }
 				searchTerms={ searchTerms }
 				popularSearchesRef={ popularSearchesRef }
 			/>


### PR DESCRIPTION
#### Proposed Changes

P2: pdh6GB-1QJ-p2

Before this PR, on the Plugin details page, it took 2 clicks on the breadcrumb links before the linked page would load.

After this PR, it takes only 1 click.

![before-2-clicks](https://user-images.githubusercontent.com/140841/186030039-f0ab16db-8a3b-4090-bdca-ccced8f3f3ee.png)

`setQueryArgs` calls `page()`, the `useEffect` on page render was running when we try to render the `PluginsBrowser`.

This PR replaces that call with the previous approach of updating the search input box content via the `searchRef` directly. This PR also removes the `useCallback` usage as it doesn't seem required.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Visit the plugin details page for any plugin
For example: http://calypso.localhost:3000/plugins/woocommerce-table-rate-shipping/{your-test-site}
* Click on "Plugins" in the breadcrumb links. It should only take 1 click to load.
* (Regression test) Additionally, you should still be able to clear a search term by pressing the "X" found in the search bar, or by clearing the search box and pressing enter/return.

![clear-search-x](https://user-images.githubusercontent.com/140841/186224606-61396ed4-4800-4e90-98f0-c7e838c5b8bd.png)

* Test around this issue.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/66795