### PR TITLE
Reader: Update Header of Followed Site Screen

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -85,6 +85,7 @@ class FeedHeader extends Component {
 		return (
 			<div className={ classes }>
 				<QueryUserSettings />
+				{ showBack && <HeaderBack /> }
 				<Card className="reader-feed-header__site">
 					<a href={ siteUrl } className="reader-feed-header__site-icon">
 						<SiteIcon site={ site } size={ 116 } />
@@ -114,7 +115,6 @@ class FeedHeader extends Component {
 					</div>
 				</Card>
 				<div className="reader-feed-header__back-and-follow">
-					{ showBack && <HeaderBack /> }
 					<div className="reader-feed-header__follow">
 						{ followerCount && (
 							<span className="reader-feed-header__follow-count">

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -87,7 +87,7 @@ class FeedHeader extends Component {
 				<QueryUserSettings />
 				<Card className="reader-feed-header__site">
 					<a href={ siteUrl } className="reader-feed-header__site-icon">
-						<SiteIcon site={ site } size={ 96 } />
+						<SiteIcon site={ site } size={ 116 } />
 					</a>
 					<div className="reader-feed-header__site-title">
 						{ site && (

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -85,6 +85,34 @@ class FeedHeader extends Component {
 		return (
 			<div className={ classes }>
 				<QueryUserSettings />
+				<Card className="reader-feed-header__site">
+					<a href={ siteUrl } className="reader-feed-header__site-icon">
+						<SiteIcon site={ site } size={ 96 } />
+					</a>
+					<div className="reader-feed-header__site-title">
+						{ site && (
+							<span className="reader-feed-header__site-badge">
+								<ReaderFeedHeaderSiteBadge site={ site } />
+								<BlogStickers blogId={ site.ID } />
+							</span>
+						) }
+						<a className="reader-feed-header__site-title-link" href={ siteUrl }>
+							{ siteTitle }
+						</a>
+					</div>
+					<div className="reader-feed-header__details">
+						<span className="reader-feed-header__description">{ description }</span>
+						{ ownerDisplayName && ! isAuthorNameBlocked( ownerDisplayName ) && (
+							<span className="reader-feed-header__byline">
+								{ translate( 'by %(author)s', {
+									args: {
+										author: ownerDisplayName,
+									},
+								} ) }
+							</span>
+						) }
+					</div>
+				</Card>
 				<div className="reader-feed-header__back-and-follow">
 					{ showBack && <HeaderBack /> }
 					<div className="reader-feed-header__follow">
@@ -129,34 +157,6 @@ class FeedHeader extends Component {
 						</div>
 					</div>
 				</div>
-				<Card className="reader-feed-header__site">
-					<a href={ siteUrl } className="reader-feed-header__site-icon">
-						<SiteIcon site={ site } size={ 96 } />
-					</a>
-					<div className="reader-feed-header__site-title">
-						{ site && (
-							<span className="reader-feed-header__site-badge">
-								<ReaderFeedHeaderSiteBadge site={ site } />
-								<BlogStickers blogId={ site.ID } />
-							</span>
-						) }
-						<a className="reader-feed-header__site-title-link" href={ siteUrl }>
-							{ siteTitle }
-						</a>
-					</div>
-					<div className="reader-feed-header__details">
-						<span className="reader-feed-header__description">{ description }</span>
-						{ ownerDisplayName && ! isAuthorNameBlocked( ownerDisplayName ) && (
-							<span className="reader-feed-header__byline">
-								{ translate( 'by %(author)s', {
-									args: {
-										author: ownerDisplayName,
-									},
-								} ) }
-							</span>
-						) }
-					</div>
-				</Card>
 			</div>
 		);
 	}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -42,7 +42,7 @@
 	font-size: $font-title-large;
 	font-weight: 600;
 	max-height: 16px * 4;
-	margin-bottom: 12px;
+	margin-bottom: 6px;
 	overflow: hidden;
 	position: relative;
 	text-align: center;
@@ -147,10 +147,12 @@
 
 	.reader-feed-header__details {
 		align-self: stretch;
-		font-size: $font-body-small;
+		font-size: 1.0625em;
 		overflow: hidden;
 		text-align: center;
 		position: relative;
+		margin-bottom: 8px;
+		top:-4px;
 
 		.reader-feed-header__description {
 			display: block;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -39,7 +39,7 @@
 .reader-feed-header__site .reader-feed-header__site-title {
 	align-self: stretch;
 	font-family: $serif;
-	font-size: $font-title-small;
+	font-size: $font-title-large;
 	font-weight: 600;
 	max-height: 16px * 4;
 	margin-bottom: 12px;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -76,7 +76,6 @@
 	.reader-feed-header__back-and-follow {
 		display: flex;
 		justify-content: center;
-		height: 0;
 		margin-left: auto;
 
 		@include breakpoint-deprecated( '<960px' ) {
@@ -105,7 +104,7 @@
 		flex: 0 0 100%;
 		justify-content:center;
 		text-align:center;
-		
+
 		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
 		}
@@ -114,7 +113,8 @@
 	.reader-feed-header__follow-and-settings {
 		display: flex;
 		flex-direction: row;
-		justify-content: flex-start;
+		justify-content: center;
+		flex: 0 0 100%;
 		gap: 20px;
 	}
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -25,7 +25,7 @@
 
 .reader-feed-header__site-icon {
 	align-self: center;
-	padding-bottom: 20px;
+	padding-bottom: 16px;
 }
 
 .reader-feed-header .reader-feed-header__site-badge {
@@ -42,6 +42,7 @@
 	font-size: $font-title-small;
 	font-weight: 600;
 	max-height: 16px * 4;
+	margin-bottom: 12px;
 	overflow: hidden;
 	position: relative;
 	text-align: center;
@@ -102,6 +103,7 @@
 		color: var( --color-text-subtle );
 		font-size: $font-body-small;
 		flex: 0 0 100%;
+		margin-bottom: 24px;
 		justify-content:center;
 		text-align:center;
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -75,7 +75,7 @@
 
 	.reader-feed-header__back-and-follow {
 		display: flex;
-		justify-content: flex-end;
+		justify-content: center;
 		height: 0;
 		margin-left: auto;
 
@@ -103,6 +103,8 @@
 		color: var( --color-text-subtle );
 		font-size: $font-body-small;
 		margin-right: 15px;
+		flex: 0 0 100%;
+		justify-content:center;
 
 		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
@@ -111,7 +113,7 @@
 
 	.reader-feed-header__follow-and-settings {
 		display: flex;
-		flex-direction: column;
+		flex-direction: row;
 		justify-content: flex-start;
 	}
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -102,10 +102,10 @@
 	.reader-feed-header__follow-count {
 		color: var( --color-text-subtle );
 		font-size: $font-body-small;
-		margin-right: 15px;
 		flex: 0 0 100%;
 		justify-content:center;
-
+		text-align:center;
+		
 		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
 		}
@@ -115,6 +115,7 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: flex-start;
+		gap: 20px;
 	}
 
 	.reader-feed-header__follow-button .follow-button {

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -196,6 +196,11 @@
 	}
 }
 
+.reader-feed-header__email-settings {
+	position: relative;
+	top: -2px;
+}
+
 .reader-feed-header__email-settings .reader-site-notification-settings .gridicons-cog {
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -204,6 +209,7 @@
 }
 
 .reader-feed-header__email-settings .reader-site-notification-settings__button-label {
+	display: inline-block;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		display: inline;

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -1,9 +1,19 @@
 .reader-site-notification-settings__button {
 	color: var( --color-text-subtle );
-
+	&:focus {
+    box-shadow: none;
+    outline: none;
+	}
 	&:hover {
 		cursor: pointer;
 	}
+}
+
+.accessible-focus .reader-site-notification-settings__button:focus {
+	border-color: var(--color-primary);
+	border-radius: 2px;
+  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: none;
 }
 
 .reader-site-notification-settings__button-label {

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -11,11 +11,13 @@
 
 .header-cake.card {
 	display: flex;
+	height:0;
 	align-items: center;
 	font-size: $font-body-small;
 	line-height: 18px;
 	padding-top: 11px;
 	padding-bottom: 11px;
+	margin-bottom:0;
 
 	&::after {
 		display: none;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -2,7 +2,7 @@
 
 // Overrides default 720px width
 .is-reader-page .following.main {
-	max-width: 800px;
+	max-width: 600px;
 }
 
 .is-reader-page .reader__card.card.is-placeholder {


### PR DESCRIPTION
#### Proposed Changes

* Attempts to update the Followed Sites header in accordance with the design in this issue:
https://github.com/Automattic/wp-calypso/issues/67166

#### Testing Instructions

* Check the following types of site feed:
 * A8C site followed
 * A8C site not yet followed
 * Public site followed
 * Public site not yet followed

#### Screenshots

<img width="953" alt="Screen Shot 2022-08-31 at 5 04 22 pm" src="https://user-images.githubusercontent.com/1842363/187615145-9fd177c8-a05c-45b6-a4bd-a2bf86ece274.png">

<img width="989" alt="Screen Shot 2022-08-31 at 5 04 39 pm" src="https://user-images.githubusercontent.com/1842363/187615189-0f436d8a-5a33-4845-9de3-55a770e88ab6.png">

Related to #67166
