### PR TITLE
Site Switcher: Update "Add New Site" button styles

### DIFF
--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -2,6 +2,22 @@
 
 .site-selector__jetpack-cloud {
 	display: block;
+
+	.site-selector__actions {
+		padding: 16px;
+	}
+
+	.site-selector__add-new-site {
+		border-color: var( --color-sidebar-text );
+		border-radius: 2px;
+
+		&,
+		&:hover {
+			box-shadow: 1px solid var( --color-neutral-20 );
+			background-color: var( --color-sidebar-background );
+			color: var( --color-sidebar-text );
+		}
+	}
 }
 
 // Menu links

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -1,5 +1,9 @@
 @import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' ); // Used for switch-sites icon.
 
+.site-selector__jetpack-cloud {
+	display: block;
+}
+
 // Menu links
 .sidebar__jetpack-cloud {
 

--- a/client/components/search-sites/index.js
+++ b/client/components/search-sites/index.js
@@ -13,11 +13,11 @@ export default function searchSites( WrappedComponent ) {
 	class Searcher extends Component {
 		state = { term: null };
 
-		setSearchTerm = ( term ) => this.setState( { term } );
+		setSearchTerm = ( term ) => this.setState( { term: term?.toLowerCase() ?? '' } );
 
 		getSearchResults() {
 			return this.state.term
-				? searchCollection( this.props.sites, this.state.term.toLowerCase(), [ 'name', 'URL' ] )
+				? searchCollection( this.props.sites, this.state.term, [ 'name', 'URL' ] )
 				: null;
 		}
 
@@ -25,6 +25,7 @@ export default function searchSites( WrappedComponent ) {
 			return (
 				<WrappedComponent
 					{ ...this.props }
+					searchTerm={ this.state.term }
 					searchSites={ this.setSearchTerm }
 					sitesFound={ this.getSearchResults() }
 				/>

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -19,15 +19,13 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	}, [ dispatch ] );
 
 	return (
-		<span className="site-selector__add-new-site">
-			<Button
-				borderless
-				href={ `${ onboardingUrl() }?ref=calypso-selector` }
-				onClick={ recordAddNewSite }
-			>
-				<Gridicon icon="add-outline" /> { translate( 'Add new site' ) }
-			</Button>
-		</span>
+		<Button
+			className="site-selector__add-new-site"
+			href={ `${ onboardingUrl() }?ref=calypso-selector` }
+			onClick={ recordAddNewSite }
+		>
+			{ translate( 'Add new site' ) }
+		</Button>
 	);
 };
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -59,10 +59,12 @@ export class SiteSelector extends Component {
 		allSitesPath: PropTypes.string,
 		navigateToSite: PropTypes.func.isRequired,
 		isReskinned: PropTypes.bool,
+		showManageSitesButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		sites: {},
+		showManageSitesButton: false,
 		showAddNewSite: false,
 		showAllSites: false,
 		siteBasePath: false,
@@ -313,12 +315,12 @@ export class SiteSelector extends Component {
 		);
 
 		// Let's not display the all sites button if there is no multi-site context.
-		if ( this.props.showManageSites && ! multiSiteContext ) {
+		if ( this.props.showManageSitesButton && ! multiSiteContext ) {
 			return null;
 		}
 
 		// Let's not display the all sites button if we are already displaying a multi-site context page.
-		if ( this.props.showManageSites && ! this.props.selectedSite ) {
+		if ( this.props.showManageSitesButton && ! this.props.selectedSite ) {
 			return null;
 		}
 
@@ -494,7 +496,7 @@ export class SiteSelector extends Component {
 						</span>
 					) }
 				</div>
-				{ this.props.showManageSites && (
+				{ this.props.showManageSitesButton && (
 					<Button
 						onClick={ this.onManageSitesClick }
 						href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -309,7 +309,7 @@ export class SiteSelector extends Component {
 		}
 
 		const allSitesMenuTitle = allSitesMenu()
-			.find( ( menu ) => menu.url === this.props.allSitesPath )
+			.find( ( menu ) => menu.url === this.props.allSitesPath.replace( '/posts/my', '/posts' ) )
 			?.title?.toLocaleLowerCase();
 
 		this.visibleSites.push( ALL_SITES );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -502,12 +502,7 @@ export class SiteSelector extends Component {
 						aria-label={ this.props.translate( 'Go to Sites' ) }
 						title={ this.props.translate( 'Go to Sites' ) }
 					>
-						{ sites.length > 0
-							? this.props.translate( 'Manage %(count)d site', 'Manage %(count)d sites', {
-									count: sites.length,
-									args: { count: sites.length },
-							  } )
-							: this.props.translate( 'Manage sites' ) }
+						{ this.props.translate( 'Manage sites' ) }
 					</Button>
 				) }
 				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -16,6 +16,7 @@ import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
 import searchSites from 'calypso/components/search-sites';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import { addQueryArgs } from 'calypso/lib/url';
 import allSitesMenu from 'calypso/my-sites/sidebar/static-data/all-sites-menu';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -478,7 +479,7 @@ export class SiteSelector extends Component {
 				</div>
 				{ this.props.showAllSites && (
 					<Button
-						href={ '/sites' }
+						href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }
 						className="site-selector__manage-sites"
 						aria-label={ this.props.translate( 'Go to Sites' ) }
 						title={ this.props.translate( 'Go to Sites' ) }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -304,13 +304,19 @@ export class SiteSelector extends Component {
 			return null;
 		}
 
-		if ( this.props.showManageSites && ! this.props.selectedSite ) {
-			return null;
-		}
-
 		const allSitesMenuTitle = allSitesMenu()
 			.find( ( menu ) => menu.url === this.props.allSitesPath.replace( '/posts/my', '/posts' ) )
 			?.title?.toLocaleLowerCase();
+
+		// Let's not display the all sites button if an all-sites section does not exist.
+		if ( this.props.showManageSites && ! allSitesMenuTitle ) {
+			return null;
+		}
+
+		// Let's not display the all sites button if we are already showing an all-sites section.
+		if ( this.props.showManageSites && ! this.props.selectedSite ) {
+			return null;
+		}
 
 		this.visibleSites.push( ALL_SITES );
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -15,6 +15,7 @@ import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
 import searchSites from 'calypso/components/search-sites';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import allSitesMenu from 'calypso/my-sites/sidebar/static-data/all-sites-menu';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
@@ -297,9 +298,19 @@ export class SiteSelector extends Component {
 	}
 
 	renderAllSites() {
-		if ( ! this.props.showAllSites || this.props.sitesFound || ! this.props.allSitesPath ) {
+		if (
+			! this.props.showAllSites ||
+			this.props.sitesFound ||
+			! this.props.allSitesPath ||
+			this.props.allSitesPath === '/sites' ||
+			! this.props.selectedSite
+		) {
 			return null;
 		}
+
+		const allSitesMenuTitle = allSitesMenu()
+			.find( ( menu ) => menu.url === this.props.allSitesPath )
+			?.title?.toLocaleLowerCase();
 
 		this.visibleSites.push( ALL_SITES );
 
@@ -313,6 +324,15 @@ export class SiteSelector extends Component {
 				onMouseEnter={ this.onAllSitesHover }
 				isHighlighted={ isHighlighted }
 				isSelected={ this.isSelected( ALL_SITES ) }
+				title={
+					allSitesMenuTitle &&
+					/* translators: allSitesMenuTitle is an entity from client/my-sites/sidebar/static-data/all-sites-menu.js */
+					this.props.translate( 'View %(allSitesMenuTitle)s for all sites', {
+						args: {
+							allSitesMenuTitle,
+						},
+					} )
+				}
 			/>
 		);
 	}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -219,6 +219,10 @@ export class SiteSelector extends Component {
 		this.onSiteSelect( event, ALL_SITES );
 	};
 
+	onManageSitesClick = () => {
+		this.props.recordTracksEvent( 'calypso_manage_sites_click' );
+	};
+
 	onSiteHover = ( event, siteId ) => {
 		if ( this.lastMouseHover !== siteId ) {
 			debug( `${ siteId } hovered` );
@@ -492,6 +496,7 @@ export class SiteSelector extends Component {
 				</div>
 				{ this.props.showManageSites && (
 					<Button
+						onClick={ this.onManageSitesClick }
 						href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }
 						className="site-selector__manage-sites"
 						aria-label={ this.props.translate( 'Go to Sites' ) }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -1,4 +1,5 @@
 import { getUrlParts, getUrlFromParts, determineUrlType, format } from '@automattic/calypso-url';
+import { Button } from '@automattic/components';
 import SearchRestyled from '@automattic/search';
 import classNames from 'classnames';
 import debugFactory from 'debug';
@@ -475,6 +476,19 @@ export class SiteSelector extends Component {
 						</span>
 					) }
 				</div>
+				{ this.props.showAllSites && (
+					<Button
+						href={ '/sites' }
+						className="site-selector__manage-sites"
+						aria-label={ this.props.translate( 'Go to Sites' ) }
+						title={ this.props.translate( 'Go to Sites' ) }
+					>
+						{ this.props.translate( 'Manage %(count)d site', 'Manage %(count)d sites', {
+							count: sites.length,
+							args: { count: sites.length },
+						} ) }
+					</Button>
+				) }
 				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
 			</div>
 		);

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -214,8 +214,8 @@ export class SiteSelector extends Component {
 		}
 	};
 
-	onAllSitesSelect = ( event ) => {
-		this.props.recordTracksEvent( 'calypso_all_my_sites_click' );
+	onAllSitesSelect = ( event, properties ) => {
+		this.props.recordTracksEvent( 'calypso_all_my_sites_click', properties );
 		this.onSiteSelect( event, ALL_SITES );
 	};
 
@@ -304,12 +304,12 @@ export class SiteSelector extends Component {
 			return null;
 		}
 
-		const multiSiteContextTitle = allSitesMenu()
-			.find( ( menu ) => menu.url === this.props.allSitesPath.replace( '/posts/my', '/posts' ) )
-			?.title?.toLocaleLowerCase();
+		const multiSiteContext = allSitesMenu().find(
+			( menu ) => menu.url === this.props.allSitesPath.replace( '/posts/my', '/posts' )
+		);
 
 		// Let's not display the all sites button if there is no multi-site context.
-		if ( this.props.showManageSites && ! multiSiteContextTitle ) {
+		if ( this.props.showManageSites && ! multiSiteContext ) {
 			return null;
 		}
 
@@ -326,16 +326,25 @@ export class SiteSelector extends Component {
 			<AllSites
 				key="selector-all-sites"
 				sites={ this.props.sites }
-				onSelect={ this.onAllSitesSelect }
+				onSelect={ ( event ) =>
+					this.onAllSitesSelect(
+						event,
+						multiSiteContext
+							? {
+									multi_site_context_slug: multiSiteContext.slug,
+							  }
+							: undefined
+					)
+				}
 				onMouseEnter={ this.onAllSitesHover }
 				isHighlighted={ isHighlighted }
 				isSelected={ this.isSelected( ALL_SITES ) }
 				title={
-					multiSiteContextTitle &&
+					multiSiteContext &&
 					/* translators: multiSiteContextTitle is an entity from client/my-sites/sidebar/static-data/all-sites-menu.js */
 					this.props.translate( 'View %(multiSiteContextTitle)s for all sites', {
 						args: {
-							multiSiteContextTitle,
+							multiSiteContextTitle: multiSiteContext.title.toLocaleLowerCase(),
 						},
 					} )
 				}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -304,16 +304,16 @@ export class SiteSelector extends Component {
 			return null;
 		}
 
-		const allSitesMenuTitle = allSitesMenu()
+		const multiSiteContextTitle = allSitesMenu()
 			.find( ( menu ) => menu.url === this.props.allSitesPath.replace( '/posts/my', '/posts' ) )
 			?.title?.toLocaleLowerCase();
 
-		// Let's not display the all sites button if an all-sites section does not exist.
-		if ( this.props.showManageSites && ! allSitesMenuTitle ) {
+		// Let's not display the all sites button if there is no multi-site context.
+		if ( this.props.showManageSites && ! multiSiteContextTitle ) {
 			return null;
 		}
 
-		// Let's not display the all sites button if we are already showing an all-sites section.
+		// Let's not display the all sites button if we are already displaying a multi-site context page.
 		if ( this.props.showManageSites && ! this.props.selectedSite ) {
 			return null;
 		}
@@ -331,11 +331,11 @@ export class SiteSelector extends Component {
 				isHighlighted={ isHighlighted }
 				isSelected={ this.isSelected( ALL_SITES ) }
 				title={
-					allSitesMenuTitle &&
-					/* translators: allSitesMenuTitle is an entity from client/my-sites/sidebar/static-data/all-sites-menu.js */
-					this.props.translate( 'View %(allSitesMenuTitle)s for all sites', {
+					multiSiteContextTitle &&
+					/* translators: multiSiteContextTitle is an entity from client/my-sites/sidebar/static-data/all-sites-menu.js */
+					this.props.translate( 'View %(multiSiteContextTitle)s for all sites', {
 						args: {
-							allSitesMenuTitle,
+							multiSiteContextTitle,
 						},
 					} )
 				}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -300,13 +300,11 @@ export class SiteSelector extends Component {
 	}
 
 	renderAllSites() {
-		if (
-			! this.props.showAllSites ||
-			this.props.sitesFound ||
-			! this.props.allSitesPath ||
-			this.props.allSitesPath === '/sites' ||
-			! this.props.selectedSite
-		) {
+		if ( ! this.props.showAllSites || this.props.sitesFound || ! this.props.allSitesPath ) {
+			return null;
+		}
+
+		if ( this.props.showManageSites && ! this.props.selectedSite ) {
 			return null;
 		}
 
@@ -477,7 +475,7 @@ export class SiteSelector extends Component {
 						</span>
 					) }
 				</div>
-				{ this.props.showAllSites && (
+				{ this.props.showManageSites && (
 					<Button
 						href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }
 						className="site-selector__manage-sites"

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -482,10 +482,12 @@ export class SiteSelector extends Component {
 						aria-label={ this.props.translate( 'Go to Sites' ) }
 						title={ this.props.translate( 'Go to Sites' ) }
 					>
-						{ this.props.translate( 'Manage %(count)d site', 'Manage %(count)d sites', {
-							count: sites.length,
-							args: { count: sites.length },
-						} ) }
+						{ sites.length > 0
+							? this.props.translate( 'Manage %(count)d site', 'Manage %(count)d sites', {
+									count: sites.length,
+									args: { count: sites.length },
+							  } )
+							: this.props.translate( 'Manage sites' ) }
 					</Button>
 				) }
 				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -496,18 +496,20 @@ export class SiteSelector extends Component {
 						</span>
 					) }
 				</div>
-				{ this.props.showManageSitesButton && (
-					<Button
-						onClick={ this.onManageSitesClick }
-						href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }
-						className="site-selector__manage-sites"
-						aria-label={ this.props.translate( 'Go to Sites' ) }
-						title={ this.props.translate( 'Go to Sites' ) }
-					>
-						{ this.props.translate( 'Manage sites' ) }
-					</Button>
-				) }
-				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
+				<div className="site-selector__actions">
+					{ this.props.showManageSitesButton && (
+						<Button
+							onClick={ this.onManageSitesClick }
+							href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }
+							className="site-selector__manage-sites"
+							aria-label={ this.props.translate( 'Go to Sites' ) }
+							title={ this.props.translate( 'Go to Sites' ) }
+						>
+							{ this.props.translate( 'Manage sites' ) }
+						</Button>
+					) }
+					{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -16,7 +16,6 @@
 	z-index: z-index( 'root', '.site-selector' );
 	display: flex;
 	flex-direction: column;
-	height: calc( 100vh - var( --masterbar-height ) );
 
 	&.is-large .search {
 		display: flex;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -208,39 +208,15 @@
 	}
 }
 
-.site-selector__add-new-site {
-	padding: 0;
-	border-top: 1px solid var( --color-neutral-5 );
-	margin: auto 0 0;
-	display: flex;
-	flex-direction: row;
-	padding-left: 10px;
-}
-
-.site-selector__add-new-site .button {
-	box-sizing: border-box;
-	display: inline-block;
-	text-transform: uppercase;
-	font-size: $font-body-extra-small;
-	font-weight: 600;
-	padding: 8px;
-	color: var( --color-neutral-40 );
-	line-height: 2.1;
+.site-selector .site-selector__add-new-site {
+	background: var( --color-primary );
+	border-color: var( --color-primary );
+	color: var( --color-surface );
 
 	&:hover {
-		color: var( --color-neutral-70 );
-	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		padding: 16px;
-	}
-
-	.gridicon {
-		display: block;
-		float: left;
-		margin-right: 6px;
-		top: auto;
-		margin-top: auto;
+		background: var( --color-primary-60 );
+		border-color: var( --color-primary-60 );
+		color: var( --color-surface );
 	}
 }
 

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -14,6 +14,9 @@
 	position: static;
 	border: none;
 	z-index: z-index( 'root', '.site-selector' );
+	display: flex;
+	flex-direction: column;
+	height: calc( 100vh - var( --masterbar-height ) );
 
 	&.is-large .search {
 		display: flex;
@@ -138,6 +141,7 @@
 .site-selector .search {
 	margin: 8px;
 	height: 33px;
+	max-height: 33px;
 	border: 1px solid var( --color-neutral-10 );
 	display: block;
 	opacity: 0;
@@ -167,6 +171,7 @@
 
 // The actual list of sites
 .site-selector__sites {
+	flex: 1;
 	max-height: calc( 100% - 93px );
 	overflow-y: auto;
 	background: var( --color-surface );
@@ -180,6 +185,21 @@
 	color: var( --color-neutral-light );
 	font-style: italic;
 	padding: 10px 20px;
+}
+
+.site-selector__manage-sites {
+	background: transparent;
+	border-color: var( --color-surface );
+	margin: 8px;
+
+	&,
+	&:visited {
+		color: var( --color-surface );
+	}
+
+	&:hover {
+		color: var( --color-neutral-20 );
+	}
 }
 
 .site-selector__add-new-site {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -186,10 +186,16 @@
 	padding: 10px 20px;
 }
 
+.site-selector__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 8px;
+}
+
 .site-selector__manage-sites {
 	background: transparent;
 	border-color: var( --color-surface );
-	margin: 8px;
 
 	&,
 	&:visited {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -188,17 +188,17 @@
 
 .site-selector__manage-sites {
 	background: transparent;
-	border-color: var( --color-neutral-20 );
+	border-color: var( --color-surface );
 	margin: 8px;
 
 	&,
 	&:visited {
-		color: var( --color-neutral-20 );
+		color: var( --color-surface );
 	}
 
 	&:hover {
-		border-color: var( --color-surface );
-		color: var( --color-surface );
+		border-color: var( --color-neutral-20 );
+		color: var( --color-neutral-20 );
 	}
 }
 

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -188,16 +188,17 @@
 
 .site-selector__manage-sites {
 	background: transparent;
-	border-color: var( --color-surface );
+	border-color: var( --color-neutral-20 );
 	margin: 8px;
 
 	&,
 	&:visited {
-		color: var( --color-surface );
+		color: var( --color-neutral-20 );
 	}
 
 	&:hover {
-		color: var( --color-neutral-20 );
+		border-color: var( --color-surface );
+		color: var( --color-surface );
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -36,7 +36,13 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 
 	return (
 		<div>
-			<SiteSelector showAddNewSite showAllSites allSitesPath={ path } siteBasePath="/backup" />
+			<SiteSelector
+				className="site-selector__jetpack-cloud"
+				showAddNewSite
+				showAllSites
+				allSitesPath={ path }
+				siteBasePath="/backup"
+			/>
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>
 					<CurrentSite

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -49,9 +49,9 @@ import { handleScroll } from './utils';
 import 'calypso/components/environment-badge/style.scss';
 import './style.scss';
 
-function SidebarScrollSynchronizer() {
+function SidebarScrollSynchronizer( { layoutFocus } ) {
 	const isNarrow = useBreakpoint( '<660px' );
-	const active = ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ); // Jetpack cloud hasn't yet aligned with WPCOM.
+	const active = ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ) && layoutFocus !== 'sites'; // Jetpack cloud hasn't yet aligned with WPCOM.
 
 	useEffect( () => {
 		if ( active ) {
@@ -229,7 +229,7 @@ class Layout extends Component {
 
 		return (
 			<div className={ sectionClass }>
-				<SidebarScrollSynchronizer />
+				<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />
 				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<BodySectionCssClass
 					group={ this.props.sectionGroup }

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -99,6 +99,7 @@ class SitePicker extends Component {
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
+					showManageSites
 					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }
 					showAddNewSite={ true }

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -99,7 +99,7 @@ class SitePicker extends Component {
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
-					showManageSites
+					showManageSitesButton
 					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }
 					showAddNewSite={ true }


### PR DESCRIPTION
#### Proposed Changes

Follows up on https://github.com/Automattic/wp-calypso/pull/67295 and fixes https://github.com/Automattic/wp-calypso/issues/67041.

This PR adds some styling to the "Add New Site" button as part of the Site Switcher re-branding task.

#### Testing Instructions

Check that the `Add New Site` button looks different and conforms to https://github.com/Automattic/wp-calypso/issues/67041 on both Calypso and Jetpack Cloud:

| Calypso | Jetpack Cloud |
| -------- | --------------- |
| ![image](https://user-images.githubusercontent.com/26530524/188239757-29c28e10-865a-4479-a453-91fe2d53fd5a.png) | ![image](https://user-images.githubusercontent.com/26530524/188239719-b6e984cd-17cb-47ce-bf59-bfbb9ec777cd.png) |
