### PR TITLE
Jetpack storage upgrade: Fix names and prices

### DIFF
--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useState } from 'react';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
@@ -51,9 +52,10 @@ export const StoragePricing: React.FC< Props > = ( {
 
 	return (
 		<>
+			<QueryProductsList type="jetpack" />
+			<QueryIntroOffers siteId={ siteId ?? 'none' } />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
-			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 
 			{ nav }
 			<Main className="storage-pricing__main" wideLayout>

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-product.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-product.ts
@@ -66,7 +66,7 @@ export const useGetTier1UpgradeProduct = (): StorageUpgradeGetter => {
 
 			return {
 				...product,
-				displayname: storageAmount,
+				displayName: storageAmount,
 				subheader: translate( 'of backup storage' ),
 				buttonLabel: translate( 'Upgrade storage' ),
 				// description: <the default description of the product being upgraded>,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Visiting `https://cloud.jetpack.com/pricing/storage/{site}`, the name of the 10GB Backup product in the card is wrong. When not authenticated, prices are erroneous as well. See capture below:

<image src="https://user-images.githubusercontent.com/1620183/187533351-69cdcb55-a255-4f4f-abe0-9bce848c1141.png" width="250">

This PR fixes that.

Context: 1202858161751496-as-1202892434753055

### Implementation notes

When a user visits the storage upgrade page while not authenticated, information about the site cannot be fetched. Thus, they'll see the page in the default state, no matter the existing subscriptions for their site.

### Testing instructions

#### Prerequisites
- Make sure you've got a Jetpack site with no Backup subscription

#### Plan

- Start cloud with this branch, in a private window
- Visit `/pricing/storage/{site}`
- Check that the page upsells 10GB and 1TB (screenshot 1), and that names and prices are right
- Visit `/pricing/storage/{site}` again, but this time while authenticated
- Do the same check
- Get a 1GB Backup subscription for your site
- Do the same check
- Get a 10GB Backup subscription for your site
- Check that the page upsells 10GB and 1TB, and that 10GB is marked as owned (screenshot 2)
- Get a 1TB Backup subscription for your site
- Check that the page upsells 1TB, and that it is marked as owned (screenshot 3)



### Screenshots

_1. Site with no Backup subscription, site with 1GB Backup subscription, or unauthenticated user_
<img width="500" alt="Screen Shot 2022-08-30 at 4 03 13 PM" src="https://user-images.githubusercontent.com/1620183/187534589-ec9dcf5d-f5b3-44e3-8d7c-a17218443eb2.png">


_2. Site with 10GB Backup subscription_
<img width="500" alt="Screen Shot 2022-08-30 at 4 03 18 PM" src="https://user-images.githubusercontent.com/1620183/187534616-71b7c1bf-a9d9-4bd3-aa5f-e8331fe5d448.png">


_3. Site with 1TB Backup subscription_
<img width="500" alt="Screen Shot 2022-08-30 at 4 03 24 PM" src="https://user-images.githubusercontent.com/1620183/187534642-abb7ea18-473d-42a1-b32f-4bb964e3e4c4.png">
