### PR TITLE
Update/plans for newsletter lib

### DIFF
--- a/client/landing/stepper/hooks/use-setup-onboarding-site.ts
+++ b/client/landing/stepper/hooks/use-setup-onboarding-site.ts
@@ -1,4 +1,5 @@
 import { SiteDetails, useSiteLogoMutation } from '@automattic/data-stores';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from 'react';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -65,7 +66,7 @@ export function useSetupOnboardingSite( options: SetupOnboardingSiteOptions ) {
 	};
 
 	const setIntent = ( site: SiteDetails, flow: string | null ) => {
-		if ( site && flow && [ 'newsletter', 'link-in-bio' ].includes( flow ) ) {
+		if ( site && flow && isNewsletterOrLinkInBioFlow( flow ) ) {
 			return setIntentOnSite( site.ID.toString(), flow );
 		}
 		return Promise.resolve();

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -4,8 +4,10 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import { connect } from 'react-redux';
 import PlanPill from 'calypso/components/plans/plan-pill';
 import PlanPrice from 'calypso/my-sites/plan-price';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 
 const PLANS_LIST = getPlans();
 
@@ -14,8 +16,21 @@ export class PlanFeaturesComparisonHeader extends Component {
 		return this.renderPlansHeaderNoTabs();
 	}
 
+	getPlanPillText() {
+		const { flow, translate } = this.props;
+
+		switch ( flow ) {
+			case 'newsletter':
+				return translate( 'Best for Newsletters' );
+			case 'link-in-bio':
+				return translate( 'Best for Link in Bio' );
+			default:
+				return translate( 'Popular' );
+		}
+	}
+
 	renderPlansHeaderNoTabs() {
-		const { planType, popular, selectedPlan, title, translate } = this.props;
+		const { planType, popular, selectedPlan, title } = this.props;
 
 		const headerClasses = classNames(
 			'plan-features-comparison__header',
@@ -26,7 +41,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			<span>
 				<div>
 					{ popular && ! selectedPlan && (
-						<PlanPill isInSignup={ true }>{ translate( 'Popular' ) }</PlanPill>
+						<PlanPill isInSignup={ true }>{ this.getPlanPillText() }</PlanPill>
 					) }
 				</div>
 				<header className={ headerClasses }>
@@ -151,10 +166,15 @@ PlanFeaturesComparisonHeader.propTypes = {
 
 	// For Monthly Pricing test
 	annualPricePerMonth: PropTypes.number,
+	flow: PropTypes.string,
 };
 
 PlanFeaturesComparisonHeader.defaultProps = {
 	popular: false,
 };
 
-export default localize( PlanFeaturesComparisonHeader );
+export default connect( ( state ) => {
+	return {
+		flow: getCurrentFlowName( state ),
+	};
+} )( localize( PlanFeaturesComparisonHeader ) );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -102,6 +102,7 @@ export class PlansFeaturesMain extends Component {
 			isJetpack,
 			isLandingPage,
 			isLaunchPage,
+			flowName,
 			onUpgradeClick,
 			selectedFeature,
 			selectedPlan,
@@ -144,6 +145,7 @@ export class PlansFeaturesMain extends Component {
 					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ getPopularPlanSpec( {
+						flowName,
 						customerType,
 						isJetpack,
 						availablePlans: visiblePlans,
@@ -277,6 +279,7 @@ export class PlansFeaturesMain extends Component {
 			hidePremiumPlan,
 			sitePlanSlug,
 			showTreatmentPlansReorderTest,
+			flowName,
 		} = this.props;
 
 		const hideBloggerPlan = ! isBloggerPlan( selectedPlan ) && ! isBloggerPlan( sitePlanSlug );
@@ -309,6 +312,12 @@ export class PlansFeaturesMain extends Component {
 
 		if ( hidePremiumPlan ) {
 			plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
+		}
+
+		if ( [ 'newsletter', 'link-in-bio' ].includes( flowName ) ) {
+			plans = plans.filter(
+				( planSlug ) => ! isBusinessPlan( planSlug ) && ! isEcommercePlan( planSlug )
+			);
 		}
 
 		if ( ! isEnabled( 'plans/personal-plan' ) ) {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -26,6 +26,7 @@ import {
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { hasTranslation } from '@wordpress/i18n';
 import warn from '@wordpress/warning';
 import classNames from 'classnames';
@@ -314,7 +315,7 @@ export class PlansFeaturesMain extends Component {
 			plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
 		}
 
-		if ( [ 'newsletter', 'link-in-bio' ].includes( flowName ) ) {
+		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			plans = plans.filter(
 				( planSlug ) => ! isBusinessPlan( planSlug ) && ! isEcommercePlan( planSlug )
 			);

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,6 +5,7 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
 import {
 	clone,
@@ -615,7 +616,7 @@ class Signup extends Component {
 			return <P2SignupProcessingScreen signupSiteName={ this.state.signupSiteName } />;
 		}
 
-		if ( [ 'newsletter', 'link-in-bio' ].includes( this.props.flowName ) ) {
+		if ( isNewsletterOrLinkInBioFlow( this.props.flowName ) ) {
 			return <TailoredFlowProcessingScreen flowName={ this.props.flowName } />;
 		}
 
@@ -749,7 +750,7 @@ class Signup extends Component {
 		const olarkSystemsGroupId = '2dfd76a39ce77758f128b93942ae44b5';
 		const progressBar = () => {
 			const flowName = this.props.initialContext?.query?.flowName || this.props.flowName;
-			if ( [ 'newsletter', 'link-in-bio' ].includes( flowName ) ) {
+			if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 				return { flowName, stepName: this.props.stepName };
 			}
 			return;

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -595,10 +595,12 @@ export function getPlanTermLabel(
 }
 
 export const getPopularPlanSpec = ( {
+	flowName,
 	customerType,
 	isJetpack,
 	availablePlans,
 }: {
+	flowName: string;
 	customerType: string;
 	isJetpack: boolean;
 	availablePlans: string[];
@@ -619,6 +621,13 @@ export const getPopularPlanSpec = ( {
 	}
 
 	const group = GROUP_WPCOM;
+
+	if ( flowName === 'link-in-bio' ) {
+		return {
+			type: TYPE_PERSONAL,
+			group,
+		};
+	}
 
 	if ( customerType === 'personal' ) {
 		if ( availablePlans.findIndex( isPremiumPlan ) !== -1 ) {

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -19,6 +19,7 @@ export { default as StepContainer } from './step-container';
 export { default as StepNavigationLink } from './step-navigation-link';
 export { default as MShotsImage } from './mshots-image';
 export { default as Notice } from './notice';
+export * from './utils';
 export type { SelectItem } from './select-items';
 export type { SelectItemAlt } from './select-items-alt';
 export type { MShotsOptions } from './mshots-image';

--- a/packages/onboarding/src/utils.ts
+++ b/packages/onboarding/src/utils.ts
@@ -1,0 +1,3 @@
+export const isNewsletterOrLinkInBioFlow = ( flowName: string ) => {
+	return [ 'newsletter', 'link-in-bio' ].includes( flowName );
+};


### PR DESCRIPTION
| Newsletter Plans Page  | Link in Bio Plans Page |
| ------------- | ------------- |
|  <img width="1124" alt="Screenshot 2022-08-25 at 18 45 09" src="https://user-images.githubusercontent.com/7000684/186723177-79b9d7c9-5541-459f-9f51-34811355f127.png"> |  <img width="1126" alt="Screenshot 2022-08-25 at 18 45 17" src="https://user-images.githubusercontent.com/7000684/186723124-bde94d93-95d5-41ec-8518-05bedc25d2a5.png"> |

#### Proposed Changes

* Filter available plans based on flow name. For newsletter and lib flow we only show `Personal` and `Premium`
* Adjust popular plan pill text based on flow name

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Using the newsletter and link in bio flow arrive at the plans page
- Check if the only plans available are `Personal` and `Premium`
- Check if the popular plan pill text matches the designs
