### PR TITLE
Licensing Portal: Hide the billing page footer note if there are no invoice items

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -154,7 +154,7 @@ export default function BillingDetails(): ReactElement {
 				</div>
 			</Card>
 
-			{ billing.isSuccess && useDailyPrices && (
+			{ billing.isSuccess && useDailyPrices && billing.data.products.length > 0 && (
 				<Card compact className="billing-details__footer">
 					<small>
 						* Estimate of the combined number of full days each license will be active for by the


### PR DESCRIPTION
Context: 1201801459945917-as-1202473924832409

#### Proposed Changes

* Licensing Portal: Hide the billing page footer note if there are no invoice items

#### Testing Instructions

* Requires that you have a partner account associated with your WPCOM user.
* Switch your partner type to Agency and your key billable type to Manual from the legacy Partner Portal (this may take a bit as it relies on async jobs). Switching your partner type will zero out your product usage so your invoice will have no products.
* Checkout patch and run Jetpack Cloud locally.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/billing
* Confirm the footer note is not present.
![billing-footer-note](https://user-images.githubusercontent.com/22746396/186924102-1a1c8e90-0245-4dd9-8763-c8b927ec8841.png)
* Add the following to your sandbox and run it: 2d6c0-pb/#php
* This will resync your usage and your billing page will be populated with products again.
* Confirm the footer note is now present.
* Don't forget to reset your partner and partner key types back.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?