### PR TITLE
Jetpack new pricing page - fix typo for featured text

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -452,13 +452,13 @@ export const getJetpackProductsFeaturedText = (): Record< string, TranslateResul
 		'Protect your site or store. Save every change with real-time cloud backups, and restore in one click.'
 	);
 	const videoPressFeaturedText = translate(
-		'Own your content. High-quality, ad-free video build specifically for WordPress.'
+		'Own your content. High-quality, ad-free video built specifically for WordPress.'
 	);
 	const antiSpamFeaturedText = translate(
 		'Stop spam in comments and forms. Save time through automation and get rid of annoying CAPTCHAs.'
 	);
 	const scanFeaturedText = translate(
-		'Stay ahead of security threats. Automattic scanning and one-click fixes give you and your customers peace of mind.'
+		'Stay ahead of security threats. Automatic scanning and one-click fixes give you and your customers peace of mind.'
 	);
 	const searchFeaturedText = translate(
 		'Instant search helps your visitors actually find what they need and improves conversion.'


### PR DESCRIPTION

#### Proposed Changes

* This PR fixes the typo from #67203 for **Videopress** and **Scan**


#### Testing Instructions

* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout add/featured-product-text`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Confirm that the description for VideoPress in **Most popular product** section is correct

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664105
  - 1202796695664022-as-1202796695664105/f