### PR TITLE
Jetpack: Redirect jetpack-videopress connections back to wp-admin

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -269,7 +269,8 @@ export class JetpackAuthorize extends Component {
 			this.isFromJetpackConnectionManager() ||
 			this.isFromJetpackSocialPlugin() ||
 			this.isFromMyJetpack() ||
-			this.isFromJetpackSearchPlugin()
+			this.isFromJetpackSearchPlugin() ||
+			this.isFromJetpackVideoPressPlugin()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -370,6 +371,11 @@ export class JetpackAuthorize extends Component {
 	isFromJetpackSocialPlugin( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jetpack-social' );
+	}
+
+	isFromJetpackVideoPressPlugin( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-videopress' );
 	}
 
 	isFromMyJetpack( props = this.props ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/25995

#### Proposed Changes

* Adds a condition to redirect connections from Jetpack VideoPress standalone plugin back to wp-admin.


#### Testing Instructions

* Checkout this branch locally in Calypso ( or rely on Calypso live branches)
* From an unconnected site using only the Jetpack VideoPress plugin. (or a JN site launched with [this link](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-videopress=master&wp-debug-log&nojetpack)), attempt to connect "Log in to get started" link and stop in the "Completing Setup" screen. The one with the green button reading "Approve"
* In the URL bar change `wordpress.com` to `calypso.localhost:3000` and press enter
  * You can also use the domain name provided by Calypso's live branches below this description)
  <img width="929" alt="image" src="https://user-images.githubusercontent.com/746152/187990609-22dc96b3-9b5e-4b8b-8c5e-f65c34fb2540.png">
 * Approve the connection
* Ensure that you land back into the Jetpack VideoPress admin page
(You can also see the video for how to test. Pay attention to the address bar)

https://user-images.githubusercontent.com/746152/187990159-dad34e98-ef18-466d-9c03-c7760fc78af6.mov


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to https://github.com/Automattic/jetpack/issues/25995
