### PR TITLE
Launchpad: Toggle launchpad_screen to 'off' if force loading my home

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { getQueryArg } from '@wordpress/url';
 import page from 'page';
-import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import { requestSite } from 'calypso/state/sites/actions';
 import { canCurrentUserUseCustomerHome, getSiteOptions } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { redirectToLaunchpad } from 'calypso/utils';
@@ -38,18 +38,13 @@ export function maybeRedirect( context, next ) {
 	// or not to redirect to launchpad. The option, however, is loading stale data in horizon, and presumably,
 	// in production as well. The forceLoadLaunchpadData query param is a temporary patch to circumvent stale data, and
 	// will avoid a redirect.
-	const forceLoadLaunchpadDataParam = getQueryArg( window.location.href, 'forceLoadLaunchpadData' );
+	const forceRequestSiteParam = getQueryArg( window.location.href, 'forceLoadLaunchpadData' );
 
-	if ( forceLoadLaunchpadDataParam ) {
-		dispatch(
-			saveSiteSettings( siteId, {
-				launchpad_screen: 'off',
-			} )
-		);
+	if ( forceRequestSiteParam ) {
+		dispatch( requestSite( siteId ) );
 	}
 
-	const shouldRedirectToLaunchpad =
-		options?.launchpad_screen === 'full' && ! forceLoadLaunchpadDataParam;
+	const shouldRedirectToLaunchpad = options?.launchpad_screen === 'full' && ! forceRequestSiteParam;
 
 	if ( shouldRedirectToLaunchpad && isEnabled( 'signup/launchpad' ) ) {
 		// The new stepper launchpad onboarding flow isn't registered within the "page"


### PR DESCRIPTION
#### Proposed Changes

* Updates the `launchpad_screen` site option in state when we force load the `/home` page

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- https://calypso.localhost:3000/setup/intro?flow=link-in-bio
- Walk through steps until arriving at the launchpad
- Complete the edit links task
- Complete the launch site task
- Verify that, after redirecting to /home, the url has a forceLoadLaunchpadData query param appended to it Ex. http://calypso.localhost:3000/home/YOUR_SITE_SLUG?forceLoad=true
- Verify that, in the network tab of the chrome dev console, a network request has been made to the `/settings` endpoint to update the `launchpad_screen` site option

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
