### PR TITLE
Remove old TODOs

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/tags-education/class-tags-education.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tags-education/class-tags-education.php
@@ -53,14 +53,6 @@ class Tags_Education {
 			true
 		);
 
-		// TODO: remove tagsEducationLocale after fixing useLocalizeUrl.
-		// See https://github.com/Automattic/wp-calypso/pull/55527.
-		wp_localize_script(
-			'tags-education-script',
-			'tagsEducationLocale',
-			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
-		);
-
 		wp_set_script_translations( 'tags-education-script', 'full-site-editing' );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/tags-education/src/add-tags-education-link.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tags-education/src/add-tags-education-link.js
@@ -20,16 +20,7 @@ const addTagsEducationLink = createHigherOrderComponent( ( PostTaxonomyType ) =>
 			<>
 				<PostTaxonomyType { ...props } />
 				<ExternalLink
-					href={ localizeUrl(
-						'https://wordpress.com/support/posts/tags/',
-						// TODO: remove tagsEducationLocale after fixing useLocalizeUrl.
-						// See https://github.com/Automattic/wp-calypso/pull/55527.
-						// `useLocalizeUrl` will try to get the current locale slug from the @wordpress/i18n locale data if missing `LocaleProvider`
-						// However, if we have any string without translation in `default` domain, the configure block will be overwritten by empty locale data
-						// so that we cannot get the correct locale from the @wordpress/i18n locale data.
-						// Also, the format of current locale slug is not ISO 639 and it makes localizeUrl not work correctly.
-						window.tagsEducationLocale
-					) }
+					href={ localizeUrl( 'https://wordpress.com/support/posts/tags/' ) }
 					onClick={ trackTagsEducationLinkClick }
 				>
 					{ __( 'Build your audience with tags', 'full-site-editing' ) }


### PR DESCRIPTION
## Summary
This PR is about removing leftover TODO comments regarding `localizeUrl`

## Testing Instructions
1. Go to https://wordpress.com/post and select a sandboxed test site

2. Open the **Settings** menu from the top right, go to the **Post** tab and click **Build your audience with tags** link under the **Tags** section

<img width="850" alt="image" src="https://user-images.githubusercontent.com/20927667/187553916-48907509-5883-4a15-bde8-fbff91092e86.png">

3. This should take you to the english version of the support docs:

<img width="889" alt="image" src="https://user-images.githubusercontent.com/20927667/187554216-149dcf8e-ee1a-42f6-bfe1-a7ffede00816.png">

4. Go to http://wordpress.com/me/account and change your UI language to German for example

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/20927667/187554412-97c15cf0-3cd4-4d62-886b-1cd86f80e9de.png">

5. Repeat **step 2**. You should now be seeing the German version of the docs:

<img width="883" alt="image" src="https://user-images.githubusercontent.com/20927667/187554645-a8e9893b-d94b-4434-b8a5-296374261663.png">

Related to #55527
