### PR TITLE
ThemeCard: Bundled Themes: Give option to upgrade plan, remove individual purchases

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -8,7 +8,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, isJetpackSiteMultiSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	activate as activateAction,
 	tryAndCustomize as tryAndCustomizeAction,
@@ -25,6 +25,7 @@ import {
 	isPremiumThemeAvailable,
 	isThemeActive,
 	isThemePremium,
+	doesThemeBundleSoftwareSet,
 	shouldShowTryAndCustomize,
 } from 'calypso/state/themes/selectors';
 
@@ -46,9 +47,11 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isUserLoggedIn( state ) || // Not logged in
 			! isThemePremium( state, themeId ) || // Not a premium theme
 			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
+			doesThemeBundleSoftwareSet( state, themeId ) || // Premium themes with bundled Software Sets cannot be purchased
 			isThemeActive( state, themeId, siteId ), // Already active
 	};
 
+	// Jetpack-specific plan upgrade
 	const upgradePlan = {
 		label: translate( 'Upgrade to activate', {
 			comment: 'label prompting user to upgrade the Jetpack plan to activate a certain theme',
@@ -67,6 +70,29 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			isSiteWpcomAtomic( state, siteId ) ||
 			! isUserLoggedIn( state ) ||
 			! isThemePremium( state, themeId ) ||
+			isThemeActive( state, themeId, siteId ) ||
+			isPremiumThemeAvailable( state, themeId, siteId ),
+	};
+
+	// WPCOM-specific plan upgrade for premium themes with bundled software sets
+	const upgradePlanForBundledThemes = {
+		label: translate( 'Upgrade to activate', {
+			comment: 'label prompting user to upgrade the WordPress.com plan to activate a certain theme',
+		} ),
+		extendedLabel: translate( 'Upgrade to activate', {
+			comment: 'label prompting user to upgrade the WordPress.com plan to activate a certain theme',
+		} ),
+		header: translate( 'Upgrade on:', {
+			context: 'verb',
+			comment: 'label for selecting a site for which to upgrade a plan',
+		} ),
+		getUrl: ( state, themeId, siteId ) => `/checkout/${ getSiteSlug( state, siteId ) }/business`,
+		hideForTheme: ( state, themeId, siteId ) =>
+			isJetpackSite( state, siteId ) ||
+			isSiteWpcomAtomic( state, siteId ) ||
+			! isUserLoggedIn( state ) ||
+			! isThemePremium( state, themeId ) ||
+			! doesThemeBundleSoftwareSet( state, themeId ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			isPremiumThemeAvailable( state, themeId, siteId ),
 	};
@@ -168,6 +194,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		preview,
 		purchase,
 		upgradePlan,
+		upgradePlanForBundledThemes,
 		activate,
 		tryandcustomize,
 		deleteTheme,

--- a/client/state/themes/selectors/does-theme-bundle-software-set.js
+++ b/client/state/themes/selectors/does-theme-bundle-software-set.js
@@ -5,6 +5,8 @@ import 'calypso/state/themes/init';
 
 export function doesThemeBundleSoftwareSet( state, themeId ) {
 	const theme = getTheme( state, 'wpcom', themeId );
-	const theme_plugin = theme?.taxonomies?.theme_plugin;
-	return isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0;
+	const theme_software_set = theme?.taxonomies?.theme_software_set;
+	return (
+		isEnabled( 'themes/plugin-bundling' ) && theme_software_set && theme_software_set.length > 0
+	);
 }

--- a/client/state/themes/selectors/does-theme-bundle-software-set.js
+++ b/client/state/themes/selectors/does-theme-bundle-software-set.js
@@ -1,0 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+
+import 'calypso/state/themes/init';
+
+export function doesThemeBundleSoftwareSet( state, themeId ) {
+	const theme = getTheme( state, 'wpcom', themeId );
+	const theme_plugin = theme?.taxonomies?.theme_plugin;
+	return isEnabled( 'themes/plugin-bundling' ) && theme_plugin && theme_plugin.length > 0;
+}

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -1,6 +1,7 @@
 export { arePremiumThemesEnabled } from 'calypso/state/themes/selectors/are-premium-themes-enabled';
 export { areRecommendedThemesLoading } from 'calypso/state/themes/selectors/are-recommended-themes-loading';
 export { areTrendingThemesLoading } from 'calypso/state/themes/selectors/are-trending-themes-loading';
+export { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
 export { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 export { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme';
 export { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';


### PR DESCRIPTION
#### Proposed Changes

* In the theme showcase, when a premium theme with a plugin bundle is not accessible, replace the "Purchase" link with a "Upgrade to activate" link. The button links to buy the business plan.
* In the theme info page, replace the "Pick this design ($50)" button with "Upgrade to activate". The button links to the business plan.

See: #67121, paYKcK-22b-p2, paYKcK-1SY-p2

#### Testing Instructions (Three dot menu)

* Use calypso localhost or force the `themes/plugin-bundling` flag on
* Visit the theme showcase on a free plan
* Baxter should no longer have a 'Purchase' link in the three dot menu. It should be replaced with 'Upgrade to activate' which links to business plan checkout.
* Other themes' menus should not be modified

![2022-08-29_16-34](https://user-images.githubusercontent.com/937354/187303575-d7db1940-2b2c-40b0-8098-3c7818bdc3eb.png)

#### Testing Instructions (Info page)

* Use calypso localhost or force the `themes/plugin-bundling` flag on
* Visit the theme showcase on a free plan
* Click on the Baxter theme to visit the info page
* Baxter should no longer have a 'Pick this design ($50)' button. It should be replaced with 'Upgrade to activate' which links to business plan checkout.
* Other themes' info pages should not be modified

![2022-08-29_16-33](https://user-images.githubusercontent.com/937354/187303392-1ac9d700-6d15-4302-bc2e-48b30659e81b.png)

#### Testing Instructions (Other scenarios, like already on business plan, atomic sites etc..)

* This one is tricky and there are a wide variety of scenarios. I only listed the most obvious things to check, there are probably lots more things to try.


Related to #67121