### PR TITLE
Plugin Management: implement plugin actions on multi-site view

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 	pluginUpdateCount: number;
 	toggleBulkManagement: () => void;
 	updateAllPlugins: () => void;
+	removePluginNotice: ( plugin: Plugin ) => void;
 }
 export default function PluginManagementV2( {
 	plugins,
@@ -29,6 +30,7 @@ export default function PluginManagementV2( {
 	pluginUpdateCount,
 	toggleBulkManagement,
 	updateAllPlugins,
+	removePluginNotice,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 
@@ -120,6 +122,7 @@ export default function PluginManagementV2( {
 					'has-bulk-management-active': isBulkManagementActive,
 				} ) }
 				selectedSite={ selectedSite }
+				removePluginNotice={ removePluginNotice }
 			/>
 		</div>
 	);

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -16,9 +16,14 @@ interface Props {
 	isLoading: boolean;
 	columns: Columns;
 	className?: string;
+	removePluginNotice: ( plugin: Plugin ) => void;
 }
 
-export default function PluginsList( { selectedSite, ...rest }: Props ): ReactElement {
+export default function PluginsList( {
+	selectedSite,
+	removePluginNotice,
+	...rest
+}: Props ): ReactElement {
 	const translate = useTranslate();
 
 	const rowFormatter = ( props: PluginRowFormatterArgs ) => {
@@ -35,12 +40,18 @@ export default function PluginsList( { selectedSite, ...rest }: Props ): ReactEl
 				>
 					{ translate( 'Manage Plugin' ) }
 				</PopoverMenuItem>
-				{ selectedSite && (
-					<>
-						<RemovePlugin site={ selectedSite } plugin={ plugin } />
-						<PluginManageConnection site={ selectedSite } plugin={ plugin } />
-					</>
+				{ selectedSite ? (
+					<RemovePlugin site={ selectedSite } plugin={ plugin } />
+				) : (
+					<PopoverMenuItem
+						onClick={ () => removePluginNotice( plugin ) }
+						icon="trash"
+						className="plugin-management-v2__actions"
+					>
+						{ translate( 'Remove' ) }
+					</PopoverMenuItem>
 				) }
+				{ selectedSite && <PluginManageConnection site={ selectedSite } plugin={ plugin } /> }
 			</>
 		);
 	};

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -230,14 +230,17 @@ export class PluginsList extends Component {
 		this.props.removePluginStatuses( 'completed', 'error' );
 	}
 
-	doActionOverSelected( actionName, action ) {
+	doActionOverSelected(
+		actionName,
+		action,
+		selectedPlugins = this.props.plugins.filter( this.isSelected ) // only use selected sites
+	) {
 		const isDeactivatingOrRemovingAndJetpackSelected = ( { slug } ) =>
 			[ 'deactivating', 'activating', 'removing' ].includes( actionName ) && 'jetpack' === slug;
 
 		const flattenArrays = ( full, partial ) => [ ...full, ...partial ];
 		this.removePluginStatuses();
-		this.props.plugins
-			.filter( this.isSelected ) // only use selected sites
+		selectedPlugins
 			.filter( ( plugin ) => ! isDeactivatingOrRemovingAndJetpackSelected( plugin ) ) // ignore sites that are deactivating, activating or removing jetpack
 			.map( ( p ) => {
 				return Object.keys( p.sites ).map( ( siteId ) => {
@@ -318,14 +321,14 @@ export class PluginsList extends Component {
 		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
 	};
 
-	getConfirmationText() {
+	getConfirmationText( selectedPlugins ) {
 		const pluginsList = {};
 		const sitesList = {};
 		let pluginName;
 		let siteName;
-		const { plugins, translate } = this.props;
+		const { translate } = this.props;
 
-		plugins.filter( this.isSelected ).forEach( ( plugin ) => {
+		selectedPlugins.forEach( ( plugin ) => {
 			pluginsList[ plugin.slug ] = true;
 			pluginName = plugin.name || plugin.slug;
 
@@ -412,44 +415,43 @@ export class PluginsList extends Component {
 		}
 	}
 
-	removePluginDialog = () => {
+	removePluginDialog = ( selectedPlugin ) => {
 		const { plugins, translate } = this.props;
+
+		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
 
 		const message = (
 			<div>
-				<span>{ this.getConfirmationText() }</span>
+				<span>{ this.getConfirmationText( selectedPlugins ) }</span>
 				<span>{ translate( 'Do you want to continue?' ) }</span>
 			</div>
 		);
 
-		const isJetpackIncluded = plugins
-			.filter( this.isSelected )
-			.some( ( { slug } ) => slug === 'jetpack' );
+		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
 
 		acceptDialog(
 			message,
-			isJetpackIncluded ? this.removeSelectedWithJetpack : this.removeSelected,
+			isJetpackIncluded
+				? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
+				: ( accepted ) => this.removeSelected( accepted, selectedPlugins ),
 			translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } )
 		);
 	};
 
-	removeSelected = ( accepted ) => {
+	removeSelected = ( accepted, selectedPlugins ) => {
 		if ( accepted ) {
-			this.doActionOverSelected( 'removing', this.props.removePlugin );
+			this.doActionOverSelected( 'removing', this.props.removePlugin, selectedPlugins );
 			this.recordEvent( 'Clicked Remove Plugin(s)', true );
 		}
 	};
 
-	removeSelectedWithJetpack = ( accepted ) => {
+	removeSelectedWithJetpack = ( accepted, selectedPlugins ) => {
 		if ( accepted ) {
-			const { plugins } = this.props;
-
-			if ( plugins.filter( this.isSelected ).length === 1 ) {
+			if ( selectedPlugins.length === 1 ) {
 				this.setState( { removeJetpackNotice: true } );
 				this.recordEvent( 'Clicked Remove Plugin(s) and Remove Jetpack', true );
 			} else {
 				let waitForRemove = false;
-
 				this.doActionOverSelected( 'removing', ( site, plugin ) => {
 					waitForRemove = true;
 					this.props.removePlugin( site, plugin );
@@ -555,7 +557,7 @@ export class PluginsList extends Component {
 					deactivateSelected={ this.deactivateSelected }
 					setAutoupdateSelected={ this.setAutoupdateSelected }
 					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
-					removePluginNotice={ this.removePluginDialog }
+					removePluginNotice={ () => this.removePluginDialog() }
 					setSelectionState={ this.setBulkSelectionState }
 					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
 					haveInactiveSelected={ this.props.plugins.some(
@@ -575,6 +577,7 @@ export class PluginsList extends Component {
 						pluginUpdateCount={ this.props.pluginUpdateCount }
 						toggleBulkManagement={ this.toggleBulkManagement }
 						updateAllPlugins={ this.updateAllPlugins }
+						removePluginNotice={ this.removePluginDialog }
 					/>
 				) : (
 					<>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -230,11 +230,10 @@ export class PluginsList extends Component {
 		this.props.removePluginStatuses( 'completed', 'error' );
 	}
 
-	doActionOverSelected(
-		actionName,
-		action,
-		selectedPlugins = this.props.plugins.filter( this.isSelected ) // only use selected sites
-	) {
+	doActionOverSelected( actionName, action, selectedPlugins ) {
+		if ( ! selectedPlugins ) {
+			selectedPlugins = this.props.plugins.filter( this.isSelected );
+		}
 		const isDeactivatingOrRemovingAndJetpackSelected = ( { slug } ) =>
 			[ 'deactivating', 'activating', 'removing' ].includes( actionName ) && 'jetpack' === slug;
 


### PR DESCRIPTION
#### Proposed Changes

This PR implements `Manage Plugin` and `Remove` on the plugin's multi-site view. 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-multi-site-plugin-actions` and `yarn start-jetpack-cloud-p`
2. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
3.  Click on  **Plugins** in the sidebar -> Click on `...` on any plugin, verify that the actions appear below and all the actions work as expected. `Remove` is a bulk action that will remove plugins on all the sites where it is installed. Confirmation popup for **Remove** will be added here - 1202518759611394-as-1202698250096233

<img width="1414" alt="Screenshot 2022-08-30 at 12 15 26 PM" src="https://user-images.githubusercontent.com/10586875/187369048-904b2678-2478-4df6-ab5c-6641697fe0b6.png">

<img width="710" alt="Screenshot 2022-08-30 at 12 28 13 PM" src="https://user-images.githubusercontent.com/10586875/187370727-3bd7a2f9-8272-4a53-ab4f-2b4531c74016.png">

4. Click on **Edit All** and verify bulk actions work as expected.
5. Test the bulk actions in Calypso Blue and verify everything works as expected.


#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202855061059179