### PR TITLE
Launchpad: Redirect to /home when launchpad is off

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -24,13 +24,13 @@ const Launchpad: Step = ( { navigation } ) => {
 	);
 
 	const site = useSite();
-	const launchpadViewOption = site?.options?.launchpad_view;
+	const launchpadScreenOption = site?.options?.launchpad_screen;
 
 	useEffect( () => {
-		if ( launchpadViewOption === 'off' ) {
+		if ( launchpadScreenOption === 'off' ) {
 			window.location.replace( `/view/${ siteSlug }` );
 		}
-	}, [ launchpadViewOption ] );
+	}, [ launchpadScreenOption ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -28,9 +28,9 @@ const Launchpad: Step = ( { navigation } ) => {
 
 	useEffect( () => {
 		if ( launchpadScreenOption === 'off' ) {
-			window.location.replace( `/view/${ siteSlug }` );
+			window.location.replace( `/home/${ siteSlug }` );
 		}
-	}, [ launchpadScreenOption ] );
+	}, [ launchpadScreenOption, siteSlug ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,7 +1,9 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import LaunchpadSitePreview from './launchpad-site-preview';
@@ -20,6 +22,15 @@ const Launchpad: Step = ( { navigation } ) => {
 			<LaunchpadSitePreview siteSlug={ siteSlug } />
 		</div>
 	);
+
+	const site = useSite();
+	const launchpadViewOption = site?.options?.launchpad_view;
+
+	useEffect( () => {
+		if ( launchpadViewOption === 'off' ) {
+			window.location.replace( `/view/${ siteSlug }` );
+		}
+	}, [ launchpadViewOption ] );
 
 	return (
 		<>

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -71,4 +71,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_difm_lite_in_progress',
 	'difm_lite_site_options',
 	'site_intent',
+	'launchpad_view',
 ].join();

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -71,5 +71,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_difm_lite_in_progress',
 	'difm_lite_site_options',
 	'site_intent',
-	'launchpad_view',
+	'launchpad_screen',
 ].join();

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -219,6 +219,7 @@ export interface SiteDetailsOptions {
 	was_created_with_blank_canvas_design?: boolean;
 	woocommerce_is_active?: boolean;
 	wordads?: boolean;
+	launchpad_view: boolean | 'off' | 'full' | 'minimized';
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -219,7 +219,7 @@ export interface SiteDetailsOptions {
 	was_created_with_blank_canvas_design?: boolean;
 	woocommerce_is_active?: boolean;
 	wordads?: boolean;
-	launchpad_view: boolean | 'off' | 'full' | 'minimized';
+	launchpad_screen: false | 'off' | 'full' | 'minimized';
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -219,7 +219,7 @@ export interface SiteDetailsOptions {
 	was_created_with_blank_canvas_design?: boolean;
 	woocommerce_is_active?: boolean;
 	wordads?: boolean;
-	launchpad_screen: false | 'off' | 'full' | 'minimized';
+	launchpad_screen?: false | 'off' | 'full' | 'minimized';
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];


### PR DESCRIPTION
#### Proposed Changes

* Read the launchpad_view site option to determine whether or not launchpad onboarding has been completed

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site and public API with this phab diff D86659-code
* Initiate SSH connection to sandbox and update site option for a test site
  * Execute `wpsh` in ssh'd terminal
  * `return switch_to_blog(YOUR_SITE_ID_HERE)`
  * `return update_option('launchpad_screen', 'off')`
  * exit the `wpsh` shell
* Navigate to http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=YOUR_SITE_SLUG_HERE
* You should be redirected to `/home`

***UPDATE: You should be redirected to `/home` instead of `/view` after latest code changes.**

![2022-08-26 02 50 10](https://user-images.githubusercontent.com/5414230/186878096-e8358c3a-cf1c-4414-866f-d0ff08e3f831.gif)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #