### PR TITLE
Emails: add visual indicator about save with annual email subscription

### DIFF
--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@automattic/components';
-import { useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
@@ -17,7 +17,9 @@ export const BillingIntervalToggle = ( {
 	onIntervalChange,
 }: BillingIntervalToggleProps ): ReactElement => {
 	const translate = useTranslate();
-	const payAnnuallyButtonRef = useRef( null );
+	const [ payAnnuallyButtonRef, setPayAnnuallyButtonRef ] = useState< HTMLSpanElement | null >(
+		null
+	);
 
 	const isMonthlyPlan = intervalLength === IntervalLength.MONTHLY;
 	const isAnnuallyPlan = intervalLength === IntervalLength.ANNUALLY;
@@ -36,13 +38,14 @@ export const BillingIntervalToggle = ( {
 					selected={ isAnnuallyPlan }
 					onClick={ () => onIntervalChange( IntervalLength.ANNUALLY ) }
 				>
-					<span ref={ payAnnuallyButtonRef }>{ translate( 'Pay annually' ) }</span>
+					<span ref={ setPayAnnuallyButtonRef }>{ translate( 'Pay annually' ) }</span>
 					{ [ 'right', 'bottom' ].map( ( pos ) => (
 						<Popover
 							isVisible={ isMonthlyPlan }
 							position={ pos }
+							key={ pos }
 							autoPosition={ false }
-							context={ payAnnuallyButtonRef.current }
+							context={ payAnnuallyButtonRef }
 							className="emails-save-paying-annually__popover"
 						>
 							{ translate( 'Save by paying annually' ) }

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
@@ -1,3 +1,5 @@
+import { Popover } from '@automattic/components';
+import { useRef } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
@@ -15,22 +17,37 @@ export const BillingIntervalToggle = ( {
 	onIntervalChange,
 }: BillingIntervalToggleProps ): ReactElement => {
 	const translate = useTranslate();
+	const payAnnuallyButtonRef = useRef( null );
+
+	const isMonthlyPlan = intervalLength === IntervalLength.MONTHLY;
+	const isAnnuallyPlan = intervalLength === IntervalLength.ANNUALLY;
 
 	return (
 		<div className="billing-interval-toggle">
 			<SegmentedControl compact primary>
 				<SegmentedControl.Item
-					selected={ intervalLength === IntervalLength.MONTHLY }
+					selected={ isMonthlyPlan }
 					onClick={ () => onIntervalChange( IntervalLength.MONTHLY ) }
 				>
 					<span>{ translate( 'Pay monthly' ) }</span>
 				</SegmentedControl.Item>
 
 				<SegmentedControl.Item
-					selected={ intervalLength === IntervalLength.ANNUALLY }
+					selected={ isAnnuallyPlan }
 					onClick={ () => onIntervalChange( IntervalLength.ANNUALLY ) }
 				>
-					<span>{ translate( 'Pay annually' ) }</span>
+					<span ref={ payAnnuallyButtonRef }>{ translate( 'Pay annually' ) }</span>
+					{ [ 'right', 'bottom' ].map( ( pos ) => (
+						<Popover
+							isVisible={ isMonthlyPlan }
+							position={ pos }
+							autoPosition={ false }
+							context={ payAnnuallyButtonRef.current }
+							className="emails-save-paying-annually__popover"
+						>
+							{ translate( 'Save paying annually' ) }
+						</Popover>
+					) ) }
 				</SegmentedControl.Item>
 			</SegmentedControl>
 		</div>

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
@@ -45,7 +45,7 @@ export const BillingIntervalToggle = ( {
 							context={ payAnnuallyButtonRef.current }
 							className="emails-save-paying-annually__popover"
 						>
-							{ translate( 'Save paying annually' ) }
+							{ translate( 'Save by paying annually' ) }
 						</Popover>
 					) ) }
 				</SegmentedControl.Item>

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
@@ -39,11 +39,11 @@ export const BillingIntervalToggle = ( {
 					onClick={ () => onIntervalChange( IntervalLength.ANNUALLY ) }
 				>
 					<span ref={ setPayAnnuallyButtonRef }>{ translate( 'Pay annually' ) }</span>
-					{ [ 'right', 'bottom' ].map( ( pos ) => (
+					{ [ 'right', 'bottom' ].map( ( position ) => (
 						<Popover
 							isVisible={ isMonthlyPlan }
-							position={ pos }
-							key={ pos }
+							position={ position }
+							key={ position }
 							autoPosition={ false }
 							context={ payAnnuallyButtonRef }
 							className="emails-save-paying-annually__popover"

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -24,6 +24,8 @@
 }
 
 .emails-save-paying-annually__popover {
+	z-index: z-index( 'root', '.masterbar' ) - 1;
+
 	.popover__inner {
 		padding: 10px;
 	}

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -1,12 +1,44 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .billing-interval-toggle {
 	align-content: space-between;
 
-	> .segmented-control.is-compact {
-		margin: 25px auto;
+	.segmented-control.is-compact {
+		margin: 25px auto 75px;
 		max-width: 480px;
 
+		@include break-wide {
+			margin-bottom: 25px;
+		}
+
 		.segmented-control__link {
-			padding: 8px 12px;
+			padding: 0;
+
+			.segmented-control__text span {
+				display: block;
+				padding: 8px 12px;
+			}
+		}
+	}
+}
+
+.emails-save-paying-annually__popover {
+	.popover__inner {
+		padding: 10px;
+	}
+
+	&.is-right {
+		display: none;
+
+		@include break-wide {
+			display: block;
+		}
+	}
+
+	&.is-bottom {
+		@include break-wide {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

At the current moment, we don't have visual tips for customers about the advantages of purchasing annual email plans.
So we decided to use a similar approach to the `Selecting Plans` page - we will show a popover in case a customer has selected a tab with a monthly subscription and will hide it if the selected tab is for annual subscription.
**NB:** Textual information will be discussed and changed before merging this PR.

#### Testing Instructions
* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* If you have a site w/o email subscription:
	* Choose your site w/o an email subscription
* Otherwise, if you don't have existed account w/o an email subscription - create it following the steps under this item:
	* Click on "Add new site" at the end of the appeared list
	* Enter any domain name for test purposes
	* In the appeared list below - choose a domain with the help of the "Select" button
	* Choose any plan from the proposed with the help of the "Select" button
	* Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
	* Note, on the page "Add Professional Email" - click on the "Skip for now" button
	* On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
* Move the mouse on the "Upgrades" item in the left sidebar
* In the dropdown, click on the "Emails" item
***Expected Result***: `Pay annually` tab is selected by default, and nothing changed. We see the next screen:
<img width="1061" alt="Screenshot 2022-08-26 at 12 09 45" src="https://user-images.githubusercontent.com/5598437/186891195-974aeaf0-08b5-46c6-88fc-d2030f4771b4.png">

* Click on the `Pay monthly` tab
***Expected Result***: `Pay monthly` tab is selected and appeared popover with textual information near the `Pay annually` button.

<table>
<tr>
	<td> BEFORE
	<td> AFTER
<tr>
	<td> 
	<td> Popover is visible if selected `Pay monthly` tab
<tr>
	<td> <img width="1058" alt="Screenshot 2022-08-26 at 12 08 41" src="https://user-images.githubusercontent.com/5598437/186891016-ebb5d035-f7c6-4ba7-8f3d-3019f2fe3ad0.png">
	<td> <img width="1085" alt="Screenshot 2022-08-26 at 15 40 33" src="https://user-images.githubusercontent.com/5598437/186929987-358f0020-80a3-4d8c-bcc0-f038971692b2.png">
</table>

* Click on the `Pay annually` tab
***Expected Result***: popover disappeared.
* Click again on the `Pay monthly` tab
* Let's check responsiveness - if the screen width is less than 1280px, then popover is located under the `Pay annually` button:
<img width="450" alt="Screenshot 2022-08-26 at 15 41 27" src="https://user-images.githubusercontent.com/5598437/186930195-b02c8415-286f-4e62-bc07-c5e9e555b01d.png">


#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202801029257661/f