### PR TITLE
Plugin Management: Update button style and implement show plugin update status in Jetpack Cloud

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -90,9 +90,13 @@ export default function PluginManagementV2( {
 						smallColumn: true,
 					},
 					{
-						key: 'last-updated',
-						header: translate( 'Last updated' ),
+						key: 'update',
+						header: translate( 'Update available' ),
 						smallColumn: true,
+					},
+					{
+						key: 'last-updated',
+						header: null,
 					},
 			  ]
 			: [
@@ -101,11 +105,16 @@ export default function PluginManagementV2( {
 						header: translate( 'Sites' ),
 						smallColumn: true,
 					},
+					{
+						key: 'update',
+						header: translate( 'Update available' ),
+						smallColumn: true,
+					},
 			  ] ),
 		{
-			key: 'update',
+			key: 'bulk-actions',
 			header: renderBulkActionsHeader(),
-			colSpan: 2,
+			colSpan: 3,
 		},
 	];
 

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -22,6 +22,7 @@ interface Props {
 	toggleBulkManagement: () => void;
 	updateAllPlugins: () => void;
 	removePluginNotice: ( plugin: Plugin ) => void;
+	updatePlugin: ( plugin: Plugin ) => void;
 }
 export default function PluginManagementV2( {
 	plugins,
@@ -33,6 +34,7 @@ export default function PluginManagementV2( {
 	toggleBulkManagement,
 	updateAllPlugins,
 	removePluginNotice,
+	updatePlugin,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -141,6 +143,7 @@ export default function PluginManagementV2( {
 				} ) }
 				selectedSite={ selectedSite }
 				removePluginNotice={ removePluginNotice }
+				updatePlugin={ updatePlugin }
 			/>
 		</div>
 	);

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -94,7 +94,6 @@ export default function PluginManagementV2( {
 					{
 						key: 'update',
 						header: translate( 'Update available' ),
-						smallColumn: true,
 					},
 					{
 						key: 'last-updated',

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/index.tsx
@@ -1,5 +1,8 @@
 import { ReactElement } from 'react';
-import { PLUGIN_INSTALLATION_IN_PROGRESS } from 'calypso/state/plugins/installed/status/constants';
+import {
+	PLUGIN_INSTALLATION_IN_PROGRESS,
+	PLUGIN_INSTALLATION_ERROR,
+} from 'calypso/state/plugins/installed/status/constants';
 import { CurrentSiteStatus } from '../types';
 import RenderStatusMessage from './render-status-message';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -9,11 +12,13 @@ import './style.scss';
 interface Props {
 	currentSiteStatuses: Array< CurrentSiteStatus | any >;
 	selectedSite?: SiteDetails;
+	showMultipleStatuses?: boolean;
 }
 
 export default function PluginActionStatus( {
 	currentSiteStatuses,
 	selectedSite,
+	showMultipleStatuses = true,
 }: Props ): ReactElement | null {
 	// Group statuses by status type(completed, error, inProgress)
 	const groupedStatues = currentSiteStatuses.reduce( ( group, plugin ) => {
@@ -31,6 +36,12 @@ export default function PluginActionStatus( {
 	if ( groupedStatusKeys.includes( PLUGIN_INSTALLATION_IN_PROGRESS ) ) {
 		filteredStatuses = groupedStatusKeys.filter(
 			( status ) => status === PLUGIN_INSTALLATION_IN_PROGRESS
+		);
+	}
+
+	if ( ! showMultipleStatuses && groupedStatusKeys.includes( PLUGIN_INSTALLATION_ERROR ) ) {
+		filteredStatuses = groupedStatusKeys.filter(
+			( status ) => status === PLUGIN_INSTALLATION_ERROR
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/index.tsx
@@ -13,12 +13,14 @@ interface Props {
 	currentSiteStatuses: Array< CurrentSiteStatus | any >;
 	selectedSite?: SiteDetails;
 	showMultipleStatuses?: boolean;
+	retryButton?: ReactElement;
 }
 
 export default function PluginActionStatus( {
 	currentSiteStatuses,
 	selectedSite,
 	showMultipleStatuses = true,
+	retryButton,
 }: Props ): ReactElement | null {
 	// Group statuses by status type(completed, error, inProgress)
 	const groupedStatues = currentSiteStatuses.reduce( ( group, plugin ) => {
@@ -39,7 +41,9 @@ export default function PluginActionStatus( {
 		);
 	}
 
-	if ( ! showMultipleStatuses && groupedStatusKeys.includes( PLUGIN_INSTALLATION_ERROR ) ) {
+	const hasFailedStatus = groupedStatusKeys.includes( PLUGIN_INSTALLATION_ERROR );
+
+	if ( ! showMultipleStatuses && hasFailedStatus ) {
 		filteredStatuses = groupedStatusKeys.filter(
 			( status ) => status === PLUGIN_INSTALLATION_ERROR
 		);
@@ -58,6 +62,7 @@ export default function PluginActionStatus( {
 					hasOneStatus={ hasOneStatus }
 				/>
 			) ) }
+			{ hasFailedStatus && retryButton }
 		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -76,6 +76,12 @@ export default function PluginCommonCard( {
 							<span className="plugin-common-card__overlay"></span>
 						</div>
 					) }
+					{ columnKeys[ 'update' ] &&
+						rowFormatter( {
+							columnKey: 'update',
+							item,
+							isSmallScreen: true,
+						} ) }
 					{ columnKeys[ 'last-updated' ] && (
 						<div className="plugin-common-card__site-data">
 							{ rowFormatter( {
@@ -109,13 +115,6 @@ export default function PluginCommonCard( {
 							) }
 						</div>
 					) }
-					{ columnKeys[ 'update' ] &&
-						rowFormatter( {
-							columnKey: 'update',
-							item,
-							isSmallScreen: true,
-							className: 'plugin-common-card__update-plugin',
-						} ) }
 					{ columnKeys[ 'sites' ] && (
 						<div className="plugin-common-card__site-data">
 							{ rowFormatter( {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -109,6 +109,13 @@ export default function PluginCommonCard( {
 							) }
 						</div>
 					) }
+					{ columnKeys[ 'update' ] &&
+						rowFormatter( {
+							columnKey: 'update',
+							item,
+							isSmallScreen: true,
+							className: 'plugin-common-card__update-plugin',
+						} ) }
 					{ columnKeys[ 'sites' ] && (
 						<div className="plugin-common-card__site-data">
 							{ rowFormatter( {
@@ -118,13 +125,6 @@ export default function PluginCommonCard( {
 							} ) }
 						</div>
 					) }
-					{ columnKeys[ 'update' ] &&
-						rowFormatter( {
-							columnKey: 'update',
-							item,
-							isSmallScreen: true,
-							className: 'plugin-common-card__update-plugin',
-						} ) }
 					{ columnKeys[ 'install' ] && (
 						<div className="plugin-common-card__install-button">
 							{ rowFormatter( {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/style.scss
@@ -1,18 +1,22 @@
 .plugin-common-card__columns {
 	display: flex;
-  	flex:1;
+	flex: 1;
 }
+
 .plugin-common-card__toggle-container {
 	margin-block-start: 16px;
-	& > div {
+
+	> div {
 		margin: 16px 0;
 	}
 }
+
 .plugin-common-card__left-content {
 	min-width: 32px;
 	max-width: 32px;
-  	order: 1;
+	order: 1;
 }
+
 .plugin-common-card__main-content {
 	flex: 1;
 	order: 2;
@@ -20,48 +24,54 @@
 	padding: 0 0 0 16px;
 	width: 70%;
 }
+
 .plugin-common-card__right-content {
 	width: 20px;
 	order: 3;
 }
+
 .plugin-common-card__plugin-icon {
 	width: 32px;
 	height: 32px;
 }
+
 .plugin-common-card__all-actions {
 	color: var( --studio-gray-40 );
 	margin: 0 0.1em;
 }
+
 .plugin-common-card__overlay {
 	display: block;
 	position: absolute;
 	height: 20px;
 	width: 20px;
-	background: linear-gradient(
-		to right,
-		rgba( 255, 255, 255, 0.8 ) 30%,
-		rgba( 255, 255, 255, 1 ) 100%
-	);
+	background:
+		linear-gradient(
+			to right,
+			rgb( 255 255 255 / 80% ) 30%,
+			rgb( 255 255 255 / 100% ) 100%
+		);
 	inset-block-start: 2px;
 	inset-inline-end: 0;
 }
+
 .plugin-common-card__site-data {
 	color: var( --studio-gray-60 );
 	font-size: 0.75rem;
-	margin: 8px 0;
+	margin: 16px 0;
 }
-.plugin-common-card__update-plugin {
-	margin-block-start: 16px;
-}
+
 .plugin-common-card__install-button {
 	.plugin-install-button__install.embed {
 		position: static;
 		width: fit-content;
 	}
 }
+
 .plugin-common-card__card.card {
 	padding: 16px;
 }
+
 .plugin-common-card__left-checkbox {
 	input[type='checkbox'] {
 		margin-top: 8px;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
@@ -60,12 +60,19 @@ export default function PluginCommonTable( {
 						return (
 							<tr key={ `table-row-${ id }` } className="plugin-common-table__table-row">
 								{ columns.map( ( column ) => {
+									if ( column.key === 'bulk-actions' ) {
+										// We don't want to render an empty table cell for the bulk actions.
+										return null;
+									}
 									return (
 										<td
 											className={ classNames(
 												column.smallColumn && 'plugin-common-table__small-column'
 											) }
 											key={ `table-data-${ column.key }-${ id }` }
+											// As we don't render the bulk actions cell, we can
+											// expand the update column a bit further.
+											colSpan={ column.key === 'update' ? 2 : undefined }
 										>
 											{ rowFormatter( { columnKey: column.key, item } ) }
 										</td>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { ReactElement, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -15,11 +16,11 @@ import {
 	getSiteObjectsWithPlugin,
 	getSiteObjectsWithoutPlugin,
 } from 'calypso/state/plugins/installed/selectors';
+import { resetPluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { isFetching as isWporgPluginFetchingSelector } from 'calypso/state/plugins/wporg/selectors';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -43,6 +44,7 @@ export default function PluginDetailsV2( {
 	isWpcom,
 }: Props ): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const siteIds: any = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
 	const sitesWithPlugin = useSelector( ( state ) =>
@@ -51,6 +53,13 @@ export default function PluginDetailsV2( {
 	const sitesWithoutPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithoutPlugin( state, siteIds, pluginSlug )
 	);
+
+	useEffect( () => {
+		return () => {
+			dispatch( resetPluginStatuses() );
+		};
+	}, [ dispatch ] );
+
 	const selectedOrAllSites = useSelector( getSelectedOrAllSites );
 
 	const isLoading = useSelector( ( state ) => isWporgPluginFetchingSelector( state, pluginSlug ) );

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -38,7 +38,7 @@ export default function SitesWithInstalledPluginsList( {
 			key: 'autoupdate',
 			header: translate( 'Autoupdate' ),
 			smallColumn: true,
-			colSpan: 3,
+			colSpan: 4,
 		},
 		{
 			key: 'update',

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -4,7 +4,7 @@ import { ReactElement, ReactChild } from 'react';
 import { useSelector } from 'react-redux';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
+import { INSTALL_PLUGIN, UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
@@ -12,11 +12,11 @@ import UpdatePlugin from 'calypso/my-sites/plugins/plugin-management-v2/update-p
 import {
 	isPluginActionInProgress,
 	getPluginOnSite,
-	getPluginStatusesByType,
 } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import PluginActionStatus from '../plugin-action-status';
 import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
+import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { MomentInput } from 'moment';
@@ -78,13 +78,11 @@ export default function PluginRowFormatter( {
 
 	const siteCount = item?.sites && Object.keys( item.sites ).length;
 
-	const inProgressStatuses = getPluginStatusesByType( state, 'inProgress' );
-	const completedStatuses = getPluginStatusesByType( state, 'completed' );
-	const errorStatuses = getPluginStatusesByType( state, 'error' );
+	const allStatuses = getPluginActionStatuses( state );
 
-	const allStatuses = [ ...inProgressStatuses, ...completedStatuses, ...errorStatuses ];
-
-	const currentSiteStatuses = allStatuses.filter( ( status ) => status.pluginId === item.id );
+	const currentSiteStatuses = allStatuses.filter(
+		( status ) => status.pluginId === item.id && status.action !== UPDATE_PLUGIN
+	);
 
 	const pluginActionStatus =
 		currentSiteStatuses.length > 0 ? (

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -187,13 +187,18 @@ export default function PluginRowFormatter( {
 			);
 		case 'last-updated':
 			if ( item?.update && item?.last_updated ) {
-				return isSmallScreen
-					? translate( 'Last updated %(ago)s', {
+				return (
+					<span className="plugin-row-formatter__last-updated">
+						{ translate( '{{span}}Updated{{/span}} %(ago)s', {
+							components: {
+								span: <span />,
+							},
 							args: {
 								ago: ago( item.last_updated ),
 							},
-					  } )
-					: ago( item.last_updated );
+						} ) }
+					</span>
+				);
 			}
 			return null;
 		case 'update':

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -29,6 +29,7 @@ interface Props {
 	selectedSite?: SiteDetails;
 	isSmallScreen?: boolean;
 	className?: string;
+	updatePlugin?: ( plugin: Plugin ) => void;
 }
 
 export default function PluginRowFormatter( {
@@ -37,6 +38,7 @@ export default function PluginRowFormatter( {
 	selectedSite,
 	isSmallScreen,
 	className,
+	updatePlugin,
 }: Props ): ReactElement | any {
 	const translate = useTranslate();
 
@@ -200,7 +202,14 @@ export default function PluginRowFormatter( {
 			}
 			return null;
 		case 'update':
-			return <UpdatePlugin plugin={ item } selectedSite={ selectedSite } className={ className } />;
+			return (
+				<UpdatePlugin
+					plugin={ item }
+					selectedSite={ selectedSite }
+					className={ className }
+					updatePlugin={ updatePlugin }
+				/>
+			);
 		case 'install':
 			return (
 				<div className="plugin-row-formatter__install-plugin">

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -186,7 +186,7 @@ export default function PluginRowFormatter( {
 				)
 			);
 		case 'last-updated':
-			if ( item.last_updated ) {
+			if ( item?.update && item?.last_updated ) {
 				return isSmallScreen
 					? translate( 'Last updated %(ago)s', {
 							args: {
@@ -210,5 +210,7 @@ export default function PluginRowFormatter( {
 					/>
 				</div>
 			);
+		case 'bulk-actions':
+			return null;
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -13,7 +13,7 @@
 	margin-inline-end: 16px;
 }
 
-.row-data-common-style {
+%row-data-common-style {
 	display: inline-block;
 	font-weight: 500;
 	white-space: nowrap;
@@ -24,22 +24,26 @@
 	font-size: 0.875rem;
 	text-align: left;
 }
+
 .has-active-status {
 	margin-top: -20px;
 }
+
 a.button.plugin-row-formatter__plugin-name {
-	@extend .row-data-common-style;
+	@extend %row-data-common-style;
+
 	width: 100%;
 }
 
 a.button.plugin-row-formatter__plugin-name-card {
-	@extend .row-data-common-style;
+	@extend %row-data-common-style;
 
 	width: calc( 100% - 10px );
 }
 
 .plugin-row-formatter__site-name {
-	@extend .row-data-common-style;
+	@extend %row-data-common-style;
+
 	display: inline-block;
 	width: 100%;
 }
@@ -49,11 +53,12 @@ a.button.plugin-row-formatter__plugin-name-card {
 	position: absolute;
 	height: 25px;
 	width: 25px;
-	background: linear-gradient(
-		to right,
-		rgba( 255, 255, 255, 0.8 ) 30%,
-		rgba( 255, 255, 255, 1 ) 100%
-	);
+	background:
+		linear-gradient(
+			to right,
+			rgb( 255 255 255 / 80% ) 30%,
+			rgb( 255 255 255 / 100% ) 100%
+		);
 	inset-block-start: 0;
 	inset-inline-end: 0;
 }
@@ -63,27 +68,33 @@ a.button.plugin-row-formatter__plugin-name-card {
 		text-decoration: underline;
 	}
 }
+
 .plugin-row-formatter__plugin-name-container {
 	width: calc( 100% - 55px );
 	position: relative;
 }
+
 .has-bulk-management-active {
 	.plugin-row-formatter__plugin-name-container {
 		width: calc( 100% - 75px );
 	}
 }
+
 .plugin-row-formatter__toggle {
 	.plugin-action .components-toggle-control .components-base-control__field {
 		flex-direction: row-reverse;
-		@include break-xlarge() {
+
+		@include break-xlarge {
 			margin: auto 0;
 			flex-direction: unset;
 		}
 	}
+
 	.components-form-toggle {
 		position: absolute;
 		inset-inline-start: 200px;
-		@include break-xlarge() {
+
+		@include break-xlarge {
 			position: relative;
 			inset-inline-start: unset;
 		}
@@ -91,9 +102,11 @@ a.button.plugin-row-formatter__plugin-name-card {
 }
 
 .plugin-row-formatter__install-plugin {
-	@include break-xlarge() {
+
+	@include break-xlarge {
 		display: flex;
 		justify-content: end;
+
 		.plugin-install-button__install.embed {
 			margin: 0;
 		}
@@ -110,7 +123,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 	margin-inline-end: 16px;
 
 	&:checked::before {
-		content: url( '/calypso/images/checkbox-icons/checkmark-jetpack.svg' );
+		content: url( /calypso/images/checkbox-icons/checkmark-jetpack.svg );
 	}
 
 	&::after {
@@ -125,17 +138,20 @@ a.button.plugin-row-formatter__plugin-name-card {
 }
 
 .plugin-row-formatter__last-updated {
-	display: none;
-
-	@include break-wide() {
-		display: inline;
+	@include break-xlarge {
+		// Align right when there's no enough space.
+		text-align: right;
+		width: 100%;
+		display: inline-block;
 	}
 
 	// Cut off the "Updated on" part when there's no enough space.
 	> span {
-		display: none;
+		@include break-xlarge {
+			display: none;
+		}
 
-		@include break-huge() {
+		@include break-huge {
 			display: inline;
 		}
 	}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -1,9 +1,10 @@
-@import '@wordpress/base-styles/_breakpoints.scss';
-@import '@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .plugin-row-formatter__row-container {
 	position: relative;
 }
+
 .plugin-row-formatter__plugin-icon {
 	min-width: 32px;
 	max-width: 32px;
@@ -11,6 +12,7 @@
 	vertical-align: middle;
 	margin-inline-end: 16px;
 }
+
 .row-data-common-style {
 	display: inline-block;
 	font-weight: 500;
@@ -29,15 +31,19 @@ a.button.plugin-row-formatter__plugin-name {
 	@extend .row-data-common-style;
 	width: 100%;
 }
+
 a.button.plugin-row-formatter__plugin-name-card {
 	@extend .row-data-common-style;
+
 	width: calc( 100% - 10px );
 }
+
 .plugin-row-formatter__site-name {
 	@extend .row-data-common-style;
 	display: inline-block;
 	width: 100%;
 }
+
 .plugin-row-formatter__overlay {
 	display: block;
 	position: absolute;
@@ -51,6 +57,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 	inset-block-start: 0;
 	inset-inline-end: 0;
 }
+
 .plugin-row-formatter__sites-count-button {
 	&:hover {
 		text-decoration: underline;
@@ -82,6 +89,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 		}
 	}
 }
+
 .plugin-row-formatter__install-plugin {
 	@include break-xlarge() {
 		display: flex;
@@ -91,6 +99,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 		}
 	}
 }
+
 .plugin-row-formatter__plugin-details {
 	display: flex;
 	align-items: center;
@@ -112,5 +121,22 @@ a.button.plugin-row-formatter__plugin-name-card {
 		left: -19px;
 		width: 56px;
 		height: 55px;
+	}
+}
+
+.plugin-row-formatter__last-updated {
+	display: none;
+
+	@include break-wide() {
+		display: inline;
+	}
+
+	// Cut off the "Updated on" part when there's no enough space.
+	> span {
+		display: none;
+
+		@include break-huge() {
+			display: inline;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -17,17 +17,25 @@ interface Props {
 	columns: Columns;
 	className?: string;
 	removePluginNotice: ( plugin: Plugin ) => void;
+	updatePlugin: ( plugin: Plugin ) => void;
 }
 
 export default function PluginsList( {
 	selectedSite,
 	removePluginNotice,
+	updatePlugin,
 	...rest
 }: Props ): ReactElement {
 	const translate = useTranslate();
 
 	const rowFormatter = ( props: PluginRowFormatterArgs ) => {
-		return <PluginRowFormatter { ...props } selectedSite={ selectedSite } />;
+		return (
+			<PluginRowFormatter
+				{ ...props }
+				selectedSite={ selectedSite }
+				updatePlugin={ updatePlugin }
+			/>
+		);
 	};
 
 	const renderActions = ( plugin: Plugin ) => {

--- a/client/my-sites/plugins/plugin-management-v2/sites-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/sites-list/index.tsx
@@ -1,3 +1,5 @@
+import { useDispatch } from 'react-redux';
+import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import PluginCommonList from '../plugin-common/plugin-common-list';
 import PluginRowFormatter from '../plugin-row-formatter';
 import type { Columns, SiteRowFormatterArgs, Plugin } from '../types';
@@ -14,8 +16,21 @@ interface Props {
 }
 
 export default function SitesList( { selectedSite, plugin, ...rest }: Props ): ReactElement {
+	const dispatch = useDispatch();
+
 	const rowFormatter = ( { item, ...rest }: SiteRowFormatterArgs ) => {
-		return <PluginRowFormatter { ...rest } item={ plugin } selectedSite={ item } />;
+		const handleUpdatePlugin = () => {
+			dispatch( updatePlugin( item.ID, plugin ) );
+		};
+
+		return (
+			<PluginRowFormatter
+				{ ...rest }
+				item={ plugin }
+				selectedSite={ item }
+				updatePlugin={ handleUpdatePlugin }
+			/>
+		);
 	};
 
 	return (

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -4,6 +4,7 @@ import {
 	DISABLE_AUTOUPDATE_PLUGIN,
 	ENABLE_AUTOUPDATE_PLUGIN,
 	REMOVE_PLUGIN,
+	UPDATE_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import {
 	PLUGIN_INSTALLATION_COMPLETED,
@@ -56,7 +57,8 @@ export type PluginActionTypes =
 	| typeof DEACTIVATE_PLUGIN
 	| typeof DISABLE_AUTOUPDATE_PLUGIN
 	| typeof ENABLE_AUTOUPDATE_PLUGIN
-	| typeof REMOVE_PLUGIN;
+	| typeof REMOVE_PLUGIN
+	| typeof UPDATE_PLUGIN;
 
 export type PluginActionStatus =
 	| typeof PLUGIN_INSTALLATION_IN_PROGRESS

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -2,10 +2,13 @@ import { Icon, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
+import PluginActionStatus from '../plugin-action-status';
 import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
+import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
@@ -57,8 +60,24 @@ export default function UpdatePlugin( {
 
 	let content;
 
+	const allStatuses = getPluginActionStatuses( state );
+
+	const updateStatuses = allStatuses.filter(
+		( status ) => status.pluginId === plugin.id && status.action === UPDATE_PLUGIN
+	);
+
 	if ( ! allowedActions?.autoupdate ) {
 		content = <div>{ translate( 'Auto-managed on this site' ) }</div>;
+	} else if ( updateStatuses.length > 0 ) {
+		content = (
+			<div className="update-plugin__plugin-action-status">
+				<PluginActionStatus
+					showMultipleStatuses={ false }
+					currentSiteStatuses={ updateStatuses }
+					selectedSite={ selectedSite }
+				/>
+			</div>
+		);
 	} else if ( hasUpdate ) {
 		content = (
 			<div className="update-plugin__plugin-update-wrapper">

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -50,14 +50,16 @@ export default function UpdatePlugin( {
 
 	const currentVersions = sites
 		.map( ( site ) => {
-			const sitePlugin = pluginsOnSites?.sites[ site.ID ];
+			const siteId = selectedSite ? selectedSite.ID : site.ID;
+			const sitePlugin = pluginsOnSites?.sites[ siteId ];
 			return sitePlugin?.version;
 		} )
 		.filter( ( version ) => version );
 
 	const updatedVersions = sites
 		.map( ( site ) => {
-			const sitePlugin = pluginsOnSites?.sites[ site.ID ];
+			const siteId = selectedSite ? selectedSite.ID : site.ID;
+			const sitePlugin = pluginsOnSites?.sites[ siteId ];
 			return sitePlugin?.update?.new_version;
 		} )
 		.filter( ( version ) => version );
@@ -85,7 +87,8 @@ export default function UpdatePlugin( {
 	}, [ currentVersions ] );
 
 	const hasUpdate = sites.some( ( site ) => {
-		const sitePlugin = pluginsOnSites?.sites[ selectedSite ? selectedSite.ID : site.ID ];
+		const siteId = selectedSite ? selectedSite.ID : site.ID;
+		const sitePlugin = pluginsOnSites?.sites[ siteId ];
 		return sitePlugin?.update?.new_version && site.canUpdateFiles;
 	} );
 
@@ -131,7 +134,8 @@ export default function UpdatePlugin( {
 		content = (
 			<div className="update-plugin__plugin-update-wrapper">
 				<span className="update-plugin__current-version">
-					{ currentVersionsRange?.min } { currentVersionsRange?.max && currentVersionsRange.max }
+					{ currentVersionsRange?.min }
+					{ currentVersionsRange?.max && ` - ${ currentVersionsRange.max }` }
 				</span>
 				<span className="update-plugin__arrow-icon">
 					<Icon size={ 24 } icon={ arrowRight } />

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -1,8 +1,7 @@
-import { Button } from '@automattic/components';
+import { Icon, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import Badge from 'calypso/components/badge';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -62,19 +61,22 @@ export default function UpdatePlugin( {
 		content = <div>{ translate( 'Auto-managed on this site' ) }</div>;
 	} else if ( hasUpdate ) {
 		content = (
-			<>
-				<Badge className="update-plugin__badge" type="warning">
-					{ updated_versions[ 0 ] } { translate( 'Available' ) }
-				</Badge>
-				<Button
-					className="update-plugin__plugin-update-button"
-					borderless
-					compact
-					href={ `/plugins/${ plugin.slug }` }
-				>
-					{ translate( 'Update' ) }
-				</Button>
-			</>
+			<div className="update-plugin__plugin-update-wrapper">
+				<span className="update-plugin__current-version">{ plugin?.version }</span>
+				<span className="update-plugin__arrow-icon">
+					<Icon size={ 24 } icon={ arrowRight } />
+				</span>
+				<span className="update-plugin__new-version">
+					<a href={ `/plugins/${ plugin.slug }` }>
+						{ translate( '{{span}}Update to {{/span}} %s', {
+							components: {
+								span: <span />,
+							},
+							args: updated_versions[ 0 ],
+						} ) }
+					</a>
+				</span>
+			</div>
 		);
 	}
 	return content ? <div className={ classNames( className ) }>{ content }</div> : null;

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -53,7 +53,7 @@ export default function UpdatePlugin( {
 
 	const hasUpdate = sites.some( ( site ) => {
 		const sitePlugin = pluginsOnSites?.sites[ site.ID ];
-		return sitePlugin?.update && site.canUpdateFiles;
+		return sitePlugin?.update?.new_version && site.canUpdateFiles;
 	} );
 
 	const allowedActions = getAllowedPluginActions( plugin, state, selectedSite );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -16,8 +16,8 @@
 
 .update-plugin__arrow-icon {
 	display: flex;
-	position: absolute;
-	inset-inline-start: 50px;
+	position: relative;
+	inset-inline-start: 10px;
 	fill: var( --studio-gray-40 );
 }
 
@@ -25,8 +25,8 @@ button.update-plugin__new-version {
 	color: var( --studio-jetpack-green-50 ) !important;
 	text-decoration: underline;
 	font-weight: 600;
-	position: absolute;
-	inset-inline-start: 100px;
+	position: relative;
+	inset-inline-start: 20px;
 
 	a {
 		display: inline !important;

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -17,19 +17,25 @@
 .update-plugin__arrow-icon {
 	display: flex;
 	position: absolute;
-	left: 50px;
+	inset-inline-start: 50px;
 	fill: var( --studio-gray-40 );
 }
 
-.update-plugin__new-version {
+button.update-plugin__new-version {
+	color: var( --studio-jetpack-green-50 ) !important;
 	text-decoration: underline;
 	font-weight: 600;
 	position: absolute;
-	left: 100px;
+	inset-inline-start: 100px;
 
 	a {
 		display: inline !important;
 	}
+}
+
+button.update-plugin__retry-button {
+	text-decoration: underline;
+	margin-inline-start: 5px;
 }
 
 .update-plugin__plugin-action-status {
@@ -40,12 +46,12 @@
 	}
 
 	.plugin-action-status-container {
-		margin-top: 12px;
+		margin-block-start: 12px;
 		transform: translateY( -50% );
 
 		@include break-xlarge {
-			margin-top: 0;
-			top: 50%;
+			margin-block-start: 0;
+			inset-block-start: 50%;
 			position: absolute;
 		}
 	}

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -1,22 +1,20 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
-
-.update-plugin__badge {
-	font-size: 0.75rem !important;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	vertical-align: middle;
-	@include break-xlarge() {
-		max-width: 70px;
-	}
-	@include break-huge() {
-		max-width: 80px;
-	}
+.update-plugin__plugin-update-wrapper {
+	display: flex;
+	align-items: center;
+	color: var( --studio-gray-60 );
 }
-a.button.update-plugin__plugin-update-button {
-	color: var( --color-primary-80 );
-	margin-left: 10px;
+
+.update-plugin__arrow-icon {
+	fill: var( --studio-gray-40 );
+	margin-inline-start: 40px;
+	margin-inline-end: 16px;
+}
+
+.update-plugin__new-version {
 	text-decoration: underline;
-	display: inline-flex;
+	font-weight: 600;
+
+	a {
+		display: inline !important;
+	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -1,20 +1,52 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .update-plugin__plugin-update-wrapper {
 	display: flex;
 	align-items: center;
 	color: var( --studio-gray-60 );
+	font-size: 0.75rem;
+	position: relative;
+	margin-block-start: 16px;
+
+	@include break-xlarge {
+		margin-block-start: 0;
+	}
 }
 
 .update-plugin__arrow-icon {
+	display: flex;
+	position: absolute;
+	left: 50px;
 	fill: var( --studio-gray-40 );
-	margin-inline-start: 40px;
-	margin-inline-end: 16px;
 }
 
 .update-plugin__new-version {
 	text-decoration: underline;
 	font-weight: 600;
+	position: absolute;
+	left: 100px;
 
 	a {
 		display: inline !important;
+	}
+}
+
+.update-plugin__plugin-action-status {
+	position: relative;
+
+	.plugin-action-status {
+		margin-block-start: 20px;
+	}
+
+	.plugin-action-status-container {
+		margin-top: 12px;
+		transform: translateY( -50% );
+
+		@include break-xlarge {
+			margin-top: 0;
+			top: 50%;
+			position: absolute;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -36,6 +36,11 @@ button.update-plugin__new-version {
 button.update-plugin__retry-button {
 	text-decoration: underline;
 	margin-inline-start: 5px;
+	margin-block-start: 15px;
+
+	@include break-xlarge {
+		margin-block-start: 0;
+	}
 }
 
 .update-plugin__plugin-action-status {
@@ -48,11 +53,13 @@ button.update-plugin__retry-button {
 	.plugin-action-status-container {
 		margin-block-start: 12px;
 		transform: translateY( -50% );
+		display: flex;
 
 		@include break-xlarge {
 			margin-block-start: 0;
 			inset-block-start: 50%;
 			position: absolute;
+			display: inherit;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-status-messages.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-status-messages.ts
@@ -6,6 +6,7 @@ import {
 	DISABLE_AUTOUPDATE_PLUGIN,
 	ENABLE_AUTOUPDATE_PLUGIN,
 	REMOVE_PLUGIN,
+	UPDATE_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import {
 	PLUGIN_INSTALLATION_COMPLETED,
@@ -149,6 +150,13 @@ export const getPluginActionStatusMessages = (
 						'Failed to remove plugin from %(count)s sites',
 						translationArgs
 				  ),
+		},
+		[ UPDATE_PLUGIN ]: {
+			[ PLUGIN_INSTALLATION_IN_PROGRESS ]: translate( 'Updating' ),
+			[ PLUGIN_INSTALLATION_COMPLETED ]: translate( 'Update successful' ),
+			[ PLUGIN_INSTALLATION_ERROR ]: selectedSite
+				? translate( 'Failed' )
+				: translate( 'Failed on %(count)s site', 'Failed on %(count)s sites', translationArgs ),
 		},
 	};
 };

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
@@ -1,0 +1,13 @@
+import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns an array of all plugin action statuses(inProgress, completed, error)
+ */
+export const getPluginActionStatuses = ( state: AppState ) => {
+	const inProgressStatuses = getPluginStatusesByType( state, 'inProgress' );
+	const completedStatuses = getPluginStatusesByType( state, 'completed' );
+	const errorStatuses = getPluginStatusesByType( state, 'error' );
+
+	return [ ...inProgressStatuses, ...completedStatuses, ...errorStatuses ];
+};

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -287,6 +287,11 @@ export class PluginsList extends Component {
 		}
 	};
 
+	updatePlugin = ( selectedPlugin ) => {
+		this.doActionOverSelected( 'updating', this.props.updatePlugin, [ selectedPlugin ] );
+		this.recordEvent( 'Clicked Update Plugin(s)', true );
+	};
+
 	activateSelected = ( accepted ) => {
 		if ( accepted ) {
 			this.doActionOverSelected( 'activating', this.props.activatePlugin );
@@ -691,6 +696,7 @@ export class PluginsList extends Component {
 						toggleBulkManagement={ this.toggleBulkManagement }
 						updateAllPlugins={ this.updateAllPlugins }
 						removePluginNotice={ this.removePluginDialog }
+						updatePlugin={ this.updatePlugin }
 					/>
 				) : (
 					<>

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -72,7 +72,7 @@ export function getPlugins( state, siteIds, pluginFilter ) {
 
 			const list = state.plugins.installed.plugins[ siteId ] || [];
 			list.forEach( ( item ) => {
-				const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update' ] );
+				const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update', 'version' ] );
 
 				memo[ item.slug ] = {
 					...memo[ item.slug ],

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -159,7 +159,7 @@ describe( 'Installed plugin selectors', () => {
 			const siteTwoId = 'site.two';
 			const plugins = selectors.getPlugins( state, [ siteOneId, siteTwoId ] );
 			const siteWithPlugin = {
-				[ siteTwoId ]: pick( jetpack, [ 'active', 'autoupdate', 'update' ] ),
+				[ siteTwoId ]: pick( jetpack, [ 'active', 'autoupdate', 'update', 'version' ] ),
 			};
 			expect( plugins ).toEqual(
 				expect.arrayContaining( [ { ...jetpack, sites: siteWithPlugin } ] )
@@ -207,7 +207,7 @@ describe( 'Installed plugin selectors', () => {
 			const siteOneId = 'site.one';
 			const plugin = selectors.getPluginOnSite( state, siteOneId, 'akismet' );
 			const siteWithPlugin = {
-				[ siteOneId ]: pick( akismet, [ 'active', 'autoupdate', 'update' ] ),
+				[ siteOneId ]: pick( akismet, [ 'active', 'autoupdate', 'update', 'version' ] ),
 			};
 			expect( plugin ).toEqual( { ...akismet, sites: siteWithPlugin } );
 		} );
@@ -227,8 +227,8 @@ describe( 'Installed plugin selectors', () => {
 			const siteIds = [ 'site.one', 'site.two' ];
 			const plugin = selectors.getPluginOnSites( state, siteIds, 'hello-dolly' );
 			const sitesWithPlugins = {
-				[ 'site.one' ]: pick( helloDolly, [ 'active', 'autoupdate', 'update' ] ),
-				[ 'site.two' ]: pick( helloDolly, [ 'active', 'autoupdate', 'update' ] ),
+				[ 'site.one' ]: pick( helloDolly, [ 'active', 'autoupdate', 'update', 'version' ] ),
+				[ 'site.two' ]: pick( helloDolly, [ 'active', 'autoupdate', 'update', 'version' ] ),
 			};
 			expect( plugin ).toEqual( { ...helloDolly, sites: sitesWithPlugins } );
 		} );


### PR DESCRIPTION
#### Proposed Changes

This PR changes the "Update plugin" button style in Jetpack Cloud and implements showing plugin update status.

**Screenshots**

**Multi-sites view - large screen**

<img width="1447" alt="Screenshot 2022-09-06 at 8 02 23 PM" src="https://user-images.githubusercontent.com/10586875/188667939-ae72362f-3ab7-4dfa-ac22-3d1421da74c0.png">
<img width="1527" alt="Screenshot 2022-09-06 at 8 02 29 PM" src="https://user-images.githubusercontent.com/10586875/188667968-875ec965-e979-4bef-8ea4-8f6c89b910c2.png">
<img width="1482" alt="Screenshot 2022-09-06 at 8 02 32 PM" src="https://user-images.githubusercontent.com/10586875/188667979-292892d9-f7c4-4ba5-bc0b-38b32e939a3c.png">

**Multi-sites view - small screen**

<img width="368" alt="Screenshot 2022-09-06 at 8 00 53 PM" src="https://user-images.githubusercontent.com/10586875/188668085-eca1b399-d08e-46bf-a662-55c2487ed8e0.png">
<img width="374" alt="Screenshot 2022-09-06 at 8 01 07 PM" src="https://user-images.githubusercontent.com/10586875/188668106-6d304f6d-95d1-4997-8ffe-c12b8d6fb90e.png">

**Single-site view - large screen**

<img width="1401" alt="Screenshot 2022-09-06 at 8 03 00 PM" src="https://user-images.githubusercontent.com/10586875/188668239-bc163a76-cba5-444b-a43f-cb2f703e5725.png">

Single-site view - small screen

<img width="370" alt="Screenshot 2022-09-06 at 8 03 19 PM" src="https://user-images.githubusercontent.com/10586875/188668549-d2223cb0-9f94-455f-9a61-fbf136e749b9.png">
<img width="368" alt="Screenshot 2022-09-06 at 8 03 43 PM" src="https://user-images.githubusercontent.com/10586875/188668582-5eb7f6aa-041e-4c4f-bb0b-b0851e7e4dc1.png">
<img width="365" alt="Screenshot 2022-09-06 at 8 03 54 PM" src="https://user-images.githubusercontent.com/10586875/188668595-d6918bf1-b3e6-4b0f-b4bd-e2c42b978450.png">
<img width="361" alt="Screenshot 2022-09-06 at 8 15 51 PM" src="https://user-images.githubusercontent.com/10586875/188668601-2c9bed11-214e-455d-81ac-ae72522043a5.png">
<img width="367" alt="Screenshot 2022-09-06 at 8 16 01 PM" src="https://user-images.githubusercontent.com/10586875/188668608-1eac01e1-973f-49b3-ac1f-ff3113eb3785.png">

#### Testing Instructions

**Prerequisites**
- Since this change is made specifically for agencies, you must set yourself (partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type when you're done with testing.
- Please ensure you have an outdated plugin on some of your sites. If you want to know how to find an older version of a specific plugin, read [this](https://wordpress.org/support/topic/old-version-of-plugin-2/).

**Instructions**
- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/plugins/manage
- Verify that the update button is displayed correctly (as per design) for the plugin requiring an update
- Choose a specific site from the sidebar (i.e. `Switch site`) and then click "Plugins" from the sidebar
- Verify that the update button is displayed correctly (as per design) for the plugin requiring an update
- Click "Edit all", choose some plugins and then click the "Update" button
- Verify that the inline feedback notice (the status) is displayed correctly and makes sense

**Test update retry**
- Create a new JN site, and add the following in `wp-config.php`, to make the "Update plugin" request always fail.
```
define( 'DISALLOW_FILE_MODS', true );
```
- Verify that "Retry" button is working as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202774994084578 & 1202518759611394-as-1202927891445246