### PR TITLE
Take 2: Add signup flow related features for Newsletter and Link in Bio

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -186,6 +186,20 @@ import {
 	FEATURE_ADVANCED_SEO_V2,
 	FEATURE_COLLECT_PAYMENTS_V3,
 	/* END - WPCOM Plan grid features update experiment */
+	FEATURE_UNLIMITED_EMAILS,
+	FEATURE_UNLIMITED_SUBSCRIBERS,
+	FEATURE_IMPORT_SUBSCRIBERS,
+	FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER,
+	FEATURE_AD_FREE_EXPERIENCE,
+	FEATURE_COLLECT_PAYMENTS_NEWSLETTER,
+	FEATURE_POST_BY_EMAIL,
+	FEATURE_REAL_TIME_ANALYTICS,
+	FEATURE_GOOGLE_ANALYTICS_V2,
+	FEATURE_ADD_UNLIMITED_LINKS,
+	FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+	FEATURE_TRACK_VIEWS_CLICKS,
+	FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
+	FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -1745,6 +1759,65 @@ export const FEATURES_LIST = {
 			i18n.translate(
 				'Boost traffic to your site with tools that make your content more findable on search engines and social media.'
 			),
+	},
+	[ FEATURE_UNLIMITED_EMAILS ]: {
+		getSlug: () => FEATURE_UNLIMITED_EMAILS,
+		getTitle: () => i18n.translate( 'Send unlimited emails' ),
+	},
+	[ FEATURE_UNLIMITED_SUBSCRIBERS ]: {
+		getSlug: () => FEATURE_UNLIMITED_SUBSCRIBERS,
+		getTitle: () => i18n.translate( 'Unlimited subscribers' ),
+	},
+	[ FEATURE_IMPORT_SUBSCRIBERS ]: {
+		getSlug: () => FEATURE_IMPORT_SUBSCRIBERS,
+		getTitle: () => i18n.translate( 'Import subscribers' ),
+	},
+	[ FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER ]: {
+		getSlug: () => FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER,
+		getTitle: () => i18n.translate( `Add multiple pages to your Newsletter's website` ),
+	},
+	[ FEATURE_AD_FREE_EXPERIENCE ]: {
+		getSlug: () => FEATURE_AD_FREE_EXPERIENCE,
+		getTitle: () => i18n.translate( 'Ad-free experience' ),
+	},
+	[ FEATURE_COLLECT_PAYMENTS_NEWSLETTER ]: {
+		getSlug: () => FEATURE_COLLECT_PAYMENTS_NEWSLETTER,
+		getTitle: () =>
+			i18n.translate( 'Monetize your Newsletter with payments, subscriptions, and donations' ),
+	},
+	[ FEATURE_POST_BY_EMAIL ]: {
+		getSlug: () => FEATURE_POST_BY_EMAIL,
+		getTitle: () => i18n.translate( 'Post by email' ),
+	},
+	[ FEATURE_REAL_TIME_ANALYTICS ]: {
+		getSlug: () => FEATURE_REAL_TIME_ANALYTICS,
+		getTitle: () => i18n.translate( 'Real-time analytics in your dashboard' ),
+	},
+	[ FEATURE_GOOGLE_ANALYTICS_V2 ]: {
+		getSlug: () => FEATURE_GOOGLE_ANALYTICS_V2,
+		getTitle: () =>
+			i18n.translate( 'Go deeper into site stats and insights with Google Analytics' ),
+	},
+	[ FEATURE_ADD_UNLIMITED_LINKS ]: {
+		getSlug: () => FEATURE_ADD_UNLIMITED_LINKS,
+		getTitle: () => i18n.translate( 'Add unlimited links to your page' ),
+	},
+	[ FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS ]: {
+		getSlug: () => FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+		getTitle: () => i18n.translate( 'Customizable themes, buttons, colors' ),
+	},
+	[ FEATURE_TRACK_VIEWS_CLICKS ]: {
+		getSlug: () => FEATURE_TRACK_VIEWS_CLICKS,
+		getTitle: () => i18n.translate( 'Track your view and click stats' ),
+	},
+	[ FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO ]: {
+		getSlug: () => FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
+		getTitle: () =>
+			i18n.translate( 'Monetize your Link in Bio with payments, subscriptions, and donations' ),
+	},
+	[ FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION ]: {
+		getSlug: () => FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
+		getTitle: () => i18n.translate( 'Advanced link in bio themes and customization' ),
 	},
 	/* END - WPCOM Plan grid features update experiment */
 };

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -27,6 +27,10 @@ import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { useExperiment } from 'calypso/lib/explat';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import {
+	getHighlightedFeatures,
+	getPlanFeatureAccessor,
+} from 'calypso/my-sites/plan-features-comparison/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import {
@@ -39,6 +43,7 @@ import {
 import { getProductCost } from 'calypso/state/products-list/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import {
 	getPlanDiscountedRawPrice,
 	getSitePlanRawPrice,
@@ -46,7 +51,6 @@ import {
 import PlanFeaturesComparisonActions from './actions';
 import PlanFeaturesComparisonHeader from './header';
 import { PlanFeaturesItem } from './item';
-
 import './style.scss';
 
 const noop = () => {};
@@ -300,7 +304,7 @@ export class PlanFeaturesComparison extends Component {
 					'is-last-feature': rowIndex + 1 === featureKeys.length,
 					'is-highlighted':
 						selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
-					'is-bold': rowIndex === 0,
+					'is-bold': rowIndex === 0 || currentFeature?.isHighlightedFeature,
 					'is-plans-quick-improvements': isPlansPageQuickImprovements,
 				}
 			);
@@ -376,6 +380,7 @@ const ConnectedPlanFeaturesComparison = connect(
 		} = ownProps;
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
+		const flowName = getCurrentFlowName( state );
 
 		let planProperties = compact(
 			map( plans, ( plan ) => {
@@ -407,10 +412,9 @@ const ConnectedPlanFeaturesComparison = connect(
 					isPlaceholder = true;
 				}
 
-				if ( ! isPlansPageQuickImprovements && planConstantObj.getSignupCompareAvailableFeatures ) {
-					planFeatures = getPlanFeaturesObject(
-						planConstantObj.getSignupCompareAvailableFeatures()
-					);
+				const featureAccessor = getPlanFeatureAccessor( { flowName, plan: planConstantObj } );
+				if ( ! isPlansPageQuickImprovements && featureAccessor ) {
+					planFeatures = getPlanFeaturesObject( featureAccessor() );
 				}
 
 				const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
@@ -451,6 +455,16 @@ const ConnectedPlanFeaturesComparison = connect(
 							...feature,
 							availableOnlyForAnnualPlans,
 							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+						};
+					} );
+				}
+
+				const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
+				if ( highlightedFeatures.length ) {
+					planFeatures = planFeatures.map( ( feature ) => {
+						return {
+							...feature,
+							isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
 						};
 					} );
 				}

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -1,0 +1,78 @@
+import { IncompleteWPcomPlan } from '@automattic/calypso-products';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+
+const newsletterFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return flowName === NEWSLETTER_FLOW && plan.getNewsletterSignupFeatures;
+};
+
+const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioSignupFeatures;
+};
+
+const blogFeatures = ( siteType: string, plan: IncompleteWPcomPlan ) => {
+	return siteType === 'blog' && plan.getBlogSignupFeatures;
+};
+
+const portfolioFeatures = ( siteType: string, plan: IncompleteWPcomPlan ) => {
+	return siteType === 'grid' && plan.getPortfolioSignupFeatures;
+};
+
+export const getPlanFeatureAccessor = ( {
+	flowName = '',
+	siteType = '',
+	plan,
+}: {
+	flowName?: string;
+	siteType?: string;
+	plan: IncompleteWPcomPlan;
+} ) => {
+	return [
+		newsletterFeatures( flowName, plan ),
+		linkInBioFeatures( flowName, plan ),
+		blogFeatures( siteType, plan ),
+		portfolioFeatures( siteType, plan ),
+	].find( ( accessor ) => {
+		return accessor instanceof Function;
+	} );
+};
+
+const newsletterHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return flowName === NEWSLETTER_FLOW && plan.getNewsletterHighlightedFeatures;
+};
+
+const linkInBioHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioHighlightedFeatures;
+};
+
+export const getHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	const accessor = [
+		newsletterHighlightedFeatures( flowName, plan ),
+		linkInBioHighlightedFeatures( flowName, plan ),
+	].find( ( accessor ) => {
+		return accessor instanceof Function;
+	} );
+
+	return ( accessor && accessor() ) || [];
+};
+
+export const getPlanDescriptionForMobile = ( {
+	flowName,
+	isInVerticalScrollingPlansExperiment,
+	plan,
+}: {
+	flowName: string;
+	isInVerticalScrollingPlansExperiment: boolean;
+	plan: IncompleteWPcomPlan;
+} ) => {
+	if ( flowName === NEWSLETTER_FLOW && plan.getNewsletterDescription ) {
+		return plan.getNewsletterDescription();
+	}
+
+	if ( flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioDescription ) {
+		return plan.getLinkInBioDescription();
+	}
+
+	return plan.getShortDescription && isInVerticalScrollingPlansExperiment
+		? plan.getShortDescription()
+		: plan.getDescription();
+};

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -9,28 +9,33 @@ const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 	return flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioSignupFeatures;
 };
 
