### PR TITLE
import @automattic/onboarding: Remove extra slash

### DIFF
--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -1,5 +1,5 @@
-import { useFlowProgress } from '@automattic//onboarding';
 import { ProgressBar } from '@automattic/components';
+import { useFlowProgress } from '@automattic/onboarding';
 import classnames from 'classnames';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import './style.scss';


### PR DESCRIPTION
#### Proposed Changes

* Change `import { useFlowProgress } from '@automattic//onboarding';` to `mport { useFlowProgress } from '@automattic/onboarding';`

#### Testing Instructions

* run ` yarn run distclean ; yarn install ; yarn build-packages ; yarn start`
* Visit `/setup?siteSlug=YOURSITEHERE`
* Before PR: Page doesn't load and you see 'AppBoot is not a function' error in console
* After PR: Page loads

For some reason, this bug only seems to exhibit itself on my machine?