### PR TITLE
Checkout: Remove concierge from post checkout url generator

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -26,7 +26,6 @@ import {
 	getAllCartItems,
 	getDomainRegistrations,
 	getRenewalItems,
-	hasConciergeSession,
 	hasJetpackPlan,
 	hasBloggerPlan,
 	hasPersonalPlan,
@@ -219,9 +218,7 @@ export default function getThankYouPageUrl( {
 	}
 
 	// If there is no purchase, then send the user to a generic page (not
-	// post-purchase related). For example, this case arises when a Skip button
-	// is clicked on a concierge upsell nudge opened by a direct link to
-	// /checkout/offer-support-session.
+	// post-purchase related).
 	if ( noPurchaseMade ) {
 		debug( 'there was no purchase, so returning calypso root' );
 		return '/';
@@ -300,11 +297,6 @@ export default function getThankYouPageUrl( {
 		return redirectUrlForPostCheckoutUpsell;
 	}
 
-	// The display mode query param (eg: `?d=concierge`) is used to show
-	// purchase-specific messaging, for e.g. the Schedule Session button when
-	// purchasing a concierge session
-	const displayModeParam = getDisplayModeParamFromCart( cart );
-
 	// Display the cookie post-checkout URL (with the display mode query param
 	// for special product-specific messaging and a notice param used by
 	// in-editor checkout) if there is one set and the cart does not contain
@@ -312,8 +304,7 @@ export default function getThankYouPageUrl( {
 	if ( cart && ! doesCartContainGoogleAppsWithoutDomainReceipt( cart ) && urlFromCookie ) {
 		debug( 'is eligible for signup destination', urlFromCookie );
 		const noticeType = getNoticeType( cart );
-		const queryParams = { ...displayModeParam, ...noticeType };
-		return getUrlWithQueryParam( urlFromCookie, queryParams );
+		return getUrlWithQueryParam( urlFromCookie, noticeType );
 	}
 
 	const fallbackUrl = getFallbackDestination( {
@@ -328,7 +319,7 @@ export default function getThankYouPageUrl( {
 		redirectTo,
 	} );
 	debug( 'returning fallback url', fallbackUrl );
-	return getUrlWithQueryParam( fallbackUrl, displayModeParam ?? {} );
+	return getUrlWithQueryParam( fallbackUrl );
 }
 
 function updateUrlInCookie( {
@@ -656,15 +647,6 @@ function getProfessionalEmailUpsellUrl( {
 	}
 
 	return `/checkout/offer-professional-email/${ domainName }/${ receiptId }/${ siteSlug }`;
-}
-
-function getDisplayModeParamFromCart(
-	cart: ResponseCart | undefined
-): undefined | { d: 'concierge' } {
-	if ( cart && hasConciergeSession( cart ) ) {
-		return { d: 'concierge' };
-	}
-	return undefined;
 }
 
 function getNoticeType(

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.ts
@@ -948,33 +948,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to thank-you page (with concierge display mode) for a new site with a domain and no failed purchases but concierge is in the cart', () => {
-		const cart = {
-			...getEmptyResponseCart(),
-			products: [
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'concierge-session',
-				},
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'some_domain',
-					is_domain_registration: true,
-					extra: { context: 'signup' },
-					meta: 'my.site',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-			receiptId: samplePurchaseId,
-		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }?d=concierge` );
-	} );
-
-	it( 'redirects to thank-you page for a new site with a domain and no failed purchases but neither G Suite nor concierge are in the cart if user is in invalid country', () => {
+	it( 'redirects to thank-you page for a new site with a domain and no failed purchases but G Suite is not in the cart if user is in invalid country', () => {
 		const cart = {
 			...getEmptyResponseCart(),
 			products: [
@@ -1092,25 +1066,6 @@ describe( 'getThankYouPageUrl', () => {
 			receiptId: samplePurchaseId,
 		} );
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
-	} );
-
-	it( 'redirects to thank-you page (with concierge display mode) if concierge is in the cart', () => {
-		const cart = {
-			...getEmptyResponseCart(),
-			products: [
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'concierge-session',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-			receiptId: samplePurchaseId,
-		} );
-		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }?d=concierge` );
 	} );
 
 	it( 'redirects to a Jetpack cloud redirectTo', () => {
@@ -1460,7 +1415,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but hideNudge is true', () => {
+	it( 'redirects to thank you page if jetpack is not in the cart, personal is in the cart, but hideNudge is true', () => {
 		const cart = {
 			...getEmptyResponseCart(),
 			products: [


### PR DESCRIPTION
#### Proposed Changes

The function `getThankYouPageUrl()` is used by checkout to generate a post-checkout URL. One of the many possible URLs it can generate is a thank-you page for the "Concierge" or "Quick Start" product: `/checkout/thank-you/foo.bar/${ purchaseId }?d=concierge`. However, that product is no longer sold and therefore will never be in the cart. 

The `getThankYouPageUrl()` function is quite complex and any work that can be done to simplify it is worthwhile.

This PR modifies `getThankYouPageUrl()` to remove support for generating Concierge post-checkout URLs.

Fixes https://github.com/Automattic/wp-calypso/issues/66874

#### Testing Instructions

Automated tests are included.