### PR TITLE
Sites Management Page: Replace 'Back to My Sites' with 'Back to Sites'

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,5 +1,5 @@
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -762,6 +762,9 @@ class DomainsStep extends Component {
 		let isExternalBackUrl = false;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
+		const sitesBackLabelText = i18n.hasTranslation( 'Back to Sites' )
+			? translate( 'Back to Sites' )
+			: translate( 'Back to My Sites' );
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;
@@ -783,10 +786,10 @@ class DomainsStep extends Component {
 				backLabelText = translate( 'Back to General Settings' );
 			} else if ( 'sites-dashboard' === source ) {
 				backUrl = '/sites';
-				backLabelText = translate( 'Back to My Sites' );
+				backLabelText = sitesBackLabelText;
 			} else if ( backUrl === this.removeQueryParam( this.props.path ) ) {
 				backUrl = '/sites/';
-				backLabelText = translate( 'Back to My Sites' );
+				backLabelText = sitesBackLabelText;
 			}
 
 			const externalBackUrl = getExternalBackUrl( source, this.props.stepSectionName );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,3 +1,4 @@
+import { englishLocales } from '@automattic/i18n-utils';
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import i18n, { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
@@ -762,9 +763,10 @@ class DomainsStep extends Component {
 		let isExternalBackUrl = false;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
-		const sitesBackLabelText = i18n.hasTranslation( 'Back to Sites' )
-			? translate( 'Back to Sites' )
-			: translate( 'Back to My Sites' );
+		const sitesBackLabelText =
+			englishLocales.includes( this.props.locale ) || i18n.hasTranslation( 'Back to Sites' )
+				? translate( 'Back to Sites' )
+				: translate( 'Back to My Sites' );
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
+import { englishLocales } from '@automattic/i18n-utils';
 import { LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
@@ -334,9 +335,10 @@ export class PlansStep extends Component {
 
 		if ( 0 === positionInFlow && hasInitializedSitesBackUrl ) {
 			backUrl = hasInitializedSitesBackUrl;
-			backLabelText = i18n.hasTranslation( 'Back to Sites' )
-				? translate( 'Back to Sites' )
-				: translate( 'Back to My Sites' );
+			backLabelText =
+				englishLocales.includes( this.props.locale ) || i18n.hasTranslation( 'Back to Sites' )
+					? translate( 'Back to Sites' )
+					: translate( 'Back to My Sites' );
 		}
 
 		let queryParams;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -334,7 +334,9 @@ export class PlansStep extends Component {
 
 		if ( 0 === positionInFlow && hasInitializedSitesBackUrl ) {
 			backUrl = hasInitializedSitesBackUrl;
-			backLabelText = translate( 'Back to My Sites' );
+			backLabelText = i18n.hasTranslation( 'Back to Sites' )
+				? translate( 'Back to Sites' )
+				: translate( 'Back to My Sites' );
 		}
 
 		let queryParams;

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -72,6 +72,10 @@ class SiteType extends Component {
 			'This is just a starting point. You can add or change features later.'
 		);
 
+		const backLabelText = i18n.hasTranslation( 'Back to Sites' )
+			? translate( 'Back to Sites' )
+			: translate( 'Back to My Sites' );
+
 		return (
 			<StepWrapper
 				flowName={ flowName }
@@ -84,7 +88,7 @@ class SiteType extends Component {
 				stepContent={ this.renderStepContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
-				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }
+				backLabelText={ hasInitializedSitesBackUrl ? backLabelText : null }
 			/>
 		);
 	}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,3 +1,4 @@
+import { englishLocales } from '@automattic/i18n-utils';
 import i18n, { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -72,9 +73,10 @@ class SiteType extends Component {
 			'This is just a starting point. You can add or change features later.'
 		);
 
-		const backLabelText = i18n.hasTranslation( 'Back to Sites' )
-			? translate( 'Back to Sites' )
-			: translate( 'Back to My Sites' );
+		const backLabelText =
+			englishLocales.includes( this.props.locale ) || i18n.hasTranslation( 'Back to Sites' )
+				? translate( 'Back to Sites' )
+				: translate( 'Back to My Sites' );
 
 		return (
 			<StepWrapper


### PR DESCRIPTION
#### Proposed Changes

* Replace all instances of `Back to My Sites` with `Back to Sites`. we conditionally replace these since `Back to Sites` translation might not be readily available.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites-dashboard` click Add New Sites
* Verify string has` Back to Sites` instead of `Back to My Sites`

##### Before
![before](https://user-images.githubusercontent.com/1500769/187555386-b34482a3-383f-4e91-8024-780ef827d2f4.png)



##### After
![after](https://user-images.githubusercontent.com/1500769/187555404-1e9caf7c-155f-4026-a4d9-3cac0f9c3e43.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/67037
