### PR TITLE
Newsletter onboarding: introduce "Add Subscribers" step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -30,6 +30,7 @@ const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null
 					{ site?.ID && (
 						<AddSubscriberForm
 							siteId={ site.ID }
+							submitBtnName={ 'Continue' }
 							onImportFinished={ handleSubmit }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { AddSubscriberForm } from '@automattic/subscriber';
+import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { useSetupOnboardingSite } from 'calypso/landing/stepper/hooks/use-setup-onboarding-site';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -8,6 +9,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null {
+	const __ = useTranslate();
 	const { submit } = navigation;
 	const site = useSite();
 
@@ -30,7 +32,7 @@ const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null
 					{ site?.ID && (
 						<AddSubscriberForm
 							siteId={ site.ID }
-							submitBtnName={ 'Continue' }
+							submitBtnName={ __( 'Continue' ) }
 							onImportFinished={ handleSubmit }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { ReactElement } from 'react';
@@ -30,7 +31,7 @@ const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null
 						<AddSubscriberForm
 							siteId={ site.ID }
 							onImportFinished={ handleSubmit }
-							showCsvUpload={ false }
+							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 						/>
 					) }
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -1,4 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
+import { AddSubscriberForm } from '@automattic/subscriber';
 import { ReactElement } from 'react';
 import { useSetupOnboardingSite } from 'calypso/landing/stepper/hooks/use-setup-onboarding-site';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -21,12 +22,17 @@ const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null
 			hideFormattedHeader={ true }
 			stepName={ 'subscribers' }
 			flowName={ 'newsletter' }
-			isHorizontalLayout={ true }
+			isHorizontalLayout={ false }
+			showJetpackPowered={ true }
 			stepContent={
 				<div className={ 'subscribers' }>
-					<h1 className="subscribers__title">This is the subscribers step</h1>
-					<p>Content here...</p>
-					<button onClick={ handleSubmit }>Go to the next step</button>
+					{ site?.ID && (
+						<AddSubscriberForm
+							siteId={ site.ID }
+							onImportFinished={ handleSubmit }
+							showCsvUpload={ false }
+						/>
+					) }
 				</div>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/package.json
+++ b/client/package.json
@@ -54,6 +54,7 @@
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/social-previews": "workspace:^",
 		"@automattic/state-utils": "workspace:^",
+		"@automattic/subscriber": "workspace:^",
 		"@automattic/tree-select": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",

--- a/config/development.json
+++ b/config/development.json
@@ -172,6 +172,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"subscriber-csv-upload": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -144,6 +144,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"subscriber-csv-upload": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -78,10 +78,15 @@ export function createActions() {
 
 		try {
 			const data: AddSubscribersResponse = yield wpcomRequest( {
-				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers`,
+				path: `/sites/${ encodeURIComponent( siteId ) }/invites/new`,
 				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				body: { emails },
+				apiNamespace: 'rest/v1.1',
+				body: {
+					invitees: emails,
+					role: 'follower',
+					source: 'calypso',
+					is_external: false,
+				},
 			} );
 
 			yield addSubscribersSuccess( siteId, data );

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -25,6 +25,7 @@ interface Props {
 	siteId: number;
 	showTitleEmoji?: boolean;
 	showSkipBtn?: boolean;
+	showCsvUpload?: boolean;
 	submitBtnName?: string;
 	onSkipBtnClick?: () => void;
 	onImportFinished?: () => void;
@@ -32,8 +33,15 @@ interface Props {
 
 export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const __ = useTranslate();
-	const { siteId, showTitleEmoji, showSkipBtn, submitBtnName, onSkipBtnClick, onImportFinished } =
-		props;
+	const {
+		siteId,
+		showTitleEmoji,
+		showSkipBtn,
+		showCsvUpload,
+		submitBtnName,
+		onSkipBtnClick,
+		onImportFinished,
+	} = props;
 
 	const { addSubscribers, importCsvSubscribers, getSubscribersImports } =
 		useDispatch( SUBSCRIBER_STORE );
@@ -199,15 +207,17 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 								</label>
 							) }
 
-							{ isSelectedFileValid && ! selectedFile && (
-								<label>
-									{ createInterpolateElement(
-										__(
-											'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
-										),
-										{ uploadBtn: formFileUploadElement }
-									) }
-								</label>
+							{ showCsvUpload && isSelectedFileValid && ! selectedFile && (
+								<>
+									<label>
+										{ createInterpolateElement(
+											__(
+												'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
+											),
+											{ uploadBtn: formFileUploadElement }
+										) }
+									</label>
+								</>
 							) }
 
 							<NextButton type={ 'submit' } className={ 'add-subscriber__form-submit-btn' }>
@@ -221,11 +231,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 									Not yet
 								</SkipButton>
 							) }
-							<p className={ 'add-subscriber__form--disclaimer' }>
-								By adding a mailing list CSV, you are confirming that you have the rights to share
-								newsletters with the people within your list.{ ' ' }
-								<Button isLink={ true }>Learn more</Button>
-							</p>
+							{ showCsvUpload && (
+								<p className={ 'add-subscriber__form--disclaimer' }>
+									By adding a mailing list CSV, you are confirming that you have the rights to share
+									newsletters with the people within your list.{ ' ' }
+									<Button isLink={ true }>Learn more</Button>
+								</p>
+							) }
 						</form>
 					</div>
 				</>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -208,16 +208,14 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 							) }
 
 							{ showCsvUpload && isSelectedFileValid && ! selectedFile && (
-								<>
-									<label>
-										{ createInterpolateElement(
-											__(
-												'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
-											),
-											{ uploadBtn: formFileUploadElement }
-										) }
-									</label>
-								</>
+								<label>
+									{ createInterpolateElement(
+										__(
+											'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
+										),
+										{ uploadBtn: formFileUploadElement }
+									) }
+								</label>
 							) }
 
 							<NextButton type={ 'submit' } className={ 'add-subscriber__form-submit-btn' }>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -216,6 +216,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						</label>
 					) }
 
+					{ showCsvUpload && isSelectedFileValid && selectedFile && (
+						<p className={ 'add-subscriber__form--disclaimer' }>
+							By clicking "continue", you represent that you've obtained the appropriate consent to
+							email each person on your list. <Button isLink={ true }>Learn more</Button>
+						</p>
+					) }
+
 					<NextButton
 						type={ 'submit' }
 						className={ 'add-subscriber__form-submit-btn' }
@@ -231,13 +238,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						>
 							Not yet
 						</SkipButton>
-					) }
-					{ showCsvUpload && (
-						<p className={ 'add-subscriber__form--disclaimer' }>
-							By adding a mailing list CSV, you are confirming that you have the rights to share
-							newsletters with the people within your list.{ ' ' }
-							<Button isLink={ true }>Learn more</Button>
-						</p>
 					) }
 				</form>
 			</div>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, NextButton, SkipButton } from '@automattic/onboarding';
 import { TextControl, FormFileUpload, Button, Notice } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -225,7 +226,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 									'By clicking "continue", you represent that you\'ve obtained the appropriate consent to ' +
 										'email each person on your list. <Button>Learn more</Button>'
 								),
-								{ Button: createElement( Button, { isLink: true } ) }
+								{
+									Button: createElement( Button, {
+										isLink: true,
+										target: '__blank',
+										href: localizeUrl( 'https://wordpress.com/support/user-roles/' ),
+									} ),
+								}
 							) }
 						</p>
 					) }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Title, NextButton, SkipButton } from '@automattic/onboarding';
-import { TextControl, FormFileUpload, Button } from '@wordpress/components';
+import { TextControl, FormFileUpload, Button, Notice } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -19,7 +19,6 @@ import { useActiveJobRecognition } from '../../hooks/use-active-job-recognition'
 import { useInProgressState } from '../../hooks/use-in-progress-state';
 import { SUBSCRIBER_STORE } from '../../store';
 import './style.scss';
-import { AddSubscribersProgressScreen } from './progress-screen';
 
 interface Props {
 	siteId: number;
@@ -141,105 +140,107 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	 */
 	return (
 		<div className={ 'add-subscriber' }>
-			{ inProgress && <AddSubscribersProgressScreen /> }
-			{ ! inProgress && (
-				<>
-					<div className={ 'add-subscriber__title-container' }>
-						{ showTitleEmoji && <h2 className={ 'add-subscriber__title-emoji' }>🤝</h2> }
-						<Title>Add subscribers to build your audience</Title>
-					</div>
+			<div className={ 'add-subscriber__title-container' }>
+				{ showTitleEmoji && <h2 className={ 'add-subscriber__title-emoji' }>🤝</h2> }
+				<Title>Add subscribers to build your audience</Title>
+			</div>
 
-					<div className={ 'add-subscriber__form--container' }>
-						<form onSubmit={ onFormSubmit }>
-							<TextControl
-								placeholder={ 'sibling@email.com' }
-								value={ emails[ 0 ] || '' }
-								help={ isValidEmails[ 0 ] ? <Icon icon={ check } /> : undefined }
-								onChange={ ( value ) => onEmailChange( value, 0 ) }
-							/>
-							<TextControl
-								placeholder={ 'parents@email.com' }
-								value={ emails[ 1 ] || '' }
-								help={ isValidEmails[ 1 ] ? <Icon icon={ check } /> : undefined }
-								onChange={ ( value ) => onEmailChange( value, 1 ) }
-							/>
-							<TextControl
-								placeholder={ 'friend@email.com' }
-								value={ emails[ 2 ] || '' }
-								help={ isValidEmails[ 2 ] ? <Icon icon={ check } /> : undefined }
-								onChange={ ( value ) => onEmailChange( value, 2 ) }
-							/>
+			<div className={ 'add-subscriber__form--container' }>
+				{ inProgress && <Notice isDismissible={ false }>You have email list importing...</Notice> }
 
-							{ ! isSelectedFileValid && (
-								<label className={ 'add-subscriber__form-label-error' }>
-									{ createInterpolateElement(
-										__(
-											'<span><icon /> Sorry, you can only upload a CSV file.</span><uploadBtn>Select another file</uploadBtn>'
-										),
-										{
-											span: createElement( 'span' ),
-											icon: createElement( Icon, { icon: info, size: 20 } ),
-											uploadBtn: formFileUploadElement,
-										}
-									) }
-								</label>
-							) }
+				<form onSubmit={ onFormSubmit }>
+					<TextControl
+						placeholder={ 'sibling@email.com' }
+						value={ emails[ 0 ] || '' }
+						help={ isValidEmails[ 0 ] ? <Icon icon={ check } /> : undefined }
+						onChange={ ( value ) => onEmailChange( value, 0 ) }
+					/>
+					<TextControl
+						placeholder={ 'parents@email.com' }
+						value={ emails[ 1 ] || '' }
+						help={ isValidEmails[ 1 ] ? <Icon icon={ check } /> : undefined }
+						onChange={ ( value ) => onEmailChange( value, 1 ) }
+					/>
+					<TextControl
+						placeholder={ 'friend@email.com' }
+						value={ emails[ 2 ] || '' }
+						help={ isValidEmails[ 2 ] ? <Icon icon={ check } /> : undefined }
+						onChange={ ( value ) => onEmailChange( value, 2 ) }
+					/>
 
-							{ isSelectedFileValid && selectedFile && (
-								<label className={ 'add-subscriber__form-label-links' }>
-									{ createInterpolateElement(
-										sprintf(
-											/* translators: the first string variable shows a selected file name, Replace and Remove are links" */
-											__(
-												'<strong>%s</strong> <uploadBtn>Replace</uploadBtn> | <removeBtn>Remove</removeBtn>'
-											),
-											selectedFile?.name
-										),
-										{
-											strong: createElement( 'strong' ),
-											uploadBtn: formFileUploadElement,
-											removeBtn: createElement( Button, {
-												isLink: true,
-												onClick: () => setSelectedFile( undefined ),
-											} ),
-										}
-									) }
-								</label>
+					{ ! isSelectedFileValid && (
+						<label className={ 'add-subscriber__form-label-error' }>
+							{ createInterpolateElement(
+								__(
+									'<span><icon /> Sorry, you can only upload a CSV file.</span><uploadBtn>Select another file</uploadBtn>'
+								),
+								{
+									span: createElement( 'span' ),
+									icon: createElement( Icon, { icon: info, size: 20 } ),
+									uploadBtn: formFileUploadElement,
+								}
 							) }
+						</label>
+					) }
 
-							{ showCsvUpload && isSelectedFileValid && ! selectedFile && (
-								<label>
-									{ createInterpolateElement(
-										__(
-											'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
-										),
-										{ uploadBtn: formFileUploadElement }
-									) }
-								</label>
+					{ isSelectedFileValid && selectedFile && (
+						<label className={ 'add-subscriber__form-label-links' }>
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: the first string variable shows a selected file name, Replace and Remove are links" */
+									__(
+										'<strong>%s</strong> <uploadBtn>Replace</uploadBtn> | <removeBtn>Remove</removeBtn>'
+									),
+									selectedFile?.name
+								),
+								{
+									strong: createElement( 'strong' ),
+									uploadBtn: formFileUploadElement,
+									removeBtn: createElement( Button, {
+										isLink: true,
+										onClick: () => setSelectedFile( undefined ),
+									} ),
+								}
 							) }
+						</label>
+					) }
 
-							<NextButton type={ 'submit' } className={ 'add-subscriber__form-submit-btn' }>
-								{ submitBtnName || 'Add subscribers' }
-							</NextButton>
-							{ showSkipBtn && (
-								<SkipButton
-									className={ 'add-subscriber__form-skip-btn' }
-									onClick={ () => onSkipBtnClick?.() }
-								>
-									Not yet
-								</SkipButton>
+					{ showCsvUpload && isSelectedFileValid && ! selectedFile && (
+						<label>
+							{ createInterpolateElement(
+								__(
+									'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
+								),
+								{ uploadBtn: formFileUploadElement }
 							) }
-							{ showCsvUpload && (
-								<p className={ 'add-subscriber__form--disclaimer' }>
-									By adding a mailing list CSV, you are confirming that you have the rights to share
-									newsletters with the people within your list.{ ' ' }
-									<Button isLink={ true }>Learn more</Button>
-								</p>
-							) }
-						</form>
-					</div>
-				</>
-			) }
+						</label>
+					) }
+
+					<NextButton
+						type={ 'submit' }
+						className={ 'add-subscriber__form-submit-btn' }
+						isBusy={ inProgress }
+						disabled={ inProgress }
+					>
+						{ submitBtnName || 'Add subscribers' }
+					</NextButton>
+					{ showSkipBtn && (
+						<SkipButton
+							className={ 'add-subscriber__form-skip-btn' }
+							onClick={ () => onSkipBtnClick?.() }
+						>
+							Not yet
+						</SkipButton>
+					) }
+					{ showCsvUpload && (
+						<p className={ 'add-subscriber__form--disclaimer' }>
+							By adding a mailing list CSV, you are confirming that you have the rights to share
+							newsletters with the people within your list.{ ' ' }
+							<Button isLink={ true }>Learn more</Button>
+						</p>
+					) }
+				</form>
+			</div>
 		</div>
 	);
 };

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -142,11 +142,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		<div className={ 'add-subscriber' }>
 			<div className={ 'add-subscriber__title-container' }>
 				{ showTitleEmoji && <h2 className={ 'add-subscriber__title-emoji' }>🤝</h2> }
-				<Title>Add subscribers to build your audience</Title>
+				<Title>{ __( 'Add subscribers to build your audience' ) }</Title>
 			</div>
 
 			<div className={ 'add-subscriber__form--container' }>
-				{ inProgress && <Notice isDismissible={ false }>You have email list importing...</Notice> }
+				{ inProgress && (
+					<Notice isDismissible={ false }>{ __( 'You have email list importing' ) }...</Notice>
+				) }
 
 				<form onSubmit={ onFormSubmit }>
 					<TextControl
@@ -218,8 +220,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 					{ showCsvUpload && isSelectedFileValid && selectedFile && (
 						<p className={ 'add-subscriber__form--disclaimer' }>
-							By clicking "continue", you represent that you've obtained the appropriate consent to
-							email each person on your list. <Button isLink={ true }>Learn more</Button>
+							{ createInterpolateElement(
+								__(
+									'By clicking "continue", you represent that you\'ve obtained the appropriate consent to ' +
+										'email each person on your list. <Button>Learn more</Button>'
+								),
+								{ Button: createElement( Button, { isLink: true } ) }
+							) }
 						</p>
 					) }
 
@@ -229,14 +236,14 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						isBusy={ inProgress }
 						disabled={ inProgress }
 					>
-						{ submitBtnName || 'Add subscribers' }
+						{ submitBtnName || __( 'Add subscribers' ) }
 					</NextButton>
 					{ showSkipBtn && (
 						<SkipButton
 							className={ 'add-subscriber__form-skip-btn' }
 							onClick={ () => onSkipBtnClick?.() }
 						>
-							Not yet
+							{ __( 'Not yet' ) }
 						</SkipButton>
 					) }
 				</form>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -152,19 +152,19 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 				<form onSubmit={ onFormSubmit }>
 					<TextControl
-						placeholder={ 'sibling@email.com' }
+						placeholder={ __( 'sibling@email.com' ) }
 						value={ emails[ 0 ] || '' }
 						help={ isValidEmails[ 0 ] ? <Icon icon={ check } /> : undefined }
 						onChange={ ( value ) => onEmailChange( value, 0 ) }
 					/>
 					<TextControl
-						placeholder={ 'parents@email.com' }
+						placeholder={ __( 'parents@email.com' ) }
 						value={ emails[ 1 ] || '' }
 						help={ isValidEmails[ 1 ] ? <Icon icon={ check } /> : undefined }
 						onChange={ ( value ) => onEmailChange( value, 1 ) }
 					/>
 					<TextControl
-						placeholder={ 'friend@email.com' }
+						placeholder={ __( 'friend@email.com' ) }
 						value={ emails[ 2 ] || '' }
 						help={ isValidEmails[ 2 ] ? <Icon icon={ check } /> : undefined }
 						onChange={ ( value ) => onEmailChange( value, 2 ) }

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -32,7 +32,7 @@
 	}
 }
 
-.add-subscriber__title-container {
+.add-subscriber .add-subscriber__title-container {
 	text-align: center;
 	margin-bottom: 1rem;
 	max-width: 376px;
@@ -54,7 +54,7 @@
 	}
 }
 
-.add-subscriber__form--container {
+.add-subscriber .add-subscriber__form--container {
 	max-width: 368px;
 
 	label {
@@ -95,11 +95,15 @@
 		}
 	}
 
+	.components-base-control__field {
+		margin: 1rem auto;
+	}
+
 	.components-text-control__input {
 		border-color: var( --studio-gray-10 );
 		box-sizing: border-box;
 		font-size: 0.875rem;
-		padding: 1rem;
+		padding: 0.875rem 1rem;
 
 		&::placeholder {
 			color: var( --studio-gray-20 );

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -152,6 +152,7 @@
 		font-size: 0.875rem;
 		line-height: 1.25rem;
 		color: var( --studio-gray-50 );
+		margin-bottom: 1.5rem;
 
 		a, button {
 			color: var( --studio-gray-100 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,7 +1297,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/subscriber@workspace:packages/subscriber":
+"@automattic/subscriber@workspace:^, @automattic/subscriber@workspace:packages/subscriber":
   version: 0.0.0-use.local
   resolution: "@automattic/subscriber@workspace:packages/subscriber"
   dependencies:
@@ -12535,6 +12535,7 @@ __metadata:
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/social-previews": "workspace:^"
     "@automattic/state-utils": "workspace:^"
+    "@automattic/subscriber": "workspace:^"
     "@automattic/tree-select": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@automattic/viewport-react": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

* Integrated `Add Subscribers form` component into `Newsletter onboarding flow`
* Add Subscriber form updated:
  * Adjusted styles to support stepper environment
  * Support translation
  * Added feature flag for supporting CSV Upload
  * Switched endpoint for manual email adding from `/subscribers` to `/invites/new`
  * Replaced `Progress bar` screen with a `Notification`

#### Testing Instructions
* Pass through the full newsletter flow `/setup/?flow=newsletter`
  * or
* Directly go to `/setup/subscribers?flow=newsletter&complete-setup=true&siteSlug={SLUG}`
* Manually add emails
* Upload CSV file (this feature is turned on for `wpcalypso` and `development` envs so far)
* Press continue

#### Screenshot
<img width="575" alt="Screenshot 2022-08-26 at 10 50 18" src="https://user-images.githubusercontent.com/1241413/186865995-de68fbb4-82d5-4758-a2ed-5f11ce03b78a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
