### PR TITLE
Tailored flows: launch newsletter site as public (not coming soon)

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -142,6 +142,8 @@ function getNewSiteParams( {
 		get( signupDependencies, 'themeSlugWithRepo', false ) ||
 		siteTypeTheme;
 
+	const launchAsComingSoon = get( signupDependencies, 'comingSoon', 1 );
+
 	// We will use the default annotation instead of theme annotation as fallback,
 	// when segment and vertical values are not sent. Check pbAok1-p2#comment-834.
 	const shouldUseDefaultAnnotationAsFallback = true;
@@ -160,7 +162,7 @@ function getNewSiteParams( {
 			},
 			site_creation_flow: flowToCheck,
 			timezone_string: guessTimezone(),
-			wpcom_public_coming_soon: 1,
+			wpcom_public_coming_soon: launchAsComingSoon,
 			...( siteAccentColor && { site_accent_color: siteAccentColor } ),
 		},
 		validate: false,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -211,13 +211,13 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
-		// the only unique thing about plans-newsletter is that it provides themeSlugWithRepo dependency
+		// the only unique thing about plans-newsletter is that it provides themeSlugWithRepo and comingSoon dependencies
 		'plans-newsletter': {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
 			optionalDependencies: [ 'emailItem' ],
-			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo', 'comingSoon' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -104,9 +104,11 @@ export class PlansStep extends Component {
 			);
 		} else if ( flowName === 'newsletter' ) {
 			// newsletter flow always uses pub/lettre
+			// newsletter always needs the site launched
 			this.props.submitSignupStep( step, {
 				cartItem,
 				themeSlugWithRepo: 'pub/lettre',
+				comingSoon: 0,
 			} );
 			this.props.goToNextStep();
 		} else if ( flowName === 'link-in-bio' ) {


### PR DESCRIPTION
#### Proposed Changes

* This launches new newsletter sites as public. 

#### Testing Instructions

1. Go to /setup?flow=newsletter.
2. Launch a site.
3. Should be public.