### PR TITLE
Fix popular plan for link in bio in mobile

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -183,6 +183,7 @@ export class PlansFeaturesMain extends Component {
 			domainAndPlanPackage,
 			translate,
 			locale,
+			flowName,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -247,6 +248,7 @@ export class PlansFeaturesMain extends Component {
 					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ getPopularPlanSpec( {
+						flowName,
 						customerType,
 						isJetpack,
 						availablePlans: visiblePlans,


### PR DESCRIPTION
<img width="355" alt="Screenshot 2022-09-02 at 13 09 05" src="https://user-images.githubusercontent.com/7000684/188127235-e30a0fe0-79f9-41b5-9a1c-5a63852ade51.png">

#### Proposed Changes

* Fixes issue discovered while testing https://github.com/Automattic/wp-calypso/pull/67305
* The popular plan for link in bio in mobile view should be `Personal` not `Premium`

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Visit http://calypso.localhost:3000/setup?flow=link-in-bio and arrive to the plans page
- Switch to mobile view
- The popular plan should be `Personal`

Related to #67311
