### PR TITLE
Remove Olark code from sign-up

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -28,7 +28,6 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
-import OlarkChat from 'calypso/components/olark-chat';
 import {
 	recordSignupStart,
 	recordSignupComplete,
@@ -745,12 +744,6 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
-		const olarkIdentity = config( 'olark_chat_identity' );
-		const olarkSystemsGroupId = '2dfd76a39ce77758f128b93942ae44b5';
-		const isEligibleForOlarkChat =
-			'onboarding' === this.props.flowName &&
-			[ 'en', 'en-gb' ].includes( this.props.localeSlug ) &&
-			this.props.existingSiteCount < 1;
 
 		return (
 			<>
@@ -784,13 +777,6 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
-				{ isEligibleForOlarkChat && (
-					<OlarkChat
-						systemsGroupId={ olarkSystemsGroupId }
-						identity={ olarkIdentity }
-						shouldDisablePreChatSurvey
-					/>
-				) }
 			</>
 		);
 	}


### PR DESCRIPTION
#### Proposed Changes

This removes the Olark code added for the signup flow in #62451. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On the Olark agent dashboard, set yourself online
* Go to `/start` in en locale and verify that you cannot see the chat widget.
* Verify that you are able to signup on /start, search and select a custom domain, and create a site without issues.


