### PR TITLE
Design and copy changes for domain step

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -75,6 +75,12 @@
 	.is-right-align & {
 		padding: 0;
 	}
+
+	.tailored-flow-subtitle__cta-text {
+		text-decoration: underline;
+		cursor: pointer;
+		color: var( --studio-gray-80 );
+	}
 }
 
 // Compact header on small screens

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,3 +1,4 @@
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
@@ -606,7 +607,7 @@ class DomainsStep extends Component {
 			return translate( 'Find the domain that defines you' );
 		}
 
-		if ( this.isTailoredFlow() ) {
+		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			const components = {
 				span: (
 					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -606,6 +606,28 @@ class DomainsStep extends Component {
 			return translate( 'Find the domain that defines you' );
 		}
 
+		if ( this.isTailoredFlow() ) {
+			const components = {
+				span: (
+					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
+					<span
+						role="button"
+						class="tailored-flow-subtitle__cta-text"
+						onClick={ this.handleDomainExplainerClick }
+					/>
+				),
+			};
+			return flowName === 'newsletter'
+				? translate(
+						'Help your Newsletter stand out with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
+						{ components }
+				  )
+				: translate(
+						'Set your Link in Bio apart with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
+						{ components }
+				  );
+		}
+
 		if ( isReskinned ) {
 			return ! stepSectionName && translate( 'Enter some descriptive keywords to get started' );
 		}
@@ -646,6 +668,10 @@ class DomainsStep extends Component {
 		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
+	isTailoredFlow() {
+		return [ 'newsletter', 'link-in-bio' ].includes( this.props.flowName );
+	}
+
 	renderContent() {
 		let content;
 		let sideContent;
@@ -658,7 +684,7 @@ class DomainsStep extends Component {
 			content = this.domainForm();
 		}
 
-		if ( ! this.props.stepSectionName && this.props.isReskinned ) {
+		if ( ! this.props.stepSectionName && this.props.isReskinned && ! this.isTailoredFlow() ) {
 			sideContent = this.getSideContent();
 		}
 


### PR DESCRIPTION
## Proposed Changes

Change text for sub-header and removes side content for for tailored flows.

## Testing Instructions

- Pull this branch and run yarn start
- Navigate to http://calypso.localhost:3000/setup/intro?flow=link-in-bio or http://calypso.localhost:3000/setup/intro?flow=newsletter and go further until the Domain step.
- Sub titles should be like bellow 
- No side content should be visible
- Test also other flows ( not tailored )

<img width="602" alt="image" src="https://user-images.githubusercontent.com/2653810/187240279-8b5ba23d-10dd-4988-968c-95a05698457b.png">

<img width="775" alt="image" src="https://user-images.githubusercontent.com/2653810/187240366-9541aa36-06ef-48f3-9605-7867fcff3c35.png">

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/2653810/187240397-52d8b9ac-93f4-4b20-a5b6-b97dc12ea11e.png">

