### PR TITLE
Tailored flows: enable dotcom blog domains for newsletter flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -376,6 +376,11 @@ class DomainsStep extends Component {
 			return true;
 		}
 
+		// newsletter users should get free .blog domain
+		if ( flowName === 'newsletter' ) {
+			return true;
+		}
+
 		// 'blog' flow, starting with blog themes
 		if ( flowName === 'blog' ) {
 			return true;


### PR DESCRIPTION
#### Proposed Changes

* Enables dotcom blog domains for newsletter flow

#### Testing Instructions

1. Go to /setup?flow=newsletter
2. Arrive to the domain step
3. You should see `yoursite.*.blog` (eg yoursite.news.blog) subdomains within suggestions when you search.