-const blogFeatures = ( siteType: string, plan: IncompleteWPcomPlan ) => {
-	return siteType === 'blog' && plan.getBlogSignupFeatures;
-};
+const signupFlowDefaultFeatures = (
+	flowName: string,
+	plan: IncompleteWPcomPlan,
+	isInVerticalScrollingPlansExperiment: boolean
+) => {
+	if ( ! flowName || [ LINK_IN_BIO_FLOW, NEWSLETTER_FLOW ].includes( flowName ) ) {
+		return;
+	}
 
-const portfolioFeatures = ( siteType: string, plan: IncompleteWPcomPlan ) => {
-	return siteType === 'grid' && plan.getPortfolioSignupFeatures;
+	return isInVerticalScrollingPlansExperiment
+		? plan.getSignupFeatures
+		: plan.getSignupCompareAvailableFeatures;
 };
 
 export const getPlanFeatureAccessor = ( {
 	flowName = '',
-	siteType = '',
+	isInVerticalScrollingPlansExperiment = false,
 	plan,
 }: {
 	flowName?: string;
-	siteType?: string;
+	isInVerticalScrollingPlansExperiment: boolean;
 	plan: IncompleteWPcomPlan;
 } ) => {
 	return [
 		newsletterFeatures( flowName, plan ),
 		linkInBioFeatures( flowName, plan ),
-		blogFeatures( siteType, plan ),
-		portfolioFeatures( siteType, plan ),
+		signupFlowDefaultFeatures( flowName, plan, isInVerticalScrollingPlansExperiment ),
 	].find( ( accessor ) => {
 		return accessor instanceof Function;
 	} );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -962,6 +962,7 @@ const ConnectedPlanFeatures = connect(
 			popularPlanSpec,
 			kindOfPlanTypeSelector,
 			isPlansPageQuickImprovements,
+			isInVerticalScrollingPlansExperiment,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -1020,8 +1021,8 @@ const ConnectedPlanFeatures = connect(
 				if ( isInSignup ) {
 					const featureAccessor = getPlanFeatureAccessor( {
 						flowName,
-						siteType,
 						plan: planConstantObj,
+						isInVerticalScrollingPlansExperiment,
 					} );
 					if ( ! isPlansPageQuickImprovements && featureAccessor ) {
 						planFeatures = getPlanFeaturesObject( featureAccessor() );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -25,6 +25,7 @@ import {
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useLocale } from '@automattic/i18n-utils';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -48,6 +49,11 @@ import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+import {
+	getHighlightedFeatures,
+	getPlanDescriptionForMobile,
+	getPlanFeatureAccessor,
+} from 'calypso/my-sites/plan-features-comparison/util';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -64,6 +70,7 @@ import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-p
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import {
 	getPlanDiscountedRawPrice,
 	getSitePlanRawPrice,
@@ -82,7 +89,6 @@ import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
 import PlanFeaturesActionsWrapper from './plan-features-action-wrapper';
 import PlanFeaturesScroller from './scroller';
-
 import './style.scss';
 
 const noop = () => {};
@@ -323,6 +329,7 @@ export class PlanFeatures extends Component {
 			showPlanCreditsApplied,
 			isLaunchPage,
 			isInVerticalScrollingPlansExperiment,
+			flowName,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -377,9 +384,11 @@ export class PlanFeatures extends Component {
 				hideMonthly,
 			} = properties;
 			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
-			const planDescription = isInVerticalScrollingPlansExperiment
-				? planConstantObj.getShortDescription()
-				: planConstantObj.getDescription();
+			const planDescription = getPlanDescriptionForMobile( {
+				flowName,
+				plan: planConstantObj,
+				isInVerticalScrollingPlansExperiment,
+			} );
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -764,13 +773,14 @@ export class PlanFeatures extends Component {
 	}
 
 	renderFeatureItem( feature, index ) {
-		const { isPlansPageQuickImprovements } = this.props;
+		const { isPlansPageQuickImprovements, flowName } = this.props;
 		const description = feature.getDescription
 			? feature.getDescription( undefined, this.props.domainName )
 			: null;
 		const classes = classNames( 'plan-features__item-info', {
 			'is-annual-plan-feature': feature.availableOnlyForAnnualPlans,
 			'is-available': feature.availableForCurrentPlan,
+			'is-bold': feature.isHighlightedFeature,
 		} );
 
 		return (
@@ -780,6 +790,7 @@ export class PlanFeatures extends Component {
 				hideGridicon={
 					isPlansPageQuickImprovements || ( this.props.isReskinned ? false : this.props.withScroll )
 				}
+				hideInfoPopover={ isNewsletterOrLinkInBioFlow( flowName ) }
 				availableForCurrentPlan={ feature.availableForCurrentPlan }
 			>
 				<span className={ classes }>
@@ -896,6 +907,7 @@ PlanFeatures.propTypes = {
 	siteId: PropTypes.number,
 	sitePlan: PropTypes.object,
 	kindOfPlanTypeSelector: PropTypes.oneOf( [ 'interval', 'customer' ] ),
+	flowName: PropTypes.string,
 };
 
 PlanFeatures.defaultProps = {
@@ -964,6 +976,7 @@ const ConnectedPlanFeatures = connect(
 		const canPurchase = ! isPaid || isCurrentUserCurrentPlanOwner( state, selectedSiteId );
 		const isLoggedInMonthlyPricing =
 			! isInSignup && ! isJetpack && kindOfPlanTypeSelector === 'interval';
+		const flowName = getCurrentFlowName( state );
 
 		let planProperties = compact(
 			map( plans, ( plan ) => {
@@ -1005,27 +1018,23 @@ const ConnectedPlanFeatures = connect(
 				}
 
 				if ( isInSignup ) {
-					switch ( siteType ) {
-						case 'blog':
-							if ( planConstantObj.getBlogSignupFeatures ) {
-								planFeatures = getPlanFeaturesObject( planConstantObj.getBlogSignupFeatures() );
-							}
+					const featureAccessor = getPlanFeatureAccessor( {
+						flowName,
+						siteType,
+						plan: planConstantObj,
+					} );
+					if ( ! isPlansPageQuickImprovements && featureAccessor ) {
+						planFeatures = getPlanFeaturesObject( featureAccessor() );
+					}
 
-							break;
-						case 'grid':
-							if ( planConstantObj.getPortfolioSignupFeatures ) {
-								planFeatures = getPlanFeaturesObject(
-									planConstantObj.getPortfolioSignupFeatures()
-								);
-							}
-
-							break;
-						default:
-							if ( ! isPlansPageQuickImprovements && planConstantObj.getSignupFeatures ) {
-								planFeatures = getPlanFeaturesObject(
-									planConstantObj.getSignupFeatures( currentPlan )
-								);
-							}
+					const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
+					if ( highlightedFeatures.length ) {
+						planFeatures = planFeatures.map( ( feature ) => {
+							return {
+								...feature,
+								isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
+							};
+						} );
 					}
 				}
 
@@ -1121,6 +1130,7 @@ const ConnectedPlanFeatures = connect(
 				planCredits &&
 				! isJetpackNotAtomic &&
 				! isInSignup,
+			flowName,
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -1018,6 +1018,7 @@ const ConnectedPlanFeatures = connect(
 					isPlaceholder = true;
 				}
 
+				// Mobile view
 				if ( isInSignup ) {
 					const featureAccessor = getPlanFeatureAccessor( {
 						flowName,

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -692,6 +692,10 @@ $plan-features-sidebar-width: 272px;
 	flex: 1 0 0;
 	width: 100%;
 
+	&.is-bold {
+		font-weight: bold;
+	}
+
 	&.is-annual-plan-feature:not( .is-available ) {
 		.plan-features__item-title {
 			text-decoration: line-through;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -7,7 +7,7 @@ import {
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import { englishLocales } from '@automattic/i18n-utils';
-import { LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -266,7 +266,29 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan, locale } = this.props;
+		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan, locale, flowName } =
+			this.props;
+
+		if ( flowName === NEWSLETTER_FLOW ) {
+			return translate(
+				`Unlock a powerful bundle of features for your Newsletter. Or {{link}}start with a free plan{{/link}}.`,
+				{
+					components: {
+						link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+					},
+				}
+			);
+		}
+		if ( flowName === LINK_IN_BIO_FLOW ) {
+			return translate(
+				`Unlock a powerful bundle of features for your Link in Bio. Or {{link}}start with a free plan{{/link}}.`,
+				{
+					components: {
+						link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+					},
+				}
+			);
+		}
 
 		if ( eligibleForProPlan ) {
 			if ( isStarterPlanEnabled() ) {

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -278,3 +278,19 @@ export const FEATURE_EMAIL_SUPPORT_V2 = 'email-support-v2';
 export const FEATURE_ADVANCED_SEO_V2 = 'advanced-seo-v2';
 export const FEATURE_COLLECT_PAYMENTS_V3 = 'collect-payments-v3';
 /* END - WPCOM Plan grid features update experiment */
+
+// Signup flow related features
+export const FEATURE_UNLIMITED_EMAILS = 'unlimited-emails';
+export const FEATURE_UNLIMITED_SUBSCRIBERS = 'unlimited-subscribers';
+export const FEATURE_IMPORT_SUBSCRIBERS = 'import-subscribers';
+export const FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER = 'add-multiple-pages-newsletter';
+export const FEATURE_AD_FREE_EXPERIENCE = 'ad-free-experience';
+export const FEATURE_COLLECT_PAYMENTS_NEWSLETTER = 'collect-payments-newsletter';
+export const FEATURE_POST_BY_EMAIL = 'post-by-email';
+export const FEATURE_REAL_TIME_ANALYTICS = 'real-time-analytics';
+export const FEATURE_GOOGLE_ANALYTICS_V2 = 'google-analytics-v2';
+export const FEATURE_ADD_UNLIMITED_LINKS = 'add-unlimited-links';
+export const FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS = 'customize-themes-buttons-colors';
+export const FEATURE_TRACK_VIEWS_CLICKS = 'track-views-clicks';
+export const FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO = 'collect-payments-link-in-bio';
+export const FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION = 'link-in-bio-themes-customization';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -230,6 +230,20 @@ import {
 	FEATURE_COLLECT_PAYMENTS_V3,
 	FEATURE_EMAIL_SUPPORT_V2,
 	FEATURE_ADVANCED_SEO_V2,
+	FEATURE_UNLIMITED_EMAILS,
+	FEATURE_UNLIMITED_SUBSCRIBERS,
+	FEATURE_IMPORT_SUBSCRIBERS,
+	FEATURE_AD_FREE_EXPERIENCE,
+	FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER,
+	FEATURE_COLLECT_PAYMENTS_NEWSLETTER,
+	FEATURE_POST_BY_EMAIL,
+	FEATURE_REAL_TIME_ANALYTICS,
+	FEATURE_GOOGLE_ANALYTICS_V2,
+	FEATURE_ADD_UNLIMITED_LINKS,
+	FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
+	FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+	FEATURE_TRACK_VIEWS_CLICKS,
+	FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
 	/* END - WPCOM Plan grid features update experiment */
 } from './constants';
 import type {
@@ -416,6 +430,47 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_NO_ADS,
 		FEATURE_COLLECT_PAYMENTS_V2,
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
+	],
+	getNewsletterDescription: () =>
+		i18n.translate(
+			'Jumpstart your Newsletter with a custom domain, ad-free experience, and the ability to sell subscriptions, take payments, and collect donations from day one. Backed with email support to help get everything just right.'
+		),
+	getNewsletterSignupFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_EMAILS,
+		FEATURE_UNLIMITED_SUBSCRIBERS,
+		FEATURE_IMPORT_SUBSCRIBERS,
+		FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_COLLECT_PAYMENTS_NEWSLETTER,
+		FEATURE_POST_BY_EMAIL,
+		FEATURE_EMAIL_SUPPORT_SIGNUP,
+	],
+	getNewsletterHighlightedFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_EMAILS,
+		FEATURE_UNLIMITED_SUBSCRIBERS,
+		FEATURE_AD_FREE_EXPERIENCE,
+	],
+	getLinkInBioDescription: () =>
+		i18n.translate(
+			'Stand out and unlock earnings with an ad-free site, custom domain, and the ability to sell subscriptions, take payments, and collect donations. Backed with email support to help get your site just right.'
+		),
+	getLinkInBioSignupFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_ADD_UNLIMITED_LINKS,
+		FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_TRACK_VIEWS_CLICKS,
+		FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
+		FEATURE_POST_BY_EMAIL,
+		FEATURE_EMAIL_SUPPORT_SIGNUP,
+	],
+	getLinkInBioHighlightedFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_ADD_UNLIMITED_LINKS,
+		FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+		FEATURE_TRACK_VIEWS_CLICKS,
 	],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
@@ -662,6 +717,59 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 		FEATURE_ADVANCED_CUSTOMIZATION,
 		FEATURE_ALL_PERSONAL_FEATURES,
+	],
+	getNewsletterDescription: () =>
+		i18n.translate(
+			'Take your Newsletter further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
+		),
+	getNewsletterSignupFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_EMAILS,
+		FEATURE_UNLIMITED_SUBSCRIBERS,
+		FEATURE_IMPORT_SUBSCRIBERS,
+		FEATURE_ADD_MULTIPLE_PAGES_NEWSLETTER,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_COLLECT_PAYMENTS_NEWSLETTER,
+		FEATURE_POST_BY_EMAIL,
+		FEATURE_EMAIL_SUPPORT_SIGNUP,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_REAL_TIME_ANALYTICS,
+		FEATURE_GOOGLE_ANALYTICS_V2,
+		FEATURE_PREMIUM_THEMES,
+	],
+	getNewsletterHighlightedFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_EMAILS,
+		FEATURE_UNLIMITED_SUBSCRIBERS,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_REAL_TIME_ANALYTICS,
+		FEATURE_PREMIUM_THEMES,
+	],
+	getLinkInBioDescription: () =>
+		i18n.translate(
+			'Take your site further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
+		),
+	getLinkInBioSignupFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_ADD_UNLIMITED_LINKS,
+		FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_TRACK_VIEWS_CLICKS,
+		FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
+		FEATURE_POST_BY_EMAIL,
+		FEATURE_EMAIL_SUPPORT_SIGNUP,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_REAL_TIME_ANALYTICS,
+		FEATURE_GOOGLE_ANALYTICS_V2,
+		FEATURE_MONETISE,
+		FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
+	],
+	getLinkInBioHighlightedFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_ADD_UNLIMITED_LINKS,
+		FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
+		FEATURE_TRACK_VIEWS_CLICKS,
 	],
 	getBlogSignupFeatures: () =>
 		[

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -34,6 +34,12 @@ export interface WPComPlan extends Plan {
 	getSignupFeatures?: () => Feature[];
 	getBlogSignupFeatures?: () => Feature[];
 	getPortfolioSignupFeatures?: () => Feature[];
+	getNewsletterDescription?: () => string;
+	getNewsletterSignupFeatures?: () => Feature[];
+	getNewsletterHighlightedFeatures?: () => Feature[];
+	getLinkInBioDescription?: () => string;
+	getLinkInBioSignupFeatures?: () => Feature[];
+	getLinkInBioHighlightedFeatures?: () => Feature[];
 	getPromotedFeatures?: () => Feature[];
 	getPathSlug: () => string;
 	getAnnualPlansOnlyFeatures?: () => string[];


### PR DESCRIPTION
Take 2 of https://github.com/Automattic/wp-calypso/pull/67053 which had to be reverted since the features list in other signup flows were also modified.

**Testing Instructions**

1. Verify that the testing instructions in https://github.com/Automattic/wp-calypso/pull/67053 pass.
2. Verify that the plans step feature list in any other signup flow is unaffected (compare with production). Try `/start` and `/start/with-theme/domains-theme-preselected?ref=calypshowcase&theme=disco`. Both **desktop and mobile versions** should be unaffected.
3. Verify that the feature list in Calypso `/plans` is unaffected.

### Screenshots
<img width="825" alt="image" src="https://user-images.githubusercontent.com/17054134/188176987-9e005995-55d6-4862-9ea5-15d9888ae94a.png">

<img width="939" alt="image" src="https://user-images.githubusercontent.com/17054134/188177191-8a53ea0f-432e-41d8-9e21-bd12e2a4f125.png">
