### PR TITLE
Signup: When creating a new user, also attribute variationName of query params

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -683,6 +683,12 @@ export function createAccount(
 	const SIGNUP_TYPE_SOCIAL = 'social';
 	const SIGNUP_TYPE_DEFAULT = 'default';
 
+	const params = new URLSearchParams( window.location.search );
+	const flowNameTracking =
+		null === params.get( 'variationName' )
+			? flowName
+			: `${ flowName }-${ params.get( 'variationName' ) }`;
+
 	const responseHandler = ( signupType ) => ( error, response ) => {
 		const emailInError =
 			signupType === SIGNUP_TYPE_SOCIAL ? { email: get( error, 'data.email', undefined ) } : {};
@@ -746,7 +752,7 @@ export function createAccount(
 		if ( newAccountCreated ) {
 			recordRegistration( {
 				userData: registrationUserData,
-				flow: flowName,
+				flow: flowNameTracking,
 				type: signupType,
 			} );
 		}
@@ -776,7 +782,7 @@ export function createAccount(
 				service,
 				access_token,
 				id_token,
-				signup_flow_name: flowName,
+				signup_flow_name: flowNameTracking,
 				locale: getLocaleSlug(),
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
@@ -793,7 +799,7 @@ export function createAccount(
 				userData,
 				{
 					validate: false,
-					signup_flow_name: flowName,
+					signup_flow_name: flowNameTracking,
 					// url sent in the confirmation email
 					jetpack_redirect: queryArgs.jetpack_redirect,
 					locale: getLocaleSlug(),


### PR DESCRIPTION
Fixes #67173

#### Proposed Changes

Begin appending `variationName` to `flowName` when creating accounts as part of the start/signup framework.

The specific use case that we're solving here is described in the issue. Another alternative here would have been to create multiple signup flows that all just handle user creation. But, that seems a bit heavy since all we're really interested here is some more specific attribution and we're going to be creating more tailored cases.

One downside to this is that the `signup_flow_name` will be something like `account-newsletters`. This seems reasonable though.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Ensure that you are logged out in Calypso
* Go to http://calypso.localhost:3000/start/account/user?variationName=link-in-bio&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=link-in-bio
* Open network panel
* Create an account
* Ensure that the `/users/new` request gets a `signup_flow_name` arg like `account-link-in-bio`
* Log out
* Go to https://calypso.localhost:3000/start/account/user
* Clear network panel
* Create an account
* Ensure that the `/users/new` request gets a `signup_flow_name` arg that is simply `account`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
