### PR TITLE
Emails: tracking provider during clicks on email upsell element

### DIFF
--- a/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
+++ b/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
@@ -23,6 +23,7 @@ const NewMailboxUpsell = ( { domains }: { domains: ResponseDomain[] } ) => {
 	let upsellURL = emailManagement( selectedSiteSlug, null, null, { source: INBOX_SOURCE } );
 
 	let isFreeTrialNow = false;
+	let provider = '';
 
 	// User has one single domain, determine / email addition page URL based on subscribed email provider.
 	if ( domains.length === 1 ) {
@@ -31,10 +32,12 @@ const NewMailboxUpsell = ( { domains }: { domains: ResponseDomain[] } ) => {
 		let slug = '';
 		if ( hasTitanMailWithUs( domainItem ) ) {
 			slug = 'titan/new';
+			provider = 'titan';
 
 			isFreeTrialNow = isUserOnTitanFreeTrial( domainItem );
 		} else if ( hasGSuiteWithUs( domainItem ) ) {
 			slug = 'google-workspace/add-users';
+			provider = 'google';
 		}
 
 		if ( slug ) {
@@ -63,6 +66,7 @@ const NewMailboxUpsell = ( { domains }: { domains: ResponseDomain[] } ) => {
 						onClick={ () =>
 							recordTracksEvent( 'calypso_inbox_new_mailbox_upsell_click', {
 								context: isFreeTrialNow ? 'free' : 'paid',
+								provider,
 							} )
 						}
 						href={ upsellURL }


### PR DESCRIPTION
#### Proposed Changes
When a user clicks on the email upsell element - we need to track - who the provider is (Titan | Google).

#### Testing Instructions
Let's check a few scenarios.
**1) Test receiving `provider` as `titan` for - titan FREE TRIAL users**
* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* If you have existed account with Professional Email (FREE TRIAL):
	* Choose your account with the Professional Email (FREE TRIAL)
* Otherwise, if you don't have existed account with the Professional Email (FREE TRIAL):
    * Click on "Add new site" at the end of the appeared list
    * Enter any domain name for test purposes
    * In the appeared list below - choose a domain with the help of the "Select" button
    * Choose any plan from the proposed with the help of the "Select" button
    * Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
    * Fill data in the "Professional Email" form to create your 3-month free email account and click on the "Add professional Email" button
    * Scroll down and click on "Complete Checkout"
    * On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
* In the left sidebar menu, click on the "Inbox" item
* In the page body, click on the "Create a new mailbox" button

**ER (Expected result)**: in the [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) appeared event `calypso_inbox_new_mailbox_upsell_click` with parameter `provider` as `titan`. AND in some time the same information appeared in "Tracks" system.



**2) Test receiving `provider` as `titan` for - titan PAID users**
* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
* Click on the "Renew now" button, which is located at the top part of the page body (on the right side of the text "Expires: {Date}")
* Scroll down and click on "Pay {amount} with credits"
* In the top left corner of the page, click the "My Sites" button
* In the left sidebar, click on the "Inbox" item
* In the page body, click on the "Create a new mailbox" button

**ER (Expected result)**: in the [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) appeared event `calypso_inbox_new_mailbox_upsell_click` with parameter `provider` as `titan`. AND in some time the same information appeared in "Tracks" system.



**3) Test receiving `provider` as `google` for - Google workspace paid users**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* Recommended if you have existed account with "Google Workspace" subscription:
	* Choose your account with the "Google Workspace" subscription
* Otherwise, if you don't have existed account with the "Google Workspace" subscription:
    * Click on "Add new site" at the end of the appeared list
    * Enter any domain name for test purposes
    * In the appeared list below - choose a domain with the help of the "Select" button
    * Choose any plan from the proposed with the help of the "Select" button
    * Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
    * Note, on the page "Add Professional Email" - click on the "Skip for now" button
    * On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
    * In the left sidebar menu, click on the "Inbox" item
    * At the bottom of the page is located the "Google Workspace" section, click on the "Select" button, on the right side of the section
    * Fill "Google Workspace" form and click on the "Purchase" button, below the form
    * Click on "Pay {amount} with credits"
    * Click on the "Manage email" button in the middle of the page body
    * In the left sidebar menu, click on the "Inbox" item
    * If you see the warning "Configuring mailboxes" at the top part of the page body - it means that it's necessary to wait a bit, so at the current moment, you can go to the kitchen and make a cup of coffee 🙃
    * Reload the page to check for any news regarding the configuration of your mailboxes. 
    * If it's finished, you will see the notification "Action required". So click on the "Finish setup" button under the notification and follow the instructions.
	* After finishing setup - come back to the dashboard
* In the left sidebar, click on the "Inbox" item
* In the page body, click on the "Create a new mailbox" button

**ER (Expected result)**: in the [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) appeared event `calypso_inbox_new_mailbox_upsell_click` with parameter `provider` as `google`. AND in some time the same information appeared in "Tracks" system.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202856305324115/f