### PR TITLE
HelpCenter: Live Chat minimized title (1 min review)

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -84,13 +84,14 @@ const HelpCenterHeader: React.FC< Header > = ( {
 							</Route>
 							<Route path="/contact-form" component={ SupportModeTitle }></Route>
 							<Route path="/post" component={ ArticleTitle }></Route>
+							<Route path="/inline-chat">{ __( 'Live Chat', __i18n_text_domain__ ) }</Route>
 						</Switch>
 					) : (
 						__( 'Help Center', __i18n_text_domain__ )
 					) }
-					{ isMinimized && unreadCount ? (
+					{ isMinimized && unreadCount && (
 						<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>
-					) : null }
+					) }
 				</p>
 				<div>
 					{ isMinimized ? (

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -89,7 +89,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 					) : (
 						__( 'Help Center', __i18n_text_domain__ )
 					) }
-					{ isMinimized && unreadCount && (
+					{ isMinimized && unreadCount > 0 && (
 						<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>
 					) }
 				</p>


### PR DESCRIPTION
## Proposed Changes

This adds the title "Live Chat" to the minimized Help Center window while chatting. This does not fix the UNREAD COUNT that will be addressed in a following PR.


## Testing Instructions

#### Calypso
1. Pull branch and `yarn start`
2. Open HelpCenter in Calypso
3. Open a live chat session and minimize the window
4. Observe the title is "Live Chat"

#### Editor
1. Pull branch and `cd apps/editing-toolkit/ && yarn dev --sync` be sure to login to sandbox and point your DNS
2. Open HelpCenter in the editor
3. Open a live chat session and minimize the window
4. Observe the title is "Live Chat"