### PR TITLE
Hosting Config: Link to the new SSH doc in the `<SftpCard />`

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -187,10 +187,19 @@ export const SftpCard = ( {
 					checked={ isSshAccessEnabled }
 					onChange={ () => toggleSshAccess() }
 					label={ translate(
-						'Enable SSH access for this site. {{em}}This feature is currently in beta.{{/em}}',
+						'Enable SSH access for this site. {{em}}This feature is currently in beta.{{/em}} For more information see {{supportLink}}SSH on WordPress.com{{/supportLink}}.',
 						{
 							components: {
 								em: <em />,
+								supportLink: (
+									<ExternalLink
+										icon
+										target="_blank"
+										href={ localizeUrl(
+											'https://wordpress.com/support/connect-to-ssh-on-wordpress-com/'
+										) }
+									/>
+								),
 							},
 						}
 					) }
@@ -281,14 +290,16 @@ export const SftpCard = ( {
 						<PanelBody title={ translate( 'What is SSH?' ) } initialOpen={ false }>
 							{ translate(
 								'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. ' +
-									'{{em}}This feature is currently in beta.{{/em}} For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}}.',
+									'For more information see {{supportLink}}SSH on WordPress.com{{/supportLink}}. {{em}}This feature is currently in beta.{{/em}}',
 								{
 									components: {
 										supportLink: (
 											<ExternalLink
 												icon
 												target="_blank"
-												href={ localizeUrl( 'https://wordpress.com/support/sftp/' ) }
+												href={ localizeUrl(
+													'https://wordpress.com/support/connect-to-ssh-on-wordpress-com/'
+												) }
 											/>
 										),
 										em: <em />,


### PR DESCRIPTION
Fixes #66604

## Proposed Changes

Links to the forthcoming SSH documentation inside of the `<SftpCard />`

### SFTP disabled

<img width="751" alt="image" src="https://user-images.githubusercontent.com/36432/186780393-eb7d0def-5243-4d28-aebf-a3b68bb1e6c0.png">

### SFTP enabled

<img width="705" alt="image" src="https://user-images.githubusercontent.com/36432/186780462-e7cbf591-5193-4cff-8b43-bf3c917058ef.png">

## Testing Instructions

1. Create a new Business site.
2. Transfer the site to Atomic.
3. Navigate to `/hosting-config`.
4. View the `<SftpCard />` in its disabled state and make sure the SSH link works. The documentation isn't yet published, so you'll need to be a super admin on WPCOM in order to display the document.
5. Click "Create credentials" to enable SFTP.
6. View the `<SftpCard />` in its enabled state and make sure the SSH link works.
