### PR TITLE
`PluginsBrowser`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,9 +1,6 @@
 /** @jest-environment jsdom */
 
 jest.mock( 'page' );
-jest.mock( 'react-query', () => ( {
-	useQuery: () => [],
-} ) );
 jest.mock( 'calypso/lib/wporg', () => ( {
 	getWporgLocaleCode: () => 'it_US',
 	fetchPluginsList: () => Promise.resolve( [] ),
@@ -11,9 +8,9 @@ jest.mock( 'calypso/lib/wporg', () => ( {
 jest.mock( 'calypso/lib/url-search', () => ( Component ) => ( props ) => (
 	<Component { ...props } doSearch={ jest.fn() } />
 ) );
-jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => ( { plan } ) => (
+	<div data-testid="upsell-nudge">{ plan }</div>
+) );
 
 let mockPlugins = [];
 jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
@@ -22,6 +19,11 @@ jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
 		data: { plugins: mockPlugins },
 		fetchNextPage: jest.fn(),
 	} ) ),
+} ) );
+
+jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
+	useWPCOMPlugins: () => ( { data: [] } ),
+	useWPCOMFeaturedPlugins: () => ( { data: [] } ),
 } ) );
 
 jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
@@ -53,23 +55,17 @@ import {
 	PLAN_BLOGGER,
 	PLAN_BLOGGER_2_YEARS,
 } from '@automattic/calypso-products';
-import { mount } from 'enzyme';
+import { screen } from '@testing-library/react';
 import { merge } from 'lodash';
-import { Provider } from 'react-redux';
-import { createStore, applyMiddleware } from 'redux';
-import thunkMiddleware from 'redux-thunk';
-import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import documentHead from 'calypso/state/document-head/reducer';
+import plugins from 'calypso/state/plugins/reducer';
+import productsList from 'calypso/state/products-list/reducer';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import PluginsBrowser from '../';
-
-window.__i18n_text_domain__ = JSON.stringify( 'default' );
-window.IntersectionObserver = jest.fn( () => ( { observe: jest.fn(), disconnect: jest.fn() } ) );
 
 const initialReduxState = {
 	plugins: {
-		wporg: {
-			lists: {},
-			fetchingLists: {},
-		},
 		installed: {
 			isRequesting: {},
 			plugins: {},
@@ -82,32 +78,19 @@ const initialReduxState = {
 		connection: { items: { 1: true } },
 	},
 	currentUser: { capabilities: { 1: { manage_options: true } } },
-	media: {
-		queries: {
-			'[]': {
-				itemKeys: [ 1 ],
-				found: 1,
-			},
-		},
-	},
 	documentHead: {},
-	preferences: { remoteValues: {} },
 	productsList: {},
-	marketplace: {
-		billingInterval: {
-			interval: IntervalLength.MONTHLY,
-		},
-	},
 };
 
-function mountWithRedux( ui, overrideState ) {
-	const store = createStore(
-		( state ) => state,
-		merge( initialReduxState, overrideState ),
-		applyMiddleware( thunkMiddleware )
-	);
-	return mount( <Provider store={ store }>{ ui }</Provider> );
-}
+const render = ( el, options = {} ) =>
+	renderWithProvider( el, {
+		...options,
+		initialState: merge( initialReduxState, options.initialState ),
+		reducers: { ui, plugins, documentHead, productsList },
+	} );
+
+window.__i18n_text_domain__ = JSON.stringify( 'default' );
+window.IntersectionObserver = jest.fn( () => ( { observe: jest.fn(), disconnect: jest.fn() } ) );
 
 describe( 'Search view', () => {
 	const myProps = {
@@ -115,98 +98,95 @@ describe( 'Search view', () => {
 	};
 
 	test( 'should show NoResults when there are no results', () => {
-		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
-		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
+		render( <PluginsBrowser { ...myProps } /> );
+		expect( screen.queryByText( /no plugins match your search/i ) ).toBeVisible();
 	} );
 	test( 'should show plugin list when there are results', () => {
 		mockPlugins = [ {} ];
-		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
-		expect( comp.find( 'PluginsBrowserList' ).length ).toBe( 1 );
+		render( <PluginsBrowser { ...myProps } /> );
+		expect( screen.queryByText( /found 0 plugins for/i ) ).toBeVisible();
 	} );
 } );
 
 describe( 'Upsell Nudge should get appropriate plan constant', () => {
-	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( product_slug ) => {
-		test( `Business 1 year for (${ product_slug })`, () => {
-			const comp = mountWithRedux( <PluginsBrowser />, {
-				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-			} );
-			expect(
-				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-			).toBe( 1 );
-			expect(
-				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
-			).toBe( PLAN_BUSINESS );
-		} );
-	} );
-
-	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach(
+	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ] )(
+		`Business 1 year for (%s)`,
 		( product_slug ) => {
-			test( `Business 2 year for (${ product_slug })`, () => {
-				const comp = mountWithRedux( <PluginsBrowser />, {
-					sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-				} );
-				expect(
-					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-				).toBe( 1 );
-				expect(
-					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
-				).toBe( PLAN_BUSINESS_2_YEARS );
-			} );
+			const initialState = { sites: { items: { 1: { jetpack: false, plan: { product_slug } } } } };
+			render( <PluginsBrowser />, { initialState } );
+			const nudge = screen.queryByTestId( 'upsell-nudge' );
+			expect( nudge ).toBeVisible();
+			expect( nudge ).toHaveTextContent( PLAN_BUSINESS );
+		}
+	);
+
+	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ] )(
+		`Business 2 year for (%s)`,
+		( product_slug ) => {
+			const initialState = {
+				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+			};
+			render( <PluginsBrowser />, { initialState } );
+			const nudge = screen.queryByTestId( 'upsell-nudge' );
+			expect( nudge ).toBeVisible();
+			expect( nudge ).toHaveTextContent( PLAN_BUSINESS_2_YEARS );
 		}
 	);
 } );
 
 describe( 'PluginsBrowser basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
-		const comp = mountWithRedux( <PluginsBrowser /> );
-		expect( comp.find( 'main' ).length ).toBe( 1 );
+		render( <PluginsBrowser /> );
+		const main = screen.queryByRole( 'main' );
+		expect( main ).toBeVisible();
+		expect( main ).toHaveClass( 'main' );
 	} );
