### PR TITLE
Client/Jetpack-Connect: Migrate `authorize`'s tests to RTL

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -1,132 +1,216 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JetpackAuthorize renders as expected 1`] = `
-<Connect(Localized(JetpackConnectMainWrapper))
-  isWoo={false}
-  pageTitle=""
-  wooDnaConfig={
-    Object {
-      "getFlowName": [Function],
-      "getServiceHelpUrl": [Function],
-      "getServiceName": [Function],
-      "isWooDnaFlow": [Function],
-    }
-  }
->
-  <div
-    className="jetpack-connect__authorize-form"
+<div>
+  <main
+    class="jetpack-connect__main main"
+    role="main"
   >
     <div
-      className="jetpack-connect__logged-in-form"
+      class="jetpack-connect__main-logo"
     >
-      <QuerySiteFeatures
-        siteIds={
-          Array [
-            98765,
-          ]
-        }
-      />
-      <QuerySitePurchases
-        siteId={98765}
-      />
-      <QueryUserConnection
-        siteId={98765}
-        siteIsOnSitesList={false}
-      />
-      <Connect(Localized(AuthFormHeader))
-        authQuery={
-          Object {
-            "authApproved": false,
-            "blogname": "Example Blog",
-            "clientId": 98765,
-            "closeWindowAfterAuthorize": false,
-            "closeWindowAfterLogin": false,
-            "from": "banner-44-slide-1-dashboard",
-            "homeUrl": "http://an.example.site",
-            "jpVersion": "5.4",
-            "nonce": "fooBarNonce",
-            "redirectAfterAuth": "http://an.example.site/wp-admin/admin.php?page=jetpack",
-            "redirectUri": "http://an.example.site/wp-admin/admin.php?page=jetpack&action=authorize&_wpnonce=fooBarNonce&redirect=http%3A%2F%2Fan.example.site%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack",
-            "scope": "administrator:fooBarBaz",
-            "secret": "fooBarSecret",
-            "site": "http://an.example.site",
-            "siteIcon": "",
-            "siteUrl": "http://an.example.site",
-            "state": "1",
-            "userEmail": "email@an.example.site",
-          }
-        }
-        isWoo={false}
-        wooDnaConfig={
-          Object {
-            "getFlowName": [Function],
-            "getServiceHelpUrl": [Function],
-            "getServiceName": [Function],
-            "isWooDnaFlow": [Function],
-          }
-        }
-      />
-      <Memo(Card)
-        className="jetpack-connect__logged-in-card"
+      <div
+        class="jetpack-header"
       >
-        <Connect(Gravatar)
-          size={64}
-          user={
-            Object {
-              "display_name": "A User's Name",
-            }
-          }
-        />
-        <p
-          className="jetpack-connect__logged-in-form-user-text"
+        <svg
+          class="jetpack-logo"
+          height="45"
+          viewBox="0 0 118 32"
         >
-          Connecting as {{strong}}%(user)s{{/strong}} ({{strong}}%(email)s{{/strong}})
-        </p>
-        <LoggedOutFormFooter
-          className="jetpack-connect__action-disclaimer"
-        >
-          <Connect(Localized(JetpackConnectDisclaimer))
-            siteName="Example Blog"
+          <title>
+            Jetpack
+          </title>
+          <path
+            class="jetpack-logo__icon-circle"
+            d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+            fill="#069e08"
           />
-          <ForwardRef(Button)
-            disabled={false}
-            onClick={[Function]}
-            primary={true}
-            type="button"
-          >
-            Approve
-          </ForwardRef(Button)>
-        </LoggedOutFormFooter>
-      </Memo(Card)>
-      <LoggedOutFormLinks>
-        <LoggedOutFormLinkItem
-          href="http://an.example.site/wp-admin/admin.php?page=jetpack"
-        >
-          <Gridicon
-            icon="arrow-left"
-            size={18}
+          <polygon
+            class="jetpack-logo__icon-triangle"
+            fill="#fff"
+            points="15,19 7,19 15,3 "
           />
-           
-          Return to %(sitename)s
-        </LoggedOutFormLinkItem>
-        <LoggedOutFormLinkItem
-          href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&from=banner-44-slide-1-dashboard"
-          onClick={[Function]}
-        >
-          Sign in as a different user
-        </LoggedOutFormLinkItem>
-        <LoggedOutFormLinkItem
-          onClick={[Function]}
-        >
-          Create a new account
-        </LoggedOutFormLinkItem>
-        <JetpackConnectHappychatButton
-          eventName="calypso_jpc_authorize_chat_initiated"
-        >
-          <JetpackConnectHelpButton />
-        </JetpackConnectHappychatButton>
-      </LoggedOutFormLinks>
+          <polygon
+            class="jetpack-logo__icon-triangle"
+            fill="#fff"
+            points="17,29 17,13 25,13 "
+          />
+          <path
+            class="jetpack-logo__text"
+            d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z"
+          />
+        </svg>
+      </div>
     </div>
