### PR TITLE
Remove `launch-wpcom-ssh` feature flag

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { FEATURE_SSH } from '@automattic/calypso-products';
 import { Card, Button, Gridicon, Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -455,8 +454,7 @@ export default connect(
 			currentUserId,
 			username,
 			password,
-			siteHasSshFeature:
-				config.isEnabled( 'launch-wpcom-ssh' ) && siteHasFeature( state, siteId, FEATURE_SSH ),
+			siteHasSshFeature: siteHasFeature( state, siteId, FEATURE_SSH ),
 			isSshAccessEnabled: 'ssh' === getAtomicHostingSshAccess( state, siteId ),
 		};
 	},

--- a/config/development.json
+++ b/config/development.json
@@ -91,7 +91,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,
-		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,
-		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,
-		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -61,7 +61,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,
-		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -54,7 +54,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": false,
-		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,7 +69,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,
-		"launch-wpcom-ssh": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,


### PR DESCRIPTION
Fixes #66578

## Proposed Changes

Removes the `launch-wpcom-ssh` feature flag from the codebase because the feature is now live.

## Testing Instructions

1. Create a new Business site if necessary, and enable SFTP access.
2. Verify 'Enable SSH access' is still present in the `<SFTPCard />`.

<img width="765" alt="image" src="https://user-images.githubusercontent.com/36432/187767309-50bbfeca-7038-4641-86d2-7f80244726e7.png">

