### PR TITLE
Marketplace search: Update author display name

### DIFF
--- a/client/data/marketplace/constants.ts
+++ b/client/data/marketplace/constants.ts
@@ -18,6 +18,7 @@ export const RETURNABLE_FIELDS = [
 	'modified_gmt',
 	'plugin.title',
 	'author',
+	'plugin.author',
 	'author_login',
 	'blog_id',
 	'date',

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -49,6 +49,7 @@ export type ESIndexResult = {
 	'plugin.support_threads_resolved'?: number;
 	'plugin.active_installs'?: number;
 	plugin: {
+		author: string;
 		title: string;
 		excerpt: string;
 		icons: string;

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -67,7 +67,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			slug: hit.slug,
 			version: hit[ 'plugin.stable_tag' ],
 			author: hit.author,
-			author_name: hit.author,
+			author_name: hit.plugin.author,
 			author_profile: '', // TODO: get author profile URL
 			tested: hit[ 'plugin.tested' ],
 			rating: mapStarRatingToPercent( hit.plugin.rating ),


### PR DESCRIPTION
The elastic search results return now `plugin.author` field that
displays the same value than the WP.org results. This new field will be
used to display the author name in search results

> **Warning**
> The related diff D86503-code must be deployed for the E2E tests to pass, otherwise the response of the search will return an error as the new `plugin.author` field is not yet in the list of returnable fields

#### Proposed Changes

- Use the new `plugin.author` to display the author name instead of the previous `author` field

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the backend and apply the following diff - D86503-code or make sure the diff already landed to production
* Make sure the flag `marketplace-jetpack-plugin-search` is active[^1]
* In the `/plugins` page, perform a search that returns a plugin with a different author and plugin.author, examples are:
  * search for `unicard` and see the only result
  * search for `ecommerce` and check `WooCommerce` result
  * search for `seo` and check `Yoast SEO`, it should be `Team Yoast`

[^1]: In order to activate the flag, you can add the following query param to the URL `&flag=+marketplace-jetpack-plugin-search` or execute the following in the _Developer Console_ `document.cookie = 'flags=+marketplace-jetpack-plugin-search;max-age=1209600;path=/'`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66159