### PR TITLE
Move premium badge below the theme name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -4,7 +4,6 @@ import { Button } from '@automattic/components';
 import { Onboard, useStarterDesignsQuery } from '@automattic/data-stores';
 import {
 	UnifiedDesignPicker,
-	PremiumBadge,
 	useCategorization,
 	getDesignPreviewUrl,
 } from '@automattic/design-picker';
@@ -384,7 +383,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			onPreview={ previewDesign }
 			onUpgrade={ upgradePlan }
 			onCheckout={ goToCheckout }
-			premiumBadge={ <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } /> }
 			heading={ heading }
 			categorization={ categorization }
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -7,10 +7,15 @@ import './style.scss';
 
 interface Props {
 	className?: string;
+	tooltipPosition?: string;
 	isPremiumThemeAvailable?: boolean;
 }
 
-const PremiumBadge: FunctionComponent< Props > = ( { className, isPremiumThemeAvailable } ) => {
+const PremiumBadge: FunctionComponent< Props > = ( {
+	className,
+	tooltipPosition = 'bottom left',
+	isPremiumThemeAvailable,
+} ) => {
 	const { __ } = useI18n();
 
 	const tooltipText = isPremiumThemeAvailable
@@ -39,7 +44,7 @@ const PremiumBadge: FunctionComponent< Props > = ( { className, isPremiumThemeAv
 				className="premium-badge__popover"
 				context={ divRef.current }
 				isVisible={ isPopoverVisible }
-				position="bottom left"
+				position={ tooltipPosition }
 			>
 				{ tooltipText }
 			</Popover>

--- a/packages/design-picker/src/components/premium-badge/style.scss
+++ b/packages/design-picker/src/components/premium-badge/style.scss
@@ -47,7 +47,8 @@
 		border-radius: 4px;
 		border: 0;
 	}
-	&.is-bottom-left {
+	&.is-bottom-left,
+	&.is-bottom-right {
 		.popover__arrow {
 			&::before {
 				border-bottom-color: #000 !important;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -229,8 +229,17 @@
 	}
 
 	.design-picker__pricing-description {
-		text-align: left;
+		align-items: flex-start;
 		color: #50575e;
+		display: flex;
+		flex-direction: row;
+		gap: 10px;
+		line-height: 20px;
+		justify-content: flex-start;
+
+		.premium-badge {
+			margin: 0;
+		}
 	}
 
 


### PR DESCRIPTION
#### Proposed Changes

This diff updates the premium badge of theme cards by moving it below the theme name. The purpose of moving the premium badge is to free the space for the upcoming style selector. See screenshots for reference:

Before (desktop):
![Screen Shot 2022-08-24 at 3 44 00 PM](https://user-images.githubusercontent.com/797888/186360658-c18ce119-538d-47bc-bc5a-2af1ad93e8b7.png)

After (desktop):
![Screen Shot 2022-08-24 at 3 43 24 PM](https://user-images.githubusercontent.com/797888/186360533-7ea68d08-d970-4118-841c-0fafb150fb79.png)

Before (mobile):
![Screen Shot 2022-08-24 at 3 45 42 PM](https://user-images.githubusercontent.com/797888/186361031-48f36bd9-f86d-4584-8b84-fcc5bae392dc.png)

After (mobile):
![Screen Shot 2022-08-24 at 3 45 02 PM](https://user-images.githubusercontent.com/797888/186360913-e9a13db5-c69a-4dfd-b632-bec44b74454d.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `setup/designSetup?siteSlug=${site_slug}`
* Make sure that the premium badge is below the theme name, and inline with the pricing text.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

