### PR TITLE
BlazePress: resize featured image used as thumbnail

### DIFF
--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -1,3 +1,4 @@
+import { safeImageUrl } from '@automattic/calypso-url';
 import { CompactCard } from '@automattic/components';
 import './style.scss';
 import { Button } from '@wordpress/components';
@@ -6,6 +7,7 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import BlazePressWidget from 'calypso/components/blazepress-widget';
 import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 import { getPostType } from 'calypso/my-sites/promote-post/utils';
@@ -49,6 +51,8 @@ export default function PostItem( { post }: Props ) {
 		dispatch( recordDSPEntryPoint( 'promoted_posts-post_item' ) );
 	};
 
+	const safeUrl = safeImageUrl( post.featured_image );
+	const featuredImage = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
 	return (
 		<CompactCard className="post-item__card">
 			<div className="post-item__main">
@@ -64,7 +68,7 @@ export default function PostItem( { post }: Props ) {
 				</div>
 			</div>
 			<div className="post-item__image-container">
-				<img className="post-item__image" src={ post.featured_image } alt="" />
+				{ featuredImage && <img className="post-item__image" src={ featuredImage } alt="" /> }
 			</div>
 			<div className="post-item__promote-link">
 				<BlazePressWidget


### PR DESCRIPTION
### Testing instructions
1. Apply this diff.
2. Go to `/advertising`.
3. Inspect one of the posts thumbnails and verify that the URL has an appropriate height parameter 
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/375980/186913882-407114c5-56a1-4d33-a6d8-dda5cb84d9b1.png">
