### PR TITLE
[sentry][fix] Handle undefined nodes in `popoverSlotObserver`

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -703,7 +703,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 	sidebarsObserver.observe( body, { childList: true } );
 
 	const popoverSlotObserver = new window.MutationObserver( ( mutations ) => {
-		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
+		const isComponentsPopover = ( node ) => node?.classList.contains( 'components-popover' );
 
 		const replaceWithManageReusableBlocksHref = ( anchorElem ) => {
 			anchorElem.href = manageReusableBlocksUrl;
@@ -712,6 +712,13 @@ async function openLinksInParentFrame( calypsoPort ) {
 
 		for ( const record of mutations ) {
 			for ( const node of record.addedNodes ) {
+				// For some reason, some nodes might be `undefined`, see:
+				// https://sentry.io/organizations/a8c/issues/3216750319/?project=5876245.
+				// We skip the iteration if that's the case.
+				if ( ! node ) {
+					continue;
+				}
+
 				if ( isComponentsPopover( node ) ) {
 					const manageReusableBlocksAnchorElem = node.querySelector(
 						'a[href$="edit.php?post_type=wp_block"]'

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -703,7 +703,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 	sidebarsObserver.observe( body, { childList: true } );
 
 	const popoverSlotObserver = new window.MutationObserver( ( mutations ) => {
-		const isComponentsPopover = ( node ) => node?.classList.contains( 'components-popover' );
+		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
 
 		const replaceWithManageReusableBlocksHref = ( anchorElem ) => {
 			anchorElem.href = manageReusableBlocksUrl;


### PR DESCRIPTION
#### Proposed Changes

Improve the resiliency of the `popoverSlotObserver` by properly ignoring falsey `node`s. This handles the following error reported in Sentry https://sentry.io/organizations/a8c/issues/3216750319/?project=5876245&query=is%3Aunresolved&sort=freq&statsPeriod=14d by treating the symptoms but might be enough to avoid further unhandled exceptions and possibly logic breakages.

#### Testing Instructions

* All checks should pass
* If you are acquainted with features that use this observer (I'm not), smoke-testing would be nice. I've found that clicking the `W` icon in the top left corner seems to trigger it, so I used that to manually smoke test. Be sure to `yarn dev --sync` the custom build of `wpcom-block-editor` to your sandbox, and sandbox `widgets.wp.com`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
