### PR TITLE
Checkout: add flow related features for newsletter and link in bio

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -151,10 +151,9 @@ function CheckoutSummaryFeaturesWrapper( props: {
 } ) {
 	const { siteId, nextDomainIsFree } = props;
 	const signupFlowName = getSignupCompleteFlowName();
-	const shouldUseFlowFeatureList =
-		!! signupFlowName && isNewsletterOrLinkInBioFlow( signupFlowName );
+	const shouldUseFlowFeatureList = isNewsletterOrLinkInBioFlow( signupFlowName );
 
-	if ( shouldUseFlowFeatureList ) {
+	if ( signupFlowName && shouldUseFlowFeatureList ) {
 		return <CheckoutSummaryFlowFeaturesList flowName={ signupFlowName } />;
 	}
 
@@ -250,20 +249,18 @@ function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
-			<>
-				{ planFeatures.map( ( feature ) => {
-					return (
-						<CheckoutSummaryFeaturesListItem key={ `feature-list-${ feature.getSlug() }` }>
-							<WPCheckoutCheckIcon id={ `feature-list-${ feature.getSlug() }-icon` } />
-							{ feature.isHighlightedFeature ? (
-								<strong>{ feature.getTitle() }</strong>
-							) : (
-								feature.getTitle()
-							) }
-						</CheckoutSummaryFeaturesListItem>
-					);
-				} ) }
-			</>
+			{ planFeatures.map( ( feature ) => {
+				return (
+					<CheckoutSummaryFeaturesListItem key={ `feature-list-${ feature.getSlug() }` }>
+						<WPCheckoutCheckIcon id={ `feature-list-${ feature.getSlug() }-icon` } />
+						{ feature.isHighlightedFeature ? (
+							<strong>{ feature.getTitle() }</strong>
+						) : (
+							feature.getTitle()
+						) }
+					</CheckoutSummaryFeaturesListItem>
+				);
+			} ) }
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -22,6 +22,7 @@ import {
 	FormStatus,
 	useFormStatus,
 } from '@automattic/composite-checkout';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
@@ -34,7 +35,9 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import getRefundDays from '../lib/get-refund-days';
 import getRefundText from '../lib/get-refund-text';
@@ -81,7 +84,7 @@ export default function WPCheckoutOrderSummary( {
 				{ isCartUpdating ? (
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
-					<CheckoutSummaryFeaturesList siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
+					<CheckoutSummaryFeaturesWrapper siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
 				) }
 			</CheckoutSummaryFeatures>
 			{ ! isCartUpdating && ! hasRenewalInCart && plan && hasMonthlyPlanInCart && (
@@ -140,6 +143,22 @@ function SwitchToAnnualPlan( {
 	const text = linkText ?? translate( 'Switch to an annual plan and save!' );
 
 	return <SwitchToAnnualPlanButton onClick={ handleClick }>{ text }</SwitchToAnnualPlanButton>;
+}
+
+function CheckoutSummaryFeaturesWrapper( props: {
+	siteId: number | undefined;
+	nextDomainIsFree: boolean;
+} ) {
+	const { siteId, nextDomainIsFree } = props;
+	const signupFlowName = getSignupCompleteFlowName();
+	const shouldUseFlowFeatureList =
+		!! signupFlowName && isNewsletterOrLinkInBioFlow( signupFlowName );
+
+	if ( shouldUseFlowFeatureList ) {
+		return <CheckoutSummaryFlowFeaturesList flowName={ signupFlowName } />;
+	}
+
+	return <CheckoutSummaryFeaturesList siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />;
 }
 
 function CheckoutSummaryFeaturesList( props: {
@@ -219,6 +238,32 @@ function CheckoutSummaryFeaturesList( props: {
 					</CheckoutSummaryFeaturesListItem>
 				);
 			} ) }
+		</CheckoutSummaryFeaturesListWrapper>
+	);
+}
+
+function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const planInCart = responseCart.products.find( ( product ) => isPlan( product ) );
+	const planFeatures = getFlowPlanFeatures( flowName, planInCart );
+
+	return (
+		<CheckoutSummaryFeaturesListWrapper>
+			<>
+				{ planFeatures.map( ( feature ) => {
+					return (
+						<CheckoutSummaryFeaturesListItem key={ `feature-list-${ feature.getSlug() }` }>
+							<WPCheckoutCheckIcon id={ `feature-list-${ feature.getSlug() }-icon` } />
+							{ feature.isHighlightedFeature ? (
+								<strong>{ feature.getTitle() }</strong>
+							) : (
+								feature.getTitle()
+							) }
+						</CheckoutSummaryFeaturesListItem>
+					);
+				} ) }
+			</>
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -31,6 +31,7 @@ export default function getFlowPlanFeatures(
 	const featureAccessor = getPlanFeatureAccessor( {
 		flowName,
 		plan: planConstantObj,
+		isInVerticalScrollingPlansExperiment: false,
 	} );
 
 	if ( ! featureAccessor ) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -1,0 +1,47 @@
+import { getPlan } from '@automattic/calypso-products';
+import { ResponseCartProduct } from '@automattic/shopping-cart';
+import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import {
+	getHighlightedFeatures,
+	getPlanFeatureAccessor,
+} from 'calypso/my-sites/plan-features-comparison/util';
+
+interface Feature {
+	getSlug: () => string;
+	getTitle: () => string;
+	isHighlightedFeature: boolean;
+}
+
+export default function getFlowPlanFeatures(
+	flowName: string,
+	plan: ResponseCartProduct | undefined
+): Feature[] {
+	const productSlug = plan?.product_slug;
+
+	if ( ! productSlug ) {
+		return [];
+	}
+
+	const planConstantObj = getPlan( productSlug );
+
+	if ( ! planConstantObj ) {
+		return [];
+	}
+
+	const featureAccessor = getPlanFeatureAccessor( {
+		flowName,
+		plan: planConstantObj,
+	} );
+
+	if ( ! featureAccessor ) {
+		return [];
+	}
+
+	const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
+	return getPlanFeaturesObject( featureAccessor() ).map( ( feature: Feature ) => {
+		return {
+			...feature,
+			isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
+		};
+	} );
+}


### PR DESCRIPTION
 | Newsletter  | Link in Bio |
| ------------- | ------------- |
| <img width="1096" alt="Screenshot 2022-08-31 at 15 37 04" src="https://user-images.githubusercontent.com/7000684/187691837-ed5cabee-50cd-468a-9b44-c0befb5cec4c.png">  | <img width="1098" alt="Screenshot 2022-08-31 at 15 39 10" src="https://user-images.githubusercontent.com/7000684/187692336-d285556d-47cb-4afa-b536-28b0dcf5f50d.png"> |

#### Proposed Changes

* This PR adds flow related features to the checkout page

#### Testing Instructions
- Follow the [newsletter flow](http://calypso.localhost:3000/setup?flow=newsletter) and verify the checkout page 
- Follow the [link in bio flow](http://calypso.localhost:3000/setup?flow=link-in-bio) and verify the checkout page 

Related to #67197 
