### PR TITLE
SiteIconPicker: add dropzone

### DIFF
--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -3,8 +3,9 @@ import { FormFileUpload } from '@wordpress/components';
 import { Icon, upload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import React from 'react';
+import React, { useCallback } from 'react';
 import ImageEditor from 'calypso/blocks/image-editor';
+import DropZone from 'calypso/components/drop-zone';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import './style.scss';
 
@@ -33,6 +34,17 @@ export function SiteIconWithPicker( {
 	const [ editingFile, setEditingFile ] = React.useState< string >();
 	const [ imageEditorOpen, setImageEditorOpen ] = React.useState< boolean >( false );
 	const siteIconUrl = site?.icon?.img;
+
+	const handleFileChange = useCallback(
+		( file: File | undefined ) => {
+			if ( file ) {
+				setEditingFileName( file.name );
+				setEditingFile( URL.createObjectURL( file ) );
+				setImageEditorOpen( true );
+			}
+		},
+		[ setEditingFileName, setEditingFile, setImageEditorOpen ]
+	);
 
 	return (
 		<>
@@ -67,14 +79,10 @@ export function SiteIconWithPicker( {
 					} ) }
 					accept=".jpg,.jpeg,.gif,.png"
 					onChange={ ( event ) => {
-						if ( event.target.files?.[ 0 ] ) {
-							setEditingFileName( event.target.files?.[ 0 ].name );
-							setEditingFile( URL.createObjectURL( event.target.files?.[ 0 ] ) );
-							setImageEditorOpen( true );
-							// onChange won't fire if the user picks the same file again
-							// delete the value so users can reselect the same file again
-							event.target.value = '';
-						}
+						handleFileChange( event.target.files?.[ 0 ] );
+						// onChange won't fire if the user picks the same file again
+						// delete the value so users can reselect the same file again
+						event.target.value = '';
 					} }
 				>
 					{ selectedFileUrl || siteIconUrl ? (
@@ -88,6 +96,13 @@ export function SiteIconWithPicker( {
 							: placeholderText || __( 'Add a site icon' ) }
 					</span>
 				</FormFileUpload>
+				<DropZone
+					className="site-icon-with-picker__dropzone"
+					fullScreen
+					onFilesDrop={ ( files: FileList ) => {
+						handleFileChange( files[ 0 ] );
+					} }
+				/>
 			</FormFieldset>
 		</>
 	);

--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -73,6 +73,14 @@ export function SiteIconWithPicker( {
 				className={ classNames( 'site-icon-with-picker__site-icon', uploadFieldClassName ) }
 				disabled={ disabled }
 			>
+				<DropZone
+					className="site-icon-with-picker__dropzone"
+					textLabel={ ' ' }
+					icon={ <Icon icon={ upload } /> }
+					onFilesDrop={ ( files: FileList ) => {
+						handleFileChange( files[ 0 ] );
+					} }
+				/>
 				<FormFileUpload
 					className={ classNames( 'site-icon-with-picker__upload-button', {
 						'has-icon-or-image': selectedFile || siteIconUrl,
@@ -96,13 +104,6 @@ export function SiteIconWithPicker( {
 							: placeholderText || __( 'Add a site icon' ) }
 					</span>
 				</FormFileUpload>
-				<DropZone
-					className="site-icon-with-picker__dropzone"
-					fullScreen
-					onFilesDrop={ ( files: FileList ) => {
-						handleFileChange( files[ 0 ] );
-					} }
-				/>
 			</FormFieldset>
 		</>
 	);

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -37,15 +37,19 @@ button.components-button.site-icon-with-picker__upload-button {
 			text-decoration: underline;
 			text-underline-position: under;
 		}
+
+		&:hover {
+			background-color: transparent;
+		}
 	}
 
 	img {
-		height: $icon-size;
-		width: $icon-size;
+		height: $icon-size - 2;
+		width: $icon-size - 2;
 		border-radius: $icon-border-radius;
 		position: absolute;
-		top: 0%;
-		left: 0%;
+		top: 0;
+		left: 0;
 	}
 	svg {
 		position: absolute;
@@ -61,7 +65,7 @@ button.components-button.site-icon-with-picker__upload-button {
 		margin-top: 50px;
 		margin-left: -75%;
 	}
-	
+
 }
 
 .site-icon-with-picker__dropzone {

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -28,7 +28,7 @@ button.components-button.site-icon-with-picker__upload-button {
 	position: relative;
 	border: 1px dashed var( --studio-gray-60 );
 	background-size: contain;
-	margin-bottom: 40px;
+	margin-bottom: 30px;
 
 	&.has-icon-or-image {
 		border: none;
@@ -45,17 +45,17 @@ button.components-button.site-icon-with-picker__upload-button {
 		border-radius: $icon-border-radius;
 	}
 	svg {
-		width: $icon-size;
-		height: $icon-size;
-		padding: 26px;
-		box-sizing: border-box;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
 	}
 	span {
 		position: absolute;
 		width: 200px;
 		display: block;
 		text-align: center;
-		margin-top: 10px;
+		margin-top: 50px;
 		margin-left: -75%;
 	}
 }
@@ -89,8 +89,9 @@ button.components-button.site-icon-with-picker__upload-button {
 
 				.drop-zone__content-icon {
 					transform: translateX( -50% ) scale( 1.05 );
+
 					svg {
-						transform: scale( 1.3 );
+						transform: translate( -50%, -50% ) scale( 1.3 );
 				 	}
 				}
 			}
@@ -106,13 +107,15 @@ button.components-button.site-icon-with-picker__upload-button {
 		border: 1px solid var( --studio-gray-10 );
 		border-radius: $icon-border-radius;
 		transition: ease 1s;
+		width: $icon-size;
+		height: $icon-size;
 
 		svg {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate( -50%, -50% );
 			fill: #fff;
-			width: $icon-size;
-			height: $icon-size;
-			padding: 26px;
-			box-sizing: border-box;
 			transition: ease 1s;
 		}
 	}

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -1,3 +1,6 @@
+$icon-size: 80px;
+$icon-border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+
 .site-icon-with-picker__image-editor {
 	position: absolute;
 	top: 0;
@@ -18,10 +21,10 @@
 button.components-button.site-icon-with-picker__upload-button {
 	cursor: pointer;
 	display: inline-block;
-	height: 80px;
-	width: 80px;
+	height: $icon-size;
+	width: $icon-size;
 	padding: 0;
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: $icon-border-radius;
 	position: relative;
 	border: 1px dashed var( --studio-gray-60 );
 	background-size: contain;
@@ -37,13 +40,13 @@ button.components-button.site-icon-with-picker__upload-button {
 	}
 
 	img {
-		height: 80px;
-		width: 80px;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		height: $icon-size;
+		width: $icon-size;
+		border-radius: $icon-border-radius;
 	}
 	svg {
-		width: 80px;
-		height: 80px;
+		width: $icon-size;
+		height: $icon-size;
 		padding: 26px;
 		box-sizing: border-box;
 	}
@@ -54,5 +57,63 @@ button.components-button.site-icon-with-picker__upload-button {
 		text-align: center;
 		margin-top: 10px;
 		margin-left: -75%;
+	}
+}
+
+.site-icon-with-picker__dropzone {
+	margin: 0;
+	border: none;
+	background-color: unset;
+
+	.drop-zone__content {
+		position: static;
+	}
+
+	&.drop-zone.is-active {
+		opacity: 0;
+		visibility: hidden;
+
+		&.is-dragging-over-document {
+			opacity: 0;
+			visibility: hidden;
+			background-color: unset;
+		}
+
+		&.is-dragging-over-element {
+			opacity: 1;
+			visibility: visible;
+			background-color: unset;
+
+			.drop-zone__content {
+				transform: none;
+
+				.drop-zone__content-icon {
+					transform: translateX( -50% ) scale( 1.05 );
+					svg {
+						transform: scale( 1.3 );
+				 	}
+				}
+			}
+		}
+	}
+
+	.drop-zone__content-icon {
+		position: absolute;
+		top: 0;
+		left: 50%;
+		transform: translateX( -50% );
+		background-color: rgba( var( --color-primary-rgb ) );
+		border: 1px solid var( --studio-gray-10 );
+		border-radius: $icon-border-radius;
+		transition: ease 1s;
+
+		svg {
+			fill: #fff;
+			width: $icon-size;
+			height: $icon-size;
+			padding: 26px;
+			box-sizing: border-box;
+			transition: ease 1s;
+		}
 	}
 }

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -43,6 +43,9 @@ button.components-button.site-icon-with-picker__upload-button {
 		height: $icon-size;
 		width: $icon-size;
 		border-radius: $icon-border-radius;
+		position: absolute;
+		top: 0%;
+		left: 0%;
 	}
 	svg {
 		position: absolute;
@@ -58,6 +61,7 @@ button.components-button.site-icon-with-picker__upload-button {
 		margin-top: 50px;
 		margin-left: -75%;
 	}
+	
 }
 
 .site-icon-with-picker__dropzone {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -12,7 +12,6 @@ $border-radius: 4px;
 	.step-container__content {
 		display: flex;
 		justify-content: center;
-		margin-bottom: 30px;
 	}
 
 	.newsletter-setup .step-container__header {


### PR DESCRIPTION
#### Proposed Changes

* We need to add drag and drop support for the site icon picker.
* This PR adds a drop zone, without causing intrusive visual changes.

<img width="807" alt="Screenshot 2022-09-01 at 12 13 25" src="https://user-images.githubusercontent.com/7000684/187890449-5932b7ff-3f7d-4fbf-bc62-fc9c852ee517.png">

#### Testing Instructions
- Checkout this branch and run `yarn start`
- Visit http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter
- Test drag and drop of image files, and see if the image is properly updated
- Test with different browsers and viewports

Related to #67199
