### PR TITLE
Add section name to RUM logging

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -191,6 +191,7 @@ class Document extends Component {
 							src={ getBilmurUrl() }
 							data-provider="wordpress.com"
 							data-service="calypso"
+							data-customproperties={ `{"route": "${ sectionName }"}` }
 						/>
 					) }
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -191,7 +191,7 @@ class Document extends Component {
 							src={ getBilmurUrl() }
 							data-provider="wordpress.com"
 							data-service="calypso"
-							data-customproperties={ `{"route": "${ sectionName }"}` }
+							data-customproperties={ `{"route_name": "${ sectionName }"}` }
 						/>
 					) }
 


### PR DESCRIPTION
#### Proposed Changes

* Add the section name to the "route" custom property in `bilmur`

#### Testing Instructions

Bilmur logging is only available on the production environment, so this is a bit tricky to test. The code change is fairly trivial, however, so there shouldn't be any need for it.

Properly testing this involves changing some configuration flags and running things locally, and then looking for the report on the other end of the reporting pipeline. To save you the trouble of having to do that, I've gone ahead and done that myself for a full end-to-end test, and was able to detect a correct document in our logs that matches the data sent by Calypso.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- (N/A) [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- (N/A) Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- (N/A) Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- (N/A) Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
