### PR TITLE
Newsletter Accent Color: Fix displaying of validity check for the color input

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -69,6 +69,10 @@ $border-radius: 4px;
 				background-position: 13px center, 95%;
 				background-repeat: no-repeat, no-repeat;
 				padding-left: 50px;
+
+				/* Overwrites the transition value set by FormInput component.
+				It was the cause of the https://github.com/Automattic/wp-calypso/issues/67326 */
+				transition: none;
 			}
 		}
 


### PR DESCRIPTION
The FormInput component implements css ease-in-out transition for all transition properties, like so: `transition: all 0.15s ease-in-out;` in `client/assets/stylesheets/shared/_extends-forms.scss`
Once the accent color input value becomes valid we add another background image, the green check, to the current one of swatch only. Therefore at first it transitions from swatch background image to green check.

#### Proposed Changes

* overwrite the `transition` property on the input element to `none`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #67326

![green-check-isssue](https://user-images.githubusercontent.com/2019970/188445892-f2049ccd-3cab-449f-b884-2cd6125c1796.gif)

