### PR TITLE
Sites Management Page: Disable hidden sites UI when `displayMode='none'`

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -150,7 +150,7 @@ export function SitesDashboard( {
 									className={ sitesMargin }
 								/>
 							) }
-							{ selectedStatus.hiddenCount > 0 && (
+							{ selectedStatus.hiddenCount > 0 && 'none' !== displayMode && (
 								<HiddenSitesMessageContainer>
 									<HiddenSitesMessage>
 										{ sprintf(


### PR DESCRIPTION
Fixes #66898

## Proposed Changes

Disables the hidden sites message and button when `displayMode='none'` (which can happen while remote preferences are loading).

### Before

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/36432/186514637-796a4068-3420-4a7f-bec8-27fc7754d9d2.png">

### After

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/36432/186514703-ed136de9-b44a-4570-95d8-8ee1f0f82908.png">


## Testing Instructions

1. Navigate to `/sites-dashboard`.
2. Refresh the page repeatedly.
3. Verify the hidden sites message and button doesn't appear unexpectedly.