### PR TITLE
My Home: fix adjusting height of Banners on receiving them in different order

### DIFF
--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -88,15 +88,19 @@ export const Swipeable = ( {
 
 	const updateEnabled = hasDynamicHeight && numPages > 1;
 
+	// is used to recalculate height, if other children were received or the same but in a different order
+	const childrenOrder = children.reduce( ( acc, child ) => acc + child.key, '' );
+
 	useLayoutEffect( () => {
 		if ( ! updateEnabled ) {
 			return;
 		}
 		const targetHeight = pagesRef.current?.querySelector( '.is-current' )?.offsetHeight;
+
 		if ( targetHeight && pagesStyle?.height !== targetHeight ) {
 			setPagesStyle( { ...pagesStyle, height: targetHeight } );
 		}
-	}, [ pagesRef, currentPage, pagesStyle, updateEnabled, containerWidth ] );
+	}, [ pagesRef, currentPage, pagesStyle, updateEnabled, containerWidth, childrenOrder ] );
 
 	const handleDragStart = useCallback(
 		( event ) => {

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -88,7 +88,7 @@ export const Swipeable = ( {
 
 	const updateEnabled = hasDynamicHeight && numPages > 1;
 
-	// is used to recalculate height, if other children were received or the same but in a different order
+	// Generate a property that denotes the order of the cards, in order to recalculate height whenever the card order changes.
 	const childrenOrder = children.reduce( ( acc, child ) => acc + child.key, '' );
 
 	useLayoutEffect( () => {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -105,7 +105,7 @@ const Primary = ( { cards, trackCard } ) => {
 				( card, index ) =>
 					cardComponents[ card ] &&
 					createElement( cardComponents[ card ], {
-						key: index,
+						key: card + index,
 						isIos: card === 'home-task-go-mobile-ios' ? true : null,
 						card,
 					} )


### PR DESCRIPTION
#### Proposed Changes
At the current moment, <[Swipable](https://github.com/Automattic/wp-calypso/tree/trunk/client/components/swipeable)> component doesn't recalculate its height if other children were received or the same but in a different order.
This PR fixes the bug.

#### Testing Instructions
* Go to your dashboard
* Click on "My Home" item in the left sidebar
* At the beginning of the page body, you can see a swipeable list of banner
	* If you haven't set up your site then you will see the "Site setup" steps. Follow all of them, and after finishing, you will see mentioned swipeable list of banners
* Reload the page (e.g. with the help of `Command + R`)

**Heads up** - previously it wasn't hard and at the same time wasn't very easy to reproduce the bug since some banners have the same height. If you didn't see problems like on the screenshot below, then you had to try to reload the page a few times. Under the hood, we render a list of banners, and then we refetch the list to change their order (every fetch return new random order), so as result we rerender them again, but the height was still used for the old visible banner, instead of the new one.

**More details in comments here 1200182182542585-as-1202777266151093/f**

<table>
<tr>
	<td> BEFORE
	<td> AFTER
<tr>
	<td> <img width="1100" alt="Markup 2022-08-30 at 15 25 07" src="https://user-images.githubusercontent.com/5598437/187463135-59865068-a2ef-432d-93dd-c80aadd63268.png">
	<td> <img width="1129" alt="Screenshot 2022-08-30 at 15 22 52" src="https://user-images.githubusercontent.com/5598437/187462475-ff6f9039-9e49-4291-85dc-689205cfe53a.png">
</table>


#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202777266151093/f