### PR TITLE
All sites: fix empty site title crashing the page.

### DIFF
--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -63,7 +63,7 @@ function getFirstGrapheme( input: string ) {
 		const segmenter = new Intl.Segmenter();
 		const [ firstSegmentData ] = segmenter.segment( input );
 
-		return firstSegmentData.segment;
+		return firstSegmentData?.segment;
 	}
 
 	return input.charAt( 0 );


### PR DESCRIPTION
#### Proposed Changes

While checking wordpress.com/sites, I got a JS fatal error which is coming from trying to get `segment` out of a null `firstSegmentData`.

<img width="582" alt="CleanShot 2022-08-31 at 10 32 14@2x" src="https://user-images.githubusercontent.com/12430020/187620661-59bbdbed-6c63-4213-ba88-d28c8df289cb.png">

While this PR fixes the error and the page loads, I am not sure if it might create any other unwanted side effects. Maybe also checking that `input` is not empty before getting into the condition would be preferable?

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* remove the site title from any of your sites
* load `/sites`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
