### PR TITLE
Site Thumbnail: Don't render blur background when `img` is ready

### DIFF
--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -63,12 +63,13 @@ export const SiteThumbnail = ( {
 	);
 
 	const showLoader = mShotsUrl && ! isError;
+	const mshotsImgLoaded = imgProps.src && ! isError;
 
 	const blurSize = width > DEFAULT_SIZE.width ? 'medium' : 'small';
 
 	return (
 		<div className={ classes } style={ { backgroundColor, color } }>
-			{ bgColorImgUrl && (
+			{ bgColorImgUrl && ! mshotsImgLoaded && (
 				<div
 					className={ `site-thumbnail__image-bg site-thumbnail__image-blur-${ blurSize }` }
 					style={ { backgroundImage: `url(${ bgColorImgUrl })` } }
@@ -81,7 +82,7 @@ export const SiteThumbnail = ( {
 					{ children }
 				</div>
 			) }
-			{ imgProps.src && ! isError && (
+			{ mshotsImgLoaded && (
 				<img
 					className={ classnames( 'site-thumbnail__image', {
 						'site-thumbnail__mshot_default_hidden': isLoading,


### PR DESCRIPTION
Fixes pdKhl6-GX-p2#comment-681

## Proposed Changes

Disables the blur background `<div>` when the mShot image is ready to display.

## Testing Instructions

1. Navigate to `/sites`.
2. Verify all screenshots display as expected.