### PR TITLE
Contact from: remove unused questions

### DIFF
--- a/apps/happychat/src/getUserInfo.ts
+++ b/apps/happychat/src/getUserInfo.ts
@@ -1,6 +1,4 @@
 type UserInfo = {
-	howCanWeHelp: string;
-	howYouFeel: string;
 	siteUrl: string;
 	siteId: number;
 	localDateTime: string;
@@ -28,9 +26,6 @@ export function getUserInfo(
 	geoLocation: UserInfo[ 'geoLocation' ]
 ) {
 	const info: UserInfo = {
-		howCanWeHelp: message,
-		// this must be a non-empty string for the intro message to work
-		howYouFeel: 'not provided',
 		siteId,
 		siteUrl,
 		localDateTime: `${ new Date().toLocaleDateString() } ${ new Date().toLocaleTimeString() }`,

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -14,8 +14,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import SegmentedControl from 'calypso/components/segmented-control';
-import SelectDropdown from 'calypso/components/select-dropdown';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -76,8 +74,6 @@ export class HelpContactForm extends PureComponent {
 		buttonLabel: PropTypes.string.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		showAlternativeSiteOptionsField: PropTypes.bool,
-		showHowCanWeHelpField: PropTypes.bool,
-		showHowYouFeelField: PropTypes.bool,
 		showSubjectField: PropTypes.bool,
 		showSiteField: PropTypes.bool,
 		showHelpLanguagePrompt: PropTypes.bool,
@@ -97,8 +93,6 @@ export class HelpContactForm extends PureComponent {
 	static defaultProps = {
 		formDescription: '',
 		showAlternativeSiteOptionsField: false,
-		showHowCanWeHelpField: false,
-		showHowYouFeelField: false,
 		showSubjectField: false,
 		showSiteField: false,
 		showHelpLanguagePrompt: false,
@@ -116,8 +110,6 @@ export class HelpContactForm extends PureComponent {
 	 * @returns {object} An object representing our initial state
 	 */
 	state = this.props.valueLink.value || {
-		howCanWeHelp: 'gettingStarted',
-		howYouFeel: 'unspecified',
 		message: '',
 		subject: '',
 		sibylClicked: false,
@@ -148,17 +140,6 @@ export class HelpContactForm extends PureComponent {
 		}
 		this.props.valueLink.requestChange( this.state );
 	}
-
-	trackClickStats = ( selectionName, selectedOption ) => {
-		const tracksEvent = {
-			howCanWeHelp: 'calypso_help_how_can_we_help_click',
-			howYouFeel: 'calypso_help_how_you_feel_click',
-		}[ selectionName ];
-
-		if ( tracksEvent ) {
-			recordTracksEvent( tracksEvent, { selected_option: selectedOption } );
-		}
-	};
 
 	trackSubmit = () => {
 		const { compact, currentUserLocale, variationSlug } = this.props;
@@ -247,59 +228,6 @@ export class HelpContactForm extends PureComponent {
 	};
 
 	/**
-	 * Render both a SegmentedControl and SelectDropdown component.
-	 *
-	 * The SegmentedControl is used for desktop and the SelectDropdown is used for mobile.
-	 * CSS will control which one is displayed to the user.
-	 *
-	 * @param  {string} selectionName    The name that will be used to store the value of a selected option appearing in selectionOptions.
-	 * @param  {object} selectionOptions An array of objects consisting of a value and a label. It can also have a property called subtext
-	 *                                   value is used when setting state, label is used for display in the selection component, and subtext
-	 *                                   is used for the second line of text displayed in the SegmentedControl
-	 * @returns {object}                  A JSX object containing both the SegmentedControl and the SelectDropdown.
-	 */
-	renderFormSelection = ( selectionName, selectionOptions ) => {
-		const { translate } = this.props;
-		const options = selectionOptions.map( ( option ) => ( {
-			label: option.label,
-			subtext: option.subtext ? (
-				<span className="help-contact-form__selection-subtext">{ option.subtext }</span>
-			) : null,
-			props: {
-				key: option.value,
-				selected: option.value === this.state[ selectionName ],
-				value: option.value,
-				title: option.label,
-				onClick: () => {
-					this.setState( { [ selectionName ]: option.value } );
-					this.trackClickStats( selectionName, option.value );
-				},
-			},
-		} ) );
-		const selectedItem = options.find( ( option ) => option.props.selected );
-
-		return (
-			<div className="help-contact-form__selection">
-				<SegmentedControl primary>
-					{ options.map( ( option ) => (
-						<SegmentedControl.Item { ...option.props }>
-							{ option.label }
-							{ option.subtext }
-						</SegmentedControl.Item>
-					) ) }
-				</SegmentedControl>
-				<SelectDropdown
-					selectedText={ selectedItem ? selectedItem.label : translate( 'Select an option' ) }
-				>
-					{ options.map( ( option ) => (
-						<SelectDropdown.Item { ...option.props }>{ option.label }</SelectDropdown.Item>
-					) ) }
-				</SelectDropdown>
-			</div>
-		);
-	};
-
-	/**
 	 * For the forums: check if we're dealing with a WP.com site.
 	 */
 	analyseSiteData = () => {
@@ -369,8 +297,6 @@ export class HelpContactForm extends PureComponent {
 	 */
 	submitForm = () => {
 		const {
-			howCanWeHelp,
-			howYouFeel,
 			message,
 			siteCount,
 			userDeclaresUnableToSeeSite,
@@ -407,8 +333,6 @@ export class HelpContactForm extends PureComponent {
 		this.trackSubmit();
 
 		this.props.onSubmit( {
-			howCanWeHelp,
-			howYouFeel,
 			message,
 			subject,
 			site: this.props.helpSite,
@@ -434,7 +358,7 @@ export class HelpContactForm extends PureComponent {
 	 * Submit additional support option
 	 */
 	submitAdditionalForm = () => {
-		const { howCanWeHelp, howYouFeel, message } = this.state;
+		const { message } = this.state;
 		const { currentUserLocale } = this.props;
 		const subject = generateSubjectFromMessage( message );
 
@@ -445,8 +369,6 @@ export class HelpContactForm extends PureComponent {
 		this.trackSubmit();
 
 		this.props.additionalSupportOption.onSubmit( {
-			howCanWeHelp,
-			howYouFeel,
 			message,
 			subject,
 			site: this.props.helpSite,
@@ -465,8 +387,6 @@ export class HelpContactForm extends PureComponent {
 			buttonLabel,
 			siteCount,
 			showAlternativeSiteOptionsField,
-			showHowCanWeHelpField,
-			showHowYouFeelField,
 			showSubjectField,
 			showSiteField,
 			showQASuggestions,
@@ -475,32 +395,6 @@ export class HelpContactForm extends PureComponent {
 			translate,
 		} = this.props;
 		const hasQASuggestions = this.state.qanda.length > 0;
-
-		const howCanWeHelpOptions = [
-			{
-				value: 'gettingStarted',
-				label: translate( 'Get started' ),
-				subtext: translate( 'Can you show me how to…' ),
-			},
-			{
-				value: 'somethingBroken',
-				label: translate( "Report something isn't working" ),
-				subtext: translate( 'Can you check this out…' ),
-			},
-			{
-				value: 'suggestion',
-				label: translate( 'Make a suggestion' ),
-				subtext: translate( 'I think it would be cool if…' ),
-			},
-		];
-		const howYouFeelOptions = [
-			{ value: 'unspecified', label: translate( "I'd rather not" ) },
-			{ value: 'happy', label: translate( 'Happy' ) },
-			{ value: 'confused', label: translate( 'Confused' ) },
-			{ value: 'discouraged', label: translate( 'Discouraged' ) },
-			{ value: 'upset', label: translate( 'Upset' ) },
-			{ value: 'panicked', label: translate( 'Panicked' ) },
-		];
 
 		const analyseSiteData = this.analyseSiteData();
 		const siteData = this.state.userDeclaredUrl && this.state.siteData;
@@ -586,20 +480,6 @@ export class HelpContactForm extends PureComponent {
 		return (
 			<div className="help-contact-form">
 				{ formDescription && <p>{ formDescription }</p> }
-
-				{ showHowCanWeHelpField && (
-					<div>
-						<FormLabel>{ translate( "You're reaching out to…" ) }</FormLabel>
-						{ this.renderFormSelection( 'howCanWeHelp', howCanWeHelpOptions ) }
-					</div>
-				) }
-
-				{ showHowYouFeelField && (
-					<div>
-						<FormLabel>{ translate( 'Mind sharing how you feel?' ) }</FormLabel>
-						{ this.renderFormSelection( 'howYouFeel', howYouFeelOptions ) }
-					</div>
-				) }
 
 				{ showSiteField && (
 					<div className="help-contact-form__site-selection">

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -169,8 +169,8 @@ class HelpContact extends Component {
 		this.recordSubmitWithActiveTickets( 'directly' );
 	};
 
-	submitKayakoTicket = ( contactForm ) => {
-		const { subject, message, howCanWeHelp, howYouFeel, site } = contactForm;
+	submitSupportTicket = ( contactForm ) => {
+		const { subject, message, site } = contactForm;
 		const { currentUserLocale, supportVariation } = this.props;
 		let plan = 'N/A';
 		if ( site ) {
@@ -179,21 +179,16 @@ class HelpContact extends Component {
 				( val ) => val // Passing an identity function instead of `translate` to always return the English string
 			) })`;
 		}
-		const ticketMeta = [
-			'How can you help: ' + howCanWeHelp,
-			'How I feel: ' + howYouFeel,
-			'Site I need help with: ' + ( site ? site.URL : 'N/A' ),
-			'Plan: ' + plan,
-		];
+		const ticketMeta = [ 'Site I need help with: ' + ( site ? site.URL : 'N/A' ), 'Plan: ' + plan ];
 
-		const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
+		const supportMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
 
 		this.setState( { isSubmitting: true } );
-		this.recordCompactSubmit( 'kayako' );
+		this.recordCompactSubmit( 'email' );
 
 		const payload = {
 			subject,
-			message: kayakoMessage,
+			message: supportMessage,
 			locale: currentUserLocale,
 			client: config( 'client_slug' ),
 			is_chat_overflow: supportVariation === SUPPORT_CHAT_OVERFLOW,
@@ -202,6 +197,7 @@ class HelpContact extends Component {
 			payload.blog_url = site.URL;
 		}
 
+		// Endpoint url has 'kayako', but actually submits to Zendesk.
 		wpcom.req
 			.post( '/help/tickets/kayako/new', payload )
 			.then( () => {
@@ -217,7 +213,7 @@ class HelpContact extends Component {
 				} );
 
 				recordTracksEvent( 'calypso_help_contact_submit', {
-					ticket_type: 'kayako',
+					ticket_type: 'email',
 					support_variation: supportVariation,
 					site_plan_product_id: site ? site.plan.product_id : null,
 					is_automated_transfer: site ? site.options.is_automated_transfer : null,
@@ -409,7 +405,7 @@ class HelpContact extends Component {
 					additionalSupportOption = {
 						enabled: true,
 						label: translate( 'Email us' ),
-						onSubmit: this.submitKayakoTicket,
+						onSubmit: this.submitSupportTicket,
 					};
 				}
 
@@ -426,7 +422,7 @@ class HelpContact extends Component {
 			case SUPPORT_TICKET:
 			case SUPPORT_UPWORK_TICKET:
 				return {
-					onSubmit: this.submitKayakoTicket,
+					onSubmit: this.submitSupportTicket,
 					buttonLabel: isSubmitting ? translate( 'Sending email' ) : translate( 'Email us' ),
 					showSubjectField: true,
 					showSiteField: hasMoreThanOneSite,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -418,8 +418,8 @@ class HelpContact extends Component {
 					onSubmit: this.startHappychat,
 					buttonLabel,
 					showSubjectField: false,
-					showHowCanWeHelpField: true,
-					showHowYouFeelField: true,
+					showHowCanWeHelpField: false,
+					showHowYouFeelField: false,
 					showSiteField: hasMoreThanOneSite,
 					showQASuggestions: true,
 				};
@@ -431,8 +431,8 @@ class HelpContact extends Component {
 					onSubmit: this.submitKayakoTicket,
 					buttonLabel: isSubmitting ? translate( 'Sending email' ) : translate( 'Email us' ),
 					showSubjectField: true,
-					showHowCanWeHelpField: true,
-					showHowYouFeelField: true,
+					showHowCanWeHelpField: false,
+					showHowYouFeelField: false,
 					showSiteField: hasMoreThanOneSite,
 					showQASuggestions: true,
 				};

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -119,9 +119,9 @@ class HelpContact extends Component {
 	startHappychat = ( contactForm ) => {
 		this.recordCompactSubmit( 'happychat' );
 		this.props.openHappychat();
-		const { howCanWeHelp, howYouFeel, message, site } = contactForm;
+		const { message, site } = contactForm;
 
-		this.props.sendUserInfo( this.props.getUserInfo( { howCanWeHelp, howYouFeel, site } ) );
+		this.props.sendUserInfo( this.props.getUserInfo( { site } ) );
 		this.props.sendHappychatMessage( message, { includeInSummary: true } );
 
 		recordTracksEvent( 'calypso_help_live_chat_begin', {
@@ -418,8 +418,6 @@ class HelpContact extends Component {
 					onSubmit: this.startHappychat,
 					buttonLabel,
 					showSubjectField: false,
-					showHowCanWeHelpField: false,
-					showHowYouFeelField: false,
 					showSiteField: hasMoreThanOneSite,
 					showQASuggestions: true,
 				};
@@ -431,8 +429,6 @@ class HelpContact extends Component {
 					onSubmit: this.submitKayakoTicket,
 					buttonLabel: isSubmitting ? translate( 'Sending email' ) : translate( 'Email us' ),
 					showSubjectField: true,
-					showHowCanWeHelpField: false,
-					showHowYouFeelField: false,
 					showSiteField: hasMoreThanOneSite,
 					showQASuggestions: true,
 				};
@@ -457,8 +453,6 @@ class HelpContact extends Component {
 						}
 					),
 					showSubjectField: false,
-					showHowCanWeHelpField: false,
-					showHowYouFeelField: false,
 					showSiteField: false,
 					showQASuggestions: true,
 				};
@@ -498,8 +492,6 @@ class HelpContact extends Component {
 								}
 						  ),
 					showSubjectField: true,
-					showHowCanWeHelpField: false,
-					showHowYouFeelField: false,
 					showSiteField: true,
 					showAlternativeSiteOptionsField: true,
 					showHidingUrlOption: true,
@@ -584,8 +576,6 @@ class HelpContact extends Component {
 		if ( this.props.compact ) {
 			return Object.assign( props, {
 				showSubjectField: false,
-				showHowCanWeHelpField: false,
-				showHowYouFeelField: false,
 				showQASuggestions: false,
 			} );
 		}

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,5 +1,4 @@
 import buildConnection from '@automattic/happychat-connection';
-import { get } from 'lodash';
 import {
 	HAPPYCHAT_BLUR,
 	HAPPYCHAT_FOCUS,
@@ -78,13 +77,8 @@ export const socketMiddleware = ( connection = null ) => {
 			case HAPPYCHAT_IO_SEND_MESSAGE_USERINFO:
 				// When user info is sent, pass it through in a message...
 				connection.send( action );
-				// ... and also set a few of the values in Custom Fields
-				store.dispatch(
-					setChatCustomFields( {
-						howCanWeHelp: get( action, 'payload.meta.howCanWeHelp', null ),
-						howYouFeel: get( action, 'payload.meta.howYouFeel', null ),
-					} )
-				);
+				// ... and also set a few of the values in Custom Fields (if any).
+				store.dispatch( setChatCustomFields( {} ) );
 				break;
 
 			case HAPPYCHAT_IO_SEND_MESSAGE_EVENT:

--- a/client/state/happychat/selectors/get-happychat-userinfo.js
+++ b/client/state/happychat/selectors/get-happychat-userinfo.js
@@ -2,10 +2,8 @@ import moment from 'moment';
 import getGeoLocation from 'calypso/state/happychat/selectors/get-geolocation';
 
 export default ( state ) =>
-	( { site, howCanWeHelp, howYouFeel } ) => {
+	( { site } ) => {
 		const info = {
-			howCanWeHelp,
-			howYouFeel,
 			siteId: site.ID,
 			siteUrl: site.URL,
 			localDateTime: moment().format( 'h:mm a, MMMM Do YYYY' ),

--- a/client/state/happychat/selectors/test/get-happychat-userinfo.js
+++ b/client/state/happychat/selectors/test/get-happychat-userinfo.js
@@ -28,8 +28,6 @@ describe( 'HAPPYCHAT_IO_SEND_MESSAGE_USERINFO action', () => {
 
 	test( 'should send relevant browser information to the connection', () => {
 		const expectedInfo = {
-			howCanWeHelp: 'howCanWeHelp',
-			howYouFeel: 'howYouFeel',
 			siteId: 'siteId',
 			siteUrl: 'siteUrl',
 			localDateTime: moment().format( 'h:mm a, MMMM Do YYYY' ),
@@ -50,8 +48,6 @@ describe( 'HAPPYCHAT_IO_SEND_MESSAGE_USERINFO action', () => {
 				ID: 'siteId',
 				URL: 'siteUrl',
 			},
-			howCanWeHelp: 'howCanWeHelp',
-			howYouFeel: 'howYouFeel',
 		} );
 
 		expect( userInfo ).toEqual( expectedInfo );


### PR DESCRIPTION
### Proposed Changes

* This removes the "You're reaching out to…" and "Mind sharing how you feel?" questions from the help contact form. It applies to both chats and tickets.
* Includes removing rendering and tracking functions, and associated state.
* Also: renames a few references to Kayako for consistency. 

### Screenshots

**Before:**
<img width="450" alt="Screen Shot 2022-09-05 at 9 08 43" src="https://user-images.githubusercontent.com/844866/188371838-d347c6cc-40cb-4cb1-9359-a9bb226808b6.png">

**After:**
<img width="450" alt="Screen Shot 2022-09-05 at 9 09 03" src="https://user-images.githubusercontent.com/844866/188371846-0e7ed359-34c8-4fee-8f14-40e4466b8012.png">

### Testing Instructions

* Visit `/help/contact` and make sure the questions aren't displayed.
* You should be able to submit a request (chat/ticket based on status)

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - **Updated existing tests**
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? - **This is user based, not related to current site.**
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) - **Not applicable**
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - **Not applicable**
