### PR TITLE
Update/improve subscribers form

### DIFF
--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -263,6 +263,7 @@
 		font-size: $font-body-extra-small;
 		font-weight: 400;
 		line-height: 20px;
+		margin: 1rem 0;
 
 		svg {
 			margin-right: 6px;

--- a/packages/subscriber/src/components/add-form/icon.tsx
+++ b/packages/subscriber/src/components/add-form/icon.tsx
@@ -1,0 +1,7 @@
+export const tip = (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<circle cx="12" cy="9" r="5" stroke="#A7AAAD" strokeWidth="1.42857" />
+		<line x1="9" y1="16.8818" x2="15" y2="16.8818" stroke="#A7AAAD" strokeWidth="1.5" />
+		<line x1="10" y1="19.25" x2="14" y2="19.25" stroke="#A7AAAD" strokeWidth="1.5" />
+	</svg>
+);

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -49,12 +49,19 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	/**
 	 * ↓ Fields
 	 */
+	const emailControlMaxNum = 10;
+	const emailControlPlaceholder = [
+		__( 'sibling@email.com' ),
+		__( 'parents@email.com' ),
+		__( 'friend@email.com' ),
+	];
 	const inProgress = useInProgressState();
 	const prevInProgress = useRef( inProgress );
 	const [ selectedFile, setSelectedFile ] = useState< File >();
 	const [ isSelectedFileValid, setIsSelectedFileValid ] = useState( true );
 	const [ emails, setEmails ] = useState< string[] >( [] );
 	const [ isValidEmails, setIsValidEmails ] = useState< boolean[] >( [] );
+	const [ emailFormControls, setEmailFormControls ] = useState( emailControlPlaceholder );
 	const [ formFileUploadElement ] = useState(
 		createElement( FormFileUpload, { name: 'import', onChange: onFileInputChange } )
 	);
@@ -75,6 +82,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}, [ inProgress ] );
 	// run active job recognition process which updates state
 	useActiveJobRecognition( siteId );
+	useEffect( extendEmailFormControls, [ emails ] );
 
 	! inProgress && prevInProgress.current && onImportFinished?.();
 
@@ -138,6 +146,21 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		setSelectedFile( undefined );
 	}
 
+	function extendEmailFormControls() {
+		const validEmailsNum = isValidEmails.filter( ( x ) => x ).length;
+		const currentEmailFormControlsNum = emailFormControls.length;
+
+		if (
+			currentEmailFormControlsNum <= emailControlMaxNum &&
+			currentEmailFormControlsNum === validEmailsNum
+		) {
+			const controls = Array.from( emailFormControls );
+			controls.push( __( 'Add another email' ) );
+
+			setEmailFormControls( controls );
+		}
+	}
+
 	/**
 	 * ↓ Templates
 	 */
@@ -154,24 +177,15 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 				) }
 
 				<form onSubmit={ onFormSubmit }>
