### PR TITLE
Add route redirections for Plugins Categories routes

### DIFF
--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -33,6 +33,8 @@ export const ALLOWED_CATEGORIES = [
 	'paid',
 ];
 
+export const DISCOVERY_CATEGORIES = [ 'popular', 'featured', 'paid' ];
+
 export function useCategories(
 	allowedCategories = ALLOWED_CATEGORIES
 ): Record< string, Category > {

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -5,7 +5,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { ALLOWED_CATEGORIES } from './categories/use-categories';
+import { ALLOWED_CATEGORIES, DISCOVERY_CATEGORIES } from './categories/use-categories';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
 import PluginDetails from './plugin-details';
@@ -145,5 +145,30 @@ export function scrollTopIfNoHash( context, next ) {
 	if ( typeof window !== 'undefined' && ! window.location.hash ) {
 		window.scrollTo( 0, 0 );
 	}
+	next();
+}
+
+export function redirectOnUnknownCategory( context, next ) {
+	const category = context.params.category;
+	const site = context.params.site;
+
+	if ( ! ALLOWED_CATEGORIES.includes( category ) ) {
+		const redirectionUrl = `/plugins/${ site || '' }`;
+		page.redirect( redirectionUrl );
+	}
+
+	next();
+}
+
+export function redirectOnSearchInDiscoveryCategories( context, next ) {
+	const category = context.params.category;
+	const searchTerm = context.query.s;
+	const site = context.params.site;
+
+	if ( searchTerm && DISCOVERY_CATEGORIES.includes( category ) ) {
+		const redirectionUrl = `/plugins/${ site || '' }?s=${ searchTerm }`;
+		page.redirect( redirectionUrl );
+	}
+
 	next();
 }

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -10,6 +10,8 @@ import {
 	plugins,
 	scrollTopIfNoHash,
 	upload,
+	redirectOnUnknownCategory,
+	redirectOnSearchInDiscoveryCategories,
 } from './controller';
 
 export default function () {
@@ -36,6 +38,8 @@ export default function () {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
+		redirectOnUnknownCategory,
+		redirectOnSearchInDiscoveryCategories,
 		browsePlugins,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
#### Proposed Changes

* Add redirects when the category not exists.
* Add redirect when searching on Discovery categories ( Top premium  / Top Free / Editor's Pick )

#### Testing Instructions

* Go to `/plugins/browse/nocategory` should redirect you to `/plugins`
* Go to any category and do a search, you should see the URL like `/plugins/browse/seo?s=searchstring`
* Go to `/plugins`, click on `Browse All` on `Top free plugins` or `Top premium plugins`, and do a search, you should be redirected to `/plugins?s=searchstring`
* Repeat all 3 tests with and without a site selected.

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
