### PR TITLE
Change circleci/node to cimg/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ commands:
 jobs:
   wp-desktop-assets:
     docker:
-      - image: circleci/node:16.17.0-browsers
+      - image: cimg/node:16.17.0-browsers
     <<: *desktop_defaults
     environment:
       VERSION: << pipeline.git.tag >>
@@ -243,7 +243,7 @@ jobs:
 
   wp-desktop-linux:
     docker:
-      - image: circleci/node:16.17.0-browsers
+      - image: cimg/node:16.17.0-browsers
     <<: *desktop_defaults
     shell: /bin/bash --login
     environment:


### PR DESCRIPTION
#### Proposed Changes

When I deployed the NodeJS 16.17.0 update (#67184), CircleCi failed. Apparently, they changed the namespace of their images from "circleci" to "cimg" (see https://circleci.com/developer/images/image/cimg/node). This PR updates to the new format.


#### Testing Instructions
CircleCI should pass after merge.
