### PR TITLE
Jetpack Cloud: Apply Jetpack cloud base styles when user is logged out

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -11,6 +11,7 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import MasterbarLogin from 'calypso/layout/masterbar/login';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
@@ -113,6 +114,9 @@ const LayoutLoggedOut = ( {
 		<div className={ classNames( 'layout', classes ) }>
 			<BodySectionCssClass group={ sectionGroup } section={ sectionName } bodyClass={ bodyClass } />
 			{ masterbar }
+			{ isJetpackCloud() && (
+				<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />
+			) }
 			<div id="content" className="layout__content">
 				<AsyncLoad require="calypso/components/global-notices" placeholder={ null } id="notices" />
 				{ isCheckout && <AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } /> }


### PR DESCRIPTION
#### Proposed Changes

* Please see #51288
* This PR adds Jetpack Cloud base styles for logged-out users.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing?flags=jetpack/pricing-page-rework-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout fix/load-jp-cloud-base-styles`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1)
- Login (if you are not already logged in)
- Open an incognito/private window and enter the same URL
- Compare that the styles are the same for both pages.
- Open dev tools in private window and Goto `Sources` > `top` >  `<jetpack cloud url>` > `calypso` > `evergreen`
- Confirm that `async-load-calypso-jetpack-cloud-style.css` is in the list.
- Confirm that there is no regression 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: 1202796695664022-as-1202891213307274/f

| BEFORE | AFTER |
| - | - |
|<img width="1201" alt="Screenshot 2022-09-02 at 2 16 02 PM" src="https://user-images.githubusercontent.com/18226415/188101963-d38f3422-dd25-4df8-bdd9-851c89ce903f.png">|<img width="1201" alt="Screenshot 2022-09-02 at 2 17 52 PM" src="https://user-images.githubusercontent.com/18226415/188102039-3ea5fc8b-fbe5-40fd-8763-a6c1b9b0c424.png">|

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202891213307274