### PR TITLE
Social Auth: Update TOS message to remove mention of creating an account on social login

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -499,9 +499,9 @@ export class LoginForm extends Component {
 
 		const socialToS = this.props.translate(
 			// To make any changes to this copy please speak to the legal team
-			'By continuing, ' +
+			'By continuing with any of the options below, ' +
 				'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and' +
-				' acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				' have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			{
 				components: {
 					tosLink: (
@@ -655,7 +655,7 @@ export class LoginForm extends Component {
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
 							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
-							socialToS={ socialToS }
+							shouldRenderToS={ false }
 						/>
 					</Fragment>
 				) }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -497,6 +497,31 @@ export class LoginForm extends Component {
 			return this.renderWooCommerce();
 		}
 
+		const socialToS = this.props.translate(
+			// To make any changes to this copy please speak to the legal team
+			'By continuing, ' +
+				'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and' +
+				' acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			{
+				components: {
+					tosLink: (
+						<a
+							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					privacyLink: (
+						<a
+							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
+
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
 				{ isCrowdsignalOAuth2Client( oauth2Client ) && (
@@ -595,32 +620,7 @@ export class LoginForm extends Component {
 						</div>
 					</div>
 
-					<p className="login__form-terms">
-						{ this.props.translate(
-							// To make any changes to this copy please speak to the legal team
-							'By continuing, ' +
-								'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and' +
-								' acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-							{
-								components: {
-									tosLink: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									privacyLink: (
-										<a
-											href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
-					</p>
+					<p className="login__form-terms">{ socialToS }</p>
 
 					<div className="login__form-action">
 						<FormsButton primary disabled={ isFormDisabled }>
@@ -655,6 +655,7 @@ export class LoginForm extends Component {
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
 							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
+							socialToS={ socialToS }
 						/>
 					</Fragment>
 				) }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -431,7 +431,6 @@ export class LoginForm extends Component {
 									socialService={ this.props.socialService }
 									socialServiceResponse={ this.props.socialServiceResponse }
 									uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
-									shouldRenderToS={ false }
 								/>
 							</div>
 						) }
@@ -660,7 +659,6 @@ export class LoginForm extends Component {
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
 							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
-							shouldRenderToS={ false }
 						/>
 					</Fragment>
 				) }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -315,7 +315,7 @@ export class LoginForm extends Component {
 		this.loginUser();
 	};
 
-	renderWooCommerce( showSocialLogin = true ) {
+	renderWooCommerce( { showSocialLogin = true, socialToS } = {} ) {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const { requestError, socialAccountIsLinking: linkingSocialUser } = this.props;
 
@@ -404,6 +404,7 @@ export class LoginForm extends Component {
 					</div>
 
 					<div className="login__form-footer">
+						<p className="login__social-tos">{ socialToS }</p>
 						<div className="login__form-action">
 							<Button
 								primary
@@ -430,6 +431,7 @@ export class LoginForm extends Component {
 									socialService={ this.props.socialService }
 									socialServiceResponse={ this.props.socialServiceResponse }
 									uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
+									shouldRenderToS={ false }
 								/>
 							</div>
 						) }
@@ -485,18 +487,6 @@ export class LoginForm extends Component {
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname, isGutenboarding );
 
-		if ( isJetpackWooCommerceFlow ) {
-			return this.renderWooCommerce();
-		}
-
-		if ( isJetpackWooDnaFlow ) {
-			return this.renderWooCommerce( !! accountType ); // Only show the social buttons after the user entered an email.
-		}
-
-		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
-			return this.renderWooCommerce();
-		}
-
 		const socialToS = this.props.translate(
 			// To make any changes to this copy please speak to the legal team
 			'By continuing with any of the options below, ' +
@@ -521,6 +511,21 @@ export class LoginForm extends Component {
 				},
 			}
 		);
+
+		if ( isJetpackWooCommerceFlow ) {
+			return this.renderWooCommerce( { socialToS } );
+		}
+
+		if ( isJetpackWooDnaFlow ) {
+			return this.renderWooCommerce( {
+				showSocialLogin: !! accountType, // Only show the social buttons after the user entered an email.
+				socialToS,
+			} );
+		}
+
+		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+			return this.renderWooCommerce( { socialToS } );
+		}
 
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -1,7 +1,5 @@
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -24,7 +22,6 @@ class SocialLoginForm extends Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectTo: PropTypes.string,
 		onSuccess: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
 		loginSocialUser: PropTypes.func.isRequired,
 		uxMode: PropTypes.string.isRequired,
 		linkingSocialService: PropTypes.string,
@@ -140,72 +137,6 @@ class SocialLoginForm extends Component {
 		return `https://${ host + login( { socialService: service } ) }`;
 	};
 
-	renderSocialTos = () => {
-		const { redirectTo, translate } = this.props;
-
-		const isJetpackMagicLinkSignUpFlow =
-			redirectTo &&
-			redirectTo.includes( 'jetpack/connect' ) &&
-			config.isEnabled( 'jetpack/magic-link-signup' );
-
-		const tosLink = (
-			<a
-				href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-				target="_blank"
-				rel="noopener noreferrer"
-			/>
-		);
-		const privacyLink = (
-			<a
-				href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-				target="_blank"
-				rel="noopener noreferrer"
-			/>
-		);
-
-		if ( isJetpackMagicLinkSignUpFlow ) {
-			return (
-				<>
-					<p className="login__social-tos">
-						{ translate(
-							'By continuing, you agree to our {{tosLink}}Terms of' +
-								' Service{{/tosLink}} and acknowledge that you have read our' +
-								' {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-							{
-								components: {
-									tosLink,
-									privacyLink,
-								},
-							}
-						) }
-					</p>
-					<p className="login__social-tos">
-						{ translate(
-							'If you continue with Google, Apple, or an email that isn’t registered yet,' +
-								' you are creating a new WordPress.com account.'
-						) }
-					</p>
-				</>
-			);
-		}
-		return (
-			<p className="login__social-tos">
-				{ translate(
-					'If you continue with Google or Apple,' +
-						' you agree to our' +
-						' {{tosLink}}Terms of Service{{/tosLink}}, and have' +
-						' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-					{
-						components: {
-							tosLink,
-							privacyLink,
-						},
-					}
-				) }
-			</p>
-		);
-	};
-
 	render() {
 		const { redirectTo, uxMode } = this.props;
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
@@ -237,8 +168,6 @@ class SocialLoginForm extends Component {
 							}
 						/>
 					</div>
-
-					{ this.props.shouldRenderToS && this.renderSocialTos() }
 				</div>
 
 				{ this.props.bearerToken && (
@@ -264,4 +193,4 @@ export default connect(
 		createSocialUserFailed,
 		recordTracksEvent,
 	}
-)( localize( SocialLoginForm ) );
+)( SocialLoginForm );

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -30,11 +30,12 @@ class SocialLoginForm extends Component {
 		linkingSocialService: PropTypes.string,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
-		socialToS: PropTypes.element,
+		shouldRenderToS: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		linkingSocialService: '',
+		shouldRenderToS: true,
 	};
 
 	reportSocialLoginFailure = ( { service, socialInfo, error } ) => {
@@ -140,11 +141,7 @@ class SocialLoginForm extends Component {
 	};
 
 	renderSocialTos = () => {
-		const { redirectTo, translate, socialToS } = this.props;
-
-		if ( socialToS ) {
-			return <p className="login__social-tos">{ socialToS }</p>;
-		}
+		const { redirectTo, translate } = this.props;
 
 		const isJetpackMagicLinkSignUpFlow =
 			redirectTo &&
@@ -241,7 +238,7 @@ class SocialLoginForm extends Component {
 						/>
 					</div>
 
-					{ this.renderSocialTos() }
+					{ this.props.shouldRenderToS && this.renderSocialTos() }
 				</div>
 
 				{ this.props.bearerToken && (

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -191,9 +191,9 @@ class SocialLoginForm extends Component {
 		return (
 			<p className="login__social-tos">
 				{ translate(
-					"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-						' are creating an account, you agree to our' +
-						' {{tosLink}}Terms of Service{{/tosLink}}, and acknowledge that you have' +
+					'If you continue with Google or Apple,' +
+						' you agree to our' +
+						' {{tosLink}}Terms of Service{{/tosLink}}, and have' +
 						' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 					{
 						components: {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -30,6 +30,7 @@ class SocialLoginForm extends Component {
 		linkingSocialService: PropTypes.string,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
+		socialToS: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -139,7 +140,11 @@ class SocialLoginForm extends Component {
 	};
 
 	renderSocialTos = () => {
-		const { redirectTo, translate } = this.props;
+		const { redirectTo, translate, socialToS } = this.props;
+
+		if ( socialToS ) {
+			return <p className="login__social-tos">{ socialToS }</p>;
+		}
 
 		const isJetpackMagicLinkSignUpFlow =
 			redirectTo &&

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -100,9 +100,14 @@
 		box-shadow: none;
 	}
 
-	.login__social-tos a {
-		color: var( --studio-gray-60 );
-		text-decoration: underline;
+	.login__social-tos {
+		margin: 1.5em auto;
+		max-width: 330px;
+
+		a {
+			color: var( --studio-gray-60 );
+			text-decoration: underline;
+		}
 	}
 
 	.jetpack-header__partner-logo-plus svg {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -105,7 +105,7 @@
 		max-width: 330px;
 
 		a {
-			color: var( --studio-gray-60 );
+			color: var( --color-accent );
 			text-decoration: underline;
 		}
 	}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -332,10 +332,6 @@
 		box-shadow: none;
 	}
 
-	.login__form-userdata {
-		margin-bottom: 2em;
-	}
-
 	.login__form label {
 		font-size: var( --p2-font-size-form-xxs );
 		color: var( --p2-color-text );

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -790,7 +790,7 @@ class SignupForm extends Component {
 	termsOfServiceLink = () => {
 		const tosText = this.props.translate(
 			'By creating an account you agree to our {{tosLink}}Terms of Service{{/tosLink}} and' +
-				' acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				' have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			{
 				components: {
 					tosLink: (

--- a/client/blocks/signup-form/social-signup-tos.jsx
+++ b/client/blocks/signup-form/social-signup-tos.jsx
@@ -5,9 +5,8 @@ function SocialSignupToS( props ) {
 	return (
 		<p className="signup-form__social-buttons-tos">
 			{ props.translate(
-				"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-					' are creating an account, you agree to our' +
-					' {{tosLink}}Terms of Service{{/tosLink}}, and acknowledge that you have' +
+				'If you continue with Google or Apple, you agree to our' +
+					' {{tosLink}}Terms of Service{{/tosLink}}, and have' +
 					' read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				{
 					components: {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -62,7 +62,6 @@
 }
 
 .signup-form__social-buttons-tos a {
-	color: var( --color-text-inverted );
 	text-decoration: underline;
 }
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -95,11 +95,6 @@
 		background: var( --studio-gray-0 );
 	}
 
-	a,
-	a:visited {
-		color: inherit;
-	}
-
 	.button {
 		background-color: var( --studio-gray-0 );
 		border-radius: 2px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -992,15 +992,13 @@
 	}
 
 	.login__form-terms {
-		font-size: $font-body-small;
-		line-height: 24px;
-		margin-top: 8px;
+		font-size: $font-body-extra-small;
+		margin-bottom: 1em;
 	}
 
 	.login__form-signup-link {
 		font-size: $font-body;
 		line-height: 24px;
-		padding-top: 0;
 	}
 
 	.login__divider {
@@ -1088,10 +1086,10 @@
 			.login__form-userdata {
 				order: 1;
 			}
-			.login__form-action {
+			.login__form-terms {
 				order: 2;
 			}
-			.login__form-terms {
+			.login__form-action {
 				order: 3;
 			}
 			.login__form-signup-link {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -241,10 +241,15 @@ $image-height: 47px;
 	}
 
 	.login__form-terms,
+	.login__form-terms {
+		text-align: left;
+		color: var( --color-neutral-60 );
+		font-size: $font-body-extra-small;
+	}
+
 	.login__form-terms a,
 	.login__form-terms a:hover {
 		text-align: left;
-		color: var( --color-neutral-60 );
 		font-size: $font-body-extra-small;
 	}
 
@@ -262,10 +267,6 @@ $image-height: 47px;
 			color: var( --studio-pink-50 );
 			box-shadow: none;
 		}
-	}
-
-	.login__social-tos a {
-		color: var( --studio-gray-60 );
 	}
 
 	.wp-login__site-return-link::after {
@@ -520,9 +521,7 @@ $image-height: 47px;
 
 	.two-factor-authentication__verification-code-form > p,
 	.login__form-terms,
-	.login__social-tos,
-	.login__form-terms a,
-	.login__social-tos a {
+	.login__social-tos {
 		color: var( --studio-gray-50 );
 	}
 

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -1,9 +1,7 @@
 body.is-section-signup.is-white-signup .signup {
 	.signup-form.is-horizontal {
 		.signup-form__terms-of-service-link,
-		.signup-form__terms-of-service-link a,
 		.signup-form__social-buttons-tos,
-		.signup-form__social-buttons-tos a,
 		.signup-form__social p,
 		.signup-form__recaptcha-tos,
 		.logged-out-form__links .logged-out-form__link-item {
@@ -22,7 +20,6 @@ body.is-section-signup.is-white-signup .signup {
 		.signup-form__terms-of-service-link a,
 		.signup-form__social-buttons-tos a,
 		.signup-form__recaptcha-tos a {
-			color: inherit;
 			text-decoration: underline;
 		}
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -339,7 +339,6 @@ body.is-section-signup .layout.gravatar .formatted-header {
 
 	.signup-form__terms-of-service-link a,
 	.signup-form__social-buttons-tos a {
-		color: var( --studio-gray-50 );
 		text-decoration: underline;
 	}
 


### PR DESCRIPTION
### Proposed Changes

On the login page, we warn the user that we're creating them an account if it doesn't exist when they try to socially sign in:

<img src="https://user-images.githubusercontent.com/26530524/186975447-6cc92ce2-51c9-45ea-af6b-ca668a907f52.png" width="400" />

But that's not true: we don't try to, and warn them that they should sign up instead (notice on top). This is misleading, so we need to update the TOS. Also, a legal representative asked to differentiate the link color from the text: p2y3YZ-5Oq-p2#comment-13737.

### Testing Instructions

Check that the login and sign-up pages do not suggest that we're creating a new account in case social login fails. It also puts the ToS copy at the beginning and covers all three authentication methods.

Don't forget to run Calypso locally. Copy the link and open it in incognito mode.

| [`/log-in`](http://calypso.localhost:3000/log-in) | [`/log-in/new`](http://calypso.localhost:3000/log-in/new) |
| ---------| -------------- |
| ![image](https://user-images.githubusercontent.com/26530524/187761380-e504d037-51a0-4681-86de-5d5bc2e90813.png) | ![image](https://user-images.githubusercontent.com/26530524/187761427-c931c5e7-9798-40d4-8f0f-2525b1e56fc7.png) |

| [`/log-in/jetpack`](http://calypso.localhost:3000/log-in/jetpack) | [`/log-in?from=woocommerce-onboarding`](http://calypso.localhost:3000/log-in?from=woocommerce-onboarding) |
| ----------------- | ------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/26530524/187761584-0941d127-7ba5-40e1-8d9a-6ef55bbd04e9.png) | ![image](https://user-images.githubusercontent.com/26530524/187761647-c12fb90e-30da-4122-8d09-6bb85fe2f7c0.png) |

| [`/log-in?from=p2`](http://calypso.localhost:3000/log-in?from=p2) | [`/start/user`](http://calypso.localhost:3000/start/user) |
| ------------------ | ------------- |
| ![image](https://user-images.githubusercontent.com/26530524/187762337-68543072-0b42-4bf6-8e73-1c30a861be7f.png) | ![image](https://user-images.githubusercontent.com/26530524/187761774-0ad37f94-66bd-4189-b63f-c408256bd4da.png) |

| [Jetpack Connect](http://calypso.localhost:3000/log-in?client_id=69040&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0) | [WooCommerce connect](http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db0e89241e21333a181c7611c1a247a628c141718e3e8e8ca6cbb432f522a7f3e%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%3D%26calypso_env%3Dproduction) | [Crowdsignal connect](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D8aab737dadcdb664bc557210a1dba62242edaf47729eb82f0101765b13c57dad%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1) |
| ----------------- | ----------------- | ------------------ |
| ![image](https://user-images.githubusercontent.com/26530524/187777082-6ef15eb0-4af9-4db1-96dc-694f9f53c98d.png) | ![image](https://user-images.githubusercontent.com/26530524/187776936-1aa07670-e4ce-4648-8138-1b9a50052356.png) | ![image](https://user-images.githubusercontent.com/26530524/187776976-7972ec99-94d5-4701-a388-28c7d4f0d5b5.png) |