+
 	test( 'should show upsell nudge when appropriate', () => {
-		const comp = mountWithRedux( <PluginsBrowser /> );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 1 );
+		render( <PluginsBrowser /> );
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).toBeVisible();
 	} );
+
 	test( 'should not show upsell nudge if no site is selected', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, { ui: { selectedSiteId: null } } );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
+		const initialState = { ui: { selectedSiteId: null } };
+		render( <PluginsBrowser />, { initialState } );
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
 	} );
+
 	test( 'should not show upsell nudge if no sitePlan', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
+		const initialState = {
 			ui: { selectedSiteId: 10 },
 			sites: { items: { 10: { ID: 10, plan: null } } },
-		} );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
+		};
+		render( <PluginsBrowser />, { initialState } );
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
 	} );
+
 	test( 'should not show upsell nudge if non-atomic jetpack site', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
+		const initialState = {
 			sites: { items: { 1: { jetpack: true } } },
-		} );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
+		};
+		render( <PluginsBrowser />, { initialState } );
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
 	} );
+
 	test( 'should not show upsell nudge has business plan', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
+		const initialState = {
 			sites: { items: { 1: { jetpack: true, plan: { productSlug: PLAN_PREMIUM } } } },
-		} );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
+		};
+		render( <PluginsBrowser />, { initialState } );
+		expect( screen.queryByTestId( 'upsell-nudge' ) ).not.toBeInTheDocument();
 	} );
+
 	test( 'should show notice if site is not connected to wpcom', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
+		const initialState = {
 			ui: { selectedSiteId: 1 },
 			sites: {
 				items: { 1: { jetpack: false } },
 				connection: { items: { 1: false } },
 			},
-		} );
-		expect( comp.containsMatchingElement( <span>I’d like to fix this now</span> ) ).toBeTruthy();
+		};
+		render( <PluginsBrowser />, { initialState } );
+		expect( screen.queryByText( 'I’d like to fix this now' ) ).toBeVisible();
 	} );
 } );

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -99,12 +99,12 @@ describe( 'Search view', () => {
 
 	test( 'should show NoResults when there are no results', () => {
 		render( <PluginsBrowser { ...myProps } /> );
-		expect( screen.queryByText( /no plugins match your search/i ) ).toBeVisible();
+		expect( screen.getByText( /no plugins match your search/i ) ).toBeVisible();
 	} );
 	test( 'should show plugin list when there are results', () => {
 		mockPlugins = [ {} ];
 		render( <PluginsBrowser { ...myProps } /> );
-		expect( screen.queryByText( /found 0 plugins for/i ) ).toBeVisible();
+		expect( screen.getByText( /found 0 plugins for/i ) ).toBeVisible();
 	} );
 } );
 
@@ -114,7 +114,7 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 		( product_slug ) => {
 			const initialState = { sites: { items: { 1: { jetpack: false, plan: { product_slug } } } } };
 			render( <PluginsBrowser />, { initialState } );
-			const nudge = screen.queryByTestId( 'upsell-nudge' );
+			const nudge = screen.getByTestId( 'upsell-nudge' );
 			expect( nudge ).toBeVisible();
 			expect( nudge ).toHaveTextContent( PLAN_BUSINESS );
 		}
@@ -127,7 +127,7 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
 			};
 			render( <PluginsBrowser />, { initialState } );
-			const nudge = screen.queryByTestId( 'upsell-nudge' );
+			const nudge = screen.getByTestId( 'upsell-nudge' );
 			expect( nudge ).toBeVisible();
 			expect( nudge ).toHaveTextContent( PLAN_BUSINESS_2_YEARS );
 		}
@@ -137,14 +137,13 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 describe( 'PluginsBrowser basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		render( <PluginsBrowser /> );
-		const main = screen.queryByRole( 'main' );
+		const main = screen.getByRole( 'main' );
 		expect( main ).toBeVisible();
-		expect( main ).toHaveClass( 'main' );
 	} );
 
 	test( 'should show upsell nudge when appropriate', () => {
 		render( <PluginsBrowser /> );
-		expect( screen.queryByTestId( 'upsell-nudge' ) ).toBeVisible();
+		expect( screen.getByTestId( 'upsell-nudge' ) ).toBeVisible();
 	} );
 
 	test( 'should not show upsell nudge if no site is selected', () => {
@@ -187,6 +186,6 @@ describe( 'PluginsBrowser basic tests', () => {
 			},
 		};
 		render( <PluginsBrowser />, { initialState } );
-		expect( screen.queryByText( 'I’d like to fix this now' ) ).toBeVisible();
+		expect( screen.getByText( 'I’d like to fix this now' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `PluginsBrowser`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 
