### PR TITLE
Updated CSS for plans step in signup

### DIFF
--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -335,25 +335,6 @@ $plan-features-sidebar-width: 272px;
 .plans-features-main__group.is-scrollable {
 	position: relative;
 
-	.is-section-signup & {
-		position: absolute;
-		width: 100%;
-		left: 50%;
-		transform: translateX(-50%);
-
-		@media ( min-width: 1600px ) {
-			max-width: 1600px;
-		}
-
-		@include breakpoint-deprecated( "<1040px" ) {
-			padding-top: 12px;
-		}
-	}
-
-	.signup__steps & .plan-features--signup {
-		max-width: 100%;
-	}
-
 	.plan-features-comparison__content {
 		margin: -16px 0 0;
 		padding-top: $plan-features-header-banner-height;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -894,10 +894,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	position: relative;
 
 	.is-section-signup & {
-		position: absolute;
-		width: 100%;
-		left: 50%;
-		transform: translateX(-50%);
+		--approximate-viewport-scrollbar-width: 20px;
+
+		width: calc(100vw - var( --approximate-viewport-scrollbar-width ));
+		margin-left: calc(50% - 50vw + var(--approximate-viewport-scrollbar-width) / 2);
 
 		@media ( min-width: 1600px ) {
 			max-width: 1600px;


### PR DESCRIPTION
#### Proposed Changes

This PR was extracted from #67220.

It fixes a CSS issue in the `PlansStep` component in the signup flow where a horizontal scrollbar would appear in the viewport (if the browser isn't using macOS overlay scrollbars). See screenshot below for clarification:

| macOS (non-overlay scrollbars) | Windows (always) |
| - | - |
| ![macOS](https://user-images.githubusercontent.com/1101677/187712659-3e2a48f7-8053-4227-b09e-81631f5438e5.png) | ![bs_win11_Edge_105 0](https://user-images.githubusercontent.com/1101677/190115314-3ce09fdb-9a07-4939-b29b-4f33a86c901c.jpg) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/start`
2. Proceed to the plans step
3. Resize viewport to 1440x900px (e.g. with "responsive mode" in the browser devtools). If you are on macOS, open System Settings > General, set "Show scroll bars" to "Always". 
4. Ensure that no horizontal scrollbar is visible in the viewport

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67220
