### PR TITLE
Add subscriber package integration with the Users section

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -34,6 +34,7 @@ const Subscribers: Step = function ( { navigation, flow } ): ReactElement | null
 							siteId={ site.ID }
 							submitBtnName={ __( 'Continue' ) }
 							onImportFinished={ handleSubmit }
+							allowEmptyFormSubmit={ true }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 						/>
 					) }

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -8,6 +8,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import EditTeamMember from './edit-team-member-form';
 import InvitePeople from './invite-people';
 import PeopleList from './main';
+import PeopleAddSubscribers from './people-add-subscribers';
 import PeopleInviteDetails from './people-invite-details';
 import PeopleInvites from './people-invites';
 
@@ -42,6 +43,10 @@ export default {
 
 	peopleInviteDetails( context, next ) {
 		renderPeopleInviteDetails( context, next );
+	},
+
+	peopleAddSubscribers( context, next ) {
+		renderPeopleAddSubscribers( context, next );
 	},
 };
 
@@ -100,6 +105,22 @@ function renderPeopleInvites( context, next ) {
 		<>
 			<PeopleInvitesTitle />
 			<PeopleInvites />
+		</>
+	);
+	next();
+}
+
+function renderPeopleAddSubscribers( context, next ) {
+	const PeopleAddSubscribersTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Add Subscribers', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<PeopleAddSubscribersTitle />
+			<PeopleAddSubscribers />
 		</>
 	);
 	next();

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -208,6 +208,8 @@ class EditUserForm extends Component {
 						onChange={ this.handleChange }
 						onFocus={ this.recordFieldFocus( fieldKeys.roles ) }
 						disabled={ isDisabled }
+						includeFollower={ this.state.roles === 'follower' }
+						includeSubscriber={ this.state.roles === 'subscriber' }
 					/>
 				);
 				break;

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { Card, Button } from '@automattic/components';
+import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
@@ -110,15 +111,12 @@ class Followers extends Component {
 			);
 		}
 
-		let emptyTitle;
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {
-				emptyTitle = preventWidows(
-					this.props.translate( 'No one is following you by email yet.' )
-				);
-			} else {
-				emptyTitle = preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );
+				return <AddSubscriberForm />;
 			}
