### PR TITLE
Launchpad: Use query params for my home redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -25,7 +25,7 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 
 	useEffect( () => {
 		if ( launchpadScreenOption === 'off' ) {
-			window.location.replace( `/home/${ siteSlug }/?forceLoad=true` );
+			window.location.replace( `/home/${ siteSlug }/?forceLoadLaunchpadData=true` );
 		}
 	}, [ launchpadScreenOption, siteSlug ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -25,7 +25,7 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 
 	useEffect( () => {
 		if ( launchpadScreenOption === 'off' ) {
-			window.location.replace( `/home/${ siteSlug }` );
+			window.location.replace( `/home/${ siteSlug }/?forceLoad=true` );
 		}
 	}, [ launchpadScreenOption, siteSlug ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -83,7 +83,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace( `/home/${ siteSlug }` );
+									window.location.replace( `/home/${ siteSlug }?forceLoad=true` );
 								} );
 
 								submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -83,7 +83,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace( `/home/${ siteSlug }?forceLoad=true` );
+									window.location.replace( `/home/${ siteSlug }?forceLoadLaunchpadData=true` );
 								} );
 
 								submit?.();

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,8 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { select } from '@wordpress/data';
 import page from 'page';
-import { canCurrentUserUseCustomerHome, getSiteOptions } from 'calypso/state/sites/selectors';
+import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { redirectToLaunchpad } from 'calypso/utils';
+import { SITE_STORE } from '../../landing/stepper/stores';
 import CustomerHome from './main';
 
 export default async function ( context, next ) {
@@ -29,7 +31,15 @@ export function maybeRedirect( context, next ) {
 	}
 
 	const siteId = getSelectedSiteId( state );
-	const options = getSiteOptions( state, siteId );
+	const { getSite, getSiteOptions } = select( SITE_STORE );
+	const options = getSiteOptions( siteId );
+
+	console.log( {
+		site: getSite( siteId ),
+		option: getSiteOptions( siteId ),
+		select: select( SITE_STORE ),
+	} );
+
 	const shouldRedirectToLaunchpad = options?.launchpad_screen === 'full';
 
 	if ( shouldRedirectToLaunchpad && isEnabled( 'signup/launchpad' ) ) {

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -34,10 +34,11 @@ export function maybeRedirect( context, next ) {
 
 	// Normally, checking the launchpad_screen option in redux state would be enough to decide whether
 	// or not to redirect to launchpad. The option, however, is loading stale data in horizon, and presumably,
-	// in production as well. The forceLoad query param is a temporary patch to circumvent stale data, and
+	// in production as well. The forceLoadLaunchpadData query param is a temporary patch to circumvent stale data, and
 	// will avoid a redirect.
 	const shouldRedirectToLaunchpad =
-		options?.launchpad_screen === 'full' && ! getQueryArg( window.location.href, 'forceLoad' );
+		options?.launchpad_screen === 'full' &&
+		! getQueryArg( window.location.href, 'forceLoadLaunchpadData' );
 
 	if ( shouldRedirectToLaunchpad && isEnabled( 'signup/launchpad' ) ) {
 		// The new stepper launchpad onboarding flow isn't registered within the "page"

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,10 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { select } from '@wordpress/data';
+import { getQueryArg } from '@wordpress/url';
 import page from 'page';
-import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
+import { canCurrentUserUseCustomerHome, getSiteOptions } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { redirectToLaunchpad } from 'calypso/utils';
-import { SITE_STORE } from '../../landing/stepper/stores';
 import CustomerHome from './main';
 
 export default async function ( context, next ) {
@@ -31,16 +30,14 @@ export function maybeRedirect( context, next ) {
 	}
 
 	const siteId = getSelectedSiteId( state );
-	const { getSite, getSiteOptions } = select( SITE_STORE );
-	const options = getSiteOptions( siteId );
+	const options = getSiteOptions( state, siteId );
 
-	console.log( {
-		site: getSite( siteId ),
-		option: getSiteOptions( siteId ),
-		select: select( SITE_STORE ),
-	} );
-
-	const shouldRedirectToLaunchpad = options?.launchpad_screen === 'full';
+	// Normally, checking the launchpad_screen option in redux state would be enough to decide whether
+	// or not to redirect to launchpad. The option, however, is loading stale data in horizon, and presumably,
+	// in production as well. The forceLoad query param is a temporary patch to circumvent stale data, and
+	// will avoid a redirect.
+	const shouldRedirectToLaunchpad =
+		options?.launchpad_screen === 'full' && ! getQueryArg( window.location.href, 'forceLoad' );
 
 	if ( shouldRedirectToLaunchpad && isEnabled( 'signup/launchpad' ) ) {
 		// The new stepper launchpad onboarding flow isn't registered within the "page"


### PR DESCRIPTION
#### Context

We check the `launchpad_screen` option in redux state to decide whether or not to redirect to launchpad. Unfortunately, the option value is stale when we redirect to `/home` after launching our link-in-bio site on `horizon.wordpress.com`. We add a `forceLoad` query param when redirecting to `/home` as **a temporary patch** to suppress launchpad redirection.

![2022-09-01 16 27 11](https://user-images.githubusercontent.com/5414230/188029138-9dde9b3c-065a-4124-ba62-f68a202333a2.gif)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Note:** The infinite redirect bug that this PR patches can only be reproduced on horizon.wordpress.com. As a result, we can only verify that ancillary behavior is working properly

* https://calypso.localhost:3000/setup/intro?flow=link-in-bio
* Walk through steps until arriving at the launchpad
* Complete the edit links task
* Complete the launch site task
* Verify that, after redirecting to `/home`, the url has a `forceLoadLaunchpadData` query param appended to it Ex. `http://calypso.localhost:3000/home/YOUR_SITE_SLUG?forceLoad=true`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
