### PR TITLE
DIFM: Text Updates in DIFM Flows

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -298,7 +298,7 @@ export default function DIFMLanding( {
 						align={ 'left' }
 						headerText={ headerText }
 						subHeaderText={ translate(
-							'{{sup}}*{{/sup}}One time fee, plus a one year subscription of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+							'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the Premium plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 							{
 								args: {
 									plan: planTitle,
@@ -455,7 +455,7 @@ export default function DIFMLanding( {
 						<FoldableFAQ id="faq-4" question={ translate( 'How much does the service cost?' ) }>
 							<p>
 								{ translate(
-									'The service costs %(displayCost)s, plus one year of the %(planTitle)s hosting plan. If you choose to use an existing site that already has the plan, you will only be charged for the website design service.',
+									'The service costs %(displayCost)s, plus an additional purchase of the %(planTitle)s hosting plan.',
 									{
 										args: {
 											displayCost,

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -298,7 +298,7 @@ export default function DIFMLanding( {
 						align={ 'left' }
 						headerText={ headerText }
 						subHeaderText={ translate(
-							'{{sup}}*{{/sup}}One time fee, plus a one year subscription of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+							'{{sup}}*{{/sup}}*One time fee, plus an additional purchase of the Premium plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 							{
 								args: {
 									plan: planTitle,
@@ -455,7 +455,7 @@ export default function DIFMLanding( {
 						<FoldableFAQ id="faq-4" question={ translate( 'How much does the service cost?' ) }>
 							<p>
 								{ translate(
-									'The service costs %(displayCost)s, plus one year of the %(planTitle)s hosting plan. If you choose to use an existing site that already has the plan, you will only be charged for the website design service.',
+									'The service costs %(displayCost)s, plus an additional purchase of the WordPress %(planTitle)s hosting plan.',
 									{
 										args: {
 											displayCost,

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -298,7 +298,7 @@ export default function DIFMLanding( {
 						align={ 'left' }
 						headerText={ headerText }
 						subHeaderText={ translate(
-							'{{sup}}*{{/sup}}*One time fee, plus an additional purchase of the Premium plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+							'{{sup}}*{{/sup}}One time fee, plus a one year subscription of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 							{
 								args: {
 									plan: planTitle,
@@ -455,7 +455,7 @@ export default function DIFMLanding( {
 						<FoldableFAQ id="faq-4" question={ translate( 'How much does the service cost?' ) }>
 							<p>
 								{ translate(
-									'The service costs %(displayCost)s, plus an additional purchase of the WordPress %(planTitle)s hosting plan.',
+									'The service costs %(displayCost)s, plus one year of the %(planTitle)s hosting plan. If you choose to use an existing site that already has the plan, you will only be charged for the website design service.',
 									{
 										args: {
 											displayCost,

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -298,7 +298,7 @@ export default function DIFMLanding( {
 						align={ 'left' }
 						headerText={ headerText }
 						subHeaderText={ translate(
-							'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the Premium plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+							'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 							{
 								args: {
 									plan: planTitle,

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -39,7 +39,21 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 	const [ siteId, setSiteId ] = useState< number | null >( null );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const headerText = translate( 'Choose where you want us to build your site.' );
-	const subHeaderText = translate( 'Some unsupported sites may be hidden.' );
+	const subHeaderText = translate(
+		'Some unsupported sites may be hidden. Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
+		{
+			components: {
+				SupportLink: <a className="subtitle-link" rel="noopener noreferrer" href="/help/contact" />,
+				NewSiteLink: (
+					<a
+						className="subtitle-link"
+						rel="noopener noreferrer"
+						href="/start/do-it-for-me/difm-options"
+					/>
+				),
+			},
+		}
+	);
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -40,7 +40,7 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const headerText = translate( 'Choose where you want us to build your site.' );
 	const subHeaderText = translate(
-		'Some unsupported sites may be hidden. Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
+		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
 		{
 			components: {
 				SupportLink: <a className="subtitle-link" rel="noopener noreferrer" href="/help/contact" />,

--- a/client/signup/steps/difm-site-picker/styles.scss
+++ b/client/signup/steps/difm-site-picker/styles.scss
@@ -1,3 +1,22 @@
+body.is-section-signup {
+	.signup__step.is-difm-site-picker {
+		.formatted-header {
+			a.subtitle-link {
+				text-decoration: underline;
+				cursor: pointer;
+				line-height: 20px;
+				padding-top: 12px;
+				color: var( --studio-gray-90 );
+				letter-spacing: -0.16px;
+				white-space: nowrap;
+				&:hover {
+					color: var( --studio-gray-70 );
+				}
+			}
+		}
+	}
+}
+
 .ReactModalPortal {
 	.difm-site-delete-confirmation {
 		.dialog__action-buttons {

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -46,7 +46,7 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 	const headerText = translate( 'Do It For Me' );
 
 	const subHeaderText = translate(
-		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the %(plan)s plan.',
+		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus an additional purchase of the %(plan)s plan.',
 		{
 			args: {
 				displayCost,

--- a/client/signup/steps/website-content/logo-upload-section.tsx
+++ b/client/signup/steps/website-content/logo-upload-section.tsx
@@ -46,7 +46,9 @@ export function LogoUploadSection( {
 
 	return (
 		<LogoUploadSectionContainer>
-			<Label>{ translate( 'Upload your business logo.' ) }</Label>
+			<Label>
+				{ translate( 'Upload a logo for your website, transparent backgrounds work best.' ) }
+			</Label>
 			<HorizontalGrid>
 				<WordpressMediaUpload
 					mediaIndex={ 0 }


### PR DESCRIPTION
#### Proposed Changes

* Updates the text for the site selector page subtitle
* Context : p1661351453854599/1660116605.386369-slack-C02KVCAL7GX
<img width="1696" alt="image" src="https://user-images.githubusercontent.com/3422709/186662384-606c00b7-0ccb-4988-be50-25e6f2f010f7.png">

* On the site info collection page change the label for the logo upload form element
* Context :  pdh1Xd-1d7-p2
<img width="1645" alt="image" src="https://user-images.githubusercontent.com/3422709/186693450-2ba9338d-db93-4ec1-aa8d-c34a395450b2.png">

* DIFM Landing page changes to the asterisk text, and explainer of the cost of DIFM
* Context : pdh1Xd-1e7-p2
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/3422709/186729121-6117f2c3-6c93-4f41-a1b1-582fa306cba3.png">
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/3422709/186729231-77a784c6-c918-4dff-93ca-9239a5dbb56d.png">


#### Testing Instructions
- Go through the DIFM flow `/start/do-it-for-me` and check if above screen text is complete
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #