### PR TITLE
[calypso/client][etk] Update Sentry packages

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -70,7 +70,7 @@
 		"@babel/core": "^7.17.5",
 		"@emotion/react": "^11.4.1",
 		"@popperjs/core": "^2.10.2",
-		"@sentry/browser": "^7.5.1",
+		"@sentry/browser": "^7.11.1",
 		"@wordpress/a11y": "^3.9.0",
 		"@wordpress/api-fetch": "^6.6.0",
 		"@wordpress/base-styles": "^4.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -67,7 +67,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
 		"@github/webauthn-json": "^0.4.1",
-		"@sentry/react": "^7.5.1",
+		"@sentry/react": "^7.11.1",
 		"@stripe/react-stripe-js": "^1.4.1",
 		"@stripe/stripe-js": "^1.17.1",
 		"@wordpress/a11y": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1604,7 +1604,7 @@ __metadata:
     "@babel/core": ^7.17.5
     "@emotion/react": ^11.4.1
     "@popperjs/core": ^2.10.2
-    "@sentry/browser": ^7.5.1
+    "@sentry/browser": ^7.11.1
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@types/node": ^15.0.2
@@ -4921,15 +4921,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:7.5.1, @sentry/browser@npm:^7.5.1":
-  version: 7.5.1
-  resolution: "@sentry/browser@npm:7.5.1"
+"@sentry/browser@npm:7.11.1, @sentry/browser@npm:^7.11.1":
+  version: 7.11.1
+  resolution: "@sentry/browser@npm:7.11.1"
   dependencies:
-    "@sentry/core": 7.5.1
-    "@sentry/types": 7.5.1
-    "@sentry/utils": 7.5.1
+    "@sentry/core": 7.11.1
+    "@sentry/types": 7.11.1
+    "@sentry/utils": 7.11.1
     tslib: ^1.9.3
-  checksum: c27f263792744547c7af7d6d59a8a51cb49d52ffe456cb79990b5ec8c661be6ab6e998237472ef2e13a243c0a7c5f4e412b15d5b29da03ed2cc11a6aaec95559
+  checksum: 0a749440b6851a19ab6dde7da1fb271e3f5a4170dcd6eb253a405d896e42513b9e32c0aaea64c2c666ab3224d81e122d9758aea79181bbb80b13f659405bbb69
   languageName: node
   linkType: hard
 
@@ -4950,58 +4950,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.5.1":
-  version: 7.5.1
-  resolution: "@sentry/core@npm:7.5.1"
+"@sentry/core@npm:7.11.1":
+  version: 7.11.1
+  resolution: "@sentry/core@npm:7.11.1"
   dependencies:
-    "@sentry/hub": 7.5.1
-    "@sentry/types": 7.5.1
-    "@sentry/utils": 7.5.1
+    "@sentry/hub": 7.11.1
+    "@sentry/types": 7.11.1
+    "@sentry/utils": 7.11.1
     tslib: ^1.9.3
-  checksum: 84020075fc861320d3ee997e7e355dd74cf4c5620f281515ca9bc2df331b3908ead125c8efbf62460a8841070a88957268ecfa1af91634b39afdd8503169540d
+  checksum: 42fa7ef174a6970cf0319cb5881f0f1f25f1dea7ddb37ce813a6992d2ca6309d9b621a1ce1e378090863d81b766b06b29fd4efbcffe55cc6efda2a00667b0f2b
   languageName: node
   linkType: hard
 
-"@sentry/hub@npm:7.5.1":
-  version: 7.5.1
-  resolution: "@sentry/hub@npm:7.5.1"
+"@sentry/hub@npm:7.11.1":
+  version: 7.11.1
+  resolution: "@sentry/hub@npm:7.11.1"
   dependencies:
-    "@sentry/types": 7.5.1
-    "@sentry/utils": 7.5.1
+    "@sentry/types": 7.11.1
+    "@sentry/utils": 7.11.1
     tslib: ^1.9.3
-  checksum: 9f4e4704e52fd98a370322428189444b7487123454e439e4d75ec7ffa16001d457b70cd26fc3ff3787e07d2ece8a10defcca4678f79d26fecde7b93f4b1251ea
+  checksum: fdcca8e6074aa6759db587888a7dfb016ce64e7a0acd12588645594a1f199fad2eff5d21cafe7a90ccb06e0f66b6c52c2b77b568b44ff012e11cddab3da15e4f
   languageName: node
   linkType: hard
 
-"@sentry/react@npm:^7.5.1":
-  version: 7.5.1
-  resolution: "@sentry/react@npm:7.5.1"
+"@sentry/react@npm:^7.11.1":
+  version: 7.11.1
+  resolution: "@sentry/react@npm:7.11.1"
   dependencies:
-    "@sentry/browser": 7.5.1
-    "@sentry/types": 7.5.1
-    "@sentry/utils": 7.5.1
+    "@sentry/browser": 7.11.1
+    "@sentry/types": 7.11.1
+    "@sentry/utils": 7.11.1
     hoist-non-react-statics: ^3.3.2
     tslib: ^1.9.3
   peerDependencies:
     react: 15.x || 16.x || 17.x || 18.x
-  checksum: 6ba1d84ca37fa55f625abfa7752ae62c0237517199c7df2f00cdf7c85887ec41b6db47fa6803819b9f3dcf5ce7ea9aabe01e9c644f70aec5bae294916fa968a1
+  checksum: 404dd621dd2c4f00826cc7f717942c7a897d0213c23e5715022d5526741973e8f6a5a3f7fa439ce5740f95228a4339d6a033dba69694017125cc167cb5721c6f
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.5.1":
-  version: 7.5.1
-  resolution: "@sentry/types@npm:7.5.1"
-  checksum: d4b5ce3d9e23e9c9bcdb7f0166ed7e54af74425eabb3dfc87c5bd76869c8cc60dd6a972a06bd6ea933c8d3a4e640fd4a2da5374958dcce7511760f27495b241a
+"@sentry/types@npm:7.11.1":
+  version: 7.11.1
+  resolution: "@sentry/types@npm:7.11.1"
+  checksum: afe2517116386c06005473cd60d8d91f3e8a67262eac3f25c738afbe5e670413ba70c16c1214c1b0a949e9f17318223a7310863c6b5497312947fb0c104aaaeb
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.5.1":
-  version: 7.5.1
-  resolution: "@sentry/utils@npm:7.5.1"
+"@sentry/utils@npm:7.11.1":
+  version: 7.11.1
+  resolution: "@sentry/utils@npm:7.11.1"
   dependencies:
-    "@sentry/types": 7.5.1
+    "@sentry/types": 7.11.1
     tslib: ^1.9.3
-  checksum: 7e63a706a5a0e0b381ec8de959172bd0b75f2755bfc21b0095c11ec144aec2145f65aa966ce08d756a24aaa4423633c1ff7601c0b347b1f31c3c826588473322
+  checksum: e8fff3d70742d65aec0264d8c9eff85bedf124a7dd9e114d94c085b6aa1b94efdeb1c8160601d54f7f7fcf852f51784360f9d7edb71bdd40c4ee815e4a2493c9
   languageName: node
   linkType: hard
 
@@ -12548,7 +12548,7 @@ __metadata:
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@github/webauthn-json": ^0.4.1
-    "@sentry/react": ^7.5.1
+    "@sentry/react": ^7.11.1
     "@sentry/webpack-plugin": ^1.18.8
     "@stripe/react-stripe-js": ^1.4.1
     "@stripe/stripe-js": ^1.17.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Sentry npm packages to their latest versions on Calypso client and ETK.

#### Testing instructions

- Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/64687.
- All tests must pass.
