### PR TITLE
plugin-bundle-flow: Add GetCurrentThemeSoftwareSets step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -1,0 +1,47 @@
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
+import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { useSite } from '../../../../hooks/use-site';
+import { SITE_STORE } from '../../../../stores';
+import type { Step } from '../../types';
+
+const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep( { navigation } ) {
+	const site = useSite();
+	const siteSlugParam = useSiteSlugParam();
+	let siteSlug: string | null = null;
+	if ( siteSlugParam ) {
+		siteSlug = siteSlugParam;
+	} else if ( site ) {
+		siteSlug = new URL( site.URL ).host;
+	}
+
+	const reduxDispatch = useReduxDispatch();
+	const { goNext } = navigation;
+	useEffect( () => {
+		reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ site?.ID ] );
+	const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
+	const currentTheme = useSelector( ( state ) =>
+		getCanonicalTheme( state, site?.ID || -1, currentThemeId )
+	);
+	const { setBundledPluginSlug } = useDispatch( SITE_STORE );
+	useEffect( () => {
+		if ( currentTheme ) {
+			const theme_software_set = currentTheme?.taxonomies?.theme_software_set;
+			if ( theme_software_set && siteSlug ) {
+				setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first software set
+				goNext();
+			} else {
+				// Current theme has no bundled plugins; they shouldn't be in this flow
+				window.location.replace( `/home/${ siteSlug }` );
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ currentTheme?.id ] );
+	return null;
+};
+export default GetCurrentThemeSoftwareSets;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -41,6 +41,7 @@ export { default as launchpad } from './launchpad';
 export { default as subscribers } from './subscribers';
 export { default as patterns } from './patterns';
 export { default as promote } from './promote';
+export { default as getCurrentThemeSoftwareSets } from './get-current-theme-software-sets';
 
 export type StepPath =
 	| 'courses'
@@ -85,4 +86,5 @@ export type StepPath =
 	| 'intro'
 	| 'launchpad'
 	| 'subscribers'
-	| 'promote';
+	| 'promote'
+	| 'getCurrentThemeSoftwareSets';

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -20,7 +20,7 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from './internals/types';
-import pluginBundleSteps from './plugin-bundle-data';
+import pluginBundleData from './plugin-bundle-data';
 import type { StepPath } from './internals/steps-repository';
 import type { BundledPlugin } from './plugin-bundle-data';
 
@@ -40,11 +40,19 @@ export const pluginBundleFlow: Flow = {
 			window.location.replace( `/home/${ siteSlugParam }` );
 		}
 
-		if ( ! pluginSlug || ! pluginBundleSteps.hasOwnProperty( pluginSlug ) ) {
-			window.location.replace( `/home/${ siteSlugParam }` );
-		}
+		// FIXME - Need to not redirect when getCurrentThemeSoftwareSets is still running
+		//
+		// if ( ! pluginSlug || ! pluginBundleData.hasOwnProperty( pluginSlug ) ) {
+		// 	window.location.replace( `/home/${ siteSlugParam }` );
+		// }
 
-		return pluginBundleSteps[ pluginSlug ] as StepPath[];
+		const steps: StepPath[] = [ 'getCurrentThemeSoftwareSets' ];
+		let bundlePluginSteps: StepPath[] = [];
+
+		if ( pluginSlug && pluginBundleData.hasOwnProperty( pluginSlug ) ) {
+			bundlePluginSteps = pluginBundleData[ pluginSlug ] as StepPath[];
+		}
+		return steps.concat( bundlePluginSteps );
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -221,15 +221,8 @@ export const siteSetupFlow: Flow = {
 						theme_software_set.length > 0 &&
 						siteSlug
 					) {
-						// Don't set it, let the new GetCurrentThemeSoftwareSets set it instead
-						// setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first plugin
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 					}
-
-					// We know this theme doesn't have a plugin bundled, so clear it in the store
-					// if ( siteSlug ) {
-					// 	setBundledPluginSlug( siteSlug, '' );
-					// }
 
 					return exitFlow( `/home/${ siteSlug }` );
 				}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -110,8 +110,7 @@ export const siteSetupFlow: Flow = {
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, setBundledPluginSlug } =
-			useDispatch( SITE_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
@@ -222,14 +221,15 @@ export const siteSetupFlow: Flow = {
 						theme_software_set.length > 0 &&
 						siteSlug
 					) {
-						setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first plugin
+						// Don't set it, let the new GetCurrentThemeSoftwareSets set it instead
+						// setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first plugin
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );
 					}
 
 					// We know this theme doesn't have a plugin bundled, so clear it in the store
-					if ( siteSlug ) {
-						setBundledPluginSlug( siteSlug, '' );
-					}
+					// if ( siteSlug ) {
+					// 	setBundledPluginSlug( siteSlug, '' );
+					// }
 
 					return exitFlow( `/home/${ siteSlug }` );
 				}


### PR DESCRIPTION
#### Proposed Changes

* Instead of depending upon the `setBundledPluginSlug()` being set prior to loading, the plugin-bundle flow now includes a new step (GetCurrentThemeSoftwareSets), which queries the current theme for bundled software sets and saves them in the store.

---

* At the end of the site-setup flow, we're sometimes passing the user to the plugin-bundle flow.
* As a part of this handoff, the site-setup flow figures out the software sets that should be installed and saves them using `setBundledPluginSlug()`.
* In #67237, I'm trying to make the thank-you modal which is outside of stepper, set this variable and redirect to the plugin-bundle flow, however, I can't seem to do it. The stepper store seems to be isolated.
* If the plugin-bundle flow can figure this data out on its own in a first step, then the flow is more self contained, and does not depend upon certain variables being set before loading.

#### Testing Instructions

* http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE
* Choose baxter
* You should progress through the GetCurrentThemeSoftwareSets step and then be sent to fill out store info

Related to #
