### PR TITLE
Plugins Browser: fix overflowing plugin cards.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -30,18 +30,19 @@
 	}
 }
 
-.plugins-browser__clear-filters, .plugins-browser__clear-filters:visited {
+.plugins-browser__clear-filters,
+.plugins-browser__clear-filters:visited {
 	text-decoration: underline;
 	color: var( --studio-black );
 }
 
 .plugins-browser__no-results {
-	@include breakpoint-deprecated('<660px') {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 16px;
 	}
 }
 .plugins-browser__main-container {
-	display: inline-block;
+	display: contents;
 
 	&::before {
 		box-sizing: border-box;


### PR DESCRIPTION
#### Proposed Changes

This issue https://github.com/Automattic/wp-calypso/pull/66884 attempted to fix the spacing around the upgrade banner. On the meantime though it create a problem for plugin searches that resulted in Plugins with long titles.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|<img width="1600" alt="CleanShot 2022-08-29 at 11 58 22@2x" src="https://user-images.githubusercontent.com/12430020/187164417-cac7dfe3-058d-4820-94f5-d269a0539765.png">|<img width="1596" alt="CleanShot 2022-08-29 at 12 00 36@2x" src="https://user-images.githubusercontent.com/12430020/187164860-2b8f6c30-ce8c-41b4-b2fa-2ce2fd9c0450.png">|

**In Production**
* Go to https://wordpress.com/plugins?s=ecommerce
* Inspect how the UI overflows
<img width="1600" alt="CleanShot 2022-08-29 at 11 58 22@2x" src="https://user-images.githubusercontent.com/12430020/187164417-cac7dfe3-058d-4820-94f5-d269a0539765.png">

**In this branch**
* Go to https://wordpress.com/plugins?s=ecommerce
* Inspect that the UI is contained in the box
* Clear search and switch to a free site, inspect that upgrade banner has spacing on the top

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
