### PR TITLE
HelpCenter: fix hidden header tooltips (1 Min Review)

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -86,7 +86,6 @@ $head-foot-height: 50px;
 			height: 80vh;
 			max-height: 800px;
 			box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
-			overflow: auto;
 
 			.help-center__container-header {
 				cursor: move;


### PR DESCRIPTION
## Proposed Changes

Remove overflow from HelpCenter CSS. This was causing issues with tooltips being cutoff. Oddly enough this was only present in Calypso, not editor.

## Testing Instructions

#### Calypso
1. Pull branch and `yarn start`
2. Open HelpCenter in Calypso
3. Minimize the window and hover on the icons. The tooltips should fully appear.
4. Click through articles and support to look for regression.

#### Editor
1. Pull branch and `cd apps/editing-toolkit/ && yarn dev --sync` be sure to login to sandbox and point your DNS
2. Open HelpCenter in the editor
3. Minimize the window and hover on the icons. The tooltips should fully appear.
4. Click through articles and support to look for regression.
