### PR TITLE
Sites Management Dashboard: Use logical properties for margin and spacing

### DIFF
--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -11,24 +11,24 @@ const NoSitesLayout = styled( EmptyContent )`
 
 	${ ( { illustration } ) =>
 		! illustration && {
-			marginTop: '10%',
+			marginBlockStart: '10%',
 		} }
 
 	.empty-content__illustration {
-		margin-bottom: 30px;
+		margin-block-end: 30px;
 	}
 `;
 
 const SecondaryText = styled.p`
 	max-width: 550px;
 	font-size: 14px;
-	margin-bottom: 0px;
+	margin-block-end: 0px;
 `;
 
 const Title = styled.div`
 	font-family: 'Recoleta', 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
 	font-size: 32px;
-	margin-bottom: 20px;
+	margin-block-end: 20px;
 `;
 
 type SitesContainerProps = {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -20,7 +20,8 @@ const FilterBar = styled.div( {
 	display: 'flex',
 	alignItems: 'center',
 	gap: '16px',
-	padding: '32px 0',
+	paddingBlock: '32px',
+	paddingInline: 0,
 
 	flexDirection: 'column',
 
@@ -29,7 +30,7 @@ const FilterBar = styled.div( {
 	},
 
 	[ MEDIA_QUERIES.mediumOrSmaller ]: {
-		padding: '16px 0',
+		paddingBlock: '16px',
 	},
 } );
 

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -23,12 +23,12 @@ const MAX_PAGE_WIDTH = '1280px';
 // want there to be some padding that extends all around the page, but the header's
 // background color and border needs to be able to extend into that padding.
 const pagePadding = {
-	paddingLeft: '32px',
-	paddingRight: '32px',
+	paddingInlineStart: '32px',
+	paddingInlineEnd: '32px',
 
 	[ MEDIA_QUERIES.mediumOrSmaller ]: {
-		paddingLeft: '16px',
-		paddingRight: '16px',
+		paddingInlineStart: '16px',
+		paddingInlineEnd: '16px',
 	},
 };
 
@@ -37,8 +37,8 @@ const PageHeader = styled.div( {
 
 	backgroundColor: 'var( --studio-white )',
 
-	paddingTop: '24px',
-	paddingBottom: '24px',
+	paddingBlockStart: '24px',
+	paddingBlockEnd: '24px',
 
 	[ MEDIA_QUERIES.mediumOrSmaller ]: {
 		padding: '16px',
@@ -50,12 +50,14 @@ const PageHeader = styled.div( {
 const PageBodyWrapper = styled.div( {
 	...pagePadding,
 	maxWidth: MAX_PAGE_WIDTH,
-	margin: '0 auto',
+	marginBlock: 0,
+	marginInline: 'auto',
 } );
 
 const HeaderControls = styled.div( {
 	maxWidth: MAX_PAGE_WIDTH,
-	margin: '0 auto',
+	marginBlock: 0,
+	marginInline: 'auto',
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
@@ -70,18 +72,22 @@ const DashboardHeading = styled.h1( {
 } );
 
 const sitesMargin = css( {
-	margin: '0 0 1.5em',
+	marginBlockStart: 0,
+	marginInline: 0,
+	marginBlockEnd: '1.5em',
 } );
 
 const HiddenSitesMessageContainer = styled.div( {
 	color: 'var( --color-text-subtle )',
 	fontSize: '14px',
-	padding: '16px 0 24px 0',
+	paddingInline: 0,
+	paddingBlockStart: '16px',
+	paddingBlockEnd: '24px',
 	textAlign: 'center',
 } );
 
 const HiddenSitesMessage = styled.div( {
-	marginBottom: '1em',
+	marginBlockEnd: '1em',
 } );
 
 export function SitesDashboard( {

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -8,7 +8,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 
 const container = css( {
-	marginLeft: 'auto',
+	marginInlineStart: 'auto',
 	display: 'flex',
 	gap: '10px',
 } );

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -85,7 +85,7 @@ const HostingConfigItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 
 const alignExternalIcon = css`
 	.gridicons-external {
-		top: 0px;
+		inset-block-start: 0px;
 	}
 `;
 

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -12,7 +12,12 @@ import { SiteItemThumbnail } from './sites-site-item-thumbnail';
 import { SiteName } from './sites-site-name';
 import { SiteUrl, Truncated } from './sites-site-url';
 
-const badges = css( { display: 'flex', gap: '8px', alignItems: 'center', marginLeft: 'auto' } );
+const badges = css( {
+	display: 'flex',
+	gap: '8px',
+	alignItems: 'center',
+	marginInlineStart: 'auto',
+} );
 
 export const siteThumbnail = css( {
 	aspectRatio: '16 / 9',
@@ -28,7 +33,7 @@ const ellipsis = css( {
 	'.gridicon.ellipsis-menu__toggle-icon': {
 		width: '24px',
 		height: '16px',
-		top: '4px',
+		insetBlockStart: '4px',
 	},
 } );
 

--- a/client/sites-dashboard/components/sites-grid-tile.tsx
+++ b/client/sites-dashboard/components/sites-grid-tile.tsx
@@ -11,8 +11,8 @@ const container = css( {
 const primaryContainer = css( {
 	display: 'flex',
 	flex: 1,
-	marginTop: '16px',
-	marginBottom: '8px',
+	marginBlockStart: '16px',
+	marginBlockEnd: '8px',
 	alignItems: 'center',
 } );
 

--- a/client/sites-dashboard/components/sites-launch-status-badge.tsx
+++ b/client/sites-dashboard/components/sites-launch-status-badge.tsx
@@ -5,7 +5,8 @@ const SitesLaunchStatusBadge = styled.span`
 	font-weight: 400;
 	color: var( --studio-gray-80 );
 	background-color: var( --studio-gray-5 );
-	padding: 0px 10px;
+	padding-block: 0;
+	padding-inline: 10px;
 	border-radius: 4px;
 	line-height: 20px;
 	display: inline-block;

--- a/client/sites-dashboard/components/sites-search-icon.tsx
+++ b/client/sites-dashboard/components/sites-search-icon.tsx
@@ -7,8 +7,8 @@ export const SitesSearchIcon = () => {
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 			style={ {
-				paddingLeft: '16px',
-				paddingRight: '10px',
+				paddingInlineStart: '16px',
+				paddingInlineEnd: '10px',
 				height: '100%',
 				backgroundColor: 'var( --color-surface )',
 			} }

--- a/client/sites-dashboard/components/sites-site-name.ts
+++ b/client/sites-dashboard/components/sites-site-name.ts
@@ -4,7 +4,7 @@ export const SiteName = styled.a< { fontSize?: number } >`
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	margin-right: 8px;
+	margin-inline-end: 8px;
 	font-weight: 500;
 	font-size: ${ ( props ) => `${ props.fontSize }px` };
 	letter-spacing: -0.4px;

--- a/client/sites-dashboard/components/sites-site-url.ts
+++ b/client/sites-dashboard/components/sites-site-url.ts
@@ -4,16 +4,13 @@ import { ExternalLink } from '@wordpress/components';
 export const SiteUrl = styled( ExternalLink )`
 	display: flex;
 	align-items: center;
+	gap: 4px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	font-size: 14px;
 	color: var( --studio-gray-60 ) !important;
 	&:hover {
 		text-decoration: underline;
-	}
-
-	.components-external-link__icon {
-		margin-left: 4px;
 	}
 `;
 

--- a/client/sites-dashboard/components/sites-table-row-loading.tsx
+++ b/client/sites-dashboard/components/sites-table-row-loading.tsx
@@ -17,14 +17,14 @@ interface SitesTableRowLoadingProps {
 
 const Row = styled.tr`
 	line-height: 2em;
-	border-bottom: 1px solid #eee;
+	border-block-end: 1px solid #eee;
 `;
 
 const Column = styled.td< { mobileHidden?: boolean } >`
-	padding-top: 12px;
-	padding-bottom: 12px;
-	padding-right: 24px;
-	vertical-align: top;
+	padding-block-start: 12px;
+	padding-block-end: 12px;
+	padding-inline-end: 24px;
+	vertical-align: block-start;
 `;
 
 const TitleRow = styled.div`
@@ -40,12 +40,12 @@ const LoadingLogo = styled( LoadingPlaceholder )< LoadingLogoProps >`
 		maxWidth: width,
 		height,
 	} ) }
-	margin-right: 10px;
+	margin-inline-end: 10px;
 `;
 
 const LoadingTitle = styled( LoadingPlaceholder )`
 	max-width: 80%;
-	margin-bottom: 10px;
+	margin-block-end: 10px;
 `;
 
 const LoadingDomain = styled( LoadingPlaceholder )`

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -19,13 +19,13 @@ interface SiteTableRowProps {
 
 const Row = styled.tr`
 	line-height: 2em;
-	border-bottom: 1px solid #eee;
+	border-block-end: 1px solid #eee;
 `;
 
 const Column = styled.td< { mobileHidden?: boolean } >`
-	padding-top: 12px;
-	padding-bottom: 12px;
-	padding-right: 24px;
+	padding-block-start: 12px;
+	padding-block-end: 12px;
+	padding-inline-end: 24px;
 	vertical-align: middle;
 	font-size: 14px;
 	line-height: 20px;
@@ -35,29 +35,29 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 
 	${ MEDIA_QUERIES.mediumOrSmaller } {
 		${ ( props ) => props.mobileHidden && 'display: none;' };
-		padding-right: 0;
+		padding-inline-end: 0;
 	}
 `;
 
 const SiteListTile = styled( ListTile )`
 	line-height: initial;
-	margin-right: 0;
+	margin-inline-end: 0;
 
 	${ MEDIA_QUERIES.mediumOrSmaller } {
-		margin-right: 12px;
+		margin-inline-end: 12px;
 	}
 `;
 
 const ListTileLeading = styled.a`
 	${ MEDIA_QUERIES.mediumOrSmaller } {
-		margin-right: 12px;
+		margin-inline-end: 12px;
 	}
 `;
 
 const ListTileTitle = styled.div`
 	display: flex;
 	align-items: center;
-	margin-bottom: 8px;
+	margin-block-end: 8px;
 `;
 
 const ListTileSubtitle = styled.div`
@@ -71,7 +71,7 @@ const SitePlan = styled.div`
 `;
 
 const SitePlanIcon = styled.div`
-	margin-right: 6px;
+	margin-inline-end: 6px;
 `;
 
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -20,30 +20,35 @@ const Table = styled.table`
 	position: relative;
 `;
 
-const THead = styled.thead< { top: number } >( ( { top } ) => ( {
-	[ MEDIA_QUERIES.mediumOrSmaller ]: {
-		display: 'none',
-	},
+const THead = styled.thead< { blockOffset: number; displayShadow: boolean } >(
+	( { blockOffset } ) => ( {
+		[ MEDIA_QUERIES.mediumOrSmaller ]: {
+			display: 'none',
+		},
 
-	position: 'sticky',
-	zIndex: 3,
-	top: `${ top }px`,
+		position: 'sticky',
+		zIndex: 3,
+		insetBlockStart: `${ blockOffset }px`,
 
-	background: '#fdfdfd',
-} ) );
-
-const headerShadow: React.CSSProperties = {
-	boxShadow: '0 0 13px -9px rgba(0, 0, 0, 0.45)',
-	clipPath: 'inset( 0 0 -10px 0 )',
-};
+		background: '#fdfdfd',
+	} ),
+	( { displayShadow } ) => {
+		if ( displayShadow ) {
+			return {
+				boxShadow: '0 0 13px -9px rgba(0, 0, 0, 0.45)',
+				clipPath: 'inset( 0 0 -10px 0 )',
+			};
+		}
+	}
+);
 
 const Row = styled.tr`
 	line-height: 2em;
-	border-bottom: 1px solid #eee;
+	border-block-end: 1px solid #eee;
 
 	th {
-		padding-top: 12px;
-		padding-bottom: 12px;
+		padding-block-start: 12px;
+		padding-block-end: 12px;
 		vertical-align: middle;
 		font-size: 14px;
 		line-height: 20px;
@@ -116,11 +121,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 
 	return (
 		<Table className={ className }>
-			<THead
-				top={ masterbarHeight }
-				ref={ headerRef }
-				style={ isHeaderStuck ? headerShadow : undefined }
-			>
+			<THead blockOffset={ masterbarHeight } ref={ headerRef } displayShadow={ isHeaderStuck }>
 				<Row>
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -20,27 +20,22 @@ const Table = styled.table`
 	position: relative;
 `;
 
-const THead = styled.thead< { blockOffset: number; displayShadow: boolean } >(
-	( { blockOffset } ) => ( {
-		[ MEDIA_QUERIES.mediumOrSmaller ]: {
-			display: 'none',
-		},
+const THead = styled.thead< { blockOffset: number } >( ( { blockOffset } ) => ( {
+	[ MEDIA_QUERIES.mediumOrSmaller ]: {
+		display: 'none',
+	},
 
-		position: 'sticky',
-		zIndex: 3,
-		insetBlockStart: `${ blockOffset }px`,
+	position: 'sticky',
+	zIndex: 3,
+	insetBlockStart: `${ blockOffset }px`,
 
-		background: '#fdfdfd',
-	} ),
-	( { displayShadow } ) => {
-		if ( displayShadow ) {
-			return {
-				boxShadow: '0 0 13px -9px rgba(0, 0, 0, 0.45)',
-				clipPath: 'inset( 0 0 -10px 0 )',
-			};
-		}
-	}
-);
+	background: '#fdfdfd',
+} ) );
+
+const headerShadow: React.CSSProperties = {
+	boxShadow: '0 0 13px -9px rgba(0, 0, 0, 0.45)',
+	clipPath: 'inset( 0 0 -10px 0 )',
+};
 
 const Row = styled.tr`
 	line-height: 2em;
@@ -121,7 +116,11 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 
 	return (
 		<Table className={ className }>
-			<THead blockOffset={ masterbarHeight } ref={ headerRef } displayShadow={ isHeaderStuck }>
+			<THead
+				blockOffset={ masterbarHeight }
+				ref={ headerRef }
+				style={ isHeaderStuck ? headerShadow : undefined }
+			>
 				<Row>
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -14,10 +14,11 @@ const globalStyles = css`
 
 		.layout__content {
 			// The page header background extends all the way to the edge of the screen
-			padding: 32px 0;
+			padding-block: 32px;
+			padding-inline: 0;
 
 			${ MEDIA_QUERIES.mediumOrSmaller } {
-				padding-top: 46px;
+				padding-block-start: 46px;
 			}
 
 			// Prevents the status dropdown from being clipped when the page content


### PR DESCRIPTION
#### Proposed Changes

Fixes right-to-left layout. Usually, this would be done automatically by the `@automattic/webpack-rtl-plugin`. But Emotion is generating CSS rules at runtime, so the build tooling can't process them.

h/t @zaguiini who suggested using the logical properties instead of selecting using the `html[dir="rtl"]` rule https://github.com/Automattic/wp-calypso/pull/66841#issuecomment-1224305543

![grid](https://user-images.githubusercontent.com/1500769/186078480-8a0c46dd-e4c8-406b-921d-45defe3a057f.png)

![rtl table](https://user-images.githubusercontent.com/1500769/186078813-f41940af-9422-4031-8291-81d9bce18a7f.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choose a right-to-left language in your account settings, like Arabic or Hebrew
* Test `/sites-dashboard`
   * Badges should have the correct spacing
   * Long text in table cells should wrap at the correct location (it should wrap before the edge of the table cell)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


