### PR TITLE
Pricing Page rework: Make View URL accessible 

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -22,11 +22,11 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const productSlugs = useProductSlugs( { siteId, duration } );
 
-	const isValidViewQuery =
-		!! urlQueryArgs?.view && [ 'products', 'bundles' ].includes( urlQueryArgs.view );
-	const defaultViewType = isValidViewQuery && urlQueryArgs?.view ? urlQueryArgs.view : 'products';
-
-	const [ currentView, setCurrentView ] = useState< ViewType >( defaultViewType );
+	const [ currentView, setCurrentView ] = useState< ViewType >( () => {
+		return urlQueryArgs?.view && [ 'products', 'bundles' ].includes( urlQueryArgs.view )
+			? urlQueryArgs.view
+			: 'products';
+	} );
 
 	return (
 		<div className="jetpack-product-store">
@@ -36,11 +36,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 				<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
 			</div>
 
-			<ViewFilter
-				currentView={ currentView }
-				setCurrentView={ setCurrentView }
-				shouldUpdateUrl={ isValidViewQuery }
-			/>
+			<ViewFilter currentView={ currentView } setCurrentView={ setCurrentView } />
 			<ItemsList currentView={ currentView } duration={ duration } siteId={ siteId } />
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -22,7 +22,12 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const productSlugs = useProductSlugs( { siteId, duration } );
 
-	const [ currentView, setCurrentView ] = useState< ViewType >( 'products' );
+	const defaultViewType =
+		urlQueryArgs?.view && [ 'products', 'bundles' ].includes( urlQueryArgs.view )
+			? urlQueryArgs.view
+			: 'products';
+
+	const [ currentView, setCurrentView ] = useState< ViewType >( defaultViewType );
 
 	return (
 		<div className="jetpack-product-store">

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -22,10 +22,9 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const productSlugs = useProductSlugs( { siteId, duration } );
 
-	const defaultViewType =
-		urlQueryArgs?.view && [ 'products', 'bundles' ].includes( urlQueryArgs.view )
-			? urlQueryArgs.view
-			: 'products';
+	const isValidViewQuery =
+		!! urlQueryArgs?.view && [ 'products', 'bundles' ].includes( urlQueryArgs.view );
+	const defaultViewType = isValidViewQuery && urlQueryArgs?.view ? urlQueryArgs.view : 'products';
 
 	const [ currentView, setCurrentView ] = useState< ViewType >( defaultViewType );
 
@@ -37,7 +36,11 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 				<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
 			</div>
 
-			<ViewFilter currentView={ currentView } setCurrentView={ setCurrentView } />
+			<ViewFilter
+				currentView={ currentView }
+				setCurrentView={ setCurrentView }
+				shouldUpdateUrl={ isValidViewQuery }
+			/>
 			<ItemsList currentView={ currentView } duration={ duration } siteId={ siteId } />
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -2,6 +2,9 @@
 @import '@wordpress/base-styles/mixins';
 
 .jetpack-product-store {
+	display: flex;
+	flex-direction: column;
+
 	&__jetpack-free {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -6,9 +6,9 @@ export interface ProductStoreBaseProps {
 	siteId: number | null;
 }
 
-export interface ProductStoreQueryArgs extends QueryArgs {
-	view: ViewType;
-}
+export type ProductStoreQueryArgs = QueryArgs & {
+	view?: ViewType;
+};
 export interface ProductStoreProps {
 	/**
 	 * Whether to show the licence activation dialog
@@ -25,6 +25,7 @@ export type ProductSlugsProps = Pick< ProductStoreProps, 'duration' > & ProductS
 export interface ViewFilterProps {
 	currentView: ViewType;
 	setCurrentView: ( currentView: ViewType ) => void;
+	shouldUpdateUrl: boolean;
 }
 
 export type ProductsListProps = ProductStoreBaseProps & Pick< ProductStoreProps, 'duration' >;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -25,7 +25,6 @@ export type ProductSlugsProps = Pick< ProductStoreProps, 'duration' > & ProductS
 export interface ViewFilterProps {
 	currentView: ViewType;
 	setCurrentView: ( currentView: ViewType ) => void;
-	shouldUpdateUrl: boolean;
 }
 
 export type ProductsListProps = ProductStoreBaseProps & Pick< ProductStoreProps, 'duration' >;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,22 +1,26 @@
-import { BasePageProps, Duration } from '../types';
+import { QueryArgs, Duration } from '../types';
+
+export type ViewType = 'products' | 'bundles';
 
 export interface ProductStoreBaseProps {
 	siteId: number | null;
 }
 
-export interface ProductStoreProps extends Pick< BasePageProps, 'urlQueryArgs' > {
+export interface ProductStoreQueryArgs extends QueryArgs {
+	view: ViewType;
+}
+export interface ProductStoreProps {
 	/**
 	 * Whether to show the licence activation dialog
 	 */
 	enableUserLicensesDialog?: boolean;
 	duration: Duration;
+	urlQueryArgs: ProductStoreQueryArgs;
 }
 
 export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;
 
 export type ProductSlugsProps = Pick< ProductStoreProps, 'duration' > & ProductStoreBaseProps;
-
-export type ViewType = 'products' | 'bundles';
 
 export interface ViewFilterProps {
 	currentView: ViewType;

--- a/client/my-sites/plans/jetpack-plans/product-store/view-filter.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/view-filter.tsx
@@ -3,11 +3,7 @@ import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/route';
 import type { ViewFilterProps } from './types';
 
-export const ViewFilter: React.FC< ViewFilterProps > = ( {
-	currentView,
-	setCurrentView,
-	shouldUpdateUrl,
-} ) => {
+export const ViewFilter: React.FC< ViewFilterProps > = ( { currentView, setCurrentView } ) => {
 	const translate = useTranslate();
 
 	const currentPath = window.location.pathname + window.location.search;
@@ -18,7 +14,7 @@ export const ViewFilter: React.FC< ViewFilterProps > = ( {
 				<SegmentedControl.Item
 					onClick={ () => setCurrentView( 'products' ) }
 					selected={ currentView === 'products' }
-					{ ...( shouldUpdateUrl && { path: addQueryArgs( { view: 'products' }, currentPath ) } ) }
+					path={ addQueryArgs( { view: 'products' }, currentPath ) }
 				>
 					{ translate( 'Products' ) }
 				</SegmentedControl.Item>
@@ -26,7 +22,7 @@ export const ViewFilter: React.FC< ViewFilterProps > = ( {
 				<SegmentedControl.Item
 					onClick={ () => setCurrentView( 'bundles' ) }
 					selected={ currentView === 'bundles' }
-					{ ...( shouldUpdateUrl && { path: addQueryArgs( { view: 'bundles' }, currentPath ) } ) }
+					path={ addQueryArgs( { view: 'bundles' }, currentPath ) }
 				>
 					{ translate( 'Bundles' ) }
 				</SegmentedControl.Item>

--- a/client/my-sites/plans/jetpack-plans/product-store/view-filter.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/view-filter.tsx
@@ -1,9 +1,16 @@
 import { useTranslate } from 'i18n-calypso';
 import SegmentedControl from 'calypso/components/segmented-control';
+import { addQueryArgs } from 'calypso/lib/route';
 import type { ViewFilterProps } from './types';
 
-export const ViewFilter: React.FC< ViewFilterProps > = ( { currentView, setCurrentView } ) => {
+export const ViewFilter: React.FC< ViewFilterProps > = ( {
+	currentView,
+	setCurrentView,
+	shouldUpdateUrl,
+} ) => {
 	const translate = useTranslate();
+
+	const currentPath = window.location.pathname + window.location.search;
 
 	return (
 		<div className="jetpack-product-store__view-filter">
@@ -11,6 +18,7 @@ export const ViewFilter: React.FC< ViewFilterProps > = ( { currentView, setCurre
 				<SegmentedControl.Item
 					onClick={ () => setCurrentView( 'products' ) }
 					selected={ currentView === 'products' }
+					{ ...( shouldUpdateUrl && { path: addQueryArgs( { view: 'products' }, currentPath ) } ) }
 				>
 					{ translate( 'Products' ) }
 				</SegmentedControl.Item>
@@ -18,6 +26,7 @@ export const ViewFilter: React.FC< ViewFilterProps > = ( { currentView, setCurre
 				<SegmentedControl.Item
 					onClick={ () => setCurrentView( 'bundles' ) }
 					selected={ currentView === 'bundles' }
+					{ ...( shouldUpdateUrl && { path: addQueryArgs( { view: 'bundles' }, currentPath ) } ) }
 				>
 					{ translate( 'Bundles' ) }
 				</SegmentedControl.Item>


### PR DESCRIPTION
#### Proposed Changes

* Make View accessible from query params 
* Update the type for query params props 
* Use a flag to decide if the URL should be updated on the view switch 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR 
    * Run `git fetch && git checkout add/add/url-accessible-view`
    * Run `yarn start-jetpack-cloud`
    * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1)
* Or click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* Confirm that the Products view is loaded by default
* Now add `&view=bundles` to the end of the URL and reload 
* Confirm that the Bundles view is loaded by default 
* Now add `&view=products` to the end of the URL and reload 
* Confirm that the Products view is loaded by default 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202796695664057