### PR TITLE
SMP: avoid triggering the `newdash_pageviews` event for `/sites`

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -343,9 +343,9 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	page( '*', function ( context, next ) {
 		const path = context.pathname;
 
-		// Bypass this global handler for legacy routes
+		// Bypass this global handler for legacy routes and site management pages
 		// to avoid bumping stats and changing focus to the content
-		if ( isLegacyRoute( path ) ) {
+		if ( isLegacyRoute( path ) || context.section?.group === 'sites-dashboard' ) {
 			return next();
 		}
 


### PR DESCRIPTION
#### Proposed Changes

Before this PR we were sending the event `newdash_pageviews` when the user entered some text in the searchbox. The event was triggered for each character entered.

* Bypass `newdash_pageviews` event for `sites-dashboard` routes section.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Make sure that your log level is set to Verbose in chrome dev console (<img width="100" src="https://user-images.githubusercontent.com/779993/190635920-6f5c187d-e14d-43b6-8e3f-5f2693b39e3c.png" />)
* Go to `/sites`
* Enter this line in your console in chrome dev tools : `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Refresh the page
* Observe the `newdash_pageviews` eventes are not sended anymore:
  * Example: `calypso:analytics:mc Bumping stats {newdash_pageviews: 'route'}`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/issues/67152