### PR TITLE
Allow the promote posts widget to close the calypso parent modal

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -33,10 +33,10 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					return;
 				}
 
-				await showDSP( props.siteId, props.postId, widgetContainer.current );
+				await showDSP( props.siteId, props.postId, widgetContainer.current, onClose );
 				setIsLoading( false );
 			} )();
-	}, [ isVisible, props.postId, props.siteId ] );
+	}, [ isVisible, onClose, props.postId, props.siteId ] );
 
 	const promoteWidgetStatus = usePromoteWidget();
 	if ( promoteWidgetStatus === PromoteWidgetStatus.DISABLED ) {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -18,6 +18,7 @@ declare global {
 				template: string;
 				urn: string;
 				onLoaded?: () => void;
+				onClose?: () => void;
 				showDialog?: boolean;
 			} ) => void;
 		};
@@ -37,7 +38,8 @@ export async function loadDSPWidgetJS(): Promise< void > {
 export async function showDSP(
 	siteId: number | string,
 	postId: number | string,
-	domNodeOrId?: HTMLElement | string | null
+	domNodeOrId?: HTMLElement | string | null,
+	onClose?: () => void
 ) {
 	await loadDSPWidgetJS();
 	return new Promise( ( resolve, reject ) => {
@@ -52,6 +54,7 @@ export async function showDSP(
 				authToken: 'wpcom-proxy-request',
 				template: 'article',
 				onLoaded: () => resolve( true ),
+				onClose: onClose,
 				urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
 			} );
 		} else {


### PR DESCRIPTION
#### Proposed Changes

The Promote post widget has a finish button, when you have created your campaign.  However, the finish button only closed the widget itself, but not the calyspso pop-out modal that it was wrapped in.   Now we fire a callback so that the modal can be closed by the child DSP promote post widget.


#### Deployment instructions

This PR must be merged alongside (543-gh-Tumblr/wordads-picard)  to avoid errors

#### Testing Instructions

- Load up this branch and visit `http://calypso.localhost:3000/advertising/`
- Here you should see a list of posts available for promotion
- Follow the steps until you see the "finish' button
- Ensure the finish button closes the modal fully

For clarification, below you can see an example of the behaviour we previously had, and what we expect to happen now.  

**Before this PR**

https://user-images.githubusercontent.com/6440498/186868985-adaebd40-c3f6-4be2-8787-4c45fc5f1a64.mov


**After PR**

https://user-images.githubusercontent.com/6440498/186869091-bc63e273-dfb8-4f14-ad45-eae2e0207955.mov



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
