### PR TITLE
Plugins: Update the 'Last updated' translation string

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -187,14 +187,15 @@ const PluginsBrowserListElement = ( props ) => {
 							</div>
 
 							<div className="plugins-browser-item__last-updated">
-								{ dateFromNow && (
-									<>
-										{ translate( 'Last updated ' ) }
-										<span className="plugins-browser-item__last-updated-value">
-											{ dateFromNow }
-										</span>
-									</>
-								) }
+								{ dateFromNow &&
+									translate( 'Last updated {{span}}%(ago)s{{/span}}', {
+										args: {
+											ago: dateFromNow,
+										},
+										components: {
+											span: <span className="plugins-browser-item__last-updated-value" />,
+										},
+									} ) }
 							</div>
 						</>
 					) }


### PR DESCRIPTION
#### Proposed Changes

Update the 'Last updated' translation string to a more elegant way and fully using the `useTranslate` method capabilities

#### Testing Instructions

* Go to the browser plugins page
* Check if the `Last updated` text on the cards is shown
* There shouldn't be any visual differences from the live version in production now

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->