### PR TITLE
Shopping Cart: Add catch to every addProductsToCart that has no other handling

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -413,7 +413,9 @@ export default function CheckoutMain( {
 					error: String( error ),
 				} );
 			}
-			addProductsToCart( [ cartItem ] );
+			addProductsToCart( [ cartItem ] ).catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 		},
 		[ addProductsToCart ]
 	);

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -94,6 +94,9 @@ class DomainSearch extends Component {
 			.addProductsToCart( [ domainTransfer( { domain } ) ] )
 			.then( () => {
 				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
+			} )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
 			} );
 	};
 
@@ -142,15 +145,23 @@ class DomainSearch extends Component {
 		if ( this.props.domainAndPlanUpsellFlow ) {
 			// If we are in the domain + annual plan upsell flow, we need to redirect
 			// to the plans page next and let it know that we are still in that flow.
-			this.props.shoppingCartManager.addProductsToCart( [ registration ] ).then( () => {
-				page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
-			} );
+			this.props.shoppingCartManager
+				.addProductsToCart( [ registration ] )
+				.then( () => {
+					page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
+				} )
+				.catch( () => {
+					// Nothing needs to be done here. CartMessages will display the error to the user.
+				} );
 			return;
 		}
 
 		this.props.shoppingCartManager
 			.addProductsToCart( [ registration ] )
-			.then( () => page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) ) );
+			.then( () => page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) ) )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 	}
 
 	removeDomain( suggestion ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -89,15 +89,14 @@ class DomainSearch extends Component {
 		this.isMounted && page( domainMappingUrl );
 	};
 
-	handleAddTransfer = ( domain ) => {
-		this.props.shoppingCartManager
-			.addProductsToCart( [ domainTransfer( { domain } ) ] )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
-			} );
+	handleAddTransfer = async ( domain ) => {
+		try {
+			await this.props.shoppingCartManager.addProductsToCart( [ domainTransfer( { domain } ) ] );
+		} catch {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+			return;
+		}
+		this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
 	};
 
 	componentDidMount() {
@@ -122,7 +121,7 @@ class DomainSearch extends Component {
 		}
 	}
 
-	addDomain( suggestion ) {
+	async addDomain( suggestion ) {
 		const {
 			domain_name: domain,
 			product_slug: productSlug,
@@ -143,25 +142,25 @@ class DomainSearch extends Component {
 		}
 
 		if ( this.props.domainAndPlanUpsellFlow ) {
-			// If we are in the domain + annual plan upsell flow, we need to redirect
-			// to the plans page next and let it know that we are still in that flow.
-			this.props.shoppingCartManager
-				.addProductsToCart( [ registration ] )
-				.catch( () => {
-					// Nothing needs to be done here. CartMessages will display the error to the user.
-				} )
-				.then( () => {
-					page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
-				} );
+			try {
+				// If we are in the domain + annual plan upsell flow, we need to redirect
+				// to the plans page next and let it know that we are still in that flow.
+				await this.props.shoppingCartManager.addProductsToCart( [ registration ] );
+			} catch {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+				return;
+			}
+			page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
 			return;
 		}
 
-		this.props.shoppingCartManager
-			.addProductsToCart( [ registration ] )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} )
-			.then( () => page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) ) );
+		try {
+			await this.props.shoppingCartManager.addProductsToCart( [ registration ] );
+		} catch {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+			return;
+		}
+		page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) );
 	}
 
 	removeDomain( suggestion ) {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -92,11 +92,11 @@ class DomainSearch extends Component {
 	handleAddTransfer = ( domain ) => {
 		this.props.shoppingCartManager
 			.addProductsToCart( [ domainTransfer( { domain } ) ] )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
-			} )
 			.catch( () => {
 				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} )
+			.then( () => {
+				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
 			} );
 	};
 
@@ -147,21 +147,21 @@ class DomainSearch extends Component {
 			// to the plans page next and let it know that we are still in that flow.
 			this.props.shoppingCartManager
 				.addProductsToCart( [ registration ] )
-				.then( () => {
-					page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
-				} )
 				.catch( () => {
 					// Nothing needs to be done here. CartMessages will display the error to the user.
+				} )
+				.then( () => {
+					page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
 				} );
 			return;
 		}
 
 		this.props.shoppingCartManager
 			.addProductsToCart( [ registration ] )
