### PR TITLE
Plugin Management: Add checkbox for bulk actions in plugin items list

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -89,6 +89,8 @@
 	&.section-header.card {
 		margin-inline-start: 0;
 		margin-inline-end: 0;
+		padding-inline-start: 16px;
+		padding-inline-end: 16px;
 		@include break-wide() {
 			margin-inline-start: 1px;
 			margin-inline-end: 1px;
@@ -123,6 +125,9 @@
 			margin-inline-start: 0;
 			flex-grow: 0;
 			justify-content: end;
+			.bulk-select__some-checked-icon {
+				color: var( --color-jetpack );
+			}
 		}
 	}
 	.bulk-select {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon, Card } from '@automattic/components';
 import classNames from 'classnames';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import PluginCommonActions from '../plugin-common-actions';
 import type { Columns, RowFormatterArgs } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -33,17 +34,30 @@ export default function PluginCommonCard( {
 		<Card className="plugin-common-card__card" compact>
 			<div className="plugin-common-card__columns">
 				{ showLeftContent && (
-					<div className="plugin-common-card__left-content">
-						{ item.icon ? (
-							<img
-								className="plugin-common-card__plugin-icon"
-								src={ item.icon }
-								alt={ item.name }
-							/>
-						) : (
-							<Gridicon className="plugin-common-card__plugin-icon has-opacity" icon="plugins" />
-						) }
-					</div>
+					<>
+						<div className="plugin-common-card__left-checkbox">
+							{ item?.isSelectable && (
+								<FormInputCheckbox
+									className="plugin-row-formatter__checkbox"
+									id={ item.slug }
+									onClick={ item.onClick }
+									checked={ item.isSelected }
+									readOnly={ true }
+								/>
+							) }
+						</div>
+						<div className="plugin-common-card__left-content">
+							{ item.icon ? (
+								<img
+									className="plugin-common-card__plugin-icon"
+									src={ item.icon }
+									alt={ item.name }
+								/>
+							) : (
+								<Gridicon className="plugin-common-card__plugin-icon has-opacity" icon="plugins" />
+							) }
+						</div>
+					</>
 				) }
 				<div
 					className={ classNames( 'plugin-common-card__main-content', {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/style.scss
@@ -59,3 +59,11 @@
 		width: fit-content;
 	}
 }
+.plugin-common-card__card.card {
+	padding: 16px;
+}
+.plugin-common-card__left-checkbox {
+	input[type='checkbox'] {
+		margin-top: 8px;
+	}
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,6 +1,7 @@
 import { Gridicon, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
@@ -91,18 +92,29 @@ export default function PluginRowFormatter( {
 				</PluginDetailsButton>
 			) : (
 				<span className="plugin-row-formatter__row-container">
-					{ item.icon ? (
-						<img
-							className="plugin-row-formatter__plugin-icon"
-							src={ item.icon }
-							alt={ item.name }
-						/>
-					) : (
-						<Gridicon className="plugin-row-formatter__plugin-icon has-opacity" icon="plugins" />
-					) }
-					<PluginDetailsButton className="plugin-row-formatter__plugin-name">
-						{ item.name }
-					</PluginDetailsButton>
+					<span className="plugin-row-formatter__plugin-details">
+						{ item?.isSelectable && (
+							<FormInputCheckbox
+								className="plugin-row-formatter__checkbox"
+								id={ item.slug }
+								onClick={ item.onClick }
+								checked={ item.isSelected }
+								readOnly={ true }
+							/>
+						) }
+						{ item.icon ? (
+							<img
+								className="plugin-row-formatter__plugin-icon"
+								src={ item.icon }
+								alt={ item.name }
+							/>
+						) : (
+							<Gridicon className="plugin-row-formatter__plugin-icon has-opacity" icon="plugins" />
+						) }
+						<PluginDetailsButton className="plugin-row-formatter__plugin-name">
+							{ item.name }
+						</PluginDetailsButton>
+					</span>
 					<span className="plugin-row-formatter__overlay"></span>
 				</span>
 			);

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -44,7 +44,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 		rgba( 255, 255, 255, 0.8 ) 30%,
 		rgba( 255, 255, 255, 1 ) 100%
 	);
-	inset-block-start: -14px;
+	inset-block-start: -10px;
 	inset-inline-end: 0;
 }
 .plugin-row-formatter__sites-count-button {
@@ -77,5 +77,28 @@ a.button.plugin-row-formatter__plugin-name-card {
 		.plugin-install-button__install.embed {
 			margin: 0;
 		}
+	}
+}
+.plugin-row-formatter__plugin-details {
+	display: flex;
+	align-items: center;
+}
+
+// Checkbox for multiselect purposes
+.plugin-row-formatter__checkbox[type='checkbox'] {
+	margin-inline-end: 16px;
+
+	&:checked::before {
+		content: url( '/calypso/images/checkbox-icons/checkmark-jetpack.svg' );
+	}
+
+	&::after {
+		// Making tap area larger
+		content: '';
+		position: absolute;
+		top: -20px;
+		left: -19px;
+		width: 56px;
+		height: 55px;
 	}
 }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -567,7 +567,7 @@ export class PluginsList extends Component {
 				/>
 				{ this.props.isJetpackCloud ? (
 					<PluginManagementV2
-						plugins={ this.props.plugins }
+						plugins={ this.getPlugins() }
 						isLoading={ this.props.isLoading }
 						selectedSite={ this.props.selectedSite }
 						searchTerm={ this.props.searchTerm }
@@ -585,6 +585,21 @@ export class PluginsList extends Component {
 				) }
 			</div>
 		);
+	}
+
+	getPlugins() {
+		return this.props.plugins.map( ( plugin ) => {
+			const selectThisPlugin = this.togglePlugin.bind( this, plugin );
+			const allowedPluginActions = this.getAllowedPluginActions( plugin );
+			const isSelectable =
+				this.state.bulkManagementActive &&
+				( allowedPluginActions.autoupdate || allowedPluginActions.activation );
+
+			return {
+				...plugin,
+				...{ onClick: selectThisPlugin, isSelected: this.isSelected( plugin ), isSelectable },
+			};
+		} );
 	}
 
 	getAllowedPluginActions( plugin ) {


### PR DESCRIPTION
#### Proposed Changes

This PR adds a checkbox to the items in the plugins list and card view for the new plugins management UI. This will allow users to select/deselect specific plugins for further bulk actions.

These changes shouldn't affect the existing plugin management UI in Calypso Blue.

#### Testing Instructions
- Checkout PR locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/plugins/manage 
- Click "Edit all" in the table header to activate bulk actions UI
- Choose different plugin items from the list (using the checkboxes) and verify that different bulk actions (e.g. activate/deactivate, etc.) are working as expected.

#### Screenshots

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/1749918/186902515-30674367-2942-456b-9071-92ba691fc37a.png">

<img width="270" alt="image" src="https://user-images.githubusercontent.com/1749918/186902618-c71f36e7-078c-4439-b7aa-31d8905da5d2.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
