### PR TITLE
Link-in-bio / Newsletter flow: Show info popover in logged in /plans page

### DIFF
--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -1,5 +1,9 @@
 import { IncompleteWPcomPlan } from '@automattic/calypso-products';
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import {
+	NEWSLETTER_FLOW,
+	LINK_IN_BIO_FLOW,
+	isNewsletterOrLinkInBioFlow,
+} from '@automattic/onboarding';
 
 const newsletterFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 	return flowName === NEWSLETTER_FLOW && plan.getNewsletterSignupFeatures;
@@ -14,7 +18,7 @@ const signupFlowDefaultFeatures = (
 	plan: IncompleteWPcomPlan,
 	isInVerticalScrollingPlansExperiment: boolean
 ) => {
-	if ( ! flowName || [ LINK_IN_BIO_FLOW, NEWSLETTER_FLOW ].includes( flowName ) ) {
+	if ( ! flowName || isNewsletterOrLinkInBioFlow( flowName ) ) {
 		return;
 	}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -25,7 +25,6 @@ import {
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useLocale } from '@automattic/i18n-utils';
-import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -773,7 +772,7 @@ export class PlanFeatures extends Component {
 	}
 
 	renderFeatureItem( feature, index ) {
-		const { isPlansPageQuickImprovements, flowName } = this.props;
+		const { isPlansPageQuickImprovements } = this.props;
 		const description = feature.getDescription
 			? feature.getDescription( undefined, this.props.domainName )
 			: null;
@@ -790,7 +789,6 @@ export class PlanFeatures extends Component {
 				hideGridicon={
 					isPlansPageQuickImprovements || ( this.props.isReskinned ? false : this.props.withScroll )
 				}
-				hideInfoPopover={ isNewsletterOrLinkInBioFlow( flowName ) }
 				availableForCurrentPlan={ feature.availableForCurrentPlan }
 			>
 				<span className={ classes }>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -25,6 +25,7 @@ import {
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useLocale } from '@automattic/i18n-utils';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -772,7 +773,8 @@ export class PlanFeatures extends Component {
 	}
 
 	renderFeatureItem( feature, index ) {
-		const { isPlansPageQuickImprovements } = this.props;
+		const { isPlansPageQuickImprovements, isInVerticalScrollingPlansExperiment, flowName } =
+			this.props;
 		const description = feature.getDescription
 			? feature.getDescription( undefined, this.props.domainName )
 			: null;
@@ -788,6 +790,9 @@ export class PlanFeatures extends Component {
 				description={ description }
 				hideGridicon={
 					isPlansPageQuickImprovements || ( this.props.isReskinned ? false : this.props.withScroll )
+				}
+				hideInfoPopover={
+					isInVerticalScrollingPlansExperiment && isNewsletterOrLinkInBioFlow( flowName )
 				}
 				availableForCurrentPlan={ feature.availableForCurrentPlan }
 			>


### PR DESCRIPTION
#### Proposed Changes

Following changes to the info popover icon:
* It will be hidden in the signup flow mobile view of LIB/newsletter flow.
* It will be visible in other signup flows mobile view.
* It will be visible in logged-in `/plans` page mobile view and desktop view.

**BEFORE**
<img width="1573" alt="Screenshot 2022-09-02 at 4 14 15 PM" src="https://user-images.githubusercontent.com/1269602/188144843-7d41803f-7b0a-4ffd-b0e8-22bd8356fdaa.png">



**AFTER**
<img width="1435" alt="Screenshot 2022-09-02 at 4 22 57 PM" src="https://user-images.githubusercontent.com/1269602/188144894-24158767-686d-4d41-8b51-6bc87e6d1c55.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the [newsletter](http://calypso.localhost:3000/setup/intro?flow=newsletter) and [link-in-bio](http://calypso.localhost:3000/setup/intro?flow=link-in-bio) signup flow mobile view, verify that the info popover icon is hidden.
* After completing the signup flow in LIB, verify that the logged-in `/plans` page shows the info popover icons
* Verify that in other signup flows, e.g. `/start`, the info popover icon is visible in the mobile view plans page.