-			.then( () => page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) ) )
 			.catch( () => {
 				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} );
+			} )
+			.then( () => page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) ) );
 	}
 
 	removeDomain( suggestion ) {

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -123,9 +123,14 @@ class SiteRedirectStep extends Component {
 	};
 
 	addSiteRedirectToCart = ( domain ) => {
-		this.props.shoppingCartManager.addProductsToCart( [ siteRedirect( { domain } ) ] ).then( () => {
-			this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
-		} );
+		this.props.shoppingCartManager
+			.addProductsToCart( [ siteRedirect( { domain } ) ] )
+			.then( () => {
+				this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
+			} )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 	};
 
 	getValidationErrorMessage = ( domain, error ) => {

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -125,11 +125,11 @@ class SiteRedirectStep extends Component {
 	addSiteRedirectToCart = ( domain ) => {
 		this.props.shoppingCartManager
 			.addProductsToCart( [ siteRedirect( { domain } ) ] )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
-			} )
 			.catch( () => {
 				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} )
+			.then( () => {
+				this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
 			} );
 	};
 

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -122,15 +122,14 @@ class SiteRedirectStep extends Component {
 		} );
 	};
 
-	addSiteRedirectToCart = ( domain ) => {
-		this.props.shoppingCartManager
-			.addProductsToCart( [ siteRedirect( { domain } ) ] )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
-			} );
+	addSiteRedirectToCart = async ( domain ) => {
+		try {
+			await this.props.shoppingCartManager.addProductsToCart( [ siteRedirect( { domain } ) ] );
+		} catch {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+			return;
+		}
+		this.isMounted && page( '/checkout/' + this.props.selectedSite.slug );
 	};
 
 	getValidationErrorMessage = ( domain, error ) => {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -65,22 +65,21 @@ export class MapDomain extends Component {
 		page( '/domains/add/' + selectedSiteSlug );
 	};
 
-	addDomainToCart = ( suggestion ) => {
+	addDomainToCart = async ( suggestion ) => {
 		const { selectedSiteSlug } = this.props;
 
-		this.props.shoppingCartManager
-			.addProductsToCart( [
+		try {
+			await this.props.shoppingCartManager.addProductsToCart( [
 				domainRegistration( {
 					productSlug: suggestion.product_slug,
 					domain: suggestion.domain_name,
 				} ),
-			] )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + selectedSiteSlug );
-			} );
+			] );
+		} catch {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+			return;
+		}
+		this.isMounted && page( '/checkout/' + selectedSiteSlug );
 	};
 
 	handleRegisterDomain = ( suggestion ) => {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -77,6 +77,9 @@ export class MapDomain extends Component {
 			] )
 			.then( () => {
 				this.isMounted && page( '/checkout/' + selectedSiteSlug );
+			} )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
 			} );
 	};
 

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -75,11 +75,11 @@ export class MapDomain extends Component {
 					domain: suggestion.domain_name,
 				} ),
 			] )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + selectedSiteSlug );
-			} )
 			.catch( () => {
 				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} )
+			.then( () => {
+				this.isMounted && page( '/checkout/' + selectedSiteSlug );
 			} );
 	};
 

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -57,22 +57,21 @@ export class TransferDomain extends Component {
 		page( '/domains/add/' + selectedSiteSlug );
 	};
 
