### PR TITLE
Add Search Results breadcrumb back to plugin details page

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -221,8 +221,21 @@ function PluginDetails( props ) {
 			},
 		];
 
+		const pluginsSearchId = 'plugins-search';
+		if ( breadcrumbs.length > 1 && breadcrumbs[ 1 ].id === pluginsSearchId ) {
+			const searchHref = breadcrumbs[ 1 ].href;
+			const searchQuery = searchHref.substring( searchHref.lastIndexOf( '?' ) );
+			items.push( {
+				helpBubble: null,
+				label: 'Search Results',
+				href: `/plugins/${ selectedSite?.slug || '' }${ searchQuery || '' }`,
+				id: pluginsSearchId,
+			} );
+		}
+
 		if ( fullPlugin.name && props.pluginSlug ) {
 			items.push( {
+				helpBubble: null,
 				label: fullPlugin.name,
 				href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
 				id: `plugin-${ props.pluginSlug }`,


### PR DESCRIPTION
#### Proposed Changes

In [Fix breadcrumbs when switching selected site on plugin details #66794 ](https://github.com/Automattic/wp-calypso/pull/66794) we inadvertently removed the "Search Results" breadcrumb from the plugin details page.

This PR adds the "Search Results" breadcrumb back while maintaining the "switch sites fix" in #66794.

![search-crumb](https://user-images.githubusercontent.com/140841/186765874-e69a55e3-ca8d-4b86-b5f7-87b655fd5c73.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Go to the /plugins/
* Search for a term
* Select a plugin result
* "Search Results" should be in the breadcrumbs and link back to the search results.
* Try switching sites using "Switch Site" in the upper left. The breadcrumbs should update to reflect the site you're on.
* Try going to a plugin details page directly, without having searched for it. The breadcrumbs should NOT include "Search Results"
* Test around this issue, both with and without a site selected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? (I'd like have a go at this during 20% time)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66666
