### PR TITLE
Add support for seoTitle, seoDescription on theme pages

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -797,11 +797,19 @@ class ThemeSheet extends Component {
 
 		const launchPricing = () => window.open( plansUrl, '_blank' );
 
-		const { canonicalUrl, description, seoDescription, name: themeName, seoTitle } = this.props;
+		const {
+			canonicalUrl,
+			currentUserId,
+			description,
+			name: themeName,
+			seoTitle,
+			seoDescription,
+		} = this.props;
+
 		const title =
 			( seoTitle || themeName ) &&
 			translate( '%(themeName)s Theme', {
-				args: { themeName: seoTitle || themeName },
+				args: { themeName },
 			} );
 
 		const metas = [

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -797,14 +797,7 @@ class ThemeSheet extends Component {
 
 		const launchPricing = () => window.open( plansUrl, '_blank' );
 
-		const {
-			canonicalUrl,
-			currentUserId,
-			description,
-			name: themeName,
-			seoTitle,
-			seoDescription,
-		} = this.props;
+		const { canonicalUrl, description, name: themeName, seoTitle, seoDescription } = this.props;
 
 		const title =
 			( seoTitle || themeName ) &&

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -93,6 +93,8 @@ class ThemeSheet extends Component {
 			PropTypes.string,
 			PropTypes.bool, // happens if no content: false
 		] ),
+		seoTitle: PropTypes.string,
+		seoDescription: PropTypes.string,
 		supportDocumentation: PropTypes.string,
 		download: PropTypes.string,
 		taxonomies: PropTypes.object,
@@ -795,11 +797,11 @@ class ThemeSheet extends Component {
 
 		const launchPricing = () => window.open( plansUrl, '_blank' );
 
-		const { canonicalUrl, description, name: themeName } = this.props;
+		const { canonicalUrl, description, seoDescription, name: themeName, seoTitle } = this.props;
 		const title =
-			themeName &&
+			( seoTitle || themeName ) &&
 			translate( '%(themeName)s Theme', {
-				args: { themeName },
+				args: { themeName: seoTitle || themeName },
 			} );
 
 		const metas = [
@@ -810,11 +812,11 @@ class ThemeSheet extends Component {
 			{ property: 'og:site_name', content: 'WordPress.com' },
 		];
 
-		if ( description ) {
+		if ( seoDescription || description ) {
 			metas.push( {
 				name: 'description',
 				property: 'og:description',
-				content: decodeEntities( description ),
+				content: decodeEntities( seoDescription || description ),
 			} );
 		}
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -93,8 +93,6 @@ class ThemeSheet extends Component {
 			PropTypes.string,
 			PropTypes.bool, // happens if no content: false
 		] ),
-		seoTitle: PropTypes.string,
-		seoDescription: PropTypes.string,
 		supportDocumentation: PropTypes.string,
 		download: PropTypes.string,
 		taxonomies: PropTypes.object,
@@ -797,10 +795,10 @@ class ThemeSheet extends Component {
 
 		const launchPricing = () => window.open( plansUrl, '_blank' );
 
-		const { canonicalUrl, description, name: themeName, seoTitle, seoDescription } = this.props;
+		const { canonicalUrl, description, name: themeName, seo_title, seo_description } = this.props;
 
 		const title =
-			( seoTitle || themeName ) &&
+			( seo_title || themeName ) &&
 			translate( '%(themeName)s Theme', {
 				args: { themeName },
 			} );
@@ -813,11 +811,11 @@ class ThemeSheet extends Component {
 			{ property: 'og:site_name', content: 'WordPress.com' },
 		];
 
-		if ( seoDescription || description ) {
+		if ( seo_description || description ) {
 			metas.push( {
 				name: 'description',
 				property: 'og:description',
-				content: decodeEntities( seoDescription || description ),
+				content: decodeEntities( seo_description || description ),
 			} );
 		}
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -797,11 +797,11 @@ class ThemeSheet extends Component {
 
 		const { canonicalUrl, description, name: themeName, seo_title, seo_description } = this.props;
 
-		const title =
-			( seo_title || themeName ) &&
-			translate( '%(themeName)s Theme', {
-				args: { themeName },
-			} );
+		const title = seo_title
+			? seo_title
+			: translate( '%(themeName)s Theme', {
+					args: { themeName },
+			  } );
 
 		const metas = [
 			{ property: 'og:title', content: title },

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -30,6 +30,8 @@ const themesSchema = {
 				theme_uri: { type: 'string' },
 				update: { type: [ 'null', 'object' ] },
 				version: { type: 'string' },
+				seo_title: { type: 'string' },
+				seo_description: { type: 'string' },
 			},
 		},
 	},

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -53,8 +53,6 @@ export function normalizeJetpackTheme( theme = {} ) {
  */
 export function normalizeWpcomTheme( theme ) {
 	const attributesMap = {
-		seo_title: 'seoTitle',
-		seo_description: 'seoDescription',
 		description_long: 'descriptionLong',
 		support_documentation: 'supportDocumentation',
 		download_uri: 'download',

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -53,6 +53,8 @@ export function normalizeJetpackTheme( theme = {} ) {
  */
 export function normalizeWpcomTheme( theme ) {
 	const attributesMap = {
+		seo_title: 'seoTitle',
+		seo_description: 'seoDescription',
 		description_long: 'descriptionLong',
 		support_documentation: 'supportDocumentation',
 		download_uri: 'download',


### PR DESCRIPTION
#### Proposed Changes

* This PR adds support for seoTitle, seoDescription on theme pages. This help with SEO for individual theme pages.

#### Testing Instructions

* Can be tested as a part of D86912-code

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #45166

