### PR TITLE
Remove combine card functionality from reader stream

### DIFF
--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -23,7 +23,7 @@ export default function A8CFollowing( props ) {
 	};
 
 	return (
-		<Stream { ...props }>
+		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed A8C Sites' ) }>
 				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }

--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -23,7 +23,7 @@ export default function A8CFollowing( props ) {
 	};
 
 	return (
-		<Stream { ...props } shouldCombineCards={ false }>
+		<Stream { ...props }>
 			<SectionHeader label={ translate( 'Followed A8C Sites' ) }>
 				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -13,7 +13,6 @@ export default function ( props ) {
 		<Stream
 			key="conversations"
 			streamKey={ props.streamKey }
-			shouldCombineCards={ false }
 			className="conversations__stream"
 			followSource="conversations"
 			useCompactCards={ true }

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -13,6 +13,7 @@ export default function ( props ) {
 		<Stream
 			key="conversations"
 			streamKey={ props.streamKey }
+			shouldCombineCards={ false }
 			className="conversations__stream"
 			followSource="conversations"
 			useCompactCards={ true }

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -54,6 +54,7 @@ class FeedStream extends Component {
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
+				shouldCombineCards={ false }
 			>
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -54,7 +54,6 @@ class FeedStream extends Component {
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
-				shouldCombineCards={ false }
 			>
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -21,7 +21,7 @@ export default function P2Following( props ) {
 	};
 
 	return (
-		<Stream { ...props } shouldCombineCards={ false }>
+		<Stream { ...props }>
 			<SectionHeader label={ translate( 'Followed P2 Sites' ) }>
 				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -21,7 +21,7 @@ export default function P2Following( props ) {
 	};
 
 	return (
-		<Stream { ...props }>
+		<Stream { ...props } shouldCombineCards={ false }>
 			<SectionHeader label={ translate( 'Followed P2 Sites' ) }>
 				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }

--- a/client/reader/post-key.js
+++ b/client/reader/post-key.js
@@ -48,12 +48,7 @@ export function keyToString( postKey ) {
 		return null;
 	}
 
-	if ( postKey.isCombination ) {
-		const feedId = postKey.feedId ? `&feedId=${ postKey.feedId }` : '';
-		const blogId = postKey.blogId ? `&feedId=${ postKey.blogId }` : '';
-		const postIds = postKey.postIds.join( ',' );
-		return `postIds=[${ postIds }, ]${ feedId }${ blogId } `;
-	} else if ( postKey.isRecommendationBlock ) {
+	if ( postKey.isRecommendationBlock ) {
 		return `rec-${ postKey.index }`;
 	} else if ( postKey.feedId ) {
 		return `${ postKey.postId }-${ postKey.feedId }`;

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -43,6 +43,7 @@ class PostResults extends Component {
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
 				placeholderFactory={ this.placeholderFactory }
+				shouldCombineCards={ true }
 				transformStreamItems={ transformStreamItems }
 				isMain={ false }
 			>

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -43,7 +43,6 @@ class PostResults extends Component {
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
 				placeholderFactory={ this.placeholderFactory }
-				shouldCombineCards={ true }
 				transformStreamItems={ transformStreamItems }
 				isMain={ false }
 			>

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -61,6 +61,7 @@ class SiteStream extends Component {
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
 				isDiscoverStream={ this.props.isDiscoverStream }
+				shouldCombineCards={ false }
 			>
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -61,7 +61,6 @@ class SiteStream extends Component {
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
 				isDiscoverStream={ this.props.isDiscoverStream }
-				shouldCombineCards={ false }
 			>
 				<DocumentHead
 					title={ this.props.translate( '%s ‹ Reader', {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -61,7 +61,6 @@ class ReaderStream extends Component {
 		placeholderFactory: PropTypes.func,
 		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
-		shouldCombineCards: PropTypes.bool,
 		useCompactCards: PropTypes.bool,
 		isMain: PropTypes.bool,
 		intro: PropTypes.object,
@@ -78,7 +77,6 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: true,
 		showPrimaryFollowButtonOnCards: true,
 		isDiscoverStream: false,
-		shouldCombineCards: true,
 		isMain: true,
 		useCompactCards: false,
 		intro: null,
@@ -473,7 +471,7 @@ class ReaderStream extends Component {
 }
 
 export default connect(
-	( state, { streamKey, recsStreamKey, shouldCombineCards = true } ) => {
+	( state, { streamKey, recsStreamKey } ) => {
 		const stream = getStream( state, streamKey );
 		const selectedPost = getPostByKey( state, stream.selected );
 
@@ -482,7 +480,6 @@ export default connect(
 			items: getTransformedStreamItems( state, {
 				streamKey,
 				recsStreamKey,
-				shouldCombine: shouldCombineCards,
 			} ),
 			notificationsOpen: isNotificationsOpen( state ),
 			stream,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -12,7 +12,7 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import scrollTo from 'calypso/lib/scroll-to';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
-import { keysAreEqual, keyToString, keyForPost } from 'calypso/reader/post-key';
+import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
 import UpdateNotice from 'calypso/reader/update-notice';
 import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
 import XPostHelper from 'calypso/reader/xpost-helper';
@@ -61,7 +61,6 @@ class ReaderStream extends Component {
 		placeholderFactory: PropTypes.func,
 		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
-		shouldCombineCards: PropTypes.bool,
 		useCompactCards: PropTypes.bool,
 		isMain: PropTypes.bool,
 		intro: PropTypes.object,
@@ -78,7 +77,6 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: true,
 		showPrimaryFollowButtonOnCards: true,
 		isDiscoverStream: false,
-		shouldCombineCards: true,
 		isMain: true,
 		useCompactCards: false,
 		intro: null,
@@ -289,18 +287,6 @@ class ReaderStream extends Component {
 				}
 			}
 
-			const candidateItem = items[ index ];
-			// is this a combo card?
-			if ( candidateItem.isCombination ) {
-				// pick the first item
-				const postKey = {
-					postId: candidateItem.postIds[ 0 ],
-					feedId: candidateItem.feedId,
-					blogId: candidateItem.blogId,
-				};
-				this.props.selectItem( { streamKey, postKey } );
-			}
-
 			// find the index of the post / gap in the items array.
 			// Start the search from the index in the items array, which has to be equal to or larger than
 			// the index in the items array.
@@ -384,7 +370,7 @@ class ReaderStream extends Component {
 		const showPost = ( args ) =>
 			this.props.showSelectedPost( {
 				...args,
-				postKey: postKey.isCombination ? keyForPost( args ) : postKey,
+				postKey: postKey,
 				streamKey,
 			} );
 
@@ -401,7 +387,7 @@ class ReaderStream extends Component {
 					showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
 					isDiscoverStream={ this.props.isDiscoverStream }
 					showSiteName={ this.props.showSiteNameOnCards }
-					selectedPostKey={ postKey.isCombination ? selectedPostKey : undefined }
+					selectedPostKey={ undefined }
 					followSource={ this.props.followSource }
 					blockedSites={ this.props.blockedSites }
 					streamKey={ streamKey }
@@ -473,7 +459,7 @@ class ReaderStream extends Component {
 }
 
 export default connect(
-	( state, { streamKey, recsStreamKey, shouldCombineCards = true } ) => {
+	( state, { streamKey, recsStreamKey } ) => {
 		const stream = getStream( state, streamKey );
 		const selectedPost = getPostByKey( state, stream.selected );
 
@@ -482,7 +468,6 @@ export default connect(
 			items: getTransformedStreamItems( state, {
 				streamKey,
 				recsStreamKey,
-				shouldCombine: shouldCombineCards,
 			} ),
 			notificationsOpen: isNotificationsOpen( state ),
 			stream,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -61,6 +61,7 @@ class ReaderStream extends Component {
 		placeholderFactory: PropTypes.func,
 		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
+		shouldCombineCards: PropTypes.bool,
 		useCompactCards: PropTypes.bool,
 		isMain: PropTypes.bool,
 		intro: PropTypes.object,
@@ -77,6 +78,7 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: true,
 		showPrimaryFollowButtonOnCards: true,
 		isDiscoverStream: false,
+		shouldCombineCards: true,
 		isMain: true,
 		useCompactCards: false,
 		intro: null,
@@ -471,7 +473,7 @@ class ReaderStream extends Component {
 }
 
 export default connect(
-	( state, { streamKey, recsStreamKey } ) => {
+	( state, { streamKey, recsStreamKey, shouldCombineCards = true } ) => {
 		const stream = getStream( state, streamKey );
 		const selectedPost = getPostByKey( state, stream.selected );
 
@@ -480,6 +482,7 @@ export default connect(
 			items: getTransformedStreamItems( state, {
 				streamKey,
 				recsStreamKey,
+				shouldCombine: shouldCombineCards,
 			} ),
 			notificationsOpen: isNotificationsOpen( state ),
 			stream,

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -2,7 +2,6 @@ import { omit, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import CombinedCard from 'calypso/blocks/reader-combined-card';
 import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import compareProps from 'calypso/lib/compare-props';
@@ -26,7 +25,7 @@ class PostLifecycle extends Component {
 	};
 
 	render() {
-		const { post, postKey, followSource, isSelected, recsStreamKey, streamKey } = this.props;
+		const { post, postKey, isSelected, recsStreamKey, streamKey } = this.props;
 
 		if ( postKey.isRecommendationBlock ) {
 			return (
@@ -35,18 +34,6 @@ class PostLifecycle extends Component {
 					index={ postKey.index }
 					streamKey={ recsStreamKey }
 					followSource={ IN_STREAM_RECOMMENDATION }
-				/>
-			);
-		} else if ( postKey.isCombination ) {
-			return (
-				<CombinedCard
-					postKey={ postKey }
-					index={ this.props.index }
-					onClick={ this.props.handleClick }
-					selectedPostKey={ this.props.selectedPostKey }
-					followSource={ followSource }
-					showFollowButton={ this.props.showPrimaryFollowButtonOnCards }
-					blockedSites={ this.props.blockedSites }
 				/>
 			);
 		} else if ( streamKey.indexOf( 'rec' ) > -1 ) {

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -1,10 +1,24 @@
 import moment from 'moment';
-import { sameDay, sameSite, injectRecommendations } from '../utils';
+import { sameDay, sameSite, combine, combineCards, injectRecommendations } from '../utils';
 
 describe( 'reader stream', () => {
 	const today = moment().toDate();
 	const postKey1 = { feedId: 'feed1', postId: 'postId1', date: today };
 	const postKey2 = { feedId: 'feed1', postId: 'postId2', date: today };
+	const postIds34 = [ 'postId3', 'postId4' ];
+	const postIds57 = [ 'postId5', 'postId6', 'postId7' ];
+	const combinedCardPostKey1 = {
+		feedId: postKey1.feedId,
+		postIds: postIds34,
+		date: today,
+		isCombination: true,
+	};
+	const combinedCardPostKey2 = {
+		feedId: postKey1.feedId,
+		postIds: postIds57,
+		date: today,
+		isCombination: true,
+	};
 
 	describe( '#sameDay', () => {
 		const datePostKey = ( date ) => ( { date } );
@@ -37,12 +51,123 @@ describe( 'reader stream', () => {
 			expect( isSame ).toBe( true );
 		} );
 
+		test( 'should return true when samesite and one item is a combinedCard', () => {
+			const isSame = sameSite( combinedCardPostKey1, combinedCardPostKey2 );
+			expect( isSame ).toBe( true );
+		} );
+
+		test( 'should return false when different site and one item is a combinedCard', () => {
+			const isSame = sameSite( { ...combinedCardPostKey1, feedId: 'feed3' }, combinedCardPostKey2 );
+			expect( isSame ).toBe( false );
+		} );
+
+		test( 'should work when both postKeys represent combinedCards', () => {
+			const isSame = sameSite( combinedCardPostKey1, combinedCardPostKey2 );
+			expect( isSame ).toBe( true );
+		} );
+
 		test( 'recs should never be marked as sameSite', () => {
 			const isSame = sameSite(
 				{ ...postKey1, isRecommendationBlock: 'isRecommendationBlock' },
 				postKey1
 			);
 			expect( isSame ).toBe( false );
+		} );
+	} );
+
+	describe( '#combine', () => {
+		test( 'should combine two regular postkeys', () => {
+			const combined = combine( postKey1, postKey2 );
+			expect( combined ).toEqual( {
+				feedId: postKey1.feedId,
+				postIds: [ postKey1.postId, postKey2.postId ],
+				isCombination: true,
+				date: today,
+			} );
+		} );
+
+		test( 'should return null if either postKey is null', () => {
+			const combined = combine( postKey1, null );
+			expect( combined ).toBeNull();
+		} );
+
+		test( 'should combine a combined card with a regular postKey', () => {
+			const combined = combine( combinedCardPostKey1, postKey1 );
+			expect( combined ).toEqual( {
+				...combinedCardPostKey1,
+				postIds: combinedCardPostKey1.postIds.concat( postKey1.postId ),
+			} );
+		} );
+
+		test( 'should combine two combined cards correctly', () => {
+			const combined = combine( combinedCardPostKey1, combinedCardPostKey2 );
+			expect( combined ).toEqual( {
+				...combinedCardPostKey1,
+				postIds: combinedCardPostKey1.postIds.concat( combinedCardPostKey2.postIds ),
+			} );
+		} );
+	} );
+
+	describe( '#combineCards', () => {
+		const date = new Date();
+		const site1Key1 = { blogId: '1', postId: '11', date };
+		const site1Key2 = { blogId: '1', postId: '12', date };
+		const site1Key3 = { blogId: '1', postId: '13', date };
+		const site2Key2 = { blogId: '2', postId: '22', date };
+		const site3Key1 = { blogId: '3', postId: '31', date };
+		const site4Key1 = { blogId: '4', postId: '41', date };
+
+		test( 'should combine series with 2 in a rows', () => {
+			const postKeysSet1 = [ site1Key1, site1Key2 ];
+			const combinedItems1 = combineCards( postKeysSet1 );
+			expect( combinedItems1 ).toEqual( [ combine( site1Key1, site1Key2 ) ] );
+
+			const postKeysSet2 = [ site4Key1, site1Key1, site1Key2, site3Key1 ];
+			const combinedItems2 = combineCards( postKeysSet2 );
+			expect( combinedItems2 ).toEqual( [ site4Key1, combine( site1Key1, site1Key2 ), site3Key1 ] );
+		} );
+
+		test( 'should combine cards with series of 3 in a row', () => {
+			const combinedCard = combine( combine( site1Key1, site1Key2 ), site1Key3 );
+
+			const postKeys1 = [ site1Key1, site1Key2, site1Key3 ];
+			const combinedItems1 = combineCards( postKeys1 );
+			expect( combinedItems1 ).toEqual( [ combinedCard ] );
+
+			const postKeys2 = [ site4Key1, site1Key1, site1Key2, site1Key3, site3Key1 ];
+			const combinedItems2 = combineCards( postKeys2 );
+			expect( combinedItems2 ).toEqual( [ site4Key1, combinedCard, site3Key1 ] );
+		} );
+
+		test( 'should not combine any cards when no series exist', () => {
+			const postKeys = [ site1Key1, site2Key2, site3Key1, site4Key1 ];
+			const combinedItems = combineCards( postKeys );
+			expect( combinedItems ).toEqual( postKeys );
+		} );
+
+		test( 'should not combine discover cards', () => {
+			const discoverFeedId = 41325786;
+			const discoverSiteId = 53424024;
+			const discoverFeedPostKeys = [
+				{ feedId: discoverFeedId, postId: '1', date },
+				{ feedId: discoverFeedId, postId: '2', date },
+			];
+			const discoverSitePostKeys = [
+				{ blogId: discoverSiteId, postId: '1', date },
+				{ blogId: discoverSiteId, postId: '2', date },
+			];
+			const combinedFeedItems = combineCards( discoverFeedPostKeys );
+			const combinedSiteItems = combineCards( discoverSitePostKeys );
+
+			expect( combinedFeedItems ).toEqual( discoverFeedPostKeys );
+			expect( combinedSiteItems ).toEqual( discoverSitePostKeys );
+		} );
+
+		test( 'should not combine cards that are greater than a day apart', () => {
+			const theDistantPast = moment().year( -1 ).toDate();
+			const postKeys = [ site1Key1, { ...site1Key2, date: theDistantPast } ];
+			const combinedItems = combineCards( postKeys );
+			expect( combinedItems ).toEqual( postKeys );
 		} );
 	} );
 

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,4 +1,4 @@
-import { flatMap, last } from 'lodash';
+import flatMap from 'lodash';
 import moment from 'moment';
 import { isDiscoverBlog, isDiscoverFeed } from 'calypso/reader/discover/helper';
 
@@ -42,51 +42,6 @@ export function sameXPost( postKey1, postKey2 ) {
 		postKey1.xPostMetadata.postId === postKey2.xPostMetadata.postId
 	);
 }
-
-/**
- * Takes two postKeys and combines them into a ReaderCombinedCard postKey.
- * Note: This only makes sense for postKeys from the same site
- *
- * @param {object} postKey1 must be either a ReaderCombinedCard postKey or a regular postKey
- * @param {object} postKey2 can only be a regular postKey. May not be a combinedCard postKey or a recommendations postKey
- * @returns {object} A ReaderCombinedCard postKey
- */
-export function combine( postKey1, postKey2 ) {
-	if ( ! postKey1 || ! postKey2 ) {
-		return null;
-	}
-
-	const combined = {
-		isCombination: true,
-		date:
-			postKey1.date && postKey1.date < postKey2.date // keep the earliest moment
-				? postKey1.date
-				: postKey2.date,
-		postIds: [
-			...( postKey1.postIds || [ postKey1.postId ] ),
-			...( postKey2.postIds || [ postKey2.postId ] ),
-		],
-	};
-	postKey1.blogId && ( combined.blogId = postKey1.blogId );
-	postKey1.feedId && ( combined.feedId = postKey1.feedId );
-
-	return combined;
-}
-
-export const combineCards = ( postKeys ) =>
-	postKeys.reduce( ( accumulator, postKey ) => {
-		const lastPostKey = last( accumulator );
-		if (
-			sameSite( lastPostKey, postKey ) &&
-			sameDay( lastPostKey, postKey ) &&
-			! isDiscoverPostKey( postKey )
-		) {
-			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
-		} else {
-			accumulator.push( postKey );
-		}
-		return accumulator;
-	}, [] );
 
 export function injectRecommendations( posts, recs = [], itemsBetweenRecs ) {
 	if ( ! recs || recs.length === 0 ) {

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,4 +1,4 @@
-import flatMap from 'lodash';
+import { flatMap, last } from 'lodash';
 import moment from 'moment';
 import { isDiscoverBlog, isDiscoverFeed } from 'calypso/reader/discover/helper';
 
@@ -42,6 +42,51 @@ export function sameXPost( postKey1, postKey2 ) {
 		postKey1.xPostMetadata.postId === postKey2.xPostMetadata.postId
 	);
 }
+
+/**
+ * Takes two postKeys and combines them into a ReaderCombinedCard postKey.
+ * Note: This only makes sense for postKeys from the same site
+ *
+ * @param {object} postKey1 must be either a ReaderCombinedCard postKey or a regular postKey
+ * @param {object} postKey2 can only be a regular postKey. May not be a combinedCard postKey or a recommendations postKey
+ * @returns {object} A ReaderCombinedCard postKey
+ */
+export function combine( postKey1, postKey2 ) {
+	if ( ! postKey1 || ! postKey2 ) {
+		return null;
+	}
+
+	const combined = {
+		isCombination: true,
+		date:
+			postKey1.date && postKey1.date < postKey2.date // keep the earliest moment
+				? postKey1.date
+				: postKey2.date,
+		postIds: [
+			...( postKey1.postIds || [ postKey1.postId ] ),
+			...( postKey2.postIds || [ postKey2.postId ] ),
+		],
+	};
+	postKey1.blogId && ( combined.blogId = postKey1.blogId );
+	postKey1.feedId && ( combined.feedId = postKey1.feedId );
+
+	return combined;
+}
+
+export const combineCards = ( postKeys ) =>
+	postKeys.reduce( ( accumulator, postKey ) => {
+		const lastPostKey = last( accumulator );
+		if (
+			sameSite( lastPostKey, postKey ) &&
+			sameDay( lastPostKey, postKey ) &&
+			! isDiscoverPostKey( postKey )
+		) {
+			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
+		} else {
+			accumulator.push( postKey );
+		}
+		return accumulator;
+	}, [] );
 
 export function injectRecommendations( posts, recs = [], itemsBetweenRecs ) {
 	if ( ! recs || recs.length === 0 ) {

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,4 +1,4 @@
-import { flatMap, last } from 'lodash';
+import { flatMap } from 'lodash';
 import moment from 'moment';
 import { isDiscoverBlog, isDiscoverFeed } from 'calypso/reader/discover/helper';
 
@@ -42,51 +42,6 @@ export function sameXPost( postKey1, postKey2 ) {
 		postKey1.xPostMetadata.postId === postKey2.xPostMetadata.postId
 	);
 }
-
-/**
- * Takes two postKeys and combines them into a ReaderCombinedCard postKey.
- * Note: This only makes sense for postKeys from the same site
- *
- * @param {object} postKey1 must be either a ReaderCombinedCard postKey or a regular postKey
- * @param {object} postKey2 can only be a regular postKey. May not be a combinedCard postKey or a recommendations postKey
- * @returns {object} A ReaderCombinedCard postKey
- */
-export function combine( postKey1, postKey2 ) {
-	if ( ! postKey1 || ! postKey2 ) {
-		return null;
-	}
-
-	const combined = {
-		isCombination: true,
-		date:
-			postKey1.date && postKey1.date < postKey2.date // keep the earliest moment
-				? postKey1.date
-				: postKey2.date,
-		postIds: [
-			...( postKey1.postIds || [ postKey1.postId ] ),
-			...( postKey2.postIds || [ postKey2.postId ] ),
-		],
-	};
-	postKey1.blogId && ( combined.blogId = postKey1.blogId );
-	postKey1.feedId && ( combined.feedId = postKey1.feedId );
-
-	return combined;
-}
-
-export const combineCards = ( postKeys ) =>
-	postKeys.reduce( ( accumulator, postKey ) => {
-		const lastPostKey = last( accumulator );
-		if (
-			sameSite( lastPostKey, postKey ) &&
-			sameDay( lastPostKey, postKey ) &&
-			! isDiscoverPostKey( postKey )
-		) {
-			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
-		} else {
-			accumulator.push( postKey );
-		}
-		return accumulator;
-	}, [] );
 
 export function injectRecommendations( posts, recs = [], itemsBetweenRecs ) {
 	if ( ! recs || recs.length === 0 ) {

--- a/client/state/reader/streams/selectors/get-reader-stream-transformed-items.js
+++ b/client/state/reader/streams/selectors/get-reader-stream-transformed-items.js
@@ -1,9 +1,5 @@
 import treeSelect from '@automattic/tree-select';
-import {
-	injectRecommendations,
-	getDistanceBetweenRecs,
-	combineCards,
-} from 'calypso/reader/stream/utils';
+import { injectRecommendations, getDistanceBetweenRecs } from 'calypso/reader/stream/utils';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import getReaderStream from 'calypso/state/reader/streams/selectors/get-reader-stream';
 
@@ -11,9 +7,9 @@ import 'calypso/state/reader/init';
 
 /*
  * getTransformedStreamItems performs the transformations from raw state to data suitable for
- * Reader cards. That means injecting recs and combining cards.
+ * Reader cards. That means injecting recs.
  * Signature is:
- * function( state, { streamKey: string, recsStreamKey: string, shouldCombine: boolean }): Array
+ * function( state, { streamKey: string, recsStreamKey: string }): Array
  */
 export const getTransformedStreamItems = treeSelect(
 	( state, { streamKey, recsStreamKey } ) => [
@@ -21,7 +17,7 @@ export const getTransformedStreamItems = treeSelect(
 		getReaderStream( state, recsStreamKey ).items,
 		getReaderFollows( state ),
 	],
-	( [ items, recs, follows ], { shouldCombine } ) => {
+	( [ items, recs, follows ] ) => {
 		if ( items.length === 0 ) {
 			return [];
 		}
@@ -30,15 +26,10 @@ export const getTransformedStreamItems = treeSelect(
 			items = injectRecommendations( items, recs, getDistanceBetweenRecs( follows.length ) );
 		}
 
-		if ( shouldCombine ) {
-			items = combineCards( items );
-		}
-
 		return items;
 	},
 	{
-		getCacheKey: ( { streamKey, recsStreamKey, shouldCombine } ) =>
-			`${ streamKey }${ recsStreamKey }${ shouldCombine }`,
+		getCacheKey: ( { streamKey, recsStreamKey } ) => `${ streamKey }${ recsStreamKey }`,
 	}
 );
 


### PR DESCRIPTION
#### Proposed Changes

* This removes the combine and combinedCard functionality from Calypso reader

#### Testing Instructions

* You should see combined cards broken into single card posts in the reader stream

Before
<img width="842" alt="Screenshot 2022-08-24 at 13 57 01" src="https://user-images.githubusercontent.com/5560595/186424302-bfe6b7ee-5e0d-4eb8-b7b9-e42313ec5d7b.png">

After
<img width="833" alt="Screenshot 2022-08-24 at 13 56 51" src="https://user-images.githubusercontent.com/5560595/186424321-d8c9a942-a6c8-4f86-bfd3-475804bca302.png">

Related to https://github.com/Automattic/wp-calypso/issues/66625
