### PR TITLE
Adjustments to email step in `onboarding-with-email` signup flow

### DIFF
--- a/client/components/emails/email-product-price/index.jsx
+++ b/client/components/emails/email-product-price/index.jsx
@@ -9,7 +9,7 @@ const EmailProductPrice = ( { isLoading, price } ) => {
 	const moment = useLocalizedMoment();
 	const startDate = moment().add( 3, 'months' ).format( 'LL' );
 	const message = translate( 'Free for the first three months' );
-	const priceText = translate( '%(price)s /user /month starting %(startDate)s', {
+	const priceText = translate( '%(price)s /year /mailbox starting %(startDate)s', {
 		args: {
 			price,
 			startDate,

--- a/client/components/emails/email-product-price/index.jsx
+++ b/client/components/emails/email-product-price/index.jsx
@@ -1,37 +1,26 @@
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { FreeTrialPriceInformation } from 'calypso/my-sites/email/email-providers-comparison/price/price-information';
 
 import './style.scss';
 
-const EmailProductPrice = ( { isLoading, price } ) => {
+const EmailProductPrice = ( { product } ) => {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
-	const startDate = moment().add( 3, 'months' ).format( 'LL' );
 	const message = translate( 'Free for the first three months' );
-	const priceText = translate( '%(price)s /year /mailbox starting %(startDate)s', {
-		args: {
-			price,
-			startDate,
-		},
-		comment:
-			'%(price)s is the price of a subscription, and %(startDate)s is the date the subscription will first renew',
-	} );
 
-	if ( isLoading ) {
+	if ( ! product ) {
 		return <div className="email-product-price is-placeholder">{ translate( 'Loading…' ) }</div>;
 	}
 
 	return (
 		<div className="email-product-price is-free-email email-product-price__email-step-signup-flow">
 			<div className="email-product-price__free-text">{ message }</div>
-			<div className="email-product-price__free-price">{ priceText }</div>
+			<FreeTrialPriceInformation className="email-product-price__free-price" product={ product } />
 		</div>
 	);
 };
 
 EmailProductPrice.propTypes = {
-	isLoading: PropTypes.bool,
 	price: PropTypes.string,
 };
 

--- a/client/components/emails/email-product-price/style.scss
+++ b/client/components/emails/email-product-price/style.scss
@@ -11,16 +11,12 @@
 	text-align: right;
 
 	> div {
-		line-height: 1.5em;
+		line-height: 1.5;
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
-		align-items: flex-end;
+		align-items: flex-start;
 		font-size: $font-body;
-
-		&.email-product-price__email-step-signup-flow {
-			align-items: flex-start;
-		}
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/components/emails/email-product-price/style.scss
+++ b/client/components/emails/email-product-price/style.scss
@@ -8,7 +8,6 @@
 	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1;
-	text-align: right;
 
 	> div {
 		line-height: 1.5;
@@ -17,22 +16,6 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-start;
 		font-size: $font-body;
-	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		display: inline-block;
-		font-size: $font-body-small;
-		text-align: left;
-
-		.is-white-signup &.email-product-price__email-step-signup-flow {
-			display: flex;
-			flex-direction: column-reverse;
-			margin-top: 4px;
-
-			> div {
-				margin-top: 4px;
-			}
-		}
 	}
 
 	.email-product-price__free-price {

--- a/client/components/emails/email-signup-titan-card/index.jsx
+++ b/client/components/emails/email-signup-titan-card/index.jsx
@@ -67,6 +67,7 @@ class EmailSignupTitanCard extends Component {
 		const {
 			addButtonTitle,
 			extraClasses,
+			hideSkip = false,
 			isReskinned,
 			onAddButtonClick,
 			onSkipButtonClick,
@@ -92,12 +93,14 @@ class EmailSignupTitanCard extends Component {
 					{ this.renderEmailSuggestion( domainItem ) }
 					{ wrapDivActionContainer(
 						<>
-							<Button
-								className="email-signup-titan-card__suggestion-action"
-								onClick={ onSkipButtonClick }
-							>
-								{ skipButtonTitle }
-							</Button>
+							{ ! hideSkip && (
+								<Button
+									className="email-signup-titan-card__suggestion-action"
+									onClick={ onSkipButtonClick }
+								>
+									{ skipButtonTitle }
+								</Button>
+							) }
 							<Button
 								className="email-signup-titan-card__suggestion-action"
 								primary

--- a/client/components/emails/email-signup-titan-card/index.jsx
+++ b/client/components/emails/email-signup-titan-card/index.jsx
@@ -1,4 +1,4 @@
-import { TITAN_MAIL_MONTHLY_SLUG } from '@automattic/calypso-products';
+import { TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -33,7 +33,7 @@ class EmailSignupTitanCard extends Component {
 	};
 
 	renderEmailSuggestion( customDomainName ) {
-		const { salePrice, titanMonthlyRenewalCost, translate } = this.props;
+		const { salePrice, titanYearlyRenewalCost, translate } = this.props;
 
 		return (
 			<div className="email-signup-titan-card__suggestion-content">
@@ -45,7 +45,7 @@ class EmailSignupTitanCard extends Component {
 					} ) }
 				</h3>
 				<EmailProductPrice
-					price={ titanMonthlyRenewalCost }
+					price={ titanYearlyRenewalCost }
 					salePrice={ salePrice }
 					isSignupStep={ true }
 					showStrikedOutPrice={ false }
@@ -125,9 +125,9 @@ class EmailSignupTitanCard extends Component {
 
 export default connect( ( state ) => {
 	const signupDependencies = getSignupDependencyStore( state );
-	const titanMonthlyRenewalCost = getProductDisplayCost( state, TITAN_MAIL_MONTHLY_SLUG );
+	const titanYearlyRenewalCost = getProductDisplayCost( state, TITAN_MAIL_YEARLY_SLUG );
 	return {
 		signupDependencies,
-		titanMonthlyRenewalCost,
+		titanYearlyRenewalCost,
 	};
 } )( localize( EmailSignupTitanCard ) );

--- a/client/components/emails/email-signup-titan-card/index.jsx
+++ b/client/components/emails/email-signup-titan-card/index.jsx
@@ -8,7 +8,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import tip from 'calypso/components/domains/register-domain-step/tip';
 import EmailProductPrice from 'calypso/components/emails/email-product-price';
-import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 
 import './style.scss';
@@ -22,8 +22,7 @@ class EmailSignupTitanCard extends Component {
 		hidePrice: PropTypes.bool,
 		onAddButtonClick: PropTypes.func.isRequired,
 		onSkipButtonClick: PropTypes.func.isRequired,
-		priceRule: PropTypes.string,
-		price: PropTypes.string,
+		product: PropTypes.object,
 		showChevron: PropTypes.bool,
 		skipButtonTitle: PropTypes.node.isRequired,
 	};
@@ -33,7 +32,7 @@ class EmailSignupTitanCard extends Component {
 	};
 
 	renderEmailSuggestion( customDomainName ) {
-		const { salePrice, titanYearlyRenewalCost, translate } = this.props;
+		const { product, translate } = this.props;
 
 		return (
 			<div className="email-signup-titan-card__suggestion-content">
@@ -44,12 +43,7 @@ class EmailSignupTitanCard extends Component {
 							'This is a sample email address for the user at their domain; %(domainName)s is a domain name, e.g. example.com',
 					} ) }
 				</h3>
-				<EmailProductPrice
-					price={ titanYearlyRenewalCost }
-					salePrice={ salePrice }
-					isSignupStep={ true }
-					showStrikedOutPrice={ false }
-				/>
+				<EmailProductPrice product={ product } />
 			</div>
 		);
 	}
@@ -125,9 +119,9 @@ class EmailSignupTitanCard extends Component {
 
 export default connect( ( state ) => {
 	const signupDependencies = getSignupDependencyStore( state );
-	const titanYearlyRenewalCost = getProductDisplayCost( state, TITAN_MAIL_YEARLY_SLUG );
+	const product = getProductBySlug( state, TITAN_MAIL_YEARLY_SLUG );
 	return {
 		signupDependencies,
-		titanYearlyRenewalCost,
+		product,
 	};
 } )( localize( EmailSignupTitanCard ) );

--- a/client/components/emails/email-step-side-bar/style.scss
+++ b/client/components/emails/email-step-side-bar/style.scss
@@ -7,32 +7,27 @@
 	.email-step-side-bar__title {
 		font-size: 1.25rem;
 		letter-spacing: 0.2px;
-		line-height: 1.625rem;
+		line-height: 1.3;
 		color: var( --studio-gray-90 );
 	}
 
 	.email-step-side-bar__contents {
 		color: var( --studio-gray-60 );
-		line-height: 1.25rem;
+		line-height: 1.425;
 		letter-spacing: -0.16px;
 		padding-top: 12px;
 		font-size: 0.875rem;
-		padding-left: 1em;
+		padding-left: 1.25em;
 		text-indent: -1em;
 	}
-}
 
-.gridicons-checkmark {
-	display: inline-flex;
-	align-self: center;
-	height: 1em;
-	width: 1em;
-	top: 0.125em;
-	position: relative;
-}
-
-svg {
-	padding-top: 4px;
-	fill: #1d2327;
-	margin-right: 13px;
+	.gridicons-checkmark {
+		display: inline-flex;
+		align-self: center;
+		height: 1em;
+		width: 1em;
+		top: 0.125em;
+		left: -0.25em;
+		position: relative;
+	}
 }

--- a/client/components/emails/email-step-side-bar/style.scss
+++ b/client/components/emails/email-step-side-bar/style.scss
@@ -2,24 +2,24 @@
 @import '@wordpress/base-styles/mixins';
 
 .email-step-side-bar {
-    width: 100%;
+	width: 100%;
 
-    .email-step-side-bar__title {
-        font-size: 1.25rem;
-        letter-spacing: 0.2px;
-        line-height: 1.625rem;
-        color: var( --studio-gray-90 );
-    }
+	.email-step-side-bar__title {
+		font-size: 1.25rem;
+		letter-spacing: 0.2px;
+		line-height: 1.625rem;
+		color: var( --studio-gray-90 );
+	}
 
-    .email-step-side-bar__contents {
-        color: var( --studio-gray-60 );
-        line-height: 1.25rem;
-        letter-spacing: -0.16px;
-        padding-top: 12px;
-        font-size: 0.875rem;
-		padding-left: 30px;
-		text-indent:-30px;
-    }
+	.email-step-side-bar__contents {
+		color: var( --studio-gray-60 );
+		line-height: 1.25rem;
+		letter-spacing: -0.16px;
+		padding-top: 12px;
+		font-size: 0.875rem;
+		padding-left: 1em;
+		text-indent: -1em;
+	}
 }
 
 .gridicons-checkmark {

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -60,9 +60,11 @@ const DiscountPriceInformation = ( {
 	);
 };
 
-const FreeTrialPriceInformation = ( {
+export const FreeTrialPriceInformation = ( {
+	className = 'price-information__free-trial',
 	product,
 }: {
+	className?: string;
 	product: ProductListItem;
 } ): ReactElement | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
@@ -79,7 +81,7 @@ const FreeTrialPriceInformation = ( {
 
 	if ( isGoogleWorkspace( product ) || ! isTitanMonthlyProduct( product ) ) {
 		return (
-			<div className="price-information__free-trial">
+			<div className={ className }>
 				{ translate(
 					'Try free today - first renewal at %(firstRenewalPrice)s after trial, regular price %(standardPrice)s per year',
 					translateArguments
@@ -90,7 +92,7 @@ const FreeTrialPriceInformation = ( {
 
 	if ( isTitanMonthlyProduct( product ) ) {
 		return (
-			<div className="price-information__free-trial">
+			<div className={ className }>
 				{ translate(
 					'Try free today - renews at %(standardPrice)s after trial',
 					translateArguments

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -150,7 +150,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-with-email',
-			steps: getAddOnsStep( [ 'user', 'mailbox-domain', 'emails', 'plans' ] ),
+			steps: getAddOnsStep( [ 'user', 'mailbox-domain', 'emails-add', 'plans' ] ),
 			destination: getSignupDestination,
 			description:
 				'Copy of the onboarding flow that always includes an email step; the flow is used by the Professional Email landing page',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -150,10 +150,10 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-with-email',
-			steps: getAddOnsStep( [ 'user', 'mailbox-domain', 'emails-add', 'plans' ] ),
+			steps: getAddOnsStep( [ 'user', 'mailbox-domain', 'mailbox', 'plans' ] ),
 			destination: getSignupDestination,
 			description:
-				'Copy of the onboarding flow that always includes an email step; the flow is used by the Professional Email landing page',
+				'Copy of the onboarding flow that includes non-skippable domain and email steps; the flow is used by the Professional Email landing page',
 			lastModified: '2022-09-07',
 			showRecaptcha: true,
 		},

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -18,6 +18,7 @@ const stepNameToModuleName = {
 	'domains-theme-preselected': 'domains',
 	'mailbox-domain': 'domains',
 	emails: 'emails',
+	'emails-add': 'emails',
 	'from-url': 'import-url',
 	/* import-url will eventually replace from-url step. Forgive temporary naming. */
 	'import-url': 'import-url-onboarding',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -18,7 +18,7 @@ const stepNameToModuleName = {
 	'domains-theme-preselected': 'domains',
 	'mailbox-domain': 'domains',
 	emails: 'emails',
-	'emails-add': 'emails',
+	mailbox: 'emails',
 	'from-url': 'import-url',
 	/* import-url will eventually replace from-url step. Forgive temporary naming. */
 	'import-url': 'import-url-onboarding',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -368,6 +368,15 @@ export function generateSteps( {
 				isDomainOnly: false,
 			},
 		},
+		'emails-add': {
+			stepName: 'emails-add',
+			dependencies: [ 'domainItem', 'siteSlug' ],
+			providesDependencies: [ 'domainItem', 'emailItem', 'shouldHideFreePlan' ],
+			props: {
+				hideSkip: true,
+				isDomainOnly: false,
+			},
+		},
 		'domain-only': {
 			stepName: 'domain-only',
 			providesDependencies: [ 'siteId', 'siteSlug', 'siteUrl', 'domainItem' ], // note: siteId, siteSlug are not provided when used in domain flow

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -368,8 +368,8 @@ export function generateSteps( {
 				isDomainOnly: false,
 			},
 		},
-		'emails-add': {
-			stepName: 'emails-add',
+		mailbox: {
+			stepName: 'mailbox',
 			dependencies: [ 'domainItem', 'siteSlug' ],
 			providesDependencies: [ 'domainItem', 'emailItem', 'shouldHideFreePlan' ],
 			props: {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -373,7 +373,7 @@ export function generateSteps( {
 			dependencies: [ 'domainItem', 'siteSlug' ],
 			providesDependencies: [ 'domainItem', 'emailItem', 'shouldHideFreePlan' ],
 			props: {
-				backUrl: 'domains-with-email/',
+				backUrl: 'mailbox-domain/',
 				hideSkip: true,
 				isDomainOnly: false,
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -373,6 +373,7 @@ export function generateSteps( {
 			dependencies: [ 'domainItem', 'siteSlug' ],
 			providesDependencies: [ 'domainItem', 'emailItem', 'shouldHideFreePlan' ],
 			props: {
+				backUrl: 'domains-with-email/',
 				hideSkip: true,
 				isDomainOnly: false,
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -371,7 +371,7 @@ export function generateSteps( {
 		mailbox: {
 			stepName: 'mailbox',
 			dependencies: [ 'domainItem', 'siteSlug' ],
-			providesDependencies: [ 'domainItem', 'emailItem', 'shouldHideFreePlan' ],
+			providesDependencies: [ 'domainItem', 'emailItem' ],
 			props: {
 				backUrl: 'mailbox-domain/',
 				hideSkip: true,

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -4,7 +4,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmailSignupTitanCard from 'calypso/components/emails/email-signup-titan-card';
 import EmailStepSideBar from 'calypso/components/emails/email-step-side-bar';
-import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
+import { titanMailYearly } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -21,16 +21,15 @@ class EmailsStep extends Component {
 		const { flowName, signupDependencies, stepName } = this.props;
 		const { domainItem } = signupDependencies;
 
-		const emailItem =
-			domainItem && domainItem.meta
-				? titanMailMonthly( {
-						domain: domainItem.meta,
-						quantity: 1,
-						extra: {
-							new_quantity: 1,
-						},
-				  } )
-				: undefined;
+		const emailItem = domainItem?.meta
+			? titanMailYearly( {
+					domain: domainItem.meta,
+					quantity: 1,
+					extra: {
+						new_quantity: 1,
+					},
+			  } )
+			: undefined;
 
 		// It may be cleaner to call handleSkip() if emailItem is undefined.
 		this.props.recordTracksEvent( 'calypso_signup_email_add', {

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -86,7 +86,7 @@ class EmailsStep extends Component {
 	};
 
 	renderContent() {
-		const { signupDependencies, step, stepSectionName, translate } = this.props;
+		const { hideSkip, signupDependencies, step, stepSectionName, translate } = this.props;
 
 		const content = (
 			<div className="emails__register-email-step">
@@ -95,6 +95,7 @@ class EmailsStep extends Component {
 						siteUrl={ signupDependencies.domainItem?.meta }
 						addButtonTitle={ translate( 'Add' ) }
 						skipButtonTitle={ translate( 'Skip' ) }
+						hideSkip={ hideSkip }
 						onAddButtonClick={ this.handleAddEmail }
 						onSkipButtonClick={ this.handleSkip }
 					/>
@@ -118,7 +119,14 @@ class EmailsStep extends Component {
 	}
 
 	render() {
-		const { flowName, translate, stepName, positionInFlow, signupDependencies } = this.props;
+		const {
+			flowName,
+			hideSkip = false,
+			positionInFlow,
+			signupDependencies,
+			stepName,
+			translate,
+		} = this.props;
 		const backUrl = 'start/domains/';
 		const headerText = translate( 'Add Professional Email' );
 		const domainName = signupDependencies.domainItem?.meta;
@@ -144,7 +152,7 @@ class EmailsStep extends Component {
 				stepContent={ this.renderContent() }
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ translate( 'Back' ) }
-				hideSkip={ false }
+				hideSkip={ hideSkip }
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }
 				skipLabelText={ translate( 'Buy an email later' ) }

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -120,6 +120,7 @@ class EmailsStep extends Component {
 
 	render() {
 		const {
+			backUrl = 'domains/',
 			flowName,
 			hideSkip = false,
 			positionInFlow,
@@ -127,7 +128,6 @@ class EmailsStep extends Component {
 			stepName,
 			translate,
 		} = this.props;
-		const backUrl = 'start/domains/';
 		const headerText = translate( 'Add Professional Email' );
 		const domainName = signupDependencies.domainItem?.meta;
 		const subHeaderText = translate(

--- a/client/signup/steps/emails/style.scss
+++ b/client/signup/steps/emails/style.scss
@@ -14,7 +14,8 @@
 	}
 }
 
-.signup__step.is-emails {
+.signup__step.is-emails,
+.signup__step.is-emails-add {
 	.emails__register-email-step--domain-name {
 		word-break: break-all;
 	}

--- a/client/signup/steps/emails/style.scss
+++ b/client/signup/steps/emails/style.scss
@@ -15,7 +15,7 @@
 }
 
 .signup__step.is-emails,
-.signup__step.is-emails-add {
+.signup__step.is-mailbox {
 	.emails__register-email-step--domain-name {
 		word-break: break-all;
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -784,7 +784,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-domains,
 	.signup__step.is-mailbox-domain,
 	.signup__step.is-emails,
-	.signup__step.is-emails-add,
+	.signup__step.is-mailbox,
 	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans-link-in-bio,
 	.signup__step.is-plans {
@@ -804,7 +804,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-domains,
 	.signup__step.is-mailbox-domain,
 	.signup__step.is-emails,
-	.signup__step.is-emails-add,
+	.signup__step.is-mailbox,
 	.is-domain-only {
 		@include break-large {
 			margin: 0 0 0 20px;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -784,6 +784,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-domains,
 	.signup__step.is-mailbox-domain,
 	.signup__step.is-emails,
+	.signup__step.is-emails-add,
 	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans-link-in-bio,
 	.signup__step.is-plans {
@@ -803,6 +804,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-domains,
 	.signup__step.is-mailbox-domain,
 	.signup__step.is-emails,
+	.signup__step.is-emails-add,
 	.is-domain-only {
 		@include break-large {
 			margin: 0 0 0 20px;

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,4 +1,4 @@
-import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
+import { isTitanMail, WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { isEmpty, reduce, snakeCase } from 'lodash';
 import { assertValidDependencies } from 'calypso/lib/signup/asserts';
@@ -55,11 +55,19 @@ function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 				propValue = otherProps;
 			}
 
+			if ( propName === 'email_item' && isTitanMail( propValue ) ) {
+				const { extra, quantity, ...otherProps } = propValue;
+				propValue = otherProps;
+			}
+
 			if ( propName === 'selected_page_titles' && Array.isArray( propValue ) ) {
 				propValue = propValue.join( ',' );
 			}
 
-			if ( [ 'cart_item', 'domain_item' ].includes( propName ) && typeof propValue !== 'string' ) {
+			if (
+				[ 'cart_item', 'domain_item', 'email_item' ].includes( propName ) &&
+				typeof propValue !== 'string'
+			) {
 				propValue = Object.entries( propValue || {} )
 					.map( ( pair ) => pair.join( ':' ) )
 					.join( ',' );


### PR DESCRIPTION
#### Proposed Changes

Letero is working on a set of improvements to the onboarding-with-email signup flow. This flow captures users that have shown interest in the email solutions offered on WordPress.com. For more context, see pbLl1t-1f6-p2.

In this PR, I have made a few changes to the email step in that signup flow:

1. Added a variation of the emails step: `mailbox`
2. Hide the "Buy an email later" button
3. Hide the "Skip" button in the `EmailSignupTitanCard` component

Here's what the `mailbox` step looks like:

![email step](https://user-images.githubusercontent.com/1101677/188581791-9ce81ddf-5977-4288-b8bd-bab081cde115.png)

This PR depends on #66921

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/start/onboarding-with-email`
2. Search for a domain, proceed to next step
3. Ensure that there is no "Buy an email later" button at the bottom of the page
4. Ensure that there is no "Skip" button next to the big blue "Add" button
5. Ensure that clicking "Add" takes you to the next step in the signup flow
6. Ensure that you can proceed to checkout and that there is a mailbox in your cart

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66921