### PR TITLE
Hide the "Create your website" banner from the site preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -16,6 +16,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 		return addQueryArgs( previewUrl, {
 			iframe: true,
 			theme_preview: true,
+			// hide the "Create your website with WordPress.com" banner
 			hide_banners: true,
 		} );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -16,6 +16,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 		return addQueryArgs( previewUrl, {
 			iframe: true,
 			theme_preview: true,
+			hide_banners: true,
 		} );
 	}
 


### PR DESCRIPTION
#### Summary
Currently we see the "Create your website with WordPress.com" banner displayed on the site preview inside the Launchpad Newsletter flow:

![4BnJct.png](https://user-images.githubusercontent.com/20927667/188231708-46b667c0-2a1c-4665-8fc2-cea6e8ee2e94.png)

The visibility of the banner is controlled by `maybe_show_marketing_bar` in `marketing-bar.php`: 

![dLgqUI.png](https://user-images.githubusercontent.com/20927667/188232089-28696951-b0d8-47d8-98d8-070ae181859a.png)

We can hide the banner by passing a `hide_banners` URL param:

![kBdntF.png](https://user-images.githubusercontent.com/20927667/188232269-6a8aae0b-fd46-4422-958d-fc153ff5e5fb.png)

#### Testing Instructions
1. Open a new Chrome Incognito tab
2. Go to `http://calypso.localhost:3000/setup/launchpad?flow=newsletter&complete-setup=true&siteSlug=YOUR_SITE_SLUG`
3. You shouldn't see the preview banner:

![GkDW4w.png](https://user-images.githubusercontent.com/20927667/188232879-8a8c1cfe-8fc5-413e-aeeb-0a97343181db.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67279 