### PR TITLE
Checkout: Update the Marketplace agreement border color to the error color (red) instead of blue

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
@@ -4,8 +4,11 @@ import { useState } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 
-const CheckboxTermsWrapper = styled( FormLabel )`
+const CheckboxTermsWrapper = styled( FormLabel )< { displayErrorMessage: boolean } >`
 	padding: 24px 24px 24px 59px;
+	border: ${ ( props ) =>
+		props.displayErrorMessage ? '3px solid var( --color-error )' : 'initial' };
+	border-radius: ${ ( props ) => ( props.displayErrorMessage ? '3px' : 'initial' ) };
 `;
 
 const StyledFormCheckbox = styled( FormCheckbox )`
@@ -47,11 +50,7 @@ function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }
 	};
 
 	return (
-		<CheckboxTermsWrapper
-			style={
-				displayErrorMessage ? { border: '3px solid var( --color-error )', borderRadius: '3px' } : {}
-			}
-		>
+		<CheckboxTermsWrapper displayErrorMessage={ displayErrorMessage }>
 			<StyledFormCheckbox
 				onChange={ handleChange }
 				onBlur={ () => setTouched( true ) }

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-developer-account.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { useState } from 'react';
@@ -37,7 +36,6 @@ type Props = ExternalProps & LocalizeProps;
 
 function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }: Props ) {
 	const [ touched, setTouched ] = useState( false );
-	const theme = useTheme();
 	const displayErrorMessage = ( isSubmitted || touched ) && ! isAccepted;
 
 	const message = translate(
@@ -51,9 +49,7 @@ function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }
 	return (
 		<CheckboxTermsWrapper
 			style={
-				displayErrorMessage
-					? { border: `3px solid ${ theme.colors.highlight }`, borderRadius: '3px' }
-					: {}
+				displayErrorMessage ? { border: '3px solid var( --color-error )', borderRadius: '3px' } : {}
 			}
 		>
 			<StyledFormCheckbox


### PR DESCRIPTION
#### Proposed Changes

Update the border color to the error color (red) instead of blue

| Before  | After |
| ------------- | ------------- |
|<img width="625" alt="Screen Shot 2022-08-23 at 16 20 47" src="https://user-images.githubusercontent.com/5039531/186259203-c03f54d8-94bc-42de-8e78-b1a30dcc057c.png">|<img width="625" alt="Screen Shot 2022-08-23 at 16 21 30" src="https://user-images.githubusercontent.com/5039531/186259390-9e285162-af9d-419c-b80e-f1e249a39373.png">|



#### Testing Instructions
1. Navigate to the plugins page of a site that allows buying Plugins (Pro, Business or eCommerce)
2. Click on a Marketplace plugin, for example `/plugins/automatewoo/:siteId`
3. Click on `Purchase and activate`
4. Ensure there is a checkbox on top of the `Pay` button
5. Click on the `Pay` button
7. Ensure the checkout process is not completed, the checkbox above is highlighted in red and there is an error message indicating that `The terms above need to be accepted`
8. Check the checkbox
9. Ensure the blue highlighting border is removed and the error message disappears.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---

cc: @SaxonF 

Fixes #66055