### PR TITLE
Checkout: Update FormPhoneMediaInput/PhoneInput to use one value prop

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -304,10 +304,10 @@ export class ContactDetailsFormFields extends Component {
 		} );
 	};
 
-	handlePhoneChange = ( { value, countryCode } ) => {
+	handlePhoneChange = ( { phoneNumber, countryCode } ) => {
 		this.formStateController.handleFieldChange( {
 			name: 'phone',
-			value,
+			value: phoneNumber,
 		} );
 
 		if ( ! countries[ countryCode ] ) {
@@ -329,7 +329,7 @@ export class ContactDetailsFormFields extends Component {
 		const basicValue = formState.getFieldValue( form, name ) || '';
 		let value = basicValue;
 		if ( name === 'phone' ) {
-			value = { value: basicValue, countryCode: this.state.phoneCountryCode };
+			value = { phoneNumber: basicValue, countryCode: this.state.phoneCountryCode };
 		}
 
 		return {

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -326,6 +326,12 @@ export class ContactDetailsFormFields extends Component {
 		const { eventFormName, getIsFieldDisabled } = this.props;
 		const { form } = this.state;
 
+		const basicValue = formState.getFieldValue( form, name ) || '';
+		let value = basicValue;
+		if ( name === 'phone' ) {
+			value = { value: basicValue, countryCode: this.state.phoneCountryCode };
+		}
+
 		return {
 			labelClass: 'contact-details-form-fields__label',
 			additionalClasses: 'contact-details-form-fields__field',
@@ -336,7 +342,7 @@ export class ContactDetailsFormFields extends Component {
 				( formState.getFieldErrorMessages( form, camelCase( name ) ) || [] ).join( '\n' ),
 			onChange: this.handleFieldChange,
 			onBlur: this.handleBlur,
-			value: formState.getFieldValue( form, name ) || '',
+			value,
 			name,
 			eventFormName,
 			...ref,
@@ -391,7 +397,6 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'Phone' ),
 							onChange: this.handlePhoneChange,
 							countriesList: this.props.countriesList,
-							countryCode: this.state.phoneCountryCode,
 							enableStickyCountry: false,
 						},
 						{

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -135,6 +135,12 @@ export class ManagedContactDetailsFormFields extends Component {
 		);
 		const camelName = camelCase( name );
 
+		const basicValue = form[ camelName ]?.value ?? '';
+		let value = basicValue;
+		if ( name === 'phone' ) {
+			value = { value: basicValue, countryCode: this.state.phoneCountryCode };
+		}
+
 		return {
 			labelClass: 'contact-details-form-fields__label',
 			additionalClasses: 'contact-details-form-fields__field',
@@ -143,7 +149,7 @@ export class ManagedContactDetailsFormFields extends Component {
 			errorMessage: customErrorMessage || getFirstError( form[ camelName ] ),
 			onChange: this.handleFieldChangeEvent,
 			onBlur: this.handleBlur( name ),
-			value: form[ camelName ]?.value ?? '',
+			value,
 			name,
 			eventFormName,
 		};
@@ -233,7 +239,6 @@ export class ManagedContactDetailsFormFields extends Component {
 								label: translate( 'Phone' ),
 								onChange: this.handlePhoneChange,
 								countriesList: this.props.countriesList,
-								countryCode: this.state.phoneCountryCode,
 								enableStickyCountry: false,
 							},
 							{
@@ -257,7 +262,6 @@ export class ManagedContactDetailsFormFields extends Component {
 							label: translate( 'Phone' ),
 							onChange: this.handlePhoneChange,
 							countriesList: this.props.countriesList,
-							countryCode: this.state.phoneCountryCode,
 							enableStickyCountry: false,
 						},
 						{

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -110,7 +110,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		this.updateParentState( form, phoneCountryCode );
 	};
 
-	handlePhoneChange = ( { value, countryCode } ) => {
+	handlePhoneChange = ( { phoneNumber, countryCode } ) => {
 		let form = getFormFromContactDetails(
 			this.props.contactDetails,
 			this.props.contactDetailsErrors
@@ -122,7 +122,7 @@ export class ManagedContactDetailsFormFields extends Component {
 			this.setState( { phoneCountryCode } );
 		}
 
-		form = updateFormWithContactChange( form, 'phone', value );
+		form = updateFormWithContactChange( form, 'phone', phoneNumber );
 		this.updateParentState( form, phoneCountryCode );
 		return;
 	};
@@ -138,7 +138,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		const basicValue = form[ camelName ]?.value ?? '';
 		let value = basicValue;
 		if ( name === 'phone' ) {
-			value = { value: basicValue, countryCode: this.state.phoneCountryCode };
+			value = { phoneNumber: basicValue, countryCode: this.state.phoneCountryCode };
 		}
 
 		return {

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -249,7 +249,7 @@ describe( 'ContactDetailsFormFields', () => {
 
 			expect( FormPhoneMediaInput ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					value: { countryCode: 'JP', value: defaultProps.contactDetails.phone },
+					value: { countryCode: 'JP', phoneNumber: defaultProps.contactDetails.phone },
 				} ),
 				expect.anything()
 			);
@@ -265,7 +265,7 @@ describe( 'ContactDetailsFormFields', () => {
 
 			expect( FormPhoneMediaInput ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					value: { countryCode: 'FR', value: defaultProps.contactDetails.phone },
+					value: { countryCode: 'FR', phoneNumber: defaultProps.contactDetails.phone },
 				} ),
 				expect.anything()
 			);
@@ -278,7 +278,7 @@ describe( 'ContactDetailsFormFields', () => {
 
 			expect( FormPhoneMediaInput ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					value: { countryCode: 'US', value: defaultProps.contactDetails.phone },
+					value: { countryCode: 'US', phoneNumber: defaultProps.contactDetails.phone },
 				} ),
 				expect.anything()
 			);

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -248,7 +248,9 @@ describe( 'ContactDetailsFormFields', () => {
 			render( <ContactDetailsFormFields { ...newProps } /> );
 
 			expect( FormPhoneMediaInput ).toHaveBeenCalledWith(
-				expect.objectContaining( { countryCode: 'JP' } ),
+				expect.objectContaining( {
+					value: { countryCode: 'JP', value: defaultProps.contactDetails.phone },
+				} ),
 				expect.anything()
 			);
 		} );
@@ -262,7 +264,9 @@ describe( 'ContactDetailsFormFields', () => {
 			render( <ContactDetailsFormFields { ...newProps } /> );
 
 			expect( FormPhoneMediaInput ).toHaveBeenCalledWith(
-				expect.objectContaining( { countryCode: 'FR' } ),
+				expect.objectContaining( {
+					value: { countryCode: 'FR', value: defaultProps.contactDetails.phone },
+				} ),
 				expect.anything()
 			);
 		} );
@@ -273,7 +277,9 @@ describe( 'ContactDetailsFormFields', () => {
 			render( <ContactDetailsFormFields { ...newProps } /> );
 
 			expect( FormPhoneMediaInput ).toHaveBeenCalledWith(
-				expect.objectContaining( { countryCode: 'US' } ),
+				expect.objectContaining( {
+					value: { countryCode: 'US', value: defaultProps.contactDetails.phone },
+				} ),
 				expect.anything()
 			);
 		} );

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -318,8 +318,10 @@ class FormFields extends PureComponent {
 					<FormFieldset>
 						<FormLabel>Form Media Phone Input</FormLabel>
 						<PhoneInput
-							countryCode={ this.state.phoneInput.countryCode }
-							value={ this.state.phoneInput.value }
+							value={ {
+								value: this.state.phoneInput.value,
+								countryCode: this.state.phoneInput.countryCode,
+							} }
 							countriesList={ this.props.countriesList }
 							onChange={ this.handlePhoneInputChange }
 						/>

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -319,7 +319,7 @@ class FormFields extends PureComponent {
 						<FormLabel>Form Media Phone Input</FormLabel>
 						<PhoneInput
 							value={ {
-								value: this.state.phoneInput.value,
+								phoneNumber: this.state.phoneInput.value,
 								countryCode: this.state.phoneInput.countryCode,
 							} }
 							countriesList={ this.props.countriesList }

--- a/client/components/forms/form-phone-media-input/index.tsx
+++ b/client/components/forms/form-phone-media-input/index.tsx
@@ -4,12 +4,12 @@ import FormLabel from 'calypso/components/forms/form-label';
 import PhoneInput from 'calypso/components/phone-input';
 import type { FC, RefObject } from 'react';
 
-type FormPhoneMediaValue = {
+export type FormPhoneMediaValue = {
 	value: string;
 	countryCode: string;
 };
 
-type FormPhoneMediaInputProps = {
+export type FormPhoneMediaInputProps = {
 	additionalClasses?: string;
 	label: string;
 	name?: string;

--- a/client/components/forms/form-phone-media-input/index.tsx
+++ b/client/components/forms/form-phone-media-input/index.tsx
@@ -3,23 +3,19 @@ import classnames from 'classnames';
 import FormLabel from 'calypso/components/forms/form-label';
 import PhoneInput from 'calypso/components/phone-input';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { PhoneInputValue } from 'calypso/components/phone-input';
 import type { FC, MutableRefObject } from 'react';
-
-export type FormPhoneMediaValue = {
-	value: string;
-	countryCode: string;
-};
 
 export type FormPhoneMediaInputProps = {
 	additionalClasses?: string;
 	label: string;
 	name?: string;
-	value: FormPhoneMediaValue;
+	value: PhoneInputValue;
 	className?: string;
 	disabled?: boolean;
 	errorMessage?: string;
 	isError?: boolean;
-	onChange: ( newValueAndCountry: FormPhoneMediaValue ) => void;
+	onChange: ( newValueAndCountry: PhoneInputValue ) => void;
 	countriesList: CountryListItem[];
 	enableStickyCountry?: boolean;
 	inputRef?: MutableRefObject< HTMLInputElement | undefined >;
@@ -48,7 +44,7 @@ const FormPhoneMediaInput: FC< FormPhoneMediaInputProps > = ( {
 					inputRef={ inputRef }
 					name={ name }
 					onChange={ onChange }
-					value={ { value: value.value, countryCode: value.countryCode.toUpperCase() } }
+					value={ { phoneNumber: value.phoneNumber, countryCode: value.countryCode.toUpperCase() } }
 					countriesList={ countriesList }
 					enableStickyCountry={ enableStickyCountry }
 					className={ className }

--- a/client/components/forms/form-phone-media-input/index.tsx
+++ b/client/components/forms/form-phone-media-input/index.tsx
@@ -2,7 +2,8 @@ import { FormInputValidation } from '@automattic/components';
 import classnames from 'classnames';
 import FormLabel from 'calypso/components/forms/form-label';
 import PhoneInput from 'calypso/components/phone-input';
-import type { FC, RefObject } from 'react';
+import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { FC, MutableRefObject } from 'react';
 
 export type FormPhoneMediaValue = {
 	value: string;
@@ -19,9 +20,9 @@ export type FormPhoneMediaInputProps = {
 	errorMessage?: string;
 	isError?: boolean;
 	onChange: ( newValueAndCountry: FormPhoneMediaValue ) => void;
-	countriesList: { code: string; name: string }[];
+	countriesList: CountryListItem[];
 	enableStickyCountry?: boolean;
-	inputRef?: RefObject< HTMLInputElement >;
+	inputRef?: MutableRefObject< HTMLInputElement | undefined >;
 };
 
 const FormPhoneMediaInput: FC< FormPhoneMediaInputProps > = ( {
@@ -47,10 +48,9 @@ const FormPhoneMediaInput: FC< FormPhoneMediaInputProps > = ( {
 					inputRef={ inputRef }
 					name={ name }
 					onChange={ onChange }
-					value={ value.value }
+					value={ { value: value.value, countryCode: value.countryCode.toUpperCase() } }
 					countriesList={ countriesList }
 					enableStickyCountry={ enableStickyCountry }
-					countryCode={ value.countryCode.toUpperCase() }
 					className={ className }
 					isError={ isError }
 					disabled={ disabled }

--- a/client/components/forms/form-phone-media-input/index.tsx
+++ b/client/components/forms/form-phone-media-input/index.tsx
@@ -2,30 +2,33 @@ import { FormInputValidation } from '@automattic/components';
 import classnames from 'classnames';
 import FormLabel from 'calypso/components/forms/form-label';
 import PhoneInput from 'calypso/components/phone-input';
-import type { PropsWithChildren, RefObject } from 'react';
+import type { FC, RefObject } from 'react';
 
-type FormPhoneMediaInputProps = {
-	additionalClasses?: string[];
-	label: string;
-	name?: string;
+type FormPhoneMediaValue = {
 	value: string;
 	countryCode: string;
+};
+
+type FormPhoneMediaInputProps = {
+	additionalClasses?: string;
+	label: string;
+	name?: string;
+	value: FormPhoneMediaValue;
 	className?: string;
 	disabled?: boolean;
 	errorMessage?: string;
 	isError?: boolean;
-	onChange: ( _: { value: string; countryCode: string } ) => void;
+	onChange: ( newValueAndCountry: FormPhoneMediaValue ) => void;
 	countriesList: { code: string; name: string }[];
 	enableStickyCountry?: boolean;
 	inputRef?: RefObject< HTMLInputElement >;
 };
 
-export default function FormPhoneMediaInput( {
+const FormPhoneMediaInput: FC< FormPhoneMediaInputProps > = ( {
 	additionalClasses,
 	label,
 	name,
 	value,
-	countryCode,
 	className,
 	disabled,
 	errorMessage,
@@ -35,7 +38,7 @@ export default function FormPhoneMediaInput( {
 	enableStickyCountry,
 	inputRef,
 	children,
-}: PropsWithChildren< FormPhoneMediaInputProps > ) {
+} ) => {
 	return (
 		<div className={ classnames( additionalClasses, 'phone' ) }>
 			<div>
@@ -44,10 +47,10 @@ export default function FormPhoneMediaInput( {
 					inputRef={ inputRef }
 					name={ name }
 					onChange={ onChange }
-					value={ value }
+					value={ value.value }
 					countriesList={ countriesList }
 					enableStickyCountry={ enableStickyCountry }
-					countryCode={ countryCode.toUpperCase() }
+					countryCode={ value.countryCode.toUpperCase() }
 					className={ className }
 					isError={ isError }
 					disabled={ disabled }
@@ -57,4 +60,6 @@ export default function FormPhoneMediaInput( {
 			{ errorMessage && <FormInputValidation text={ errorMessage } isError /> }
 		</div>
 	);
-}
+};
+
+export default FormPhoneMediaInput;

--- a/client/components/phone-input/index.tsx
+++ b/client/components/phone-input/index.tsx
@@ -22,7 +22,7 @@ import './style.scss';
 const debug = debugFactory( 'calypso:phone-input' );
 
 export type PhoneInputValue = {
-	value: string;
+	phoneNumber: string;
 	countryCode: string;
 };
 
@@ -61,7 +61,7 @@ const PhoneInput: FC< PhoneInputProps > = ( {
 	const translate = useTranslate();
 	const [ freezeSelection, setFreezeSelection ] = useState( enableStickyCountry );
 	const [ phoneNumberState, setPhoneNumberState ] = usePhoneNumberState(
-		value.value,
+		value.phoneNumber,
 		value.countryCode,
 		countriesList,
 		freezeSelection
@@ -241,7 +241,7 @@ function getPhoneNumberStatesFromProp(
 	countryCode: string,
 	freezeSelection: boolean
 ) {
-	const { value: displayValue } = calculateInputAndCountryCode(
+	const { phoneNumber: displayValue } = calculateInputAndCountryCode(
 		rawValue,
 		countryCode,
 		freezeSelection
@@ -261,7 +261,7 @@ function getInputHandler(
 		const rawValue = event.target.value;
 		recordCursorPosition( oldCursorPosition, event.target.selectionStart );
 
-		const { countryCode, value: displayValue } = calculateInputAndCountryCode(
+		const { countryCode, phoneNumber: displayValue } = calculateInputAndCountryCode(
 			rawValue,
 			countryCodeValue,
 			freezeSelection
@@ -272,7 +272,7 @@ function getInputHandler(
 			return { rawValue, displayValue };
 		} );
 
-		onChange( { value: displayValue, countryCode } );
+		onChange( { phoneNumber: displayValue, countryCode } );
 	};
 }
 
@@ -301,7 +301,7 @@ function calculateInputAndCountryCode(
 	const calculatedValue = format( value, calculatedCountry.isoCode );
 	const calculatedCountryCode = calculatedCountry.isoCode;
 
-	return { value: calculatedValue, countryCode: calculatedCountryCode };
+	return { phoneNumber: calculatedValue, countryCode: calculatedCountryCode };
 }
 
 /**
@@ -404,7 +404,7 @@ function getCountrySelectionHandler(
 		}
 		onChange( {
 			countryCode: newCountryCode,
-			value: format( inputValue, newCountryCode ),
+			phoneNumber: format( inputValue, newCountryCode ),
 		} );
 		debug( 'setting freeze to', enableStickyCountry );
 		setFreezeSelection( enableStickyCountry );

--- a/client/components/phone-input/phone-number.ts
+++ b/client/components/phone-input/phone-number.ts
@@ -1,6 +1,10 @@
 import debugFactory from 'debug';
-import { find, flatten, includes, map, startsWith } from 'lodash';
-import { countries, dialCodeMap } from 'calypso/components/phone-input/data';
+import { flatten, map, startsWith } from 'lodash';
+import {
+	countries as countriesRaw,
+	dialCodeMap as dialCodeMapRaw,
+} from 'calypso/components/phone-input/data';
+import type { PhoneNumberPattern, CountryData } from './types';
 
 const debug = debugFactory( 'phone-input:metadata' );
 
@@ -11,15 +15,18 @@ const LONGEST_NUMBER = '999999999999999';
 const LONGEST_NUMBER_MATCH = /9/g;
 export const MIN_LENGTH_TO_FORMAT = 3;
 
+const countries: Record< string, CountryData > = countriesRaw;
+const dialCodeMap: Record< string, string[] > = dialCodeMapRaw;
+
 /**
  * Removes non digit characters from the string
  *
  * @param {string} inputNumber - Text to remove non-digits from
  * @returns {string} - Text with non-digits removed
  */
-export const stripNonDigits = ( inputNumber ) => inputNumber.replace( /\D/g, '' );
+export const stripNonDigits = ( inputNumber: string ): string => inputNumber.replace( /\D/g, '' );
 
-function prefixSearch( prefixQuery ) {
+function prefixSearch( prefixQuery: string ) {
 	return flatten(
 		Object.keys( dialCodeMap )
 			.filter( ( dialCode ) => startsWith( prefixQuery, dialCode ) )
@@ -27,7 +34,7 @@ function prefixSearch( prefixQuery ) {
 	);
 }
 
-export function findCountryFromNumber( inputNumber ) {
+export function findCountryFromNumber( inputNumber: string ) {
 	let lastExactMatch;
 
 	for ( let i = 1; i <= 6; i++ ) {
@@ -35,7 +42,7 @@ export function findCountryFromNumber( inputNumber ) {
 		if ( Object.prototype.hasOwnProperty.call( dialCodeMap, query ) ) {
 			const exactMatch = dialCodeMap[ query ];
 			if ( exactMatch.length === 1 ) {
-				return countries[ exactMatch[ 0 ] ];
+				return countries[ exactMatch[ 0 ] as keyof typeof countries ];
 			}
 			if ( exactMatch.length > 1 ) {
 				lastExactMatch = exactMatch;
@@ -46,24 +53,24 @@ export function findCountryFromNumber( inputNumber ) {
 
 		if ( ! prefixMatch.length && lastExactMatch ) {
 			// the one with high priority
-			return map( lastExactMatch, ( key ) => countries[ key ] )[ 0 ];
+			return map( lastExactMatch, ( key ) => countries[ key as keyof typeof countries ] )[ 0 ];
 		}
 
 		if ( prefixMatch.length === 1 ) {
 			// not an exact match, but there is only one option with this prefix
-			return countries[ prefixMatch[ 0 ] ];
+			return countries[ prefixMatch[ 0 ] as keyof typeof countries ];
 		}
 	}
 
 	if ( lastExactMatch ) {
-		return map( lastExactMatch, ( key ) => countries[ key ] )[ 0 ];
+		return map( lastExactMatch, ( key ) => countries[ key as keyof typeof countries ] )[ 0 ];
 	}
 
 	return null;
 }
 
-export const findPattern = ( inputNumber, patterns ) =>
-	find( patterns, ( { match, leadingDigitPattern } ) => {
+export const findPattern = ( inputNumber: string, patterns: PhoneNumberPattern[] ) =>
+	patterns.find( ( { match, leadingDigitPattern } ) => {
 		if ( leadingDigitPattern && inputNumber.search( leadingDigitPattern ) !== 0 ) {
 			return false;
 		}
@@ -79,11 +86,8 @@ export const findPattern = ( inputNumber, patterns ) =>
  * @param {Array} patterns - The list of patterns
  * @returns {string} The template string
  */
-export function makeTemplate( phoneNumber, patterns ) {
-	const selectedPattern = find( patterns, ( pattern ) => {
-		if ( includes( pattern.format, '|' ) ) {
-			return false;
-		}
+export function makeTemplate( phoneNumber: string, patterns: PhoneNumberPattern[] ): string {
+	const selectedPattern = patterns.find( ( pattern ) => {
 		if ( pattern.leadingDigitPattern && phoneNumber.search( pattern.leadingDigitPattern ) !== 0 ) {
 			return false;
 		}
@@ -91,7 +95,7 @@ export function makeTemplate( phoneNumber, patterns ) {
 		const match = pattern.match
 			.replace( CHARACTER_CLASS_PATTERN, '\\d' )
 			.replace( STANDALONE_DIGIT_PATTERN, '\\d' );
-		const matchingNumber = LONGEST_NUMBER.match( new RegExp( match ) )[ 0 ];
+		const matchingNumber = LONGEST_NUMBER.match( new RegExp( match ) )?.[ 0 ] ?? '';
 
 		return matchingNumber.length >= phoneNumber.length;
 	} );
@@ -104,7 +108,7 @@ export function makeTemplate( phoneNumber, patterns ) {
 		.replace( CHARACTER_CLASS_PATTERN, '\\d' )
 		.replace( STANDALONE_DIGIT_PATTERN, '\\d' );
 
-	const matchingNumber = LONGEST_NUMBER.match( new RegExp( selectedPatternMatch ) )[ 0 ];
+	const matchingNumber = LONGEST_NUMBER.match( new RegExp( selectedPatternMatch ) )?.[ 0 ] ?? '';
 	const template = matchingNumber.replace(
 		new RegExp( selectedPatternMatch, 'g' ),
 		selectedPattern.replace
@@ -121,7 +125,11 @@ export function makeTemplate( phoneNumber, patterns ) {
  *   position. The function will update the pos property to the match the new position after applying the template.
  * @returns {string} The formatted number
  */
-export function applyTemplate( phoneNumber, template, positionTracking = { pos: 0 } ) {
+export function applyTemplate(
+	phoneNumber: string,
+	template: string,
+	positionTracking: { pos: number } = { pos: 0 }
+): string {
 	let res = '';
 	let phoneNumberIndex = 0;
 
@@ -154,7 +162,10 @@ export function applyTemplate( phoneNumber, template, positionTracking = { pos: 
  * @returns {{nationalNumber: string, prefix: string}} - Phone is the national phone number and prefix is to be
  *   shown before the phone number
  */
-export function processNumber( inputNumber, numberRegion ) {
+export function processNumber(
+	inputNumber: string,
+	numberRegion: CountryData
+): { nationalNumber: string; prefix: string } {
 	let prefix = numberRegion.nationalPrefix || '';
 
 	let nationalNumber = stripNonDigits( inputNumber );
@@ -212,7 +223,7 @@ export function processNumber( inputNumber, numberRegion ) {
  * @param {object} country - The region for which we are formatting
  * @returns {string} - Formatted number
  */
-export function formatNumber( inputNumber, country ) {
+export function formatNumber( inputNumber: string, country: CountryData ): string {
 	const digitCount = stripNonDigits( inputNumber ).length;
 	if ( digitCount < MIN_LENGTH_TO_FORMAT || digitCount < ( country.dialCode || '' ).length ) {
 		if ( inputNumber[ 0 ] === '+' ) {
@@ -252,12 +263,12 @@ export function formatNumber( inputNumber, country ) {
 	return inputNumber;
 }
 
-export function toE164( inputNumber, country ) {
+export function toE164( inputNumber: string, country: CountryData ) {
 	const { nationalNumber } = processNumber( inputNumber, country );
 	return '+' + country.dialCode + nationalNumber;
 }
 
-export function toIcannFormat( inputNumber, country ) {
+export function toIcannFormat( inputNumber: string, country: CountryData ) {
 	if ( ! country ) {
 		return inputNumber;
 	}
@@ -294,9 +305,13 @@ export function toIcannFormat( inputNumber, country ) {
  * @param {number} oldCursorPosition Index of the cursor in oldValue
  * @returns {number} The new cursor position
  */
-export function getUpdatedCursorPosition( oldValue, newValue, oldCursorPosition ) {
-	const toList = ( str ) => str.split( '' );
-	const unmask = ( list ) => list.filter( ( char ) => /\d/.test( char ) );
+export function getUpdatedCursorPosition(
+	oldValue: string,
+	newValue: string,
+	oldCursorPosition: number
+): number {
+	const toList = ( str: string ) => str.split( '' );
+	const unmask = ( list: string[] ) => list.filter( ( char ) => /\d/.test( char ) );
 
 	if ( newValue.match( /^\+$/ ) ) {
 		return 1;
@@ -355,7 +370,7 @@ export function getUpdatedCursorPosition( oldValue, newValue, oldCursorPosition 
  * @returns [number, number] Index of the longest common suffix
  *   in each argument
  */
-export function indexOfLongestCommonSuffix( array1, array2 ) {
+export function indexOfLongestCommonSuffix< A >( array1: A[], array2: A[] ): [ number, number ] {
 	if ( array1.length === 0 || array2.length === 0 ) {
 		return [ array1.length, array2.length ];
 	}
@@ -398,8 +413,8 @@ export function indexOfLongestCommonSuffix( array1, array2 ) {
  * @returns [number, array] Index after the last array1 item in
  *   array2, as well as the remainder of array2
  */
-export function indexOfStrictSubsequenceEnd( array1, array2 ) {
-	const accumulate = ( a1, a2, offset ) => {
+export function indexOfStrictSubsequenceEnd< A >( array1: A[], array2: A[] ): [ number, A[] ] {
+	const accumulate = ( a1: A[], a2: A[], offset: number ): [ number, A[] ] => {
 		if ( a1.length === 0 ) {
 			return [ offset, a2 ];
 		}
@@ -409,7 +424,7 @@ export function indexOfStrictSubsequenceEnd( array1, array2 ) {
 		}
 		const c1 = a1.shift(); // mutate!
 		const c2 = a2.shift(); // mutate!
-		if ( c1 !== c2 ) {
+		if ( c1 !== c2 && c1 ) {
 			a1.unshift( c1 );
 		}
 		return accumulate( a1, a2, 1 + offset );
@@ -425,13 +440,13 @@ export function indexOfStrictSubsequenceEnd( array1, array2 ) {
  * @param array An array of characters
  * @returns number Number of non-digit characters appearing at the start
  */
-export function nonDigitsAtStart( array ) {
-	const accumulate = ( a, offset ) => {
+export function nonDigitsAtStart( array: string[] ): number {
+	const accumulate = ( a: string[], offset: number ): number => {
 		if ( a.length === 0 ) {
 			return offset;
 		}
 		const c = a.shift(); // mutate!
-		if ( /\d/.test( c ) ) {
+		if ( c && /\d/.test( c ) ) {
 			return offset;
 		}
 		return accumulate( a, 1 + offset );
@@ -447,6 +462,6 @@ export function nonDigitsAtStart( array ) {
  * @param array An array
  * @param index Index at which to cut off the count
  */
-export function numDigitsBeforeIndex( array, index ) {
+export function numDigitsBeforeIndex( array: string[], index: number ) {
 	return array.slice( 0, index ).filter( ( x ) => /\d/.test( x ) ).length;
 }

--- a/client/components/phone-input/phone-number.ts
+++ b/client/components/phone-input/phone-number.ts
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { flatten, map, startsWith } from 'lodash';
 import {
 	countries as countriesRaw,
 	dialCodeMap as dialCodeMapRaw,
@@ -27,11 +26,10 @@ const dialCodeMap: Record< string, string[] > = dialCodeMapRaw;
 export const stripNonDigits = ( inputNumber: string ): string => inputNumber.replace( /\D/g, '' );
 
 function prefixSearch( prefixQuery: string ) {
-	return flatten(
-		Object.keys( dialCodeMap )
-			.filter( ( dialCode ) => startsWith( prefixQuery, dialCode ) )
-			.map( ( dialCode ) => dialCodeMap[ dialCode ] )
-	);
+	return Object.keys( dialCodeMap )
+		.filter( ( dialCode ) => prefixQuery.startsWith( dialCode ) )
+		.map( ( dialCode ) => dialCodeMap[ dialCode ] )
+		.flat();
 }
 
 export function findCountryFromNumber( inputNumber: string ) {
@@ -53,7 +51,7 @@ export function findCountryFromNumber( inputNumber: string ) {
 
 		if ( ! prefixMatch.length && lastExactMatch ) {
 			// the one with high priority
-			return map( lastExactMatch, ( key ) => countries[ key as keyof typeof countries ] )[ 0 ];
+			return lastExactMatch.map( ( key ) => countries[ key as keyof typeof countries ] )[ 0 ];
 		}
 
 		if ( prefixMatch.length === 1 ) {
@@ -63,7 +61,7 @@ export function findCountryFromNumber( inputNumber: string ) {
 	}
 
 	if ( lastExactMatch ) {
-		return map( lastExactMatch, ( key ) => countries[ key as keyof typeof countries ] )[ 0 ];
+		return lastExactMatch.map( ( key ) => countries[ key as keyof typeof countries ] )[ 0 ];
 	}
 
 	return null;

--- a/client/components/phone-input/types.ts
+++ b/client/components/phone-input/types.ts
@@ -1,0 +1,18 @@
+export interface PhoneNumberPattern {
+	match: string;
+	replace: string;
+	nationalFormat?: string;
+	leadingDigitPattern?: string;
+}
+
+export interface CountryData {
+	isoCode: string;
+	dialCode: string;
+	regionCode?: string;
+	countryDialCode?: string;
+	nationalPrefix?: string;
+	priority?: number;
+	patternRegion?: string;
+	patterns?: PhoneNumberPattern[];
+	internationalPatterns?: PhoneNumberPattern[];
+}

--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -58,7 +58,7 @@ export class CountrySpecificPaymentFields extends Component {
 			// country as the billing address.
 			const phoneCountryCode = this.state.userSelectedPhoneCountryCode || this.props.countryCode;
 			value = {
-				value: baseValue,
+				phoneNumber: baseValue,
 				countryCode: phoneCountryCode,
 			};
 		}
@@ -85,8 +85,8 @@ export class CountrySpecificPaymentFields extends Component {
 			: null;
 	};
 
-	handlePhoneFieldChange = ( { value, countryCode } ) => {
-		this.props.handleFieldChange( 'phone-number', value );
+	handlePhoneFieldChange = ( { phoneNumber, countryCode } ) => {
+		this.props.handleFieldChange( 'phone-number', phoneNumber );
 		this.setState( { userSelectedPhoneCountryCode: countryCode } );
 	};
 

--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -49,6 +49,20 @@ export class CountrySpecificPaymentFields extends Component {
 	createField = ( fieldName, componentClass, props ) => {
 		const errorMessage = this.props.getErrorMessage( fieldName ) || [];
 		const isError = ! isEmpty( errorMessage );
+
+		const baseValue = this.props.getFieldValue( fieldName ) || '';
+		let value = baseValue;
+		if ( fieldName === 'phone-number' ) {
+			// If the user has manually selected a country for the phone
+			// number, use that, but otherwise default this to the same
+			// country as the billing address.
+			const phoneCountryCode = this.state.userSelectedPhoneCountryCode || this.props.countryCode;
+			value = {
+				value: baseValue,
+				countryCode: phoneCountryCode,
+			};
+		}
+
 		const fieldProps = Object.assign(
 			{},
 			{
@@ -58,7 +72,7 @@ export class CountrySpecificPaymentFields extends Component {
 				name: fieldName,
 				onBlur: this.onFieldChange,
 				onChange: this.onFieldChange,
-				value: this.props.getFieldValue( fieldName ) || '',
+				value,
 				autoComplete: 'off',
 				labelClass: 'checkout__form-label',
 				disabled: this.props.disableFields,


### PR DESCRIPTION
#### Problem

The input component `FormPhoneMediaInput` effectively is a control for two pieces of data: the string that contains the phone number and the country code of that phone number. Currently these are injected into the component via two separate props: `value` (the phone number) and `countryCode`. This mimics the API of the component it wraps, `PhoneInput`. However, both components have an `onChange` callback prop which is passed a single object for each change; that object looks like `{value: string, countryCode: string}`. 

To summarize, the components require two **inputs** of `value: string` and `countryCode: string` and they have one "**output**" (change event argument) of `{value: string; countryCode: string}`.

This inconsistency between input and change events is not intuitive (controlled inputs typically render one `value` which is set by their change event) and in some places requires additional code to support.

#### Proposed Changes

In this PR we modify **both** components to accept one input `value` prop instead, which is in the same format as the change event argument, modified slightly by this PR to be `{phoneNumber: string, countryCode: string}`. While this does not immediately reduce the code needed to support the form, it makes it more consistent and will make it easier to reduce in later PRs. As an aside, this also converts the above-mentioned components to TypeScript.

#### Testing Instructions

First, make sure there are no uses of `PhoneInput` or `FormPhoneMediaInput` apart from the files changed in this PR, specifically: `ContactDetailsFormFields`, `ManagedContactDetailsFormFields`, and `CountrySpecificPaymentFields`.

Second we can test the changed components:

##### ContactDetailsFormFields

This component is only used by the "edit contact info" page of domain management.

- Use a site that already has a domain registration purchased.
- Visit `/domains/manage/:site/edit-contact-info/:site` where both instances of `:site` are your domain name.
- Confirm that the phone number field renders as expected and that it updates when you change it.

<img width="652" alt="Screen Shot 2022-09-06 at 6 46 07 PM" src="https://user-images.githubusercontent.com/2036909/188753441-a1456a2d-79e0-49e3-846a-9fafdff04249.png">


##### ManagedContactDetailsFormFields

This component is only used by checkout for domain products.

- Visit `/domains/add` and select a domain to add to the cart.
- Click to skip the email product upsell, if one appears.
- In checkout, click to edit the contact details step unless it's already active.
- Confirm that the phone number field renders as expected and that it updates when you change it.

<img width="542" alt="Screen Shot 2022-09-06 at 6 39 41 PM" src="https://user-images.githubusercontent.com/2036909/188752862-8d9c11ca-3145-49a6-906c-142414f8822c.png">


##### CountrySpecificPaymentFields

This component is only used by Ebanx and Netbanking, but it's the Ebanx usage that includes the phone number.

- Set your user's currency to BRL.
- Visit `/plans` and add any product to your cart.
- In checkout, edit the billing information step unless it's already active.
- Select "Brazil" as the country and enter a valid postal code like `12345-678`. Press Continue.
- Pick "Credit or debit card" as the payment method.
- Verify that the phone number field renders as expected and that it updates when you change it.

<img width="523" alt="Screen Shot 2022-09-06 at 6 43 30 PM" src="https://user-images.githubusercontent.com/2036909/188753190-52659511-0d78-4d53-8427-a74b67a0dd7c.png">

