### PR TITLE
Add VCS to sourcemap uploader job

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -192,6 +192,12 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 		name = "Upload Gutenberg Source Maps to Sentry";
 		id("WPComPlugins_GutenbergUploadSourceMapsToSentry");
 
+		// Only needed so that we can test the job in different branches.
+		vcs {
+			root(Settings.WpCalypso)
+			cleanCheckout = true
+		}
+
 		params {
 			text(
 				name = "GUTENBERG_VERSION",


### PR DESCRIPTION
#### Proposed Changes
I realized in #67240 that we can't test the job using configuration specific to the branch. (E.g. in https://teamcity.a8c.com/buildConfiguration/calypso_WPComPlugins_GutenbergUploadSourceMapsToSentry, there's no option to run with "changes")

My theory is that we need to add the VCS root for that to work, which is what I do here. This should only add a few seconds to the build time, though it doesn't really impact the build.

#### Testing Instructions

None, this can only be tested on trunk. If TeamCity builds complete successfully, that means the syntax is correct, at least.

