### PR TITLE
CircleCI: Remove nvm install steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/wp-calypso
-      - run: *update-node
       - run:
           name: Install Linux deps
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   win: circleci/windows@2.2.0
+  path-filtering: circleci/path-filtering@0.1.3
 
 references:
   defaults: &defaults
@@ -447,6 +448,7 @@ workflows:
             branches:
               only:
                 - trunk
+                - fix-circleci-windows-build
                 - /release\/.*/
                 - /desktop\/.*/
 #     - wp-desktop-mac:
@@ -465,6 +467,7 @@ workflows:
             branches:
               only:
                 - trunk
+                - fix-circleci-windows-build
                 - /release\/.*/
                 - /desktop\/.*/
       - wp-desktop-windows:
@@ -474,6 +477,7 @@ workflows:
             branches:
               only:
                 - trunk
+                - fix-circleci-windows-build
                 - /release\/.*/
                 - /desktop\/.*/
   wp-desktop-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,24 +80,9 @@ references:
 
   yarn-install: &yarn-install
     name: Install dependencies
+    # Note that yarn is already available in cimg/node.
     command: |
-      source "$HOME/.nvm/nvm.sh"
-      nvm use
-      npm install -g yarn
       yarn install --immutable --inline-builds
-
-  update-node: &update-node
-    name: Update node
-    command: |
-      set +e
-      set +x
-      export NVM_DIR="$HOME/.nvm" && (
-        git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR"
-        cd "$NVM_DIR"
-        git checkout v0.35.3
-      ) && \. "$NVM_DIR/nvm.sh" --no-use
-      nvm install
-      nvm use
 
   save-yarn-cache: &save-yarn-cache
     name: 'Save yarn cache'
@@ -151,7 +136,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/wp-calypso
-      - run: *update-node
       - when:
           condition: << pipeline.git.tag >>
           steps:
@@ -177,7 +161,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /Users/distiller/wp-calypso
-      - run: *update-node
       - restore_cache: *restore-yarn-cache
       - run: *yarn-install
       - save_cache: *save-yarn-cache


### PR DESCRIPTION
#### Proposed Changes
The CircleCi windows build is [failing on trunk](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/144317/workflows/807ba571-9d0b-4282-91db-c521d4be7d81/jobs/1102948) because of this issue: https://github.com/npm/cli/issues/4234. According to reports there, the problem is related to nvm.

I looked through our code, and I think our use of `nvm` in CircleCI is redundant. When we update NodeJS, we update the version used by the CircleCI images, which means we don't need to install it separately. Additionally, `yarn` is already available in the image, so we don't need to install it separately either.

#### Testing Instructions

CircleCi windows build should pass. Will have to figure out how to run it manually.