### PR TITLE
[etk] Remove deprecated `hide-plugin-buttons-mobile` fix

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.js
@@ -1,1 +1,0 @@
-import './hide-plugin-buttons-mobile.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.scss
@@ -1,9 +1,0 @@
-@import '@wordpress/base-styles/mixins';
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/breakpoints';
-
-.interface-pinned-items > button:not( :first-child ) {
-	@media ( max-width: $break-medium ) {
-		display: none;
-	}
-}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -204,27 +204,6 @@ function get_iso_639_locale( $language ) {
 }
 
 /**
- * Hides plugin buttons that appear in the header on mobile devices
- * (because there's not enough room).
- *
- * Can be disabled with the `a8c_fse_enqueue_hide_plugin_buttons_mobile_style` filter.
- */
-function enqueue_hide_plugin_buttons_mobile_style() {
-	if ( apply_filters( 'a8c_fse_enqueue_hide_plugin_buttons_mobile_style', true ) ) {
-		$style_file = is_rtl()
-			? 'hide-plugin-buttons-mobile.rtl.css'
-			: 'hide-plugin-buttons-mobile.css';
-		wp_enqueue_style(
-			'a8c-fse-hide-plugin-buttons-mobile',
-			plugins_url( 'dist/' . $style_file, __FILE__ ),
-			array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
-		);
-	}
-}
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_hide_plugin_buttons_mobile_style' );
-
-/**
  * Prevent HEIC images from being uploaded by drag and drop
  * See: https://github.com/Automattic/wp-calypso/issues/55102
  *

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"build": "NODE_ENV=production yarn dev",
 		"build:block-inserter-modifications": "calypso-build --env source='block-inserter-modifications/contextual-tips'",
-		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url'",
+		"build:common": " calypso-build --env source='common','common/data-stores','common/disable-heic-images','common/override-preview-button-url'",
 		"build:error-reporting": "calypso-build --env source='error-reporting'",
 		"build:event-countdown-block": "calypso-build --env source='event-countdown-block'",
 		"build:global-styles": "calypso-build --env source='global-styles'",


### PR DESCRIPTION
#### Proposed Changes

Follow up to: https://github.com/Automattic/wp-calypso/pull/49329

Further context: p1661852852314429-slack-C7YPUHBB2

I don't think this fix is needed anymore. I did a quick test here, and it seems the display: none is not even being applied anymore, being superseded by other rules in core GB. Notice how the blue background is applied, but the element is still visible:

https://user-images.githubusercontent.com/81248/187983309-7709b35c-dcb7-4044-8698-2b4db74306c2.mp4

Thanks @simison for reaching out about this.


#### Testing Instructions

* Checkout branch, sandbox a test site, and run yarn dev --sync
* Open a post or page in the block editor
* Shrink viewport down to mobile size and observe the plugin buttons disappear (they should still be available in the more menu)
* The menu layout should not break.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->