### PR TITLE
Plugin Management: Enable bulk actions in all possible cases in Jetpack Cloud

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .plugin-activate-toggle__disabled,
 .plugin-activate-toggle__link {
 	display: inline-flex;
@@ -42,5 +45,20 @@
 	margin: auto 0 auto 3px;
 	.gridicon {
 		display: block;
+	}
+}
+
+.plugin-row-formatter__toggle {
+	.plugin-autoupdate-toggle {
+		.plugin-action__label {
+			@include break-xlarge() {
+				// We don't want to use display: none here, because it will hide the popover icon
+				// that might contain useful details about why the action is disabled.
+				font-size: 0;
+			}
+			.plugin-action__disabled-info {
+				color: var( --studio-gray-40 );
+			}
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -115,6 +115,10 @@ export class PluginsListHeader extends PureComponent {
 		return this.props.selected.length && this.canUpdatePlugins();
 	}
 
+	hasSelectedPlugins() {
+		return this.props.selected.length > 0;
+	}
+
 	renderCurrentActionButtons() {
 		const { hasManagePluginsFeature, isWpcom, isWpComAtomic, translate, siteId } = this.props;
 		const buttons = [];
@@ -158,7 +162,7 @@ export class PluginsListHeader extends PureComponent {
 				<Button
 					key="plugin-list-header__buttons-update"
 					compact
-					disabled={ ! this.props.haveUpdatesSelected }
+					disabled={ isWpcom ? ! this.props.haveUpdatesSelected : ! this.hasSelectedPlugins() }
 					primary={ isWpcom }
 					onClick={ this.props.updateSelected }
 				>
@@ -177,7 +181,7 @@ export class PluginsListHeader extends PureComponent {
 			activateButtons.push(
 				<Button
 					key="plugin-list-header__buttons-activate"
-					disabled={ ! this.props.haveInactiveSelected }
+					disabled={ isWpcom ? ! this.props.haveInactiveSelected : ! this.hasSelectedPlugins() }
 					onClick={ this.props.activateSelected }
 					compact
 				>
@@ -189,7 +193,7 @@ export class PluginsListHeader extends PureComponent {
 				<Button
 					compact
 					key="plugin-list-header__buttons-deactivate"
-					disabled={ ! this.props.haveActiveSelected }
+					disabled={ isWpcom ? ! this.props.haveActiveSelected : ! this.hasSelectedPlugins() }
 					onClick={
 						isJetpackSelected
 							? this.props.deactiveAndDisconnectSelected
@@ -211,7 +215,7 @@ export class PluginsListHeader extends PureComponent {
 			autoupdateButtons.push(
 				<Button
 					key="plugin-list-header__buttons-autoupdate-on"
-					disabled={ ! this.canUpdatePlugins() }
+					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					compact
 					onClick={ this.props.setAutoupdateSelected }
 				>
@@ -221,7 +225,7 @@ export class PluginsListHeader extends PureComponent {
 			autoupdateButtons.push(
 				<Button
 					key="plugin-list-header__buttons-autoupdate-off"
-					disabled={ ! this.canUpdatePlugins() }
+					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					compact
 					onClick={ this.props.unsetAutoupdateSelected }
 				>
@@ -234,12 +238,21 @@ export class PluginsListHeader extends PureComponent {
 					{ autoupdateButtons }
 				</ButtonGroup>
 			);
+
+			if ( ! isWpcom ) {
+				leftSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-update-button">
+						{ updateButton }
+					</ButtonGroup>
+				);
+			}
+
 			leftSideButtons.push(
 				<ButtonGroup key="plugin-list-header__buttons-remove-button">
 					<Button
 						compact
 						scary
-						disabled={ ! needsRemoveButton }
+						disabled={ isWpcom ? ! needsRemoveButton : ! this.hasSelectedPlugins() }
 						onClick={ this.props.removePluginNotice }
 					>
 						{ translate( 'Remove' ) }
@@ -302,7 +315,7 @@ export class PluginsListHeader extends PureComponent {
 				<SelectDropdown.Separator />
 
 				<SelectDropdown.Item
-					disabled={ ! this.props.haveUpdatesSelected }
+					disabled={ isWpcom ? ! this.props.haveUpdatesSelected : ! this.hasSelectedPlugins() }
 					onClick={ this.props.updateSelected }
 				>
 					{ ! isWpcom ? translate( 'Update Plugins' ) : translate( 'Update' ) }
@@ -311,7 +324,7 @@ export class PluginsListHeader extends PureComponent {
 				<SelectDropdown.Separator />
 				{ isJetpackOnlySelected && (
 					<SelectDropdown.Item
-						disabled={ ! this.props.haveInactiveSelected }
+						disabled={ isWpcom ? ! this.props.haveInactiveSelected : ! this.hasSelectedPlugins() }
 						onClick={ this.props.activateSelected }
 					>
 						{ translate( 'Activate' ) }
@@ -319,7 +332,7 @@ export class PluginsListHeader extends PureComponent {
 				) }
 				{ isJetpackOnlySelected && (
 					<SelectDropdown.Item
-						disabled={ ! this.props.haveActiveSelected }
+						disabled={ isWpcom ? ! this.props.haveActiveSelected : ! this.hasSelectedPlugins() }
 						onClick={
 							isJetpackSelected
 								? this.props.deactiveAndDisconnectSelected
@@ -333,14 +346,14 @@ export class PluginsListHeader extends PureComponent {
 				<SelectDropdown.Separator />
 
 				<SelectDropdown.Item
-					disabled={ ! this.canUpdatePlugins() }
+					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					onClick={ this.props.setAutoupdateSelected }
 				>
 					{ translate( 'Autoupdate' ) }
 				</SelectDropdown.Item>
 
 				<SelectDropdown.Item
-					disabled={ ! this.canUpdatePlugins() }
+					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					onClick={ this.props.unsetAutoupdateSelected }
 				>
 					{ ! isWpcom ? translate( 'Disable' ) : translate( 'Disable Autoupdates' ) }
@@ -349,7 +362,7 @@ export class PluginsListHeader extends PureComponent {
 				<SelectDropdown.Separator />
 				<SelectDropdown.Item
 					className="plugin-list-header__actions-remove-item"
-					disabled={ ! needsRemoveButton }
+					disabled={ isWpcom ? ! needsRemoveButton : ! this.hasSelectedPlugins() }
 					onClick={ this.props.removePluginNotice }
 				>
 					{ translate( 'Remove' ) }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -151,7 +151,6 @@ export default function PluginRowFormatter( {
 				canUpdate && (
 					<div className="plugin-row-formatter__toggle">
 						<PluginAutoupdateToggle
-							hideLabel={ ! isSmallScreen }
 							plugin={ pluginOnSite }
 							site={ selectedSite }
 							wporg={ !! item.wporg }

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -96,6 +96,11 @@ export function activatePlugin( siteId, plugin ) {
 			siteId,
 			pluginId,
 		};
+
+		if ( plugin.active ) {
+			return dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_SUCCESS, data: plugin } );
+		}
+
 		dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST } );
 
 		const afterActivationCallback = ( error, data ) => {
@@ -158,6 +163,15 @@ export function deactivatePlugin( siteId, plugin ) {
 			siteId,
 			pluginId,
 		};
+
+		if ( ! plugin.active ) {
+			return dispatch( {
+				...defaultAction,
+				type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS,
+				data: plugin,
+			} );
+		}
+
 		dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST } );
 
 		const afterDeactivationCallback = ( error ) => {
@@ -222,16 +236,17 @@ export function togglePluginActivation( siteId, plugin ) {
 
 export function updatePlugin( siteId, plugin ) {
 	return ( dispatch ) => {
-		if ( ! plugin.update ) {
-			return Promise.reject( 'Error: Plugin already up-to-date.' );
-		}
-
 		const pluginId = plugin.id;
 		const defaultAction = {
 			action: UPDATE_PLUGIN,
 			siteId,
 			pluginId,
 		};
+
+		if ( ! plugin.update ) {
+			return dispatch( { ...defaultAction, type: PLUGIN_UPDATE_REQUEST_SUCCESS, data: plugin } );
+		}
+
 		dispatch( { ...defaultAction, type: PLUGIN_UPDATE_REQUEST } );
 
 		const afterUpdateCallback = ( error ) => {
@@ -264,6 +279,14 @@ export function enableAutoupdatePlugin( siteId, plugin ) {
 			siteId,
 			pluginId,
 		};
+
+		if ( plugin.autoupdate ) {
+			return dispatch( {
+				...defaultAction,
+				type: PLUGIN_AUTOUPDATE_ENABLE_REQUEST_SUCCESS,
+				data: plugin,
+			} );
+		}
 
 		dispatch( { ...defaultAction, type: PLUGIN_AUTOUPDATE_ENABLE_REQUEST } );
 
@@ -299,6 +322,14 @@ export function disableAutoupdatePlugin( siteId, plugin ) {
 			siteId,
 			pluginId,
 		};
+
+		if ( ! plugin.autoupdate ) {
+			return dispatch( {
+				...defaultAction,
+				type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST_SUCCESS,
+				data: { ...plugin },
+			} );
+		}
 
 		dispatch( { ...defaultAction, type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST } );
 

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -210,7 +210,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )( spy, getState );
+			deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet', active: true } )(
+				spy,
+				getState
+			);
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_DEACTIVATE_REQUEST,
@@ -221,7 +224,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch plugin deactivate request success action when request completes', async () => {
-			await deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet' } )(
+			await deactivatePlugin( 2916284, { slug: 'akismet', id: 'akismet/akismet', active: true } )(
 				spy,
 				getState
 			);
@@ -235,7 +238,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', async () => {
-			await deactivatePlugin( 2916284, { slug: 'fake', id: 'fake/fake' } )( spy, getState );
+			await deactivatePlugin( 2916284, { slug: 'fake', id: 'fake/fake', active: true } )(
+				spy,
+				getState
+			);
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_DEACTIVATE_REQUEST_FAILURE,
 				action: DEACTIVATE_PLUGIN,
@@ -332,15 +338,19 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should not dispatch actions when plugin already up-to-date', async () => {
-			const response = updatePlugin( site.ID, { slug: 'jetpack', id: 'jetpack/jetpack' } )(
+		test( 'should dispatch site update actions when plugin already up-to-date', async () => {
+			await updatePlugin( site.ID, { slug: 'jetpack', id: 'jetpack/jetpack', update: true } )(
 				spy,
 				getState
 			);
 
-			// updatePlugin returns a rejected promise here
-			await expect( response ).rejects.toEqual( 'Error: Plugin already up-to-date.' );
-			expect( spy ).not.toHaveBeenCalled();
+			expect( spy ).toHaveBeenCalledWith( {
+				type: PLUGIN_UPDATE_REQUEST_SUCCESS,
+				action: UPDATE_PLUGIN,
+				siteId: 2916284,
+				pluginId: 'jetpack/jetpack',
+				data: jetpackUpdated,
+			} );
 		} );
 	} );
 
@@ -460,10 +470,11 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request action when triggered', () => {
-			disableAutoupdatePlugin( site.ID, { slug: 'akismet', id: 'akismet/akismet' } )(
-				spy,
-				getState
-			);
+			disableAutoupdatePlugin( site.ID, {
+				slug: 'akismet',
+				id: 'akismet/akismet',
+				autoupdate: true,
+			} )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST,
@@ -477,6 +488,7 @@ describe( 'actions', () => {
 			await disableAutoupdatePlugin( site.ID, {
 				slug: 'akismet',
 				id: 'akismet/akismet',
+				autoupdate: true,
 			} )( spy, getState );
 
 			expect( spy ).toHaveBeenCalledWith( {
@@ -489,7 +501,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', async () => {
-			await disableAutoupdatePlugin( site.ID, { slug: 'fake', id: 'fake/fake' } )( spy, getState );
+			await disableAutoupdatePlugin( site.ID, { slug: 'fake', id: 'fake/fake', autoupdate: true } )(
+				spy,
+				getState
+			);
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: PLUGIN_AUTOUPDATE_DISABLE_REQUEST_FAILURE,


### PR DESCRIPTION
#### Proposed Changes

This PR aims to change the existing UX around different actions in the plugin management UI. On WPCOM, we have disabled states that would prevent users from applying specific actions again on the same set of items. However, if you pick one other item eligible for the action, the action buttons will be enabled, but the request will always fail for already processed items.

Here's one video illustrating the issue:

https://user-images.githubusercontent.com/1749918/187498608-19531c31-a4f1-4832-8c5c-e0624737facc.mov

**What are the changes here?**

With this PR, if the user tries to activate an already activated plugin, we will dispatch a success event, as that will be the actual state of the plugin itself. We will use the state we have to determine if the action is already done.

#### Testing Instructions

**Prerequisites**
- Since this change is made specifically for agencies, you must set yourself (partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type when you're done with testing.
- You might want to create a couple of JN (or WoA) sites to make the testing easier.

**Instructions**
- Checkout this branch 
- Run `yarn start` and wait for the build to complete
- Run `yarn start-jetpack-cloud-p`
- Visit http://jetpack.cloud.localhost:3001/plugins/manage
- Verify that all bulk actions work and that the feedback you see (on the top notification bar) makes sense
- Visit http://calypso.localhost:3000/plugins/manage
- Verify that all bulk actions work and that the feedback you see (on the top notification bar) makes sense
- Verify there's no regression in Calypso Blue introduced by this PR

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202819374195611