### PR TITLE
Theme/Plugin Bundling: Check for eligibility before entering the plugin-bundle flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -4,12 +4,14 @@ import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 
 const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep( { navigation } ) {
 	const site = useSite();
+	const isPluginBundleEligible = useIsPluginBundleEligible();
 	const siteSlugParam = useSiteSlugParam();
 	let siteSlug: string | null = null;
 	if ( siteSlugParam ) {
@@ -42,6 +44,13 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ currentTheme?.id ] );
+
+	useEffect( () => {
+		if ( ! isPluginBundleEligible ) {
+			window.location.replace( `/home/${ siteSlug }` );
+		}
+	}, [ isPluginBundleEligible, siteSlug ] );
+
 	return null;
 };
 export default GetCurrentThemeSoftwareSets;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -9,6 +9,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligible';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -93,6 +94,7 @@ export const siteSetupFlow: Flow = {
 		const isEnglishLocale = useIsEnglishLocale();
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 		const urlQueryParams = useQuery();
+		const isPluginBundleEligible = useIsPluginBundleEligible();
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -219,6 +221,7 @@ export const siteSetupFlow: Flow = {
 						isEnabled( 'themes/plugin-bundling' ) &&
 						theme_software_set &&
 						theme_software_set.length > 0 &&
+						isPluginBundleEligible &&
 						siteSlug
 					) {
 						return exitFlow( `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle` );

--- a/client/landing/stepper/hooks/use-is-plugin-bundle-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-plugin-bundle-eligible.ts
@@ -1,0 +1,16 @@
+import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import { useSelect } from '@wordpress/data';
+import { SITE_STORE } from '../stores';
+import { useSite } from './use-site';
+
+export function useIsPluginBundleEligible(): boolean | null {
+	const site = useSite();
+	const hasWooFeature = useSelect( ( select ) =>
+		select( SITE_STORE ).siteHasFeature( site?.ID, FEATURE_WOOP )
+	);
+	const hasAtomicFeature = useSelect( ( select ) =>
+		select( SITE_STORE ).siteHasFeature( site?.ID, WPCOM_FEATURES_ATOMIC )
+	);
+
+	return hasWooFeature && hasAtomicFeature;
+}


### PR DESCRIPTION
#### Proposed Changes

This checks for user eligibility before entering the plugin bundle flow. We check both after submitting the `processing` step in the `site-setup-flow` _and_ in the `getCurrentThemeSoftwareSets` step at the beginning of the plugin bundle flow.

Eligibility is determined by checking for the `WPCOM_FEATURES_ATOMIC` and `FEATURE_WOOP` features in addition to checking the theme software set.

#### Testing Instructions

**Eligible, starting from theme selection:**
- Using a site that has a "Business plan", got to `http://calypso.localhost:3000/setup/designSetup?siteSlug=[SITESLUG]&flags=themes/plugin-bundling`.
- Select the Baxter theme.
- After the processing step, you should be taken to the plugin bundle flow `storeAddress` step.

**Eligible, going directly to the plugin bundle flow:**
- Using a site that has a "Business plan", got to `http://calypso.localhost:3000/setup/designSetup?siteSlug=[SITESLUG]&flags=themes/plugin-bundling&flow=plugin-bundle`.
- You should be taken to the plugin bundle flow `storeAddress` step.

**Ineligible, going directly to the plugin bundle flow:**
- Using a free site, got to `http://calypso.localhost:3000/setup/designSetup?siteSlug=[SITESLUG]&flags=themes/plugin-bundling&flow=plugin-bundle`.
- You should be taken to `/home/[SITESLUG]`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66689
