### PR TITLE
Backup credentials: correct margin on credentials input form

### DIFF
--- a/client/components/advanced-credentials/credentials-form/style.scss
+++ b/client/components/advanced-credentials/credentials-form/style.scss
@@ -23,12 +23,17 @@
 		font-size: $font-body-small;
 	}
 
+	.credentials-form__buttons.form-fieldset:last-child {
+		margin-bottom: 20px;
+	}
+
 	@include breakpoint-deprecated( '>660px' ) {
 		.credentials-form__intro-text {
 			font-size: $font-body;
 		}
 	}
 }
+
 
 .credentials-form__buttons .credentials-form__buttons-flex {
 	display: flex;

--- a/client/components/advanced-credentials/credentials-form/style.scss
+++ b/client/components/advanced-credentials/credentials-form/style.scss
@@ -34,7 +34,6 @@
 	}
 }
 
-
 .credentials-form__buttons .credentials-form__buttons-flex {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
#### Proposed Changes

* Correct the bottom margin on the credentials page:

BEFORE
<img width="761" alt="Screen Shot 2022-08-30 at 02 34 22" src="https://user-images.githubusercontent.com/16329583/187322656-14f9c3cd-73a3-423f-9a15-91cbf013fea9.png">

AFTER
<img width="736" alt="Screen Shot 2022-08-30 at 02 34 12" src="https://user-images.githubusercontent.com/16329583/187322649-d2204d9f-5ade-4ad5-811c-1d88103d4f1a.png">

#### Testing Instructions
1- On a test site with a Jetpack Backup subscription, visit the credentials page:
https://wordpress.com/settings/jetpack/YOUR_SITE_URL
2- Select a host
3- Confirm that the margin is shown as expected
4- Confirm that it also shows as expected on the Jetpack Cloud page:
https://cloud.jetpack.com/settings/YOUR_SITE_URL