### PR TITLE
Upload plugin sourcemaps along with Gutenberg

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -250,13 +250,13 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 
 			uploadPluginSourceMaps(
 				slug = "wpcom-block-editor",
-				buildId = "WPComPlugins_WpcomBlockEditor",
+				buildId = "calypso_WPComPlugins_WpcomBlockEditor",
 				wpcomURL = "~/wpcom-block-editor"
 			)
 
 			uploadPluginSourceMaps(
 				slug = "notifications",
-				buildId = "WPComPlugins_Notifications",
+				buildId = "calypso_WPComPlugins_Notifications",
 				wpcomURL = "~/notifications"
 			)
 		}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -4,6 +4,8 @@ import _self.bashNodeScript
 import _self.lib.wpcom.WPComPluginBuild
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
@@ -220,18 +222,20 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 
 		steps {
 			bashNodeScript {
-				name = "Upload source maps to Sentry"
-				scriptContent = """
-					# Install the Sentry CLI binary
-					curl -sL https://sentry.io/get-cli/ | bash
+				name = "Install Sentry CLI"
+				scriptContent = "curl -sL https://sentry.io/get-cli/ | bash"
+			}
 
+			bashNodeScript {
+				name = "Upload Gutenberg source maps to Sentry"
+				scriptContent = """
 					rm -rf gutenberg gutenberg.zip
 
 					wget https://github.com/WordPress/gutenberg/releases/download/%GUTENBERG_VERSION%/gutenberg.zip
 					unzip gutenberg.zip -d gutenberg
 					cd gutenberg
 
-					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
+					# Upload the .js and .js.map files to Sentry for the given release.
 					sentry-cli releases files %SENTRY_RELEASE_NAME% upload-sourcemaps . \
 							--auth-token %SENTRY_AUTH_TOKEN% \
 							--org a8c \
@@ -239,6 +243,54 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 							--url-prefix "~/wp-content/plugins/gutenberg-core/%GUTENBERG_VERSION%/"
 				"""
 			}
+
+			uploadPluginSourceMaps(
+				slug = "editing-toolkit",
+				buildId = "calypso_WPComPlugins_EditorToolKit",
+				buildTag = "etk-release-build",
+				wpcomURL = "~/wp-content/plugins/editing-toolkit-plugin/prod/"
+			)
+
+			uploadPluginSourceMaps(
+				slug = "wpcom-block-editor",
+				buildId = "WPComPlugins_WpcomBlockEditor",
+				wpcomURL = "~/wpcom-block-editor"
+			)
+
+			uploadPluginSourceMaps(
+				slug = "notifications",
+				buildId = "WPComPlugins_Notifications",
+				wpcomURL = "~/notifications"
+			)
 		}
+	}
+}
+
+// Given the plugin information, get the source code and upload any sourcemaps
+// to Sentry.
+fun BuildSteps.uploadPluginSourceMaps(
+	slug: String,
+	buildId: String,
+	wpcomURL: String,
+	buildTag: String = "$slug-release-build",
+): ScriptBuildStep {
+	return bashNodeScript {
+		name = "Upload $slug source maps to Sentry"
+		scriptContent = """
+			rm -rf code code.zip
+
+			# Downloads the latest release build for the plugin.
+			wget "%teamcity.serverUrl%/repository/download/$buildId/$buildTag.tcbuildtag/$slug.zip?guest=1&branch=trunk" -O ./code.zip
+			
+			unzip -q ./code.zip -d ./code
+			cd code
+
+			# Upload the .js and .js.map files to Sentry for the given release.
+			sentry-cli releases files %SENTRY_RELEASE_NAME% upload-sourcemaps . \
+					--auth-token %SENTRY_AUTH_TOKEN% \
+					--org a8c \
+					--project wpcom-gutenberg-wp-admin \
+					--url-prefix "$wpcomURL"
+		"""
 	}
 }

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -224,11 +224,6 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 
 		steps {
 			bashNodeScript {
-				name = "Install Sentry CLI"
-				scriptContent = "curl -sL https://sentry.io/get-cli/ | bash"
-			}
-
-			bashNodeScript {
 				name = "Upload Gutenberg source maps to Sentry"
 				scriptContent = """
 					rm -rf gutenberg gutenberg.zip

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -191,7 +191,9 @@ private object InlineHelp : WPComPluginBuild(
 
 private object GutenbergUploadSourceMapsToSentry: BuildType() {
 	init {
-		name = "Upload Gutenberg Source Maps to Sentry";
+		name = "Upload Source Maps";
+		description = "Uploads sourcemaps for various WordPress.com plugins to Sentry. Often triggered per-comment by a WPCOM post-deploy job.";
+
 		id("WPComPlugins_GutenbergUploadSourceMapsToSentry");
 
 		// Only needed so that we can test the job in different branches.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -125,4 +125,7 @@ RUN apt update &&\
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose &&\
 	composer install
 
+# Install sentry-cli.
+RUN wget -O - https://sentry.io/get-cli/ | bash
+
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
### Proposed Changes

Adds other Calypso-controlled wpcom plugins to our Gutenberg source map uploader.

I also moved the sentry CLI installation to the docker image build. I couldn't get the script to be shared across subsequent steps in the build, so I think the Docker image would centralize it better. This will require the base image to be rebuild before this will work. (I successfully did this with a custom tag to test it below.)

### Testing Instructions

**Note: these don't really need to be done more than once -- I linked to everything I did for testing and you can verify it looks right!**

- Trigger the base image build ([here](https://teamcity.a8c.com/buildConfiguration/calypso_BuildBaseImages/8519909)) with a custom docker tag using this branch's changes.
- Trigger the source map uploader using the above custom tag ([here](https://teamcity.a8c.com/buildConfiguration/calypso_WPComPlugins_GutenbergUploadSourceMapsToSentry/8520081)), this branch's changes and the other info
- Verify all the files show up in Sentry as expected (https://sentry.io/settings/a8c/projects/wpcom-gutenberg-wp-admin/source-maps/archiveme-noah-test-2/)

### TODO
- [x] Figure out what URL prefix to use for widgets.wp.com. (I think it just needs to be relative to the root domain.)
