### PR TITLE
Newsletter accent color input text to be gray until first change

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -180,7 +180,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 								generateSwatchSVG( accentColor ?? DEFAULT_ACCENT_COLOR ),
 								getBackgroundImage( accentColor ?? DEFAULT_ACCENT_COLOR ),
 							].join( ', ' ),
-							...( ! accentColor && { color: 'var( --studio-gray-30 )' } ),
+							...( accentColor.default && { color: 'var( --studio-gray-30 )' } ),
 						} }
 						name="accentColor"
 						id="accentColor"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -19,6 +19,8 @@ import type { Step } from '../../types';
 
 import './style.scss';
 
+const DEFAULT_ACCENT_COLOR = '#0675C4';
+
 /**
  * Generates an inline SVG for the color picker swatch
  *
@@ -35,6 +37,7 @@ function generateSwatchSVG( color: string | undefined ) {
 			: ''
 	}%3C/svg%3E")`;
 }
+
 const NewsletterSetup: Step = ( { navigation } ) => {
 	const { submit } = navigation;
 	const { __ } = useI18n();
@@ -50,7 +53,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
-	const [ accentColor, setAccentColor ] = React.useState< string | undefined >( '#0675C4' );
+	const [ accentColor, setAccentColor ] = React.useState< string | undefined >();
 	const [ base64Image, setBase64Image ] = React.useState< string | null >();
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const siteTitleError =
@@ -84,7 +87,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
-		setSiteAccentColor( accentColor );
+		setSiteAccentColor( accentColor ?? DEFAULT_ACCENT_COLOR );
 
 		if ( selectedFile && base64Image ) {
 			try {
@@ -95,7 +98,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 
 		if ( siteTitle.trim().length ) {
-			submit?.( { siteTitle, tagline, siteAccentColor: accentColor } );
+			submit?.( { siteTitle, tagline, siteAccentColor: accentColor ?? DEFAULT_ACCENT_COLOR } );
 		}
 	};
 
@@ -174,15 +177,16 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						className="newsletter-setup__accent-color"
 						style={ {
 							backgroundImage: [
-								generateSwatchSVG( accentColor ),
-								...( accentColor ? [ getBackgroundImage( accentColor ) ] : [] ),
+								generateSwatchSVG( accentColor ?? DEFAULT_ACCENT_COLOR ),
+								getBackgroundImage( accentColor ?? DEFAULT_ACCENT_COLOR ),
 							].join( ', ' ),
+							...( ! accentColor && { color: 'var( --studio-gray-30 )' } ),
 						} }
 						name="accentColor"
 						id="accentColor"
 						onFocus={ () => setColorPickerOpen( ! colorPickerOpen ) }
 						readOnly
-						value={ accentColor }
+						value={ accentColor ?? DEFAULT_ACCENT_COLOR }
 					/>
 				</FormFieldset>
 				<Button className="newsletter-setup__submit-button" type="submit" primary>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -19,8 +19,6 @@ import type { Step } from '../../types';
 
 import './style.scss';
 
-type AccentColor = { color: string; default?: boolean };
-
 /**
  * Generates an inline SVG for the color picker swatch
  *
@@ -53,7 +51,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
-	const [ accentColor, setAccentColor ] = React.useState< AccentColor >( {
+	const [ accentColor, setAccentColor ] = React.useState< { color: string; default?: boolean } >( {
 		color: '#0675C4',
 		default: true,
 	} );
@@ -117,11 +115,8 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const getBackgroundImage = ( fieldValue: AccentColor ) => {
-		if ( fieldValue.default ) {
-			return '';
-		}
-		return fieldValue.color.trim() !== '' ? `url( ${ greenCheckmarkImg } )` : '';
+	const getBackgroundImage = ( fieldValue: string | undefined ) => {
+		return fieldValue && fieldValue.trim() ? `url( ${ greenCheckmarkImg } )` : '';
 	};
 
 	const stepContent = (
@@ -184,7 +179,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						style={ {
 							backgroundImage: [
 								generateSwatchSVG( accentColor.color ),
-								getBackgroundImage( accentColor.color ),
+								...( ! accentColor.default ? [ getBackgroundImage( accentColor.color ) ] : [] ),
 							].join( ', ' ),
 							...( accentColor.default && { color: 'var( --studio-gray-30 )' } ),
 						} }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -53,7 +53,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
-	const [ accentColor, setAccentColor ] = React.useState< string | undefined >();
+	const [ accentColor, setAccentColor ] = React.useState< { color: string, default?: boolean } >( { color: '#0675C4', default: true} );
 	const [ base64Image, setBase64Image ] = React.useState< string | null >();
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const siteTitleError =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -19,6 +19,8 @@ import type { Step } from '../../types';
 
 import './style.scss';
 
+type AccentColor = { color: string; default?: boolean };
+
 /**
  * Generates an inline SVG for the color picker swatch
  *
@@ -51,7 +53,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
-	const [ accentColor, setAccentColor ] = React.useState< { color: string; default?: boolean } >( {
+	const [ accentColor, setAccentColor ] = React.useState< AccentColor >( {
 		color: '#0675C4',
 		default: true,
 	} );
@@ -115,8 +117,11 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const getBackgroundImage = ( fieldValue: string | undefined ) => {
-		return fieldValue && fieldValue.trim() ? `url( ${ greenCheckmarkImg } )` : '';
+	const getBackgroundImage = ( fieldValue: AccentColor ) => {
+		if ( fieldValue.default ) {
+			return '';
+		}
+		return fieldValue.color.trim() !== '' ? `url( ${ greenCheckmarkImg } )` : '';
 	};
 
 	const stepContent = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -19,8 +19,6 @@ import type { Step } from '../../types';
 
 import './style.scss';
 
-const DEFAULT_ACCENT_COLOR = '#0675C4';
-
 /**
  * Generates an inline SVG for the color picker swatch
  *
@@ -53,7 +51,10 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
-	const [ accentColor, setAccentColor ] = React.useState< { color: string, default?: boolean } >( { color: '#0675C4', default: true} );
+	const [ accentColor, setAccentColor ] = React.useState< { color: string; default?: boolean } >( {
+		color: '#0675C4',
+		default: true,
+	} );
 	const [ base64Image, setBase64Image ] = React.useState< string | null >();
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const siteTitleError =
@@ -87,7 +88,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
-		setSiteAccentColor( accentColor ?? DEFAULT_ACCENT_COLOR );
+		setSiteAccentColor( accentColor.color );
 
 		if ( selectedFile && base64Image ) {
 			try {
@@ -98,7 +99,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 
 		if ( siteTitle.trim().length ) {
-			submit?.( { siteTitle, tagline, siteAccentColor: accentColor ?? DEFAULT_ACCENT_COLOR } );
+			submit?.( { siteTitle, tagline, siteAccentColor: accentColor.color } );
 		}
 	};
 
@@ -110,7 +111,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			case 'tagline':
 				return setTagline( event.currentTarget.value );
 			case 'accentColor':
-				return setAccentColor( event.currentTarget.value );
+				return setAccentColor( { color: event.currentTarget.value } );
 		}
 	};
 
@@ -138,8 +139,8 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 				>
 					<ColorPicker
 						disableAlpha
-						color={ accentColor || '#000000' }
-						onChangeComplete={ ( value ) => setAccentColor( value.hex ) }
+						color={ accentColor.color }
+						onChangeComplete={ ( { hex } ) => setAccentColor( { color: hex } ) }
 					/>
 				</Popover>
 				<FormFieldset>
@@ -177,8 +178,8 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						className="newsletter-setup__accent-color"
 						style={ {
 							backgroundImage: [
-								generateSwatchSVG( accentColor ?? DEFAULT_ACCENT_COLOR ),
-								getBackgroundImage( accentColor ?? DEFAULT_ACCENT_COLOR ),
+								generateSwatchSVG( accentColor.color ),
+								getBackgroundImage( accentColor.color ),
 							].join( ', ' ),
 							...( accentColor.default && { color: 'var( --studio-gray-30 )' } ),
 						} }
@@ -186,7 +187,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 						id="accentColor"
 						onFocus={ () => setColorPickerOpen( ! colorPickerOpen ) }
 						readOnly
-						value={ accentColor ?? DEFAULT_ACCENT_COLOR }
+						value={ accentColor.color }
 					/>
 				</FormFieldset>
 				<Button className="newsletter-setup__submit-button" type="submit" primary>


### PR DESCRIPTION
Addresses the issue raised here https://github.com/Automattic/wp-calypso/pull/67217#issuecomment-1234026719

#### Proposed Changes

* accent color input text color gray until user makes a selection
* black thenafter

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screen Capture on 2022-09-01 at 14-10-13](https://user-images.githubusercontent.com/2019970/187910803-d0bb6e92-01f1-4dbd-87dd-d4f9f3655dec.gif)


Closes #66995
