### PR TITLE
show hidden sites after display is rendered

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -150,7 +150,7 @@ export function SitesDashboard( {
 									className={ sitesMargin }
 								/>
 							) }
-							{ selectedStatus.hiddenCount > 0 && (
+							{ selectedStatus.hiddenCount > 0 && displayMode !== 'none' && (
 								<HiddenSitesMessageContainer>
 									<HiddenSitesMessage>
 										{ sprintf(


### PR DESCRIPTION
#### Proposed Changes

* Fix hidden sites being displayed before sites data is rendered (_This occurs because the sites data is available before the display mode and the sites table is rendered after the display mode is set_)
![Screenshot 2022-08-24 at 2 07 11 PM](https://user-images.githubusercontent.com/47489215/186511818-c8d6f335-7647-4c1a-94dc-6c35bde48f51.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites-dashboard`
* Hidden sites rendered after sites are rendered

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
