### PR TITLE
stepper: processing step: log errors to console

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -52,6 +52,8 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 					setDestinationState( destination );
 					setHasActionSuccessfullyRun( true );
 				} catch ( e ) {
+					// eslint-disable-next-line no-console
+					console.error( 'ProcessingStep failed:', e );
 					submit?.( {}, ProcessingResult.FAILURE );
 				}
 			} else {


### PR DESCRIPTION
#### Proposed Changes

* In stepper, when the ProcessingStep fails and sends you to an error page, log the error to the console
  * Should make investigations of stepper errors easier

#### Testing Instructions

* In an incognito window, create a new account, visit `http://calypso.localhost:3000/start`, create a new site, free plan, no intent, no vertical, choose geologist yellow design, see error. There should now be a report in the console.
  * You will need to unrevert the revert to recreate this error (1285fcad75522ad7c709b77bbbef1ea37e291ca5). Or create your own error.

![2022-09-01_10-24](https://user-images.githubusercontent.com/937354/187952214-acc7d3da-c5ba-460e-adf6-29a363efb5d2.png)