-	addDomainToCart = ( suggestion ) => {
+	addDomainToCart = async ( suggestion ) => {
 		const { selectedSiteSlug, shoppingCartManager } = this.props;
 
-		shoppingCartManager
-			.addProductsToCart( [
+		try {
+			await shoppingCartManager.addProductsToCart( [
 				domainRegistration( {
 					productSlug: suggestion.product_slug,
 					domain: suggestion.domain_name,
 				} ),
-			] )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} )
-			.then( () => {
-				page( '/checkout/' + selectedSiteSlug );
-			} );
+			] );
+		} catch {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+			return;
+		}
+		page( '/checkout/' + selectedSiteSlug );
 	};
 
 	handleRegisterDomain = ( suggestion ) => {
@@ -88,7 +87,7 @@ export class TransferDomain extends Component {
 		this.addDomainToCart( suggestion );
 	};
 
-	handleTransferDomain = ( domain, authCode, supportsPrivacy ) => {
+	handleTransferDomain = async ( domain, authCode, supportsPrivacy ) => {
 		const { selectedSiteSlug, shoppingCartManager } = this.props;
 
 		this.setState( { errorMessage: null } );
@@ -105,14 +104,13 @@ export class TransferDomain extends Component {
 			transfer = updatePrivacyForDomain( transfer, true );
 		}
 
-		shoppingCartManager
-			.addProductsToCart( [ transfer ] )
-			.then( () => {
-				page( '/checkout/' + selectedSiteSlug );
-			} )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} );
+		try {
+			await shoppingCartManager.addProductsToCart( [ transfer ] );
+		} catch {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+			return;
+		}
+		page( '/checkout/' + selectedSiteSlug );
 	};
 
 	componentDidMount() {

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -69,6 +69,9 @@ export class TransferDomain extends Component {
 			] )
 			.then( () => {
 				page( '/checkout/' + selectedSiteSlug );
+			} )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
 			} );
 	};
 
@@ -102,9 +105,14 @@ export class TransferDomain extends Component {
 			transfer = updatePrivacyForDomain( transfer, true );
 		}
 
-		shoppingCartManager.addProductsToCart( [ transfer ] ).then( () => {
-			page( '/checkout/' + selectedSiteSlug );
-		} );
+		shoppingCartManager
+			.addProductsToCart( [ transfer ] )
+			.then( () => {
+				page( '/checkout/' + selectedSiteSlug );
+			} )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 	};
 
 	componentDidMount() {

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -67,11 +67,11 @@ export class TransferDomain extends Component {
 					domain: suggestion.domain_name,
 				} ),
 			] )
-			.then( () => {
-				page( '/checkout/' + selectedSiteSlug );
-			} )
 			.catch( () => {
 				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} )
+			.then( () => {
+				page( '/checkout/' + selectedSiteSlug );
 			} );
 	};
 

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -309,7 +309,10 @@ const MailboxesForm = ( {
 			.then( () => {
 				page( '/checkout/' + selectedSite?.slug ?? '' );
 			} )
-			.finally( () => setIsAddingToCart( false ) );
+			.finally( () => setIsAddingToCart( false ) )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 	};
 
 	return (

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/get-on-submit-new-mailboxes-handler.ts
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/get-on-submit-new-mailboxes-handler.ts
@@ -98,7 +98,10 @@ const getOnSubmitNewMailboxesHandler =
 			.then( () => {
 				page( '/checkout/' + siteSlug );
 			} )
-			.finally( () => setAddingToCart( false ) );
+			.finally( () => setAddingToCart( false ) )
+			.catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 	};
 
 export default getOnSubmitNewMailboxesHandler;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -579,7 +579,7 @@ export class PlanFeatures extends Component {
 		} );
 	}
 
