### PR TITLE
Tailored flows: remove post-checkout plan upsell

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -26,6 +26,7 @@ import {
 	getUrlParts,
 	getUrlFromParts,
 } from '@automattic/calypso-url';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
 import {
 	getGoogleApps,
@@ -285,16 +286,20 @@ export default function getThankYouPageUrl( {
 		return newBlogReceiptUrl;
 	}
 
-	const redirectUrlForPostCheckoutUpsell = receiptIdOrPlaceholder
-		? getRedirectUrlForPostCheckoutUpsell( {
-				receiptId: receiptIdOrPlaceholder,
-				cart,
-				siteSlug,
-				hideUpsell: Boolean( hideNudge ),
-				domains,
-				isDomainOnly,
-		  } )
-		: undefined;
+	// disable upsell for tailored signup users
+	const isTailoredSignup = isNewsletterOrLinkInBioFlow( signupFlowName );
+
+	const redirectUrlForPostCheckoutUpsell =
+		! isTailoredSignup && receiptIdOrPlaceholder
+			? getRedirectUrlForPostCheckoutUpsell( {
+					receiptId: receiptIdOrPlaceholder,
+					cart,
+					siteSlug,
+					hideUpsell: Boolean( hideNudge ),
+					domains,
+					isDomainOnly,
+			  } )
+			: undefined;
 
 	if ( redirectUrlForPostCheckoutUpsell ) {
 		debug(

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -16,6 +16,7 @@ import {
 	TITAN_MAIL_MONTHLY_SLUG,
 	WPCOM_DIFM_LITE,
 } from '@automattic/calypso-products';
+import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
@@ -1570,6 +1571,36 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 			} );
 			expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
+		} );
+
+		it( 'Does not offers discounted annual business plan for tailored flows (https://wp.me/p58i-cBr).', () => {
+			[ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW ].forEach( ( flowName ) => {
+				const getUrlFromCookie = jest.fn( () => '/cookie' );
+
+				// set a tailored flow name
+				sessionStorage.setItem( 'wpcom_signup_complete_flow_name', flowName );
+
+				const cart = {
+					...getEmptyResponseCart(),
+					products: [
+						{
+							...getEmptyResponseCartProduct(),
+							product_slug: 'value_bundle',
+							bill_period: '365',
+						},
+					],
+				};
+				const url = getThankYouPageUrl( {
+					...defaultArgs,
+					getUrlFromCookie,
+					cart,
+				} );
+
+				expect( url ).toBe( `/cookie?notice=purchase-success` );
+
+				// clean up the tailored flow name
+				sessionStorage.removeItem( 'wpcom_signup_complete_flow_name' );
+			} );
 		} );
 	} );
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -113,7 +113,7 @@ export class PlansStep extends Component {
 			} );
 			this.props.goToNextStep();
 		} else if ( flowName === LINK_IN_BIO_FLOW ) {
-			// newsletter flow always uses pub/lettre
+			// link-in-bio flow always uses pub/lynx
 			this.props.submitSignupStep( step, {
 				cartItem,
 				themeSlugWithRepo: 'pub/lynx',

--- a/packages/onboarding/src/utils.ts
+++ b/packages/onboarding/src/utils.ts
@@ -1,6 +1,6 @@
 export const NEWSLETTER_FLOW = 'newsletter';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
 
-export const isNewsletterOrLinkInBioFlow = ( flowName: string ) => {
-	return [ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW ].includes( flowName );
+export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
#### Proposed Changes

* Remove post-checkout upsell for tailored flows. 

#### Testing Instructions

1. Go to /setup?flow=link-in-bio.
2. Go through setup and make sure to pick a premium plan.
3. After checkout, you should **not** see the upset shown in https://github.com/Automattic/wp-calypso/issues/66967.
4. Repeat for /setup?flow=newsletter.
5. Expect the same result.

#### Regression testing
1. Go to /start.
2. Pick premium plan.
3. You **should** see the upsell after checkout.

Fixes #66967