### PR TITLE
SMP: Use `<PageViewTracker>` to record page views

### DIFF
--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -4,6 +4,7 @@ import {
 } from '@automattic/components';
 import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { SitesDashboard } from './components/sites-dashboard';
 import { MEDIA_QUERIES } from './utils';
 import type { Context as PageJSContext } from 'page';
@@ -64,6 +65,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
+			<PageViewTracker path="/sites" title="Sites Management Page" />
 			<SitesDashboard
 				queryParams={ {
 					search: context.query.search,

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -65,7 +65,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<Global styles={ globalStyles } />
-			<PageViewTracker path="/sites" title="Sites Management Page" />
+			<PageViewTracker path="/sites" title="Sites Management Page" delay={ 500 } />
 			<SitesDashboard
 				queryParams={ {
 					search: context.query.search,


### PR DESCRIPTION
#### Proposed Changes

The standard `calypso_page_view` tracks event isn't working with the Sites Management Page. That's because it was never set up.

* Add `<PageViewTracker>` to the root SMP component so that it mounts when the user lands on the page

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Filter network tab by `calypso_page_view` and confirm the correct event properties are recorded
* Jump directly to `/sites`
   * `path = '/sites'`
   * `last_pageview_path_with_count = 'null(0)'`
   * `this_pageview_path_with_count = '/sites(1)'`
* Click to go to a site's dashboard
   * `path = '/home/:site'`
   * `last_pageview_path_with_count = '/sites(1)'`
   * `this_pageview_path_with_count = '/home/:site(2)'`
   * **This is different for Jetpack sites, confirm that it's recording the correct props given where navigation lands**
* Go back to SMP using site switcher
   * `path = '/sites'`
   * `last_pageview_path_with_count = '/home/:site(2)'`
   * `this_pageview_path_with_count = '/sites(3)'`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67132
