### PR TITLE
Jetpack New pricing page - fix the header text in WPcom

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION,
 	PLAN_JETPACK_FREE,
@@ -39,7 +40,9 @@ const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: Standard
 		{ ! shouldShowPlanRecommendation && (
 			<h2 className="jetpack-plans__pricing-header">
 				{ preventWidows(
-					translate( 'Security, performance, and marketing tools made for WordPress' )
+					! isEnabled( 'jetpack/pricing-page-rework-v1' )
+						? translate( 'Security, performance, and marketing tools made for WordPress' )
+						: translate( 'Best-in-class products for your WordPress site' )
 				) }
 			</h2>
 		) }


### PR DESCRIPTION
This PR updates the header text for the new pricing page in WPCOM

#### Proposed Changes

* Uses the flag to render header text on WPCOM plans page

#### Testing Instructions

* click on Calypso live link below
* or boot up this PR 
    * Run `git fetch && git checkout add/wpcom-plans-header;`
    * Run `yarn start`
    * Goto http://calypso.localhost:3000/
* If Jetpack is not connect for this site, setup a connection or switch to site which has jetpack connected
* In the siedebar navigate to `Upgrades->Plans->Plans Tab`
* Confirm that the header text shown on the page is **Security, performance, and marketing tools made for WordPress**
* Now add this query param(`?flags=jetpact/pricing-page-rework-v1`) in the URL to show the new pricing page and then reload
* Confirm that the text shown on the page is **Best-in-class products for your WordPress site**

#### Screenshots

##### Page without new pricing page flag 

![Screenshot 2022-09-01 at 7 28 39 PM](https://user-images.githubusercontent.com/2027003/187933620-047bf85d-be54-40fb-b6eb-09732c6f12a6.png)

##### Page with new pricing page flag

![Screenshot 2022-09-01 at 7 28 20 PM](https://user-images.githubusercontent.com/2027003/187933685-b8f56885-9c9a-4525-84d9-4796a1b010b8.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?



---
- Completes 1202796695664022-as-1202898214902395/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202898214902395