### PR TITLE
Add e2e to test breadcrumbs on plugin details page

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -67,7 +67,7 @@ interface Props {
 const FixedNavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
 	const { id, className, children, navigationItems, mobileItem, compactBreadcrumb } = props;
 	return (
-		<Header id={ id } className={ className } ref={ ref }>
+		<Header id={ id } className={ 'fixed-navigation-header__header ' + className } ref={ ref }>
 			<Container>
 				<Breadcrumb
 					items={ navigationItems }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -319,7 +319,11 @@ function PluginDetails( props ) {
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist={ ! wporgPluginNotFound } />
-			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
+			<FixedNavigationHeader
+				compactBreadcrumb={ ! isWide }
+				navigationItems={ breadcrumbs }
+				className="plugins-browser__header"
+			/>
 
 			<PluginNotices
 				pluginId={ fullPlugin.id }
@@ -438,7 +442,11 @@ function LegacyPluginDetails( props ) {
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist />
-			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs }>
+			<FixedNavigationHeader
+				compactBreadcrumb={ ! isWide }
+				navigationItems={ breadcrumbs }
+				className="plugins-browser__header"
+			>
 				{ showBillingIntervalSwitcher && (
 					<BillingIntervalSwitcher
 						billingPeriod={ billingPeriod }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -319,11 +319,7 @@ function PluginDetails( props ) {
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist={ ! wporgPluginNotFound } />
-			<FixedNavigationHeader
-				compactBreadcrumb={ ! isWide }
-				navigationItems={ breadcrumbs }
-				className="plugins-browser__header"
-			/>
+			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 
 			<PluginNotices
 				pluginId={ fullPlugin.id }
@@ -442,11 +438,7 @@ function LegacyPluginDetails( props ) {
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist />
-			<FixedNavigationHeader
-				compactBreadcrumb={ ! isWide }
-				navigationItems={ breadcrumbs }
-				className="plugins-browser__header"
-			>
+			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs }>
 				{ showBillingIntervalSwitcher && (
 					<BillingIntervalSwitcher
 						billingPeriod={ billingPeriod }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -28,7 +28,7 @@ import PluginDetailsV2 from 'calypso/my-sites/plugins/plugin-management-v2/plugi
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
-import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { siteObjectsToSiteIds, useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -88,6 +88,7 @@ function PluginDetails( props ) {
 	const isRequestingSites = useSelector( checkRequestingSites );
 	const requestingPluginsForSites = useSelector( ( state ) => isRequestingForAllSites( state ) );
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
+	const { localizePath } = useLocalizedPlugins();
 
 	// Plugin information.
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -28,7 +28,7 @@ import PluginDetailsV2 from 'calypso/my-sites/plugins/plugin-management-v2/plugi
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
-import { siteObjectsToSiteIds, useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -88,7 +88,6 @@ function PluginDetails( props ) {
 	const isRequestingSites = useSelector( checkRequestingSites );
 	const requestingPluginsForSites = useSelector( ( state ) => isRequestingForAllSites( state ) );
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
-	const { localizePath } = useLocalizedPlugins();
 
 	// Plugin information.
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -147,7 +147,6 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 
 	return (
 		<FixedNavigationHeader
-			className="plugins-browser__header"
 			navigationItems={ breadcrumbs }
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -22,7 +22,7 @@ const selectors = {
 	browseFirstCategory: 'button:has-text("Search Engine Optimization")',
 	categoryButton: ( section: string ) =>
 		`button:has-text("${ section }"),a:has-text("${ section }")`,
-	breadcrumb: ( section: string ) => `.plugins-browser__header a:text("${ section }") `,
+	breadcrumb: ( section: string ) => `.fixed-navigation-header__header a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -45,6 +45,10 @@ const selectors = {
 
 	// Category selector
 	selectedCategory: ( categoryTitle: string ) => `.categories__header:text("${ categoryTitle }")`,
+
+	// Plugin details view
+	pluginDetailsHeaderTitle: ( section: string ) =>
+		`.plugin-details-header__name:text("${ section }")`,
 };
 
 /**
@@ -111,6 +115,13 @@ export class PluginsPage {
 	 */
 	async validateHasHeaderTitle( section: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.headerTitle( section ) );
+	}
+
+	/**
+	 * Validate plugin details page has a header title containing text
+	 */
+	async validatePluginDetailsHasHeaderTitle( section: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.pluginDetailsHeaderTitle( section ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -181,17 +181,24 @@ export class PluginsPage {
 	}
 
 	/**
-	 * Click the Back breadcrumb
+	 * Click the "Back" breadcrumb
 	 */
 	async clickBackBreadcrumb(): Promise< void > {
 		await this.page.click( selectors.breadcrumb( 'Back' ) );
 	}
 
 	/**
-	 * Click the Plugins breadcrumb
+	 * Click the "Plugins" breadcrumb
 	 */
 	async clickPluginsBreadcrumb(): Promise< void > {
 		await this.page.click( selectors.breadcrumb( 'Plugins' ) );
+	}
+
+	/**
+	 * Click the "Search Results" breadcrumb
+	 */
+	async clickSearchResultsBreadcrumb(): Promise< void > {
+		await this.page.click( selectors.breadcrumb( 'Search Results' ) );
 	}
 
 	/**

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -26,7 +26,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		}
 	} );
 
-	it( 'Search for ecommerce', async function () {
+	it( 'Search for shipping', async function () {
 		await pluginsPage.search( 'shipping' );
 		await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 	} );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -27,13 +27,13 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	} );
 
 	it( 'Search for ecommerce', async function () {
-		await pluginsPage.search( 'ecommerce' );
-		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
+		await pluginsPage.search( 'shipping' );
+		await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 	} );
 
 	it( 'Can click on a search result', async function () {
-		await pluginsPage.clickSearchResult( 'WooCommerce' );
-		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'WooCommerce' );
+		await pluginsPage.clickSearchResult( 'Royal Mail' );
+		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'Royal Mail' );
 	} );
 
 	it( 'Can click on breadcrumbs "Search Results"', async function () {
@@ -42,16 +42,17 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		} else {
 			await pluginsPage.clickBackBreadcrumb();
 		}
-		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
+		await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 	} );
 
 	it( 'Can click on breadcrumbs "Plugins"', async function () {
-		await pluginsPage.clickSearchResult( 'WooCommerce' );
+		await pluginsPage.clickSearchResult( 'Royal Mail' );
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await pluginsPage.clickPluginsBreadcrumb();
+			await pluginsPage.validateHasSection( 'Top premium plugins' );
 		} else {
 			await pluginsPage.clickBackBreadcrumb();
+			await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 		}
-		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -2,7 +2,7 @@
  * @group calypso-pr
  */
 
-import { DataHelper, TestAccount, PluginsPage } from '@automattic/calypso-e2e';
+import { DataHelper, TestAccount, PluginsPage, envVariables } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -20,8 +20,10 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
 		await pluginsPage.visit();
-		// Ensure page is wide enough to show the breadcrumb details
-		await page.setViewportSize( { width: 1300, height: 1080 } );
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			// Ensure the page is wide enough to show the breadcrumb details.
+			await page.setViewportSize( { width: 1300, height: 1080 } );
+		}
 	} );
 
 	it( 'Search for ecommerce', async function () {
@@ -35,13 +37,21 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	} );
 
 	it( 'Can click on breadcrumbs "Search Results"', async function () {
-		await pluginsPage.clickSearchResultsBreadcrumb();
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			await pluginsPage.clickSearchResultsBreadcrumb();
+		} else {
+			await pluginsPage.clickBackBreadcrumb();
+		}
 		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 
 	it( 'Can click on breadcrumbs "Plugins"', async function () {
 		await pluginsPage.clickSearchResult( 'WooCommerce' );
-		await pluginsPage.clickPluginsBreadcrumb();
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			await pluginsPage.clickPluginsBreadcrumb();
+		} else {
+			await pluginsPage.clickBackBreadcrumb();
+		}
 		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -29,12 +29,19 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 
-	it( 'Can click on search result', async function () {
+	it( 'Can click on a search result', async function () {
 		await pluginsPage.clickSearchResult( 'WooCommerce' );
 		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'WooCommerce' );
 	} );
 
+	it( 'Can click on breadcrumbs "Search Results"', async function () {
+		await pluginsPage.clickSearchResultsBreadcrumb();
+		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
+	} );
+
 	it( 'Can click on breadcrumbs "Plugins"', async function () {
+		await pluginsPage.clickSearchResult( 'WooCommerce' );
 		await pluginsPage.clickPluginsBreadcrumb();
+		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -31,7 +31,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 
 	it( 'Can click on search result', async function () {
 		await pluginsPage.clickSearchResult( 'WooCommerce' );
-		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'WooCommessrce' );
+		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'WooCommerce' );
 	} );
 
 	it( 'Can click on breadcrumbs "Plugins"', async function () {

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -15,28 +15,29 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		page = await browser.newPage();
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
-	} );
 
-	it( 'Visit plugins page', async function () {
-		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit();
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			// Ensure the page is wide enough to show the breadcrumb details.
 			await page.setViewportSize( { width: 1300, height: 1080 } );
 		}
 	} );
 
-	it( 'Search for shipping', async function () {
+	it( 'Visit plugins page', async function () {
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit();
+	} );
+
+	it( 'Search for "shipping"', async function () {
 		await pluginsPage.search( 'shipping' );
 		await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 	} );
 
-	it( 'Can click on a search result', async function () {
+	it( 'Click on a search result', async function () {
 		await pluginsPage.clickSearchResult( 'Royal Mail' );
 		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'Royal Mail' );
 	} );
 
-	it( 'Can click on breadcrumbs "Search Results"', async function () {
+	it( 'Click on breadcrumbs "Search Results"', async function () {
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await pluginsPage.clickSearchResultsBreadcrumb();
 		} else {
@@ -45,7 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 	} );
 
-	it( 'Can click on breadcrumbs "Plugins"', async function () {
+	it( 'Click on breadcrumbs "Plugins"', async function () {
 		await pluginsPage.clickSearchResult( 'Royal Mail' );
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await pluginsPage.clickPluginsBreadcrumb();

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -20,10 +20,21 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
 		await pluginsPage.visit();
+		// Ensure page is wide enough to show the breadcrumb details
+		await page.setViewportSize( { width: 1300, height: 1080 } );
 	} );
 
 	it( 'Search for ecommerce', async function () {
 		await pluginsPage.search( 'ecommerce' );
 		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
+	} );
+
+	it( 'Can click on search result', async function () {
+		await pluginsPage.clickSearchResult( 'WooCommerce' );
+		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'WooCommessrce' );
+	} );
+
+	it( 'Can click on breadcrumbs "Plugins"', async function () {
+		await pluginsPage.clickPluginsBreadcrumb();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

These e2e tests prove that after searching for a plugin and arriving at the plugin details page, we can navigate back to the search results using the "Search Results" breadcrumb, and we can navigate back to the "discovery" page using the "Plugins" breadcrumbs.

These tests also prove that the "Plugins" and "Search Results" breadcrumbs only require 1 click.

![plugin-details-breadcrumbs](https://user-images.githubusercontent.com/140841/187311002-2f9694d5-b960-4b8c-a140-8b53ac23d8a7.png)


#### Testing Instructions

This PR adds the `fixed-navigation-header__header` class to the `fixedNavigationHeader` component so the e2e test can find the breadcrumbs to click on. As such, you need to run these tests against localhost so that change is available.

[Prereq setup](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

```
cd test/e2e
yarn workspace @automattic/calypso-e2e build && CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn jest specs/plugins/plugins__search.ts
yarn workspace @automattic/calypso-e2e build && VIEWPORT_NAME=mobile CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn jest specs/plugins/plugins__search.ts
```

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#66924](https://github.com/Automattic/wp-calypso/issues/66924)
