### PR TITLE
Remove Professional Email experiment code

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -57,7 +57,6 @@ import {
 	FEATURE_FILTERING_V2,
 	FEATURE_FREE_BLOG_DOMAIN,
 	FEATURE_FREE_DOMAIN,
-	FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
 	FEATURE_FREE_THEMES,
 	FEATURE_FREE_THEMES_SIGNUP,
 	FEATURE_FREE_WORDPRESS_THEMES,
@@ -339,15 +338,6 @@ export const FEATURES_LIST = {
 						br: <br />,
 					},
 				}
-			),
-	},
-
-	[ FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL ]: {
-		getSlug: () => FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
-		getTitle: () => i18n.translate( 'Free Professional Email for 3 months' ),
-		getDescription: () =>
-			i18n.translate(
-				'Custom email address with mailbox, calendar, templates and more. Register free for 3 months with your custom domain. After 3 months, you have the option to renew or cancel your email subscription.'
 			),
 	},
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -877,7 +877,6 @@ PlanFeatures.propTypes = {
 	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isJetpack: PropTypes.bool,
-	isProfessionalEmailPromotionAvailable: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	// either you specify the plans prop or isPlaceholder prop
 	plans: PropTypes.array,
@@ -937,7 +936,6 @@ const ConnectedPlanFeatures = connect(
 	( state, ownProps ) => {
 		const {
 			isInSignup,
-			isProfessionalEmailPromotionAvailable,
 			placeholder,
 			plans,
 			isLandingPage,
@@ -969,7 +967,6 @@ const ConnectedPlanFeatures = connect(
 					: '';
 				const planConstantObj = applyTestFiltersToPlansList( plan, experiment, {
 					isLoggedInMonthlyPricing,
-					isProfessionalEmailPromotionAvailable,
 				} );
 				const planProductId = planConstantObj.getProductId();
 				const planObject = getPlan( state, planProductId );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -179,7 +179,6 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
-			isProfessionalEmailPromotionAvailable,
 			redirectToAddDomainFlow,
 			domainAndPlanPackage,
 			translate,
@@ -238,7 +237,6 @@ export class PlansFeaturesMain extends Component {
 					isInSignup={ isInSignup }
 					isLandingPage={ isLandingPage }
 					isLaunchPage={ isLaunchPage }
-					isProfessionalEmailPromotionAvailable={ isProfessionalEmailPromotionAvailable }
 					onUpgradeClick={ onUpgradeClick }
 					plans={ plans }
 					redirectTo={ redirectTo }
@@ -516,7 +514,7 @@ PlansFeaturesMain.propTypes = {
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
-	isProfessionalEmailPromotionAvailable: PropTypes.bool,
+
 	onUpgradeClick: PropTypes.func,
 	redirectTo: PropTypes.string,
 	selectedFeature: PropTypes.string,
@@ -538,7 +536,6 @@ PlansFeaturesMain.defaultProps = {
 	hidePremiumPlan: false,
 	intervalType: 'yearly',
 	isChatAvailable: false,
-	isProfessionalEmailPromotionAvailable: false,
 	showFAQ: true,
 	siteId: null,
 	siteSlug: '',

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, getIntervalTypeForTerm, PLAN_FREE } from '@automattic/calypso-products';
-import styled from '@emotion/styled';
 import { addQueryArgs } from '@wordpress/url';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -18,7 +17,6 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
-import { useExperiment } from 'calypso/lib/explat';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -31,44 +29,6 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-
-const ProfessionalEmailPromotionPlaceholder = styled.div`
-	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: var( --color-neutral-10 );
-	color: transparent;
-	min-height: 250px;
-`;
-
-const ProfessionalEmailPromotionWrapper = ( props ) => {
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_promote_professional_email_as_a_plan_feature_2022_02'
-	);
-
-	if ( isLoadingExperimentAssignment ) {
-		return <ProfessionalEmailPromotionPlaceholder />;
-	}
-
-	const isProfessionalEmailPromotionAvailable = 'treatment' === experimentAssignment?.variationName;
-
-	return (
-		<PlansFeaturesMain
-			redirectToAddDomainFlow={ props.redirectToAddDomainFlow }
-			domainAndPlanPackage={ props.domainAndPlanPackage }
-			hideFreePlan={ props.hideFreePlan }
-			customerType={ props.customerType }
-			intervalType={ props.intervalType }
-			selectedFeature={ props.selectedFeature }
-			selectedPlan={ props.selectedPlan }
-			redirectTo={ props.redirectTo }
-			withDiscount={ props.withDiscount }
-			discountEndDate={ props.discountEndDate }
-			site={ props.site }
-			plansWithScroll={ props.plansWithScroll }
-			showTreatmentPlansReorderTest={ props.showTreatmentPlansReorderTest }
-			isProfessionalEmailPromotionAvailable={ isProfessionalEmailPromotionAvailable }
-		/>
-	);
-};
 
 function DomainAndPlanUpsellNotice() {
 	const translate = useTranslate();
@@ -179,7 +139,7 @@ class Plans extends Component {
 		}
 
 		return (
-			<ProfessionalEmailPromotionWrapper
+			<PlansFeaturesMain
 				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
 				domainAndPlanPackage={ this.props.domainAndPlanPackage }
 				hideFreePlan={ true }

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -96,7 +96,6 @@ export const FEATURE_SITE_BACKUPS_AND_RESTORE = 'site-backups-and-restore';
 export const FEATURE_SECURITY_SETTINGS = 'security-settings';
 export const FEATURE_WOOP = 'woop';
 export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
-export const FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL = 'free-professional-email-trial';
 
 // Jetpack features constants
 export const FEATURE_BLANK = 'blank-feature';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -48,7 +48,6 @@ import {
 	FEATURE_EMAIL_SUPPORT_SIGNUP,
 	FEATURE_FREE_BLOG_DOMAIN,
 	FEATURE_FREE_DOMAIN,
-	FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
 	FEATURE_FREE_THEMES,
 	FEATURE_FREE_THEMES_SIGNUP,
 	FEATURE_FREE_WORDPRESS_THEMES,
@@ -360,7 +359,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			'Boost your website with a custom domain name, and remove all WordPress.com advertising. ' +
 				'Unlock unlimited, expert customer support via email.'
 		),
-	getPlanCompareFeatures: ( experiment, { isProfessionalEmailPromotionAvailable } = {} ) =>
+	getPlanCompareFeatures: ( experiment ) =>
 		compact(
 			experiment
 				? [
@@ -374,7 +373,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 						FEATURE_FREE_THEMES_V2,
 						FEATURE_COLLECT_PAYMENTS_V3,
 						FEATURE_BLANK,
-
 						FEATURE_6GB_STORAGE,
 						FEATURE_BASIC_DESIGN_V2,
 						FEATURE_SEO_PREVIEW_TOOLS_V2,
@@ -386,7 +384,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 				: [
 						// pay attention to ordering, shared features should align on /plan page
 						FEATURE_CUSTOM_DOMAIN,
-						isProfessionalEmailPromotionAvailable && FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
 						FEATURE_HOSTING,
 						FEATURE_JETPACK_ESSENTIAL,
 						FEATURE_EMAIL_SUPPORT,
@@ -452,10 +449,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Learn more about everything included with eCommerce and take advantage of its powerful marketplace features.'
 		),
-	getPlanCompareFeatures: (
-		experiment,
-		{ isLoggedInMonthlyPricing, isProfessionalEmailPromotionAvailable } = {}
-	) =>
+	getPlanCompareFeatures: ( experiment, { isLoggedInMonthlyPricing } = {} ) =>
 		compact(
 			experiment
 				? [
@@ -502,7 +496,6 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 				: [
 						// pay attention to ordering, shared features should align on /plan page
 						FEATURE_CUSTOM_DOMAIN,
-						isProfessionalEmailPromotionAvailable && FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
 						isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
 						isLoggedInMonthlyPricing && FEATURE_EMAIL_SUPPORT,
 						FEATURE_HOSTING,
@@ -609,10 +602,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 				' Google Analytics support,' +
 				' and the ability to monetize your site with ads.'
 		),
-	getPlanCompareFeatures: (
-		experiment,
-		{ isLoggedInMonthlyPricing, isProfessionalEmailPromotionAvailable } = {}
-	) =>
+	getPlanCompareFeatures: ( experiment, { isLoggedInMonthlyPricing } = {} ) =>
 		compact(
 			experiment
 				? [
@@ -645,7 +635,6 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 				: [
 						// pay attention to ordering, shared features should align on /plan page
 						FEATURE_CUSTOM_DOMAIN,
-						isProfessionalEmailPromotionAvailable && FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
 						isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 						isLoggedInMonthlyPricing && FEATURE_EMAIL_SUPPORT,
 						FEATURE_HOSTING,
@@ -734,10 +723,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Learn more about everything included with Business and take advantage of its professional features.'
 		),
-	getPlanCompareFeatures: (
-		experiment,
-		{ isLoggedInMonthlyPricing, isProfessionalEmailPromotionAvailable } = {}
-	) =>
+	getPlanCompareFeatures: ( experiment, { isLoggedInMonthlyPricing } = {} ) =>
 		compact(
 			experiment
 				? [
@@ -776,7 +762,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 				: [
 						// pay attention to ordering, shared features should align on /plan page
 						FEATURE_CUSTOM_DOMAIN,
-						isProfessionalEmailPromotionAvailable && FEATURE_FREE_PROFESSIONAL_EMAIL_TRIAL,
 						isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
 						isLoggedInMonthlyPricing && FEATURE_EMAIL_SUPPORT,
 						FEATURE_HOSTING,


### PR DESCRIPTION
#### Proposed Changes

* Removes the experiment introduced in https://github.com/Automattic/wp-calypso/pull/61149

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test that the signup flow can complete successfully, the plans step renders correctly. 
* Verify that there's no interference to the currently running plans step experiment `pricing_packaging_plans_page_quick_improvements_v2`.

