### PR TITLE
`Concierge(Main)`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -1,11 +1,20 @@
-jest.mock( '../shared/upsell', () => 'Upsell' );
-jest.mock( '../shared/no-available-times', () => 'NoAvailableTimes' );
+/** @jest-environment jsdom */
+jest.mock( '../shared/upsell', () => () => <div data-testid="upsell" /> );
+jest.mock( '../shared/no-available-times', () => () => <div data-testid="no-available-times" /> );
+jest.mock( 'calypso/me/reauth-required', () => () => null );
 
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ConciergeMain } from '../main';
 
+const render = ( el, options ) => renderWithProvider( el, { ...options, reducers: { ui } } );
+
+const StepOne = () => <div data-testid="step-1" />;
+const Skeleton = () => <div data-testid="skeleton" />;
+
 const props = {
-	steps: [ 'Step1' ],
+	steps: [ StepOne ],
 	availableTimes: [
 		1541506500000, 1541508300000, 1541510100000, 1541511900000, 1541513700000, 1541515500000,
 		1541516400000,
@@ -14,56 +23,56 @@ const props = {
 		plan: {},
 	},
 	userSettings: {},
-	skeleton: 'Skeleton',
+	skeleton: Skeleton,
+	analyticsPath: '/arbitrary/analytics-path',
+	analyticsTitle: 'arbitrary analytics title',
 };
 
 describe( 'ConciergeMain basic tests', () => {
 	test( 'should not blow up', () => {
-		const comp = shallow( <ConciergeMain { ...props } /> );
-		expect( comp.find( 'Main' ) ).toHaveLength( 1 );
+		render( <ConciergeMain { ...props } /> );
+		expect( screen.getByRole( 'main' ) ).toBeVisible();
 	} );
 
 	test( 'should short-circuit to <Skeleton /> when data is insufficient to render anything else', () => {
-		let comp;
+		const { rerender } = render( <ConciergeMain { ...props } availableTimes={ null } /> );
+		expect( screen.queryByTestId( 'skeleton' ) ).toBeVisible();
 
-		comp = shallow( <ConciergeMain { ...props } availableTimes={ null } /> );
-		expect( comp.find( 'Skeleton' ) ).toHaveLength( 1 );
+		rerender( <ConciergeMain { ...props } site={ null } /> );
+		expect( screen.queryByTestId( 'skeleton' ) ).toBeVisible();
 
-		comp = shallow( <ConciergeMain { ...props } site={ null } /> );
-		expect( comp.find( 'Skeleton' ) ).toHaveLength( 1 );
+		rerender( <ConciergeMain { ...props } site={ { plan: null } } /> );
+		expect( screen.queryByTestId( 'skeleton' ) ).toBeVisible();
 
-		comp = shallow( <ConciergeMain { ...props } site={ { plan: null } } /> );
-		expect( comp.find( 'Skeleton' ) ).toHaveLength( 1 );
-
-		comp = shallow( <ConciergeMain { ...props } userSettings={ null } /> );
-		expect( comp.find( 'Skeleton' ) ).toHaveLength( 1 );
+		rerender( <ConciergeMain { ...props } userSettings={ null } /> );
+		expect( screen.queryByTestId( 'skeleton' ) ).toBeVisible();
 	} );
 } );
 
 describe( 'ConciergeMain.render()', () => {
 	test( 'Should render upsell for non-eligible users', () => {
-		const comp = shallow( <ConciergeMain { ...props } scheduleId={ 0 } /> );
-		expect( comp.find( 'Upsell' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Step1' ) ).toHaveLength( 0 );
+		render( <ConciergeMain { ...props } scheduleId={ 0 } /> );
+		expect( screen.queryByTestId( 'upsell' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'step-1' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'Should render NoAvailableTimes if no times are available.', () => {
 		const propsWithoutAvailableTimes = { ...props, availableTimes: [] };
-		const comp = shallow(
+		render(
 			<ConciergeMain
 				{ ...propsWithoutAvailableTimes }
 				scheduleId={ 1 }
 				site={ { plan: { product_slug: 'a-plan' } } }
 			/>
 		);
-		expect( comp.find( 'NoAvailableTimes' ) ).toHaveLength( 1 );
+		expect( screen.queryByTestId( 'no-available-times' ) ).toBeVisible();
 	} );
 
 	test( 'Should render CurrentStep for eligible users', () => {
-		const comp = shallow(
+		render(
 			<ConciergeMain { ...props } scheduleId={ 1 } site={ { plan: { product_slug: 'a-plan' } } } />
 		);
-		expect( comp.find( 'Upsell' ) ).toHaveLength( 0 );
-		expect( comp.find( 'Step1' ) ).toHaveLength( 1 );
+		expect( screen.queryByTestId( 'upsell' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'step-1' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `Concierge(Main)`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 
