### PR TITLE
Sites Management Page: Add `title=""` attributes to the buttons

### DIFF
--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -63,6 +63,7 @@ export const SitesDisplayModeSwitcher = ( {
 			<Button
 				role="radio"
 				aria-label={ __( 'Tile view' ) }
+				title={ __( 'Switch to tile view' ) }
 				onClick={ () => onDisplayModeChange( 'tile' ) }
 				icon={ <Gridicon icon="grid" /> }
 				isPressed={ displayMode === 'tile' }
@@ -70,6 +71,7 @@ export const SitesDisplayModeSwitcher = ( {
 			<Button
 				role="radio"
 				aria-label={ __( 'List view' ) }
+				title={ __( 'Switch to list view' ) }
 				onClick={ () => onDisplayModeChange( 'list' ) }
 				icon={ <Gridicon icon="list-unordered" /> }
 				isPressed={ displayMode === 'list' }


### PR DESCRIPTION
## Proposed Changes

Adds `title=""` attributes to the buttons:

<img width="372" alt="image" src="https://user-images.githubusercontent.com/36432/186239833-d57526bd-2552-401a-bf40-ac811d956ea2.png">

<img width="332" alt="image" src="https://user-images.githubusercontent.com/36432/186239865-81fa9539-fd6b-4d3f-8e89-a81771592637.png">

## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Hover over the buttons to see the titles display.