### PR TITLE
Login: accept redirect_to from QR login

### DIFF
--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -1,6 +1,7 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import QRCode from 'qrcode.react';
 import { useEffect, useState } from 'react';
@@ -151,7 +152,6 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 		try {
 			const responseData = await getLoginActionResponse( 'qr-code-authentication-endpoint', {
 				anon_id: anonId,
-				redirect_to: redirectToAfterLoginUrl,
 				token,
 				data: encrypted,
 			} );
@@ -185,11 +185,17 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 	// Send the user to the login state.
 	useEffect( () => {
 		if ( authState?.auth_url ) {
+			// if redirect URL is set, append to to the response URL as a query param.
+			if ( redirectToAfterLoginUrl ) {
+				authState.auth_url = addQueryArgs( authState?.auth_url, {
+					redirect_to: redirectToAfterLoginUrl,
+				} );
+			}
 			// Clear the data.
 			setStoredItem( LOCALE_STORAGE_KEY, null );
 			window.location.replace( authState.auth_url );
 		}
-	}, [ authState ] );
+	}, [ authState, redirectToAfterLoginUrl ] );
 
 	useEffect( () => {
 		getStoredItem( LOCALE_STORAGE_KEY ).then( ( storedTokenData ) =>

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -187,7 +187,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 		if ( authState?.auth_url ) {
 			// if redirect URL is set, append to to the response URL as a query param.
 			if ( redirectToAfterLoginUrl ) {
-				authState.auth_url = addQueryArgs( authState?.auth_url, {
+				authState.auth_url = addQueryArgs( authState.auth_url, {
 					redirect_to: redirectToAfterLoginUrl,
 				} );
 			}

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -115,7 +115,6 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 		try {
 			const responseData = await getLoginActionResponse( 'qr-code-token-request-endpoint', {
 				anon_id: anonId,
-				redirect_to: redirectToAfterLoginUrl,
 			} );
 			if ( isStillValidToken( responseData.body.data ) ) {
 				setTokenState( responseData.body.data );

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -115,6 +115,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 		try {
 			const responseData = await getLoginActionResponse( 'qr-code-token-request-endpoint', {
 				anon_id: anonId,
+				redirect_to: redirectToAfterLoginUrl,
 			} );
 			if ( isStillValidToken( responseData.body.data ) ) {
 				setTokenState( responseData.body.data );
@@ -151,6 +152,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 		try {
 			const responseData = await getLoginActionResponse( 'qr-code-authentication-endpoint', {
 				anon_id: anonId,
+				redirect_to: redirectToAfterLoginUrl,
 				token,
 				data: encrypted,
 			} );


### PR DESCRIPTION
## Proposed Changes

This addresses a possible early exit from the tailored flow from the qr code login option. It passes the `redirect_to` value through to the magic link creation.

## Testing Instructions

1. Log in to your sandbox and patch this diff - D86804-code
2. Pull this branch and `yarn start`
3. Make sure you have sandboxed the public api and cleared the DNS cache
4. Go to: http://calypso.localhost:3000/log-in/new?redirect_to=%2Fsetup%2Fpatterns%3Fflow%3Dlink-in-bio
5. Use the "mobile login" link to login. This will require the Jetpack app on your phone.
6. After you login and click the button, you should be taken to `/setup/patterns?flow=link-in-bio`