### PR TITLE
Revert "Design Picker: Enable standard-theme-v13n flag"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,7 +111,7 @@
 		"signup/seller-upgrade-modal": false,
 		"signup/site-vertical-step": true,
 		"signup/social": true,
-		"signup/standard-theme-v13n": true,
+		"signup/standard-theme-v13n": false,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
 		"signup/theme-preview-screen": true,

--- a/config/production.json
+++ b/config/production.json
@@ -129,7 +129,7 @@
 		"signup/seller-upgrade-modal": false,
 		"signup/site-vertical-step": true,
 		"signup/social": true,
-		"signup/standard-theme-v13n": true,
+		"signup/standard-theme-v13n": false,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
 		"signup/theme-preview-screen": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -128,7 +128,7 @@
 		"signup/seller-upgrade-modal": false,
 		"signup/site-vertical-step": true,
 		"signup/social": true,
-		"signup/standard-theme-v13n": true,
+		"signup/standard-theme-v13n": false,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
 		"signup/theme-preview-screen": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,7 +136,7 @@
 		"signup/seller-upgrade-modal": false,
 		"signup/site-vertical-step": true,
 		"signup/social": true,
-		"signup/standard-theme-v13n": true,
+		"signup/standard-theme-v13n": false,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
 		"signup/theme-preview-screen": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#67077