-	handleUpgradeClick = ( singlePlanProperties ) => {
+	handleUpgradeClick = async ( singlePlanProperties ) => {
 		const {
 			isInSignup,
 			onUpgradeClick: ownPropsOnUpgradeClick,
@@ -614,60 +614,60 @@ export class PlanFeatures extends Component {
 		}
 
 		if ( domainAndPlanPackage ) {
-			// In this flow we redirect to checkout with both the plan and domain
-			// product in the cart.
-			shoppingCartManager
-				.addProductsToCart( [
+			try {
+				// In this flow we redirect to checkout with both the plan and domain
+				// product in the cart.
+				await shoppingCartManager.addProductsToCart( [
 					{
 						product_slug: productSlug,
 						extra: {
 							afterPurchaseUrl: redirectTo ?? undefined,
 						},
 					},
-				] )
-				.then( () => {
-					if ( withDiscount && this.isMounted ) {
-						return shoppingCartManager.applyCoupon( withDiscount ).catch( () => {
-							// If the coupon does not apply, let's continue to checkout anyway.
-							return Promise.resolve();
-						} );
-					}
-				} )
-				.catch( () => {
-					// Nothing needs to be done here. CartMessages will display the error to the user.
-				} )
-				.then( () => {
-					this.isMounted && page( `/checkout/${ selectedSiteSlug }` );
-				} );
+				] );
+			} catch {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+				return;
+			}
+
+			if ( withDiscount && this.isMounted ) {
+				try {
+					await shoppingCartManager.applyCoupon( withDiscount );
+				} catch {
+					// If the coupon does not apply, let's continue to checkout anyway.
+				}
+			}
+
+			this.isMounted && page( `/checkout/${ selectedSiteSlug }` );
 			return;
 		}
 
 		if ( redirectToAddDomainFlow === true ) {
-			// In this flow, we add the product to the cart directly and then
-			// redirect to the "add a domain" page.
-			shoppingCartManager
-				.addProductsToCart( [
+			try {
+				// In this flow, we add the product to the cart directly and then
+				// redirect to the "add a domain" page.
+				await shoppingCartManager.addProductsToCart( [
 					{
 						product_slug: productSlug,
 						extra: {
 							afterPurchaseUrl: redirectTo ?? undefined,
 						},
 					},
-				] )
-				.catch( () => {
-					// Nothing needs to be done here. CartMessages will display the error to the user.
-				} )
-				.then( () => {
-					if ( withDiscount && this.isMounted ) {
-						return shoppingCartManager.applyCoupon( withDiscount ).catch( () => {
-							// If the coupon does not apply, let's continue to the next page anyway.
-							return Promise.resolve();
-						} );
-					}
-				} )
-				.then( () => {
-					this.isMounted && page( `/domains/add/${ selectedSiteSlug }` );
-				} );
+				] );
+			} catch {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+				return;
+			}
+
+			if ( withDiscount && this.isMounted ) {
+				try {
+					await shoppingCartManager.applyCoupon( withDiscount );
+				} catch {
+					// If the coupon does not apply, let's continue to the next page anyway.
+				}
+			}
+
+			this.isMounted && page( `/domains/add/${ selectedSiteSlug }` );
 			return;
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -633,11 +633,11 @@ export class PlanFeatures extends Component {
 						} );
 					}
 				} )
-				.then( () => {
-					this.isMounted && page( `/checkout/${ selectedSiteSlug }` );
-				} )
 				.catch( () => {
 					// Nothing needs to be done here. CartMessages will display the error to the user.
+				} )
+				.then( () => {
+					this.isMounted && page( `/checkout/${ selectedSiteSlug }` );
 				} );
 			return;
 		}
@@ -654,6 +654,9 @@ export class PlanFeatures extends Component {
 						},
 					},
 				] )
+				.catch( () => {
+					// Nothing needs to be done here. CartMessages will display the error to the user.
+				} )
 				.then( () => {
 					if ( withDiscount && this.isMounted ) {
 						return shoppingCartManager.applyCoupon( withDiscount ).catch( () => {
@@ -664,9 +667,6 @@ export class PlanFeatures extends Component {
 				} )
 				.then( () => {
 					this.isMounted && page( `/domains/add/${ selectedSiteSlug }` );
-				} )
-				.catch( () => {
-					// Nothing needs to be done here. CartMessages will display the error to the user.
 				} );
 			return;
 		}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -635,6 +635,9 @@ export class PlanFeatures extends Component {
 				} )
 				.then( () => {
 					this.isMounted && page( `/checkout/${ selectedSiteSlug }` );
+				} )
+				.catch( () => {
+					// Nothing needs to be done here. CartMessages will display the error to the user.
 				} );
 			return;
 		}
@@ -661,6 +664,9 @@ export class PlanFeatures extends Component {
 				} )
 				.then( () => {
 					this.isMounted && page( `/domains/add/${ selectedSiteSlug }` );
+				} )
+				.catch( () => {
+					// Nothing needs to be done here. CartMessages will display the error to the user.
 				} );
 			return;
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR adds a noop `catch()` to every call of `addProductsToCart()` that has no other error handler. This is because if any of those calls fails (eg: due to an invalid product or a validation error), the rejected Promise will bubble up to the console and our error logging systems and neither of those are necessary for a failure of adding something to the cart. The user will already know about the failure due to the `CartMessages` component.

This is part of https://github.com/Automattic/wp-calypso/issues/67012

#### Testing Instructions

No testing should be required. A visual review of the code should be sufficient.