### PR TITLE
Checkout: Convert UpsellNudge to TypeScript

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -309,6 +309,8 @@ export function upsellNudge( context, next ) {
 	} else if ( context.path.includes( 'offer-professional-email' ) ) {
 		upsellType = PROFESSIONAL_EMAIL_UPSELL;
 		upgradeItem = context.params.domain;
+	} else {
+		upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -2,7 +2,7 @@ import { Circle, SVG } from '@wordpress/components';
 import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -12,6 +12,7 @@ import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-manage
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 

--- a/client/state/sites/plans/selectors/get-plan-discounted-raw-price.js
+++ b/client/state/sites/plans/selectors/get-plan-discounted-raw-price.js
@@ -8,7 +8,7 @@ import { isSitePlanDiscounted } from 'calypso/state/sites/plans/selectors/is-sit
  * @param  {object}  state         global state
  * @param  {number|undefined}  siteId        the site id
  * @param  {string}  productSlug   the plan product slug
- * @param  {boolean} isMonthly     if true, returns monthly price
+ * @param  {{isMonthly?: boolean}} [isMonthly]     if true, returns monthly price
  * @returns {number}                plan discounted raw price
  */
 export function getPlanDiscountedRawPrice(

--- a/client/state/sites/plans/selectors/get-site-plan-raw-price.js
+++ b/client/state/sites/plans/selectors/get-site-plan-raw-price.js
@@ -8,7 +8,7 @@ import { getSitePlan } from 'calypso/state/sites/plans/selectors/get-site-plan';
  * @param  {object}  state         global state
  * @param  {number}  siteId        the site id
  * @param  {string}  productSlug   the plan product slug
- * @param  {boolean} isMonthly     if true, returns monthly price
+ * @param  {{isMonthly?: boolean}} [isMonthly]     if true, returns monthly price
  * @returns {number}                plan raw price
  */
 export function getSitePlanRawPrice( state, siteId, productSlug, { isMonthly = false } = {} ) {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -25,8 +25,8 @@ export {
 	useSitesTableFiltering,
 	siteLaunchStatusFilterValues,
 	DEFAULT_SITE_LAUNCH_STATUS_FILTER_VALUE,
-	type FilterableSiteLaunchStatuses,
 } from './sites-table/use-sites-table-filtering';
+export type { FilterableSiteLaunchStatuses } from './sites-table/use-sites-table-filtering';
 export { useSitesTableSorting } from './sites-table/use-sites-table-sorting';
 export { getSiteLaunchStatus, useSiteLaunchStatusLabel } from './sites-table/site-status';
 export { SitesTableTabPanel } from './sites-table/sites-table-tab-panel';


### PR DESCRIPTION
#### Proposed Changes

This converts the `UpsellNudge` component to TypeScript, making as few logical changes as possible.

Fixes https://github.com/Automattic/wp-calypso/pull/67179

#### Testing Instructions

Use an account that has at least one saved credit card.

With this PR running, visit `/checkout/example.com/offer-plan-upgrade/business/12345` but replace `example.com` with your test site.

Click to agree to the upsell.

Click to purchase the upsell and verify that it works.

<img width="536" alt="one-click-upsell" src="https://user-images.githubusercontent.com/2036909/187542713-17ce7d8c-bbe1-41ab-b4ef-a01fa50a865f.png">
