### PR TITLE
Theme/Plugin Bundling: Adds the plugin-bundle-flow to the stepper global CSS

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -52,6 +52,7 @@ button {
  * Site Setup
  */
 .site-setup,
+.plugin-bundle,
 .newsletter-setup,
 .patterns,
 .link-in-bio-setup,


### PR DESCRIPTION
#### Proposed Changes

This primarily fixes the progress bar but also affects some other less
noticeable layout differences.

#### Testing Instructions

Prior to applying this branch, go to `http://calypso.localhost:3000/setup/storeAddress?siteSlug=[SITESLUG]&flow=plugin-bundle` and notice the progress bar looks like this:
![image](https://user-images.githubusercontent.com/917632/186259619-a789e7b0-f9b0-4aad-9540-f3e0f82cd960.png)

Apply this branch and go to the above url and you should see the correct progress bar.
![image](https://user-images.githubusercontent.com/917632/186259665-b2a62d7b-b235-4bcc-8e42-11c168fd666b.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