+
+			const emptyTitle = preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );
 			return <EmptyContent title={ emptyTitle } action={ this.renderInviteFollowersAction() } />;
 		}
 

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -113,7 +113,11 @@ class Followers extends Component {
 
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {
-				return <AddSubscriberForm />;
+				return (
+					<Card>
+						<AddSubscriberForm />
+					</Card>
+				);
 			}
 
 			const emptyTitle = preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -145,8 +145,8 @@ class Followers extends Component {
 
 			if ( this.props.type === 'email' ) {
 				headerText = this.props.translate(
-					'You have %(number)d follower receiving updates by email',
-					'You have %(number)d followers receiving updates by email',
+					'You have %(number)d subscriber receiving updates by email',
+					'You have %(number)d subscribers receiving updates by email',
 					{
 						args: { number: this.props.totalFollowers },
 						count: this.props.totalFollowers,

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -5,6 +5,7 @@ import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
@@ -115,7 +116,14 @@ class Followers extends Component {
 			if ( 'email' === this.props.type ) {
 				return (
 					<Card>
-						<AddSubscriberForm />
+						<EmailVerificationGate
+							noticeText={ this.props.translate(
+								'You must verify your email to add subscribers.'
+							) }
+							noticeStatus="is-info"
+						>
+							<AddSubscriberForm />
+						</EmailVerificationGate>
 					</Card>
 				);
 			}

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -122,7 +122,7 @@ class Followers extends Component {
 							) }
 							noticeStatus="is-info"
 						>
-							<AddSubscriberForm />
+							<AddSubscriberForm siteId={ this.props.site.ID } />
 						</EmailVerificationGate>
 					</Card>
 				);

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
@@ -125,6 +126,7 @@ class Followers extends Component {
 						>
 							<AddSubscriberForm
 								siteId={ this.props.site.ID }
+								showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 								onImportFinished={ () => {
 									page.redirect( `/people/email-followers/${ this.props.site.slug }` );
 								} }

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -3,6 +3,7 @@
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
@@ -122,7 +123,12 @@ class Followers extends Component {
 							) }
 							noticeStatus="is-info"
 						>
-							<AddSubscriberForm siteId={ this.props.site.ID } />
+							<AddSubscriberForm
+								siteId={ this.props.site.ID }
+								onImportFinished={ () => {
+									page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+								} }
+							/>
 						</EmailVerificationGate>
 					</Card>
 				);

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -114,31 +114,38 @@ class Followers extends Component {
 			);
 		}
 
+		let emptyTitle;
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {
-				return (
-					<Card>
-						<EmailVerificationGate
-							noticeText={ this.props.translate(
-								'You must verify your email to add subscribers.'
-							) }
-							noticeStatus="is-info"
-						>
-							<AddSubscriberForm
-								siteId={ this.props.site.ID }
-								showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
-								onImportFinished={ () => {
-									page.redirect( `/people/email-followers/${ this.props.site.slug }` );
-								} }
-							/>
-						</EmailVerificationGate>
-					</Card>
+				if ( isEnabled( 'subscriber-importer' ) ) {
+					return (
+						<Card>
+							<EmailVerificationGate
+								noticeText={ this.props.translate(
+									'You must verify your email to add subscribers.'
+								) }
+								noticeStatus="is-info"
+							>
+								<AddSubscriberForm
+									siteId={ this.props.site.ID }
+									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
+									onImportFinished={ () => {
+										page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+									} }
+								/>
+							</EmailVerificationGate>
+						</Card>
+					);
+				}
+				emptyTitle = preventWidows(
+					this.props.translate( 'No one is following you by email yet.' )
 				);
+			} else {
+				emptyTitle = isEnabled( 'subscriber-importer' )
+					? preventWidows( this.props.translate( 'No WordPress.com subscribers yet.' ) )
+					: preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );
 			}
 
-			const emptyTitle = preventWidows(
-				this.props.translate( 'No WordPress.com subscribers yet.' )
-			);
 			return <EmptyContent title={ emptyTitle } action={ this.renderInviteFollowersAction() } />;
 		}
 
@@ -154,14 +161,22 @@ class Followers extends Component {
 			);
 
 			if ( this.props.type === 'email' ) {
-				headerText = this.props.translate(
-					'You have %(number)d subscriber receiving updates by email',
-					'You have %(number)d subscribers receiving updates by email',
-					{
-						args: { number: this.props.totalFollowers },
-						count: this.props.totalFollowers,
-					}
-				);
+				const translateArgs = {
+					args: { number: this.props.totalFollowers },
+					count: this.props.totalFollowers,
+				};
+
+				headerText = isEnabled( 'subscriber-importer' )
+					? this.props.translate(
+							'You have %(number)d subscriber receiving updates by email',
+							'You have %(number)d subscribers receiving updates by email',
+							translateArgs
+					  )
+					: this.props.translate(
+							'You have %(number)d follower receiving updates by email',
+							'You have %(number)d followers receiving updates by email',
+							translateArgs
+					  );
 			}
 		}
 

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -134,7 +134,9 @@ class Followers extends Component {
 				);
 			}
 
