### PR TITLE
Improved pricing page intro banner and fix mobile view misalignment 

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -69,13 +69,14 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 					<>
 						<div className="intro-pricing-banner__item">
 							<img
+								className="intro-pricing-banner__item-icon"
 								src={ rocket }
 								alt={ translate( 'Rocket representing %(percent)d%% sale', {
 									args: { percent: discountPercentage },
 									textOnly: true,
 								} ) }
 							/>
-							<span>
+							<span className="intro-pricing-banner__item-label">
 								{ preventWidows(
 									translate( 'Get up to %(percent)d%% off your first year.', {
 										args: {
@@ -86,8 +87,8 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 							</span>
 						</div>
 						<div className="intro-pricing-banner__item">
-							<img src={ guaranteeBadge } alt="" />
-							<span>
+							<img className="intro-pricing-banner__item-icon" src={ guaranteeBadge } alt="" />
+							<span className="intro-pricing-banner__item-label">
 								{ preventWidows(
 									translate( '%(days)d day money back guarantee.', {
 										args: { days: GUARANTEE_DAYS },
@@ -96,8 +97,9 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 							</span>
 						</div>
 						<div className="intro-pricing-banner__item is-agencies">
-							<img src={ people } alt="" />
+							<img className="intro-pricing-banner__item-icon" src={ people } alt="" />
 							<a
+								className="intro-pricing-banner__item-label is-link"
 								onClick={ () =>
 									recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' )
 								}

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -53,20 +53,18 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 	const discountPercentage =
 		fullJetpackSaleDiscount > 0 ? fullJetpackSaleDiscount : highestDiscount;
 
-	let className;
+	let classModifier = '';
 
 	if ( isLoading ) {
-		className = 'intro-pricing-banner__loading';
+		classModifier = 'is-loading';
 	} else if ( hasCrossed ) {
-		className = 'intro-pricing-banner__sticky';
-	} else {
-		className = 'intro-pricing-banner';
+		classModifier = 'is-sticky';
 	}
 
 	return (
 		<>
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
-			<div className={ className }>
+			<div className={ `intro-pricing-banner ${ classModifier }` }>
 				{ ( discountPercentage > 0 || isLoading ) && (
 					<>
 						<div className="intro-pricing-banner__discount">

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -66,7 +66,7 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
 			<div className={ `intro-pricing-banner ${ classModifier }` }>
 				{ ( discountPercentage > 0 || isLoading ) && (
-					<>
+					<div className="intro-pricing-banner__content">
 						<div className="intro-pricing-banner__item">
 							<img
 								className="intro-pricing-banner__item-icon"
@@ -110,7 +110,7 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 								{ preventWidows( translate( 'Explore Jetpack for Agencies' ) ) }
 							</a>
 						</div>
-					</>
+					</div>
 				) }
 			</div>
 		</>

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -67,7 +67,7 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 			<div className={ `intro-pricing-banner ${ classModifier }` }>
 				{ ( discountPercentage > 0 || isLoading ) && (
 					<>
-						<div className="intro-pricing-banner__discount">
+						<div className="intro-pricing-banner__item">
 							<img
 								src={ rocket }
 								alt={ translate( 'Rocket representing %(percent)d%% sale', {
@@ -85,7 +85,7 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 								) }
 							</span>
 						</div>
-						<div className="intro-pricing-banner__guarantee">
+						<div className="intro-pricing-banner__item">
 							<img src={ guaranteeBadge } alt="" />
 							<span>
 								{ preventWidows(
@@ -95,7 +95,7 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 								) }
 							</span>
 						</div>
-						<div className="intro-pricing-banner__agencies">
+						<div className="intro-pricing-banner__item is-agencies">
 							<img src={ people } alt="" />
 							<a
 								onClick={ () =>

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -49,10 +49,10 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	justify-content: center;
 
 	@include break-large {
 		flex-direction: row;
+		align-items: center;
 	}
 }
 
@@ -68,8 +68,8 @@
 }
 
 .intro-pricing-banner__item-icon {
-	width: 32px;
-	height: 32px;
+	min-width: 2em;
+	margin-inline-end: 0.5em;
 }
 
 .intro-pricing-banner__item-label.is-link {

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -3,25 +3,53 @@
 
 .intro-pricing-banner {
 	display: flex;
-	flex-direction: column;
-
-	align-items: center;
 	justify-content: center;
 
-	&:not( .is-sticky ) {
-		height: 120px;
-		margin-bottom: 2rem;
+	&.is-sticky {
+		position: fixed;
+		width: 100%;
+		left: 0;
+		top: var( --masterbar-height );
+		background-color: var( --color-surface );
+		box-shadow: 0 4px 4px 0 #00000014;
+		z-index: 2;
+		height: 74px;
 
-		gap: 1.25rem;
+		align-items: center;
 
 		@include break-large {
-			height: 54px;
+			height: 52px;
 		}
 	}
+}
 
-	> :not( :last-child ) {
-		margin-right: 16px;
+.intro-pricing-banner.is-loading .intro-pricing-banner__item-label {
+	@include placeholder();
+}
+
+.intro-pricing-banner.is-sticky .intro-pricing-banner__item.is-agencies {
+	display: none;
+
+	@include break-large {
+		display: flex;
 	}
+}
+
+.intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__content {
+	height: 120px;
+	margin-bottom: 2rem;
+	gap: 1.25rem;
+
+	@include break-large {
+		height: 54px;
+	}
+}
+
+.intro-pricing-banner__content {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: center;
 
 	@include break-large {
 		flex-direction: row;
@@ -33,10 +61,15 @@
 	flex-direction: row;
 	align-items: center;
 	font-size: $font-body;
+
+	&:not( :last-child ) {
+		margin-right: 16px;
+	}
 }
 
-.intro-pricing-banner.is-loading .intro-pricing-banner__item-label {
-	@include placeholder();
+.intro-pricing-banner__item-icon {
+	width: 32px;
+	height: 32px;
 }
 
 .intro-pricing-banner__item-label.is-link {
@@ -46,41 +79,9 @@
 	text-underline-offset: 3px;
 }
 
-.intro-pricing-banner__item-icon {
-	width: 32px;
-	height: 32px;
-}
-
-.intro-pricing-banner.is-sticky {
-	position: fixed;
-	width: 100%;
-	left: 0;
-	top: var( --masterbar-height );
-
-	background-color: var( --color-surface );
-	box-shadow: 0 4px 4px 0 #00000014;
-
-	z-index: 2;
-	height: 74px;
-
-	@include break-large {
-		height: 52px;
-	}
-}
-
-.intro-pricing-banner.is-sticky .intro-pricing-banner__item.is-agencies {
-	display: none;
-
-	@include break-large {
-		display: flex;
-	}
-}
-
-.is-section-jetpack-connect,
-.is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
-	.intro-pricing-banner.is-sticky {
-		top: 0;
-	}
+.is-section-jetpack-connect .intro-pricing-banner.is-sticky,
+.is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .intro-pricing-banner.is-sticky {
+	top: 0;
 }
 
 // target Calypso pricing filter bar, not jetpack cloud

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -1,14 +1,23 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/breakpoints';
 
-.intro-pricing-banner,
-.intro-pricing-banner__sticky,
-.intro-pricing-banner__loading {
+.intro-pricing-banner {
 	display: flex;
 	flex-direction: column;
 
 	align-items: center;
 	justify-content: center;
+
+	&:not( .is-sticky ) {
+		height: 120px;
+		margin-bottom: 2rem;
+
+		gap: 1.25rem;
+
+		@include break-large {
+			height: 54px;
+		}
+	}
 
 	.intro-pricing-banner__discount,
 	.intro-pricing-banner__guarantee,
@@ -36,22 +45,10 @@
 	}
 }
 
-.intro-pricing-banner,
-.intro-pricing-banner__loading {
-	height: 120px;
-	margin-bottom: 2rem;
-
-	gap: 1.25rem;
-
-	@include break-large {
-		height: 54px;
-	}
-}
-
-.intro-pricing-banner__loading {
+.intro-pricing-banner.is-loading {
 	.intro-pricing-banner__discount,
 	.intro-pricing-banner__guarantee,
-	.intro-pricing-banner__agencies, {
+	.intro-pricing-banner__agencies {
 		span,
 		a {
 			@include placeholder();
@@ -59,7 +56,7 @@
 	}
 }
 
-.intro-pricing-banner__sticky {
+.intro-pricing-banner.is-sticky {
 	position: fixed;
 	width: 100%;
 	left: 0;
@@ -85,13 +82,13 @@
 }
 .is-section-jetpack-connect,
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
-	.intro-pricing-banner__sticky {
+	.intro-pricing-banner.is-sticky {
 		top: 0;
 	}
 }
 
 // target Calypso pricing filter bar, not jetpack cloud
-.is-group-sites.is-section-plans .intro-pricing-banner__sticky {
+.is-group-sites.is-section-plans .intro-pricing-banner.is-sticky {
 	// At this screen size, the left sidebar is 228px;
 	@include breakpoint-deprecated( '>660px' ) {
 		width: calc( 100% - 228px );

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -19,23 +19,6 @@
 		}
 	}
 
-	.intro-pricing-banner__discount,
-	.intro-pricing-banner__guarantee,
-	.intro-pricing-banner__agencies {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-
-		font-size: $font-body;
-
-		a {
-			color: var( --color-primary-100 );
-			text-decoration: underline;
-			// This works in all major browsers except for Firefox for Android. It is also not imperative that this works
-			text-underline-offset: 3px;
-		}
-	}
-
 	> :not( :last-child ) {
 		margin-right: 16px;
 	}
@@ -45,14 +28,25 @@
 	}
 }
 
-.intro-pricing-banner.is-loading {
-	.intro-pricing-banner__discount,
-	.intro-pricing-banner__guarantee,
-	.intro-pricing-banner__agencies {
-		span,
-		a {
-			@include placeholder();
-		}
+.intro-pricing-banner__item {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	font-size: $font-body;
+
+	a {
+		color: var( --color-primary-100 );
+		text-decoration: underline;
+		// This works in all major browsers except for Firefox for Android. It is also not imperative that this works
+		text-underline-offset: 3px;
+	}
+}
+
+.intro-pricing-banner.is-loading .intro-pricing-banner__item {
+	span,
+	a {
+		@include placeholder();
 	}
 }
 
@@ -68,18 +62,20 @@
 	z-index: 2;
 	height: 74px;
 
-	.intro-pricing-banner__agencies {
-		display: none;
-
-		@include break-large {
-			display: flex;
-		}
-	}
-
 	@include break-large {
 		height: 52px;
 	}
 }
+
+.intro-pricing-banner.is-sticky .intro-pricing-banner__item.is-agencies {
+	display: none;
+
+	@include break-large {
+		display: flex;
+	}
+}
+
+
 .is-section-jetpack-connect,
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
 	.intro-pricing-banner.is-sticky {

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -32,22 +32,23 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-
 	font-size: $font-body;
-
-	a {
-		color: var( --color-primary-100 );
-		text-decoration: underline;
-		// This works in all major browsers except for Firefox for Android. It is also not imperative that this works
-		text-underline-offset: 3px;
-	}
 }
 
-.intro-pricing-banner.is-loading .intro-pricing-banner__item {
-	span,
-	a {
-		@include placeholder();
-	}
+.intro-pricing-banner.is-loading .intro-pricing-banner__item-label {
+	@include placeholder();
+}
+
+.intro-pricing-banner__item-label.is-link {
+	color: var( --color-primary-100 );
+	text-decoration: underline;
+	// This works in all major browsers except for Firefox for Android. It is also not imperative that this works
+	text-underline-offset: 3px;
+}
+
+.intro-pricing-banner__item-icon {
+	width: 32px;
+	height: 32px;
 }
 
 .intro-pricing-banner.is-sticky {
@@ -74,7 +75,6 @@
 		display: flex;
 	}
 }
-
 
 .is-section-jetpack-connect,
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {


### PR DESCRIPTION
### Description
The initial issue was that the intro banner items were not perfectly aligned when viewed on a mobile screen. While I restructured the `IntroPricingBanner` component to fix the issue, I noticed that there are a couple of CSS codes that do not align to the [CSS Coding guidelines](https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines). I decided to update it and added some class names and modifiers to make sure it follows the guidelines.

<img width="300" alt="Screen Shot 2022-08-25 at 3 48 55 PM" src="https://user-images.githubusercontent.com/56598660/186606772-adbfbb8d-6f2b-4846-b797-20e76b15350c.png">

#### Proposed Changes

* Instead of having 3 different class names (`intro-pricing-banner`, `intro-pricing-banner__loading` & `intro-pricing-banner__sticky`), I have modified the component so it will only have 1 class name which is `intro-pricing-banner` and converted `__loading` and `__sticky` as an `is-*` modifier. This simplifies our CSS code and allows us to nest 'is-*' modifiers without violating the coding guidelines.

* Instead of having 3 different class names for the banner items (`intro-pricing-banner__discount`, `intro-pricing-banner__guarantee` & `intro-pricing-banner__agencies`), we now use `intro-pricing-banner__item`. We also converted `__agencies` into `is-agencies` modifier. This simplifies our CSS code and allows us to nest 'is-*' modifiers without violating the coding guidelines.

* Added `intro-pricing-banner__item-icon` and `intro-pricing-banner__item-label` class names for img, span & a elements. Also use `is-link` modifier for `intro-pricing-banner__item-label`.

* Added inner container `intro-pricing-banner__content` to hold the 3 items. This allows us to align the container at the center while making our items align to the left. 

#### Testing Instructions

* Boot up this PR
* Run `git fetch && git checkout fix/pricing-banner-misalignment`
* Run `yarn start-jetpack-cloud`

* Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
* Confirm that the pricing banner is correctly align at the center during and after loading.
    
<img width="1019" alt="Screen Shot 2022-08-25 at 3 59 47 PM" src="https://user-images.githubusercontent.com/56598660/186609352-be7c41fd-3380-4dd7-9296-464317df420c.png">

<img width="1030" alt="Screen Shot 2022-08-25 at 4 00 00 PM" src="https://user-images.githubusercontent.com/56598660/186609288-0e4d1b9f-3b16-4dcd-a357-b7170fdd3e08.png">

* Scroll down to show the sticky version of the banner and make sure that the items are properly align at the center.

<img width="1373" alt="Screen Shot 2022-08-25 at 4 01 25 PM" src="https://user-images.githubusercontent.com/56598660/186609707-ec9393ae-a02f-41ee-8500-ffb9de80f062.png">

---

* Resize your browser to make the screen smaller or if you are using Chrome, use Device tool to view the screen in Mobile. Confirm that the items are perfectly align and positioned at the center. See reference below.
    
<img width="300" alt="Screen Shot 2022-08-25 at 4 05 05 PM" src="https://user-images.githubusercontent.com/56598660/186610556-7304f067-8d94-4ff3-8f86-84062e45cf37.png">

<img width="300" alt="Screen Shot 2022-08-25 at 4 05 18 PM" src="https://user-images.githubusercontent.com/56598660/186610570-876508ec-5bcb-43da-8fe2-e22dd24546e9.png">

<img width="300" alt="Screen Shot 2022-08-25 at 4 05 40 PM" src="https://user-images.githubusercontent.com/56598660/186610578-d496943e-d691-45fc-a5d6-cf25dc08ec2a.png">

---

  * **(Testing new pricing page)** Repeat the same procedure above but this time use the following link http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and go to `/pricing?flags=jetpack/pricing-page-rework-v1`
  
---

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202852882964038

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202852882964038