### PR TITLE
Launchpad: Set launchpad_screen setting during onboarding

### DIFF
--- a/client/landing/stepper/hooks/use-setup-onboarding-site.ts
+++ b/client/landing/stepper/hooks/use-setup-onboarding-site.ts
@@ -77,6 +77,15 @@ export function useSetupOnboardingSite( options: SetupOnboardingSiteOptions ) {
 		return Promise.resolve();
 	};
 
+	const setLaunchpadScreen = ( site: SiteDetails, flow: string ) => {
+		if ( isNewsletterOrLinkInBioFlow( flow ) ) {
+			return saveSiteSettings( site.ID, {
+				launchpad_screen: 'full',
+			} );
+		}
+		return Promise.resolve();
+	};
+
 	const setPattern = async (
 		site: SiteDetails,
 		flow: string,
@@ -112,6 +121,7 @@ export function useSetupOnboardingSite( options: SetupOnboardingSiteOptions ) {
 					setPattern( site, flow, logoUploadResult )
 				),
 				setIntent( site, flow ),
+				setLaunchpadScreen( site, flow ),
 			] ).then( () => {
 				recordTracksEvent( 'calypso_signup_site_options_submit', {
 					has_site_title: !! state.siteTitle,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -114,12 +114,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		response,
 	} );
 
-	const receiveLaunchpadScreen = ( siteId: number, launchpadScreen: string | undefined ) => ( {
-		type: 'RECEIVE_LAUNCHPAD_SCREEN' as const,
-		siteId,
-		launchpadScreen,
-	} );
-
 	const reset = () => ( {
 		type: 'RESET_SITE_STORE' as const,
 	} );
@@ -244,9 +238,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			}
 			if ( 'site_vertical_id' in settings ) {
 				yield receiveSiteVerticalId( siteId, settings.site_vertical_id );
-			}
-			if ( 'launchpad_screen' in settings ) {
-				yield receiveLaunchpadScreen( siteId, settings.launchpad_screen );
 			}
 			yield updateSiteSettings( siteId, settings );
 		} catch ( e ) {}
@@ -523,7 +514,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSiteFailed,
 		receiveSiteTagline,
 		receiveSiteVerticalId,
-		receiveLaunchpadScreen,
 		updateSiteSettings,
 		saveSiteTagline,
 		reset,
@@ -570,7 +560,6 @@ export type Action =
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSiteTagline' ]
 			| ActionCreators[ 'receiveSiteVerticalId' ]
-			| ActionCreators[ 'receiveLaunchpadScreen' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'updateSiteSettings' ]

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -114,6 +114,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		response,
 	} );
 
+	const receiveLaunchpadScreen = ( siteId: number, launchpadScreen: string | undefined ) => ( {
+		type: 'RECEIVE_LAUNCHPAD_SCREEN' as const,
+		siteId,
+		launchpadScreen,
+	} );
+
 	const reset = () => ( {
 		type: 'RESET_SITE_STORE' as const,
 	} );
@@ -212,6 +218,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		settings: {
 			blogname?: string;
 			blogdescription?: string;
+			launchpad_screen?: string;
 			site_vertical_id?: string;
 			woocommerce_store_address?: string;
 			woocommerce_store_address_2?: string;
@@ -237,6 +244,9 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			}
 			if ( 'site_vertical_id' in settings ) {
 				yield receiveSiteVerticalId( siteId, settings.site_vertical_id );
+			}
+			if ( 'launchpad_screen' in settings ) {
+				yield receiveLaunchpadScreen( siteId, settings.launchpad_screen );
 			}
 			yield updateSiteSettings( siteId, settings );
 		} catch ( e ) {}
@@ -513,6 +523,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSiteFailed,
 		receiveSiteTagline,
 		receiveSiteVerticalId,
+		receiveLaunchpadScreen,
 		updateSiteSettings,
 		saveSiteTagline,
 		reset,
@@ -559,6 +570,7 @@ export type Action =
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSiteTagline' ]
 			| ActionCreators[ 'receiveSiteVerticalId' ]
+			| ActionCreators[ 'receiveLaunchpadScreen' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'updateSiteSettings' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -132,6 +132,17 @@ export const sites: Reducer< { [ key: number | string ]: SiteDetails | undefined
 				},
 			},
 		};
+	} else if ( action.type === 'RECEIVE_LAUNCHPAD_SCREEN' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				...( state[ action.siteId ] as SiteDetails ),
+				options: {
+					...state[ action.siteId ]?.options,
+					launchpad_screen: action.launchpadScreen,
+				},
+			},
+		};
 	}
 	return state;
 };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -132,17 +132,6 @@ export const sites: Reducer< { [ key: number | string ]: SiteDetails | undefined
 				},
 			},
 		};
-	} else if ( action.type === 'RECEIVE_LAUNCHPAD_SCREEN' ) {
-		return {
-			...state,
-			[ action.siteId ]: {
-				...( state[ action.siteId ] as SiteDetails ),
-				options: {
-					...state[ action.siteId ]?.options,
-					launchpad_screen: action.launchpadScreen,
-				},
-			},
-		};
 	}
 	return state;
 };


### PR DESCRIPTION
### Updated PR Description

Many changes have been made to this PR since it was initiated, including a recent rebase that also alters it. Given all the changes, I'm posting an updated PR description with testing instructions.

### Proposed Changes

This PR sets a new launchpad_screen setting during the onboarding process if/when the user is inside of a relevant onboarding flow. The setting can have three values: 'full', 'off', or 'minimized' and is set to full initially for any relevant flow. The setting will be used for other actions later.

### Testing Instructions

1. Checkout this branch of Calypso and run `yarn` and `yarn start` if needed.
2. Go to /setup?flow=link-in-bio
3. Open DevTools > Network. Filter requests by 'settings'.
4. Go through the flow. When you get to plans page, choose a plan. I just pick to use a free site.
5. The onboarding process will go through some setup. 
6. Once you arrive at the Launchpad screen, you'll see two 'settings' network requests (note there are some of these earlier in the process, but they are not relevant). In the second one, check the response, and you should see "updated":{"launchpad_screen":"full"} . That means that the endpoint properly recognize the request and update the launchpad_screen to full.
7. For extra credit, go to the developer [WP.com api developer console](https://developer.wordpress.com/docs/api/console/)  and run the following request: `/sites/YOURNEWDOMAIN/settings`. In the response, look for the launchpad_screen setting, and confirm that it is there, and that it is set to 'full'.

### Related

Related to #https://github.com/Automattic/wp-calypso/issues/66706
