### PR TITLE
Domains: Always search for suggested query parameter if present

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -158,10 +158,6 @@ class RegisterDomainStep extends Component {
 		if ( props.initialState ) {
 			this.state = { ...this.state, ...props.initialState };
 
-			if ( props.suggestion ) {
-				this.state.lastQuery = props.suggestion;
-			}
-
 			if ( props.initialState.searchResults ) {
 				this.state.loadingResults = false;
 				this.state.searchResults = props.initialState.searchResults;
@@ -180,6 +176,11 @@ class RegisterDomainStep extends Component {
 				this.state.lastQuery = props.initialState.lastQuery;
 			} else {
 				this.state.railcarId = this.getNewRailcarId();
+			}
+
+			// If there's a domain name as a query parameter suggestion, we always search for it first when the page loads
+			if ( props.suggestion ) {
+				this.state.lastQuery = getFixedDomainSearch( props.suggestion );
 			}
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the `RegisterDomainStep` component to use the provided `suggestion` property to search for domains initially. This will only happen the first time the component is loaded.

It solves the following problem:

https://user-images.githubusercontent.com/5324818/187002631-f62629cb-5ee9-42c5-93b0-785c07e6608d.mp4

Steps to reproduce:
- Visit the `wordpress.com/domains` landing page and search for a domain there
- In the domain search page, search for another term
- Go back to the `wordpress.com/domains` page and search for a third term, or, alternatively, just refresh the page
- The previous searched term should load

Apparently the last query term is stored in the Redux store and overrides the suggested term.

#### Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to `/start/domain/domain-only?new=test+search&search=yes`
- Ensure the searched term is "test search"
- Search for another random term
- Go to `/start/domain/domain-only?new=test+search+again&search=yes`
- Ensure the searched term is "test search again"

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
