### PR TITLE
site-setup-flow: Rename theme_plugin to theme_software_set

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
@@ -1,5 +1,5 @@
 const pluginBundleSteps = {
-	woocommerce: [
+	'woo-on-plans': [
 		'storeAddress',
 		'businessInfo',
 		'wooConfirm',

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -215,14 +215,14 @@ export const siteSetupFlow: Flow = {
 
 					// Check current theme: Does it have a plugin bundled?
 					// If so, send them to the plugin-bundle flow.
-					const theme_plugin = currentTheme?.taxonomies?.theme_plugin;
+					const theme_software_set = currentTheme?.taxonomies?.theme_software_set;
 					if (
 						isEnabled( 'themes/plugin-bundling' ) &&
-						theme_plugin &&
-						theme_plugin.length > 0 &&
+						theme_software_set &&
+						theme_software_set.length > 0 &&
 						siteSlug
 					) {
-						setBundledPluginSlug( siteSlug, theme_plugin[ 0 ].slug ); // only install first plugin
+						setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first plugin
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 					}
 

--- a/client/types.ts
+++ b/client/types.ts
@@ -45,7 +45,7 @@ export interface Theme {
 	tags: string[];
 	taxonomies?: {
 		theme_feature?: ThemeFeature[];
-		theme_plugin?: ThemePlugin[];
+		theme_software_set?: ThemeSoftwareSet[];
 	};
 	template: string;
 	theme_uri: string;
@@ -65,7 +65,7 @@ interface ThemeFeature {
 	term_id: string;
 }
 
-interface ThemePlugin {
+interface ThemeSoftwareSet {
 	name: string;
 	slug: string;
 	term_id: string;


### PR DESCRIPTION
#### Proposed Changes

* In the check done at the end of the site-setup-flow (added in #66832), check for the `theme_software_set` taxonomy instead of the `theme_plugin` taxonomy.
  * woocommerce is renamed to `woo-on-plans` to match the name of the software set
* See D86795-code and paYKcK-1SY-p2#comment-1601 

#### Testing Instructions

* Visit `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE&notice=purchase-success`
* Choose baxter
* Click the button in the top right to "start with baxter"
* You should be moved to the plugin-bundle-flow (you'll see a screen about putting in your address)

Related to #65555