-			const emptyTitle = preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );
+			const emptyTitle = preventWidows(
+				this.props.translate( 'No WordPress.com subscribers yet.' )
+			);
 			return <EmptyContent title={ emptyTitle } action={ this.renderInviteFollowersAction() } />;
 		}
 

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -45,6 +45,16 @@ export default function () {
 	);
 
 	page(
+		'/people/add-subscribers/:site_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.peopleAddSubscribers,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/people/new/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/invite-button.jsx
+++ b/client/my-sites/people/invite-button.jsx
@@ -11,7 +11,7 @@ const InviteButton = ( { isPrimary = true, siteSlug } ) => {
 	return (
 		<Button primary={ isPrimary } href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />
-			<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
+			<span>{ translate( 'Add User', { context: 'Verb. Button to invite more users.' } ) }</span>
 		</Button>
 	);
 };

--- a/client/my-sites/people/invite-button.jsx
+++ b/client/my-sites/people/invite-button.jsx
@@ -11,7 +11,7 @@ const InviteButton = ( { isPrimary = true, siteSlug } ) => {
 	return (
 		<Button primary={ isPrimary } href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />
-			<span>{ translate( 'Add User', { context: 'Verb. Button to invite more users.' } ) }</span>
+			<span>{ translate( 'Invite User', { context: 'Verb. Button to invite more users.' } ) }</span>
 		</Button>
 	);
 };

--- a/client/my-sites/people/invite-button.jsx
+++ b/client/my-sites/people/invite-button.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 
@@ -11,7 +12,11 @@ const InviteButton = ( { isPrimary = true, siteSlug } ) => {
 	return (
 		<Button primary={ isPrimary } href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />
-			<span>{ translate( 'Invite User', { context: 'Verb. Button to invite more users.' } ) }</span>
+			<span>
+				{ isEnabled( 'subscriber-importer' )
+					? translate( 'Invite User', { context: 'Verb. Button to invite more users.' } )
+					: translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+			</span>
 		</Button>
 	);
 };

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -73,14 +73,7 @@ class InvitePeople extends Component {
 	};
 
 	getInitialState = () => {
-		const { isAtomic, isWPForTeamsSite } = this.props;
-
-		let defaultRole = 'follower';
-		if ( isWPForTeamsSite ) {
-			defaultRole = 'editor';
-		} else if ( isAtomic ) {
-			defaultRole = 'subscriber';
-		}
+		const defaultRole = 'editor';
 
 		return {
 			isExternal: false,
@@ -398,10 +391,6 @@ class InvitePeople extends Component {
 	renderInviteForm = () => {
 		const { site, translate, needsVerification, isJetpack, showSSONotice } = this.props;
 
-		// Atomic private sites don't support Viewers/Followers.
-		// @see https://github.com/Automattic/wp-calypso/issues/43919
-		const includeFollower = ! this.props.isAtomic;
-
 		const inviteForm = (
 			<Card>
 				<EmailVerificationGate>
@@ -434,7 +423,6 @@ class InvitePeople extends Component {
 						<RoleSelect
 							id="role"
 							name="role"
-							includeFollower={ includeFollower }
 							siteId={ this.props.siteId }
 							onChange={ this.onRoleChange }
 							onFocus={ this.onFocusRoleSelect }

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -70,7 +70,7 @@ class PeopleInvites extends PureComponent {
 						noticeText={ this.props.translate( 'You must verify your email to add subscribers.' ) }
 						noticeStatus="is-info"
 					>
-						<AddSubscriberForm />
+						<AddSubscriberForm siteId={ this.props.site.ID } />
 					</EmailVerificationGate>
 				</Card>
 			</Main>

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -1,0 +1,90 @@
+import { Card } from '@automattic/components';
+import { AddSubscriberForm } from '@automattic/subscriber';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import EmptyContent from 'calypso/components/empty-content';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import {
+	isRequestingInvitesForSite,
+	getPendingInvitesForSite,
+	getAcceptedInvitesForSite,
+	getNumberOfInvitesFoundForSite,
+	isDeletingAnyInvite,
+} from 'calypso/state/invites/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+class PeopleInvites extends PureComponent {
+	static propTypes = {
+		site: PropTypes.object,
+	};
+
+	goBack = () => {
+		const siteSlug = get( this.props, 'site.slug' );
+		const fallback = siteSlug ? '/people/team/' + siteSlug : '/people/team';
+
+		// Go back to last route with /people/team/$site as the fallback
+		page.back( fallback );
+	};
+
+	render() {
+		const { site, canViewPeople, translate } = this.props;
+		const siteId = site && site.ID;
+
+		if ( siteId && ! canViewPeople ) {
+			return (
+				<Main>
+					<PageViewTracker
+						path="/people/add-subscribers/:site_id"
+						title="People > Add Subscribers"
+					/>
+					<EmptyContent
+						title={ translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
+
+		return (
+			<Main>
+				<PageViewTracker path="/people/add-subscribers/:site_id" title="People > Add Subscribers" />
+				<HeaderCake isCompact onClick={ this.goBack }>
+					{ translate( 'Add Subscribers to %(sitename)s', {
+						args: {
+							sitename: site.name,
+						},
+					} ) }
+				</HeaderCake>
+				<Card>
+					<AddSubscriberForm />
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const site = getSelectedSite( state );
+	const siteId = site && site.ID;
+
+	return {
+		site,
+		isJetpack: isJetpackSite( state, siteId ),
+		isPrivate: isPrivateSite( state, siteId ),
+		requesting: isRequestingInvitesForSite( state, siteId ),
+		pendingInvites: getPendingInvitesForSite( state, siteId ),
+		acceptedInvites: getAcceptedInvitesForSite( state, siteId ),
+		totalInvitesFound: getNumberOfInvitesFoundForSite( state, siteId ),
+		deleting: isDeletingAnyInvite( state, siteId ),
+		canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
+	};
+} )( localize( PeopleInvites ) );

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -6,6 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
@@ -65,7 +66,12 @@ class PeopleInvites extends PureComponent {
 					} ) }
 				</HeaderCake>
 				<Card>
-					<AddSubscriberForm />
+					<EmailVerificationGate
+						noticeText={ this.props.translate( 'You must verify your email to add subscribers.' ) }
+						noticeStatus="is-info"
+					>
+						<AddSubscriberForm />
+					</EmailVerificationGate>
 				</Card>
 			</Main>
 		);

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -59,7 +59,7 @@ class PeopleInvites extends PureComponent {
 			<Main>
 				<PageViewTracker path="/people/add-subscribers/:site_id" title="People > Add Subscribers" />
 				<HeaderCake isCompact onClick={ this.goBack }>
-					{ translate( 'Add Subscribers to %(sitename)s', {
+					{ translate( 'Add subscribers to %(sitename)s', {
 						args: {
 							sitename: site.name,
 						},

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -70,7 +70,12 @@ class PeopleInvites extends PureComponent {
 						noticeText={ this.props.translate( 'You must verify your email to add subscribers.' ) }
 						noticeStatus="is-info"
 					>
-						<AddSubscriberForm siteId={ this.props.site.ID } />
+						<AddSubscriberForm
+							siteId={ this.props.site.ID }
+							onImportFinished={ () => {
+								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+							} }
+						/>
 					</EmailVerificationGate>
 				</Card>
 			</Main>

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
@@ -72,6 +73,7 @@ class PeopleInvites extends PureComponent {
 					>
 						<AddSubscriberForm
 							siteId={ this.props.site.ID }
+							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							onImportFinished={ () => {
 								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
 							} }

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -38,6 +38,12 @@ class PeopleListSectionHeader extends Component {
 		return '/people/new/' + siteSlug;
 	}
 
+	getAddSubscriberLink() {
+		const siteSlug = get( this.props, 'site.slug' );
+
+		return '/people/add-subscribers/' + siteSlug;
+	}
+
 	getPopoverText() {
 		const { currentRoute, translate } = this.props;
 
@@ -52,9 +58,22 @@ class PeopleListSectionHeader extends Component {
 		return null;
 	}
 
+	isFollowersTab() {
+		const { currentRoute } = this.props;
+
+		return startsWith( currentRoute, '/people/followers' );
+	}
+
+	isSubscribersTab() {
+		const { currentRoute } = this.props;
+
+		return startsWith( currentRoute, '/people/email-followers' );
+	}
+
 	render() {
 		const { label, count, children, translate } = this.props;
 		const siteLink = this.getAddLink();
+		const addSubscriberLink = this.getAddSubscriberLink();
 		const classes = classNames( this.props.className, 'people-list-section-header' );
 
 		return (
@@ -66,12 +85,17 @@ class PeopleListSectionHeader extends Component {
 				popoverText={ this.getPopoverText() }
 			>
 				{ children }
-				{ siteLink && (
+				{ siteLink && this.isFollowersTab() && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
 						<span>
 							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 						</span>
+					</Button>
+				) }
+				{ addSubscriberLink && this.isSubscribersTab() && (
+					<Button href={ addSubscriberLink } compact primary>
+						{ translate( 'Add Subscribers', { context: 'Verb. Button to add more subscribers.' } ) }
 					</Button>
 				) }
 			</SectionHeader>

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -58,12 +58,6 @@ class PeopleListSectionHeader extends Component {
 		return null;
 	}
 
-	isFollowersTab() {
-		const { currentRoute } = this.props;
-
-		return startsWith( currentRoute, '/people/followers' );
-	}
-
 	isSubscribersTab() {
 		const { currentRoute } = this.props;
 
@@ -85,7 +79,7 @@ class PeopleListSectionHeader extends Component {
 				popoverText={ this.getPopoverText() }
 			>
 				{ children }
-				{ siteLink && this.isFollowersTab() && (
+				{ siteLink && ! this.isSubscribersTab() && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
 						<span>

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -89,7 +89,7 @@ class PeopleListSectionHeader extends Component {
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
 						<span>
-							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+							{ translate( 'Add User', { context: 'Verb. Button to invite more users.' } ) }
 						</span>
 					</Button>
 				) }

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -70,6 +71,11 @@ class PeopleListSectionHeader extends Component {
 		const addSubscriberLink = this.getAddSubscriberLink();
 		const classes = classNames( this.props.className, 'people-list-section-header' );
 
+		const showInviteUserBtn =
+			( siteLink && ! this.isSubscribersTab() ) || ! isEnabled( 'subscriber-importer' );
+		const showAddSubscriberBtn =
+			addSubscriberLink && this.isSubscribersTab() && isEnabled( 'subscriber-importer' );
+
 		return (
 			<SectionHeader
 				className={ classes }
@@ -79,15 +85,17 @@ class PeopleListSectionHeader extends Component {
 				popoverText={ this.getPopoverText() }
 			>
 				{ children }
-				{ siteLink && ! this.isSubscribersTab() && (
+				{ showInviteUserBtn && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
 						<Gridicon icon="user-add" />
 						<span>
-							{ translate( 'Add User', { context: 'Verb. Button to invite more users.' } ) }
+							{ isEnabled( 'subscriber-importer' )
+								? translate( 'Add User', { context: 'Verb. Button to invite more users.' } )
+								: translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 						</span>
 					</Button>
 				) }
-				{ addSubscriberLink && this.isSubscribersTab() && (
+				{ showAddSubscriberBtn && (
 					<Button href={ addSubscriberLink } compact primary>
 						{ translate( 'Add Subscribers', { context: 'Verb. Button to add more subscribers.' } ) }
 					</Button>

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -72,7 +72,8 @@ class PeopleListSectionHeader extends Component {
 		const classes = classNames( this.props.className, 'people-list-section-header' );
 
 		const showInviteUserBtn =
-			( siteLink && ! this.isSubscribersTab() ) || ! isEnabled( 'subscriber-importer' );
+			( siteLink && ! this.isSubscribersTab() ) ||
+			( siteLink && ! isEnabled( 'subscriber-importer' ) );
 		const showAddSubscriberBtn =
 			addSubscriberLink && this.isSubscribersTab() && isEnabled( 'subscriber-importer' );
 

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -71,7 +71,7 @@ class PeopleSectionNav extends Component {
 				id: 'viewers',
 			},
 			{
-				title: translate( 'Invites' ),
+				title: translate( 'User Invites' ),
 				path: '/people/invites/' + siteFilter,
 				id: 'invites',
 			},

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -61,7 +61,7 @@ class PeopleSectionNav extends Component {
 				id: 'followers',
 			},
 			{
-				title: translate( 'Email Followers', { context: 'Filter label for people list' } ),
+				title: translate( 'Subscribers', { context: 'Filter label for people list' } ),
 				path: '/people/email-followers/' + siteFilter,
 				id: 'email-followers',
 			},

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -61,7 +61,7 @@ class PeopleSectionNav extends Component {
 				id: 'followers',
 			},
 			{
-				title: translate( 'Subscribers', { context: 'Filter label for people list' } ),
+				title: translate( 'Email Subscribers', { context: 'Filter label for people list' } ),
 				path: '/people/email-followers/' + siteFilter,
 				id: 'email-followers',
 			},

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { find, get, includes } from 'lodash';
 import { Component } from 'react';
@@ -61,7 +62,9 @@ class PeopleSectionNav extends Component {
 				id: 'followers',
 			},
 			{
-				title: translate( 'Email Subscribers', { context: 'Filter label for people list' } ),
+				title: isEnabled( 'subscriber-importer' )
+					? translate( 'Email Subscribers', { context: 'Filter label for people list' } )
+					: translate( 'Email Followers', { context: 'Filter label for people list' } ),
 				path: '/people/email-followers/' + siteFilter,
 				id: 'email-followers',
 			},
@@ -71,7 +74,9 @@ class PeopleSectionNav extends Component {
 				id: 'viewers',
 			},
 			{
-				title: translate( 'User Invites' ),
+				title: isEnabled( 'subscriber-importer' )
+					? translate( 'User Invites' )
+					: translate( 'Invites' ),
 				path: '/people/invites/' + siteFilter,
 				id: 'invites',
 			},

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -13,7 +13,15 @@ import { ROLES_LIST } from './constants';
 
 import './style.scss';
 
-export default function RoleSelect( { includeFollower, siteId, id, explanation, value, ...rest } ) {
+export default function RoleSelect( {
+	includeFollower,
+	includeSubscriber,
+	siteId,
+	id,
+	explanation,
+	value,
+	...rest
+} ) {
 	const translate = useTranslate();
 	const { data } = useSiteRolesQuery( siteId );
 	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
@@ -27,6 +35,12 @@ export default function RoleSelect( { includeFollower, siteId, id, explanation, 
 		if ( includeFollower ) {
 			const wpcomFollowerRole = getWpcomFollowerRole( isSitePrivate, translate );
 			siteRoles = siteRoles.concat( wpcomFollowerRole );
+		}
+
+		if ( ! includeSubscriber ) {
+			// Remove subscriber role from the roles list
+			// https://github.com/Automattic/wp-calypso/issues/65776
+			siteRoles = siteRoles.filter( ( x ) => x.name !== 'subscriber' );
 		}
 	}
 

--- a/client/package.json
+++ b/client/package.json
@@ -52,6 +52,7 @@
 		"@automattic/request-external-access": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
+		"@automattic/subscriber": "workspace:^",
 		"@automattic/social-previews": "workspace:^",
 		"@automattic/state-utils": "workspace:^",
 		"@automattic/subscriber": "workspace:^",

--- a/client/package.json
+++ b/client/package.json
@@ -52,7 +52,6 @@
 		"@automattic/request-external-access": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
-		"@automattic/subscriber": "workspace:^",
 		"@automattic/social-previews": "workspace:^",
 		"@automattic/state-utils": "workspace:^",
 		"@automattic/subscriber": "workspace:^",

--- a/config/development.json
+++ b/config/development.json
@@ -174,6 +174,7 @@
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
+		"subscriber-importer": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -145,6 +145,7 @@
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
+		"subscriber-importer": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -266,7 +266,7 @@
 		margin: 1rem 0;
 
 		svg {
-			margin-right: 6px;
+			margin-inline-end: 6px;
 		}
 	}
 }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -218,9 +218,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						<FormInputValidation isError={ true } text={ '' }>
 							{ createInterpolateElement(
 								__(
-									'Sorry, you can only upload CSV files right now. ' +
-									'Most providers will let you export this from your settings. ' +
-									'<uploadBtn>Select another file</uploadBtn>'
+									'Sorry, you can only upload CSV files right now. Most providers will let you export this from your settings. <uploadBtn>Select another file</uploadBtn>'
 								),
 								{ uploadBtn: formFileUploadElement }
 							) }
@@ -264,8 +262,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						<p className={ 'add-subscriber__form--disclaimer' }>
 							{ createInterpolateElement(
 								__(
-									'By clicking "continue", you represent that you\'ve obtained the appropriate consent to ' +
-									'email each person on your list. <Button>Learn more</Button>'
+									'By clicking "continue", you represent that you\'ve obtained the appropriate consent to email each person on your list. <Button>Learn more</Button>'
 								),
 								{
 									Button: createElement( Button, {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -219,8 +219,8 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 							{ createInterpolateElement(
 								__(
 									'Sorry, you can only upload CSV files right now. ' +
-										'Most providers will let you export this from your settings. ' +
-										'<uploadBtn>Select another file</uploadBtn>'
+									'Most providers will let you export this from your settings. ' +
+									'<uploadBtn>Select another file</uploadBtn>'
 								),
 								{ uploadBtn: formFileUploadElement }
 							) }
@@ -265,7 +265,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 							{ createInterpolateElement(
 								__(
 									'By clicking "continue", you represent that you\'ve obtained the appropriate consent to ' +
-										'email each person on your list. <Button>Learn more</Button>'
+									'email each person on your list. <Button>Learn more</Button>'
 								),
 								{
 									Button: createElement( Button, {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -29,6 +29,7 @@ interface Props {
 	showSkipBtn?: boolean;
 	showCsvUpload?: boolean;
 	submitBtnName?: string;
+	allowEmptyFormSubmit?: boolean;
 	onSkipBtnClick?: () => void;
 	onImportFinished?: () => void;
 }
@@ -41,6 +42,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		showSkipBtn,
 		showCsvUpload,
 		submitBtnName,
+		allowEmptyFormSubmit,
 		onSkipBtnClick,
 		onImportFinished,
 	} = props;
@@ -104,7 +106,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		validEmails.length && addSubscribers( siteId, validEmails );
 		selectedFile && importCsvSubscribers( siteId, selectedFile );
 
-		! validEmails.length && ! selectedFile && onImportFinished?.();
+		! validEmails.length && ! selectedFile && allowEmptyFormSubmit && onImportFinished?.();
 	}
 
 	function onEmailChange( value: string, index: number ) {


### PR DESCRIPTION
#### Proposed Changes

* Add Subscriber form: add `allowEmptyFormSumbit` property
* Introduced `subscriber-importer` feature flag (turned on for `development` and `wpcalypso` envs)  
  * Updated users page, people section replacing Email Followers with Subscribers introducing a new Add Subscriber form
  * Added a new route /people/add-subscribers/{SLUG}
  * Removed Follower and Subscribers roles from the Add/edit user form
  * Blurred out the subscriber form for the user without a verified email
* RTL support: Fixed step container footer element

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/followers/{SLUG}`
* If you want to turn off the feature, provide query param `?flags=-subscriber-importer`
* Check how the Add Subscriber form works in the Users sections

#### Screenshots
**Add Subscriber form**
<img width="763" alt="1" src="https://user-images.githubusercontent.com/1241413/187698174-4e8c0095-e251-4171-8593-c1f22365a91d.png">

**Blurred out screen**
<img width="764" alt="2" src="https://user-images.githubusercontent.com/1241413/187698189-b19abe13-9ed0-44ae-b590-0b38ce9456b5.png">

**Roles list**
<img width="750" alt="3" src="https://user-images.githubusercontent.com/1241413/187698184-091e4f70-279d-4c21-9adc-bf4294cdabb7.png">

**Added 'Add Subscriber' button**
<img width="772" alt="4" src="https://user-images.githubusercontent.com/1241413/187698180-548ad859-c05f-4eb9-97b0-78ad20e2dce7.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to the obsolete PR: https://github.com/Automattic/wp-calypso/pull/65878

Closes #67098
Closes #65545
Closes #65666
Closes #65673
Closes #65675
Closes #65542
Closes #65635
Closes #65776
Closes #65835
Closes #65544
