### PR TITLE
Theme/Plugin Bundling: Added UI changes for bundled themes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
@@ -56,8 +56,7 @@ const ThemeInfoPopup = ( { slug }: ThemeInfoPopupProps ) => {
 	}
 
 	const { author, author_uri, description } = theme;
-	const features = theme.taxonomies.features;
-
+	const features = theme.taxonomies.theme_feature;
 	return (
 		<div className="theme-info-popup">
 			<ThemeDescription author_uri={ author_uri } author={ author } description={ description } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -95,6 +95,13 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 		font-size: $font-headline-small;
 		line-height: 1.1;
 		margin-bottom: 15px;
+		&.bundle {
+			margin-top: 15px;
+		}
+	}
+
+	&__woo-logo {
+		width: 70px;
 	}
 
 	p {
@@ -112,27 +119,37 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 		}
 	}
 
-	&__upgrade.button.is-primary {
-		background: $design-button-primary-color;
-        border-color: $design-button-primary-color;
-        padding: 9px 25px;
-        border-radius: 4px;
-        font-weight: 500;
+	.button {
+		padding: 9px 25px;
+		border-radius: 4px;
+		font-weight: 500;
 		margin-bottom: 15px;
-        box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
-		width: 100%;
+		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
 
-        &:hover,
-        &:focus {
-            background: $design-button-primary-hover-color;
-            border-color: $design-button-primary-hover-color;
-        }
+		&.is-primary {
+			background: $design-button-primary-color;
+			border-color: $design-button-primary-color;
+			width: 100%;
+
+			&:hover,
+			&:focus {
+				background: $design-button-primary-hover-color;
+				border-color: $design-button-primary-hover-color;
+			}
+		}
+	}
+
+	&__actions.bundle {
+		display: grid;
+		grid-template-columns: 50% 50%;
+		column-gap: 20px;
 	}
 
 	&__included {
 		margin-bottom: 25px;
 
-		ul, li {
+		ul,
+		li {
 			font-size: $font-body-small;
 			line-height: 1.7;
 			list-style: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -119,30 +119,30 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 		}
 	}
 
-	.button {
-		padding: 9px 25px;
-		border-radius: 4px;
-		font-weight: 500;
-		margin-bottom: 15px;
-		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
-
-		&.is-primary {
-			background: $design-button-primary-color;
-			border-color: $design-button-primary-color;
-			width: 100%;
-
-			&:hover,
-			&:focus {
-				background: $design-button-primary-hover-color;
-				border-color: $design-button-primary-hover-color;
-			}
-		}
-	}
-
 	&__actions.bundle {
 		display: grid;
 		grid-template-columns: 50% 50%;
 		column-gap: 20px;
+
+		.button {
+			padding: 9px 25px;
+			border-radius: 4px;
+			font-weight: 500;
+			margin-bottom: 15px;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
+
+			&.is-primary {
+				background: $design-button-primary-color;
+				border-color: $design-button-primary-color;
+				width: 100%;
+
+				&:hover,
+				&:focus {
+					background: $design-button-primary-hover-color;
+					border-color: $design-button-primary-hover-color;
+				}
+			}
+		}
 	}
 
 	&__included {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -1,7 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
+import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import wooCommerceImage from 'calypso/assets/images/onboarding/woo-commerce.svg';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
 import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
@@ -19,7 +22,7 @@ interface UpgradeModalProps {
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
 	const theme = useThemeDetails( slug );
-	const features = theme.data && theme.data.taxonomies.features;
+	const features = theme.data && theme.data.taxonomies.theme_feature;
 	const featuresHeading = translate( 'Theme features' ) as string;
 	//@TODO This is a placeholder until we have theme products to choose from
 	const themeYearlyProduct = useSelect( ( select ) =>
@@ -29,6 +32,89 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 
 	//Wait until we have theme and product data to show content
 	const isLoading = ! themeYearlyProduct?.cost || ! theme.data;
+
+	// Check current theme: Does it have a plugin bundled?
+	const theme_software_set = theme?.data?.taxonomies?.theme_software_set?.length;
+
+	let header = (
+		<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
+	);
+
+	let text = (
+		<p>
+			{ translate(
+				'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
+			) }
+		</p>
+	);
+
+	const price = (
+		<div className="upgrade-modal__theme-price">
+			{ translate( '{{span}}%(themePrice)s{{/span}} per year', {
+				components: {
+					span: <span />,
+				},
+				args: {
+					themePrice,
+				},
+			} ) }
+		</div>
+	);
+
+	let action = (
+		<>
+			<div className="upgrade-modal__actions">
+				<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
+					{ translate( 'Buy and activate theme' ) }
+				</Button>
+			</div>
+			<p className="upgrade-modal__plan-nudge">
+				{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
+					components: {
+						button: <Button onClick={ () => checkout() } plain />,
+					},
+				} ) }
+			</p>
+		</>
+	);
+
+	const showBundleVersion = isEnabled( 'themes/plugin-bundling' ) && theme_software_set;
+
+	if ( showBundleVersion ) {
+		header = (
+			<>
+				<img src={ wooCommerceImage } alt="WooCommerce" className="upgrade-modal__woo-logo" />
+				<h1 className="upgrade-modal__heading bundle">
+					{ translate( 'Unlock this WooCommerce theme' ) }
+				</h1>
+			</>
+		);
+
+		text = (
+			<p>
+				{ translate(
+					"This theme comes bundled with {{link}}WooCommerce{{/link}} and requires a Business plan to unlock. It's %s a year, risk-free with a 14-day money-back-guarantee.",
+					{
+						components: {
+							link: <ExternalLink target="_blank" href={ 'https://woocommerce.com/' } />,
+						},
+						args: themePrice,
+					}
+				) }
+			</p>
+		);
+
+		action = (
+			<div className="upgrade-modal__actions bundle">
+				<Button className="upgrade-modal__cancel" onClick={ () => closeModal() }>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>
+					{ translate( 'Upgrade Plan' ) }
+				</Button>
+			</div>
+		);
+	}
 
 	return (
 		<Dialog
@@ -41,34 +127,10 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			{ ! isLoading && (
 				<>
 					<div className="upgrade-modal__col">
-						<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
-						<p>
-							{ translate(
-								'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
-							) }
-						</p>
-						<div className="upgrade-modal__theme-price">
-							{ translate( '{{span}}%(themePrice)s{{/span}} per year', {
-								components: {
-									span: <span />,
-								},
-								args: {
-									themePrice,
-								},
-							} ) }
-						</div>
-						<div className="upgrade-modal__actions">
-							<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
-								{ translate( 'Buy and activate theme' ) }
-							</Button>
-						</div>
-						<p className="upgrade-modal__plan-nudge">
-							{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
-								components: {
-									button: <Button onClick={ () => checkout() } plain />,
-								},
-							} ) }
-						</p>
+						{ header }
+						{ text }
+						{ ! showBundleVersion && price }
+						{ action }
 					</div>
 					<div className="upgrade-modal__col">
 						<div className="upgrade-modal__included">

--- a/client/landing/stepper/hooks/use-theme-details.ts
+++ b/client/landing/stepper/hooks/use-theme-details.ts
@@ -13,8 +13,8 @@ type Theme = {
 
 export function useThemeDetails( slug: string ): UseQueryResult< Theme > {
 	return useQuery< Theme >(
-		'theme-details',
-		() => wpcom.req.get( `/themes/${ slug }`, { apiVersion: '1.1' } ),
+		`theme-details-${ slug }`,
+		() => wpcom.req.get( `/themes/${ slug }`, { apiVersion: '1.2' } ),
 		{
 			staleTime: Infinity,
 			refetchOnWindowFocus: false,


### PR DESCRIPTION
#### Proposed Changes

* Added specific UI for when the theme has bundled plugins (WooCommerce for now). 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with these flags on: `themes/plugin-bundling`, `signup/seller-upgrade-modal` 
* On the design picker choose Baxter (that has bundling)
* Check Modal
* Pick a different premium theme, like Alonso.
* Check Modal

#### Regular Modal

![2022-09-01_09-47](https://user-images.githubusercontent.com/937354/187944038-4cafc2ce-75e2-4cd6-b46a-3b77dc72dba9.png)


#### New Modal

![2022-09-01_09-47_1](https://user-images.githubusercontent.com/937354/187944003-f8fcec10-eac0-49b2-9eb0-f7dec49ca83a.png)


Related to https://github.com/Automattic/wp-calypso/issues/67120