-  </div>
-</Connect(Localized(JetpackConnectMainWrapper))>
+    <div
+      class="jetpack-connect__authorize-form"
+    >
+      <div
+        class="jetpack-connect__logged-in-form"
+      >
+        <div>
+          <header
+            class="formatted-header"
+            id=""
+          >
+            <h1
+              class="formatted-header__title"
+            >
+              Create an account to set up Jetpack
+               
+              
+            </h1>
+            <p
+              class="formatted-header__subtitle"
+            >
+              You are moments away from a better WordPress.
+            </p>
+          </header>
+          <div
+            class="card jetpack-connect__site is-compact"
+          >
+            <div
+              class="site"
+            >
+              <a
+                aria-label="an.example.site"
+                class="site__content"
+                title="an.example.site"
+              >
+                <div
+                  class="site-icon is-blank"
+                  style="height: 32px; width: 32px; line-height: 32px; font-size: 32px;"
+                >
+                  <svg
+                    class="gridicon gridicons-globe"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <use
+                      xlink:href="gridicons.svg#gridicons-globe"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="site__info"
+                >
+                  <div
+                    class="site__title"
+                  >
+                    Example Blog
+                  </div>
+                  <div
+                    class="site__domain"
+                  >
+                    an.example.site
+                  </div>
+                </div>
+              </a>
+              <div
+                class="site-indicator__wrapper"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card jetpack-connect__logged-in-card"
+        >
+          <img
+            alt="A User's Name"
+            class="gravatar"
+            height="64"
+            src="https://www.gravatar.com/avatar/0?s=96&d=mm"
+            width="64"
+          />
+          <p
+            class="jetpack-connect__logged-in-form-user-text"
+          >
+            Connecting as {{strong}}%(user)s{{/strong}} ({{strong}}%(email)s{{/strong}})
+          </p>
+          <div
+            class="card logged-out-form__footer jetpack-connect__action-disclaimer"
+          >
+            <p
+              class="jetpack-connect__tos-link"
+            >
+              By connecting your site, you agree to 
+              <a
+                class="jetpack-connect__sso-actions-modal-link"
+                href="https://jetpack.com/support/what-data-does-jetpack-sync/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                share details
+              </a>
+               between WordPress.com and Example Blog.
+            </p>
+            <button
+              class="button is-primary"
+              type="button"
+            >
+              Approve
+            </button>
+          </div>
+        </div>
+        <div
+          class="logged-out-form__links"
+        >
+          <a
+            class="logged-out-form__link-item"
+            href="http://an.example.site/wp-admin/admin.php?page=jetpack"
+          >
+            <svg
+              class="gridicon gridicons-arrow-left needs-offset-y"
+              height="18"
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="gridicons.svg#gridicons-arrow-left"
+              />
+            </svg>
+             
+            Return to %(sitename)s
+          </a>
+          <a
+            class="logged-out-form__link-item"
+            href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&from=banner-44-slide-1-dashboard"
+          >
+            Sign in as a different user
+          </a>
+          <a
+            class="logged-out-form__link-item"
+          >
+            Create a new account
+          </a>
+          <div>
+            <a
+              class="logged-out-form__link-item jetpack-connect__help-button"
+              href="https://jetpack.com/contact-support?hpi=1"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <svg
+                class="gridicon gridicons-help-outline needs-offset"
+                height="18"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="gridicons.svg#gridicons-help-outline"
+                />
+              </svg>
+               
+              Get help setting up Jetpack
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
 `;

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -4,6 +4,11 @@
 
 import deepFreeze from 'deep-freeze';
 import { shallow } from 'enzyme';
+import documentHeadReducer from 'calypso/state/document-head/reducer';
+import happychatReducer from 'calypso/state/happychat/reducer';
+import purchasesReducer from 'calypso/state/purchases/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from '../../../client/test-helpers/testing-library';
 import { JetpackAuthorize } from '../authorize';
 import { JPC_PATH_PLANS } from '../constants';
 import { OFFER_RESET_FLOW_TYPES } from '../flow-types';
@@ -63,6 +68,17 @@ const DEFAULT_PROPS = deepFreeze( {
 	userHasUnattachedLicenses: false,
 } );
 
+function renderWithRedux( ui ) {
+	return renderWithProvider( ui, {
+		reducers: {
+			ui: uiReducer,
+			documentHead: documentHeadReducer,
+			purchases: purchasesReducer,
+			happychat: happychatReducer,
+		},
+	} );
+}
+
 jest.mock( '@automattic/calypso-config', () => {
 	const mock = () => 'development';
 	mock.isEnabled = jest.fn( ( featureFlag ) => {
@@ -76,9 +92,9 @@ jest.mock( '@automattic/calypso-config', () => {
 
 describe( 'JetpackAuthorize', () => {
 	test( 'renders as expected', () => {
-		const wrapper = shallow( <JetpackAuthorize { ...DEFAULT_PROPS } /> );
+		const { container } = renderWithRedux( <JetpackAuthorize { ...DEFAULT_PROPS } /> );
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	describe( 'isSso', () => {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -379,7 +379,7 @@ describe( 'JetpackAuthorize', () => {
 					} }
 					partnerSlug="pressable"
 					isAlreadyOnSitesList
-					isFetchingSites={ true }
+					isFetchingSites
 				/>
 			);
 

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -396,8 +396,8 @@ describe( 'JetpackAuthorize', () => {
 						...DEFAULT_PROPS.authQuery,
 						alreadyAuthorized: true,
 					} }
-					isAlreadyOnSitesList={ true }
-					isFetchingSites={ true }
+					isAlreadyOnSitesList
+					isFetchingSites
 					selectedPlanSlug={ OFFER_RESET_FLOW_TYPES[ 0 ] }
 				/>
 			);
@@ -423,9 +423,9 @@ describe( 'JetpackAuthorize', () => {
 						...DEFAULT_PROPS.authQuery,
 						alreadyAuthorized: true,
 					} }
-					isAlreadyOnSitesList={ true }
-					isFetchingSites={ true }
-					siteHasJetpackPaidProduct={ true }
+					isAlreadyOnSitesList
+					isFetchingSites
+					siteHasJetpackPaidProduct
 				/>
 			);
 
@@ -444,9 +444,9 @@ describe( 'JetpackAuthorize', () => {
 						...DEFAULT_PROPS.authQuery,
 						alreadyAuthorized: true,
 					} }
-					isAlreadyOnSitesList={ true }
-					isFetchingSites={ true }
-					userHasUnattachedLicenses={ true }
+					isAlreadyOnSitesList
+					isFetchingSites
+					userHasUnattachedLicenses
 				/>
 			);
 
@@ -469,8 +469,8 @@ describe( 'JetpackAuthorize', () => {
 						...DEFAULT_PROPS.authQuery,
 						alreadyAuthorized: true,
 					} }
-					isAlreadyOnSitesList={ true }
-					isFetchingSites={ true }
+					isAlreadyOnSitesList
+					isFetchingSites
 				/>
 			);
 

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -179,9 +179,13 @@ describe( 'JetpackAuthorize', () => {
 	} );
 
 	describe( 'shouldAutoAuthorize', () => {
-		test( 'should authorize if isSso', () => {
-			const authorizeMock = jest.fn();
+		let authorizeMock;
 
+		beforeEach( () => {
+			authorizeMock = jest.fn();
+		} );
+
+		test( 'should authorize if isSso', () => {
 			const authQuery = {
 				...DEFAULT_PROPS.authQuery,
 				from: 'sso',
@@ -200,8 +204,6 @@ describe( 'JetpackAuthorize', () => {
 		} );
 
 		test( 'should auto-authorize for WOO services', () => {
-			const authorizeMock = jest.fn();
-
 			const authQuery = {
 				...DEFAULT_PROPS.authQuery,
 				from: 'woocommerce-services-auto-authorize',
@@ -219,8 +221,6 @@ describe( 'JetpackAuthorize', () => {
 		} );
 
 		test( 'should not auto-authorize for WOO onboarding', () => {
-			const authorizeMock = jest.fn();
-
 			const authQuery = {
 				...DEFAULT_PROPS.authQuery,
 				from: 'woocommerce-onboarding',
@@ -238,8 +238,6 @@ describe( 'JetpackAuthorize', () => {
 		} );
 
 		test( 'should auto-authorize for the old WOO setup wizard', () => {
-			const authorizeMock = jest.fn();
-
 			const authQuery = {
 				...DEFAULT_PROPS.authQuery,
 				from: 'woocommerce-setup-wizard',

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -354,14 +354,22 @@ describe( 'JetpackAuthorize', () => {
 	} );
 
 	describe( 'getRedirectionTarget', () => {
-		test( 'should redirect to pressable if partnerSlug is "pressable"', async () => {
-			const originalWindowLocation = global.window.location;
+		let originalWindowLocation;
+
+		beforeEach( () => {
+			originalWindowLocation = global.window.location;
 			delete global.window.location;
 			global.window.location = {
 				href: 'http://wwww.example.com',
 				origin: 'http://www.example.com',
 			};
+		} );
 
+		afterEach( () => {
+			global.window.location = originalWindowLocation;
+		} );
+
+		test( 'should redirect to pressable if partnerSlug is "pressable"', async () => {
 			renderWithRedux(
 				<JetpackAuthorize
 					{ ...DEFAULT_PROPS }
@@ -379,19 +387,10 @@ describe( 'JetpackAuthorize', () => {
 
 			const target = global.window.location.href;
 
-			global.window.location = originalWindowLocation;
-
 			expect( target ).toBe( `/start/pressable-nux?blogid=${ DEFAULT_PROPS.authQuery.clientId }` );
 		} );
 
 		test( 'should redirect to /checkout if the selected plan/product is Jetpack plan/product', async () => {
-			const originalWindowLocation = global.window.location;
-			delete global.window.location;
-			global.window.location = {
-				href: 'http://wwww.example.com',
-				origin: 'http://www.example.com',
-			};
-
 			renderWithRedux(
 				<JetpackAuthorize
 					{ ...DEFAULT_PROPS }
@@ -409,13 +408,10 @@ describe( 'JetpackAuthorize', () => {
 
 			const target = global.window.location.href;
 
-			global.window.location = originalWindowLocation;
-
 			expect( target ).toBe( `/checkout/${ SITE_SLUG }/${ OFFER_RESET_FLOW_TYPES[ 0 ] }` );
 		} );
 
 		test( 'should redirect to wp-admin when site has a purchased plan/product', async () => {
-			const originalWindowLocation = global.window.location;
 			delete global.window.location;
 			global.window.location = {
 				href: 'http://wwww.example.com',
@@ -439,19 +435,10 @@ describe( 'JetpackAuthorize', () => {
 
 			const target = global.window.location.href;
 
-			global.window.location = originalWindowLocation;
-
 			expect( target ).toBe( DEFAULT_PROPS.authQuery.redirectAfterAuth );
 		} );
 
 		test( 'should redirect to /jetpack/connect/plans when user has an unattached "user"(not partner) license key', async () => {
-			const originalWindowLocation = global.window.location;
-			delete global.window.location;
-			global.window.location = {
-				href: 'http://wwww.example.com',
-				origin: 'http://www.example.com',
-			};
-
 			renderWithRedux(
 				<JetpackAuthorize
 					{ ...DEFAULT_PROPS }
@@ -469,8 +456,6 @@ describe( 'JetpackAuthorize', () => {
 
 			const target = global.window.location.href;
 
-			global.window.location = originalWindowLocation;
-
 			expect( target ).toBe(
 				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect=${ encodeURIComponent(
 					DEFAULT_PROPS.authQuery.redirectAfterAuth
@@ -479,13 +464,6 @@ describe( 'JetpackAuthorize', () => {
 		} );
 
 		test( 'should redirect to redirect to the /jetpack/connect/plans page by default', async () => {
-			const originalWindowLocation = global.window.location;
-			delete global.window.location;
-			global.window.location = {
-				href: 'http://wwww.example.com',
-				origin: 'http://www.example.com',
-			};
-
 			renderWithRedux(
 				<JetpackAuthorize
 					{ ...DEFAULT_PROPS }
@@ -501,8 +479,6 @@ describe( 'JetpackAuthorize', () => {
 			await userEvent.click( screen.getByText( 'Return to your site' ) );
 
 			const target = global.window.location.href;
-
-			global.window.location = originalWindowLocation;
 
 			expect( target ).toBe(
 				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect=${ encodeURIComponent(

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -378,7 +378,7 @@ describe( 'JetpackAuthorize', () => {
 						alreadyAuthorized: true,
 					} }
 					partnerSlug="pressable"
-					isAlreadyOnSitesList={ true }
+					isAlreadyOnSitesList
 					isFetchingSites={ true }
 				/>
 			);

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -463,7 +463,7 @@ describe( 'JetpackAuthorize', () => {
 			);
 		} );
 
-		test( 'should redirect to redirect to the /jetpack/connect/plans page by default', async () => {
+		test( 'should redirect to the /jetpack/connect/plans page by default', async () => {
 			renderWithRedux(
 				<JetpackAuthorize
 					{ ...DEFAULT_PROPS }


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/63409.

#### Proposed Changes

* Migrate `cient/jetpack-connect/authorize`'s component's tests to RTL, and remove Enzime's references from it.

#### Testing Instructions

* Tests should pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
