### PR TITLE
Fix misalignment of item price component in the new pricing page when viewed in mobile.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -98,3 +98,17 @@
 	justify-content: flex-start;
 	margin-top: 24px;
 }
+
+
+.featured-item-card .display-price {
+	@media screen and (min-width: 320px) {
+		display: flex;
+		min-height: 24px;
+	}
+}
+
+.featured-item-card .item-price .display-price .display-price__billing-time-frame {
+	@media screen and (min-width: 320px) {
+		margin-top: 0;
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -50,6 +50,10 @@
 		color: var( --studio-gray-100 );
 		font-weight: 700;
 	}
+
+	.display-price__billing-time-frame {
+		margin-top: 3px;
+	}
 }
 
 .item-price .display-price.is-placeholder {

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -38,6 +38,8 @@
 }
 
 .item-price .display-price:not(.is-placeholder) {
+	max-height: 24px;
+
 	.plan-price.is-original {
 		color: var( --studio-gray-50 );
 		text-decoration: line-through;
@@ -49,6 +51,19 @@
 		font-weight: 700;
 	}
 }
+
+.item-price .display-price.is-placeholder {
+	max-height: 24px;
+
+	.plan-price {
+		max-height: 40px;
+	}
+
+	.display-price__billing-time-frame {
+		line-height: 20px;
+	}
+}
+
 
 .item-price__is-owned {
 	font-size: $font-body-extra-small;

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -1,6 +1,9 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .item-price .display-price {
-	display: flex;
-	align-items: center;
+	display: block;
+	min-height: 48px;
 
 	.plan-price__currency-symbol,
 	.plan-price__integer,
@@ -29,11 +32,25 @@
 		display: none;
 	}
 
+	&__billing-time-frame {
+		margin-top: 0;
+
+		@include break-mobile {
+			margin-top: 3px;
+		}
+	}
+
 	&__billing-time-frame,
 	&__expiration-date {
 		color: var( --studio-gray-50 );
 		font-size: 0.75rem;
 		line-height: 24px;
+	}
+
+	@include break-mobile {
+		display: flex;
+		align-items: center;
+		min-height: 24px;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/style.scss
@@ -72,3 +72,21 @@
 	text-decoration: underline;
 	margin-top: 4px;
 }
+
+.simple-product-card .display-price {
+	display: block;
+	min-height: 48px;
+
+	@include break-mobile {
+		display: flex;
+		min-height: 24px;
+	}
+}
+
+.simple-product-card .item-price .display-price .display-price__billing-time-frame {
+	margin-top: 0;
+
+	@include break-mobile {
+		margin-top: 3px;
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/style.scss
@@ -72,21 +72,3 @@
 	text-decoration: underline;
 	margin-top: 4px;
 }
-
-.simple-product-card .display-price {
-	display: block;
-	min-height: 48px;
-
-	@include break-mobile {
-		display: flex;
-		min-height: 24px;
-	}
-}
-
-.simple-product-card .item-price .display-price .display-price__billing-time-frame {
-	margin-top: 0;
-
-	@include break-mobile {
-		margin-top: 3px;
-	}
-}


### PR DESCRIPTION
#### Proposed Changes

* Set maximum item price component height to 24px to make sure it does not move other component when it is in `fetching` state.
* Align time frame component to next line when viewing the simple card to smaller screen. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `git fetch && git checkout fix/pricing-page-display-price-issue`
  * Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
* Confirm that `ItemPrice` component doesn't move other components.

<img width="300" alt="Screen Shot 2022-09-05 at 3 05 40 PM" src="https://user-images.githubusercontent.com/56598660/188387610-5330176b-c62b-4775-adbd-e77394954245.png"> <img width="300" alt="Screen Shot 2022-09-05 at 3 05 06 PM" src="https://user-images.githubusercontent.com/56598660/188387769-c4bfff85-c1ae-4145-ba97-7513945b4caf.png">

* View page in smaller screen (If you are using Chrome, use device tool and set device to 'Iphone SE'). Confirm the time frame component is align below the actual price component.

<img width="300" alt="Screen Shot 2022-09-05 at 3 07 16 PM" src="https://user-images.githubusercontent.com/56598660/188390876-5c081c6a-a3b5-4c16-8892-6ab98a7ec916.png"> <img width="300" alt="Screen Shot 2022-09-05 at 3 06 55 PM" src="https://user-images.githubusercontent.com/56598660/188390885-535d10b0-3da3-4df0-a47a-8699284fe691.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202891213307291


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202891213307291