### PR TITLE
Circleci: fix windows build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
-  win: circleci/windows@2.2.0
+  win: circleci/windows@5.0.0
 
 references:
   defaults: &defaults
@@ -324,14 +324,21 @@ jobs:
       - attach_workspace:
           at: C:\Users\circleci\wp-calypso
       - run:
+          name: Install NVM
+          command: choco install nvm yarn
+      - run:
           name: Install Node Version
           command: |
             $NODE_VERSION = Get-Content .nvmrc
             nvm install $NODE_VERSION
             nvm use $NODE_VERSION
       - run:
-          name: Install Yarn
-          command: npm install -g yarn@1.22.10
+          name: Verify versions
+          shell: bash.exe
+          command: |
+            node --version
+            nvm --version
+            yarn --version
       - run:
           name: Install Make
           command: cinst make
@@ -465,6 +472,7 @@ workflows:
             branches:
               only:
                 - trunk
+                - /circleci\/.*/
                 - /release\/.*/
                 - /desktop\/.*/
 #     - wp-desktop-mac:
@@ -483,6 +491,7 @@ workflows:
             branches:
               only:
                 - trunk
+                - /circleci\/.*/
                 - /release\/.*/
                 - /desktop\/.*/
       - wp-desktop-windows:
@@ -492,6 +501,7 @@ workflows:
             branches:
               only:
                 - trunk
+                - /circleci\/.*/
                 - /release\/.*/
                 - /desktop\/.*/
   wp-desktop-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,13 +325,16 @@ jobs:
           at: C:\Users\circleci\wp-calypso
       - run:
           name: Install NVM
-          command: choco install -y nvm yarn
+          command: choco install -y nvm
       - run:
-          name: Install Node Version
+          name: Install Node environment
           command: |
             $NODE_VERSION = Get-Content .nvmrc
             nvm install $NODE_VERSION
             nvm use $NODE_VERSION
+      - run:
+          name: Install Yarn
+          command: npm install -g yarn
       - run:
           name: Verify versions
           shell: bash.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ workflows:
             branches:
               only:
                 - trunk
-                - /circleci\/.*/
+                - /circleci.*/
                 - /release\/.*/
                 - /desktop\/.*/
 #     - wp-desktop-mac:
@@ -491,7 +491,7 @@ workflows:
             branches:
               only:
                 - trunk
-                - /circleci\/.*/
+                - /circleci.*/
                 - /release\/.*/
                 - /desktop\/.*/
       - wp-desktop-windows:
@@ -501,7 +501,7 @@ workflows:
             branches:
               only:
                 - trunk
-                - /circleci\/.*/
+                - /circleci.*/
                 - /release\/.*/
                 - /desktop\/.*/
   wp-desktop-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,7 @@ jobs:
           at: C:\Users\circleci\wp-calypso
       - run:
           name: Install NVM
-          command: choco install nvm yarn
+          command: choco install -y nvm yarn
       - run:
           name: Install Node Version
           command: |


### PR DESCRIPTION
#### Proposed Changes

The CircleCi windows build is [failing on trunk](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/144317/workflows/807ba571-9d0b-4282-91db-c521d4be7d81/jobs/1102948) because of this issue: https://github.com/npm/cli/issues/4234. According to reports there, the problem is related to old nvm versions.

The issue appears to be fixed after updating a bunch of versions.

- Update windows image
- Better installs `nvm` -- this way, we use a more recent version.
- Adds a branch matcher so that the build runs on "circleci*" branches for testing.

#### Testing Instructions

CircleCI should pass

