### PR TITLE
Fix issue when handling the onClose function in BlazePress

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -47,7 +47,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				);
 				setIsLoading( false );
 			} )();
-	}, [ isVisible, onClose, props.postId, props.siteId, selectedSiteSlug ] );
+	}, [ isVisible, props.postId, props.siteId, selectedSiteSlug ] );
 
 	const cancelDialogButtons = [
 		{


### PR DESCRIPTION
The widget was being reloaded because a function was in its dependencies. That dependency is removed and it should be working fine.

Testing
N/A