### PR TITLE
Update Premium Themes copy

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -327,10 +327,10 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_PREMIUM_THEMES ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES,
-		getTitle: () => i18n.translate( 'Premium themes' ),
+		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
 		getDescription: () =>
 			i18n.translate(
-				'Access to all of our advanced premium theme templates, including templates specifically tailored for businesses.'
+				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
 			),
 	},
 

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1,4 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_SPAM_10K_PER_MONTH,
 	FEATURE_13GB_STORAGE,
@@ -327,11 +327,30 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_PREMIUM_THEMES ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES,
-		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
-		getDescription: () =>
-			i18n.translate(
-				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
-			),
+		getTitle: () => {
+			const shouldShowNewString =
+				config( 'english_locales' ).includes( i18n.getLocaleSlug() ) ||
+				i18n.hasTranslation( 'Unlimited premium themes' );
+
+			return shouldShowNewString
+				? i18n.translate( 'Unlimited premium themes' )
+				: i18n.translate( 'Premium themes' );
+		},
+		getDescription: () => {
+			const shouldShowNewString =
+				config( 'english_locales' ).includes( i18n.getLocaleSlug() ) ||
+				i18n.hasTranslation(
+					'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
+				);
+
+			return shouldShowNewString
+				? i18n.translate(
+						'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
+				  )
+				: i18n.translate(
+						'Access to all of our advanced premium theme templates, including templates specifically tailored for businesses.'
+				  );
+		},
 	},
 
 	[ FEATURE_MONETISE ]: {


### PR DESCRIPTION
#### Proposed Changes

* Premium themes copy was updated in https://github.com/Automattic/wp-calypso/pull/59006, let's revert it to the original string.

**BEFORE**
<img width="1464" alt="Screenshot 2022-09-05 at 10 16 18 AM" src="https://user-images.githubusercontent.com/1269602/188373455-d7ea6132-2d9e-4b2f-8878-116eaf1b9882.png">



**AFTER**
<img width="1387" alt="Screenshot 2022-09-05 at 10 18 47 AM" src="https://user-images.githubusercontent.com/1269602/188373502-a81bbb2b-b5d2-4557-9260-db0128c3bdc1.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that "Premium themes" is updated to "Unlimited Premium Themes" is `/start/plans` and `/plans/{SITE_SLUG}`, and the tooltip copy is updated in `/plans/{SITE_SLUG}`.
* Verify that translations exist in non-EN.

