### PR TITLE
Theme/Plugin Bundling: Fix to Sell intent flow progress

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -431,6 +431,11 @@ export const siteSetupFlow: Flow = {
 
 				case 'designSetup':
 					if ( intent === 'sell' ) {
+						// For theme/plugin bundling, we skip the store features step because we use the theme to decide if they're going through "Start simple" or "More power"
+						if ( isEnabled( 'themes/plugin-bundling' ) ) {
+							return navigate( 'options' );
+						}
+
 						// this means we came from sell => store-features => start simple, we go back to store features
 						return navigate( 'storeFeatures' );
 					} else if ( intent === 'write' ) {

--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -99,6 +99,22 @@ export function useSiteSetupFlowProgress(
 						break;
 				}
 			}
+			if ( isEnabled( 'themes/plugin-bundling' ) ) {
+				switch ( currentStep ) {
+					case 'goals':
+						middleProgress = { progress: 1, count: 4 };
+						break;
+					case 'vertical':
+						middleProgress = { progress: 2, count: 4 };
+						break;
+					case 'options':
+						middleProgress = { progress: 3, count: 4 };
+						break;
+					case 'designSetup':
+						middleProgress = { progress: 4, count: 4 };
+						break;
+				}
+			}
 
 			break;
 		}


### PR DESCRIPTION
#### Proposed Changes

This fixes two issues related to flow progress during the theme/plugin-bundle process.

1. The "Back" button from the `designSetup` step will take you to `options` instead of `storeFeatures. This is necessary as part of #66867.
1. Fixes the flow progress bar so it steps correctly.

#### Testing Instructions

1. Go to `http://calypso.localhost:3000/setup/goals?siteSlug=[SITESLUG]&notice=purchase-success&flags=themes/plugin-bundling` and select "Sell online"
2. Continue through the `vertical` and `options` steps until you reach `designSetup`. The progress bar should move forward appropriately.
3. From `designSetup`, click the "Back" link and you should go back to the `options` step.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66986
