### PR TITLE
Add 'Need more info' section in the new pricing page.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -6,6 +6,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useProductSlugs from './hooks/use-product-slugs';
 import { ItemsList } from './items-list';
 import { JetpackFree } from './jetpack-free';
+import { NeedMoreInfo } from './need-more-info';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
 import { ViewFilter } from './view-filter';
@@ -36,6 +37,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
 
 			<Recommendations />
+
+			{ currentView === 'bundles' && <NeedMoreInfo /> }
 
 			<StoreFooter />
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/need-more-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/need-more-info.tsx
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import {
+	PLAN_COMPARISON_PAGE,
+	AGENCIES_PAGE,
+} from 'calypso/my-sites/plans/jetpack-plans/constants';
+import MoreInfoBox from '../more-info-box';
+
+export const NeedMoreInfo: React.FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<div className="jetpack-product-store__need-more-info">
+			<h3 className="jetpack-product-store__need-more-info-headline">
+				{ translate( 'Need more info?' ) }
+			</h3>
+			<div className="jetpack-product-store__need-more-info-buttons">
+				<MoreInfoBox
+					buttonLabel={ translate( 'Compare all product bundles' ) }
+					buttonLink={ PLAN_COMPARISON_PAGE }
+					trackEventName="calypso_plans_comparison_table_link_click"
+				/>
+				<MoreInfoBox
+					buttonLabel={ translate( 'Explore Jetpack for Agencies' ) }
+					buttonLink={ AGENCIES_PAGE }
+					trackEventName="calypso_jpcom_agencies_page_more_info_button_link_click"
+				/>
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -123,12 +123,39 @@
 
 .jetpack-product-store__pricing-banner {
 	height: 120px;
-
 	margin-bottom: 1.25rem;
 
 	@include break-large {
 		height: 54px;
-
 		margin-bottom: 0;
 	}
+}
+
+.jetpack-product-store__need-more-info {
+	background-color: var( --color-surface );
+	padding: 5rem 0;
+	text-align: center;
+}
+
+.jetpack-product-store__need-more-info-headline {
+	padding-bottom: 0.9375rem;
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: inherit;
+}
+
+.jetpack-product-store__need-more-info-buttons {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+
+	@include break-medium {
+		justify-content: center;
+		flex-direction: row;
+	}
+}
+
+.jetpack-product-store__need-more-info-buttons .more-info-box__more-button.button {
+	color: var( --color-neutral-100 );
 }


### PR DESCRIPTION
#### Proposed Changes

* Add Need more info section in the new pricing page.

#### Testing Instructions

* Boot up this PR
  * Run `git fetch && git checkout add/pricing-page-need-more-info`
  * Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/pricing?flags=pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=pricing-page-rework-v1`.
* Press 'Bundle' product filter.
* Confirm that the 'Need more info' section is visible above the FAQ section.

<img width="1010" alt="Screen Shot 2022-08-26 at 3 23 40 PM" src="https://user-images.githubusercontent.com/56598660/186846174-2e3dbaf0-e010-4951-b388-a041ae4d0244.png">

* Confirm clicking the 'Compare all product bundles' button will redirect to https://jetpack.com/features/comparison/
* Confirm clicking the 'Explore jetpack for Agencies' button will redirect to https://jetpack.com/for/agencies/


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  1202796695664022-as-1202796695664070

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202796695664070