### PR TITLE
Wrap target_url in an anchor

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -213,7 +213,13 @@ export default function CampaignItem( { campaign }: Props ) {
 								{ __( 'Ad destination' ) }
 							</div>
 							<div className="campaign-item__block_value campaign-item__target-value">
-								{ target_url || '-' }
+								{ target_url ? (
+									<a href={ target_url } target="_blank" rel="noreferrer">
+										{ target_url }
+									</a>
+								) : (
+									'-'
+								) }
 							</div>
 						</div>
 					</div>

--- a/client/my-sites/promote-post/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post/components/campaign-item/style.scss
@@ -75,5 +75,7 @@
 		margin-bottom: 10px;
 	}
 
+	.campaign-item__target-value {
+		word-break: break-all;
+	}
 }
-


### PR DESCRIPTION
#### Proposed Changes

Currently in the advertising tools > campaign list.  The ad destination url would be plain text.

This PR simply updates this to a hyperlink that will open in a new tab.

Expected behaviour
![Screenshot 2022-08-31 at 10 56 26](https://user-images.githubusercontent.com/6440498/187652884-26e132d0-0084-4845-abf1-ceca993998ed.png)

Expected behaviour when URL is empty
![Screenshot 2022-08-31 at 10 55 43](https://user-images.githubusercontent.com/6440498/187652887-bf17dedd-3cf3-437d-919c-c25c642e082a.png)


#### Testing Instructions

Visit http://calypso.localhost:3000/advertising/yoursite.co.uk

![Screenshot 2022-08-31 at 10 58 55](https://user-images.githubusercontent.com/6440498/187652681-991da462-4abe-4803-b929-05fab58c4883.png)

- [ ] If you do not have any existing campaigns, then promote a post from your list of posts (ready to promote tab)
- [ ] Then when you do have campaigns, hit the campaign tab
- [ ] The Ad url should be a hyperlink

The fallback for this will simply be a hyphen when there is no URL to display - this is a  legacy feature - all ads have URLS now.



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
