### PR TITLE
Fix breadcrumb localization

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -221,7 +221,7 @@ function PluginDetails( props ) {
 			dispatch(
 				appendBreadcrumb( {
 					label: translate( 'Plugins' ),
-					href: `/plugins/${ selectedSite?.slug || '' }`,
+					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 					id: 'plugins',
 					helpBubble: translate(
 						'Add new functionality and integrations to your site with plugins.'
@@ -234,12 +234,20 @@ function PluginDetails( props ) {
 			dispatch(
 				appendBreadcrumb( {
 					label: fullPlugin.name,
-					href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
+					href: localizePath( `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }` ),
 					id: `plugin-${ props.pluginSlug }`,
 				} )
 			);
 		}
-	}, [ fullPlugin.name, props.pluginSlug, selectedSite ] );
+	}, [
+		fullPlugin.name,
+		props.pluginSlug,
+		selectedSite,
+		breadcrumbs.length,
+		dispatch,
+		translate,
+		localizePath,
+	] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
@@ -111,12 +112,13 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	const shouldShowManageButton = useMemo( () => {
 		return jetpackNonAtomic || ( isJetpack && ( hasInstallPurchasedPlugins || hasManagePlugins ) );
 	}, [ jetpackNonAtomic, isJetpack, hasInstallPurchasedPlugins, hasManagePlugins ] );
+	const { localizePath } = useLocalizedPlugins();
 
 	useEffect( () => {
 		const items = [
 			{
 				label: translate( 'Plugins' ),
-				href: `/plugins/${ selectedSite?.slug || '' }`,
+				href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 				id: 'plugins',
 				helpBubble: translate(
 					'Add new functionality and integrations to your site with plugins.'
@@ -127,7 +129,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 		if ( category ) {
 			items.push( {
 				label: categoryName,
-				href: `/plugins/browse/${ category }/${ selectedSite?.slug || '' }`,
+				href: localizePath( `/plugins/browse/${ category }/${ selectedSite?.slug || '' }` ),
 				id: 'category',
 			} );
 		}
@@ -135,13 +137,13 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 		if ( search ) {
 			items.push( {
 				label: translate( 'Search Results' ),
-				href: `/plugins/${ selectedSite?.slug || '' }?s=${ search }`,
+				href: localizePath( `/plugins/${ selectedSite?.slug || '' }?s=${ search }` ),
 				id: 'plugins-search',
 			} );
 		}
 
 		dispatch( updateBreadcrumbs( items ) );
-	}, [ selectedSite?.slug, search, category, categoryName, dispatch, translate ] );
+	}, [ selectedSite?.slug, search, category, categoryName, dispatch, translate, localizePath ] );
 
 	return (
 		<FixedNavigationHeader


### PR DESCRIPTION
#### Proposed Changes

* Localizes logged out breadcrumb urls

#### Testing Instructions

* `yarn run build-languages` - required for local testing
* Click around the the marketplace while logged out and visiting under a different locale, all appended breadcrumbs should be localized.
* e.g. http://calypso.localhost:3000/ko/plugins/ check for ko in the path of each breadcrumb link

Before

https://user-images.githubusercontent.com/811776/187328987-e962fd6b-a4c5-4472-8f48-4334d14ef215.mp4

After

https://user-images.githubusercontent.com/811776/187328996-e289e96d-47e9-4170-ae07-77eda7b97d99.mp4

Fixes #67139