### PR TITLE
Fix vertical alignment for items on Posts page

### DIFF
--- a/client/my-sites/post-type-list/post-item/style.scss
+++ b/client/my-sites/post-type-list/post-item/style.scss
@@ -106,6 +106,15 @@ a.post-item__title-link:visited {
 	margin-right: 2px;
 }
 
+/* Force all items in the meta section to be middle-aligned */
+.post-item__meta a,
+.post-item__meta div,
+.post-item__meta li,
+.post-item__meta span,
+.post-item__meta ul {
+	vertical-align: middle;
+}
+
 .post-item__meta-time-status {
 	display: inline-block;
 	margin-right: 16px;


### PR DESCRIPTION
#### Proposed Changes

* This PR ensures that the smaller metadata items for each post listed on the Posts page are vertically aligned

#### Testing Instructions

* Open the live branch for this PR
* Navigate to the Posts page for a WPCOM Simple site (_Posts_ -> _All Posts_)
* Verify that the items listed for each post are aligned

#### Screenshots

##### Before

<img width="1068" alt="Screenshot 2022-08-30 at 13 58 05" src="https://user-images.githubusercontent.com/3376401/187436175-372e7f4e-d664-4d7e-bed2-cf07d4183f26.png">
_Note the mis-aligned time and view data_

##### After

<img width="1068" alt="Screenshot 2022-08-30 at 13 57 33" src="https://user-images.githubusercontent.com/3376401/187436148-145059eb-4679-4f87-861c-bd52dd6d67c9.png">


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ x ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?