### PR TITLE
Add VideoPress to personal plan

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -182,7 +182,7 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getPersonalFeatures() {
-		const { isPlaceholder, isMonthlyPlan, selectedSite, planHasDomainCredit } = this.props;
+		const { isPlaceholder, isMonthlyPlan, selectedSite, planHasDomainCredit, plan } = this.props;
 
 		return (
 			<Fragment>
@@ -193,6 +193,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<AdvertisingRemoved isEligiblePlan selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
+				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -1,4 +1,5 @@
 import {
+	isPersonalPlan,
 	isProPlan,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
@@ -40,6 +41,13 @@ function getDescription( plan, translate ) {
 	if ( isWpComPremiumPlan( plan ) ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload up to 13 GB of media directly to your site.'
+		);
+	}
+
+	if ( isPersonalPlan( plan ) ) {
+		return translate(
+			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+				'directly to your site — the Personal Plan has 6 GB storage.'
 		);
 	}
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -362,6 +362,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_NO_ADS,
 			FEATURE_MEMBERSHIPS,
 			FEATURE_PREMIUM_CONTENT_BLOCK,
+			FEATURE_VIDEO_UPLOADS,
 		] ),
 	getSignupFeatures: () => [
 		FEATURE_FREE_DOMAIN,

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -7,6 +7,7 @@ import {
 	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_T2_YEARLY,
 	FEATURE_VIDEO_UPLOADS,
+	FEATURE_SHIPPING_CARRIERS,
 	GROUP_JETPACK,
 	GROUP_WPCOM,
 	PLAN_BUSINESS_MONTHLY,
@@ -1081,7 +1082,7 @@ describe( 'planHasFeature', () => {
 	} );
 
 	test( 'should return false when a plan does not have a feature', () => {
-		expect( planHasFeature( PLAN_PERSONAL, FEATURE_VIDEO_UPLOADS ) ).toBe( false );
+		expect( planHasFeature( PLAN_PERSONAL, FEATURE_SHIPPING_CARRIERS ) ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
#### Proposed Changes

This PR adds VideoPress to the personal WPCOM plan.

#### Testing Instructions

* Sandbox public-api
* Apply D87186-code to your sandbox
* Go to http://calypso.localhost:3000/plans/<your_domain>
* :white_check_mark: You should see "VideoPress support" in personal plan
* Select the personal plan (or update your site to a personal plan in site admin
* Go to "My plan" (`http://calypso.localhost:3000/plans/my-plan/<your_domain>`)
* :white_check_mark: The "Video and audio posts" block should appear
* Go to "Media"
* Upload a video
* :white_check_mark: The video should be properly uploaded to VideoPress
* :white_check_mark: Your storage space should decrease (the storage used percentage should increase)

Related to gh-1285-Automattic/greenhouse