### PR TITLE
Close promote post widget "are you sure" dialog

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -1,3 +1,5 @@
+import { Dialog } from '@automattic/components';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
@@ -18,6 +20,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
 	const { isVisible = false, onClose = () => {} } = props;
 	const [ isLoading, setIsLoading ] = useState( true );
+	const [ showCancelDialog, setShowCancelDialog ] = useState( false );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
@@ -44,7 +47,23 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				);
 				setIsLoading( false );
 			} )();
-	}, [ isVisible, props.postId, props.siteId ] );
+	}, [ isVisible, onClose, props.postId, props.siteId, selectedSiteSlug ] );
+
+	const cancelDialogButtons = [
+		{
+			action: 'cancel',
+			label: __( 'No' ),
+		},
+		{
+			action: 'close',
+			isPrimary: true,
+			label: __( 'Yes, cancel' ),
+			onClick: async () => {
+				setShowCancelDialog( false );
+				onClose();
+			},
+		},
+	];
 
 	const promoteWidgetStatus = usePromoteWidget();
 	if ( promoteWidgetStatus === PromoteWidgetStatus.DISABLED ) {
@@ -61,9 +80,9 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						<span
 							role="button"
 							className={ 'blazepress-widget__cancel' }
-							onKeyDown={ onClose }
+							onKeyDown={ () => setShowCancelDialog( true ) }
 							tabIndex={ 0 }
-							onClick={ onClose }
+							onClick={ () => setShowCancelDialog( true ) }
 						>
 							Cancel
 						</span>
@@ -73,6 +92,18 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 							isLoading ? 'blazepress-widget__content loading' : 'blazepress-widget__content'
 						}
 					>
+						<Dialog
+							isVisible={ showCancelDialog }
+							buttons={ cancelDialogButtons }
+							onClose={ () => setShowCancelDialog( false ) }
+						>
+							<h1>{ __( 'Cancel the campaign' ) }</h1>
+							<p>
+								{ __(
+									'If you cancel now, you will lose any progress you have made. Are you sure you want to cancel?'
+								) }
+							</p>
+						</Dialog>
 						{ isLoading && <LoadingEllipsis /> }
 						<div ref={ widgetContainer }></div>
 					</div>


### PR DESCRIPTION
#### Proposed Changes

* Adds a confirmation dialog before closing the promote posts widget, previously the cancel button would just close the widget directly.
* The main purpose of this is becuase if they cancel - they will loose any progress, so this dialog warns them of that before they confirm

![Screenshot 2022-08-31 at 16 43 52](https://user-images.githubusercontent.com/6440498/187721319-0050c065-a163-4e25-ad08-a7013cae2336.png)

#### Testing Instructions

https://user-images.githubusercontent.com/6440498/187720073-0e94e67d-463a-465a-9bb3-8cc36eb2aa1b.mov

- [ ] Load http://calypso.localhost:3000/advertising/yourdomain.com
- [ ] Click the promote button to launch the widget
- [ ] press cancel in the top right to close the widget
- [ ] The "no" button should keep the widget open
- [ ] the "yes, cancel" button should close the widget back down

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
