### PR TITLE
Increases the "promote posts" sidebar so that it stretches to fill th…

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -74,7 +74,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						}
 					>
 						{ isLoading && <LoadingEllipsis /> }
-						<div ref={ widgetContainer }></div>
+						<div className={ 'blazepress-widget__widget-container' } ref={ widgetContainer }></div>
 					</div>
 				</BlankCanvas>
 			) }

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -1,16 +1,19 @@
 @import '@automattic/typography/styles/variables';
 @import '@automattic/onboarding/styles/mixins.scss';
 
+$headerHeight: 72px;
+
 .blazepress-widget {
     display: flex;
     flex-direction: column;
     z-index: 1001;
+	height: 100%;
 
     .blazepress-widget__header-bar {
         align-items: center;
         display: flex;
         justify-content: space-between;
-        min-height: 72px;
+        min-height: $headerHeight;
         padding: 0 rem( 24px );
 
         h2 {
@@ -40,10 +43,18 @@
     .blazepress-widget__content {
         display: flex;
         flex-direction: column;
+		height: calc( 100% - #{$headerHeight} );
     }
     .blazepress-widget__content.loading {
         justify-content: center;
         align-items: center;
         flex: auto;
     }
+	.blazepress-widget__widget-container {
+		height:100%;
+
+		.wpcom-dsp-widget-shadow-dom {
+			height: 100%;
+		}
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

- Makes the promote post widget full height as per the figma designs.   This was noticeable mainly becuase the grey sidebar should stretch to fill the space.

These changes rely on (635-gh-Tumblr/wordads-picard) to work, we should ensure these have been deployed before pushing these changes.

**Figma Designs**
![Screenshot 2022-08-31 at 17 48 38](https://user-images.githubusercontent.com/6440498/187734607-0d8eb089-8942-4fb5-a269-a3e55db1f6fc.png)


**Before this PR**
![Screenshot 2022-08-31 at 17 50 14](https://user-images.githubusercontent.com/6440498/187735014-3507a7f6-38c9-4fea-97cc-2562193fa2f5.png)


**After this PR**
![Screenshot 2022-08-31 at 17 28 16](https://user-images.githubusercontent.com/6440498/187733969-1c6022f4-dda3-4f0f-8b4b-c175131c7305.png)

#### Testing Instructions

* These changes will require a local instance of the DSP widget, with the following branch loaded  (635-gh-Tumblr/wordads-picard)
* Once running, point calypso to your local widget by changing `"dsp_widget_js_src"` to  `"http://localhost:3004/widget.js"` in `config/development.json` and then restart your local calypso instance.
* Now we can visit http://calypso.localhost:3000/advertising/your-site.com
* Press the "promote" button from the post list, to launch the advertising widget
* Proceed past the intro screen,  all other screens that have the grey sidebar should now stretch to fill the screen.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
