### PR TITLE
Add description for Most Popular products/bundles to calypso-products

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -18,7 +18,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 	siteId,
 } ) => {
 	const translate = useTranslate();
-	const { displayName: title, description } = item;
+	const { displayName: title, featuredDescription } = item;
 
 	return (
 		<div className="featured-item-card">
@@ -37,7 +37,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 					</div>
 					<div className="featured-item-card--desc">
 						<p>
-							<span>{ description }</span>
+							<span>{ featuredDescription }</span>
 							<br />
 							<Button
 								className="featured-item-card--learn-more"

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/isolate-popular-items.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/isolate-popular-items.ts
@@ -8,12 +8,15 @@ export const isolatePopularItems = < Item extends { productSlug: string } >(
 	popularItemSlugs: Array< Item[ 'productSlug' ] >
 ) => {
 	const popularItems: typeof allItems = [];
+	const otherItems: typeof allItems = [];
 
 	for ( const item of allItems ) {
 		if ( popularItemSlugs.includes( item.productSlug ) ) {
 			popularItems.push( item );
+		} else {
+			otherItems.push( item );
 		}
 	}
 
-	return [ popularItems, allItems ] as const;
+	return [ popularItems, otherItems ] as const;
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/isolate-popular-items.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/isolate-popular-items.ts
@@ -8,15 +8,12 @@ export const isolatePopularItems = < Item extends { productSlug: string } >(
 	popularItemSlugs: Array< Item[ 'productSlug' ] >
 ) => {
 	const popularItems: typeof allItems = [];
-	const otherItems: typeof allItems = [];
 
 	for ( const item of allItems ) {
 		if ( popularItemSlugs.includes( item.productSlug ) ) {
 			popularItems.push( item );
-		} else {
-			otherItems.push( item );
 		}
 	}
 
-	return [ popularItems, otherItems ] as const;
+	return [ popularItems, allItems ] as const;
 };

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -4,6 +4,7 @@ import {
 	getJetpackProductCallToAction,
 	getJetpackProductDescription,
 	getJetpackProductShortDescription,
+	getJetpackProductFeaturedText,
 	getJetpackProductDisclaimer,
 	getJetpackProductShortName,
 	getMonthlyPlanByYearly,
@@ -30,6 +31,8 @@ import {
 	EXTERNAL_PRODUCTS_SLUG_MAP,
 	ITEM_TYPE_PRODUCT,
 	ITEM_TYPE_PLAN,
+	MOST_POPULAR_PRODUCTS,
+	MOST_POPULAR_BUNDLES,
 } from './constants';
 import { getForCurrentCROIteration } from './iterations';
 import objectIsPlan from './object-is-plan';
@@ -93,6 +96,21 @@ function getDisclaimerLink() {
 		: `https://cloud.jetpack.com/pricing#${ backupStorageFaqId }`;
 }
 
+function getFeaturedProductText( item: Product ) {
+	if ( ! MOST_POPULAR_PRODUCTS.includes( item.product_slug ) ) {
+		return '';
+	}
+
+	return getJetpackProductFeaturedText( item ) ?? '';
+}
+
+function getFeaturedPlanText( item: Plan, productSlug: string ) {
+	if ( ! MOST_POPULAR_BUNDLES.includes( productSlug ) || ! item.getFeaturedText ) {
+		return '';
+	}
+
+	return getForCurrentCROIteration( item.getFeaturedText ) ?? '';
+}
 /**
  * Converts data from a product, plan, or selector product to selector product.
  *
@@ -139,6 +157,7 @@ function itemToSelectorProduct(
 			tagline: getJetpackProductTagline( item ) ?? '',
 			description: getJetpackProductDescription( item ),
 			shortDescription: getJetpackProductShortDescription( item ),
+			featuredDescription: getFeaturedProductText( item ),
 			buttonLabel: getJetpackProductCallToAction( item ),
 			monthlyProductSlug,
 			term: item.term,
@@ -174,6 +193,7 @@ function itemToSelectorProduct(
 			shortName: getForCurrentCROIteration( item.getTitle ) ?? '',
 			tagline: getForCurrentCROIteration( item.getTagline ) || '',
 			description: getForCurrentCROIteration( item.getDescription ),
+			featuredDescription: getFeaturedPlanText( item, productSlug ),
 			monthlyProductSlug,
 			term: item.term === TERM_BIENNIALLY ? TERM_ANNUALLY : item.term,
 			features: {

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -121,6 +121,7 @@ export interface SelectorProduct extends SelectorProductCost {
 	displayFrom?: boolean;
 	belowPriceText?: TranslateResult;
 	categories?: JetpackProductCategory[];
+	featuredDescription?: TranslateResult | string;
 }
 
 export type SiteProduct = {

--- a/packages/calypso-products/src/get-jetpack-product-featured-text.tsx
+++ b/packages/calypso-products/src/get-jetpack-product-featured-text.tsx
@@ -1,0 +1,14 @@
+import { getJetpackProductsFeaturedText } from './translations';
+import type { Product } from './types';
+import type { TranslateResult } from 'i18n-calypso';
+
+/**
+ * Get Jetpack product featured text based on the product purchase object.
+ */
+export function getJetpackProductFeaturedText( product: Product ): TranslateResult | undefined {
+	const jetpackProductsFeatureText = getJetpackProductsFeaturedText() as Record<
+		string,
+		TranslateResult
+	>;
+	return jetpackProductsFeatureText[ product.product_slug ];
+}

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1163,6 +1163,10 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 		translate(
 			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection.'
 		),
+	getFeaturedText: () =>
+		translate(
+			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection.'
+		),
 	getPlanCardFeatures: () => [
 		FEATURE_JETPACK_PRODUCT_BACKUP,
 		FEATURE_JETPACK_REAL_TIME_MALWARE_SCANNING,
@@ -1233,6 +1237,10 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 	getDescription: () =>
 		translate(
 			'Get the full power of Jetpack with all Security, Performance, Growth, and Design tools.'
+		),
+	getFeaturedText: () =>
+		translate(
+			'Get the full Jetpack suite with real-time security tools, improved site performance, and tools to grow your business.'
 		),
 	getTagline: () => translate( 'For best-in-class WordPress sites' ),
 	getPlanCardFeatures: () => [

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -3,6 +3,7 @@ export * from './get-jetpack-item-term-variants';
 export { getJetpackProductCallToAction } from './get-jetpack-product-call-to-action';
 export { getJetpackProductDescription } from './get-jetpack-product-description';
 export { getJetpackProductShortDescription } from './get-jetpack-product-short-description';
+export { getJetpackProductFeaturedText } from './get-jetpack-product-featured-text';
 export { getJetpackProductDisclaimer } from './get-jetpack-product-disclaimer';
 export { getJetpackProductDisplayName } from './get-jetpack-product-display-name';
 export { getJetpackProductShortName } from './get-jetpack-product-short-name';

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -451,6 +451,21 @@ export const getJetpackProductsFeaturedText = (): Record< string, TranslateResul
 	const videoPressFeaturedText = translate(
 		'Own your content. High-quality, ad-free video build specifically for WordPress.'
 	);
+	const antiSpamFeaturedText = translate(
+		'Stop spam in comments and forms. Save time through automation and get rid of annoying CAPTCHAs.'
+	);
+	const scanFeaturedText = translate(
+		'Stay ahead of security threats. Automattic scanning and one-click fixes give you and your customers peace of mind.'
+	);
+	const searchFeaturedText = translate(
+		'Instant search helps your visitors actually find what they need and improves conversion.'
+	);
+	const boostFeaturedText = translate(
+		'Instant speed and SEO boost. Get the same advantages as the top sites, no developer required.'
+	);
+	const socialFeaturedText = translate(
+		'Write once, post everywhere. Easily share your content on social media from WordPress.'
+	);
 
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDailyFeaturedText,
@@ -463,6 +478,18 @@ export const getJetpackProductsFeaturedText = (): Record< string, TranslateResul
 		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupDailyFeaturedText,
 		[ PRODUCT_JETPACK_VIDEOPRESS ]: videoPressFeaturedText,
 		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: videoPressFeaturedText,
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamFeaturedText,
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpamFeaturedText,
+		[ PRODUCT_JETPACK_SCAN ]: scanFeaturedText,
+		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanFeaturedText,
+		[ PRODUCT_JETPACK_SCAN_REALTIME ]: scanFeaturedText,
+		[ PRODUCT_JETPACK_SCAN_REALTIME_MONTHLY ]: scanFeaturedText,
+		[ PRODUCT_JETPACK_SEARCH ]: searchFeaturedText,
+		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchFeaturedText,
+		[ PRODUCT_JETPACK_BOOST ]: boostFeaturedText,
+		[ PRODUCT_JETPACK_BOOST_MONTHLY ]: boostFeaturedText,
+		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: socialFeaturedText,
+		[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: socialFeaturedText,
 	};
 };
 export const useJetpack10GbStorageAmountText = (): TranslateResult => {

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -446,6 +446,9 @@ export const getJetpackProductsShortDescriptions = (): Record< string, Translate
 
 export const getJetpackProductsFeaturedText = (): Record< string, TranslateResult > => {
 	const backupDailyFeaturedText = translate(
+		'Never lose a word, image, page, or time worrying about your site with automated daily backups & one-click restores.'
+	);
+	const backupFeaturedText = translate(
 		'Protect your site or store. Save every change with real-time cloud backups, and restore in one click.'
 	);
 	const videoPressFeaturedText = translate(
@@ -470,12 +473,12 @@ export const getJetpackProductsFeaturedText = (): Record< string, TranslateResul
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDailyFeaturedText,
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDailyFeaturedText,
-		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: backupDailyFeaturedText,
-		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: backupDailyFeaturedText,
-		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupDailyFeaturedText,
-		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupDailyFeaturedText,
-		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupDailyFeaturedText,
-		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: backupFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: backupFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupFeaturedText,
 		[ PRODUCT_JETPACK_VIDEOPRESS ]: videoPressFeaturedText,
 		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: videoPressFeaturedText,
 		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamFeaturedText,

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -444,6 +444,27 @@ export const getJetpackProductsShortDescriptions = (): Record< string, Translate
 	};
 };
 
+export const getJetpackProductsFeaturedText = (): Record< string, TranslateResult > => {
+	const backupDailyFeaturedText = translate(
+		'Protect your site or store. Save every change with real-time cloud backups, and restore in one click.'
+	);
+	const videoPressFeaturedText = translate(
+		'Own your content. High-quality, ad-free video build specifically for WordPress.'
+	);
+
+	return {
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupDailyFeaturedText,
+		[ PRODUCT_JETPACK_VIDEOPRESS ]: videoPressFeaturedText,
+		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: videoPressFeaturedText,
+	};
+};
 export const useJetpack10GbStorageAmountText = (): TranslateResult => {
 	const _translate = useTranslate();
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -133,6 +133,7 @@ export type Plan = BillingTerm & {
 	 * a feature for 20GB of storage space would be inferior to it.
 	 */
 	getInferiorFeatures?: () => Feature[];
+	getFeaturedText?: () => TranslateResult;
 };
 
 export type WithSnakeCaseSlug = { product_slug: string };


### PR DESCRIPTION
This PR updates the pricing page featured section to show the correct description. 

#### Proposed Changes

* Adds the function in `calypso-products` to fetch featured text for Products
* Adds the functions in `calypso-products` to fetch featured text for Bundles
* Adds a new property `featuredText` to selector object
* Uses the new property in `FeaturedItemCard ` 

#### Testing Instructions

* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout add/featured-product-text`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Confirm that the text inside the cards in *Most popular product* matches the design 
* Switch to *Bundles* section and confirm the text inside the cards in *Most popular bundle* matches the design

#### Screenshots
**BEFORE:**

![Screenshot 2022-08-31 at 3 43 17 PM](https://user-images.githubusercontent.com/2027003/187656425-993a5f96-d47a-4509-ad02-bd990107ca23.png)

![Screenshot 2022-08-31 at 3 44 58 PM](https://user-images.githubusercontent.com/2027003/187656443-88972d44-40e9-46f1-b68f-8947350cfa03.png)

-------------------------------

**AFTER:** 

![Screenshot 2022-08-31 at 3 54 59 PM](https://user-images.githubusercontent.com/2027003/187657739-afd8d329-c661-4ff5-b5b8-b839b92e5632.png)

![Screenshot 2022-08-31 at 3 56 24 PM](https://user-images.githubusercontent.com/2027003/187658020-58524d1f-2b65-44d4-8408-ebde3f3b5a7e.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202796695664105
  - 0-as-1202796695664105
  - 1202796695664022-as-1202796695664105/f