### PR TITLE
Purchases Page: Fix Bi-Yearly plan price showing incorrectly as yearly

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -247,18 +247,6 @@ function PurchaseMetaPrice( { purchase } ) {
 		return translate( 'Free with Plan' );
 	}
 
-	if ( plan && plan.term ) {
-		switch ( plan.term ) {
-			case TERM_BIENNIALLY:
-				period = translate( 'two years' );
-				break;
-
-			case TERM_MONTHLY:
-				period = translate( 'month' );
-				break;
-		}
-	}
-
 	if ( isEmailMonthly( purchase ) ) {
 		period = translate( 'month' );
 	}
@@ -276,6 +264,18 @@ function PurchaseMetaPrice( { purchase } ) {
 				break;
 			case 'per day':
 				period = translate( 'day' );
+				break;
+		}
+	}
+
+	if ( plan && plan.term ) {
+		switch ( plan.term ) {
+			case TERM_BIENNIALLY:
+				period = translate( 'two years' );
+				break;
+
+			case TERM_MONTHLY:
+				period = translate( 'month' );
 				break;
 		}
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -247,10 +247,6 @@ function PurchaseMetaPrice( { purchase } ) {
 		return translate( 'Free with Plan' );
 	}
 
-	if ( isEmailMonthly( purchase ) ) {
-		period = translate( 'month' );
-	}
-
 	if ( purchase.billPeriodLabel ) {
 		switch ( purchase.billPeriodLabel ) {
 			case 'per year':
@@ -278,6 +274,10 @@ function PurchaseMetaPrice( { purchase } ) {
 				period = translate( 'month' );
 				break;
 		}
+	}
+
+	if ( isEmailMonthly( purchase ) ) {
+		period = translate( 'month' );
 	}
 
 	// translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")


### PR DESCRIPTION
#### Description:

* Upon purchasing a Bi-yearly plan, when visiting the purchases page, it incorrectly shows as yearly.

#### Testing Instructions

1. Add a Business plan to cart and select to pay Bi annually i.e. every two years.
2. Complete the purchase.
3. Now visit the Purchase page at /purchases/subscriptions/:site/
4. Click the product to arrive at the purchase page.
5. You should correct see the `/ two years` like below:

![](https://d.pr/i/ht3blf+)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66025 