-					<TextControl
-						placeholder={ __( 'sibling@email.com' ) }
-						value={ emails[ 0 ] || '' }
-						help={ isValidEmails[ 0 ] ? <Icon icon={ check } /> : undefined }
-						onChange={ ( value ) => onEmailChange( value, 0 ) }
-					/>
-					<TextControl
-						placeholder={ __( 'parents@email.com' ) }
-						value={ emails[ 1 ] || '' }
-						help={ isValidEmails[ 1 ] ? <Icon icon={ check } /> : undefined }
-						onChange={ ( value ) => onEmailChange( value, 1 ) }
-					/>
-					<TextControl
-						placeholder={ __( 'friend@email.com' ) }
-						value={ emails[ 2 ] || '' }
-						help={ isValidEmails[ 2 ] ? <Icon icon={ check } /> : undefined }
-						onChange={ ( value ) => onEmailChange( value, 2 ) }
-					/>
+					{ emailFormControls.map( ( placeholder, i ) => (
+						<TextControl
+							placeholder={ placeholder }
+							key={ i }
+							value={ emails[ i ] || '' }
+							help={ isValidEmails[ i ] ? <Icon icon={ check } /> : undefined }
+							onChange={ ( value ) => onEmailChange( value, i ) }
+						/>
+					) ) }
 
 					{ ! isSelectedFileValid && (
 						<label className={ 'add-subscriber__form-label-error' }>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -6,7 +6,7 @@ import { TextControl, FormFileUpload, Button, Notice } from '@wordpress/componen
 import { useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, check, info } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import React, {
@@ -221,18 +221,16 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					) }
 
 					{ ! isSelectedFileValid && (
-						<label className={ 'add-subscriber__form-label-error' }>
+						<FormInputValidation isError={ true } text={ '' }>
 							{ createInterpolateElement(
 								__(
-									'<span><icon /> Sorry, you can only upload a CSV file.</span><uploadBtn>Select another file</uploadBtn>'
+									'Sorry, you can only upload CSV files right now. ' +
+										'Most providers will let you export this from your settings. ' +
+										'<uploadBtn>Select another file</uploadBtn>'
 								),
-								{
-									span: createElement( 'span' ),
-									icon: createElement( Icon, { icon: info, size: 20 } ),
-									uploadBtn: formFileUploadElement,
-								}
+								{ uploadBtn: formFileUploadElement }
 							) }
-						</label>
+						</FormInputValidation>
 					) }
 
 					{ isSelectedFileValid && selectedFile && (

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -63,6 +63,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ isSelectedFileValid, setIsSelectedFileValid ] = useState( true );
 	const [ emails, setEmails ] = useState< string[] >( [] );
 	const [ isValidEmails, setIsValidEmails ] = useState< boolean[] >( [] );
+	const [ isDirtyEmails, setIsDirtyEmails ] = useState< boolean[] >( [] );
 	const [ emailFormControls, setEmailFormControls ] = useState( emailControlPlaceholder );
 	const [ formFileUploadElement ] = useState(
 		createElement( FormFileUpload, { name: 'import', onChange: onFileInputChange } )
@@ -123,6 +124,12 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		setIsValidEmails( _isValidEmails );
 	}
 
+	function setIsDirtyEmail( value: string, index: number ) {
+		const _isDirtyEmails = Array.from( isDirtyEmails );
+		_isDirtyEmails[ index ] = !! value;
+		setIsDirtyEmails( _isDirtyEmails );
+	}
+
 	function isValidExtension( fileName: string ) {
 		const extensionRgx = new RegExp( /[^\\]*\.(?<extension>\w+)$/ );
 		const validExtensions = [ 'csv' ];
@@ -179,15 +186,30 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 				) }
 
 				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>
-					{ emailFormControls.map( ( placeholder, i ) => (
-						<TextControl
-							placeholder={ placeholder }
-							key={ i }
-							value={ emails[ i ] || '' }
-							help={ isValidEmails[ i ] ? <Icon icon={ check } /> : undefined }
-							onChange={ ( value ) => onEmailChange( value, i ) }
-						/>
-					) ) }
+					{ emailFormControls.map( ( placeholder, i ) => {
+						const showError = isDirtyEmails[ i ] && ! isValidEmails[ i ] && emails[ i ];
+
+						return (
+							<>
+								<TextControl
+									className={ showError ? 'is-error' : '' }
+									placeholder={ placeholder }
+									key={ i }
+									value={ emails[ i ] || '' }
+									help={ isValidEmails[ i ] ? <Icon icon={ check } /> : undefined }
+									onChange={ ( value ) => onEmailChange( value, i ) }
+									onBlur={ () => setIsDirtyEmail( emails[ i ], i ) }
+								/>
+
+								{ showError && (
+									<FormInputValidation
+										isError={ true }
+										text={ __( 'The format of the email is invalid' ) }
+									/>
+								) }
+							</>
+						);
+					} ) }
 
 					{ emailControlMaxNum === isValidEmails.filter( ( x ) => x ).length && (
 						<FormInputValidation icon={ 'tip' } isError={ false } isWarning={ true } text={ '' }>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -53,9 +53,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	 */
 	const emailControlMaxNum = 10;
 	const emailControlPlaceholder = [
-		__( 'sibling@email.com' ),
-		__( 'parents@email.com' ),
-		__( 'friend@email.com' ),
+		__( 'sibling@example.com' ),
+		__( 'parents@example.com' ),
+		__( 'friend@example.com' ),
 	];
 	const inProgress = useInProgressState();
 	const prevInProgress = useRef( inProgress );

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, NextButton, SkipButton } from '@automattic/onboarding';
 import { TextControl, FormFileUpload, Button, Notice } from '@wordpress/components';
@@ -19,6 +20,7 @@ import React, {
 import { useActiveJobRecognition } from '../../hooks/use-active-job-recognition';
 import { useInProgressState } from '../../hooks/use-in-progress-state';
 import { SUBSCRIBER_STORE } from '../../store';
+import { tip } from './icon';
 import './style.scss';
 
 interface Props {
@@ -151,7 +153,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		const currentEmailFormControlsNum = emailFormControls.length;
 
 		if (
-			currentEmailFormControlsNum <= emailControlMaxNum &&
+			currentEmailFormControlsNum < emailControlMaxNum &&
 			currentEmailFormControlsNum === validEmailsNum
 		) {
 			const controls = Array.from( emailFormControls );
@@ -186,6 +188,15 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 							onChange={ ( value ) => onEmailChange( value, i ) }
 						/>
 					) ) }
+
+					{ emailControlMaxNum === isValidEmails.filter( ( x ) => x ).length && (
+						<FormInputValidation icon={ 'tip' } isError={ false } isWarning={ true } text={ '' }>
+							<Icon icon={ tip } />
+							{ __(
+								'Nice start there! If you have more subscribers to add, we’ll help you get them added later.'
+							) }
+						</FormInputValidation>
+					) }
 
 					{ ! isSelectedFileValid && (
 						<label className={ 'add-subscriber__form-label-error' }>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -178,7 +178,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					<Notice isDismissible={ false }>{ __( 'You have email list importing' ) }...</Notice>
 				) }
 
-				<form onSubmit={ onFormSubmit }>
+				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>
 					{ emailFormControls.map( ( placeholder, i ) => (
 						<TextControl
 							placeholder={ placeholder }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -66,7 +66,11 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ isDirtyEmails, setIsDirtyEmails ] = useState< boolean[] >( [] );
 	const [ emailFormControls, setEmailFormControls ] = useState( emailControlPlaceholder );
 	const [ formFileUploadElement ] = useState(
-		createElement( FormFileUpload, { name: 'import', onChange: onFileInputChange } )
+		createElement( FormFileUpload, {
+			name: 'import',
+			onChange: onFileInputChange,
+			disabled: inProgress,
+		} )
 	);
 
 	/**
@@ -79,10 +83,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	useEffect( () => {
 		getSubscribersImports( siteId );
 	}, [] );
-	// reset form when add/import starts
-	useEffect( () => {
-		inProgress && resetForm();
-	}, [ inProgress ] );
 	// run active job recognition process which updates state
 	useActiveJobRecognition( siteId );
 	useEffect( extendEmailFormControls, [ emails ] );
@@ -149,12 +149,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		isValid && setSelectedFile( file );
 	}
 
-	function resetForm() {
-		setEmails( [] );
-		setIsValidEmails( [] );
-		setSelectedFile( undefined );
-	}
-
 	function extendEmailFormControls() {
 		const validEmailsNum = isValidEmails.filter( ( x ) => x ).length;
 		const currentEmailFormControlsNum = emailFormControls.length;
@@ -190,11 +184,11 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						const showError = isDirtyEmails[ i ] && ! isValidEmails[ i ] && emails[ i ];
 
 						return (
-							<>
+							<div key={ i }>
 								<TextControl
 									className={ showError ? 'is-error' : '' }
+									disabled={ inProgress }
 									placeholder={ placeholder }
-									key={ i }
 									value={ emails[ i ] || '' }
 									help={ isValidEmails[ i ] ? <Icon icon={ check } /> : undefined }
 									onChange={ ( value ) => onEmailChange( value, i ) }
@@ -207,7 +201,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 										text={ __( 'The format of the email is invalid' ) }
 									/>
 								) }
-							</>
+							</div>
 						);
 					} ) }
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -182,7 +182,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 			<div className={ 'add-subscriber__form--container' }>
 				{ inProgress && (
-					<Notice isDismissible={ false }>{ __( 'You have email list importing' ) }...</Notice>
+					<Notice isDismissible={ false }>{ __( 'Your email list is being uploaded' ) }...</Notice>
 				) }
 
 				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -99,6 +99,10 @@
 		}
 	}
 
+	.components-base-control.is-error input {
+		border-color: var( --color-error-dark );
+	}
+
 	.components-base-control__field {
 		margin: 1rem auto;
 	}

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -54,6 +54,25 @@
 	}
 }
 
+.add-subscriber .add-subscriber__form--container label,
+.add-subscriber .add-subscriber__form--container .form-input-validation {
+	.components-base-control__field {
+		margin: 0.5rem auto;
+	}
+
+	.components-button {
+		height: auto;
+		padding: 0;
+		font-size: 1em; /* stylelint-disable-line */
+		color: var( --color-text );
+		text-decoration: underline;
+
+		&:hover {
+			color: var( --color-text-subtle );
+		}
+	}
+}
+
 .add-subscriber .add-subscriber__form--container {
 	max-width: 368px;
 
@@ -64,43 +83,15 @@
 		line-height: 1.25rem;
 		margin: 0.75rem 0 1.5rem;
 
-		.components-base-control__field {
-			margin: 0.5rem auto;
-		}
-
-		.components-button {
-			height: auto;
-			padding: 0;
-			font-size: 1em; /* stylelint-disable-line */
-			color: var( --color-text );
-			text-decoration: underline;
-
-			&:hover {
-				color: var( --color-text-subtle );
-			}
-		}
-
 		&.add-subscriber__form-label-links {
 			.components-button {
 				margin: 0 0.2rem;
 			}
 		}
-
-		&.add-subscriber__form-label-error {
-			span, svg {
-				color: var( --color-error );
-				fill: var( --color-error );
-			}
-
-			svg {
-				position: relative;
-				top: 4px;
-			}
-		}
 	}
 
 	.components-base-control.is-error input {
-		border-color: var( --color-error-dark );
+		border-color: var( --color-error );
 	}
 
 	.components-base-control__field {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -148,6 +148,22 @@
 		}
 	}
 
+	.form-input-validation {
+		padding: 0;
+		padding-inline-start: 2rem;
+		padding-inline-end: 0;
+		margin-bottom: 1.5rem;
+
+		svg {
+			position: absolute;
+			margin-inline-start: -2rem;
+		}
+
+		&.is-warning {
+			color: var( --studio-gray-40 );
+		}
+	}
+
 	.add-subscriber__form--disclaimer {
 		font-size: 0.875rem;
 		line-height: 1.25rem;

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -74,6 +74,10 @@
 			font-size: 1em; /* stylelint-disable-line */
 			color: var( --color-text );
 			text-decoration: underline;
+
+			&:hover {
+				color: var( --color-text-subtle );
+			}
 		}
 
 		&.add-subscriber__form-label-links {


### PR DESCRIPTION
#### Proposed Changes

* Improved UX to dynamically add email form controls. It is limited to 10 controls.
* Turned off form field autocomplete
* Added validation error messages
* Updated hover style for the "Upload CSV" button
* Adjusted style of step container footer (Jetpack powered)
* Preserved the form data while importing is in progress

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/subscribers?flow=newsletter&complete-setup=true&siteSlug={SLUG}
* Check out described changes

#### Screenshot
<table>
<tr>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/187221607-d3d2ff31-b64a-4076-892c-28bb605181cf.gif" />
</td><td>
Form validation errors:
<img width="446" alt="Screenshot 2022-08-30 at 11 00 44" src="https://user-images.githubusercontent.com/1241413/187396370-cadd36f5-805e-4df4-a0fd-52c17f2fcc9a.png">

</td></tr>
<tr>
<td>
Before:
<img width="389" alt="Screenshot 2022-08-29 at 16 29 17" src="https://user-images.githubusercontent.com/1241413/187225302-6f16f924-b65e-49d0-8068-fdef69c3e52c.png">
</td>
<td>
After:
<img width="388" alt="Screenshot 2022-08-29 at 16 29 26" src="https://user-images.githubusercontent.com/1241413/187225321-2d218c13-b2fa-4ab5-bcb6-dcb223179e0a.png">
</td>
</tr>
<tr>
<td>
Before:
<img width="425" alt="Screenshot 2022-08-30 at 11 56 31" src="https://user-images.githubusercontent.com/1241413/187409095-b0a03cd7-d351-4466-9873-32c8d7d3802b.png">
</td>
<td>
After:
<img width="457" alt="Screenshot 2022-08-30 at 11 55 43" src="https://user-images.githubusercontent.com/1241413/187409168-9813ec0f-7dba-4f61-869d-e79d39cf31e5.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #67080
Closes #67099
Closes #67082
Closes #67149
Closes #67083
Closes #67081
Closes #67086