### PR TITLE
Add/subscriber data store

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -12,6 +12,7 @@ import * as ProductsList from './products-list';
 import * as Reader from './reader';
 import * as Site from './site';
 import * as StepperInternal from './stepper-internal';
+import * as Subscriber from './subscriber';
 import * as User from './user';
 import * as WPCOMFeatures from './wpcom-features';
 export { useHappinessEngineersQuery } from './queries/use-happiness-engineers-query';
@@ -46,6 +47,7 @@ export {
 	ProductsList,
 	AutomatedTransferEligibility,
 	StepperInternal,
+	Subscriber,
 };
 
 /**

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -1,0 +1,159 @@
+import { wpcomRequest } from '../wpcom-request-controls';
+import {
+	AddSubscribersResponse,
+	GetSubscribersImportResponse,
+	GetSubscribersImportsResponse,
+	ImportJob,
+	ImportJobStatus,
+	ImportSubscribersError,
+	ImportSubscribersResponse,
+} from './types';
+
+export function createActions() {
+	/**
+	 * ↓ Import subscribers by CSV
+	 */
+	const importCsvSubscribersStart = ( siteId: number ) => ( {
+		type: 'IMPORT_CSV_SUBSCRIBERS_START' as const,
+		siteId,
+	} );
+
+	const importCsvSubscribersSuccess = ( siteId: number, data: ImportSubscribersResponse ) => ( {
+		type: 'IMPORT_CSV_SUBSCRIBERS_SUCCESS' as const,
+		siteId,
+		data,
+	} );
+
+	const importCsvSubscribersFailed = ( siteId: number, error: ImportSubscribersError ) => ( {
+		type: 'IMPORT_CSV_SUBSCRIBERS_FAILED' as const,
+		siteId,
+		error,
+	} );
+
+	function* importCsvSubscribers( siteId: number, file: File ) {
+		yield importCsvSubscribersStart( siteId );
+
+		try {
+			const data: ImportSubscribersResponse = yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`,
+				method: 'POST',
+				apiNamespace: 'wpcom/v2',
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				formData: [ [ 'import', file, file.name ] ],
+			} );
+
+			yield importCsvSubscribersSuccess( siteId, data );
+		} catch ( error ) {
+			yield importCsvSubscribersFailed( siteId, error as ImportSubscribersError );
+		}
+	}
+
+	/**
+	 * ↓ Add subscribers
+	 */
+	const addSubscribersStart = ( siteId: number ) => ( {
+		type: 'ADD_SUBSCRIBERS_START' as const,
+		siteId,
+	} );
+
+	const addSubscribersSuccess = ( siteId: number, response: AddSubscribersResponse ) => ( {
+		type: 'ADD_SUBSCRIBERS_SUCCESS' as const,
+		siteId,
+		response,
+	} );
+
+	const addSubscribersFailed = ( siteId: number ) => ( {
+		type: 'ADD_SUBSCRIBERS_FAILED' as const,
+		siteId,
+	} );
+
+	function* addSubscribers( siteId: number, emails: string[] ) {
+		yield addSubscribersStart( siteId );
+
+		try {
+			const data: AddSubscribersResponse = yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers`,
+				method: 'POST',
+				apiNamespace: 'wpcom/v2',
+				body: { emails },
+			} );
+
+			yield addSubscribersSuccess( siteId, data );
+		} catch ( err ) {
+			yield addSubscribersFailed( siteId );
+		}
+	}
+
+	/**
+	 * ↓ Get import
+	 */
+	const getSubscribersImportSuccess = ( siteId: number, importJob: ImportJob ) => ( {
+		type: 'GET_SUBSCRIBERS_IMPORT_SUCCESS' as const,
+		siteId,
+		importJob,
+	} );
+
+	function* getSubscribersImport( siteId: number, importId: string ) {
+		try {
+			const data: GetSubscribersImportResponse = yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import/${ importId }`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			} );
+
+			yield getSubscribersImportSuccess( siteId, data );
+		} catch ( e ) {}
+	}
+
+	/**
+	 * ↓ Get imports
+	 */
+	const getSubscribersImportsSuccess = (
+		siteId: number,
+		imports: GetSubscribersImportsResponse
+	) => ( {
+		type: 'GET_SUBSCRIBERS_IMPORTS_SUCCESS' as const,
+		siteId,
+		imports,
+	} );
+
+	function* getSubscribersImports( siteId: number, status?: ImportJobStatus ) {
+		const path = `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`;
+		const data: GetSubscribersImportsResponse = yield wpcomRequest( {
+			path: ! status ? path : `${ path }?status=${ encodeURIComponent( status ) }`,
+			method: 'GET',
+			apiNamespace: 'wpcom/v2',
+		} );
+
+		yield getSubscribersImportsSuccess( siteId, data );
+	}
+
+	return {
+		importCsvSubscribersStart,
+		importCsvSubscribersSuccess,
+		importCsvSubscribersFailed,
+		importCsvSubscribers,
+		addSubscribersStart,
+		addSubscribersSuccess,
+		addSubscribersFailed,
+		addSubscribers,
+		getSubscribersImport,
+		getSubscribersImportSuccess,
+		getSubscribersImports,
+		getSubscribersImportsSuccess,
+	};
+}
+
+export type ActionCreators = ReturnType< typeof createActions >;
+
+export type Action = ReturnType<
+	| ActionCreators[ 'importCsvSubscribersStart' ]
+	| ActionCreators[ 'importCsvSubscribersSuccess' ]
+	| ActionCreators[ 'importCsvSubscribersFailed' ]
+	| ActionCreators[ 'addSubscribersStart' ]
+	| ActionCreators[ 'addSubscribersSuccess' ]
+	| ActionCreators[ 'addSubscribersFailed' ]
+	| ActionCreators[ 'getSubscribersImportSuccess' ]
+	| ActionCreators[ 'getSubscribersImportsSuccess' ]
+>;

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -18,16 +18,21 @@ export function createActions() {
 		siteId,
 	} );
 
-	const importCsvSubscribersSuccess = ( siteId: number, data: ImportSubscribersResponse ) => ( {
-		type: 'IMPORT_CSV_SUBSCRIBERS_SUCCESS' as const,
+	const importCsvSubscribersStartSuccess = ( siteId: number, jobId: number ) => ( {
+		type: 'IMPORT_CSV_SUBSCRIBERS_START_SUCCESS' as const,
 		siteId,
-		data,
+		jobId,
 	} );
 
-	const importCsvSubscribersFailed = ( siteId: number, error: ImportSubscribersError ) => ( {
-		type: 'IMPORT_CSV_SUBSCRIBERS_FAILED' as const,
+	const importCsvSubscribersStartFailed = ( siteId: number, error: ImportSubscribersError ) => ( {
+		type: 'IMPORT_CSV_SUBSCRIBERS_START_FAILED' as const,
 		siteId,
 		error,
+	} );
+
+	const importCsvSubscribersUpdate = ( job: ImportJob | undefined ) => ( {
+		type: 'IMPORT_CSV_SUBSCRIBERS_UPDATE' as const,
+		job,
 	} );
 
 	function* importCsvSubscribers( siteId: number, file: File ) {
@@ -43,9 +48,9 @@ export function createActions() {
 				formData: [ [ 'import', file, file.name ] ],
 			} );
 
-			yield importCsvSubscribersSuccess( siteId, data );
+			yield importCsvSubscribersStartSuccess( siteId, data.id );
 		} catch ( error ) {
-			yield importCsvSubscribersFailed( siteId, error as ImportSubscribersError );
+			yield importCsvSubscribersStartFailed( siteId, error as ImportSubscribersError );
 		}
 	}
 
@@ -94,7 +99,7 @@ export function createActions() {
 		importJob,
 	} );
 
-	function* getSubscribersImport( siteId: number, importId: string ) {
+	function* getSubscribersImport( siteId: number, importId: number ) {
 		try {
 			const data: GetSubscribersImportResponse = yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import/${ importId }`,
@@ -131,8 +136,9 @@ export function createActions() {
 
 	return {
 		importCsvSubscribersStart,
-		importCsvSubscribersSuccess,
-		importCsvSubscribersFailed,
+		importCsvSubscribersStartSuccess,
+		importCsvSubscribersStartFailed,
+		importCsvSubscribersUpdate,
 		importCsvSubscribers,
 		addSubscribersStart,
 		addSubscribersSuccess,
@@ -149,8 +155,9 @@ export type ActionCreators = ReturnType< typeof createActions >;
 
 export type Action = ReturnType<
 	| ActionCreators[ 'importCsvSubscribersStart' ]
-	| ActionCreators[ 'importCsvSubscribersSuccess' ]
-	| ActionCreators[ 'importCsvSubscribersFailed' ]
+	| ActionCreators[ 'importCsvSubscribersStartSuccess' ]
+	| ActionCreators[ 'importCsvSubscribersStartFailed' ]
+	| ActionCreators[ 'importCsvSubscribersUpdate' ]
 	| ActionCreators[ 'addSubscribersStart' ]
 	| ActionCreators[ 'addSubscribersSuccess' ]
 	| ActionCreators[ 'addSubscribersFailed' ]

--- a/packages/data-stores/src/subscriber/constants.ts
+++ b/packages/data-stores/src/subscriber/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/subscriber';

--- a/packages/data-stores/src/subscriber/index.ts
+++ b/packages/data-stores/src/subscriber/index.ts
@@ -1,0 +1,28 @@
+import { registerStore } from '@wordpress/data';
+import { controls } from '../wpcom-request-controls';
+import { createActions } from './actions';
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducers';
+import * as selectors from './selectors';
+export * from './types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+export type { State };
+
+let isRegistered = false;
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions: createActions(),
+			controls: controls as any,
+			reducer: reducer as any,
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< ReturnType< typeof createActions > >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/subscriber/reducers.ts
+++ b/packages/data-stores/src/subscriber/reducers.ts
@@ -1,0 +1,82 @@
+import { combineReducers } from '@wordpress/data';
+import { findIndex } from 'lodash';
+import type { Action } from './actions';
+import type { SubscriberState } from './types';
+import type { Reducer } from 'redux';
+
+const subscriber: Reducer< SubscriberState, Action > = ( state = {}, action ) => {
+	/**
+	 * ↓ Import subscribers
+	 */
+	if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_START' ) {
+		return Object.assign( {}, state, {
+			import: {
+				inProgress: true,
+				error: '',
+			},
+		} );
+	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_SUCCESS' ) {
+		return Object.assign( {}, state, {
+			import: {
+				inProgress: false,
+			},
+		} );
+	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_FAILED' ) {
+		return Object.assign( {}, state, {
+			import: {
+				inProgress: false,
+				error: action.error,
+			},
+		} );
+	}
+
+	/**
+	 * ↓ Add subscribers
+	 */
+	if ( action.type === 'ADD_SUBSCRIBERS_START' ) {
+		return Object.assign( {}, state, {
+			add: { inProgress: true },
+		} );
+	} else if ( action.type === 'ADD_SUBSCRIBERS_SUCCESS' ) {
+		return Object.assign( {}, state, {
+			add: {
+				inProgress: false,
+				response: action.response,
+			},
+		} );
+	} else if ( action.type === 'ADD_SUBSCRIBERS_FAILED' ) {
+		return Object.assign( {}, state, {
+			add: { inProgress: false },
+		} );
+	}
+
+	/**
+	 * ↓ Get import
+	 */
+	if ( action.type === 'GET_SUBSCRIBERS_IMPORT_SUCCESS' ) {
+		const imports = state.imports ? Array.from( state.imports ) : [];
+		const i = findIndex( imports, { id: action.importJob.id } );
+		i !== -1 ? ( imports[ i ] = action.importJob ) : imports.push( action.importJob );
+
+		return Object.assign( {}, state, {
+			imports,
+		} );
+	}
+
+	/**
+	 * ↓ Get imports
+	 */
+	if ( action.type === 'GET_SUBSCRIBERS_IMPORTS_SUCCESS' ) {
+		return Object.assign( {}, state, {
+			imports: action.imports,
+		} );
+	}
+
+	return state;
+};
+
+const reducers = combineReducers( { subscriber } );
+
+export type State = ReturnType< typeof reducers >;
+
+export default reducers;

--- a/packages/data-stores/src/subscriber/reducers.ts
+++ b/packages/data-stores/src/subscriber/reducers.ts
@@ -12,20 +12,40 @@ const subscriber: Reducer< SubscriberState, Action > = ( state = {}, action ) =>
 		return Object.assign( {}, state, {
 			import: {
 				inProgress: true,
-				error: '',
 			},
 		} );
-	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_SUCCESS' ) {
+	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_START_SUCCESS' ) {
+		const imports = Array.from( state.imports || [] );
+		imports.push( {
+			id: action.jobId,
+			status: 'pending',
+		} );
 		return Object.assign( {}, state, {
 			import: {
-				inProgress: false,
+				inProgress: true,
+				job: { id: action.jobId },
 			},
+			imports,
 		} );
-	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_FAILED' ) {
+	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_START_FAILED' ) {
 		return Object.assign( {}, state, {
 			import: {
 				inProgress: false,
 				error: action.error,
+			},
+		} );
+	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_UPDATE' ) {
+		if ( action.job )
+			return Object.assign( {}, state, {
+				import: {
+					inProgress: true,
+					job: action.job,
+				},
+			} );
+
+		return Object.assign( {}, state, {
+			import: {
+				inProgress: false,
 			},
 		} );
 	}
@@ -69,6 +89,7 @@ const subscriber: Reducer< SubscriberState, Action > = ( state = {}, action ) =>
 	if ( action.type === 'GET_SUBSCRIBERS_IMPORTS_SUCCESS' ) {
 		return Object.assign( {}, state, {
 			imports: action.imports,
+			hydrated: true,
 		} );
 	}
 

--- a/packages/data-stores/src/subscriber/reducers.ts
+++ b/packages/data-stores/src/subscriber/reducers.ts
@@ -4,7 +4,7 @@ import type { Action } from './actions';
 import type { SubscriberState } from './types';
 import type { Reducer } from 'redux';
 
-const subscriber: Reducer< SubscriberState, Action > = ( state = {}, action ) => {
+export const subscriber: Reducer< SubscriberState, Action > = ( state = {}, action ) => {
 	/**
 	 * ↓ Import subscribers
 	 */

--- a/packages/data-stores/src/subscriber/selectors.ts
+++ b/packages/data-stores/src/subscriber/selectors.ts
@@ -1,0 +1,6 @@
+import type { State } from './reducers';
+
+export const getState = ( state: State ) => state;
+export const getAddSubscribersSelector = ( state: State ) => state.subscriber.add;
+export const getImportSubscribersSelector = ( state: State ) => state.subscriber.import;
+export const getImportJobsSelector = ( state: State ) => state.subscriber.imports;

--- a/packages/data-stores/src/subscriber/selectors.ts
+++ b/packages/data-stores/src/subscriber/selectors.ts
@@ -1,6 +1,7 @@
 import type { State } from './reducers';
 
-export const getState = ( state: State ) => state;
+export const getState = ( state: State ) => state.subscriber;
+export const getHydrationStatus = ( state: State ) => state.subscriber.hydrated;
 export const getAddSubscribersSelector = ( state: State ) => state.subscriber.add;
 export const getImportSubscribersSelector = ( state: State ) => state.subscriber.import;
 export const getImportJobsSelector = ( state: State ) => state.subscriber.imports;

--- a/packages/data-stores/src/subscriber/test/reducers.ts
+++ b/packages/data-stores/src/subscriber/test/reducers.ts
@@ -1,0 +1,220 @@
+import { subscriber } from '../reducers';
+import type { SubscriberState } from '../types';
+
+const EMPTY_STATE = {};
+
+describe( 'Subscriber reducer', () => {
+	/**
+	 * ↓ Import subscribers
+	 */
+	it( 'change import inProgress state', () => {
+		const state = subscriber( EMPTY_STATE, {
+			type: 'IMPORT_CSV_SUBSCRIBERS_START',
+			siteId: 1,
+		} );
+
+		const expectedState = { import: { inProgress: true } };
+
+		expect( state ).toEqual( expectedState );
+	} );
+
+	it( 'import start, update imports array', () => {
+		const initState: SubscriberState = {
+			hydrated: true,
+			import: { inProgress: true },
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 8,
+				},
+			],
+		};
+
+		const state = subscriber( initState, {
+			type: 'IMPORT_CSV_SUBSCRIBERS_START_SUCCESS',
+			siteId: 1,
+			jobId: 11112,
+		} );
+
+		const expectedState = {
+			hydrated: true,
+			import: { inProgress: true, job: { id: 11112 } },
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 8,
+				},
+				{
+					id: 11112,
+					status: 'pending',
+				},
+			],
+		};
+
+		expect( state ).toEqual( expectedState );
+	} );
+
+	/**
+	 * ↓ Add subscribers
+	 */
+	it( 'manually add subscribers start', () => {
+		const state = subscriber( EMPTY_STATE, {
+			type: 'ADD_SUBSCRIBERS_START',
+			siteId: 1,
+		} );
+
+		const expectedState = { add: { inProgress: true } };
+
+		expect( state ).toEqual( expectedState );
+	} );
+
+	it( 'manually add subscribers start success', () => {
+		const state = subscriber( EMPTY_STATE, {
+			type: 'ADD_SUBSCRIBERS_SUCCESS',
+			siteId: 1,
+			response: {
+				subscribed: 2,
+				errors: [],
+			},
+		} );
+
+		const expectedState = {
+			add: {
+				inProgress: false,
+				response: {
+					subscribed: 2,
+					errors: [],
+				},
+			},
+		};
+
+		expect( state ).toEqual( expectedState );
+	} );
+
+	/**
+	 * ↓ Get import
+	 */
+	it( 'get import job, add to `imports` array', () => {
+		const initState: SubscriberState = {
+			hydrated: true,
+			import: { inProgress: true },
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 8,
+				},
+			],
+		};
+
+		const state = subscriber( initState, {
+			type: 'GET_SUBSCRIBERS_IMPORT_SUCCESS',
+			siteId: 1,
+			importJob: {
+				id: 11113,
+				status: 'importing',
+				email_count: 1,
+				subscribed_count: 1,
+			},
+		} );
+
+		const expectedState = {
+			hydrated: true,
+			import: { inProgress: true },
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 8,
+				},
+				{
+					id: 11113,
+					status: 'importing',
+					email_count: 1,
+					subscribed_count: 1,
+				},
+			],
+		};
+
+		expect( state ).toEqual( expectedState );
+	} );
+
+	it( 'get import job, update `imports` array', () => {
+		const initState: SubscriberState = {
+			hydrated: true,
+			import: { inProgress: true },
+			imports: [
+				{
+					id: 11111,
+					status: 'importing',
+					email_count: 10,
+					subscribed_count: 0,
+				},
+			],
+		};
+
+		const state = subscriber( initState, {
+			type: 'GET_SUBSCRIBERS_IMPORT_SUCCESS',
+			siteId: 1,
+			importJob: {
+				id: 11111,
+				status: 'imported',
+				email_count: 10,
+				subscribed_count: 10,
+			},
+		} );
+
+		const expectedState = {
+			hydrated: true,
+			import: { inProgress: true },
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 10,
+				},
+			],
+		};
+
+		expect( state ).toEqual( expectedState );
+	} );
+
+	/**
+	 * ↓ Get imports
+	 */
+	it( 'get imports', () => {
+		const state = subscriber( EMPTY_STATE, {
+			type: 'GET_SUBSCRIBERS_IMPORTS_SUCCESS',
+			siteId: 1,
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 10,
+				},
+			],
+		} );
+
+		const expectedState = {
+			hydrated: true,
+			imports: [
+				{
+					id: 11111,
+					status: 'imported',
+					email_count: 10,
+					subscribed_count: 10,
+				},
+			],
+		};
+
+		expect( state ).toEqual( expectedState );
+	} );
+} );

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -1,0 +1,51 @@
+import * as actions from './actions';
+import type { DispatchFromMap } from '../mapped-types';
+
+export interface SubscriberState {
+	add?: {
+		inProgress: boolean;
+		response: AddSubscribersResponse;
+	};
+	import?: {
+		inProgress: boolean;
+		error?: ImportSubscribersError;
+	};
+	imports?: ImportJob[];
+}
+
+export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed';
+
+export type ImportJob = {
+	id: number;
+	status: ImportJobStatus;
+	email_count: number;
+	scheduled_at: string;
+	subscribed_count: number;
+};
+
+export type GenericError = {
+	code: string;
+	message: string;
+};
+
+export type AddSubscriberError =
+	| {
+			email: string;
+	  }
+	| GenericError;
+
+export type AddSubscribersResponse = {
+	subscribed: number;
+	errors: AddSubscriberError[];
+};
+
+export type ImportSubscribersError = Record< string, unknown > | GenericError;
+
+export type ImportSubscribersResponse = Record< string, unknown >;
+
+export type GetSubscribersImportResponse = ImportJob;
+export type GetSubscribersImportsResponse = ImportJob[];
+
+export interface Dispatch {
+	dispatch: DispatchFromMap< typeof actions >;
+}

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -8,9 +8,11 @@ export interface SubscriberState {
 	};
 	import?: {
 		inProgress: boolean;
+		job?: ImportJob;
 		error?: ImportSubscribersError;
 	};
 	imports?: ImportJob[];
