### PR TITLE
E2E: visit page instead of clickTab in PlansPage.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
 
@@ -50,6 +51,24 @@ export class PlansPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+	}
+
+	/**
+	 * Visits the Plans page.
+	 *
+	 * @param {PlansPageTab} target Target page.
+	 * @param {string} siteSlug Site slug.
+	 */
+	async visit( target: PlansPageTab, siteSlug: string ): Promise< void > {
+		const sanitized = target.toLowerCase().replace( ' ', '-' );
+
+		if ( target === 'My Plan' ) {
+			await this.page.goto( getCalypsoURL( `plans/${ sanitized }/${ siteSlug }` ) );
+		}
+
+		if ( target === 'Plans' ) {
+			await this.page.goto( getCalypsoURL( `plans/${ siteSlug }` ) );
+		}
 	}
 
 	/* Plans */
@@ -122,7 +141,7 @@ export class PlansPage {
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
 		await Promise.all( [
 			this.page.waitForLoadState( 'networkidle' ),
-			this.page.waitForResponse( /.*plans.*/ ),
+			this.page.waitForResponse( /.*active-promotions.*/ ),
 		] );
 		await clickNavTab( this.page, targetTab, { force: true } );
 	}

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -114,11 +114,16 @@ export class PlansPage {
 	async clickTab( targetTab: PlansPageTab ): Promise< void > {
 		// The way PlansPage loads its contents is particularly prone to
 		// flakiness outside the control of Playwright auto-retry mechanism.
-		// To work around this, forcibly click on the target selector.
+		// To work around this, forcibly click on the target selector
+		// once everything has been loaded.
 		// This affects primarily Mobile viewports but also can also occur
 		// on Desktop viewports.
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
+		await Promise.all( [
+			this.page.waitForLoadState( 'networkidle' ),
+			this.page.waitForResponse( /.*plans.*/ ),
+		] );
 		await clickNavTab( this.page, targetTab, { force: true } );
 	}
 

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -124,7 +124,7 @@ describe(
 
 			it( `Plans page states user is on WordPress.com ${ planName } plan`, async function () {
 				const plansPage = new PlansPage( page );
-				await plansPage.clickTab( 'My Plan' );
+				await plansPage.visit( 'My Plan', newSiteDetails.blog_details.site_slug );
 				await plansPage.validateActivePlan( 'Premium' );
 			} );
 		} );


### PR DESCRIPTION
#### Proposed Changes

This PR replaces the under-the-hood logic for `PlansPage.clickTab` due to recurring problems.

Key changes:
- implement new method `PlansPage.visit`, analogous to other existing `visit` methods.
- replaces the click-related actions of `PlansPage.clickTab` with the `visit` method.

Explanations of the change :
We've been experiencing intermittent flakiness on Pre-Release Tests (Desktop viewport) where the PlansPage fails to complete the click on the **My Plan** tab. It would appear that the click action on the navtab is being swallowed up by Calypso due to the sheer speed at which Playwright executes.

So far, we have tried the following:
- waiting for a slow-loading query or page element to finish;
- forcing a click through;

However, neither of these approaches led to an elimination of the intermittent failure. 

While it can be argued by purists that triggering a hard navigation to a specific link isn't exactly simulating user behavior, my counterpoint to support this PR is that Playwright typically executes at blazingly fast speeds. This particular failure is due to the execution speed, as a typical human user would only trigger a click action on the navtabs after the slowest loading elements have loaded.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes  https://github.com/Automattic/wp-calypso/issues/66465
