### PR TITLE
Subscriber form: allow empty form submission

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,6 +117,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"subscriber-csv-upload": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -92,6 +92,8 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 		validEmails.length && addSubscribers( siteId, validEmails );
 		selectedFile && importCsvSubscribers( siteId, selectedFile );
+
+		! validEmails.length && ! selectedFile && onImportFinished?.();
 	}
 
 	function onEmailChange( value: string, index: number ) {


### PR DESCRIPTION
#### Proposed Changes

* Turn on the CSV upload feature for the horizon env
* Allow form submission when the form is empty. (this is the temp solution, in the next PR Subscriber form will contain flag param for it)

#### Testing Instructions

* Go to `/setup/subscribers?flow=newsletter&complete-setup=true&siteSlug={SLUG}`
* Click on the 'Continue' button
* Check if redirects to the next step

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
