### PR TITLE
Launchpad: Make Choose a Plan task dynamic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -26,7 +26,9 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				<p className={ `launchpad__checklist-item-text ${ isCompleted && 'is-complete' }` }>
 					{ title }
 				</p>
-				{ task.displayBadge ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
+				{ task.displayBadge && task.badgeText ? (
+					<Badge type="info-blue">{ task.badgeText }</Badge>
+				) : null }
 				{ ! task.isCompleted && (
 					<Gridicon
 						className="launchpad__checklist-item-chevron"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -5,7 +5,6 @@ import { Task } from './types';
 
 const ChecklistItem = ( { task }: { task: Task } ) => {
 	const { id, isCompleted, actionUrl, title } = task;
-
 	return (
 		<li className={ `launchpad__task-${ id }` }>
 			<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -1,23 +1,16 @@
 import { Button, Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
-import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import Badge from 'calypso/components/badge';
 import { Task } from './types';
 
-interface ChecklistItemProps {
-	task: Task;
-	site: SiteDetails | null;
-}
-
-const ChecklistItem = ( { task, site }: ChecklistItemProps ) => {
+const ChecklistItem = ( { task }: { task: Task } ) => {
 	const { id, isCompleted, actionUrl, title } = task;
-	const isFreePlan = task.id === 'plan_selected' && site?.plan?.product_slug === 'free_plan';
 
 	return (
 		<li className={ `launchpad__task-${ id }` }>
 			<Button
-				className={ `launchpad__checklist-item ${ isCompleted && 'is-complete' }` }
-				disabled={ task.isCompleted && ! isFreePlan }
+				className="launchpad__checklist-item"
+				disabled={ task.isCompleted }
 				href={ actionUrl }
 				data-task={ id }
 			>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -1,15 +1,23 @@
 import { Button, Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
+import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import Badge from 'calypso/components/badge';
 import { Task } from './types';
 
-const ChecklistItem = ( { task }: { task: Task } ) => {
+interface ChecklistItemProps {
+	task: Task;
+	site: SiteDetails | null;
+}
+
+const ChecklistItem = ( { task, site }: ChecklistItemProps ) => {
 	const { id, isCompleted, actionUrl, title } = task;
+	const isFreePlan = task.id === 'plan_selected' && site?.plan?.product_slug === 'free_plan';
+
 	return (
 		<li className={ `launchpad__task-${ id }` }>
 			<Button
-				className="launchpad__checklist-item"
-				disabled={ task.isCompleted }
+				className={ `launchpad__checklist-item ${ isCompleted && 'is-complete' }` }
+				disabled={ task.isCompleted && ! isFreePlan }
 				href={ actionUrl }
 				data-task={ id }
 			>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -1,24 +1,27 @@
+import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import ChecklistItem from './checklist-item';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { Task } from './types';
 
-const Checklist = ( {
-	tasks,
-	siteSlug,
-	flow,
-}: {
+interface ChecklistProps {
 	tasks: Task[];
+	site: SiteDetails | null;
 	siteSlug: string | null;
 	flow: string | null;
-} ) => {
+}
+
+const Checklist = ( { tasks, site, siteSlug, flow }: ChecklistProps ) => {
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
 
-	const enhancedTasks = arrayOfFilteredTasks && getEnhancedTasks( arrayOfFilteredTasks, siteSlug );
+	const enhancedTasks =
+		arrayOfFilteredTasks && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site );
 
 	return (
 		<ul className="launchpad__checklist" aria-label="Launchpad Checklist">
 			{ enhancedTasks &&
-				enhancedTasks.map( ( task: Task ) => <ChecklistItem key={ task.id } task={ task } /> ) }
+				enhancedTasks.map( ( task: Task ) => (
+					<ChecklistItem key={ task.id } task={ task } site={ site } />
+				) ) }
 		</ul>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -1,27 +1,30 @@
-import { SiteDetails } from 'calypso/../packages/data-stores/src';
+import { useEffect, useState } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import ChecklistItem from './checklist-item';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { Task } from './types';
 
 interface ChecklistProps {
 	tasks: Task[];
-	site: SiteDetails | null;
 	siteSlug: string | null;
 	flow: string | null;
 }
 
-const Checklist = ( { tasks, site, siteSlug, flow }: ChecklistProps ) => {
+const Checklist = ( { tasks, siteSlug, flow }: ChecklistProps ) => {
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
+	const [ enhancedTasks, setEnhancedTasks ] = useState< Task[] | null >( null );
+	const site = useSite();
 
-	const enhancedTasks =
-		arrayOfFilteredTasks && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site );
+	useEffect( () => {
+		if ( arrayOfFilteredTasks ) {
+			setEnhancedTasks( getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site ) );
+		}
+	}, [ arrayOfFilteredTasks, site, siteSlug ] );
 
 	return (
 		<ul className="launchpad__checklist" aria-label="Launchpad Checklist">
 			{ enhancedTasks &&
-				enhancedTasks.map( ( task: Task ) => (
-					<ChecklistItem key={ task.id } task={ task } site={ site } />
-				) ) }
+				enhancedTasks.map( ( task: Task ) => <ChecklistItem key={ task.id } task={ task } /> ) }
 		</ul>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import ChecklistItem from './checklist-item';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
@@ -11,15 +10,10 @@ interface ChecklistProps {
 }
 
 const Checklist = ( { tasks, siteSlug, flow }: ChecklistProps ) => {
-	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
-	const [ enhancedTasks, setEnhancedTasks ] = useState< Task[] | null >( null );
 	const site = useSite();
-
-	useEffect( () => {
-		if ( arrayOfFilteredTasks ) {
-			setEnhancedTasks( getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site ) );
-		}
-	}, [ arrayOfFilteredTasks, site, siteSlug ] );
+	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
+	const enhancedTasks =
+		arrayOfFilteredTasks && site && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site );
 
 	return (
 		<ul className="launchpad__checklist" aria-label="Launchpad Checklist">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -2,6 +2,7 @@ import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import Checklist from './checklist';
 import { getArrayOfFilteredTasks } from './task-helper';
 import { tasks } from './tasks';
@@ -34,6 +35,7 @@ function getChecklistCompletionProgress( tasks: Task[] ) {
 const Sidebar = ( { siteSlug }: { siteSlug: string | null } ) => {
 	let siteName = '';
 	let topLevelDomain = '';
+	const site = useSite();
 	const flow = useFlowParam();
 	const translate = useTranslate();
 	const translatedStrings = getLaunchpadTranslations( flow );
@@ -70,7 +72,7 @@ const Sidebar = ( { siteSlug }: { siteSlug: string | null } ) => {
 					<span>{ siteName }</span>
 					<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
 				</div>
-				<Checklist siteSlug={ siteSlug } tasks={ tasks } flow={ flow } />
+				<Checklist site={ site } siteSlug={ siteSlug } tasks={ tasks } flow={ flow } />
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -2,7 +2,6 @@ import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import Checklist from './checklist';
 import { getArrayOfFilteredTasks } from './task-helper';
 import { tasks } from './tasks';
@@ -35,7 +34,6 @@ function getChecklistCompletionProgress( tasks: Task[] ) {
 const Sidebar = ( { siteSlug }: { siteSlug: string | null } ) => {
 	let siteName = '';
 	let topLevelDomain = '';
-	const site = useSite();
 	const flow = useFlowParam();
 	const translate = useTranslate();
 	const translatedStrings = getLaunchpadTranslations( flow );
@@ -72,7 +70,7 @@ const Sidebar = ( { siteSlug }: { siteSlug: string | null } ) => {
 					<span>{ siteName }</span>
 					<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
 				</div>
-				<Checklist site={ site } siteSlug={ siteSlug } tasks={ tasks } flow={ flow } />
+				<Checklist siteSlug={ siteSlug } tasks={ tasks } flow={ flow } />
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -5,7 +5,8 @@
 // Launchpad - Layout
 // This is styling common parts of stepper page
 .launchpad {
-	.flow-progress, .step-container__header {
+	.flow-progress,
+	.step-container__header {
 		display: none;
 	}
 
@@ -59,7 +60,7 @@
 .launchpad__sidebar-content-container {
 	margin-left: 0;
 	margin-top: 100px;
-	
+
 	@include break-large {
 		margin-left: 16px;
 	}
@@ -161,6 +162,9 @@
 	width: 100%;
 	margin: 0;
 	color: var( --color-text );
+	&.is-complete {
+		color: var( --color-neutral-20 );
+	}
 }
 
 .button.launchpad__checklist-item:hover:not( [disabled] ),
@@ -174,8 +178,9 @@
 	background-color: var( --studio-blue-5 );
 	color: var( --studio-blue-80 );
 }
- 
-.launchpad__checklist-item[disabled],  .launchpad__checklist-item[disabled]:focus {
+
+.launchpad__checklist-item[disabled],
+.launchpad__checklist-item[disabled]:focus {
 	background-color: transparent;
 	pointer-events: none;
 }
@@ -257,13 +262,9 @@
 		max-width: 95%;
 
 		@include break-large {
-			box-shadow: 
-				0 76px 65px rgba( 0, 0, 0, 0.04 ), 
-				0 50px 40px rgba( 0, 0, 0, 0.03 ), 
-				0 30px 20px rgba( 0, 0, 0, 0.03 ), 
-				0 15px 13px rgba( 0, 0, 0, 0.02 ), 
-				0 6px 5px rgba( 0, 0, 0, 0.02 ), 
-				0 2px 3px rgba( 0, 0, 0, 0.01 );
+			box-shadow: 0 76px 65px rgba( 0, 0, 0, 0.04 ), 0 50px 40px rgba( 0, 0, 0, 0.03 ),
+				0 30px 20px rgba( 0, 0, 0, 0.03 ), 0 15px 13px rgba( 0, 0, 0, 0.02 ),
+				0 6px 5px rgba( 0, 0, 0, 0.02 ), 0 2px 3px rgba( 0, 0, 0, 0.01 );
 			max-width: 340px;
 			height: 680px;
 			border-radius: 40px; /* stylelint-disable-line scales/radii */
@@ -282,15 +283,11 @@
 		box-sizing: border-box;
 		height: 780px;
 		max-width: 95%;
-		box-shadow: 
-			0 5px 15px rgba( 0, 0, 0, 0.07 ),
-			0 3px 10px rgba( 0, 0, 0, 0.04 );
+		box-shadow: 0 5px 15px rgba( 0, 0, 0, 0.07 ), 0 3px 10px rgba( 0, 0, 0, 0.04 );
 
 		@include break-large {
 			margin-top: 0;
-			box-shadow: 
-				0 15px 20px rgba( 0, 0, 0, 0.04 ), 
-				0 13px 10px rgba( 0, 0, 0, 0.03 ), 
+			box-shadow: 0 15px 20px rgba( 0, 0, 0, 0.04 ), 0 13px 10px rgba( 0, 0, 0, 0.03 ),
 				0 6px 6px rgba( 0, 0, 0, 0.02 );
 			border-radius: 20px; /* stylelint-disable-line scales/radii */
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -162,9 +162,6 @@
 	width: 100%;
 	margin: 0;
 	color: var( --color-text );
-	&.is-complete {
-		color: var( --color-neutral-20 );
-	}
 }
 
 .button.launchpad__checklist-item:hover:not( [disabled] ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,4 +1,5 @@
 import { translate } from 'i18n-calypso';
+import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import { launchpadFlowTasks } from './tasks';
 import { Task } from './types';
@@ -9,6 +10,9 @@ export function getEnhancedTasks(
 	site: SiteDetails | null
 ) {
 	const enhancedTaskList: Task[] = [];
+	const productSlug = site?.plan?.product_slug;
+	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
+
 	tasks &&
 		tasks.map( ( task ) => {
 			let taskData = {};
@@ -21,7 +25,7 @@ export function getEnhancedTasks(
 				case 'plan_selected':
 					taskData = {
 						title: translate( 'Choose a Plan' ),
-						badgeText: site?.plan?.product_name_short || '',
+						badgeText: translatedPlanName,
 					};
 					break;
 				case 'subscribers_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,8 +1,13 @@
 import { translate } from 'i18n-calypso';
+import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import { launchpadFlowTasks } from './tasks';
 import { Task } from './types';
 
-export function getEnhancedTasks( tasks: Task[], siteSlug: string | null ) {
+export function getEnhancedTasks(
+	tasks: Task[],
+	siteSlug: string | null,
+	site: SiteDetails | null
+) {
 	const enhancedTaskList: Task[] = [];
 	tasks &&
 		tasks.map( ( task ) => {
@@ -15,7 +20,8 @@ export function getEnhancedTasks( tasks: Task[], siteSlug: string | null ) {
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: translate( 'Free Plan' ),
+						title: translate( 'Choose a Plan' ),
+						badgeText: site?.plan?.product_name_short || '',
 					};
 					break;
 				case 'subscribers_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -7,7 +7,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 	{
 		id: 'plan_selected',
@@ -15,7 +14,6 @@ export const tasks: Task[] = [
 		taskType: 'blog',
 		actionUrl: '#',
 		displayBadge: true,
-		badgeText: 'Personal',
 	},
 	{
 		id: 'subscribers_added',
@@ -23,7 +21,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 	{
 		id: 'first_post_published',
@@ -31,7 +28,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 	{
 		id: 'design_selected',
@@ -39,7 +35,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 	{
 		id: 'setup_link_in_bio',
@@ -47,7 +42,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 	{
 		id: 'links_added',
@@ -55,7 +49,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 	{
 		id: 'link_in_bio_launched',
@@ -63,7 +56,6 @@ export const tasks: Task[] = [
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
-		badgeText: '',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -5,7 +5,7 @@ export interface Task {
 	taskType: string;
 	title?: string;
 	displayBadge: boolean;
-	badgeText: string;
+	badgeText?: string;
 }
 
 export interface LaunchpadFlowTaskList {


### PR DESCRIPTION
### Proposed Changes

This PR adds dynamic handling for the Choose a Plan task for Launchpad. In particular the following changes have been made: 
- Update text for task item to to "Choose a Plan" per Figma.
- Make the badge text on the Choose a Plan task dynamic. This had been hard coded. It will show the actual plan name, and the plan name will be translated. If no badge text is defined, the badge will now show.
- Related: I made badge text optional for the Task type since we're only using that in a few places. 

NOTE: Prettier made some extra formatting updates to style.scss. Those aren't required for this PR, but I also didn't want to directly override them.

### Testing Instructions

1. **Checkout and setup.** Checkout this branch, do yarn and yarn start if needed. 


2. **Test Free Plan.** Go to http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=SITESLUG (replace SITESLUG with any site that has free plan).
  - Confirm plan task says Choose a Plan
  - Confirm there is a badge for that task, and it says "Free"
 
<img width="1508" alt="choose plan 3" src="https://user-images.githubusercontent.com/21228350/187268534-f9e8ab8f-7869-4169-bcf1-fea26484f5b5.png">


3. **Test Paid Plan.** Go to http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=SITESLUG (replace SITESLUG with any site with a paid plan).
  - Confirm plan task says Choose a Plan
  - Confirm there is a badge for that task, and it says "Personal" (or the name of whatever plan your site has)


4. **Extra: Test Another Paid Plan.** Consider testing with the same URL again but with any other paid plan and confirm plan name shows correctly. The Choose a Plan task should always show the accurate plan name.


