### PR TITLE
Plugin Management: implement plugin actions on single site view

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -91,13 +91,15 @@ export class PluginActivateToggle extends Component {
 	}
 
 	render() {
-		const { inProgress, site, plugin, disabled, translate, hideLabel } = this.props;
+		const { inProgress, site, plugin, disabled, translate, hideLabel, isJetpackCloud } = this.props;
 
 		if ( ! site ) {
 			return null;
 		}
 
-		if ( plugin && 'jetpack' === plugin.slug ) {
+		const isJetpackPlugin = plugin && 'jetpack' === plugin.slug;
+
+		if ( ! isJetpackCloud && isJetpackPlugin ) {
 			return (
 				<PluginAction
 					className="plugin-activate-toggle"
@@ -109,7 +111,7 @@ export class PluginActivateToggle extends Component {
 		}
 		return (
 			<PluginAction
-				disabled={ disabled }
+				disabled={ disabled || isJetpackPlugin }
 				className="plugin-activate-toggle"
 				label={ translate( 'Active', { context: 'plugin status' } ) }
 				inProgress={ inProgress }

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -94,6 +94,7 @@ export default function PluginManagementV2( {
 		{
 			key: 'update',
 			header: renderBulkActionsHeader(),
+			colSpan: 2,
 		},
 	];
 

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -82,7 +82,6 @@ export default function PluginManagementV2( {
 						key: 'last-updated',
 						header: translate( 'Last updated' ),
 						smallColumn: true,
-						colSpan: 1,
 					},
 			  ]
 			: [
@@ -90,13 +89,11 @@ export default function PluginManagementV2( {
 						key: 'sites',
 						header: translate( 'Sites' ),
 						smallColumn: true,
-						colSpan: 1,
 					},
 			  ] ),
 		{
 			key: 'update',
 			header: renderBulkActionsHeader(),
-			colSpan: 3,
 		},
 	];
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
@@ -37,7 +37,6 @@ export default function PluginCommonTable( {
 								{ column.header }
 							</th>
 						) ) }
-					{ renderActions && <th></th> }
 				</tr>
 			</thead>
 			<tbody>
@@ -54,11 +53,6 @@ export default function PluginCommonTable( {
 								<TextPlaceholder />
 							</td>
 						) ) }
-						{ renderActions && (
-							<td>
-								<TextPlaceholder />
-							</td>
-						) }
 					</tr>
 				) : (
 					items.map( ( item ) => {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getSitesWithSecondarySites } from 'calypso/my-sites/plugins/plugin-management-v2/utils/get-sites-with-secondary-sites';
+import PluginManageConnection from '../plugin-manage-connection';
 import RemovePlugin from '../remove-plugin';
 import SitesList from '../sites-list';
 import type { Plugin } from '../types';
@@ -37,7 +38,7 @@ export default function SitesWithInstalledPluginsList( {
 			key: 'autoupdate',
 			header: translate( 'Autoupdate' ),
 			smallColumn: true,
-			colSpan: 2,
+			colSpan: 3,
 		},
 		{
 			key: 'update',
@@ -55,7 +56,12 @@ export default function SitesWithInstalledPluginsList( {
 	const siteCount = sitesWithSecondarySites.length;
 
 	const renderActions = ( site: SiteDetails ) => {
-		return <RemovePlugin site={ site } plugin={ plugin } />;
+		return (
+			<>
+				<RemovePlugin site={ site } plugin={ plugin } />
+				<PluginManageConnection site={ site } plugin={ plugin } />
+			</>
+		);
 	};
 
 	return (

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { getManageConnectionHref } from 'calypso/lib/plugins/utils';
+import type { Plugin } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { ReactElement } from 'react';
+
+import '../style.scss';
+
+interface Props {
+	site: SiteDetails;
+	plugin: Plugin;
+}
+
+export default function PluginManageConnection( { site, plugin }: Props ): ReactElement | null {
+	const translate = useTranslate();
+
+	const isJetpackPlugin = plugin && 'jetpack' === plugin.slug;
+
+	return isJetpackPlugin ? (
+		<PopoverMenuItem
+			className="plugin-management-v2__actions"
+			icon="cog"
+			href={ getManageConnectionHref( site.slug ) }
+		>
+			{ translate( 'Manage Connection', {
+				comment: 'manage Jetpack connnection settings link',
+			} ) }
+		</PopoverMenuItem>
+	) : null;
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -126,6 +126,7 @@ export default function PluginRowFormatter( {
 				canActivate && (
 					<div className="plugin-row-formatter__toggle">
 						<PluginActivateToggle
+							isJetpackCloud
 							hideLabel={ ! isSmallScreen }
 							plugin={ pluginOnSite }
 							site={ selectedSite }

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PluginCommonList from '../plugin-common/plugin-common-list';
+import PluginManageConnection from '../plugin-manage-connection';
 import PluginRowFormatter from '../plugin-row-formatter';
 import RemovePlugin from '../remove-plugin';
 import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
@@ -8,6 +9,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
 
 import '../style.scss';
+
 interface Props {
 	selectedSite: SiteDetails;
 	items: Array< Plugin >;
@@ -33,7 +35,12 @@ export default function PluginsList( { selectedSite, ...rest }: Props ): ReactEl
 				>
 					{ translate( 'Manage Plugin' ) }
 				</PopoverMenuItem>
-				{ selectedSite && <RemovePlugin site={ selectedSite } plugin={ plugin } /> }
+				{ selectedSite && (
+					<>
+						<RemovePlugin site={ selectedSite } plugin={ plugin } />
+						<PluginManageConnection site={ selectedSite } plugin={ plugin } />
+					</>
+				) }
 			</>
 		);
 	};

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -1,9 +1,13 @@
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PluginCommonList from '../plugin-common/plugin-common-list';
 import PluginRowFormatter from '../plugin-row-formatter';
+import RemovePlugin from '../remove-plugin';
 import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
 
+import '../style.scss';
 interface Props {
 	selectedSite: SiteDetails;
 	items: Array< Plugin >;
@@ -13,8 +17,25 @@ interface Props {
 }
 
 export default function PluginsList( { selectedSite, ...rest }: Props ): ReactElement {
+	const translate = useTranslate();
+
 	const rowFormatter = ( props: PluginRowFormatterArgs ) => {
 		return <PluginRowFormatter { ...props } selectedSite={ selectedSite } />;
+	};
+
+	const renderActions = ( plugin: Plugin ) => {
+		return (
+			<>
+				<PopoverMenuItem
+					className="plugin-management-v2__actions"
+					icon="chevron-right"
+					href={ `/plugins/${ plugin.slug }${ selectedSite ? `/${ selectedSite.domain }` : '' }` }
+				>
+					{ translate( 'Manage Plugin' ) }
+				</PopoverMenuItem>
+				{ selectedSite && <RemovePlugin site={ selectedSite } plugin={ plugin } /> }
+			</>
+		);
 	};
 
 	return (
@@ -23,6 +44,7 @@ export default function PluginsList( { selectedSite, ...rest }: Props ): ReactEl
 			selectedSite={ selectedSite }
 			rowFormatter={ rowFormatter }
 			primaryKey="id"
+			renderActions={ renderActions }
 		/>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

This PR

- Adds actions such as `Manage Plugin` and `Remove` to single-site plugins view
- Moves the` Manage connection` link as an action instead of a link in the **Active** column for Jetpack Plugin

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-single-site-plugin-actions` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3.  Click on **Switch Site** -> Select any site -> Click on **Plugins** -> Click on `...` on any plugin, verify that the actions appear below and all the actions work as expected.

For Jetpack plugin, notice the Activate toggle is disabled.

<img width="1385" alt="Screenshot 2022-08-29 at 11 50 42 AM" src="https://user-images.githubusercontent.com/10586875/187136590-2a280178-8dde-4657-9256-f11a4e547f52.png">

For other plugins

<img width="1411" alt="Screenshot 2022-08-29 at 11 56 42 AM" src="https://user-images.githubusercontent.com/10586875/187136636-046a1638-5219-4c3e-b176-8d4122ae5a60.png">

Plugin details page(Jetpack plugin)

<img width="1379" alt="Screenshot 2022-08-29 at 11 51 33 AM" src="https://user-images.githubusercontent.com/10586875/187136808-acf05484-5b5e-4471-ab2f-ed8397f39f66.png">

> **_NOTE:_** Actions for plugins in multi-site will be added in the upcoming PR.

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202855142002324 & 1202518759611394-as-1202880761044117