### PR TITLE
Fix copy mistake on titles

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -12,7 +12,7 @@ import type { Flow } from './internals/types';
 
 export const newsletter: Flow = {
 	name: 'newsletter',
-	title: 'Newsletters',
+	title: 'Newsletter',
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -124,7 +124,7 @@ export function generateFlows( {
 			showRecaptcha: true,
 			hideBackButton: true,
 			get pageTitle() {
-				return translate( 'Newsletters' );
+				return translate( 'Newsletter' );
 			},
 		},
 		{


### PR DESCRIPTION
## Proposed Changes

Rename from Newsletters to Newsletter


<img width="220" alt="image" src="https://user-images.githubusercontent.com/2653810/186679845-655e25b0-95bc-4266-88ff-0c11ee748f0b.png">

<img width="205" alt="image" src="https://user-images.githubusercontent.com/2653810/186679895-b0c1b25f-0a9d-41dc-81a3-6637cb0b329b.png">


## Testing Instructions

- Checkout this branch
- Run yarn start
- Visit the [newsletter setup](http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter) 
- You should not see newsletters written anywhere.
