### PR TITLE
Prevent page jump when switching filters

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -452,6 +452,8 @@
 
 	// Customize styles for standard designs
 	.unified-design-picker__standard-designs {
+		min-height: 100vh;
+
 		.unified-design-picker__subtitle {
 			margin-bottom: 14px;
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR adds `min-height: 100vh` to the standard designs section, in order to prevent the page to jump when switching filters due to the filtered results being too few. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/designSetup?siteSlug=${site_slug}`.
* Ensure that the page doesn't jump when switching around filters.
* Ensure that the rest of the layout works as before.

https://user-images.githubusercontent.com/797888/186623895-d3c2ba7b-123e-4a54-8ddc-1a04233f7905.mp4

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66440
