### PR TITLE
Plugins Management: Disable actions per single item when bulk actions are active

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -142,6 +142,7 @@ export default function PluginRowFormatter( {
 							hideLabel={ ! isSmallScreen }
 							plugin={ pluginOnSite }
 							site={ selectedSite }
+							disabled={ !! item?.isSelectable }
 						/>
 					</div>
 				)
@@ -156,6 +157,7 @@ export default function PluginRowFormatter( {
 							site={ selectedSite }
 							wporg={ !! item.wporg }
 							isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
+							disabled={ !! item?.isSelectable }
 						/>
 					</div>
 				)


### PR DESCRIPTION
#### Proposed Changes

In Calypso Blue, we disable the single-item actions when bulk actions are enabled. This PR brings the same functionality to the Jetpack Cloud.

Before | After
--|--
![image](https://user-images.githubusercontent.com/1749918/187654157-318621d8-098c-441d-b483-9045e5217f2f.png)|![image](https://user-images.githubusercontent.com/1749918/187653397-181f91c3-4eb2-4192-a76d-eed604d79702.png)

#### Testing Instructions

**Prerequisites**
- Since this change is made specifically for agencies, you must set yourself (partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type when you're done with testing.

**Instructions**
- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/plugins/manage
- Activate bulk actions by clicking the "Edit all" button
- Verify that single-item actions (e.g. auto-update, activate) are disabled when you are in bulk actions mode
- Close bulk actions mode by clicking the "X" button
- Verify that the single-item actions are enabled again

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202881340073852