### PR TITLE
Blazepress: Fix reloading

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -44,7 +44,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				);
 				setIsLoading( false );
 			} )();
-	}, [ isVisible, onClose, props.postId, props.siteId ] );
+	}, [ isVisible, props.postId, props.siteId ] );
 
 	const promoteWidgetStatus = usePromoteWidget();
 	if ( promoteWidgetStatus === PromoteWidgetStatus.DISABLED ) {


### PR DESCRIPTION
The widget was being reloaded because a function was in its dependencies. That dependency is removed and it should be working fine.

### Testing
N/A