### PR TITLE
Signup (TailoredProcessingScreen): remove visible scrollbars

### DIFF
--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -55,6 +55,14 @@ export default function TailoredFlowProcessingScreen( { flowName } ) {
 	const progress = ( currentStep + 1 ) / totalSteps;
 	const isComplete = progress >= 1;
 
+	// Temporarily override document styles to prevent scrollbars from showing
+	useEffect( () => {
+		document.documentElement.classList.add( 'no-scroll' );
+		return () => {
+			document.documentElement.classList.remove( 'no-scroll' );
+		};
+	}, [] );
+
 	useInterval(
 		() => setCurrentStep( ( s ) => s + 1 ),
 		// Enable the interval when progress is incomplete.

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -13,9 +13,9 @@
 		}
 
 		.reskinned-processing-screen__container {
-			height: 100vh;
-			width: 100vw;
-			position: absolute;
+			height: 100%;
+			width: 100%;
+			position: fixed;
 			top: 0;
 			left: 0;
 			display: flex;


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| <img width="1670" alt="Screenshot 2022-08-25 at 10 51 12" src="https://user-images.githubusercontent.com/7000684/186620421-a1a37540-3931-4b70-9077-b0da382a057d.png"> | <img width="1676" alt="Screenshot 2022-08-25 at 10 50 24" src="https://user-images.githubusercontent.com/7000684/186620471-b3790c14-9645-4b40-8e6c-0d9fc75f2154.png"> |

#### Proposed Changes

* In the tailored processing screen for some browsers there are visible horizontal and vertical scrollbars.
* To fix this, this PR modifies the vh and vw styling and overrides the default overflow setting of the html node while the component is visible.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- If you want you can force the tailored processing component to always show by modifying [this check](https://github.com/Automattic/wp-calypso/blob/fix/tailored-flow-processing-scrollbars/client/signup/main.jsx#L682)
- Open browser stack with Windows 10 and browser Chrome 104.0
- Visit http://calypso.localhost:3000/start/newsletter/domains
- Make sure that there are no visible scrollbars
