### PR TITLE
Blazepress: removes Advertising option is not enabled

### DIFF
--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
+import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-sites/sidebar/actions';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import MySitesSidebarUnifiedItem from './item';
@@ -41,6 +42,8 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const showAsExpanded =
 		( isMobile && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
 		( isDesktop && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
+
+	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
 	const onClick = ( event ) => {
 		// Block the navigation on mobile viewports and just toggle the section,
@@ -76,6 +79,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				{ ...props }
 			>
 				{ children.map( ( item ) => {
+					if ( ! shouldShowAdvertisingOption && item.title === 'Advertising' ) return;
 					const isSelected = selectedMenuItem?.url === item.url;
 					return (
 						<MySitesSidebarUnifiedItem


### PR DESCRIPTION
This removes the Advertising menu item if the feature is not enabled. The menu item will be activated by default in Atomic and this change makes sure that the Advertising item will only be visible to the users intended as described in this p2 pMyNb-5CW-p2.

### Testing
1. Apply this PR.
2. Verify that everything works normally. The `Advertising` menu entry is visible on a11n accounts and disabled otherwise.