### PR TITLE
Remove special chars for domain validation

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -63,7 +63,6 @@ import Notice from 'calypso/components/notice';
 import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
 import {
 	checkDomainAvailability,
-	getFixedDomainSearch,
 	getAvailableTlds,
 	getDomainSuggestionSearch,
 	getTld,
@@ -180,13 +179,13 @@ class RegisterDomainStep extends Component {
 
 			// If there's a domain name as a query parameter suggestion, we always search for it first when the page loads
 			if ( props.suggestion ) {
-				this.state.lastQuery = getFixedDomainSearch( props.suggestion );
+				this.state.lastQuery = getDomainSuggestionSearch( props.suggestion, MIN_QUERY_LENGTH );
 			}
 		}
 	}
 
 	getState( props ) {
-		const suggestion = props.suggestion ? getFixedDomainSearch( props.suggestion ) : '';
+		const suggestion = getDomainSuggestionSearch( props.suggestion, MIN_QUERY_LENGTH );
 		const loadingResults = Boolean( suggestion );
 
 		return {

--- a/client/lib/domains/get-fixed-domain-search.js
+++ b/client/lib/domains/get-fixed-domain-search.js
@@ -5,5 +5,5 @@ export function getFixedDomainSearch( domainName ) {
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
 		.replace( /^www[0-9]?\./, '' )
-		.replace( /[^a-z0-9-\\.]/, '' );
+		.replace( /[^a-z0-9-.]/, '' );
 }

--- a/client/lib/domains/get-fixed-domain-search.js
+++ b/client/lib/domains/get-fixed-domain-search.js
@@ -5,5 +5,5 @@ export function getFixedDomainSearch( domainName ) {
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
 		.replace( /^www[0-9]?\./, '' )
-		.replace( /[^a-z0-9-]/, '' );
+		.replace( /[^a-z0-9-\\.]/, '' );
 }

--- a/client/lib/domains/get-fixed-domain-search.js
+++ b/client/lib/domains/get-fixed-domain-search.js
@@ -7,5 +7,6 @@ export function getFixedDomainSearch( domainName ) {
 		.replace( /^www[0-9]?\./, '' )
 		.replace( /\/$/, '' )
 		.replace( /_/g, '-' )
+		.replace( /[^a-z0-9-]/, '' )
 		.replace( /^\.+|\.+$/, '' );
 }

--- a/client/lib/domains/get-fixed-domain-search.js
+++ b/client/lib/domains/get-fixed-domain-search.js
@@ -5,8 +5,5 @@ export function getFixedDomainSearch( domainName ) {
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
 		.replace( /^www[0-9]?\./, '' )
-		.replace( /\/$/, '' )
-		.replace( /_/g, '-' )
-		.replace( /[^a-z0-9-]/, '' )
-		.replace( /^\.+|\.+$/, '' );
+		.replace( /[^a-z0-9-]/, '' );
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,7 +20,11 @@ import {
 	domainMapping,
 	domainTransfer,
 } from 'calypso/lib/cart-values/cart-items';
-import { getDomainProductSlug } from 'calypso/lib/domains';
+import {
+	getDomainProductSlug,
+	getDomainSuggestionSearch,
+	getFixedDomainSearch,
+} from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
@@ -491,7 +495,9 @@ class DomainsStep extends Component {
 				initialState.searchResults = null;
 				initialState.subdomainSearchResults = null;
 				// If length is less than 2 it will not fetch any data.
-				initialState.loadingResults = initialQuery.length >= 2;
+				// filter before counting length
+				initialState.loadingResults =
+					getDomainSuggestionSearch( getFixedDomainSearch( initialQuery ) ).length >= 2;
 				initialState.hideInitialQuery = hideInitialQuery;
 			}
 		}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -490,7 +490,8 @@ class DomainsStep extends Component {
 			if ( initialState ) {
 				initialState.searchResults = null;
 				initialState.subdomainSearchResults = null;
-				initialState.loadingResults = true;
+				// If length is less than 2 it will not fetch any data.
+				initialState.loadingResults = initialQuery.length >= 2;
 				initialState.hideInitialQuery = hideInitialQuery;
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

Removes special chars from domain suggestions

## Testing Instructions

- Pull this branch and run yarn
- Navigate to `setup/intro?flow=newsletter`
- Choose any site title
- On the domain step you should not see the error message describe on the [issue](66969).

Related to #66969
Fixes #66969
