### PR TITLE
Use the correct function names for the signup flow and calypso /plans…

### DIFF
--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -9,28 +9,33 @@ const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 	return flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioSignupFeatures;
 };
 
-const blogFeatures = ( siteType: string, plan: IncompleteWPcomPlan ) => {
-	return siteType === 'blog' && plan.getBlogSignupFeatures;
-};
+const defaulSignupFlowFeatures = (
+	flowName: string,
+	plan: IncompleteWPcomPlan,
+	isInVerticalScrollingPlansExperiment: boolean
+) => {
+	if ( ! flowName || [ LINK_IN_BIO_FLOW, NEWSLETTER_FLOW ].includes( flowName ) ) {
+		return;
+	}
 
-const portfolioFeatures = ( siteType: string, plan: IncompleteWPcomPlan ) => {
-	return siteType === 'grid' && plan.getPortfolioSignupFeatures;
+	return isInVerticalScrollingPlansExperiment
+		? plan.getSignupFeatures
+		: plan.getSignupCompareAvailableFeatures;
 };
 
 export const getPlanFeatureAccessor = ( {
 	flowName = '',
-	siteType = '',
+	isInVerticalScrollingPlansExperiment,
 	plan,
 }: {
 	flowName?: string;
-	siteType?: string;
+	isInVerticalScrollingPlansExperiment: boolean;
 	plan: IncompleteWPcomPlan;
 } ) => {
 	return [
 		newsletterFeatures( flowName, plan ),
 		linkInBioFeatures( flowName, plan ),
-		blogFeatures( siteType, plan ),
-		portfolioFeatures( siteType, plan ),
+		defaulSignupFlowFeatures( flowName, plan, isInVerticalScrollingPlansExperiment ),
 	].find( ( accessor ) => {
 		return accessor instanceof Function;
 	} );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -962,6 +962,7 @@ const ConnectedPlanFeatures = connect(
 			popularPlanSpec,
 			kindOfPlanTypeSelector,
 			isPlansPageQuickImprovements,
+			isInVerticalScrollingPlansExperiment,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -1020,8 +1021,8 @@ const ConnectedPlanFeatures = connect(
 				if ( isInSignup ) {
 					const featureAccessor = getPlanFeatureAccessor( {
 						flowName,
-						siteType,
 						plan: planConstantObj,
+						isInVerticalScrollingPlansExperiment,
 					} );
 					if ( ! isPlansPageQuickImprovements && featureAccessor ) {
 						planFeatures = getPlanFeaturesObject( featureAccessor() );


### PR DESCRIPTION
… view

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