+	hydrated?: boolean;
 }
 
 export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed';
@@ -18,9 +20,9 @@ export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed';
 export type ImportJob = {
 	id: number;
 	status: ImportJobStatus;
-	email_count: number;
-	scheduled_at: string;
-	subscribed_count: number;
+	email_count?: number;
+	scheduled_at?: string;
+	subscribed_count?: number;
 };
 
 export type GenericError = {
@@ -28,11 +30,7 @@ export type GenericError = {
 	message: string;
 };
 
-export type AddSubscriberError =
-	| {
-			email: string;
-	  }
-	| GenericError;
+export type AddSubscriberError = { email: string } | GenericError;
 
 export type AddSubscribersResponse = {
 	subscribed: number;
@@ -41,7 +39,10 @@ export type AddSubscribersResponse = {
 
 export type ImportSubscribersError = Record< string, unknown > | GenericError;
 
-export type ImportSubscribersResponse = Record< string, unknown >;
+export type ImportSubscribersResponse = {
+	id: number;
+	success: boolean;
+};
 
 export type GetSubscribersImportResponse = ImportJob;
 export type GetSubscribersImportsResponse = ImportJob[];


### PR DESCRIPTION
#### Proposed Changes

* Added subscriber data store with API integration for adding, importing, and getting subscribers
* Added reducer unit tests

#### Testing Instructions
* Unit tests
* In the following PRs there will be the integration of this data store

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
