### PR TITLE
Update calypso_signup_unified_design_picker_view props

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -115,7 +115,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			recordTracksEvent( 'calypso_signup_unified_design_picker_view', {
 				vertical_id: siteVerticalId,
 				generated_designs: generatedDesigns.map( ( design ) => design.slug ).join( ',' ),
-				static_designs: staticDesigns.map( ( design ) => design.slug ).join( ',' ),
+				has_vertical_images: generatedDesigns.length > 0,
 			} );
 		}
 	}, [ hasTrackedView, generatedDesigns, staticDesigns ] );


### PR DESCRIPTION
## Proposed Changes

* Update `calypso_signup_unified_design_picker_view` prop: remove static_design and add has_vertical_images 

## Testing Instructions

* Open network tab
* Visit the onboarding flow 
* When landed on Unified design picker step, confirm that `calypso_signup_unified_design_picker_view` has correct `has_vertical_images` prop
![image](https://user-images.githubusercontent.com/10071857/186544269-271f310c-91aa-40d2-afc9-3a94d4e11438.png)


## Reference

Related to [ticket](https://github.com/Automattic/dotcom-forge/issues/904)
