### PR TITLE
Style selection: Implement core style switching logic

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -92,6 +92,14 @@ export default class WebPreviewContent extends Component {
 				window.removeEventListener( 'resize', this.handleResize );
 			}
 		}
+
+		if ( this.props.inlineCss !== prevProps.inlineCss ) {
+			const data = {
+				type: 'inline-css',
+				inline_css: this.props.inlineCss,
+			};
+			this.iframe.contentWindow.postMessage( data, '*' );
+		}
 	}
 
 	handleMessage = ( e ) => {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -95,6 +95,7 @@ export default class WebPreviewContent extends Component {
 
 		if ( this.props.inlineCss !== prevProps.inlineCss ) {
 			const data = {
+				channel: 'preview-' + this.previewId,
 				type: 'inline-css',
 				inline_css: this.props.inlineCss,
 			};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style-variation-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style-variation-selector.tsx
@@ -1,0 +1,11 @@
+import { Button } from '@automattic/components';
+
+const StyleVariationSelector = ( { styleVariations, onSelectStyleVariation } ) => {
+	return styleVariations.map( ( variation ) => (
+		<Button key={ variation.slug } onClick={ () => onSelectStyleVariation( variation ) }>
+			{ variation.title }
+		</Button>
+	) );
+};
+
+export default StyleVariationSelector;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -30,6 +30,7 @@ import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import PreviewToolbar from './preview-toolbar';
+import StyleVariationSelector from './style-variation-selector';
 import UpgradeModal from './upgrade-modal';
 import getThemeIdFromDesign from './util/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
@@ -138,6 +139,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const categorizationOptions = getCategorizationOptions( intent, true );
 
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
+
+	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState( {
+		inline_css: undefined,
+	} );
 
 	const handleSubmit = ( providedDependencies?: ProvidedDependencies ) => {
 		const _selectedDesign = providedDependencies?.selectedDesign as Design;
@@ -306,6 +311,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					externalUrl={ siteSlug }
 					showExternal={ true }
 					previewUrl={ previewUrl }
+					inlineCss={ selectedStyleVariation.inline_css }
 					loadingMessage={ translate(
 						'{{strong}}One moment, please…{{/strong}} loading your site.',
 						{
@@ -328,6 +334,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		const actionButtons = (
 			<div>
+				<StyleVariationSelector
+					styleVariations={ selectedDesign.style_variations }
+					onSelectStyleVariation={ setSelectedStyleVariation }
+				/>
 				{ shouldUpgrade ? (
 					<Button primary borderless={ false } onClick={ upgradePlan }>
 						{ translate( 'Unlock theme' ) }


### PR DESCRIPTION
#### Proposed Changes

WIP

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
