### PR TITLE
Shopping Cart: add catch to cart actions that might have an error

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -399,6 +399,8 @@ export default function CheckoutMain( {
 			replaceProductInCart( uuidToReplace, {
 				product_slug: newProductSlug,
 				product_id: newProductId,
+			} ).catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
 			} );
 		},
 		[ replaceProductInCart, reduxDispatch ]

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -405,7 +405,9 @@ export class UpsellNudge extends Component {
 				countryCode,
 				postalCode,
 			} );
-			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] );
+			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ).catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 			return;
 		}
 
@@ -419,21 +421,26 @@ export class UpsellNudge extends Component {
 				? null
 				: this.getThankYouPageUrlForIncomingCart( true );
 
-			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ).then( () => {
-				if ( this.props?.cart?.messages ) {
-					const { errors } = this.props.cart.messages;
-					if ( errors && errors.length ) {
-						// Stay on the page to show the relevant error(s)
-						return;
+			this.props.shoppingCartManager
+				.replaceProductsInCart( [ productToAdd ] )
+				.then( () => {
+					if ( this.props?.cart?.messages ) {
+						const { errors } = this.props.cart.messages;
+						if ( errors && errors.length ) {
+							// Stay on the page to show the relevant error(s)
+							return;
+						}
 					}
-				}
 
-				if ( destinationToPersist ) {
-					persistSignupDestination( destinationToPersist );
-				}
+					if ( destinationToPersist ) {
+						persistSignupDestination( destinationToPersist );
+					}
 
-				page( '/checkout/' + siteSlug );
-			} );
+					page( '/checkout/' + siteSlug );
+				} )
+				.catch( () => {
+					// Nothing needs to be done here. CartMessages will display the error to the user.
+				} );
 			return;
 		}
 

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -162,7 +162,9 @@ class DomainSearch extends Component {
 		);
 		if ( productToRemove ) {
 			const uuidToRemove = productToRemove.uuid;
-			this.props.shoppingCartManager.removeProductFromCart( uuidToRemove );
+			this.props.shoppingCartManager.removeProductFromCart( uuidToRemove ).catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 		}
 	}
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -969,7 +969,9 @@ function WPLineItem( {
 							setIsModalVisible( false );
 						} }
 						primaryAction={ () => {
-							removeProductFromCart( product.uuid );
+							removeProductFromCart( product.uuid ).catch( () => {
+								// Nothing needs to be done here. CartMessages will display the error to the user.
+							} );
 							onRemoveProduct?.( label );
 						} }
 						cancelAction={ () => {


### PR DESCRIPTION
#### Proposed Changes

This PR adds a noop `catch()` to every call of `replaceProductsInCart()`, `removeProductFromCart()`, and `replaceProductInCart()` that have no other error handler. This is because if any of those calls fails (eg: due to an invalid product or a validation error), the rejected Promise will bubble up to the console and our error logging systems and neither of those are necessary for these sorts of expected failures. The user will already know about the failure due to the `CartMessages` component.

This is part of https://github.com/Automattic/wp-calypso/issues/67012

#### Testing Instructions

No testing should be required. A visual review of the code should be sufficient.