### PR TITLE
Shopping Cart: Update getCartKey to use SiteDetails TypeScript type

### DIFF
--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -1,4 +1,4 @@
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { CartKey } from '@automattic/shopping-cart';
 
 export default function getCartKey( {
@@ -6,7 +6,7 @@ export default function getCartKey( {
 	isLoggedOutCart,
 	isNoSiteCart,
 }: {
-	selectedSite: SiteData | undefined | null;
+	selectedSite: SiteDetails | undefined | null;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 } ): CartKey | undefined {

--- a/client/state/sites/selectors/get-site.js
+++ b/client/state/sites/selectors/get-site.js
@@ -13,7 +13,7 @@ let getSiteCache = new WeakMap();
  *
  * @param  {object}  state  Global state tree
  * @param  {number|string}  siteIdOrSlug Site ID or site slug
- * @returns {import('calypso/state/ui/selectors/site-data').SiteData|null|undefined}        Site object
+ * @returns {import('@automattic/data-stores').SiteDetails|null|undefined}        Site object
  */
 export default function getSite( state, siteIdOrSlug ) {
 	const rawSite = getRawSite( state, siteIdOrSlug ) || getSiteBySlug( state, siteIdOrSlug );

--- a/client/state/ui/selectors/get-selected-site.ts
+++ b/client/state/ui/selectors/get-selected-site.ts
@@ -1,21 +1,15 @@
 import getSite from 'calypso/state/sites/selectors/get-site';
 import getSelectedSiteId from './get-selected-site-id';
-
-/**
- * @typedef { import("./site-data").SiteData } SiteData
- */
+import type { SiteDetails } from '@automattic/data-stores';
+import type { AppState } from 'calypso/types';
 
 /**
  * Returns the site object for the currently selected site.
- *
- * @param  {object}  state  Global state tree
- * @returns {SiteData|null}        Selected site
  */
-export default function getSelectedSite( state ) {
+export default function getSelectedSite( state: AppState ): SiteDetails | null | undefined {
 	const siteId = getSelectedSiteId( state );
 	if ( ! siteId ) {
 		return null;
 	}
-
 	return getSite( state, siteId );
 }


### PR DESCRIPTION
#### Proposed Changes

Another attempt to extract some changes from https://github.com/Automattic/wp-calypso/pull/66729 to a smaller PR.

TBD

#### Testing Instructions

TBD