### PR TITLE
Sites Management Page: Display grid thumbnails as 16x11

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -20,7 +20,7 @@ const badges = css( {
 } );
 
 export const siteThumbnail = css( {
-	aspectRatio: '16 / 9',
+	aspectRatio: '16 / 11',
 	width: '100%',
 	height: 'auto',
 } );


### PR DESCRIPTION
See pdKhl6-E5-p2

## Proposed Changes

Displays grid thumbnails as 16x11 instead of 16x9.

### After

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/36432/186484858-af1a95f7-569a-4910-969f-f4d46fd0d0be.png">

### Before

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/36432/186484961-8fc39976-62b9-4e2a-abfc-321e8d90f61a.png">

## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. See the thumbnails with better clarity.