### PR TITLE
Add 'See all features' section in Pricing bundle page.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/products.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/products.tsx
@@ -7,6 +7,7 @@ const Products: React.FC< ProductProps > = ( { type } ) => {
 			{ type === 'products' && <div>Product Component goes here</div> }
 			{ type === 'bundles' && (
 				<div>
+					Bundle Component goes here
 					<SeeAllFeatures />
 				</div>
 			) }

--- a/client/my-sites/plans/jetpack-plans/product-store/products.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/products.tsx
@@ -1,10 +1,15 @@
+import { SeeAllFeatures } from './see-all-features';
 import type { ProductProps } from './types';
 
 const Products: React.FC< ProductProps > = ( { type } ) => {
 	return (
 		<div className="jetpack-product-store__product">
 			{ type === 'products' && <div>Product Component goes here</div> }
-			{ type === 'bundles' && <div>Bundle Component goes here</div> }
+			{ type === 'bundles' && (
+				<div>
+					<SeeAllFeatures />
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/see-all-features.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/see-all-features.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { PLAN_COMPARISON_PAGE } from '../constants';
+
+export const SeeAllFeatures: React.FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<div className="jetpack-product-store__see-all-features">
+			<Button
+				onClick={ () => recordTracksEvent( 'calypso_product_seel_all_features_click' ) }
+				href={ PLAN_COMPARISON_PAGE }
+				target="_blank"
+				rel="noreferrer"
+			>
+				{ translate( 'See all features' ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/see-all-features.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/see-all-features.tsx
@@ -9,7 +9,7 @@ export const SeeAllFeatures: React.FC = () => {
 	return (
 		<div className="jetpack-product-store__see-all-features">
 			<Button
-				onClick={ () => recordTracksEvent( 'calypso_product_seel_all_features_click' ) }
+				onClick={ () => recordTracksEvent( 'calypso_product_see_all_features_click' ) }
 				href={ PLAN_COMPARISON_PAGE }
 				target="_blank"
 				rel="noreferrer"

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -44,7 +44,7 @@
 		color: var( --color-neutral-100 );
 		border: 1px solid var( --color-neutral-100 );
 		font-weight: 600;
-		font-size: $font-body;
+		min-width: 225px;
 	}
 
 	.jetpack-product-store__product-filter {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -43,6 +43,8 @@
 	.button {
 		color: var( --color-neutral-100 );
 		border: 1px solid var( --color-neutral-100 );
+		font-family: 'SF Pro Text', $sans;
+		font-size: $font-body;
 		font-weight: 600;
 		min-width: 225px;
 	}

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -34,10 +34,17 @@
 		}
 	}
 
+	&__see-all-features {
+		display: flex;
+		justify-content: center;
+		margin: 3rem auto;
+	}
+
 	.button {
 		color: var( --color-neutral-100 );
 		border: 1px solid var( --color-neutral-100 );
 		font-weight: 600;
+		font-size: $font-body;
 	}
 
 	.jetpack-product-store__product-filter {


### PR DESCRIPTION
#### Proposed Changes

* Add 'See all features' button in the Pricing bundle page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR
  * Run `git fetch && git checkout add/pricing-age-see-all-features-button`
  * Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/pricing?flags=pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=pricing-page-rework-v1`.
* Press 'Bundle' product filter.
* Confirm that the 'See all features' button is visible
<img width="962" alt="Screen Shot 2022-08-25 at 5 07 35 PM" src="https://user-images.githubusercontent.com/56598660/186624186-7b1d08a3-48f7-49c0-8851-33c5906d506d.png">

* Upon clicking the button, make sure you are redirected to https://jetpack.com/features/comparison/ page.
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202796695664067

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202796695664067