### PR TITLE
Import: adjust the gap between the columns of the import layout

### DIFF
--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -162,6 +162,7 @@
 	@include onboarding-heading-padding;
 	display: flex;
 	flex-direction: column;
+	gap: 0 20px;
 
 	@include break-small {
 		flex-direction: row;


### PR DESCRIPTION
#### Proposed Changes

* Adjust the gap between the columns of the import layout using `gap`

Before:

<img width="788" alt="Screen Shot 2022-08-30 at 2 23 07 PM" src="https://user-images.githubusercontent.com/1024985/187367046-769df6c4-3a47-438d-9ea7-dd92b4689e80.png">

After:

<img width="849" alt="Screen Shot 2022-08-30 at 2 26 00 PM" src="https://user-images.githubusercontent.com/1024985/187367074-456e6fce-5314-450c-ad09-7bef4541caf1.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/me/account and set your locale to `Русский`

<img width="1439" alt="Screen Shot 2022-08-10 at 4 48 13 PM" src="https://user-images.githubusercontent.com/1024985/183859310-c82faab1-8f9b-4824-9ec6-18cc20cd5234.png">

* Go to http://calypso.localhost:3000/setup/import?siteSlug={YOUR_SITE_SLUG}
* Fill in `https://welcome-manatee.jurassic.ninja` and then click `Продолжить`

<img width="1182" alt="Screen Shot 2022-08-30 at 2 42 50 PM" src="https://user-images.githubusercontent.com/1024985/187368021-beaa1478-a949-4c6e-b866-2b0fe81edf5f.png">

* Proceed to `http://calypso.localhost:3000/setup/importerWordpress?siteSlug={YOUR_SITE_SLUG}&from=https://welcome-manatee.jurassic.ninja`
* Switch to tablet mode using Chrome Dev Tool
* This import layout should appear

<img width="869" alt="Screen Shot 2022-08-30 at 2 26 11 PM" src="https://user-images.githubusercontent.com/1024985/187368292-87be565d-94c9-4d40-8835-992180ff85ba.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66591
