### PR TITLE
Update launchpad dependency validation logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -93,15 +93,15 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 
 // This function will determine whether we want to disable or enable a task on the checklist
 // If a task is completed, we disable it
-// If a task is NOT completed AND the task contains dependencies, we want to want check if all dependencies are set to true:
+// If a task is NOT completed AND the task contains dependencies, we want to check if all dependencies are set to true:
 //    ^ If all the dependencies are true, then the task is enabled
-//    ^ If all the dependencies are false, then the task is disabled
+//    ^ If at least one of the dependencies is false, then the task is disabled
 export function isTaskDisabled( task: Task ) {
 	if ( task.isCompleted ) {
 		return task.isCompleted;
 	}
 
 	if ( task.dependencies ) {
-		return task.dependencies.every( ( dependency: boolean ) => dependency === false );
+		return task.dependencies.some( ( dependency: boolean ) => dependency === false );
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This is an update for the Launchpad checklist dependencies validation. We will disable the checklist task if at least ONE dependency is false.

These changes only affect the `link-in-bio` launchpad flow. 

* **Disable the `Launch Link bio` until the user completes the `Add links` task**

Before completing `Add links` task:

<img width="458" alt="image" src="https://user-images.githubusercontent.com/10482592/187726296-90dde9cb-36c6-45d2-9008-7b7906fa8c88.png">


After completing `Add links` task:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/10482592/187726362-ebfd12aa-1bc3-46dc-ae1a-ae5314628c2e.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and execute `yarn start` command
* Create a new `link-in-bio` site. Visit https://wordpress.com/hp-2022-tailored-flows/ and scroll down to the` Put a dent in the web.` In 3 minutes flat. subheading. You should end up on the launchpad at the end of the flow.
* Switch to local calypso and load the launchpad page again (http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=YOUR_SITE_SLUG)
* **The `Add links` task should be enabled and the `Launch Link in bio` task should be disabled**
* Click the `Add links` task
* Navigate back to the launchpad using the navigation sidebar in the site editor
*  **The `Add links` task should be disabled and the `Launch Link in bio` task should be enabled**

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
