### PR TITLE
Email comparison view: Add the ability to present regional discounts

### DIFF
--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -8,11 +8,9 @@ import type { ReactElement } from 'react';
 import './style.scss';
 
 const getSalePrice = ( {
-	isEligibleForIntroductoryOffer,
 	isDiscounted,
 	product,
 }: {
-	isEligibleForIntroductoryOffer: boolean;
 	isDiscounted: boolean;
 	product: ProductListItem | null;
 } ) => {
@@ -22,10 +20,7 @@ const getSalePrice = ( {
 	if ( isDiscounted ) {
 		return product?.sale_cost ?? 0;
 	}
-	if ( isEligibleForIntroductoryOffer ) {
-		return product?.introductory_offer?.cost_per_interval ?? 0;
-	}
-	return 0;
+	return product?.introductory_offer?.cost_per_interval ?? 0;
 };
 
 const SalePriceWithInterval = ( {
@@ -115,11 +110,7 @@ const PriceWithInterval = ( {
 
 	if ( isDiscounted || isEligibleForIntroductoryOffer ) {
 		const salePrice = formatCurrency(
-			getSalePrice( {
-				isEligibleForIntroductoryOffer,
-				isDiscounted,
-				product,
-			} ),
+			getSalePrice( { isDiscounted, product } ),
 			currencyCode ?? '',
 			{ stripZeros: true }
 		);

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -110,15 +110,6 @@ const PriceWithInterval = ( {
 		stripZeros: true,
 	} );
 
-	window.console.log( 'ZXX', {
-		cost: product?.cost,
-		isEligibleForIntroductoryOffer,
-		isDiscounted,
-		name: product?.product_name,
-		offerCost: product?.introductory_offer?.cost_per_interval,
-		saleCost: product?.sale_cost,
-	} );
-
 	if ( isDiscounted || isEligibleForIntroductoryOffer ) {
 		const salePrice = formatCurrency(
 			getSalePrice( {

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -19,10 +19,13 @@ const getSalePrice = ( {
 	if ( hasIntroductoryOfferFreeTrial( product ) ) {
 		return 0;
 	}
-	if ( isEligibleForIntroductoryOffer && ! isDiscounted ) {
+	if ( isDiscounted ) {
+		return product?.sale_cost ?? 0;
+	}
+	if ( isEligibleForIntroductoryOffer ) {
 		return product?.introductory_offer?.cost_per_interval ?? 0;
 	}
-	return product?.sale_cost ?? 0;
+	return 0;
 };
 
 const SalePriceWithInterval = ( {

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -1,10 +1,29 @@
 import formatCurrency from '@automattic/format-currency';
 import { translate } from 'i18n-calypso';
+import { hasIntroductoryOfferFreeTrial } from 'calypso/lib/emails';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import type { ReactElement } from 'react';
 
 import './style.scss';
+
+const getSalePrice = ( {
+	isEligibleForIntroductoryOffer,
+	isDiscounted,
+	product,
+}: {
+	isEligibleForIntroductoryOffer: boolean;
+	isDiscounted: boolean;
+	product: ProductListItem | null;
+} ) => {
+	if ( hasIntroductoryOfferFreeTrial( product ) ) {
+		return 0;
+	}
+	if ( isEligibleForIntroductoryOffer && ! isDiscounted ) {
+		return product?.introductory_offer?.cost_per_interval ?? 0;
+	}
+	return product?.sale_cost ?? 0;
+};
 
 const SalePriceWithInterval = ( {
 	intervalLength,
@@ -91,11 +110,22 @@ const PriceWithInterval = ( {
 		stripZeros: true,
 	} );
 
+	window.console.log( 'ZXX', {
+		cost: product?.cost,
+		isEligibleForIntroductoryOffer,
+		isDiscounted,
+		name: product?.product_name,
+		offerCost: product?.introductory_offer?.cost_per_interval,
+		saleCost: product?.sale_cost,
+	} );
+
 	if ( isDiscounted || isEligibleForIntroductoryOffer ) {
 		const salePrice = formatCurrency(
-			isEligibleForIntroductoryOffer && ! isDiscounted
-				? product?.introductory_offer?.cost_per_interval ?? 0
-				: product?.sale_cost ?? 0,
+			getSalePrice( {
+				isEligibleForIntroductoryOffer,
+				isDiscounted,
+				product,
+			} ),
 			currencyCode ?? '',
 			{ stripZeros: true }
 		);

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -78,22 +78,24 @@ const PriceWithInterval = ( {
 	currencyCode,
 	intervalLength,
 	isDiscounted = false,
-	isEligibleForFreeTrial,
+	isEligibleForIntroductoryOffer,
 	product,
 }: {
 	currencyCode: string | null;
 	intervalLength: IntervalLength;
 	isDiscounted?: boolean;
-	isEligibleForFreeTrial: boolean;
+	isEligibleForIntroductoryOffer: boolean;
 	product: ProductListItem | null;
 } ): ReactElement => {
 	const standardPrice = formatCurrency( product?.cost ?? 0, currencyCode ?? '', {
 		stripZeros: true,
 	} );
 
-	if ( isDiscounted || isEligibleForFreeTrial ) {
+	if ( isDiscounted || isEligibleForIntroductoryOffer ) {
 		const salePrice = formatCurrency(
-			isEligibleForFreeTrial ? 0 : product?.sale_cost ?? 0,
+			isEligibleForIntroductoryOffer && ! isDiscounted
+				? product?.introductory_offer?.cost_per_interval ?? 0
+				: product?.sale_cost ?? 0,
 			currencyCode ?? '',
 			{ stripZeros: true }
 		);

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -4,19 +4,18 @@ import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 } from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
-import {
-	hasGSuiteSupportedDomain,
-	isDomainEligibleForGoogleWorkspaceFreeTrial,
-} from 'calypso/lib/gsuite';
+import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
 import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
 import PriceInformation from 'calypso/my-sites/email/email-providers-comparison/price/price-information';
+import useGetDomainIntroductoryOfferEligibilities from 'calypso/my-sites/email/email-providers-comparison/price/use-get-domain-introductory-offer-eligibilities';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
@@ -26,6 +25,20 @@ const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string
 	return intervalLength === IntervalLength.MONTHLY
 		? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
 		: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+};
+
+const getApproximateDiscountForOffer = ( product: ProductListItem | null ) => {
+	if ( ! product || ! product?.introductory_offer ) {
+		return 0;
+	}
+
+	const offer = product.introductory_offer;
+
+	if ( ! offer.cost_per_interval ) {
+		return 100;
+	}
+
+	return ( ( product.cost - offer.cost_per_interval ) / product.cost ) * 100;
 };
 
 type GoogleWorkspacePriceProps = {
@@ -40,11 +53,19 @@ const GoogleWorkspacePrice = ( {
 	isDomainInCart,
 }: GoogleWorkspacePriceProps ) => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const translate = useTranslate();
 
 	const productSlug = getGoogleWorkspaceProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
+
+	const { isEligibleForIntroductoryOffer, isEligibleForIntroductoryOfferFreeTrial } =
+		useGetDomainIntroductoryOfferEligibilities( {
+			domain,
+			isDomainInCart,
+			product,
+		} );
 
 	if ( ! domain && ! isDomainInCart ) {
 		return null;
@@ -62,39 +83,75 @@ const GoogleWorkspacePrice = ( {
 	}
 
 	const isDiscounted = hasDiscount( product );
-	const isEligibleForFreeTrial = isDomainEligibleForGoogleWorkspaceFreeTrial( { domain, product } );
 
 	const priceWithInterval = (
 		<PriceWithInterval
 			currencyCode={ currencyCode ?? '' }
 			intervalLength={ intervalLength }
 			isDiscounted={ isDiscounted }
-			isEligibleForFreeTrial={ isEligibleForFreeTrial }
+			isEligibleForIntroductoryOffer={ isEligibleForIntroductoryOffer }
 			product={ product }
 		/>
 	);
 
+	const numberOfTrialMonths = product?.introductory_offer?.interval_count ?? 1;
+
 	return (
 		<>
-			{ isDiscounted && (
-				<div className="google-workspace-price__discount-badge badge badge--info-green">
-					{ translate( 'Limited time: %(discount)d%% off', {
+			{ isEligibleForIntroductoryOfferFreeTrial && (
+				<div className="google-workspace-price__trial-badge badge badge--info-green">
+					{ translate(
+						'%(numberOfTrialMonths)d month free',
+						'%(numberOfTrialMonths)d months free',
+						{
+							args: {
+								numberOfTrialMonths: numberOfTrialMonths,
+							},
+							count: numberOfTrialMonths,
+							comment:
+								"%(numberOfTrialMonths)d is the number of months when the trial is active (e.g. '3')",
+						}
+					) }
+				</div>
+			) }
+
+			{ isEligibleForIntroductoryOffer && ! isEligibleForIntroductoryOfferFreeTrial && (
+				<div className="google-workspace-price__trial-badge badge badge--info-green">
+					{ translate( '%(approximateDiscountForOffer)d%% off', {
 						args: {
-							discount: product?.sale_coupon?.discount,
+							approximateDiscountForOffer: getApproximateDiscountForOffer( product ),
 						},
-						comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
+						comment: "%(approximateDiscountForOffer)d is a numeric discount percentage (e.g. '40')",
 					} ) }
 				</div>
 			) }
 
-			{ isEligibleForFreeTrial && (
-				<div className="google-workspace-price__trial-badge badge badge--info-green">
-					{ translate( '1 month free' ) }
+			{ isDiscounted && ! isEligibleForIntroductoryOfferFreeTrial && (
+				<div className="google-workspace-price__discount-badge badge badge--info-green">
+					{ isEligibleForIntroductoryOffer
+						? translate( 'Extra %(discount)d%% off', {
+								args: {
+									discount: product?.sale_coupon?.discount,
+								},
+								comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
+						  } )
+						: translate( 'Limited time: %(discount)d%% off', {
+								args: {
+									discount: product?.sale_coupon?.discount,
+								},
+								comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
+						  } ) }
 				</div>
 			) }
 
 			<PriceBadge
-				priceInformation={ <PriceInformation domain={ domain } product={ product } /> }
+				priceInformation={
+					<PriceInformation
+						domain={ domain }
+						isDomainInCart={ isDomainInCart }
+						product={ product }
+					/>
+				}
 				price={ priceWithInterval }
 			/>
 		</>

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -115,7 +115,7 @@ const GoogleWorkspacePrice = ( {
 				</div>
 			) }
 
-			{ isEligibleForIntroductoryOffer && ! isEligibleForIntroductoryOfferFreeTrial && (
+			{ ! isEligibleForIntroductoryOfferFreeTrial && isEligibleForIntroductoryOffer && (
 				<div className="google-workspace-price__trial-badge badge badge--info-green">
 					{ translate( '%(approximateDiscountForOffer)d%% off', {
 						args: {

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -113,7 +113,7 @@ const GoogleWorkspacePrice = ( {
 				</div>
 			) }
 
-			{ isDiscounted && ! isEligibleForIntroductoryOfferFreeTrial && (
+			{ ! isEligibleForIntroductoryOfferFreeTrial && isDiscounted && (
 				<div className="google-workspace-price__discount-badge badge badge--info-green">
 					{ isEligibleForIntroductoryOffer
 						? translate( 'Extra %(discount)d%% off', {

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -94,24 +94,11 @@ const GoogleWorkspacePrice = ( {
 		/>
 	);
 
-	const numberOfTrialMonths = product?.introductory_offer?.interval_count ?? 0;
-
 	return (
 		<>
 			{ isEligibleForIntroductoryOfferFreeTrial && (
 				<div className="google-workspace-price__trial-badge badge badge--info-green">
-					{ translate(
-						'%(numberOfTrialMonths)d month free',
-						'%(numberOfTrialMonths)d months free',
-						{
-							args: {
-								numberOfTrialMonths: numberOfTrialMonths,
-							},
-							count: numberOfTrialMonths,
-							comment:
-								"%(numberOfTrialMonths)d is the number of months when the trial is active (e.g. '3')",
-						}
-					) }
+					{ translate( '1 month free' ) }
 				</div>
 			) }
 

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -94,7 +94,7 @@ const GoogleWorkspacePrice = ( {
 		/>
 	);
 
-	const numberOfTrialMonths = product?.introductory_offer?.interval_count ?? 1;
+	const numberOfTrialMonths = product?.introductory_offer?.interval_count ?? 0;
 
 	return (
 		<>

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -2,16 +2,14 @@
 
 import { isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
-import { translate } from 'i18n-calypso';
+import { translate, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import InfoPopover from 'calypso/components/info-popover';
-import {
-	getGoogleMailServiceFamily,
-	isDomainEligibleForGoogleWorkspaceFreeTrial,
-} from 'calypso/lib/gsuite';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
-import { isDomainEligibleForTitanFreeTrial, isTitanMonthlyProduct } from 'calypso/lib/titan';
+import { isTitanMonthlyProduct } from 'calypso/lib/titan';
+import useGetDomainIntroductoryOfferEligibilities from 'calypso/my-sites/email/email-providers-comparison/price/use-get-domain-introductory-offer-eligibilities';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
@@ -109,25 +107,46 @@ const FreeTrialPriceInformation = ( {
 
 const PriceInformation = ( {
 	domain,
+	isDomainInCart = false,
 	product,
 }: {
 	domain?: ResponseDomain;
+	isDomainInCart?: boolean;
 	product: ProductListItem | null;
 } ): ReactElement | null => {
+	const { isEligibleForIntroductoryOffer, isEligibleForIntroductoryOfferFreeTrial } =
+		useGetDomainIntroductoryOfferEligibilities( {
+			domain,
+			isDomainInCart,
+			product,
+		} );
+
+	const translate = useTranslate();
+
 	if ( ! product ) {
 		return null;
 	}
 
-	if ( isGoogleWorkspace( product ) && hasDiscount( product ) ) {
+	const isGoogleWorkspaceProduct = isGoogleWorkspace( product );
+
+	if ( ! isGoogleWorkspaceProduct && ! isTitanMail( product ) ) {
+		return null;
+	}
+
+	if ( isGoogleWorkspaceProduct && hasDiscount( product ) && ! isEligibleForIntroductoryOffer ) {
 		return <DiscountPriceInformation product={ product } />;
 	}
 
-	if (
-		( isGoogleWorkspace( product ) &&
-			isDomainEligibleForGoogleWorkspaceFreeTrial( { domain, product } ) ) ||
-		( isTitanMail( product ) && isDomainEligibleForTitanFreeTrial( { domain, product } ) )
-	) {
+	if ( isEligibleForIntroductoryOfferFreeTrial ) {
 		return <FreeTrialPriceInformation product={ product } />;
+	}
+
+	if ( isGoogleWorkspaceProduct && isEligibleForIntroductoryOffer ) {
+		return (
+			<div className="price-information__free-trial">
+				{ translate( 'Enjoy first year subscription at the discounted price' ) }
+			</div>
+		);
 	}
 
 	return null;

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -2,12 +2,11 @@
 
 import { isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
-import { translate, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import InfoPopover from 'calypso/components/info-popover';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
-import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 import { isTitanMonthlyProduct } from 'calypso/lib/titan';
 import useGetDomainIntroductoryOfferEligibilities from 'calypso/my-sites/email/email-providers-comparison/price/use-get-domain-introductory-offer-eligibilities';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -32,20 +31,11 @@ const getFirstRenewalPrice = ( product: ProductListItem, currencyCode: string ):
 };
 
 const DiscountPriceInformation = ( { product }: { product: ProductListItem } ): ReactElement => {
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const translate = useTranslate();
 
 	return (
 		<div className="price-information__discount">
-			{ translate( 'Pay only %(discountedPrice)s today - renews at %(standardPrice)s', {
-				args: {
-					discount: product.sale_coupon?.discount,
-					discountedPrice: formatPrice( product.sale_cost ?? 0, currencyCode ?? '' ),
-					standardPrice: formatPrice( product.cost ?? 0, currencyCode ?? '' ),
-				},
-				comment:
-					"%(discount)d is a numeric percentage discount (e.g. '50'), " +
-					"%(discountedPrice)s and %(standardPrice)s are formatted prices with the currency (e.g. '$5')",
-			} ) }
+			{ translate( 'Enjoy first year subscription at the discounted price' ) }
 
 			{ isGoogleWorkspace( product ) && (
 				<InfoPopover position="right" showOnHover>
@@ -70,6 +60,7 @@ const FreeTrialPriceInformation = ( {
 	product: ProductListItem;
 } ): ReactElement | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const translate = useTranslate();
 
 	const translateArguments = {
 		args: {
@@ -121,32 +112,20 @@ const PriceInformation = ( {
 			product,
 		} );
 
-	const translate = useTranslate();
-
 	if ( ! product ) {
 		return null;
 	}
 
-	const isGoogleWorkspaceProduct = isGoogleWorkspace( product );
-
-	if ( ! isGoogleWorkspaceProduct && ! isTitanMail( product ) ) {
+	if ( ! isGoogleWorkspace( product ) && ! isTitanMail( product ) ) {
 		return null;
-	}
-
-	if ( hasDiscount( product ) && ! isEligibleForIntroductoryOffer ) {
-		return <DiscountPriceInformation product={ product } />;
 	}
 
 	if ( isEligibleForIntroductoryOfferFreeTrial ) {
 		return <FreeTrialPriceInformation product={ product } />;
 	}
 
-	if ( isGoogleWorkspaceProduct && isEligibleForIntroductoryOffer ) {
-		return (
-			<div className="price-information__free-trial">
-				{ translate( 'Enjoy first year subscription at the discounted price' ) }
-			</div>
-		);
+	if ( hasDiscount( product ) || isEligibleForIntroductoryOffer ) {
+		return <DiscountPriceInformation product={ product } />;
 	}
 
 	return null;

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -133,7 +133,7 @@ const PriceInformation = ( {
 		return null;
 	}
 
-	if ( isGoogleWorkspaceProduct && hasDiscount( product ) && ! isEligibleForIntroductoryOffer ) {
+	if ( hasDiscount( product ) && ! isEligibleForIntroductoryOffer ) {
 		return <DiscountPriceInformation product={ product } />;
 	}
 

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -30,14 +30,20 @@ const getFirstRenewalPrice = ( product: ProductListItem, currencyCode: string ):
 	return null;
 };
 
-const DiscountPriceInformation = ( { product }: { product: ProductListItem } ): ReactElement => {
+const DiscountPriceInformation = ( {
+	isEligibleForIntroductoryOffer,
+	product,
+}: {
+	isEligibleForIntroductoryOffer: boolean;
+	product: ProductListItem;
+} ): ReactElement => {
 	const translate = useTranslate();
 
 	return (
 		<div className="price-information__discount">
 			{ translate( 'Enjoy first year subscription at the discounted price' ) }
 
-			{ isGoogleWorkspace( product ) && (
+			{ isGoogleWorkspace( product ) && ! isEligibleForIntroductoryOffer && (
 				<InfoPopover position="right" showOnHover>
 					{ translate(
 						'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
@@ -125,7 +131,12 @@ const PriceInformation = ( {
 	}
 
 	if ( hasDiscount( product ) || isEligibleForIntroductoryOffer ) {
-		return <DiscountPriceInformation product={ product } />;
+		return (
+			<DiscountPriceInformation
+				product={ product }
+				isEligibleForIntroductoryOffer={ isEligibleForIntroductoryOffer }
+			/>
+		);
 	}
 
 	return null;

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -61,7 +61,13 @@ const ProfessionalEmailPrice = ( {
 			) }
 
 			<PriceBadge
-				priceInformation={ <PriceInformation domain={ domain } product={ product } /> }
+				priceInformation={
+					<PriceInformation
+						domain={ domain }
+						isDomainInCart={ isDomainInCart }
+						product={ product }
+					/>
+				}
 				price={ priceWithInterval }
 			/>
 		</>

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -47,7 +47,7 @@ const ProfessionalEmailPrice = ( {
 		<PriceWithInterval
 			currencyCode={ currencyCode ?? '' }
 			intervalLength={ intervalLength }
-			isEligibleForFreeTrial={ isEligibleForFreeTrial }
+			isEligibleForIntroductoryOffer={ isEligibleForFreeTrial }
 			product={ product }
 		/>
 	);

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -4,14 +4,11 @@
 	margin-bottom: 12px;
 }
 
-.google-workspace-price__discount-badge.badge--info-green {
-	&:not( :first-child ) {
-		margin-left: 5px;
-	}
-
+.badge--info-green + .google-workspace-price__discount-badge.badge--info-green {
 	background-color: rgba( 184, 230, 191, 0.24 );
 	border: solid 1px var( --studio-green-30 );
 	color: var( --studio-green-50 );
+	margin-left: 5px;
 	padding: 1px 10px;
 }
 

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -4,6 +4,17 @@
 	margin-bottom: 12px;
 }
 
+.google-workspace-price__discount-badge.badge--info-green {
+	&:not( :first-child ) {
+		margin-left: 5px;
+	}
+
+	background-color: rgba( 184, 230, 191, 0.24 );
+	border: solid 1px var( --studio-green-30 );
+	color: var( --studio-green-50 );
+	padding: 1px 10px;
+}
+
 .price-information__discount,
 .price-information__free-trial {
 	color: var( --color-text-subtle );

--- a/client/my-sites/email/email-providers-comparison/price/use-get-domain-introductory-offer-eligibilities.ts
+++ b/client/my-sites/email/email-providers-comparison/price/use-get-domain-introductory-offer-eligibilities.ts
@@ -1,0 +1,53 @@
+import { isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
+import { hasIntroductoryOffer, hasIntroductoryOfferFreeTrial } from 'calypso/lib/emails';
+import { isDomainEligibleForGoogleWorkspaceIntroductoryOffer } from 'calypso/lib/gsuite';
+import { isDomainEligibleForTitanIntroductoryOffer } from 'calypso/lib/titan';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+type DomainIntroductoryOfferEligibilitiesProps = {
+	domain?: ResponseDomain;
+	isDomainInCart?: boolean;
+	product: ProductListItem | null;
+};
+
+type DomainIntroductoryOfferEligibilities = {
+	isEligibleForIntroductoryOffer: boolean;
+	isEligibleForIntroductoryOfferFreeTrial: boolean;
+};
+
+const DEFAULT_ELIGIBILITY: DomainIntroductoryOfferEligibilities = {
+	isEligibleForIntroductoryOffer: false,
+	isEligibleForIntroductoryOfferFreeTrial: false,
+};
+
+const useGetDomainIntroductoryOfferEligibilities = ( {
+	domain = undefined,
+	isDomainInCart = false,
+	product,
+}: DomainIntroductoryOfferEligibilitiesProps ) => {
+	if ( ! product ) {
+		return DEFAULT_ELIGIBILITY;
+	}
+
+	const isTitanMailProduct = isTitanMail( product );
+
+	if ( ! isTitanMailProduct && ! isGoogleWorkspace( product ) ) {
+		return DEFAULT_ELIGIBILITY;
+	}
+
+	const isDomainEligibleForIntroductoryOffer = isTitanMailProduct
+		? isDomainEligibleForTitanIntroductoryOffer( domain )
+		: isDomainEligibleForGoogleWorkspaceIntroductoryOffer( domain );
+
+	const isEligibleForIntroductoryOffer = domain
+		? isDomainEligibleForIntroductoryOffer
+		: isDomainInCart && hasIntroductoryOffer( product );
+
+	const isEligibleForIntroductoryOfferFreeTrial =
+		isEligibleForIntroductoryOffer && hasIntroductoryOfferFreeTrial( product );
+
+	return { isEligibleForIntroductoryOffer, isEligibleForIntroductoryOfferFreeTrial };
+};
+
+export default useGetDomainIntroductoryOfferEligibilities;


### PR DESCRIPTION
To support the regional pricing work we are currently wrangling in the backend, we need a few pieces in the frontend to ensure that we display discounts and product offers properly.

Sometimes the target product also has a regular sale coupon attached and we have to factor that into the display as well.

#### Proposed Changes

* Extend the introductory product offer display to support non-zero discounts. We used to only display zero pricing, optimized for free trials.
* Extend the offer eligibility for email products to include new domains in the cart. 

#### Screenshot

This is an example of how the discount is presented when both the regional offer and a sale coupon are active:
 
<img width="1065" alt="Screen Shot 2022-09-02 at 8 10 27 AM" src="https://user-images.githubusercontent.com/104910361/188140719-01865ef2-a207-40df-8533-789dd78e1472.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See setup instructions from 2d726-pb
* Load the stacked email comparison view in your local dev server i.e. http://calypso.localhost:3000/email/[:site] . You can also use [Calypso Live](https://github.com/Automattic/wp-calypso/pull/66153#issuecomment-1201968909) to navigate that view. You can also reach this view by attempting to purchase a new domain, which leads you to the email upsell. Either way, always ensure to use a domain that has not been used to purchase email before.
* The best way to test the price information unit is to have about four users, with four different currencies: 
    * MXN - introductory offer
    * PHP - introductory offer
    * TRY - introductory offer
    * USD - default system billing plans
    * You can also mix in a sale coupon ( optional )
* Scenarios to test:
    - Price display for each of the currencies is in conformance with the resolution here: pbLl1t-1iP-p2#comment-1253
    - Ensure that the offer discount is displayed as a percentage
    - Ensure that the display works well when a sale discount is also active

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #