### PR TITLE
BlazePress: Add modal to stats

### DIFF
--- a/client/my-sites/stats/stats-list/action-promote.jsx
+++ b/client/my-sites/stats/stats-list/action-promote.jsx
@@ -1,29 +1,36 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import {
 	recordDSPEntryPoint,
-	showDSPWidgetModal,
 	usePromoteWidget,
 	PromoteWidgetStatus,
 } from 'calypso/lib/promote-post';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PromotePost = ( props ) => {
-	const { moduleName, postId } = props;
+	const { moduleName, postId, onToggleVisibility } = props;
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const showPromotePost = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
+	const keyValue = 'post-' + postId;
+	const { isModalOpen, value, openModal, closeModal } = useRouteModal(
+		'blazepress-widget',
+		keyValue
+	);
+
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	const showDSPWidget = async ( event ) => {
 		event.stopPropagation();
-		await showDSPWidgetModal( selectedSiteSlug, selectedSiteId, postId );
+		onToggleVisibility( true );
+		openModal();
 
 		gaRecordEvent(
 			'Stats',
@@ -37,6 +44,15 @@ const PromotePost = ( props ) => {
 		<>
 			{ showPromotePost && (
 				<li className="stats-list__item-action module-content-list-item-action">
+					<BlazePressWidget
+						isVisible={ isModalOpen && value === keyValue }
+						siteId={ selectedSiteId }
+						postId={ postId }
+						onClose={ () => {
+							closeModal();
+							onToggleVisibility( false );
+						} }
+					/>
 					<button
 						onClick={ showDSPWidget }
 						rel="noopener noreferrer"

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -26,6 +26,7 @@ class StatsListItem extends Component {
 		active: this.props.active,
 		actionMenuOpen: false,
 		disabled: false,
+		promoteWidgetOpen: false,
 	};
 
 	addMenuListener = () => {
@@ -79,6 +80,10 @@ class StatsListItem extends Component {
 			return;
 		}
 
+		if ( this.state.promoteWidgetOpen ) {
+			return;
+		}
+
 		debug( 'props', this.props );
 		if ( ! this.state.disabled ) {
 			if ( this.props.children ) {
@@ -124,6 +129,12 @@ class StatsListItem extends Component {
 		const actionClassSet = classNames( 'module-content-list-item-actions', {
 			collapsed: actionMenu && ! this.state.disabled,
 		} );
+
+		const onTogglePromoteWidget = ( visible ) => {
+			this.setState( {
+				promoteWidgetOpen: visible,
+			} );
+		};
 
 		// If we have more than a default action build out actions ul
 		if ( data.actions ) {
@@ -173,7 +184,12 @@ class StatsListItem extends Component {
 			}, this );
 
 			actionItems.push(
-				<Promote postId={ data.id } key={ 'promote-post-' + data.id } moduleName={ moduleName } />
+				<Promote
+					postId={ data.id }
+					key={ 'promote-post-' + data.id }
+					moduleName={ moduleName }
+					onToggleVisibility={ onTogglePromoteWidget }
+				/>
 			);
 
 			if ( actionItems.length > 0 ) {


### PR DESCRIPTION
On the stats page the widget was being loaded the old way. This PR loads the widget inside the Modal.

### Testing
1. Apply this diff.
2.  Go to `http://calypso.localhost:3000/stats/day/[YOUR_SITE]`.
3. Click the Speaker icon. <img width="373" alt="image" src="https://user-images.githubusercontent.com/375980/187925674-02bd3a5f-790f-4b49-aa61-e57cffdee49d.png">
4. Verify you see the modal as always 
<img width="1450" alt="image" src="https://user-images.githubusercontent.com/375980/187925804-dd5cde51-2a31-4248-a679-03bbd3b55378.png">
