### PR TITLE
BlazePress: Read widget version from settings

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import { showDSP } from 'calypso/lib/promote-post';
+import { showDSP, usePromoteWidgetVersion } from 'calypso/lib/promote-post';
 
 import './style.scss';
 
@@ -19,6 +19,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const { isVisible = false, onClose = () => {} } = props;
 	const [ isLoading, setIsLoading ] = useState( true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
+	const widgetVersion = usePromoteWidgetVersion();
 
 	// Scroll to top on initial load regardless of previous page position
 	useEffect( () => {
@@ -34,7 +35,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					return;
 				}
 
-				await showDSP( props.siteId, props.postId, widgetContainer.current );
+				await showDSP( props.siteId, props.postId, widgetContainer.current, widgetVersion );
 				setIsLoading( false );
 			} )();
 	}, [ isVisible ] );

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -24,22 +24,23 @@ declare global {
 	}
 }
 
-export async function loadDSPWidgetJS(): Promise< void > {
+export async function loadDSPWidgetJS( version?: string | null ): Promise< void > {
 	// check if already loaded
 	if ( window.BlazePress ) {
 		return;
 	}
-	const src =
-		config( 'dsp_widget_js_src' ) + '?ver=' + Math.round( Date.now() / ( 1000 * 60 * 60 ) );
+	const ver = version ?? Math.round( Date.now() / ( 1000 * 60 * 60 ) );
+	const src = config( 'dsp_widget_js_src' ) + '?ver=' + ver;
 	await loadScript( src );
 }
 
 export async function showDSP(
 	siteId: number | string,
 	postId: number | string,
-	domNodeOrId?: HTMLElement | string | null
+	domNodeOrId?: HTMLElement | string | null,
+	version?: string | null
 ) {
-	await loadDSPWidgetJS();
+	await loadDSPWidgetJS( version );
 	return new Promise( ( resolve, reject ) => {
 		if ( window.BlazePress ) {
 			window.BlazePress.render( {
@@ -127,12 +128,31 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 		if ( settings ) {
 			const originalSetting = settings[ 'has_promote_widget' ];
 			if ( originalSetting !== undefined ) {
-				return originalSetting === true
+				return originalSetting[ 'enabled' ] === true
 					? PromoteWidgetStatus.ENABLED
 					: PromoteWidgetStatus.DISABLED;
 			}
 		}
 		return PromoteWidgetStatus.FETCHING;
+	} );
+	return value;
+};
+
+/**
+ * Hook to get the widget version
+ *
+ * @returns string | null
+ */
+export const usePromoteWidgetVersion = (): string | null => {
+	const value = useSelector( ( state ) => {
+		const settings = getUserSettings( state );
+		if ( settings ) {
+			const originalSetting = settings[ 'has_promote_widget' ];
+			if ( originalSetting !== undefined ) {
+				return originalSetting[ 'ver' ];
+			}
+		}
+		return null;
 	} );
 	return value;
 };

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -128,7 +128,7 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 		if ( settings ) {
 			const originalSetting = settings[ 'has_promote_widget' ];
 			if ( originalSetting !== undefined ) {
-				return originalSetting[ 'enabled' ] === true
+				return originalSetting === true
 					? PromoteWidgetStatus.ENABLED
 					: PromoteWidgetStatus.DISABLED;
 			}
@@ -147,9 +147,9 @@ export const usePromoteWidgetVersion = (): string | null => {
 	const value = useSelector( ( state ) => {
 		const settings = getUserSettings( state );
 		if ( settings ) {
-			const originalSetting = settings[ 'has_promote_widget' ];
+			const originalSetting = settings[ 'promote_widget_version' ];
 			if ( originalSetting !== undefined ) {
-				return originalSetting[ 'ver' ];
+				return originalSetting;
 			}
 		}
 		return null;

--- a/client/state/selectors/get-user-setting.ts
+++ b/client/state/selectors/get-user-setting.ts
@@ -2,7 +2,7 @@ import type { AppState } from 'calypso/types';
 
 import 'calypso/state/user-settings/init';
 
-export type UserSettingValue = boolean | number | string;
+export type UserSettingValue = boolean | number | string | Record< string, any >;
 
 /**
  * Given a settingName, returns the value of that setting if it exists or null

--- a/client/state/selectors/get-user-setting.ts
+++ b/client/state/selectors/get-user-setting.ts
@@ -2,7 +2,7 @@ import type { AppState } from 'calypso/types';
 
 import 'calypso/state/user-settings/init';
 
-export type UserSettingValue = boolean | number | string | Record< string, any >;
+export type UserSettingValue = boolean | number | string;
 
 /**
  * Given a settingName, returns the value of that setting if it exists or null


### PR DESCRIPTION
This PR starts reading the widget version from the user settings.

### Testing
1. Apply this diff to your sandbox if not merged: D86406-code
2. Apply this diff.
3. Filter for `widget` on developer tools > network
4. Open the widget
5. Verify the `widget.js` `ver` parameter corresponds with the one set in D86406-code, change it to see if it affects the value correctly.