### PR TITLE
Checkout: Update EBANX terms 'BUY' text to be more accurate

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/ebanx-terms-of-service.tsx
@@ -25,7 +25,7 @@ export function EbanxTermsOfService() {
 	const tosUrl =
 		'http://go.pardot.com/e/779123/br-termos-/2s9d1h/1387578788?h=Y8e15EGjfwatzTqGa7lilIlSEGTaOz-BZC5xFvBZICk';
 	const tosText = translate(
-		'This is an international purchase, which is subject to a currency exchange operation, to be processed by EBANX, according to these {{tosLink}}terms and conditions{{/tosLink}}. By clicking "BUY", you state acknowledgment and acceptance of the terms and conditions of this transaction.',
+		'This is an international purchase, which is subject to a currency exchange operation, to be processed by EBANX, according to these {{tosLink}}terms and conditions{{/tosLink}}. By clicking to purchase, you state acknowledgment and acceptance of the terms and conditions of this transaction.',
 		{
 			components: {
 				tosLink: <a href={ tosUrl } target="_blank" rel="noopener noreferrer" />,


### PR DESCRIPTION
#### Proposed Changes

This change will update the 'BUY' text found in the EBANX terms of service to 'By clicking to purchase' which more closely matches the original intent of EBANX's provided copy. Context can be found [here](p2y3YZ-4MJ-p2#comment-13416).

Before this is deployed, we will want to update the BR-PT translation for this string:

- [x] Update BR-PT string

#### Testing Instructions
- Make sure to follow Nathan's instructions here to load EBANX on your sandbox (skip this step if you already live in a locale that supports br-pt) p1641942150008200-slack-D028EKVDYAJ
- Load this PR
- Add purchase to your site in Calypso, then proceed to checkout
- Set your billing information location to 61919-230, BR
- Under 'Pick a payment method' scroll down to add a credit card, then scroll to below the new card form to see the terms of service, you should see the update ToS which should now read 'By clicking to purchase' _instead of_ 'BUY'.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before

<img width="591" alt="image" src="https://user-images.githubusercontent.com/16580129/187316261-fc1724e5-54a1-40da-9536-3f4dfde5b3ea.png">


After

<img width="580" alt="image" src="https://user-images.githubusercontent.com/16580129/187316154-2449368c-e0b2-4147-bb79-2accc94e946a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1049-gh-Automattic/payments-shilling