### PR TITLE
Plugin Details: Add plan periodicity to the plan USP

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -131,6 +131,9 @@ export const PlanUSPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, billin
 	const planDisplayCost = useSelector( ( state ) => {
 		return getProductDisplayCost( state, requiredPlan || '' );
 	} );
+	const monthlyLabel = translate( 'Monthly' );
+	const annualLabel = translate( 'Annually' );
+	const periodicityLabel = isAnnualPeriod ? annualLabel : monthlyLabel;
 
 	if ( ! shouldUpgrade ) {
 		return null;
@@ -140,14 +143,20 @@ export const PlanUSPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, billin
 	switch ( requiredPlan ) {
 		case PLAN_PERSONAL:
 		case PLAN_PERSONAL_MONTHLY:
-			planText = translate( 'Included in the Personal plan (%s):', {
-				args: [ planDisplayCost ],
+			planText = translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
+				args: {
+					cost: planDisplayCost,
+					periodicity: periodicityLabel,
+				},
 			} );
 			break;
 		case PLAN_BUSINESS:
 		case PLAN_BUSINESS_MONTHLY:
-			planText = translate( 'Included in the Business plan (%s):', {
-				args: [ planDisplayCost ],
+			planText = translate( 'Included in the Business plan (%(cost)s/%(periodicity)s):', {
+				args: {
+					cost: planDisplayCost,
+					periodicity: periodicityLabel,
+				},
 			} );
 			break;
 	}


### PR DESCRIPTION
#### Proposed Changes

Add plan periodicity to the plan USP
<img width="314" alt="Screen Shot 2022-08-30 at 15 12 29" src="https://user-images.githubusercontent.com/5039531/187523599-225070d8-1cb8-48f5-bdc7-5522254b3dc3.png">



#### Testing Instructions
* Select a free site
* Go to a paid plugin page. Ex: 
* Check if the periodicity is being shown on the plan USP
* Change the billing selector option
* Check if the periodicity change is reflected on the plan USP
* Go to a free plugin page. Ex: `/plugins/elementor/{site}`
* Check if the periodicity is being shown on the plan USP

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67113 