### PR TITLE
Marketplace search: Use plugin.author.raw and author_name to filter by author

### DIFF
--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -87,12 +87,12 @@ export function search( options: SearchParams ) {
 
 function getFilterbyAuthor( author: string ): {
 	bool: {
-		must: { term: object }[];
+		should: { term: object }[];
 	};
 } {
 	return {
 		bool: {
-			must: [ { term: { 'author.raw': author } } ],
+			should: [ { term: { 'plugin.author.raw': author } }, { term: { 'plugin.author': author } } ],
 		},
 	};
 }

--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -87,12 +87,12 @@ export function search( options: SearchParams ) {
 
 function getFilterbyAuthor( author: string ): {
 	bool: {
-		should: { term: object }[];
+		must: { term: object }[];
 	};
 } {
 	return {
 		bool: {
-			should: [ { term: { 'plugin.author.raw': author } }, { term: { 'plugin.author': author } } ],
+			must: [ { term: { 'plugin.author.raw': author } } ],
 		},
 	};
 }

--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -92,7 +92,7 @@ function getFilterbyAuthor( author: string ): {
 } {
 	return {
 		bool: {
-			must: [ { term: { 'plugin.author': author } } ],
+			must: [ { term: { 'author.raw': author } } ],
 		},
 	};
 }

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -41,9 +41,9 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 									author: (
 										<a
 											href={ localizePath(
-												`/plugins/${
-													selectedSite?.slug || ''
-												}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"`
+												`/plugins/${ selectedSite?.slug || '' }?s=developer:"${ getPluginAuthor(
+													plugin
+												) }"`
 											) }
 										>
 											{ plugin.author_name }
@@ -128,7 +128,7 @@ function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 						) : (
 							<a
 								href={ localizePath(
-									`/plugins/${ selectedSite?.slug || '' }?s=developer:"${ getPluginAuthorKeyword(
+									`/plugins/${ selectedSite?.slug || '' }?s=developer:"${ getPluginAuthor(
 										plugin
 									) }"`
 								) }
@@ -198,6 +198,12 @@ function PluginDetailsHeaderPlaceholder() {
 			</div>
 		</div>
 	);
+}
+
+function getPluginAuthor( plugin ) {
+	if ( config.isEnabled( 'marketplace-jetpack-plugin-search' ) ) return plugin.author_name;
+
+	return getPluginAuthorKeyword( plugin );
 }
 
 export default PluginDetailsHeader;


### PR DESCRIPTION
#### Proposed Changes

* Use `author_name` to build the author link 
![CleanShot 2022-09-09 at 18 49 13@2x](https://user-images.githubusercontent.com/3519124/189400971-94eafba4-513a-433d-a400-66a6daf92f05.png)
* Then use that value to filter by `plugin.author.raw` instead of the previous `plugin.author`. 
* That will fix issues for plugins with different author values like `LiteSpeed Technologies`, `Team Yoast` or `Automattic`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a plugins `/plugins` and search for a plugin
* Click on the plugins so the plugin details page is opened
* Click on the Author link (screenshot above)
* Make sure the results are the expected ones. This means that the plugins listed should contain the selected result in the previous step and other additional plugins created by the author.

> **Note** Please note that the search criterion has changed slightly to use `author_name` so in some cases like `developer:"litespeedtech"` has changed to `developer:"LiteSpeed Technologies"`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64939
