### PR TITLE
Site Switcher: Add Tracks event for click on site item

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -196,7 +196,7 @@ export class SiteSelector extends Component {
 		if ( siteId !== ALL_SITES ) {
 			const visibleSites = this.visibleSites.filter( ( ID ) => ID !== ALL_SITES );
 			this.props.recordTracksEvent( 'calypso_switch_site_click_item', {
-				position: visibleSites.indexOf( siteId ),
+				position: visibleSites.indexOf( siteId ) + 1,
 				list_item_count: visibleSites.length,
 				is_searching: this.state.searchTerm.length > 0,
 			} );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -198,7 +198,7 @@ export class SiteSelector extends Component {
 			this.props.recordTracksEvent( 'calypso_switch_site_click_item', {
 				position: visibleSites.indexOf( siteId ),
 				list_item_count: visibleSites.length,
-				is_searching: this.state.searchTerm.trim().length > 0,
+				is_searching: this.state.searchTerm.length > 0,
 			} );
 		}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -76,6 +76,7 @@ export class SiteSelector extends Component {
 		highlightedIndex: -1,
 		showSearch: false,
 		isKeyboardEngaged: false,
+		searchTerm: '',
 	};
 
 	onSearch = ( terms ) => {
@@ -85,6 +86,7 @@ export class SiteSelector extends Component {
 			highlightedIndex: terms ? 0 : -1,
 			showSearch: terms ? true : this.state.showSearch,
 			isKeyboardEngaged: true,
+			searchTerm: terms,
 		} );
 	};
 
@@ -191,6 +193,15 @@ export class SiteSelector extends Component {
 	};
 
 	onSiteSelect = ( event, siteId ) => {
+		if ( siteId !== ALL_SITES ) {
+			const visibleSites = this.visibleSites.filter( ( ID ) => ID !== ALL_SITES );
+			this.props.recordTracksEvent( 'calypso_switch_site_click_item', {
+				position: visibleSites.indexOf( siteId ),
+				list_item_count: visibleSites.length,
+				is_searching: this.state.searchTerm.trim().length > 0,
+			} );
+		}
+
 		const handledByHost = this.props.onSiteSelect( siteId );
 		this.props.onClose( event, siteId );
 


### PR DESCRIPTION
#### Proposed Changes

* Add track `calypso_switch_site_click_item` whenever an item is clicked from the site switcher
![image](https://user-images.githubusercontent.com/47489215/187975331-7b7188f0-fce0-4b5d-b2c6-98cfefa59358.png)


#### Testing Instructions

- In your console enter `localStorage.setItem( 'debug', 'calypso:analytics*' );`
- Go to site switcher, select a site and verify the track event is logged based on the screenshot
- Enter a search term, select a site and verify the track event is logged.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/67209
