### PR TITLE
Launchpad - fix infinite redirect / use site option selector in customer-home.

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,9 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
-import getSite from 'calypso/state/sites/selectors/get-site.js';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { redirectToLaunchpad } from 'calypso/utils';
+import { getSiteOptions } from '../../state/sites/selectors';
 import CustomerHome from './main';
 
 export default async function ( context, next ) {
@@ -30,8 +30,7 @@ export function maybeRedirect( context, next ) {
 	}
 
 	const siteId = getSelectedSiteId( state );
-	const site = getSite( state, siteId );
-	const options = site?.options;
+	const options = getSiteOptions( state, siteId );
 	const shouldRedirectToLaunchpad = options?.launchpad_screen === 'full';
 
 	if ( shouldRedirectToLaunchpad && isEnabled( 'signup/launchpad' ) ) {

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,9 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
-import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
+import { canCurrentUserUseCustomerHome, getSiteOptions } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { redirectToLaunchpad } from 'calypso/utils';
-import { getSiteOptions } from '../../state/sites/selectors';
 import CustomerHome from './main';
 
 export default async function ( context, next ) {


### PR DESCRIPTION
addresses https://github.com/Automattic/wp-calypso/issues/67214

The `getSite` selector we were using here has its return value cached based off a weakMap using the `rawSite` object as the key. Since the `rawSite` object itself doesn't change when site options are updated, the cached return value is returned even after updating `launchpadStatus` from `full` to `off`.

Here we use the `getSiteOptions` selector instead, which is not cached and directly returns the site options from the `rawSite` object every time.

### Testing
* Load this branch in calypso
* load a site with the `launchpadSetting` as `full`.
* navigate to MyHome and get redirected to the launchpad.
* now update the `launchpadSetting` to be `off`. (this can be done using wpsh commands in your sandbox - good examples of doing this can be found in testing instructions of this recent diff - D86254-code)
* reload the page, notice you are redirected to MyHome without the infinite redirect loop. (similarly click 'go to admin' and then click on "my home" and shouldn't get redirected)