### PR TITLE
Pricing page rework: Display “Jetpack is successfully installed” notice at the top of the jetpack/connect/plans page.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
@@ -1,8 +1,20 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import LicensingActivationBanner from 'calypso/components/jetpack/licensing-activation-banner';
 import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
+import { successNotice } from 'calypso/state/notices/actions';
 import { ProductStoreBaseProps } from './types';
 
 export const UserLicensesDialog: React.FC< ProductStoreBaseProps > = ( { siteId } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( successNotice( translate( 'Jetpack is successfully installed' ) ) );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	return (
 		<div>
 			{ siteId && (


### PR DESCRIPTION
Completes: 1202796695664022-as-1202796695664093/f
Project Thread: p1HpG7-gBI-p2



#### Proposed Changes

This PR updates `client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx` component to show a notice on Jetpack connection plans page to let the user know that Jetpack is installed successfully.

#### Testing Instructions

- Boot up this PR by running `git fetch && git checkout add/jp-pricing-rework/jetpack-installed-notice`
- Run `yarn start` and open [http://calypso.localhost:3000/](http://calypso.localhost:3000/)
- Create a JN site
- While connecting Jetpack,  pause on the plans page i.e. `https://wordpress.com/jetpack/connect/plans/:site`
- Copy the above URL and open it in another tab after replacing `https://wordpress.com` with `http://calypso.localhost:3000`
- Now in the tab with `calypso.localhost` URL add `&flags=jetpack/pricing-page-rework-v1` to the URL and hit enter. It will enable the feature flag.
- Confirm that you see the new notice `Jetpack is successfully installed`.
- Click on the Dismiss button (X) for the notice.
- Confirm that the notice is dismissed.
- In another terminal window, run `yarn start-jetpack-cloud-p`
- Goto [http://jetpack.cloud.localhost:3001/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3001/pricing?flags=jetpack/pricing-page-rework-v1)
- Confirm that you DON'T see the new notice.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Figma: m0y1jHTuDpvMPkFsOJBoNP-fi-3669%3A110782

<img width="1545" alt="Screenshot 2022-08-25 at 11 08 00 AM" src="https://user-images.githubusercontent.com/18226415/186585360-f281b401-0a06-4aad-a394-1128f256155b.png">

<img width="1422" alt="Screenshot 2022-08-25 at 11 09 04 AM" src="https://user-images.githubusercontent.com/18226415/186585346-e72a2d6f-781c-49bf-9b27-d8ba203d13e9.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202796695664093