### PR TITLE
Plugin Details: Update the alignment between the plugin header and sidebar sections

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -26,7 +26,7 @@
 	font-family: $brand-serif;
 	font-size: $font-title-large;
 	color: var( --studio-gray-100 );
-	margin: 32px 0 16px;
+	margin-bottom: 16px;
 	min-height: 48px;
 	display: flex;
 	align-items: baseline;
@@ -149,6 +149,10 @@
 
 	.plugin-details-cta__period {
 		padding-left: 0;
+	}
+
+	.plugin-details-cta__price {
+		margin: 32px 0 16px;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -11,7 +11,6 @@ $mobile-icon-height: 175px;
 }
 
 .plugin-details-header__main-info {
-	margin-top: 16px;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
@@ -167,6 +166,7 @@ $mobile-icon-height: 175px;
 	}
 
 	.plugin-details-header__main-info {
+		margin-top: 16px;
 		margin-bottom: 30px;
 	}
 	


### PR DESCRIPTION
#### Proposed Changes

* Update the alignment between the plugin header and sidebar sections, making them have the same distance from the top.
* Remove additional padding on the Plugin price.


<img width="1122" alt="Screen Shot 2022-08-29 at 16 27 34" src="https://user-images.githubusercontent.com/5039531/187293990-8b6a694b-eee2-4bc9-8c4b-18691374deaa.png">

#### Testing Instructions
* Go to a paid plugin page. Ex: /plugins/woocommerce-bookings/{site}
* Check if the alignment matches with the describe on this PR.

| Before  | After |
| ------------- | ------------- |
|<img width="1122" alt="Screen Shot 2022-08-29 at 16 17 53" src="https://user-images.githubusercontent.com/5039531/187294028-3388d3b5-776d-4d80-b17f-74878dca301e.png">|<img width="1122" alt="Screen Shot 2022-08-29 at 16 22 44" src="https://user-images.githubusercontent.com/5039531/187294197-b7089f46-0b72-4ff7-885e-a002aacff0dd.png">|<img width="1122" alt="Screen Shot 2022-08-29 at 16 39 10" src="https://user-images.githubusercontent.com/5039531/187294525-df431270-f001-471f-94d9-a6217c6a67f0.png">|


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---

Fixes #66953