### PR TITLE
Design setup: remove direct link to checkout

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -130,14 +130,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				);
 			} else {
 				text = (
-					<Button
-						isLink={ true }
-						className="design-picker__button-link"
-						onClick={ ( e: any ) => {
-							e.stopPropagation();
-							onCheckout?.();
-						} }
-					>
+					<Button isLink={ true } className="design-picker__button-link">
 						{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
 							? __( 'Included in WordPress.com Premium' )
 							: __( 'Upgrade to Premium' ) }
@@ -217,8 +210,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						) }
 					</span>
 				</span>
+				{ getPricingDescription() }
 			</button>
-			{ getPricingDescription() }
 		</div>
 	);
 };


### PR DESCRIPTION
This PR addresses an issue that was raised by Ian a while ago. It felt off to click on the `Included in WordPress.com Premium` and get to the checkout screen. This PR changes that link behaviour to open the theme preview.

| Before  | After |
| ------------- | ------------- |
| ![2022-08-30 10 32 38](https://user-images.githubusercontent.com/375980/187450834-724211e5-a814-4d2a-b1af-a4e1037615ef.gif)  | ![2022-08-30 10 32 03](https://user-images.githubusercontent.com/375980/187450763-364fec66-d84d-4f29-bfaa-75eb88286be5.gif)  |


### Testing
1. Apply this PR.
2. Go to `/setup/designSetup?siteSlug=[YOUR_SITE]`.
3. Find a Premium theme.
4. Click on the `Included in the WordPress.com Premium` link.
5. Verify that the theme preview is opened.

Closes https://github.com/Automattic/wp-calypso/issues/65364