### PR TITLE
Jetpack Agency Dashboard: fix broken link to plugin management area

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import { urlToSlug } from 'calypso/lib/url';
 import type {
 	AllowedTypes,
 	SiteData,
@@ -220,12 +221,15 @@ const getLinks = (
 } => {
 	let link = '';
 	let isExternalLink = false;
+
+	const siteUrlWithSupportForSecondarySites = urlToSlug( siteUrl );
+
 	switch ( type ) {
 		case 'backup': {
 			if ( status === 'inactive' ) {
 				link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-backup-realtime&source=dashboard`;
 			} else {
-				link = `/backup/${ siteUrl }`;
+				link = `/backup/${ siteUrlWithSupportForSecondarySites }`;
 			}
 			break;
 		}
@@ -233,7 +237,7 @@ const getLinks = (
 			if ( status === 'inactive' ) {
 				link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-scan&source=dashboard`;
 			} else {
-				link = `/scan/${ siteUrl }`;
+				link = `/scan/${ siteUrlWithSupportForSecondarySites }`;
 			}
 			break;
 		}
@@ -248,12 +252,14 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
-			link = `https://wordpress.com/plugins/updates/${ siteUrl }`;
+			link = `https://wordpress.com/plugins/updates/${ siteUrlWithSupportForSecondarySites }`;
 			isExternalLink = true;
 			// FIXME: Remove this condition when we enable plugin management in production
 			if ( config.isEnabled( 'jetpack/plugin-management' ) ) {
 				link =
-					status === 'warning' ? `/plugins/updates/${ siteUrl }` : `/plugins/manage/${ siteUrl }`;
+					status === 'warning'
+						? `/plugins/updates/${ siteUrlWithSupportForSecondarySites }`
+						: `/plugins/manage/${ siteUrlWithSupportForSecondarySites }`;
 				isExternalLink = false;
 			}
 			break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -253,7 +253,7 @@ const getLinks = (
 			// FIXME: Remove this condition when we enable plugin management in production
 			if ( config.isEnabled( 'jetpack/plugin-management' ) ) {
 				link =
-					status === 'warning' ? `/plugin/updates/${ siteUrl }` : `/plugins/manage/${ siteUrl }`;
+					status === 'warning' ? `/plugins/updates/${ siteUrl }` : `/plugins/manage/${ siteUrl }`;
 				isExternalLink = false;
 			}
 			break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -222,14 +222,14 @@ const getLinks = (
 	let link = '';
 	let isExternalLink = false;
 
-	const siteUrlWithSupportForSecondarySites = urlToSlug( siteUrl );
+	const siteUrlWithMultiSiteSupport = urlToSlug( siteUrl );
 
 	switch ( type ) {
 		case 'backup': {
 			if ( status === 'inactive' ) {
 				link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-backup-realtime&source=dashboard`;
 			} else {
-				link = `/backup/${ siteUrlWithSupportForSecondarySites }`;
+				link = `/backup/${ siteUrlWithMultiSiteSupport }`;
 			}
 			break;
 		}
@@ -237,7 +237,7 @@ const getLinks = (
 			if ( status === 'inactive' ) {
 				link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-scan&source=dashboard`;
 			} else {
-				link = `/scan/${ siteUrlWithSupportForSecondarySites }`;
+				link = `/scan/${ siteUrlWithMultiSiteSupport }`;
 			}
 			break;
 		}
@@ -252,14 +252,14 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
-			link = `https://wordpress.com/plugins/updates/${ siteUrlWithSupportForSecondarySites }`;
+			link = `https://wordpress.com/plugins/updates/${ siteUrlWithMultiSiteSupport }`;
 			isExternalLink = true;
 			// FIXME: Remove this condition when we enable plugin management in production
 			if ( config.isEnabled( 'jetpack/plugin-management' ) ) {
 				link =
 					status === 'warning'
-						? `/plugins/updates/${ siteUrlWithSupportForSecondarySites }`
-						: `/plugins/manage/${ siteUrlWithSupportForSecondarySites }`;
+						? `/plugins/updates/${ siteUrlWithMultiSiteSupport }`
+						: `/plugins/manage/${ siteUrlWithMultiSiteSupport }`;
 				isExternalLink = false;
 			}
 			break;


### PR DESCRIPTION
#### Proposed Changes

* The link to plugin management is broken due to having a wrong path. Instead of it pointing to `/plugins/update/:site`, it points to `/plugin/update/:site` (notice the missing `s`).

#### Testing Instructions
##### Prerequisites

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

##### Instructions

* Run `git checkout fix/link-to-plugin-management-in-agency-dashboard` and `yarn start-jetpack-cloud`.
* Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
* Look for a site with a plugin needing an update (you can find one by the yellow label in the Plugin Updates column.
* Click on the label.
* Make sure you're redirected to the plugin management area, and the link works.
 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202835755237001