### PR TITLE
Pricing page rework: Update cards to display existing subscriptions

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-card/product-button-label.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-button-label.ts
@@ -12,6 +12,7 @@ interface productButtonLabelProps {
 	isSuperseded: boolean;
 	isDeprecated: boolean;
 	currentPlan?: SitePlan | null;
+	fallbackLabel?: TranslateResult;
 }
 
 export default function productButtonLabel( {
@@ -21,6 +22,7 @@ export default function productButtonLabel( {
 	isDeprecated,
 	isSuperseded,
 	currentPlan,
+	fallbackLabel,
 }: productButtonLabelProps ): TranslateResult {
 	if ( isDeprecated ) {
 		return translate( 'No longer available' );
@@ -38,6 +40,10 @@ export default function productButtonLabel( {
 		return product.type !== ITEM_TYPE_PRODUCT
 			? translate( 'Manage Plan' )
 			: translate( 'Manage Subscription' );
+	}
+
+	if ( fallbackLabel ) {
+		return fallbackLabel;
 	}
 
 	const { buttonLabel, displayName } = product;

--- a/client/my-sites/plans/jetpack-plans/product-store/bundles-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/bundles-list.tsx
@@ -4,7 +4,7 @@ import productButtonLabel from '../product-card/product-button-label';
 import { FeaturedItemCard } from './featured-item-card';
 import { HeroImage } from './hero-image';
 import { useBundlesToDisplay } from './hooks/use-bundles-to-display';
-import { useStoreItemInto } from './hooks/use-store-item-info';
+import { useStoreItemInfo } from './hooks/use-store-item-info';
 import { MostPopular } from './most-popular';
 import { SeeAllFeatures } from './see-all-features';
 import type { BundlesListProps } from './types';
@@ -28,7 +28,7 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 		isSuperseded,
 		isUpgradeableToYearly,
 		sitePlan,
-	} = useStoreItemInto( {
+	} = useStoreItemInfo( {
 		createCheckoutURL,
 		onClickPurchase,
 		duration,

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -7,7 +7,10 @@ import './style.scss';
 
 export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 	checkoutURL,
+	ctaAsPrimary,
+	ctaLabel,
 	hero,
+	isIncludedInPlan,
 	isOwned,
 	item,
 	onClickMore,
@@ -25,7 +28,12 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 				<div>
 					<h2 className="featured-item-card--title">{ title }</h2>
 					<div className="featured-item-card--price">
-						<ItemPrice isOwned={ isOwned } item={ item } siteId={ siteId } />
+						<ItemPrice
+							isIncludedInPlan={ isIncludedInPlan }
+							isOwned={ isOwned }
+							item={ item }
+							siteId={ siteId }
+						/>
 					</div>
 					<div className="featured-item-card--desc">
 						<p>
@@ -47,8 +55,8 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 					</div>
 				</div>
 				<div className="featured-item-card--footer">
-					<Button primary onClick={ onClickPurchase } href={ checkoutURL }>
-						{ translate( 'Get' ) }
+					<Button primary={ ctaAsPrimary } onClick={ onClickPurchase } href={ checkoutURL }>
+						{ ctaLabel }
 					</Button>
 				</div>
 			</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -16,6 +16,7 @@
 	margin: 0 0 16px;
 	overflow: hidden;
 	width: 100%;
+	height: 100%;
 
 	@media only screen and ( min-width: 468px ) {
 		flex-direction: row-reverse;

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.ts
@@ -15,7 +15,7 @@ import { UseStoreItemInfoProps } from '../types';
 
 const isDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
-export const useStoreItemInto = ( {
+export const useStoreItemInfo = ( {
 	createCheckoutURL,
 	duration: selectedTerm,
 	onClickPurchase,

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.ts
@@ -11,14 +11,16 @@ import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSitePlan, getSiteProducts } from 'calypso/state/sites/selectors';
 import { SelectorProduct } from '../../types';
-import { CreateCheckoutURLProps } from '../types';
+import { UseStoreItemInfoProps } from '../types';
 
-export const useCreateCheckout = ( {
+const isDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
+
+export const useStoreItemInto = ( {
 	createCheckoutURL,
 	duration: selectedTerm,
 	onClickPurchase,
 	siteId,
-}: CreateCheckoutURLProps ) => {
+}: UseStoreItemInfoProps ) => {
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
@@ -45,18 +47,25 @@ export const useCreateCheckout = ( {
 		[ isOwned, selectedTerm ]
 	);
 
-	const getPurchase = useCallback(
-		( item: SelectorProduct ) => {
-			const isItemPlanFeature = !! (
-				sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug )
-			);
+	const isPlanFeature = useCallback(
+		( item: SelectorProduct ) =>
+			!! ( sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug ) ),
+		[ sitePlan ]
+	);
 
-			const isDeprecated = Boolean( item.legacy );
-			const isIncludedInPlan = ! isOwned && isItemPlanFeature;
-			const isSuperseded = !! (
-				! isDeprecated &&
-				! isOwned &&
-				! isIncludedInPlan &&
+	const isIncludedInPlan = useCallback(
+		( item: SelectorProduct ) => {
+			return ! isOwned( item ) && isPlanFeature( item );
+		},
+		[ isOwned, isPlanFeature ]
+	);
+
+	const isSuperseded = useCallback(
+		( item: SelectorProduct ) => {
+			return !! (
+				! isDeprecated( item ) &&
+				! isOwned( item ) &&
+				! isIncludedInPlan( item ) &&
 				sitePlan &&
 				item &&
 				isSupersedingJetpackItem(
@@ -64,16 +73,30 @@ export const useCreateCheckout = ( {
 					item.productSlug as JetpackPurchasableItemSlug
 				)
 			);
+		},
+		[ isIncludedInPlan, isOwned, sitePlan ]
+	);
+
+	const isIncludedInPlanOrSuperseded = useCallback(
+		( item: SelectorProduct ) => isIncludedInPlan( item ) || isSuperseded( item ),
+		[ isIncludedInPlan, isSuperseded ]
+	);
+
+	const getPurchase = useCallback(
+		( item: SelectorProduct ) => {
+			const isItemPlanFeature = isPlanFeature( item );
+
+			const isItemSuperseded = isSuperseded( item );
 
 			// If item is a plan feature, use the plan purchase object.
 			const purchase =
-				isItemPlanFeature || isSuperseded
+				isItemPlanFeature || isItemSuperseded
 					? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
 					: getPurchaseByProductSlug( purchases, item.productSlug );
 
 			return purchase;
 		},
-		[ isOwned, purchases, sitePlan ]
+		[ isPlanFeature, isSuperseded, purchases, sitePlan?.product_slug ]
 	);
 
 	const getCheckoutURL = useCallback(
@@ -94,8 +117,25 @@ export const useCreateCheckout = ( {
 		() => ( {
 			getCheckoutURL,
 			getOnClickPurchase,
+			isDeprecated,
+			isIncludedInPlan,
+			isIncludedInPlanOrSuperseded,
 			isOwned,
+			isPlanFeature,
+			isSuperseded,
+			isUpgradeableToYearly,
+			sitePlan,
 		} ),
-		[ getCheckoutURL, getOnClickPurchase, isOwned ]
+		[
+			getCheckoutURL,
+			getOnClickPurchase,
+			isIncludedInPlan,
+			isIncludedInPlanOrSuperseded,
+			isOwned,
+			isPlanFeature,
+			isSuperseded,
+			isUpgradeableToYearly,
+			sitePlan,
+		]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price.tsx
@@ -1,16 +1,34 @@
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import useItemPrice from '../use-item-price';
 import { ItemPriceProps } from './types';
 
-export const ItemPrice: React.FC< ItemPriceProps > = ( { isOwned, item, siteId } ) => {
+export const ItemPrice: React.FC< ItemPriceProps > = ( {
+	isIncludedInPlan,
+	isOwned,
+	item,
+	siteId,
+} ) => {
 	const { originalPrice, discountedPrice, isFetching } = useItemPrice(
 		siteId,
 		item,
 		item?.monthlyProductSlug || ''
 	);
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const translate = useTranslate();
+
+	if ( isOwned || isIncludedInPlan ) {
+		return (
+			<div className="item-price__is-owned">
+				<span className="item-price__is-owned--dot"></span>
+				<span className="item-price__is-owned--text">
+					{ isOwned ? translate( 'Active on your site' ) : translate( 'Part of the current plan' ) }
+				</span>
+			</div>
+		);
+	}
 
 	return (
 		<DisplayPrice

--- a/client/my-sites/plans/jetpack-plans/product-store/products-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/products-list.tsx
@@ -5,7 +5,7 @@ import productButtonLabel from '../product-card/product-button-label';
 import { FeaturedItemCard } from './featured-item-card';
 import { HeroImage } from './hero-image';
 import { useProductsToDisplay } from './hooks/use-products-to-display';
-import { useStoreItemInto } from './hooks/use-store-item-info';
+import { useStoreItemInfo } from './hooks/use-store-item-info';
 import { MostPopular } from './most-popular';
 import SimpleProductCard from './simple-product-card';
 import { getSortedDisplayableProducts } from './utils/get-sorted-displayable-products';
@@ -30,7 +30,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 		isDeprecated,
 		isUpgradeableToYearly,
 		sitePlan,
-	} = useStoreItemInto( {
+	} = useStoreItemInfo( {
 		createCheckoutURL,
 		onClickPurchase,
 		duration,

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
@@ -7,12 +7,15 @@ import getProductIcon from '../utils/get-product-icon';
 import './style.scss';
 
 const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
-	item,
+	checkoutURL,
+	ctaAsPrimary,
+	ctaLabel,
+	isIncludedInPlan,
 	isOwned,
-	siteId,
+	item,
 	onClickMore,
 	onClickPurchase,
-	checkoutURL,
+	siteId,
 } ) => {
 	const translate = useTranslate();
 	const { shortName: name, description } = item;
@@ -27,16 +30,21 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 					<div className="simple-product-card__info-header-content">
 						<h3 className="simple-product-card__info-header-text">{ name }</h3>
 
-						<ItemPrice isOwned={ isOwned } item={ item } siteId={ siteId } />
+						<ItemPrice
+							isIncludedInPlan={ isIncludedInPlan }
+							isOwned={ isOwned }
+							item={ item }
+							siteId={ siteId }
+						/>
 					</div>
 					<Button
 						className="simple-product-card__info-header-checkout"
 						onClick={ onClickPurchase }
 						href={ checkoutURL }
-						primary
+						primary={ ctaAsPrimary }
 						compact
 					>
-						{ translate( 'Get' ) }
+						{ ctaLabel }
 					</Button>
 				</div>
 				<div className="simple-product-card__info-content">

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -53,10 +53,10 @@
 		list-style-type: none;
 		display: grid;
 		grid-template-columns: 1fr;
+		gap: 24px;
 		margin-top: 24px;
 
 		@media only screen and ( min-width: 821px ) {
-			  grid-column-gap: 24px;
 			  grid-template-columns: 1fr 1fr;
 			  margin: 32px auto 0;
 		  }
@@ -105,6 +105,22 @@
 		}
 	}
 
+	.item-price__is-owned {
+		font-size: $font-body-extra-small;
+		color: var( --studio-jetpack-green-50 );
+		font-weight: 600;
+		display: flex;
+		align-items: center;
+	}
+	.item-price__is-owned--dot {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		background: var( --studio-jetpack-green-50 );
+		border-radius: 50%; // stylelint-disable-line declaration-property-unit-allowed-list
+		margin-inline-end: 4px;
+	}
+
 	&__products-list-all {
 		margin-top: 4em;
 	}
@@ -128,6 +144,7 @@
 	&__items-list .button.is-primary {
 		color: var( --color-text-inverted );
 		min-width: 5.7em;
+		border: none;
 	}
 
 	.jetpack-product-store__view-filter {

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -57,7 +57,7 @@ export type HeroImageProps = {
 	item: SelectorProduct;
 };
 
-export type CreateCheckoutURLProps = ProductStoreBaseProps & {
+export type UseStoreItemInfoProps = ProductStoreBaseProps & {
 	createCheckoutURL?: PurchaseURLCallback;
 	duration: Duration;
 	onClickPurchase?: PurchaseCallback;
@@ -66,10 +66,13 @@ export type CreateCheckoutURLProps = ProductStoreBaseProps & {
 export type ItemPriceProps = ProductStoreBaseProps &
 	HeroImageProps & {
 		isOwned?: boolean;
+		isIncludedInPlan?: boolean;
 	};
 
 export type FeaturedItemCardProps = ItemPriceProps & {
 	checkoutURL?: string;
+	ctaAsPrimary?: boolean;
+	ctaLabel: React.ReactNode;
 	hero: React.ReactNode;
 	item: SelectorProduct;
 	onClickMore: VoidFunction;


### PR DESCRIPTION
It's possible that users will visit the store when they already own a product or a subscription to a plan. This PR takes that into consideration to make the appropriate changes.

#### Proposed Changes

* Enhance `productButtonLabel` function to add support for `fallbackLabel`
* Rename `useCreateCheckout` to `useStoreItemInto` to represent the correct functionality.
* Enhance `ItemPrice` component to show existing subscriptions
* Update card components (`SimpleProductCard` and `FeaturedItemCard`) to render the updated price and CTA

#### Testing Instructions

1. Do any one of these
    * Click on Jetpack Cloud live link below and goto `/pricing?flags=jetpack/pricing-page-rework-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout add/jp-pricing-rework/featured-product-cards`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1)
2. Confirm that featured and simple product cards work fine for both Products and Bundles
3. Create a JN site, connect Jetpack, and add a monthly product e.g. Backup (Monthly)
4. Goto site wp-admin > Jetpack
5. Click **Plans** tab
6. After redirect, replace `https://cloud.jetpack.com` with `http://jetpack.cloud.localhost:3000` or Jetpack Cloud Live link above and add `&flags=jetpack/pricing-page-rework-v1` to the URL
7. Confirm that you see "Active on your site" in place of price for Backup
8. Confirm that you see "Upgrade to yearly" as the CTA label
10. Confirm that the design matches what is in Firma
11. Confirm that CTA click works as expected
12. Now create another JN site with Backup (Yearly)
13. Follow steps 4-6
14. Confirm that you see "Active on your site" in place of the price for Backup
15. Confirm that you see "Manage Subscription" as the CTA label
16. Confirm that the design matches what is in Firma
17. Confirm that CTA click works as expected
18. Now create another JN site with Security plan
19. Follow steps 4-6
20. Confirm that you see "Part of the current plan" in place of the price for Backup
21. Confirm that you see "Manage Subscription" as the CTA label
22. Confirm that the design matches what is in Firma
23. Confirm that CTA click works as expected
25. Goto Bundles tab
26. Confirm that you see "Active on your site" in place of the price for Security card
27. Confirm that you see "Manage Plan" as the CTA label
28. Confirm that the design matches what is in Firma
29. Confirm that CTA click works as expected
30. Repeat the above steps for Calypso Blue `http://calypso.localhost:3000/plans/:site?flags=jetpack/pricing-page-rework-v1`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When the site has Backup (Monthly)
<img width="1308" alt="Screenshot 2022-08-31 at 2 53 10 PM" src="https://user-images.githubusercontent.com/18226415/187658516-61d0a93a-e2e0-4560-b92e-64d5833c552d.png">

When the site has Backup (Yearly)
<img width="1351" alt="Screenshot 2022-08-31 at 2 59 46 PM" src="https://user-images.githubusercontent.com/18226415/187658556-c66183dd-b6a1-4328-9a5e-493a5506b938.png">
<img width="354" alt="Screenshot 2022-08-31 at 3 00 50 PM" src="https://user-images.githubusercontent.com/18226415/187658564-5dd6d40e-fe0b-45c0-8156-488e6f840a45.png">
<img width="353" alt="Screenshot 2022-08-31 at 3 01 06 PM" src="https://user-images.githubusercontent.com/18226415/187658575-d68f65b0-27c2-420c-abf2-dbfc53214c9a.png">

When the site has Security plan
<img width="1285" alt="Screenshot 2022-08-31 at 3 12 08 PM" src="https://user-images.githubusercontent.com/18226415/187658583-1cdd1749-3378-409e-9eb7-7bbf3d2d3c38.png">
<img width="1293" alt="Screenshot 2022-08-31 at 3 11 03 PM" src="https://user-images.githubusercontent.com/18226415/187658577-4b086442-7f10-4df0-89c9-d17d9209c870.png">

When the site has Complete plan
<img width="1255" alt="Screenshot 2022-08-31 at 3 33 10 PM" src="https://user-images.githubusercontent.com/18226415/187658591-ba11967d-d1d9-4f23-831b-6904b6b4eb78.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202882592179858