### PR TITLE
Minor styling changes to the blazepress header

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { useEffect, useRef, useState } from 'react';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -37,7 +36,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				await showDSP( props.siteId, props.postId, widgetContainer.current );
 				setIsLoading( false );
 			} )();
-	}, [ isVisible ] );
+	}, [ isVisible, props.postId, props.siteId ] );
 
 	const promoteWidgetStatus = usePromoteWidget();
 	if ( promoteWidgetStatus === PromoteWidgetStatus.DISABLED ) {
@@ -53,12 +52,12 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						<h2>Promote</h2>
 						<span
 							role="button"
-							className={ 'blazepress-widget__cross' }
+							className={ 'blazepress-widget__cancel' }
 							onKeyDown={ onClose }
 							tabIndex={ 0 }
 							onClick={ onClose }
 						>
-							<Gridicon icon="cross" size={ 24 } />
+							Cancel
 						</span>
 					</div>
 					<div

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -11,25 +11,30 @@
         display: flex;
         justify-content: space-between;
         min-height: 72px;
-        padding: 0 20px;
+        padding: 0 rem( 24px );
 
         h2 {
             @include onboarding-font-recoleta;
-            font-size: $font-title-small;
+            font-size: $font-body-large;
             letter-spacing: 0;
             flex: 1;
+            line-height: 1;
+			padding-top: 3px; // helps align with the logo
         }
 
         .wordpress-logo {
             width: 1.5rem;
             height: 1.5rem;
             fill: var( --color-text );
-            margin: 0 1.5rem 0 0;
+            margin: 0 rem( 10px ) 0 0;
         }
 
-        .blazepress-widget__cross {
+        .blazepress-widget__cancel {
             height: 24px;
             cursor: pointer;
+			font-style: normal;
+			font-weight: 500;
+			font-size: $font-body-extra-small;
         }
     }
     .blazepress-widget__content {


### PR DESCRIPTION
#### Proposed Changes

Some very minor tweaks to fully match the blazepress header to the designs, more easily demonstrated by the screenshots below:


**Before**
This is what we have in trunk right now vs the designs,  

![Screenshot 2022-08-25 at 14 05 49](https://user-images.githubusercontent.com/6440498/186676591-080f6914-e87f-4ebf-bb1f-3acfd4129f92.png)

**After**
Here is this PR vs the designs.
![Screenshot 2022-08-25 at 14 16 02](https://user-images.githubusercontent.com/6440498/186676584-8e50a3e2-10d9-406c-82cd-3cd924b24099.png)

#### Testing Instructions

Visit `/advertising` with this branch loaded, then press the "promote" button to launch the widget, you should now see the updated styles once the pop-out loads

![image](https://user-images.githubusercontent.com/6440498/186678695-a922b595-77c0-4b26-88be-9c23243a5d0d.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
