### PR TITLE
Launch WPCOM SSH: Enable production feature flag

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,
-		"launch-wpcom-ssh": false,
+		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,


### PR DESCRIPTION
See #66578

## Proposed Changes

Enables `launch-wpcom-ssh` for production.

## Testing Instructions

After deploy, turn off proxy and verify the "Enable SSH access" toggle is available in production.