### PR TITLE
Purchases: Sort all user purchases by status urgency.

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -6,6 +6,7 @@ import {
 	PLAN_BIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
+import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import classNames from 'classnames';
 import i18n, { localize, useTranslate } from 'i18n-calypso';
@@ -77,7 +78,18 @@ class PurchaseItem extends Component {
 		if ( isDisconnectedSite ) {
 			if ( isJetpackTemporarySite ) {
 				return (
-					<span className="purchase-item__is-error">{ translate( 'Pending activation' ) }</span>
+					<>
+						<span className="purchase-item__is-error">
+							{ translate( 'Activate your product license key' ) }
+						</span>
+						<br />
+						<ExternalLink
+							className="purchase-item__link"
+							href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/#how-can-i-activate-my-license-key-in-my-jetpack-installation"
+						>
+							Learn more
+						</ExternalLink>
+					</>
 				);
 			}
 

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -73,17 +73,6 @@
 	}
 }
 
-.purchase-item,
-.membership-item {
-	&:hover {
-		background: var(--color-neutral-0);
-	}
-
-	&:focus {
-		z-index: 1;
-	}
-}
-
 .purchase-item--disconnected {
 	&.card.is-compact {
 		padding-right: 48px;
@@ -97,7 +86,8 @@
 .purchase-item__placeholder {
 	display: block;
 	height: 40px;
-	@include placeholder();
+
+	@include placeholder;
 }
 
 .purchase-item__site,
@@ -111,6 +101,17 @@
 		border-radius: 2px;
 		width: 36px;
 		height: 36px;
+	}
+}
+
+.purchase-item,
+.membership-item {
+	&:hover {
+		background: var(--color-neutral-0);
+	}
+
+	&:focus {
+		z-index: 1;
 	}
 }
 
@@ -139,11 +140,11 @@
 .purchase-item__purchase-type {
 	font-size: $font-body-small;
 	color: var(--color-neutral-50);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.4em;
+	line-height: 1.4;
 }
 
-.purchase-item__link {
+.purchase-item__link,
+a.purchase-item__link {
 	color: var(--color-neutral-50);
 	text-decoration: underline;
 
@@ -164,8 +165,7 @@
 .purchase-item__status {
 	font-size: $font-body-small;
 	color: var(--color-neutral-80);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.3em;
+	line-height: 1.3;
 
 	.purchase-item__is-error,
 	.purchase-item__is-warning {
@@ -231,8 +231,10 @@
 	display: flex;
 	align-items: center;
 	gap: 4px;
+
 	svg {
 		flex-shrink: 0;
+
 		path {
 			fill: var(--color-warning-30);
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR sorts the purchases list at `/me/purchases` by "**Status**" (the Status column), so that purchases that are requiring some action (such as Pending activation, or Disconnected, or Plan expired, or Payment method expired, etc) will appear at the top of the list, sorted by importance/urgency.

Partially completes: https://github.com/Automattic/jetpack/issues/22913#issuecomment-1047032937
Completes task: 1164141197617539-as-1201858908716160/f

#### Implementation notes:

The Purchases are still grouped together by site (like they always have been), and then the purchases/sites that require some action (such as disconnected site, license pending activation, expiring/expired subscription, etc are sorted to the top based on importance.

The sort order looks like this:
1. Site is disconnected
2. License not activated
3. Subscription expired
4. Subscription expiring soon (or CC expires before renew date)
5. Purchases where no action is needed
6. Purchases that are managed elsewhere (by hosting partner)

Also this PR updates the status for non-activated license-based purchases from "Pending activation" to a more actionable message of, "Activate your product license key" with a _Learn more_ link pointing to a Jetpack.com page explaining how to activate product license keys. As suggested per issue https://github.com/Automattic/jetpack/issues/22913

Ideally, next steps to follow-up this PR would be to convert `/client/me/purchases-list` component to a functional component and then memoize the `getPurchasesBySite()` with `useMemo`. Probably some other optimizations also..


#### Testing Instructions

It's kind of difficult to test this PR.
The best way to test this PR is with a WordPress account with multiple connected sites, and ideally some of the sites will have 2 or more purchased products.  And also ideally you will have 1 or more purchased, unactivated product license(s).
If you don't have multiple sites with purchases, you will have to create/connect multiple Jurassic Ninja sites, and purchase a product (or more) for each of them. Then also purchase a product originating from Jetpack.com so that you will obtain a product license (But do not attach/activate it to a site).

- Do one of these:
    - Use the Calypso Live link:
        - Click the Calypso Live link below, and go to `/me/purchases`
    - Or spin up this PR by: `git fetch && git checkout add/sort-all-user-purchases && yarn start`
- Then go to `http://calypso.localhost:3000/me/purchases`
- Compare with Wordpress.com and see that all purchases needing action are sorted to the top based on importance.
- You will likely want to Disconnect a site, then reload the page to see that it gets sorted to the top. (reconnect it when done)
- You may also likely want to open your purchases/subscriptions in Store Admin(SA) and modify subscription expiration dates to force products to be expired or expiring soon (<30 days). (Remember to set them back to the way they were, if they are on real, non-testing sites you own)



#### Screenshots: (Before & After):

**BEFORE:**

![Screenshot on 2022-10-07 at 12-47-01](https://user-images.githubusercontent.com/11078128/194605701-e00617a7-8147-47e9-aa8e-360f3eda9875.png)

.
**AFTER:**

![Screenshot on 2022-10-07 at 12-47-34](https://user-images.githubusercontent.com/11078128/194605723-b1d35ac6-7cc8-4e99-8c02-5c5723ce37d8.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1201858908716160