### PR TITLE
Tailored flows: set Lynx as LiB theme

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -48,7 +48,7 @@ export const linkInBio: Flow = {
 
 				case 'linkInBioSetup':
 					return window.location.replace(
-						`/start/newsletter/domains?new=${ encodeURIComponent(
+						`/start/link-in-bio/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string
 						) }&search=yes&hide_initial_query=yes`
 					);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -129,7 +129,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'link-in-bio',
-			steps: [ 'domains', 'plans' ],
+			steps: [ 'domains', 'plans-link-in-bio' ],
 			destination: ( dependencies ) =>
 				`/setup/completingPurchase?flow=link-in-bio&siteSlug=${ encodeURIComponent(
 					dependencies.siteSlug

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -31,6 +31,7 @@ const stepNameToModuleName = {
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
 	'plans-newsletter': 'plans',
+	'plans-link-in-bio': 'plans',
 	'plans-personal': 'plans',
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -221,6 +221,16 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 
+		// the only unique thing about plans-link-in-bio is that it provides themeSlugWithRepo dependency
+		'plans-link-in-bio': {
+			stepName: 'plans',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			optionalDependencies: [ 'emailItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isPlanFulfilled,
+		},
+
 		'plans-new': {
 			stepName: 'plans',
 			providesDependencies: [ 'cartItem' ],

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -109,6 +109,13 @@ export class PlansStep extends Component {
 				themeSlugWithRepo: 'pub/lettre',
 			} );
 			this.props.goToNextStep();
+		} else if ( flowName === 'link-in-bio' ) {
+			// newsletter flow always uses pub/lettre
+			this.props.submitSignupStep( step, {
+				cartItem,
+				themeSlugWithRepo: 'pub/lynx',
+			} );
+			this.props.goToNextStep();
 		} else {
 			this.props.submitSignupStep( step, {
 				cartItem,

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -39,6 +39,7 @@
 	margin-top: 25px;
 }
 
+.signup__step.is-plans-link-in-bio .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans-newsletter .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans-launch .formatted-header__subtitle .button.is-borderless {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -784,6 +784,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-domains,
 	.signup__step.is-emails,
 	.signup__step.is-plans-newsletter,
+	.signup__step.is-plans-link-in-bio,
 	.signup__step.is-plans {
 		.formatted-header {
 			.formatted-header__title {
@@ -821,6 +822,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
+	.signup__step.is-plans-link-in-bio,
 	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans {
 		.formatted-header__title {
@@ -872,6 +874,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
  * and the current back button is redundent.
 */
 body.is-section-signup.is-white-signup {
+	.signup__step.is-plans-link-in-bio .step-wrapper__navigation,
 	.signup__step.is-plans-newsletter .step-wrapper__navigation,
 	.signup__step.is-plans .step-wrapper__navigation,
 	.signup__step.is-domains .step-wrapper__navigation {


### PR DESCRIPTION
#### Proposed Changes

* This fixes a bug where we redirect Stepper LiB users to /start/newsletter
* It sets the theme to Lynx for all LiB sites. [Exact copy of this PR](https://github.com/Automattic/wp-calypso/pull/66878). 

#### Testing Instructions

1. Go to /setup?flow=link-in-bio.
2. Make a site.
3. Go to https://wordpress.com/themes, the site should have Lynx.
