### PR TITLE
Pricing page rework: Create section and heading for most popular items

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -6,7 +6,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useProductSlugs from './hooks/use-product-slugs';
 import { JetpackFree } from './jetpack-free';
 import ProductFilter from './product-filter';
-import Product from './products';
+import Products from './products';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
 import type { FilterType, ProductStoreProps } from './types';
@@ -32,7 +32,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			</div>
 
 			<ProductFilter filterType={ filterType } setFilterType={ setFilterType } />
-			<Product type={ filterType }></Product>
+			<Products type={ filterType } />
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 
 			<Recommendations />

--- a/client/my-sites/plans/jetpack-plans/product-store/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/most-popular.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames';
+import { MostPopularProps } from './types';
+
+export const MostPopular: React.FC< MostPopularProps > = ( { className, heading, items } ) => {
+	const wrapperClassName = classNames( 'jetpack-product-store__most-popular', className );
+
+	return (
+		<div className={ wrapperClassName }>
+			<h3 className="jetpack-product-store__most-popular--heading">{ heading }</h3>
+			<div className="jetpack-product-store__most-popular--items">{ items }</div>
+		</div>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/products.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/products.tsx
@@ -1,13 +1,21 @@
+import { useTranslate } from 'i18n-calypso';
+import { MostPopular } from './most-popular';
 import { SeeAllFeatures } from './see-all-features';
 import type { ProductProps } from './types';
 
 const Products: React.FC< ProductProps > = ( { type } ) => {
+	const translate = useTranslate();
+
 	return (
-		<div className="jetpack-product-store__product">
-			{ type === 'products' && <div>Product Component goes here</div> }
+		<div className="jetpack-product-store__products">
+			{ type === 'products' && (
+				<div>
+					<MostPopular heading={ translate( 'Most popular products' ) } items={ <></> } />
+				</div>
+			) }
 			{ type === 'bundles' && (
 				<div>
-					Bundle Component goes here
+					<MostPopular heading={ translate( 'Most popular bundles' ) } items={ <></> } />
 					<SeeAllFeatures />
 				</div>
 			) }

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -33,6 +33,9 @@
 			gap: 1.5em;
 		}
 	}
+	&__most-popular {
+		margin-top: 3em;
+	}
 
 	&__see-all-features {
 		display: flex;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -25,3 +25,9 @@ export interface ProductFilterProps {
 export interface ProductProps {
 	type: FilterType;
 }
+
+export type MostPopularProps = {
+	className?: string;
+	heading: string;
+	items: React.ReactNode;
+};


### PR DESCRIPTION
#### Proposed Changes

* Create `MostPopular` component to display both the most popular products as well as bundles.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR 
    * Run `git fetch && git checkout add/jp-pricing-rework/most-popular-section`
    * Run `yarn start-jetpack-cloud`
    * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1)
* Or click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* Confirm that you see the most popular items section for both products as well as bundles.
* Confirm that the design matches the Figma design
* Confirm that it looks good on both Desktop and Mobile

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Completes 1202796695664022-as-1202796695664099/f
Figma: m0y1jHTuDpvMPkFsOJBoNP-fi-3711%3A119683

<img width="1494" alt="Screenshot 2022-08-25 at 5 57 14 PM" src="https://user-images.githubusercontent.com/18226415/186665179-509ec702-7a6c-4d4d-a0e4-02588551e6df.png">

<img width="407" alt="Screenshot 2022-08-25 at 5 57 35 PM" src="https://user-images.githubusercontent.com/18226415/186665166-ff818bc5-0695-4c86-804a-16bc7e749252.png">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664099
  - 0-as-1202796695664120