### PR TITLE
Remove padding when viewing pricing page in wide view.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 /* cyrillic-ext */
 @font-face {
 	font-family: 'Inter';
@@ -77,6 +80,10 @@
 
 .main.is-wide-layout.jetpack-pricing-page-rework-v1 {
 	max-width: 1192px;
+
+	@include break-wide {
+		padding: 0;
+	}
 }
 
 .jetpack-plans__pricing-header {


### PR DESCRIPTION
#### Proposed Changes

* Remove padding for the new pricing page when in wide view.

#### Testing Instructions

* Run `git fetch && git checkout fix/pricing-page-maximum-width`
  * Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
* Confirm the page has maximum 1192px width in wide view without padding.

![1202886227656197 DomdQZY538XczvyljwLp_height640](https://user-images.githubusercontent.com/56598660/187877951-0c160e8e-ffd2-4c85-b95b-8a4c906ee0f6.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202886227656193


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202886227656193