### PR TITLE
Theme/Plugin Bundling: Fix padding on theme upgrade modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -7,7 +7,10 @@ $design-button-primary-hover-color: var( --color-primary-60 );
 .upgrade-modal {
 	display: flex;
 	flex-direction: column;
-	padding: 0;
+
+	&.dialog__content {
+		padding: 0;
+	}
 
 	&.loading {
 		display: flex;


### PR DESCRIPTION
#### Proposed Changes

* Fix padding on upgrade modal

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use calypso live (I can't reproduce the problem locally)
- Create a site with these flags on: `themes/plugin-bundling,signup/seller-upgrade-modal`
- On the design picker choose a premium theme
- Check Modal

Wrong padding:
![image](https://user-images.githubusercontent.com/3801502/188127476-2041d93f-1f96-47ba-b474-05b1bdebd35c.png)

Fixed padding:
![image](https://user-images.githubusercontent.com/3801502/188127650-05f97254-53d5-4674-89f9-017db8a9632c.png)



Closes https://github.com/Automattic/wp-calypso/issues/67314
