### PR TITLE
SMP: Test the logic that generates a site's initial used in the fallback site icon

### DIFF
--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -4,7 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentProps } from 'react';
 import Image from 'calypso/components/image';
-import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const NoIcon = styled.div( {
 	fontSize: 'xx-large',

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -67,5 +67,9 @@ function getFirstGrapheme( input: string ) {
 		return firstSegmentData?.segment ?? '';
 	}
 
-	return input.charAt( 0 );
+	const codePoint = input.codePointAt( 0 );
+	if ( codePoint ) {
+		return String.fromCodePoint( codePoint );
+	}
+	return '';
 }

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -64,7 +64,7 @@ function getFirstGrapheme( input: string ) {
 		const segmenter = new Intl.Segmenter();
 		const [ firstSegmentData ] = segmenter.segment( input );
 
-		return firstSegmentData?.segment;
+		return firstSegmentData?.segment ?? '';
 	}
 
 	return input.charAt( 0 );

--- a/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { SiteItemThumbnail } from '../sites-site-item-thumbnail';
+
+function makeTestSite( { name = 'test' } = {} ) {
+	return {
+		ID: 1,
+		name: name as string | undefined,
+		slug: '',
+		URL: '',
+		launch_status: 'launched',
+		options: {},
+		jetpack: false,
+	};
+}
+
+describe( '<SiteItemThumbnail>', () => {
+	describe( 'Fallback site icon', () => {
+		describe( 'Intl.Segmenter API is available', () => {
+			test( 'confirm Intl available', () => {
+				expect( Intl.Segmenter ).toBeDefined();
+			} );
+
+			defineCommonSiteInitialTests();
+
+			test( 'site name can be multi-codepoint emoji', () => {
+				render(
+					<SiteItemThumbnail
+						site={ makeTestSite( { name: '👩‍👩‍👦‍👦 family: woman, woman, boy, boy' } ) }
+					/>
+				);
+				expect( screen.getByLabelText( 'Site Icon' ) ).toHaveTextContent( /^👩‍👩‍👦‍👦$/ );
+			} );
+		} );
+
+		describe( 'Intl.Segmenter API is not available', () => {
+			let rememberSegmenter;
+			beforeAll( () => {
+				rememberSegmenter = Intl.Segmenter;
+				delete Intl.Segmenter;
+			} );
+
+			afterAll( () => {
+				Intl.Segmenter = rememberSegmenter;
+			} );
+
+			defineCommonSiteInitialTests();
+
+			test( 'site name can be multi-codepoint emoji', () => {
+				// Without the Segmenter API we fall back to returning the first codepoint
+				render(
+					<SiteItemThumbnail
+						site={ makeTestSite( { name: '👩‍👩‍👦‍👦 family: woman, woman, boy, boy' } ) }
+					/>
+				);
+				expect( screen.getByLabelText( 'Site Icon' ) ).toHaveTextContent( /^👩$/ );
+			} );
+		} );
+	} );
+} );
+
+function defineCommonSiteInitialTests() {
+	test( 'an English site name', () => {
+		render( <SiteItemThumbnail site={ makeTestSite( { name: 'hello' } ) } /> );
+		expect( screen.getByLabelText( 'Site Icon' ) ).toHaveTextContent( /^h$/ );
+	} );
+
+	test( 'diacritic mark on first letter', () => {
+		render( <SiteItemThumbnail site={ makeTestSite( { name: 'öwl' } ) } /> );
+		expect( screen.getByLabelText( 'Site Icon' ) ).toHaveTextContent( /^ö$/ );
+	} );
+
+	test( 'empty site name renders no initial', () => {
+		render( <SiteItemThumbnail site={ makeTestSite( { name: '' } ) } /> );
+		expect( screen.getByLabelText( 'Site Icon' ) ).toBeEmptyDOMElement();
+	} );
+
+	test( 'undefined site name renders no initial', () => {
+		const testSite = makeTestSite();
+		testSite.name = undefined;
+
+		render( <SiteItemThumbnail site={ testSite } /> );
+		expect( screen.getByLabelText( 'Site Icon' ) ).toBeEmptyDOMElement();
+	} );
+}


### PR DESCRIPTION
#### Proposed Changes

The dashboard "crashed" when it encountered a site with a non-existent site name. @cpapazoglou graciously fixed this in #67194.

This PR is a follow up that adds an explicit fallback of `''` for the site's first initial when the site name is `undefined`. It also unit tests the logic for generating the first initial

It's hard to test this as a user because it appears that site name is only `undefined` when the site is in a broken state p1661935274139249/1661931616.045399-slack-C0347E545HR

But it's still possible, and the TypeScript types make this clear.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load `/sites`
* Site icon fallbacks work just as before
* Tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- ~[ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- ~[ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

