### PR TITLE
Bulk Actions: Implement the new bulk actions UI in the Jetpack Cloud

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -378,19 +378,14 @@ export class PluginsListHeader extends PureComponent {
 						/>
 						{ ! isWpcom && (
 							<div className="plugin-list-header__bulk-select-label">
-								{ translate(
-									'%(number)d {{span}}Selected{{/span}}',
-									'%(number)d {{span}}Selected{{/span}}',
-									{
-										count: selected.length,
-										args: {
-											number: selected.length,
-										},
-										components: {
-											span: <span />,
-										},
-									}
-								) }
+								{ translate( '%(number)d {{span}}Selected{{/span}}', {
+									args: {
+										number: selected.length,
+									},
+									components: {
+										span: <span />,
+									},
+								} ) }
 							</div>
 						) }
 					</div>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -37,6 +37,7 @@ export class PluginsListHeader extends PureComponent {
 		hasManagePluginsFeature: PropTypes.bool,
 		isBulkManagementActive: PropTypes.bool,
 		isWpComAtomic: PropTypes.bool,
+		isWpcom: PropTypes.bool,
 		toggleBulkManagement: PropTypes.func.isRequired,
 		updateAllPlugins: PropTypes.func.isRequired,
 		updateSelected: PropTypes.func.isRequired,
@@ -115,7 +116,7 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	renderCurrentActionButtons() {
-		const { hasManagePluginsFeature, isWpComAtomic, translate, siteId } = this.props;
+		const { hasManagePluginsFeature, isWpcom, isWpComAtomic, translate, siteId } = this.props;
 		const buttons = [];
 
 		if ( siteId && isWpComAtomic && ! hasManagePluginsFeature ) {
@@ -156,17 +157,22 @@ export class PluginsListHeader extends PureComponent {
 			const updateButton = (
 				<Button
 					key="plugin-list-header__buttons-update"
-					disabled={ ! this.props.haveUpdatesSelected }
 					compact
-					primary
+					disabled={ ! this.props.haveUpdatesSelected }
+					primary={ this.isWpcom }
 					onClick={ this.props.updateSelected }
 				>
-					{ translate( 'Update' ) }
+					{ ! isWpcom ? translate( 'Update Plugins' ) : translate( 'Update' ) }
 				</Button>
 			);
-			leftSideButtons.push(
-				<ButtonGroup key="plugin-list-header__buttons-update-button">{ updateButton }</ButtonGroup>
-			);
+
+			if ( isWpcom ) {
+				leftSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-update-button">
+						{ updateButton }
+					</ButtonGroup>
+				);
+			}
 
 			activateButtons.push(
 				<Button
@@ -219,7 +225,7 @@ export class PluginsListHeader extends PureComponent {
 					compact
 					onClick={ this.props.unsetAutoupdateSelected }
 				>
-					{ translate( 'Disable Autoupdates' ) }
+					{ ! isWpcom ? translate( 'Disable' ) : translate( 'Disable Autoupdates' ) }
 				</Button>
 			);
 
@@ -228,7 +234,6 @@ export class PluginsListHeader extends PureComponent {
 					{ autoupdateButtons }
 				</ButtonGroup>
 			);
-
 			leftSideButtons.push(
 				<ButtonGroup key="plugin-list-header__buttons-remove-button">
 					<Button
@@ -276,7 +281,7 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	renderCurrentActionDropdown() {
-		const { translate, selected, isBulkManagementActive } = this.props;
+		const { translate, selected, isBulkManagementActive, isWpcom } = this.props;
 		if ( ! isBulkManagementActive ) {
 			return null;
 		}
@@ -300,7 +305,7 @@ export class PluginsListHeader extends PureComponent {
 					disabled={ ! this.props.haveUpdatesSelected }
 					onClick={ this.props.updateSelected }
 				>
-					{ translate( 'Update' ) }
+					{ ! isWpcom ? translate( 'Update Plugins' ) : translate( 'Update' ) }
 				</SelectDropdown.Item>
 
 				<SelectDropdown.Separator />
@@ -338,7 +343,7 @@ export class PluginsListHeader extends PureComponent {
 					disabled={ ! this.canUpdatePlugins() }
 					onClick={ this.props.unsetAutoupdateSelected }
 				>
-					{ translate( 'Disable Autoupdates' ) }
+					{ ! isWpcom ? translate( 'Disable' ) : translate( 'Disable Autoupdates' ) }
 				</SelectDropdown.Item>
 
 				<SelectDropdown.Separator />
@@ -354,21 +359,41 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	render() {
-		const { label, selected, plugins, isBulkManagementActive } = this.props;
+		const { label, selected, plugins, isBulkManagementActive, isWpcom, translate } = this.props;
 		const sectionClasses = classNames( {
 			'plugin-list-header': true,
+			'plugin-list-header-new': ! isWpcom,
 			'is-bulk-editing': isBulkManagementActive,
 			'is-action-bar-visible': this.state.actionBarVisible,
 		} );
 		return (
 			<SectionHeader label={ label } className={ sectionClasses }>
 				{ isBulkManagementActive && (
-					<BulkSelect
-						key="plugin-list-header__bulk-select"
-						totalElements={ plugins.length }
-						selectedElements={ selected.length }
-						onToggle={ this.unselectOrSelectAll }
-					/>
+					<div className="plugin-list-header__bulk-select-wrapper">
+						<BulkSelect
+							key="plugin-list-header__bulk-select"
+							totalElements={ plugins.length }
+							selectedElements={ selected.length }
+							onToggle={ this.unselectOrSelectAll }
+						/>
+						{ ! isWpcom && (
+							<div className="plugin-list-header__bulk-select-label">
+								{ translate(
+									'%(number)d {{span}}Selected{{/span}}',
+									'%(number)d {{span}}Selected{{/span}}',
+									{
+										count: selected.length,
+										args: {
+											number: selected.length,
+										},
+										components: {
+											span: <span />,
+										},
+									}
+								) }
+							</div>
+						) }
+					</div>
 				) }
 				{ this.renderCurrentActionDropdown() }
 				{ this.renderCurrentActionButtons() }

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -159,7 +159,7 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-update"
 					compact
 					disabled={ ! this.props.haveUpdatesSelected }
-					primary={ this.isWpcom }
+					primary={ isWpcom }
 					onClick={ this.props.updateSelected }
 				>
 					{ ! isWpcom ? translate( 'Update Plugins' ) : translate( 'Update' ) }

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -85,9 +85,14 @@
 }
 
 .plugin-list-header-new {
+	margin-block-start: 8px;
 	&.section-header.card {
-		margin-left: 1px;
-		margin-right: 1px;
+		margin-inline-start: 0;
+		margin-inline-end: 0;
+		@include break-wide() {
+			margin-inline-start: 1px;
+			margin-inline-end: 1px;
+		}
 		&:not( .is-bulk-editing ) {
 			@include break-xlarge() {
 				display: none;
@@ -98,6 +103,7 @@
 			margin-block-end: 0;
 			.section-header__actions {
 				width: 100%;
+				flex-wrap: wrap;
 			}
 		}
 		.button-group {
@@ -114,7 +120,7 @@
 			}
 		}
 		.section-header__actions {
-			margin-left: 0;
+			margin-inline-start: 0;
 			flex-grow: 0;
 			justify-content: end;
 		}
@@ -156,5 +162,8 @@
 		@include break-medium() {
 			margin-inline-start: 32px;
 		}
+	}
+	.plugin-list-header__bulk-select-label {
+		margin-inline-end: 16px;
 	}
 }

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -2,8 +2,6 @@
 @import '@wordpress/base-styles/_mixins.scss';
 
 .plugin-list-header.section-header.card {
-	padding-right: 8px;
-
 	.section-header__actions {
 		flex-grow: 1;
 		display: flex;
@@ -87,10 +85,6 @@
 }
 
 .plugin-list-header-new {
-	@include break-mobile() {
-		margin-top: 8px;
-		margin-bottom: 0;
-	}
 	&.section-header.card {
 		&:not( .is-bulk-editing ) {
 			@include break-xlarge() {
@@ -115,6 +109,9 @@
 			}
 		}
 	}
+	.section-header__label { 
+		flex-basis: auto;
+	}
 	.section-header__actions {
 		margin-left: 0;
 	}
@@ -129,11 +126,9 @@
 		}
 	}
 	.plugin-list-header__action-buttons {
-		justify-content: end;
-	}
-	.plugin-list-header__mode-buttons {
-		flex-grow: 0;
-		margin-inline-start: 36px;
+		@include break-wide() {
+			justify-content: end;
+		}
 	}
 	.plugin-list-header__bulk-select-wrapper {
 		display: flex;
@@ -149,5 +144,8 @@
 				display: inline;
 			}
 		}
+	}
+	.plugin-list-header__actions-dropdown {
+		margin-inline-start: 38px;
 	}
 }

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -86,14 +86,19 @@
 
 .plugin-list-header-new {
 	&.section-header.card {
+		margin-left: 1px;
+		margin-right: 1px;
 		&:not( .is-bulk-editing ) {
 			@include break-xlarge() {
 				display: none;
 			}
 		}
 		&.is-bulk-editing {
-			margin-top: 8px;
-			margin-bottom: 0;
+			margin-block-start: 8px;
+			margin-block-end: 0;
+			.section-header__actions {
+				width: 100%;
+			}
 		}
 		.button-group {
 			margin-inline-start: 14px;
@@ -108,12 +113,11 @@
 				}
 			}
 		}
-	}
-	.section-header__label {
-		flex-basis: auto;
-	}
-	.section-header__actions {
-		margin-left: 0;
+		.section-header__actions {
+			margin-left: 0;
+			flex-grow: 0;
+			justify-content: end;
+		}
 	}
 	.bulk-select {
 		.count {
@@ -126,9 +130,7 @@
 		}
 	}
 	.plugin-list-header__action-buttons {
-		@include break-wide() {
-			justify-content: end;
-		}
+		justify-content: end;
 	}
 	.plugin-list-header__bulk-select-wrapper {
 		display: flex;
@@ -140,12 +142,19 @@
 		
 		span {
 			display: none;
-			@include break-medium() {
+			@include breakpoint-deprecated( '>960px' ) {
 				display: inline;
 			}
 		}
 	}
 	.plugin-list-header__actions-dropdown {
-		margin-inline-start: 38px;
+		margin-inline-start: auto;
+	}
+	.plugin-list-header__mode-buttons {
+		flex-grow: 0;
+		margin-inline-start: 16px;
+		@include break-medium() {
+			margin-inline-start: 32px;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -109,7 +109,7 @@
 			}
 		}
 	}
-	.section-header__label { 
+	.section-header__label {
 		flex-basis: auto;
 	}
 	.section-header__actions {

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .plugin-list-header.section-header.card {
 	padding-right: 8px;
 
@@ -81,4 +84,70 @@
 	align-items: center;
 	display: none;
 	flex-grow: 1;
+}
+
+.plugin-list-header-new {
+	@include break-mobile() {
+		margin-top: 8px;
+		margin-bottom: 0;
+	}
+	&.section-header.card {
+		&:not( .is-bulk-editing ) {
+			@include break-xlarge() {
+				display: none;
+			}
+		}
+		&.is-bulk-editing {
+			margin-top: 8px;
+			margin-bottom: 0;
+		}
+		.button-group {
+			margin-inline-start: 14px;
+			.button {
+				&:first-child {
+					border-top-left-radius: 4px;
+					border-bottom-left-radius: 4px;
+				}
+				&:last-child {
+					border-top-right-radius: 4px;
+					border-bottom-right-radius: 4px;
+				}
+			}
+		}
+	}
+	.section-header__actions {
+		margin-left: 0;
+	}
+	.bulk-select {
+		.count {
+			display: none;
+		}
+		.form-checkbox {
+			&:checked::before {
+				content: url( '/calypso/images/checkbox-icons/checkmark-jetpack.svg' );
+			}
+		}
+	}
+	.plugin-list-header__action-buttons {
+		justify-content: end;
+	}
+	.plugin-list-header__mode-buttons {
+		flex-grow: 0;
+		margin-inline-start: 36px;
+	}
+	.plugin-list-header__bulk-select-wrapper {
+		display: flex;
+		align-items: center;
+	}
+	.plugin-list-header__bulk-select-label {
+		font-size: 0.75rem;
+		font-weight: bold;
+		
+		span {
+			display: none;
+			@include break-medium() {
+				display: inline;
+			}
+		}
+	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -82,7 +82,7 @@ export default function PluginManagementV2( {
 						key: 'last-updated',
 						header: translate( 'Last updated' ),
 						smallColumn: true,
-						colSpan: 2,
+						colSpan: 1,
 					},
 			  ]
 			: [
@@ -96,7 +96,7 @@ export default function PluginManagementV2( {
 		{
 			key: 'update',
 			header: renderBulkActionsHeader(),
-			colSpan: 2,
+			colSpan: 3,
 		},
 	];
 

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -39,7 +39,7 @@ export default function PluginManagementV2( {
 
 		return (
 			<div className="plugin-common-table__bulk-actions">
-				{ pluginUpdateCount && (
+				{ !! pluginUpdateCount && (
 					<ButtonGroup>
 						<Button compact primary onClick={ updateAllPlugins }>
 							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,4 +1,8 @@
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import ButtonGroup from 'calypso/components/button-group';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import PluginsList from './plugins-list';
 import type { Plugin } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -11,34 +15,72 @@ interface Props {
 	isLoading: boolean;
 	selectedSite: SiteDetails;
 	searchTerm: string;
+	isBulkManagementActive: boolean;
+	pluginUpdateCount: number;
+	toggleBulkManagement: () => void;
+	updateAllPlugins: () => void;
 }
 export default function PluginManagementV2( {
 	plugins,
 	isLoading,
 	selectedSite,
 	searchTerm,
+	isBulkManagementActive,
+	pluginUpdateCount,
+	toggleBulkManagement,
+	updateAllPlugins,
 }: Props ): ReactElement {
 	const translate = useTranslate();
+
+	const renderBulkActionsHeader = () => {
+		if ( isLoading ) {
+			return <TextPlaceholder />;
+		}
+
+		return (
+			<div className="plugin-common-table__bulk-actions">
+				{ pluginUpdateCount && (
+					<ButtonGroup>
+						<Button compact primary onClick={ updateAllPlugins }>
+							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
+								context: 'button label',
+								count: pluginUpdateCount,
+								args: {
+									numUpdates: pluginUpdateCount,
+								},
+							} ) }
+						</Button>
+					</ButtonGroup>
+				) }
+				<ButtonGroup>
+					<Button compact onClick={ toggleBulkManagement }>
+						{ translate( 'Edit All', { context: 'button label' } ) }
+					</Button>
+				</ButtonGroup>
+			</div>
+		);
+	};
+
 	const columns = [
 		{
 			key: 'plugin',
-			title: translate( 'Installed Plugins' ),
+			header: translate( 'Installed Plugins' ),
 		},
 		...( selectedSite
 			? [
 					{
 						key: 'activate',
-						title: translate( 'Active' ),
+						header: translate( 'Active' ),
 						smallColumn: true,
 					},
 					{
 						key: 'autoupdate',
-						title: translate( 'Autoupdate' ),
+						header: translate( 'Autoupdate' ),
 						smallColumn: true,
 					},
 					{
 						key: 'last-updated',
-						title: translate( 'Last updated' ),
+						header: translate( 'Last updated' ),
 						smallColumn: true,
 						colSpan: 2,
 					},
@@ -46,13 +88,15 @@ export default function PluginManagementV2( {
 			: [
 					{
 						key: 'sites',
-						title: translate( 'Sites' ),
+						header: translate( 'Sites' ),
 						smallColumn: true,
-						colSpan: 2,
+						colSpan: 1,
 					},
 			  ] ),
 		{
 			key: 'update',
+			header: renderBulkActionsHeader(),
+			colSpan: 2,
 		},
 	];
 
@@ -64,16 +108,20 @@ export default function PluginManagementV2( {
 		return <div className="plugin-management-v2__no-sites">{ emptyStateMessage }</div>;
 	}
 
-	const title = translate( 'Installed Plugins' );
-
 	return (
-		<div className="plugin-management-v2__main-content-container">
+		<div
+			className={ classNames( 'plugin-management-v2__main-content-container', {
+				'is-bulk-management-active': isBulkManagementActive,
+			} ) }
+		>
 			<PluginsList
 				items={ plugins }
 				columns={ columns }
 				isLoading={ isLoading }
+				className={ classNames( {
+					'has-bulk-management-active': isBulkManagementActive,
+				} ) }
 				selectedSite={ selectedSite }
-				title={ title }
 			/>
 		</div>
 	);

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/index.tsx
@@ -13,7 +13,6 @@ interface Props {
 	items: Array< any >;
 	isLoading: boolean;
 	columns: Columns;
-	title?: ReactNode;
 	hasMoreActions: boolean;
 	primaryKey: string;
 	rowFormatter: ( args: RowFormatterArgs ) => ReactNode;
@@ -21,7 +20,6 @@ interface Props {
 
 export default function PluginCommonList( {
 	items,
-	title,
 	isLoading,
 	primaryKey,
 	selectedSite,
@@ -37,12 +35,6 @@ export default function PluginCommonList( {
 			/>
 			<div className="plugin-common-list__mobile-view">
 				<>
-					{ title && (
-						<Card className="plugin-common-list__content-header">
-							<div>{ title }</div>
-						</Card>
-					) }
-
 					{ isLoading ? (
 						<Card>
 							<TextPlaceholder />

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/style.scss
@@ -2,10 +2,6 @@
 @import '@wordpress/base-styles/_mixins.scss';
 
 .plugin-common-list__mobile-view {
-	margin: 0 -16px;
-	@include breakpoint-deprecated( '>660px' ) {
-		margin: unset;
-	}
 	@include break-xlarge() {
 		display: none;
 	}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
@@ -13,6 +13,7 @@ interface Props {
 	rowFormatter: ( args: RowFormatterArgs ) => ReactNode;
 	hasMoreActions: boolean;
 	primaryKey: string;
+	className?: string;
 }
 
 export default function PluginCommonTable( {
@@ -22,19 +23,19 @@ export default function PluginCommonTable( {
 	rowFormatter,
 	hasMoreActions,
 	primaryKey,
+	className,
 }: Props ): ReactElement {
 	return (
-		<table className="plugin-common-table__table">
+		<table className={ classNames( 'plugin-common-table__table', className ) }>
 			<thead>
 				<tr>
 					{ columns
-						.filter( ( column ) => column.title )
+						.filter( ( column ) => column.header )
 						.map( ( column ) => (
 							<th colSpan={ column.colSpan || 1 } key={ column.key }>
-								{ column.title }
+								{ column.header }
 							</th>
 						) ) }
-					<th></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -51,6 +51,11 @@
 		min-width: 50%;
 		vertical-align: middle;
 	}
+	&.has-bulk-management-active {
+		thead {
+			display: none;
+		}
+	}
 }
 td.plugin-common-table__actions {
 	padding: 0;
@@ -90,4 +95,17 @@ td.plugin-common-table__actions {
 	height: 24px;
 	vertical-align: middle;
 	margin-inline-end: 16px;
+}
+.plugin-common-table__bulk-actions {
+	display: flex;
+	justify-content: end;
+	.button-group {
+		margin-inline-end: 8px;
+		button {
+			&:first-child,
+			&:last-child {
+				border-radius: 4px;
+			}
+		}
+	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -100,7 +100,9 @@ td.plugin-common-table__actions {
 	display: flex;
 	justify-content: end;
 	.button-group {
-		margin-inline-end: 8px;
+		&:not( :last-child ) {
+			margin-inline-end: 8px;
+		}
 		button {
 			&:first-child,
 			&:last-child {

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -2,15 +2,15 @@ import PluginCommonList from '../plugin-common/plugin-common-list';
 import PluginRowFormatter from '../plugin-row-formatter';
 import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 
 interface Props {
 	selectedSite: SiteDetails;
 	items: Array< Plugin >;
 	isLoading: boolean;
 	columns: Columns;
-	title?: ReactNode;
 	hasMoreActions?: boolean;
+	className?: string;
 }
 
 export default function PluginsList( {

--- a/client/my-sites/plugins/plugin-management-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .has-opacity {
 	opacity: 0.3;
 }
@@ -9,7 +12,13 @@
 	padding: 0;
 }
 .plugin-management-v2__main-content-container {
-	margin-top: 8px;
+	margin-top: 0;
+	@include break-xlarge() {
+		margin-top: 8px;
+	}
+	&.is-bulk-management-active {
+		margin-top: 0;
+	}
 }
 .plugin-management-v2__no-sites {
 	text-align: center;

--- a/client/my-sites/plugins/plugin-management-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/style.scss
@@ -12,12 +12,12 @@
 	padding: 0;
 }
 .plugin-management-v2__main-content-container {
-	margin-top: 0;
+	margin-block-start: 0;
 	@include break-xlarge() {
-		margin-top: 8px;
+		margin-block-start: 8px;
 	}
 	&.is-bulk-management-active {
-		margin-top: 0;
+		margin-block-start: 0;
 	}
 }
 .plugin-management-v2__no-sites {

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -4,7 +4,7 @@ import type { ReactChild } from 'react';
 
 export type Columns = Array< {
 	key: string;
-	title?: ReactChild;
+	header?: ReactChild;
 	smallColumn?: boolean;
 	colSpan?: number;
 } >;

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -539,42 +539,45 @@ export class PluginsList extends Component {
 			<div className="plugins-list">
 				<QueryProductsList />
 				<PluginNotices sites={ this.getPluginsSites() } plugins={ this.props.plugins } />
+				<PluginsListHeader
+					label={ this.props.header }
+					isBulkManagementActive={ this.state.bulkManagementActive }
+					isWpcom={ ! this.props.isJetpackCloud }
+					selectedSiteSlug={ selectedSiteSlug }
+					plugins={ this.props.plugins }
+					selected={ this.getSelected() }
+					toggleBulkManagement={ this.toggleBulkManagement }
+					updateAllPlugins={ this.updateAllPlugins }
+					updateSelected={ this.updateSelected }
+					pluginUpdateCount={ this.props.pluginUpdateCount }
+					activateSelected={ this.activateSelected }
+					deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
+					deactivateSelected={ this.deactivateSelected }
+					setAutoupdateSelected={ this.setAutoupdateSelected }
+					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
+					removePluginNotice={ this.removePluginDialog }
+					setSelectionState={ this.setBulkSelectionState }
+					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
+					haveInactiveSelected={ this.props.plugins.some(
+						this.filterSelection.inactive.bind( this )
+					) }
+					haveUpdatesSelected={ this.props.plugins.some(
+						this.filterSelection.updates.bind( this )
+					) }
+				/>
 				{ this.props.isJetpackCloud ? (
 					<PluginManagementV2
 						plugins={ this.props.plugins }
 						isLoading={ this.props.isLoading }
 						selectedSite={ this.props.selectedSite }
 						searchTerm={ this.props.searchTerm }
+						isBulkManagementActive={ this.state.bulkManagementActive }
+						pluginUpdateCount={ this.props.pluginUpdateCount }
+						toggleBulkManagement={ this.toggleBulkManagement }
+						updateAllPlugins={ this.updateAllPlugins }
 					/>
 				) : (
 					<>
-						<PluginsListHeader
-							label={ this.props.header }
-							isBulkManagementActive={ this.state.bulkManagementActive }
-							selectedSiteSlug={ selectedSiteSlug }
-							plugins={ this.props.plugins }
-							selected={ this.getSelected() }
-							toggleBulkManagement={ this.toggleBulkManagement }
-							updateAllPlugins={ this.updateAllPlugins }
-							updateSelected={ this.updateSelected }
-							pluginUpdateCount={ this.props.pluginUpdateCount }
-							activateSelected={ this.activateSelected }
-							deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
-							deactivateSelected={ this.deactivateSelected }
-							setAutoupdateSelected={ this.setAutoupdateSelected }
-							unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
-							removePluginNotice={ this.removePluginDialog }
-							setSelectionState={ this.setBulkSelectionState }
-							haveActiveSelected={ this.props.plugins.some(
-								this.filterSelection.active.bind( this )
-							) }
-							haveInactiveSelected={ this.props.plugins.some(
-								this.filterSelection.inactive.bind( this )
-							) }
-							haveUpdatesSelected={ this.props.plugins.some(
-								this.filterSelection.updates.bind( this )
-							) }
-						/>
 						<Card className={ itemListClasses }>
 							{ this.orderPluginsByUpdates( this.props.plugins ).map( this.renderPlugin ) }
 						</Card>


### PR DESCRIPTION
#### Proposed Changes

This PR brings the new bulk actions UI to Jetpack Cloud Plugin Management. I tried to reuse the existing `<PluginsListHeader />` component to avoid more considerable refactoring. The table itself will have duplicated buttons for the `Edit all` and `Update plugins`, but when we are in bulk action mode, the table header will be no longer displayed, and the `<PluginListHeader />` component will be rendered instead.

#### Testing Instructions

- Checkout PR locally
- Run `yarn start`
- When the build is ready, run `yarn start-jetpack-cloud-p`
- Visit http://calypso.localhost:3000/plugins/manage and verify that the UI isn't changed. The easiest way would be to open wordpress.com/plugins/manage and compare both UIs.
- On the same page, verify that the bulk actions work as expected.
- Visit http://jetpack.cloud.localhost:3001/plugins/manage and verify that the bulk actions UI on top looks as expected on different screen sizes.
- On the same page, verify that the bulk actions work as expected.

#### Screenshots

**Desktop**

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/1749918/186415360-e40d3e33-7bdd-41c4-a83e-bc79c08b6084.png">

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/1749918/186415485-b4c9c950-904b-45d3-bb03-e81d1bdc7960.png" >

**Mobile**

<img width="275" alt="image" src="https://user-images.githubusercontent.com/1749918/186415876-0a92d8cb-d0e2-489f-860b-a382b47e433c.png">

<img width="277" alt="image" src="https://user-images.githubusercontent.com/1749918/186416121-c1242da2-366f-487c-9efc-de5192fc3afb.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: 1202518759611394-as-1202698250096200