### PR TITLE
Make each tab a dedicated route

### DIFF
--- a/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
@@ -1,16 +1,19 @@
+import { useSelector } from 'react-redux';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import './style.scss';
 import { TabType } from 'calypso/my-sites/promote-post/main';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 type Props = {
 	tabs: { id: TabType; name: string }[];
 	selectedTab: TabType;
-	selectTab: ( tab: TabType ) => void;
 };
 
-export default function PromotePostTabBar( { tabs, selectedTab, selectTab }: Props ) {
+export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+
 	return (
 		<SectionNav>
 			<NavTabs>
@@ -18,7 +21,7 @@ export default function PromotePostTabBar( { tabs, selectedTab, selectTab }: Pro
 					return (
 						<NavItem
 							key={ id }
-							onClick={ () => selectTab( id ) }
+							path={ `/advertising/${ selectedSiteSlug }/${ id }` }
 							selected={ selectedTab === id }
 							children={ name }
 						/>

--- a/client/my-sites/promote-post/controller.js
+++ b/client/my-sites/promote-post/controller.js
@@ -1,6 +1,7 @@
 import PromotedPosts from 'calypso/my-sites/promote-post/main';
 
 export const promotedPosts = ( context, next ) => {
-	context.primary = <PromotedPosts />;
+	const { tab } = context.params;
+	context.primary = <PromotedPosts tab={ tab } />;
 	next();
 };

--- a/client/my-sites/promote-post/index.js
+++ b/client/my-sites/promote-post/index.js
@@ -4,5 +4,12 @@ import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { promotedPosts } from './controller';
 
 export default () => {
-	page( '/advertising/:site?', siteSelection, navigation, promotedPosts, makeLayout, clientRender );
+	page(
+		'/advertising/:site?/:tab?',
+		siteSelection,
+		navigation,
+		promotedPosts,
+		makeLayout,
+		clientRender
+	);
 };

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -1,7 +1,6 @@
 import './style.scss';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import SitePreview from 'calypso/blocks/site-preview';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -20,8 +19,13 @@ export type TabOption = {
 	id: TabType;
 	name: string;
 };
-export default function PromotedPosts() {
-	const [ selectedTab, setSelectedTab ] = useState< TabType >( 'posts' );
+
+interface Props {
+	tab?: TabType;
+}
+
+export default function PromotedPosts( { tab }: Props ) {
+	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const { isLoading: campaignsIsLoading, data: campaignsData } = useCampaignsQuery(
 		selectedSiteId ?? 0
@@ -50,11 +54,7 @@ export default function PromotedPosts() {
 			<DocumentHead title={ translate( 'Advertising' ) } />
 			<SitePreview />
 			{ ! campaignsData?.length && ! campaignsIsLoading && <PostsListBanner /> }
-			<PromotePostTabBar
-				tabs={ tabs }
-				selectedTab={ selectedTab }
-				selectTab={ ( tab ) => setSelectedTab( tab ) }
-			/>
+			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
 			{ selectedTab === 'campaigns' && campaignsData && (
 				<CampaignsList isLoading={ campaignsIsLoading } campaigns={ campaignsData } />
 			) }

--- a/client/sections.js
+++ b/client/sections.js
@@ -542,9 +542,9 @@ const sections = [
 	},
 	{
 		name: 'promote-post',
-		paths: [ '/advertising', '/advertising/[^\\/]+' ],
+		paths: [ '/advertising', '/advertising/[^\\/]+(/[^\\/])?' ],
 		module: 'calypso/my-sites/promote-post',
-		group: 'sites', // todo what group should this be?
+		group: 'sites',
 	},
 ];
 


### PR DESCRIPTION
#### Proposed Changes

Give each tab a dedicated route

#### Testing Instructions

* visit your promoted post page http://calypso.localhost:3000/advertising/benzarre.com/campaigns
* click on tabs should change the route
* pasting the URL in a new browser should open the tab straight away.
* if no tab or wrong tab name specified, default to posts tab.
![image](https://user-images.githubusercontent.com/6070516/188120040-7245f086-86f1-455b-9bb0-23d61626fec4.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
