### PR TITLE
Fix text headers font size and spacing for both Desktop and Mobile view.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -53,11 +53,11 @@
 }
 
 .featured-item-card--title {
-	font-size: $font-title-large;
+	font-size: $font-title-medium;
 	font-weight: 700;
 
 	@include break-medium {
-		font-size: $font-title-medium;
+		font-size: $font-title-large;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -34,9 +34,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 		<div className="jetpack-product-store">
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
 
-			<div className="jetpack-product-store__pricing-banner">
-				<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
-			</div>
+			<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
 
 			<ViewFilter currentView={ currentView } setCurrentView={ setCurrentView } />
 			<ItemsList

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -37,7 +37,9 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
 
-			<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
+			<div className="jetpack-product-store__pricing-banner">
+				<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
+			</div>
 
 			<ViewFilter currentView={ currentView } setCurrentView={ setCurrentView } />
 			<ItemsList

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -20,6 +20,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	enableUserLicensesDialog,
 	onClickPurchase,
 	urlQueryArgs,
+	header,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const productSlugs = useProductSlugs( { siteId, duration } );
@@ -32,6 +33,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 
 	return (
 		<div className="jetpack-product-store">
+			{ header }
+
 			{ enableUserLicensesDialog && <UserLicensesDialog siteId={ siteId } /> }
 
 			<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />

--- a/client/my-sites/plans/jetpack-plans/product-store/products-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/products-list.tsx
@@ -83,7 +83,9 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 			<MostPopular heading={ translate( 'Most popular products' ) } items={ mostPopularItems } />
 
 			<div className="jetpack-product-store__products-list-all">
-				<h3>{ translate( 'All products' ) }</h3>
+				<h3 className="jetpack-product-store__products-list-all-header">
+					{ translate( 'All products' ) }
+				</h3>
 
 				<div className="jetpack-product-store__products-list-all-grid">
 					{ allItems.map( ( item ) => {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -71,11 +71,20 @@
 	}
 
 	&__most-popular--heading {
-		margin-bottom: 2em;
+		margin-bottom: rem( 24px );
+		font-size: $font-title-medium;
+		line-height: rem( 29px );
+
+		@media only screen and ( min-width: 821px ) {
+			margin-bottom: rem( 32px );
+		}
+
+	&__most-popular--items {
+		display: flex;
+		justify-content: space-evenly;
 	}
 
 	&__most-popular--items {
-		justify-content: space-evenly;
 		list-style-type: none;
 		display: grid;
 		grid-template-columns: 1fr;
@@ -350,6 +359,9 @@
 	color: var( --color-neutral-100 );
 }
 
+.jetpack-product-store__products-list-all {
+	margin-bottom: 48px;
+}
 
 .jetpack-product-store__products-list-all-grid {
 	display: grid;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -118,14 +118,18 @@
 				margin: 0;
 			}
 		}
-
-		.plan-price.is-discounted,
-		.plan-price.is-original {
+		.plan-price.is-discounted, .plan-price.is-original {
 			margin-right: 0.1em;
 		}
-
-		.plan-price.is-original::before,
-		.is-placeholder .plan-price::after {
+		.plan-price.is-discounted {
+			color: var( --studio-gray-100 );
+			font-weight: 700;
+		}
+		.plan-price.is-original {
+			color: var( --studio-gray-100 );
+			font-weight: semibold;
+		}
+		.plan-price.is-original::before, .is-placeholder .plan-price::after {
 			display: none;
 		}
 
@@ -361,6 +365,21 @@
 
 .jetpack-product-store__products-list-all {
 	margin-bottom: 48px;
+}
+
+.jetpack-product-store__products-list-all-header {
+	margin-top: rem( 32px );
+	margin-bottom: rem( 24px );
+	font-size: $font-title-small;
+	font-weight: 700;
+
+	@include break-medium {
+		margin-top: rem( 72px );
+		margin-bottom: rem( 48px );
+		font-size: $font-title-medium;
+		line-height: rem( 29px );
+		font-weight: 600;
+	}
 }
 
 .jetpack-product-store__products-list-all-grid {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -5,6 +5,25 @@
 	display: flex;
 	flex-direction: column;
 
+	.header {
+		margin-bottom: 36px;
+	}
+
+	.header .formatted-header {
+		margin: 0;
+	}
+
+	.header .formatted-header__title {
+		margin: 0 auto !important;
+		font-size: $font-title-large !important;
+		line-height: rem( 38px ) !important;
+
+		@include break-large {
+			font-size: $font-headline-small !important;
+			line-height: rem( 40px ) !important;
+		}
+	}
+
 	&__jetpack-free {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -13,17 +13,6 @@
 		margin: 0;
 	}
 
-	.header .formatted-header__title {
-		margin: 0 auto !important;
-		font-size: $font-title-large !important;
-		line-height: rem( 38px ) !important;
-
-		@include break-large {
-			font-size: $font-headline-small !important;
-			line-height: rem( 40px ) !important;
-		}
-	}
-
 	&__jetpack-free {
 		display: flex;
 		flex-direction: column;
@@ -406,5 +395,16 @@
 
 	@include break-medium {
 		grid-template-columns: repeat( 2, 1fr );
+	}
+}
+
+.is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .jetpack-product-store .header .header__main-title .formatted-header__title {
+	margin: 0 auto;
+	font-size: $font-title-large;
+	line-height: rem( 38px );
+
+	@include break-large {
+		font-size: $font-headline-small;
+		line-height: rem( 40px );
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -325,34 +325,34 @@
 			}
 		}
 	}
+}
 
 	.intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__content {
 		margin-bottom: 40px;
 		height: auto;
 
-		@include break-large {
-			max-height: 32px;
-		}
+	@include break-large {
+		height: 32px;
 	}
+}
 
-	.intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__item {
+.jetpack-product-store__pricing-banner .intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__content {
+	height: 112px;
+	gap: 12px;
+
+	@include break-large {
+		gap: 32px;
 		max-height: 32px;
 	}
 }
 
-.jetpack-product-store__jetpack-free .button,
-.jetpack-product-store__see-all-features .button {
-	min-width: 225px;
+.jetpack-product-store__pricing-banner .intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__item {
+	max-height: 32px;
+	margin: 0;
 }
 
-.jetpack-product-store__pricing-banner {
-	height: 120px;
-	margin-bottom: 1.25rem;
-
-	@include break-large {
-		height: 54px;
-		margin-bottom: 0;
-	}
+.jetpack-product-store__pricing-banner .intro-pricing-banner__item-icon {
+	margin-right: 10px;
 }
 
 .jetpack-product-store__need-more-info {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -91,11 +91,14 @@
 
 	&__most-popular--heading {
 		margin-bottom: rem( 24px );
-		font-size: $font-title-medium;
+		font-size: $font-title-small;
+		font-weight: 700;
 		line-height: rem( 29px );
 
 		@media only screen and ( min-width: 821px ) {
 			margin-bottom: rem( 32px );
+			font-size: $font-title-medium;
+			font-weight: 600;
 		}
 
 	&__most-popular--items {
@@ -392,7 +395,7 @@
 	font-size: $font-title-small;
 	font-weight: 700;
 
-	@include break-medium {
+	@media only screen and ( min-width: 821px ) {
 		margin-top: rem( 72px );
 		margin-bottom: rem( 48px );
 		font-size: $font-title-medium;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -95,15 +95,11 @@
 		font-weight: 700;
 		line-height: rem( 29px );
 
-		@media only screen and ( min-width: 821px ) {
+		@include break-medium {
 			margin-bottom: rem( 32px );
 			font-size: $font-title-medium;
 			font-weight: 600;
 		}
-
-	&__most-popular--items {
-		display: flex;
-		justify-content: space-evenly;
 	}
 
 	&__most-popular--items {
@@ -132,6 +128,9 @@
 		}
 
 		.plan-price.is-original {
+			color: var( --studio-gray-100 );
+			font-weight: 600;
+
 			.plan-price__currency-symbol,
 			.plan-price__integer,
 			.plan-price__fraction {
@@ -139,18 +138,19 @@
 				margin: 0;
 			}
 		}
-		.plan-price.is-discounted, .plan-price.is-original {
+
+		.plan-price.is-discounted,
+		.plan-price.is-original {
 			margin-right: 0.1em;
 		}
+
 		.plan-price.is-discounted {
 			color: var( --studio-gray-100 );
 			font-weight: 700;
 		}
-		.plan-price.is-original {
-			color: var( --studio-gray-100 );
-			font-weight: semibold;
-		}
-		.plan-price.is-original::before, .is-placeholder .plan-price::after {
+
+		.plan-price.is-original::before,
+		.is-placeholder .plan-price::after {
 			display: none;
 		}
 
@@ -278,7 +278,7 @@
 		border-color: var( --studio-gray-5 );
 		border-radius: 8px; /* stylelint-disable-line */
 		color: var( --color-text );
-		margin: 0 auto 1em;
+		margin: 0 auto;
 		max-width: 21.4375em;
 
 		.segmented-control__item {
@@ -327,16 +327,16 @@
 	}
 }
 
-	.intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__content {
-		margin-bottom: 40px;
-		height: auto;
+.jetpack-product-store__pricing-banner {
+	height: 112px;
+	margin-bottom: 40px;
 
 	@include break-large {
 		height: 32px;
 	}
 }
 
-.jetpack-product-store__pricing-banner .intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__content {
+.jetpack-product-store__pricing-banner .intro-pricing-banner:not(.is-sticky) .intro-pricing-banner__content {
 	height: 112px;
 	gap: 12px;
 
@@ -346,7 +346,7 @@
 	}
 }
 
-.jetpack-product-store__pricing-banner .intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__item {
+.jetpack-product-store__pricing-banner .intro-pricing-banner:not(.is-sticky) .intro-pricing-banner__item {
 	max-height: 32px;
 	margin: 0;
 }
@@ -384,17 +384,13 @@
 	color: var( --color-neutral-100 );
 }
 
-.jetpack-product-store__products-list-all {
-	margin-bottom: 48px;
-}
-
 .jetpack-product-store__products-list-all-header {
 	margin-top: rem( 32px );
 	margin-bottom: rem( 24px );
 	font-size: $font-title-small;
 	font-weight: 700;
 
-	@media only screen and ( min-width: 821px ) {
+	@include break-medium {
 		margin-top: rem( 72px );
 		margin-bottom: rem( 48px );
 		font-size: $font-title-medium;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -117,9 +117,6 @@
 		}
 
 		.plan-price.is-original {
-			color: var( --studio-gray-100 );
-			font-weight: 600;
-
 			.plan-price__currency-symbol,
 			.plan-price__integer,
 			.plan-price__fraction {
@@ -131,11 +128,6 @@
 		.plan-price.is-discounted,
 		.plan-price.is-original {
 			margin-right: 0.1em;
-		}
-
-		.plan-price.is-discounted {
-			color: var( --studio-gray-100 );
-			font-weight: 700;
 		}
 
 		.plan-price.is-original::before,

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -234,10 +234,6 @@
 		border: none;
 	}
 
-	.jetpack-product-store__view-filter {
-		margin-top: 0.75em;
-	}
-
 	.jetpack-product-store__view-filter .jetpack-product-store__view-filter--toggle.segmented-control {
 		display: flex;
 		flex-direction: row;
@@ -248,7 +244,7 @@
 		border-color: var( --studio-gray-5 );
 		border-radius: 8px; /* stylelint-disable-line */
 		color: var( --color-text );
-		margin: 0.5em auto 1em;
+		margin: 0 auto 1em;
 		max-width: 21.4375em;
 
 		.segmented-control__item {
@@ -294,6 +290,19 @@
 				border-color: #0000000a;
 			}
 		}
+	}
+
+	.intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__content {
+		margin-bottom: 40px;
+		height: auto;
+
+		@include break-large {
+			max-height: 32px;
+		}
+	}
+
+	.intro-pricing-banner:not( .is-sticky ) .intro-pricing-banner__item {
+		max-height: 32px;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -110,8 +110,7 @@
 		list-style-type: none;
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: 32px;
-		margin-top: 24px;
+		grid-gap: 24px;
 
 		@include break-medium {
 			grid-template-columns: 1fr 1fr;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import type {
 	QueryArgs,
 	SelectorProduct,
@@ -24,6 +25,7 @@ export interface ProductStoreProps {
 	createCheckoutURL?: PurchaseURLCallback;
 	onClickPurchase?: PurchaseCallback;
 	urlQueryArgs: ProductStoreQueryArgs;
+	header: ReactNode;
 }
 
 export type JetpackFreeProps = Pick< ProductStoreProps, 'urlQueryArgs' > & ProductStoreBaseProps;
@@ -39,7 +41,8 @@ export interface ViewFilterProps {
 	setCurrentView: ( currentView: ViewType ) => void;
 }
 
-export type ProductsListProps = ProductStoreBaseProps & Omit< ProductStoreProps, 'urlQueryArgs' >;
+export type ProductsListProps = ProductStoreBaseProps &
+	Omit< ProductStoreProps, 'urlQueryArgs' | 'header' >;
 
 export type BundlesListProps = ProductsListProps;
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -223,17 +223,14 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 				/>
 
 				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (
-					<>
-						{ header }
-
-						<ProductStore
-							createCheckoutURL={ createProductURL }
-							duration={ currentDuration }
-							enableUserLicensesDialog={ enableUserLicensesDialog }
-							onClickPurchase={ selectProduct }
-							urlQueryArgs={ urlQueryArgs }
-						/>
-					</>
+					<ProductStore
+						createCheckoutURL={ createProductURL }
+						duration={ currentDuration }
+						enableUserLicensesDialog={ enableUserLicensesDialog }
+						onClickPurchase={ selectProduct }
+						urlQueryArgs={ urlQueryArgs }
+						header={ header }
+					/>
 				) : (
 					<>
 						{ siteId && enableUserLicensesDialog && (


### PR DESCRIPTION
#### Proposed Changes

* Fix font styling and spacing for Most popular items and All products header text.
* Fix Price banner and filter spacing.
* Move header component inside ProductStore to make it easier for us to override the styling and match the design spec for the new pricing page on the header's font size and spacing. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR
  * Run `git fetch && git checkout fix/pricing-page-font-sizing-and-spacing`
  * Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
* Confirm header, pricing banner, filter and heading text has matches font-size and spacing in the figma design for both Desktop and Mobile view.

### Before applying fix
<img width="1377" alt="Screen Shot 2022-08-31 at 4 24 45 PM" src="https://user-images.githubusercontent.com/56598660/187631618-e48f9f57-1c0a-44b7-a750-47336f4260e2.png">

### After applying fix
<img width="1149" alt="Screen Shot 2022-08-31 at 7 35 47 PM" src="https://user-images.githubusercontent.com/56598660/187669601-4a3affc1-b03e-4d7a-b0c1-bb47ba8df351.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202890485805669

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202890485805669