### PR TITLE
Update/subscriber package

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -130,7 +130,7 @@ class Followers extends Component {
 									siteId={ this.props.site.ID }
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 									onImportFinished={ () => {
-										page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+										page.redirect( `/people/invites/${ this.props.site.slug }` );
 									} }
 								/>
 							</EmailVerificationGate>

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -75,7 +75,7 @@ class PeopleInvites extends PureComponent {
 							siteId={ this.props.site.ID }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							onImportFinished={ () => {
-								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+								page.redirect( `/people/invites/${ this.props.site.slug }` );
 							} }
 						/>
 					</EmailVerificationGate>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -59,7 +59,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		__( 'parents@example.com' ),
 		__( 'friend@example.com' ),
 	];
-	const inProgress = useInProgressState();
+	const inProgress = useInProgressState( 0 );
 	const prevInProgress = useRef( inProgress );
 	const [ selectedFile, setSelectedFile ] = useState< File >();
 	const [ isSelectedFileValid, setIsSelectedFileValid ] = useState( true );

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -3,7 +3,7 @@ import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, NextButton, SkipButton } from '@automattic/onboarding';
 import { TextControl, FormFileUpload, Button, Notice } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
@@ -67,6 +67,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ isValidEmails, setIsValidEmails ] = useState< boolean[] >( [] );
 	const [ isDirtyEmails, setIsDirtyEmails ] = useState< boolean[] >( [] );
 	const [ emailFormControls, setEmailFormControls ] = useState( emailControlPlaceholder );
+	const importSelector = useSelect( ( s ) => s( SUBSCRIBER_STORE ).getImportSubscribersSelector() );
 	const [ formFileUploadElement ] = useState(
 		createElement( FormFileUpload, {
 			name: 'import',
@@ -78,9 +79,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	/**
 	 * ↓ Effects
 	 */
-	useEffect( () => {
-		prevInProgress.current = inProgress;
-	}, [ inProgress ] );
 	// get initial list of jobs
 	useEffect( () => {
 		getSubscribersImports( siteId );
@@ -88,8 +86,11 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	// run active job recognition process which updates state
 	useActiveJobRecognition( siteId );
 	useEffect( extendEmailFormControls, [ emails ] );
+	useEffect( importFinishedRecognition );
 
-	! inProgress && prevInProgress.current && onImportFinished?.();
+	useEffect( () => {
+		prevInProgress.current = inProgress;
+	}, [ inProgress ] );
 
 	/**
 	 * ↓ Functions
@@ -166,6 +167,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		}
 	}
 
+	function importFinishedRecognition() {
+		! importSelector?.error && prevInProgress.current && ! inProgress && onImportFinished?.();
+	}
+
 	/**
 	 * ↓ Templates
 	 */
@@ -179,6 +184,12 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			<div className={ 'add-subscriber__form--container' }>
 				{ inProgress && (
 					<Notice isDismissible={ false }>{ __( 'Your email list is being uploaded' ) }...</Notice>
+				) }
+
+				{ importSelector?.error && (
+					<Notice isDismissible={ false } status={ 'error' }>
+						{ importSelector.error.message as string }
+					</Notice>
 				) }
 
 				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>

--- a/packages/subscriber/src/hooks/use-active-job-recognition.ts
+++ b/packages/subscriber/src/hooks/use-active-job-recognition.ts
@@ -16,7 +16,9 @@ export function useActiveJobRecognition( siteId: number ) {
 	const jobs = imports.filter( ( x: ImportJob ) => ACTIVE_STATE.includes( x.status ) );
 	const activeJob = jobs.length ? jobs[ 0 ] : undefined;
 
-	importCsvSubscribersUpdate( activeJob );
+	useEffect( () => {
+		importCsvSubscribersUpdate( activeJob );
+	}, [ activeJob?.status ] );
 
 	useEffect( () => {
 		const interval = setInterval(

--- a/packages/subscriber/src/hooks/use-in-progress-state.ts
+++ b/packages/subscriber/src/hooks/use-in-progress-state.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { IMPORT_PROGRESS_SIMULATION_DURATION } from '../config';
 import { SUBSCRIBER_STORE } from '../store';
 
-export function useInProgressState() {
+export function useInProgressState( simulationDuration = IMPORT_PROGRESS_SIMULATION_DURATION ) {
 	const addSelector = useSelect( ( s ) => s( SUBSCRIBER_STORE ).getAddSubscribersSelector() );
 	const importSelector = useSelect( ( s ) => s( SUBSCRIBER_STORE ).getImportSubscribersSelector() );
 	const IN_PROGRESS = addSelector?.inProgress || importSelector?.inProgress;
@@ -15,7 +15,7 @@ export function useInProgressState() {
 		if ( inProgress ) {
 			timer = setTimeout( () => {
 				setInProgress( false );
-			}, IMPORT_PROGRESS_SIMULATION_DURATION );
+			}, simulationDuration );
 		}
 
 		return () => clearTimeout( timer );


### PR DESCRIPTION
#### Proposed Changes

* Reduced in progress/busy (simulated) time. Now, we are switching to the next step right after the successful API response.
* Show error message when API returns it.
* Redirect to the Invites tab after successfully adding new subscribers.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `https://wpcalypso.wordpress.com/people/email-followers/{SLUG}`
* Check if redirect to the Invites tab after successfully adding subscribers

#### Screenshots
<table>
<tr>
<td>
From:
<img width="754" alt="Screenshot 2022-09-02 at 14 16 02" src="https://user-images.githubusercontent.com/1241413/188141294-75b7a899-e6d1-4d8f-9306-e7ff04f7bfb7.png">
</td>
<td>
To:
<img width="744" alt="Screenshot 2022-09-02 at 14 16 12" src="https://user-images.githubusercontent.com/1241413/188141329-c0b2fd5d-0647-49bf-94c2-dca94c377fc8.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #67256
Closes #67084
Closes #67257