### PR TITLE
Add Product Filter component to the new pricing page 

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,12 +1,15 @@
+import { useState } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useProductSlugs from './hooks/use-product-slugs';
 import { JetpackFree } from './jetpack-free';
+import ProductFilter from './product-filter';
+import Product from './products';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
-import type { ProductStoreProps } from './types';
+import type { FilterType, ProductStoreProps } from './types';
 
 import './style.scss';
 
@@ -18,6 +21,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const productSlugs = useProductSlugs( { siteId, duration } );
 
+	const [ filterType, setFilterType ] = useState< FilterType >( 'products' );
+
 	return (
 		<div className="jetpack-product-store">
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
@@ -26,6 +31,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 				<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
 			</div>
 
+			<ProductFilter filterType={ filterType } setFilterType={ setFilterType } />
+			<Product type={ filterType }></Product>
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 
 			<Recommendations />

--- a/client/my-sites/plans/jetpack-plans/product-store/product-filter.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/product-filter.tsx
@@ -7,7 +7,7 @@ const ProductFilter: React.FC< ProductFilterProps > = ( { filterType, setFilterT
 
 	return (
 		<div className="jetpack-product-store__product-filter">
-			<SegmentedControl className="jetpack-product-store__product-filter-toggle" compact primary>
+			<SegmentedControl className="jetpack-product-store__product-filter--toggle" compact primary>
 				<SegmentedControl.Item
 					onClick={ () => setFilterType( 'products' ) }
 					selected={ filterType === 'products' }

--- a/client/my-sites/plans/jetpack-plans/product-store/product-filter.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/product-filter.tsx
@@ -1,0 +1,29 @@
+import { useTranslate } from 'i18n-calypso';
+import SegmentedControl from 'calypso/components/segmented-control';
+import type { ProductFilterProps } from './types';
+
+const ProductFilter: React.FC< ProductFilterProps > = ( { filterType, setFilterType } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="jetpack-product-store__product-filter">
+			<SegmentedControl className="jetpack-product-store__product-filter-toggle" compact primary>
+				<SegmentedControl.Item
+					onClick={ () => setFilterType( 'products' ) }
+					selected={ filterType === 'products' }
+				>
+					{ translate( 'Products' ) }
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					onClick={ () => setFilterType( 'bundles' ) }
+					selected={ filterType === 'bundles' }
+				>
+					{ translate( 'Bundles' ) }
+				</SegmentedControl.Item>
+			</SegmentedControl>
+		</div>
+	);
+};
+
+export default ProductFilter;

--- a/client/my-sites/plans/jetpack-plans/product-store/products.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/products.tsx
@@ -1,0 +1,12 @@
+import type { ProductProps } from './types';
+
+const Products: React.FC< ProductProps > = ( { type } ) => {
+	return (
+		<div className="jetpack-product-store__product">
+			{ type === 'products' && <div>Product Component goes here</div> }
+			{ type === 'bundles' && <div>Bundle Component goes here</div> }
+		</div>
+	);
+};
+
+export default Products;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -2,43 +2,116 @@
 @import '@wordpress/base-styles/mixins';
 
 .jetpack-product-store {
-    &__jetpack-free {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin: 4em 0;
+	&__jetpack-free {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin: 4em 0;
 
-        &--headline {
-            font-size: $font-title-large;
-            margin-bottom: 1em;
-        }
-        &--info {
-            font-size: $font-body-small;
-            text-align: center;
-        }
-    }
-    &__recommendations {
-        padding: 4em 0;
+		&--headline {
+			font-size: $font-title-large;
+			margin-bottom: 1em;
+		}
+		&--info {
+			font-size: $font-body-small;
+			text-align: center;
+		}
+	}
+	&__recommendations {
+		padding: 4em 0;
 
-        &--title {
-            text-align: center;
-        }
-        &--logos {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-wrap: wrap;
-            list-style-type: none;
-            margin: 0 auto;
-            gap: 1.5em;
-        }
-    }
-    
-    .button {
-        color: var( --color-neutral-100 );
-        border: 1px solid var( --color-neutral-100 );
-        font-weight: 600;
-    }
+		&--title {
+			text-align: center;
+		}
+		&--logos {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			flex-wrap: wrap;
+			list-style-type: none;
+			margin: 0 auto;
+			gap: 1.5em;
+		}
+	}
+
+	.button {
+		color: var( --color-neutral-100 );
+		border: 1px solid var( --color-neutral-100 );
+		font-weight: 600;
+	}
+
+	&__product-filter {
+		&-toggle.segmented-control.is-compact.is-primary {
+			display: flex;
+			flex-direction: row;
+			align-items: flex-start;
+			list-style: none;
+
+			height: 33px;
+			background-color: #f2f2f2;
+			border-color: var( --studio-gray-5 );
+			border-radius: 8px; /* stylelint-disable-line */
+			color: var( --color-text );
+
+			margin: 0.5em auto 1em;
+			max-width: 21.4375em;
+
+			&.is_compact {
+				& .segmented-control__link {
+					font-size: 0.875rem;
+				}
+			}
+
+			.segmented-control__item {
+				padding: 2px;
+				border-radius: 4px;
+				border-color: var( --studio-gray-5 );
+
+				cursor: pointer;
+				flex: 1 1 auto;
+
+				&:first-child {
+					margin-right: 5px;
+				}
+
+				.segmented-control__link {
+					color: var( --color-text );
+					padding: 6px 11px;
+					border: 1px solid #f2f2f2;
+
+					line-height: 15px;
+					height: 15px;
+					font-size: 0.75rem;
+					font-weight: 600;
+
+					text-align: center;
+					transition: color 0.1s linear, background-color 0.1s linear;
+
+					&:hover {
+						background-color: unset;
+						border: 1px solid var( --studio-gray-10 );
+						border-radius: 4px;
+					}
+				}
+
+				&.is-selected .segmented-control__link {
+					background-color: var( --studio-white );
+					border-color: var( --studio-white );
+
+					color: var( --color-text );
+
+					border: 0.5px solid #0000000a;
+					border-radius: 4px;
+					box-shadow: 0 0.125em 0.5em #0000001f, 0 0.125em 0.0625em #0000000a;
+
+					&:hover {
+						background-color: var( --studio-white );
+						border-color: #0000000a;
+					}
+				}
+			}
+		}
+	}
 }
 
 .jetpack-product-store__pricing-banner {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -40,75 +40,70 @@
 		font-weight: 600;
 	}
 
-	&__product-filter {
-		&-toggle.segmented-control.is-compact.is-primary {
-			display: flex;
-			flex-direction: row;
-			align-items: flex-start;
-			list-style: none;
+	.jetpack-product-store__product-filter {
+		margin-top: 0.75em;
+	}
 
-			height: 33px;
-			background-color: #f2f2f2;
+	.jetpack-product-store__product-filter
+		.jetpack-product-store__product-filter--toggle.segmented-control {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		list-style: none;
+
+		height: 33px;
+		background-color: #f2f2f2;
+		border-color: var( --studio-gray-5 );
+		border-radius: 8px; /* stylelint-disable-line */
+		color: var( --color-text );
+
+		margin: 0.5em auto 1em;
+		max-width: 21.4375em;
+
+		.segmented-control__item {
+			padding: 2px;
+			border-radius: 4px;
 			border-color: var( --studio-gray-5 );
-			border-radius: 8px; /* stylelint-disable-line */
+
+			cursor: pointer;
+			flex: 1 1 auto;
+
+			&:first-child {
+				margin-right: 5px;
+			}
+		}
+		.segmented-control__item .segmented-control__link {
+			color: var( --color-text );
+			padding: 6px 11px;
+			border: 1px solid #f2f2f2;
+
+			line-height: 15px;
+			height: 15px;
+			font-size: 0.75rem;
+			font-weight: 600;
+
+			text-align: center;
+			transition: color 0.1s linear, background-color 0.1s linear;
+
+			&:hover {
+				background-color: unset;
+				border: 1px solid var( --studio-gray-10 );
+				border-radius: 4px;
+			}
+		}
+		.segmented-control__item.is-selected .segmented-control__link {
+			background-color: var( --studio-white );
+			border-color: var( --studio-white );
+
 			color: var( --color-text );
 
-			margin: 0.5em auto 1em;
-			max-width: 21.4375em;
+			border: 0.5px solid #0000000a;
+			border-radius: 4px;
+			box-shadow: 0 0.125em 0.5em #0000001f, 0 0.125em 0.0625em #0000000a;
 
-			&.is_compact {
-				& .segmented-control__link {
-					font-size: 0.875rem;
-				}
-			}
-
-			.segmented-control__item {
-				padding: 2px;
-				border-radius: 4px;
-				border-color: var( --studio-gray-5 );
-
-				cursor: pointer;
-				flex: 1 1 auto;
-
-				&:first-child {
-					margin-right: 5px;
-				}
-
-				.segmented-control__link {
-					color: var( --color-text );
-					padding: 6px 11px;
-					border: 1px solid #f2f2f2;
-
-					line-height: 15px;
-					height: 15px;
-					font-size: 0.75rem;
-					font-weight: 600;
-
-					text-align: center;
-					transition: color 0.1s linear, background-color 0.1s linear;
-
-					&:hover {
-						background-color: unset;
-						border: 1px solid var( --studio-gray-10 );
-						border-radius: 4px;
-					}
-				}
-
-				&.is-selected .segmented-control__link {
-					background-color: var( --studio-white );
-					border-color: var( --studio-white );
-
-					color: var( --color-text );
-
-					border: 0.5px solid #0000000a;
-					border-radius: 4px;
-					box-shadow: 0 0.125em 0.5em #0000001f, 0 0.125em 0.0625em #0000000a;
-
-					&:hover {
-						background-color: var( --studio-white );
-						border-color: #0000000a;
-					}
-				}
+			&:hover {
+				background-color: var( --studio-white );
+				border-color: #0000000a;
 			}
 		}
 	}

--- a/client/my-sites/plans/jetpack-plans/product-store/test/product-filter.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/test/product-filter.tsx
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import ProductFilter from '../product-filter';
+describe( '<ProductFilter />', () => {
+	test( 'should render the filter with Products selected', async () => {
+		const setFilterType = jest.fn();
+		render( <ProductFilter filterType={ 'products' } setFilterType={ setFilterType } /> );
+		expect( screen.getByRole( 'radio', { name: 'Products' } ) ).toBeChecked();
+	} );
+
+	test( 'should switch the filter on click', async () => {
+		const user = userEvent.setup();
+		const setFilterType = jest.fn();
+		render( <ProductFilter filterType={ 'products' } setFilterType={ setFilterType } /> );
+		expect( screen.getByRole( 'radio', { name: 'Products' } ) ).toBeChecked();
+
+		await user.click( screen.getByRole( 'radio', { name: 'Bundles' } ) );
+		expect( setFilterType ).toHaveBeenLastCalledWith( 'bundles' );
+	} );
+} );

--- a/client/my-sites/plans/jetpack-plans/product-store/test/products.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/test/products.tsx
@@ -1,0 +1,16 @@
+/** @jest-environment jsdom */
+import { screen, render } from '@testing-library/react';
+import React from 'react';
+import Products from '../products';
+
+describe( '<Products />', () => {
+	test( 'should render Product component', async () => {
+		render( <Products type="products" /> );
+		expect( screen.getByText( /Product/i ) ).toBeInTheDocument();
+	} );
+
+	test( 'should render Bundles component', async () => {
+		render( <Products type="bundles" /> );
+		expect( screen.getByText( /Bundle/i ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -15,3 +15,13 @@ export interface ProductStoreProps extends Pick< BasePageProps, 'urlQueryArgs' >
 export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;
 
 export type ProductSlugsProps = Pick< ProductStoreProps, 'duration' > & ProductStoreBaseProps;
+
+export type FilterType = 'products' | 'bundles';
+export interface ProductFilterProps {
+	filterType: FilterType;
+	setFilterType: ( filterType: FilterType ) => void;
+}
+
+export interface ProductProps {
+	type: FilterType;
+}


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a new `Products` and `ProductFilter` component inside `ProductStore`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR 
    * Run `git fetch && git checkout add/product-filter-component`
    * Run `yarn start-jetpack-cloud`
    * Goto [http://jetpack.cloud.localhost:3001/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3001/pricing?flags=jetpack/pricing-page-rework-v1)
* Or click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* Confirm that you see the Products and Bundles Filter in the top of the page 
* Confirm that the design matches the Figma design
* Switch between the filter and make sure the respective component loads 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Desktop Screenshot
![image](https://user-images.githubusercontent.com/2027003/186350856-f6bd8d30-60ec-4815-9d0f-b54e56ea3e14.png)


### Mobile Screenshot 
![image](https://user-images.githubusercontent.com/2027003/186350639-639d98a0-9512-48f4-bdd7-09c90b9a228e.png)



Completes: [1202796695664022-as-1202796695664061/f](1202796695664022-as-1202796695664055/f)
Figma: m0y1jHTuDpvMPkFsOJBoNP-fi-3715%3A132855

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664061