### PR TITLE
DIFM: Update copy on onboarding landing page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -1,4 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
 import type { Step } from '../../types';
@@ -21,6 +22,8 @@ const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 		goNext?.();
 	};
 
+	const siteId = useSite()?.ID;
+
 	return (
 		<StepContainer
 			stepName={ STEP_NAME }
@@ -30,7 +33,12 @@ const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 			isWideLayout={ true }
 			isLargeSkipLayout={ false }
 			stepContent={
-				<DIFMLanding onSubmit={ onSubmit } onSkip={ onSkip } isInOnboarding={ true } />
+				<DIFMLanding
+					onSubmit={ onSubmit }
+					onSkip={ onSkip }
+					isInOnboarding={ true }
+					siteId={ siteId }
+				/>
 			}
 			recordTracksEvent={ recordTracksEvent }
 		/>

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -4,6 +4,10 @@ import {
 	getPlan,
 	PLAN_WPCOM_PRO,
 	PLAN_PREMIUM,
+	isBusiness,
+	isPremium,
+	isEcommerce,
+	isPro,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -22,6 +26,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { incrementCounter } from 'calypso/state/persistent-counter/actions';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { getProductCost } from 'calypso/state/products-list/selectors';
+import { getSitePlan } from 'calypso/state/sites/selectors';
 import type { TranslateResult } from 'i18n-calypso';
 
 const Placeholder = styled.span`
@@ -232,10 +237,12 @@ export default function DIFMLanding( {
 	onSubmit,
 	onSkip,
 	isInOnboarding = true,
+	siteId,
 }: {
 	onSubmit: () => void;
 	onSkip?: () => void;
 	isInOnboarding: boolean;
+	siteId?: number | null;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -290,26 +297,45 @@ export default function DIFMLanding( {
 		}
 	);
 
+	const currentPlan = useSelector( ( state ) => ( siteId ? getSitePlan( state, siteId ) : null ) );
+	const hasPremiumOrHigherPlan = currentPlan?.product_slug
+		? [ isPremium, isBusiness, isEcommerce, isPro ].some( ( planMatcher ) =>
+				planMatcher( {
+					productSlug: currentPlan.product_slug,
+				} )
+		  )
+		: false;
+
+	const subHeaderText = hasPremiumOrHigherPlan
+		? translate(
+				'{{sup}}*{{/sup}}One time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				{
+					args: {
+						freePages: 5,
+					},
+					components: {
+						sup: <sup />,
+					},
+				}
+		  )
+		: translate(
+				'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				{
+					args: {
+						plan: planTitle,
+						freePages: 5,
+					},
+					components: {
+						sup: <sup />,
+					},
+				}
+		  );
+
 	return (
 		<>
 			<Wrapper>
 				<ContentSection>
-					<Header
-						align={ 'left' }
-						headerText={ headerText }
-						subHeaderText={ translate(
-							'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
-							{
-								args: {
-									plan: planTitle,
-									freePages: 5,
-								},
-								components: {
-									sup: <sup />,
-								},
-							}
-						) }
-					/>
+					<Header align={ 'left' } headerText={ headerText } subHeaderText={ subHeaderText } />
 					<VerticalStepProgress>
 						<Step
 							index={ translate( '1' ) }


### PR DESCRIPTION
#### Proposed Changes

Context: pdh1Xd-1e7-p2#comment-1451

If the site is on a Premium or higher plan, an additional purchase of a plan is not required for DIFM. This PR hides the text `plus an additional purchase of the %(plan)s plan.` if the site is already on a Premium or higher plan.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/difmStartingPoint?siteSlug=<site slug>` where the site slug corresponds to a site on the Free or Personal plan.
* Confirm that the text `plus an additional purchase of the Premium plan` is visible.
<img width="701" alt="Screenshot 2022-09-01 at 1 17 27 PM" src="https://user-images.githubusercontent.com/5436027/187864179-d259cca2-2bbc-4a1e-8c9e-5c44ed5ad0d9.png">

* Go to `/setup/difmStartingPoint?siteSlug=<site slug>` where the site slug corresponds to a site on a Premium or higher plan.
* Confirm that the text `plus an additional purchase of the Premium plan` is not visible.
<img width="651" alt="Screenshot 2022-09-01 at 1 17 46 PM" src="https://user-images.githubusercontent.com/5436027/187864337-2d4ffbc3-d858-4c99-8ad6-d61a891a293c.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - NA
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? - NA
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) - NA
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - NA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1048