### PR TITLE
Tailored flows: LIB - Limit site logo size to 512px so it fits in localStorage

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -43,6 +43,7 @@ export class ImageEditorCanvas extends Component {
 		onLoadError: PropTypes.func,
 		isImageLoaded: PropTypes.bool,
 		showCrop: PropTypes.bool,
+		widthLimit: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -62,6 +63,7 @@ export class ImageEditorCanvas extends Component {
 		onLoadError: noop,
 		isImageLoaded: false,
 		showCrop: true,
+		widthLimit: Infinity,
 	};
 
 	// throttle the frame rate of window.resize() to circa 30fps
@@ -151,6 +153,7 @@ export class ImageEditorCanvas extends Component {
 	};
 
 	toBlob( callback ) {
+		const { widthLimit } = this.props;
 		const { leftRatio, topRatio, widthRatio, heightRatio } = this.props.crop;
 
 		const { mimeType, transform } = this.props;
@@ -175,7 +178,17 @@ export class ImageEditorCanvas extends Component {
 		const newContext = newCanvas.getContext( '2d' );
 		newContext.putImageData( imageData, 0, 0 );
 
-		canvasToBlob( newCanvas, callback, mimeType, 1 );
+		if ( Number.isFinite( widthLimit ) && widthLimit < croppedWidth ) {
+			const resizedCanvas = document.createElement( 'canvas' );
+			const scale = widthLimit / croppedWidth;
+			resizedCanvas.width = scale * croppedHeight;
+			resizedCanvas.height = scale * croppedWidth;
+			const resizedContext = resizedCanvas.getContext( '2d' );
+			resizedContext.drawImage( newCanvas, 0, 0, scale * croppedWidth, scale * croppedHeight );
+			canvasToBlob( resizedCanvas, callback, mimeType, 1 );
+		} else {
+			canvasToBlob( newCanvas, callback, mimeType, 1 );
+		}
 	}
 
 	drawImage() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -137,6 +137,7 @@ class ImageEditor extends Component {
 				...imageProperties,
 				width: transientImage.width,
 				height: transientImage.height,
+				transientImageUrl,
 			} );
 		};
 
@@ -233,7 +234,7 @@ class ImageEditor extends Component {
 	};
 
 	render() {
-		const { className, siteId, allowedAspectRatios } = this.props;
+		const { className, siteId, allowedAspectRatios, widthLimit } = this.props;
 
 		const { noticeText } = this.state;
 
@@ -246,7 +247,11 @@ class ImageEditor extends Component {
 
 				<figure>
 					<div className="image-editor__content">
-						<ImageEditorCanvas ref={ this.editCanvasRef } onLoadError={ this.onLoadCanvasError } />
+						<ImageEditorCanvas
+							ref={ this.editCanvasRef }
+							widthLimit={ widthLimit }
+							onLoadError={ this.onLoadCanvasError }
+						/>
 						<ImageEditorToolbar
 							onShowNotice={ this.showNotice }
 							allowedAspectRatios={ allowedAspectRatios }

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -137,7 +137,6 @@ class ImageEditor extends Component {
 				...imageProperties,
 				width: transientImage.width,
 				height: transientImage.height,
-				transientImageUrl,
 			} );
 		};
 

--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -54,6 +54,7 @@ export function SiteIconWithPicker( {
 						setEditingFileName( undefined );
 						setImageEditorOpen( false );
 					} }
+					widthLimit={ 512 }
 				/>
 			) }
 			<FormFieldset


### PR DESCRIPTION
#### Proposed Changes

* localStorage is slow and limited, and since we're storing the site icon in it for a while, picking a big image is breaking the site setup step.
* This limits the image width to 512px, and since the aspect ratio is set to 1:1, the height as well. 

#### Testing Instructions

1. Go to /setup?flow=link-in-bio.
2. Pick a large image (maybe a screenshot).
3. Crop a big square out of it.
4. Inspect the icon preview and visit the URL of the image set to it. 
5. It should have 512x512 size.

Fixes #66980