### PR TITLE
Signup: move flow names used for checking to constants

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
@@ -1,3 +1,4 @@
+import { LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -58,7 +59,7 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 			return;
 		}
 
-		if ( flow === 'link-in-bio' ) {
+		if ( flow === LINK_IN_BIO_FLOW ) {
 			completeLinkInBioFlow();
 		} else {
 			completeNewsletterFlow();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -1,3 +1,4 @@
+import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
 
@@ -9,11 +10,11 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 	};
 
 	switch ( flow ) {
-		case 'newsletter':
+		case NEWSLETTER_FLOW:
 			translatedStrings.flowName = translate( 'Newsletter' );
 			translatedStrings.sidebarTitle = translate( 'Your Newsletter is ready to launch!' );
 			break;
-		case 'link-in-bio':
+		case LINK_IN_BIO_FLOW:
 			translatedStrings.flowName = translate( 'Link in Bio' );
 			translatedStrings.sidebarTitle = translate( 'Your Link in Bio is ready to launch!' );
 			break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement, useEffect, useState } from 'react';
@@ -96,7 +96,7 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 	}, [ simulatedProgress, progress, __ ] );
 
 	const flowName = props.flow || '';
-	const isJetpackPowered = [ 'link-in-bio', 'newsletter' ].includes( flowName );
+	const isJetpackPowered = isNewsletterOrLinkInBioFlow( flowName );
 
 	return (
 		<StepContainer

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -1,5 +1,6 @@
 import { getPlans, getPlanClass } from '@automattic/calypso-products';
 import { getCurrencyObject } from '@automattic/format-currency';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -20,9 +21,9 @@ export class PlanFeaturesComparisonHeader extends Component {
 		const { flow, translate } = this.props;
 
 		switch ( flow ) {
-			case 'newsletter':
+			case NEWSLETTER_FLOW:
 				return translate( 'Best for Newsletters' );
-			case 'link-in-bio':
+			case LINK_IN_BIO_FLOW:
 				return translate( 'Best for Link in Bio' );
 			default:
 				return translate( 'Popular' );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
+import { LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -111,7 +112,7 @@ export class PlansStep extends Component {
 				comingSoon: 0,
 			} );
 			this.props.goToNextStep();
-		} else if ( flowName === 'link-in-bio' ) {
+		} else if ( flowName === LINK_IN_BIO_FLOW ) {
 			// newsletter flow always uses pub/lettre
 			this.props.submitSignupStep( step, {
 				cartItem,

--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -1,3 +1,4 @@
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
@@ -13,7 +14,7 @@ const useSteps = ( flowName ) => {
 	let steps = [];
 
 	switch ( flowName ) {
-		case 'link-in-bio':
+		case LINK_IN_BIO_FLOW:
 			steps = [
 				{ title: __( 'Great choices. Nearly there!' ) },
 				{ title: __( 'Shining and polishing your Bio' ) },
@@ -21,7 +22,7 @@ const useSteps = ( flowName ) => {
 				{ title: __( 'Looking good. Time for checkout!' ) },
 			];
 			break;
-		case 'newsletter':
+		case NEWSLETTER_FLOW:
 			steps = [
 				{ title: __( 'Excellent choices. Nearly there!' ) },
 				{ title: __( 'Smoothing down the stationery' ) },

--- a/packages/onboarding/src/utils.ts
+++ b/packages/onboarding/src/utils.ts
@@ -1,3 +1,6 @@
+export const NEWSLETTER_FLOW = 'newsletter';
+export const LINK_IN_BIO_FLOW = 'link-in-bio';
+
 export const isNewsletterOrLinkInBioFlow = ( flowName: string ) => {
-	return [ 'newsletter', 'link-in-bio' ].includes( flowName );
+	return [ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW ].includes( flowName );
 };


### PR DESCRIPTION
#### Proposed Changes

* Move flow names we use for checking as constants exported by the onboard package

#### Testing Instructions
* Do sanity testing on the affected places