### PR TITLE
Signup: Send flowName as vendor for domains search API

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -529,6 +529,7 @@ class DomainsStep extends Component {
 					vendor={ getSuggestionsVendor( {
 						isSignup: true,
 						isDomainOnly: this.props.isDomainOnly,
+						flowName: this.props.flowName,
 					} ) }
 					deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 					selectedSite={ this.props.selectedSite }

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -34,12 +34,21 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
+	flowName?: 'link-in-bio' | 'newsletter';
 }
-type DomainSuggestionsVendor = 'variation2_front' | 'variation4_front' | 'variation8_front';
+type DomainSuggestionsVendor =
+	| 'variation2_front'
+	| 'variation4_front'
+	| 'variation8_front'
+	| 'link-in-bio'
+	| 'newsletter';
 
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
 ): DomainSuggestionsVendor {
+	if ( options.flowName && [ 'link-in-bio', 'newsletter' ].includes( options.flowName ) ) {
+		return options.flowName;
+	}
 	if ( options.isSignup && ! options.isDomainOnly ) {
 		return 'variation4_front';
 	}

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -34,19 +34,18 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: 'link-in-bio' | 'newsletter';
+	flowName?: 'link-in-bio';
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
 	| 'variation4_front'
 	| 'variation8_front'
-	| 'link-in-bio'
-	| 'newsletter';
+	| 'link-in-bio';
 
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
 ): DomainSuggestionsVendor {
-	if ( options.flowName && [ 'link-in-bio', 'newsletter' ].includes( options.flowName ) ) {
+	if ( options.flowName === 'link-in-bio' ) {
 		return options.flowName;
 	}
 	if ( options.isSignup && ! options.isDomainOnly ) {


### PR DESCRIPTION
#### Proposed Changes

* This sets the `vendor` value to  `link-in-bio`link-in-bio flow. To weigh `.link` TLDs higher for this flow.

#### Testing Instructions

1. Go to /setup?flow=link-in-bio.
2. Arrive to the domain step.
3. A .link domain should be high on the list.