### PR TITLE
Launchpad: Add site launch functionality to link in bio flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -5,8 +5,8 @@ import { isTaskDisabled } from './task-helper';
 import { Task } from './types';
 
 const ChecklistItem = ( { task }: { task: Task } ) => {
-	const { id, isCompleted, actionUrl, title } = task;
-
+	const { id, isCompleted, actionUrl, title, actionDispatch } = task;
+	const action = actionDispatch ? { onClick: actionDispatch } : { href: actionUrl };
 	const taskDisabled = isTaskDisabled( task );
 	return (
 		<li className={ `launchpad__task-${ id }` }>
@@ -15,6 +15,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				disabled={ taskDisabled }
 				href={ actionUrl }
 				data-task={ id }
+				{ ...action }
 			>
 				{ isCompleted && taskDisabled && (
 					<div className="launchpad__checklist-item-status">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -1,4 +1,7 @@
+import { useDispatch } from '@wordpress/data';
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ONBOARD_STORE } from '../../../../stores';
 import ChecklistItem from './checklist-item';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { Task } from './types';
@@ -7,13 +10,25 @@ interface ChecklistProps {
 	tasks: Task[];
 	siteSlug: string | null;
 	flow: string | null;
+	submit: NavigationControls[ 'submit' ];
 }
 
-const Checklist = ( { tasks, siteSlug, flow }: ChecklistProps ) => {
+const Checklist = ( { tasks, siteSlug, flow, submit }: ChecklistProps ) => {
 	const site = useSite();
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
+	const { setPendingAction, setProgressTitle } = useDispatch( ONBOARD_STORE );
+
 	const enhancedTasks =
-		arrayOfFilteredTasks && site && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site );
+		arrayOfFilteredTasks &&
+		site &&
+		getEnhancedTasks(
+			arrayOfFilteredTasks,
+			siteSlug,
+			site,
+			submit,
+			setPendingAction,
+			setProgressTitle
+		);
 
 	return (
 		<ul className="launchpad__checklist" aria-label="Launchpad Checklist">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -1,7 +1,5 @@
-import { useDispatch } from '@wordpress/data';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { ONBOARD_STORE } from '../../../../stores';
 import ChecklistItem from './checklist-item';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { Task } from './types';
@@ -16,19 +14,11 @@ interface ChecklistProps {
 const Checklist = ( { tasks, siteSlug, flow, submit }: ChecklistProps ) => {
 	const site = useSite();
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
-	const { setPendingAction, setProgressTitle } = useDispatch( ONBOARD_STORE );
 
 	const enhancedTasks =
 		arrayOfFilteredTasks &&
 		site &&
-		getEnhancedTasks(
-			arrayOfFilteredTasks,
-			siteSlug,
-			site,
-			submit,
-			setPendingAction,
-			setProgressTitle
-		);
+		getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site, submit );
 
 	return (
 		<ul className="launchpad__checklist" aria-label="Launchpad Checklist">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -7,26 +7,13 @@ import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/int
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import LaunchpadSitePreview from './launchpad-site-preview';
-import Sidebar from './sidebar';
+import StepContent from './step-content';
 import type { Step } from '../../types';
 import './style.scss';
-
-type StepContentProps = {
-	siteSlug: string | null;
-	submit: NavigationControls[ 'submit' ];
-};
 
 type LaunchpadProps = {
 	navigation: NavigationControls;
 };
-
-const StepContent = ( { siteSlug, submit }: StepContentProps ) => (
-	<div className="launchpad__content">
-		<Sidebar siteSlug={ siteSlug } submit={ submit } />
-		<LaunchpadSitePreview siteSlug={ siteSlug } />
-	</div>
-);
 
 const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -11,17 +12,26 @@ import Sidebar from './sidebar';
 import type { Step } from '../../types';
 import './style.scss';
 
-const Launchpad: Step = ( { navigation } ) => {
+type StepContentProps = {
+	siteSlug: string | null;
+	submit: NavigationControls[ 'submit' ];
+};
+
+type LaunchpadProps = {
+	navigation: NavigationControls;
+};
+
+const StepContent = ( { siteSlug, submit }: StepContentProps ) => (
+	<div className="launchpad__content">
+		<Sidebar siteSlug={ siteSlug } submit={ submit } />
+		<LaunchpadSitePreview siteSlug={ siteSlug } />
+	</div>
+);
+
+const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 	const translate = useTranslate();
 	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
 	const siteSlug = useSiteSlugParam();
-
-	const stepContent = (
-		<div className="launchpad__content">
-			<Sidebar siteSlug={ siteSlug } />
-			<LaunchpadSitePreview siteSlug={ siteSlug } />
-		</div>
-	);
 
 	const site = useSite();
 	const launchpadScreenOption = site?.options?.launchpad_screen;
@@ -42,7 +52,7 @@ const Launchpad: Step = ( { navigation } ) => {
 				skipLabelText={ translate( 'Go to Admin' ) }
 				skipButtonAlign={ 'bottom' }
 				hideBack={ true }
-				stepContent={ stepContent }
+				stepContent={ <StepContent siteSlug={ siteSlug } submit={ navigation.submit } /> }
 				formattedHeader={
 					<FormattedHeader
 						id={ 'launchpad-header' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,12 +1,18 @@
 import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
 import Checklist from './checklist';
 import { getArrayOfFilteredTasks } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
+
+type SidebarProps = {
+	siteSlug: string | null;
+	submit: NavigationControls[ 'submit' ];
+};
 
 function getUrlInfo( url: string ) {
 	const urlWithoutProtocol = url.replace( /^https?:\/\//, '' );
@@ -31,7 +37,7 @@ function getChecklistCompletionProgress( tasks: Task[] ) {
 	return Math.round( ( totalCompletedTasks / tasks.length ) * 100 );
 }
 
-const Sidebar = ( { siteSlug }: { siteSlug: string | null } ) => {
+const Sidebar = ( { siteSlug, submit }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	const flow = useFlowParam();
@@ -70,7 +76,7 @@ const Sidebar = ( { siteSlug }: { siteSlug: string | null } ) => {
 					<span>{ siteName }</span>
 					<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
 				</div>
-				<Checklist siteSlug={ siteSlug } tasks={ tasks } flow={ flow } />
+				<Checklist siteSlug={ siteSlug } tasks={ tasks } flow={ flow } submit={ submit } />
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,0 +1,17 @@
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import LaunchpadSitePreview from './launchpad-site-preview';
+import Sidebar from './sidebar';
+
+type StepContentProps = {
+	siteSlug: string | null;
+	submit: NavigationControls[ 'submit' ];
+};
+
+const StepContent = ( { siteSlug, submit }: StepContentProps ) => (
+	<div className="launchpad__content">
+		<Sidebar siteSlug={ siteSlug } submit={ submit } />
+		<LaunchpadSitePreview siteSlug={ siteSlug } />
+	</div>
+);
+
+export default StepContent;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,6 +1,8 @@
+import { dispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
+import { SITE_STORE } from '../../../../stores';
 import { launchpadFlowTasks } from './tasks';
 import { Task } from './types';
 
@@ -67,6 +69,13 @@ export function getEnhancedTasks(
 						title: translate( 'Launch Link in bio' ),
 						isCompleted: linkInBioSiteLaunchCompleted,
 						dependencies: [ linkInBioLinksEditCompleted ],
+						actionDispatch: async () => {
+							if ( site?.ID ) {
+								await dispatch( SITE_STORE ).launchSite( site.ID );
+							}
+
+							window.location.replace( `/home/${ siteSlug }` );
+						},
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,7 +1,9 @@
 import { dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { SITE_STORE } from '../../../../stores';
 import { launchpadFlowTasks } from './tasks';
 import { Task } from './types';
@@ -9,7 +11,10 @@ import { Task } from './types';
 export function getEnhancedTasks(
 	tasks: Task[],
 	siteSlug: string | null,
-	site: SiteDetails | null
+	site: SiteDetails | null,
+	submit: NavigationControls[ 'submit' ],
+	setPendingAction: ( pendingAction: ( () => Promise< void > ) | undefined ) => void,
+	setProgressTitle: ( progressTitle: string | undefined ) => void
 ) {
 	const enhancedTaskList: Task[] = [];
 	const productSlug = site?.plan?.product_slug;
@@ -69,12 +74,19 @@ export function getEnhancedTasks(
 						title: translate( 'Launch Link in bio' ),
 						isCompleted: linkInBioSiteLaunchCompleted,
 						dependencies: [ linkInBioLinksEditCompleted ],
-						actionDispatch: async () => {
+						actionDispatch: () => {
 							if ( site?.ID ) {
-								await dispatch( SITE_STORE ).launchSite( site.ID );
-							}
+								setPendingAction( async () => {
+									setProgressTitle( __( 'Launching Link in bio' ) );
+									await dispatch( SITE_STORE ).launchSite( site.ID );
 
-							window.location.replace( `/home/${ siteSlug }` );
+									// Waits for half a second so that the loading screen doesn't flash away too quickly
+									await new Promise( ( res ) => setTimeout( res, 500 ) );
+									window.location.replace( `/home/${ siteSlug }` );
+								} );
+
+								submit?.();
+							}
 						},
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,7 +4,7 @@ import { translate } from 'i18n-calypso';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { SITE_STORE } from '../../../../stores';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { launchpadFlowTasks } from './tasks';
 import { Task } from './types';
 
@@ -12,9 +12,7 @@ export function getEnhancedTasks(
 	tasks: Task[],
 	siteSlug: string | null,
 	site: SiteDetails | null,
-	submit: NavigationControls[ 'submit' ],
-	setPendingAction: ( pendingAction: ( () => Promise< void > ) | undefined ) => void,
-	setProgressTitle: ( progressTitle: string | undefined ) => void
+	submit: NavigationControls[ 'submit' ]
 ) {
 	const enhancedTaskList: Task[] = [];
 	const productSlug = site?.plan?.product_slug;
@@ -76,9 +74,12 @@ export function getEnhancedTasks(
 						dependencies: [ linkInBioLinksEditCompleted ],
 						actionDispatch: () => {
 							if ( site?.ID ) {
+								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
+								const { launchSite } = dispatch( SITE_STORE );
+
 								setPendingAction( async () => {
 									setProgressTitle( __( 'Launching Link in bio' ) );
-									await dispatch( SITE_STORE ).launchSite( site.ID );
+									await launchSite( site.ID );
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -7,6 +7,7 @@ export interface Task {
 	displayBadge: boolean;
 	badgeText?: string;
 	dependencies?: boolean[];
+	actionDispatch?: () => void;
 }
 
 export interface LaunchpadFlowTaskList {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -60,6 +60,10 @@ export const linkInBio: Flow = {
 				case 'processing': {
 					return navigate( providedDependencies?.destination as StepPath );
 				}
+
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
 			}
 			return providedDependencies;
 		}


### PR DESCRIPTION
#### Proposed Changes

* Clicking on the Launch site task will launch the site and redirect the user to `/home` when successful.

![2022-08-31 16 01 49](https://user-images.githubusercontent.com/5414230/187799838-a51fcc1c-b34e-4850-8269-5e4061a3b65b.gif)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Setup**
* Check out this branch
* `yarn start`
* Visit https://wordpress.com/hp-2022-tailored-flows/ and scroll down to the `Put a dent in the web. In 3 minutes flat.` subheading
* Create a new link-in-bio site through horizon.wordpress.com
* Continue until you reach the link-in-bio launchpad
* Click on the edit site links task
* Navigate back to the launchpad
  * Open the navigation sidebar in the editor
  * Click on the back to dashboard button
  
 **Behavior to Test**
* Switch from horizon to http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=YOUR_SITE_SLUG
* Click on the launch site task -- this may take a few moments
* Verify that we are redirected to `/home` successfully
* Verify that the `launchpad_screen` site option is now `off` for the site
* Verify that the `launchpad_checklist_tasks_statuses` site option has both the `links_edited` and `site_launched` properties set to true

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
