### PR TITLE
Launchpad: Improve placement/styles of Launchpad admin link

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -39,7 +39,13 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 				skipLabelText={ translate( 'Go to Admin' ) }
 				skipButtonAlign={ 'bottom' }
 				hideBack={ true }
-				stepContent={ <StepContent siteSlug={ siteSlug } submit={ navigation.submit } /> }
+				stepContent={
+					<StepContent
+						siteSlug={ siteSlug }
+						submit={ navigation.submit }
+						goNext={ navigation.goNext }
+					/>
+				}
 				formattedHeader={
 					<FormattedHeader
 						id={ 'launchpad-header' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,5 +1,6 @@
 import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
@@ -13,6 +14,7 @@ import { Task } from './types';
 type SidebarProps = {
 	siteSlug: string | null;
 	submit: NavigationControls[ 'submit' ];
+	goNext: NavigationControls[ 'goNext' ];
 };
 
 function getUrlInfo( url: string ) {
@@ -38,7 +40,7 @@ function getChecklistCompletionProgress( tasks: Task[] | null ) {
 	return Math.round( ( totalCompletedTasks / tasks.length ) * 100 );
 }
 
-const Sidebar = ( { siteSlug, submit }: SidebarProps ) => {
+const Sidebar = ( { siteSlug, submit, goNext }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	const flow = useFlowParam();
@@ -80,6 +82,14 @@ const Sidebar = ( { siteSlug, submit }: SidebarProps ) => {
 					<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
 				</div>
 				<Checklist tasks={ enhancedTasks } />
+			</div>
+			<div className="launchpad__sidebar-admin-link">
+				<StepNavigationLink
+					direction="forward"
+					handleClick={ goNext }
+					label={ translate( 'Go to Admin' ) }
+					borderless={ true }
+				/>
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -5,11 +5,12 @@ import Sidebar from './sidebar';
 type StepContentProps = {
 	siteSlug: string | null;
 	submit: NavigationControls[ 'submit' ];
+	goNext: NavigationControls[ 'goNext' ];
 };
 
-const StepContent = ( { siteSlug, submit }: StepContentProps ) => (
+const StepContent = ( { siteSlug, submit, goNext }: StepContentProps ) => (
 	<div className="launchpad__content">
-		<Sidebar siteSlug={ siteSlug } submit={ submit } />
+		<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } />
 		<LaunchpadSitePreview siteSlug={ siteSlug } />
 	</div>
 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -41,14 +41,14 @@
 
 .launchpad__sidebar {
 	max-width: 100%;
-	margin: 24px 16px 16px;
+	margin: 24px 16px 32px;
 	display: flex;
 	flex-direction: column;
-	height: 97vh;
 
 	@include break-large {
 		max-width: 440px;
 		margin: 24px 20px 24px 40px;
+		height: 97vh;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -48,7 +48,7 @@
 	@include break-large {
 		max-width: 440px;
 		margin: 24px 20px 24px 40px;
-		height: 97vh;
+		height: 95vh;
 	}
 }
 
@@ -114,7 +114,7 @@
 }
 
 .launchpad__sidebar-admin-link {
-	padding: 80px 20px 40px;
+	padding: 80px 20px 10px;
 	display: none;
 	button {
 		text-decoration: underline;
@@ -245,12 +245,10 @@
 
 .launchpad__site-preview-wrapper {
 	margin: 16px;
-	height: 850px;
 	flex-grow: 1;
 
 	@include break-large {
 		margin: 73px 40px 12px 20px;
-		height: 900px;
 	}
 
 	.preview-toolbar__toolbar {
@@ -258,6 +256,11 @@
 		@include break-large {
 			display: block;
 		}
+	}
+
+	.web-preview__placeholder {
+		overflow-y: visible;
+		min-height: 720px;
 	}
 
 	.preview-toolbar__devices {
@@ -272,7 +275,6 @@
 				0 30px 20px rgba( 0, 0, 0, 0.03 ), 0 15px 13px rgba( 0, 0, 0, 0.02 ),
 				0 6px 5px rgba( 0, 0, 0, 0.02 ), 0 2px 3px rgba( 0, 0, 0, 0.01 );
 			max-width: 340px;
-			height: 680px;
 			border-radius: 40px; /* stylelint-disable-line scales/radii */
 		}
 	}
@@ -288,6 +290,7 @@
 		border-radius: 40px; /* stylelint-disable-line scales/radii */
 		box-sizing: border-box;
 		height: 780px;
+		height: 680px;
 		max-width: 95%;
 		box-shadow: 0 5px 15px rgba( 0, 0, 0, 0.07 ), 0 3px 10px rgba( 0, 0, 0, 0.04 );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -16,13 +16,6 @@
 		margin: 0;
 		max-width: none;
 		min-height: 100vh;
-		.step-container__navigation.action-buttons {
-			top: auto;
-			inset-inline-start: 40px;
-			.step-container__skip-wrapper {
-				margin-inline-start: 0;
-			}
-		}
 	}
 
 	.step-container__buttons {
@@ -31,8 +24,7 @@
 		text-align: center;
 
 		@include break-large {
-			text-align: left;
-			padding: 0 0 40px 40px;
+			display: none;
 		}
 	}
 }
@@ -50,6 +42,9 @@
 .launchpad__sidebar {
 	max-width: 100%;
 	margin: 24px 16px 16px;
+	display: flex;
+	flex-direction: column;
+	height: 97vh;
 
 	@include break-large {
 		max-width: 440px;
@@ -60,6 +55,7 @@
 .launchpad__sidebar-content-container {
 	margin-left: 0;
 	margin-top: 100px;
+	flex-grow: 1;
 
 	@include break-large {
 		margin-left: 16px;
@@ -112,8 +108,21 @@
 	margin: 32px 0;
 	padding: 0 20px;
 }
+
 .launchpad__url-box-top-level-domain {
 	font-weight: 500;
+}
+
+.launchpad__sidebar-admin-link {
+	padding: 80px 20px 40px;
+	display: none;
+	button {
+		text-decoration: underline;
+	}
+
+	@include break-large {
+		display: block;
+	}
 }
 
 // Launchpad - Progress Bar


### PR DESCRIPTION
### Proposed Changes

Addresses https://github.com/Automattic/wp-calypso/issues/67107. The Launchpad "Go to Admin" link is off the screen for many screen sizes. Currently the "Go to Admin" link is the default link provided by stepper. It is in a div at the bottom of the page, under all other divs. So if the Site Preview stretches below the visible screen, the admin link will as well, since it is below that.

To address this, this PR: 
- Hides the default "Go to Admin" link on larger screens (still shown on smaller screens)
- Adds a new "Go to Admin" link, nested in the sidebar, on larger screens (hidden on smaller screens)
- Adds some styles to the new link to ensure it behaves well across screen sizes

Note: I also tried absolute positioning of the "Go to Admin" link in the lower left corner. This is a simpler solution, but in some cases, it allows the link to hover on top of the Checklist items. To avoid that, I've adopted the approach above.

### Testing Instructions

1. Checkout branch, run `yarn` and `yarn start` if needed.
2. Load Launchpad screen: http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=SITESLUG (replace site slug with your domain).
3. Try different screen sizes and confirm the Go to Admin link always shows is correct, nice looking, usable places. 
  - On small screen sizes, the sidebar and web preview will stack, and the "Go to Admin" link continues to be at the very bottom as it was before.
  - On larger screens, the 'Go to Admin' link should nearly always be immediately visible at the bottom of the sidebar. The exception is if you have a wide but short screen (ie, open your chrome dev tools). In this case, the link cannot be visible with hovering over the checklist, so scrolling will be needed. 

**Example: Go to Admin link on 14" Macbook Pro**
<img width="1510" alt="14 inch macbook" src="https://user-images.githubusercontent.com/21228350/187802305-85a9b794-0c5a-407b-a449-85155cb8411c.png">

**Example: Go to Admin link, zoomed out to mimic very large screen**
<img width="1507" alt="large screens" src="https://user-images.githubusercontent.com/21228350/187802319-d7043b26-906d-4018-bdd4-e1dd98c87fbc.png">