### PR TITLE
Promoted posts layout issues

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -76,7 +76,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				<BlankCanvas className={ 'blazepress-widget' }>
 					<div className={ 'blazepress-widget__header-bar' }>
 						<WordPressLogo />
-						<h2>Promote</h2>
+						<h2>Advertising</h2>
 						<span
 							role="button"
 							className={ 'blazepress-widget__cancel' }

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -147,7 +147,7 @@ export default function CampaignItem( { campaign }: Props ) {
 								{ __( 'Impressions' ) }
 							</div>
 							<div className="campaign-item__block_value campaign-item__reach-value">
-								${ impressions_total || 0 }
+								{ impressions_total || 0 }
 							</div>
 						</div>
 						<div className="campaign-item__column campaign-item__clicks">

--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -54,22 +54,35 @@ export default function PostItem( { post }: Props ) {
 	const safeUrl = safeImageUrl( post.featured_image );
 	const featuredImage = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
 	return (
-		<CompactCard className="post-item__card">
-			<div className="post-item__main">
-				<div className="post-item__body">
-					<div className="post-item__title">{ post.title }</div>
-					<div className="post-item__subtitle">
-						<PostRelativeTimeStatus showPublishedStatus={ false } post={ post } />
-						<span className="post-item__posttype">{ getPostType( post.type ) }</span>
-						<Button isLink href={ post.URL }>
-							{ __( 'View' ) }
-						</Button>
-					</div>
+		<CompactCard className="post-item__panel">
+			<div className="post-item__detail">
+				<h1 // eslint-disable-line
+					className="post-item__title"
+				>
+					<a href={ post.URL } className="post-item__title-link">
+						{ post.title || __( 'Untitled' ) }
+					</a>
+				</h1>
+				<div className="post-item__meta">
+					<span className="post-item__meta-time-status">
+						{ post && (
+							<PostRelativeTimeStatus
+								showPublishedStatus={ false }
+								post={ post }
+								gridiconSize={ 12 }
+							/>
+						) }
+					</span>
+					<span className="post-item__post-type">{ getPostType( post.type ) }</span>
 				</div>
 			</div>
-			<div className="post-item__image-container">
-				{ featuredImage && <img className="post-item__image" src={ featuredImage } alt="" /> }
-			</div>
+
+			{ featuredImage && (
+				<div className="post-item__post-thumbnail-wrapper ">
+					<img className="post-item__post-thumbnail" src={ featuredImage } alt="" />
+				</div>
+			) }
+
 			<div className="post-item__promote-link">
 				<BlazePressWidget
 					isVisible={ isModalOpen && value === keyValue }

--- a/client/my-sites/promote-post/components/post-item/style.scss
+++ b/client/my-sites/promote-post/components/post-item/style.scss
@@ -1,46 +1,96 @@
+$post-item-background-color: var( --color-surface );
 
-.post-item__card {
+.post-item__panel {
+	box-sizing: border-box;
 	display: flex;
+	justify-content: space-between;
 	align-items: center;
+	padding: 0 16px;
+	background: $post-item-background-color;
+}
 
-	.post-item__image-container {
-		margin: 0 20px 0 0;
-		flex-shrink: 0;
-		width: 80px;
-		height: 60px;
+.post-item__detail {
+	position: relative;
+	width: calc( 100% - 50px );
+	margin-right: auto;
+	word-break: break-word;
+	word-wrap: break-word;
+	padding: 16px 0;
+}
 
-		.post-item__image {
-			height: 60px;
-			object-fit: cover;
-		}
+.card.is-compact {
+	padding: 0 16px;
+}
+
+.post-item__title {
+	margin: 0;
+	padding: 0 0 2px;
+	font-weight: 600;
+	font-size: $font-title-small;
+	line-height: 1.2;
+}
+
+.post-item__meta,
+.post-item__post-type {
+	font-size: $font-body-extra-small;
+	color: var( --color-text-subtle );
+}
+
+.post-item__meta-time-status {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.post-item__post-type {
+	margin-right: 16px;
+}
+
+/* Force all items in the meta section to be middle-aligned */
+.post-item__meta a,
+.post-item__meta div,
+.post-item__meta li,
+.post-item__meta span,
+.post-item__meta ul {
+	display: inline-block;
+	vertical-align: bottom;
+}
+
+a.post-item__title-link,
+a.post-item__title-link:visited {
+	color: var( --color-neutral-70 );
+	display: block;
+	padding-bottom: 2px;
+	padding-right: 8px;
+
+	&:hover {
+		color: var( --color-neutral-50 );
 	}
 
-	.post-item__main {
-		flex: 1;
-		display: flex;
-		align-items: center;
-
-		.post-item__body {
-			display: flex;
-			flex-direction: column;
-			justify-content: space-between;
-		}
-
-		.post-item__title {
-			color: var( --color-neutral-70 );
-			font-weight: 600;
-			font-size: 1.25rem;
-		}
-
-		.post-item__subtitle, .post-item__posttype {
-			color: var( --color-neutral-50 );
-			font-size: 0.875rem;
-		}
-
-		.post-item__posttype {
-			margin-right: 10px;
-		}
+	.post-item__panel.is-untitled & {
+		color: var( --color-text-subtle );
+		font-style: italic;
 	}
 }
 
+.post-item__post-thumbnail-wrapper {
+	display: block;
+	position: relative;
+	width: 80px;
+	align-self: stretch;
+	overflow: hidden;
+	margin: 8px 0;
+}
 
+.post-item__post-thumbnail {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	height: 100%;
+	max-height: 80px;
+	max-width: none;
+}
+
+.post-item__promote-link {
+	margin-left: 32px;
+}

--- a/client/my-sites/promote-post/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post/components/posts-list/index.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import megaphoneIllustration from 'calypso/assets/images/customer-home/illustration--megaphone.svg';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
-import ListEnd from 'calypso/components/list-end';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import PostItem, { Post } from 'calypso/my-sites/promote-post/components/post-item';
 import './style.scss';
@@ -57,7 +56,6 @@ export default function PostsList() {
 					{ posts.map( function ( post: Post ) {
 						return <PostItem key={ post.ID } post={ post } />;
 					} ) }
-					<ListEnd />
 				</>
 			) }
 		</>

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -59,6 +59,20 @@ export default function PromotedPosts( { tab }: Props ) {
 				<CampaignsList isLoading={ campaignsIsLoading } campaigns={ campaignsData } />
 			) }
 			{ selectedTab === 'posts' && <PostsList /> }
+
+			<div className="promote-post__footer">
+				<p>
+					By promoting your post you agree to{ ' ' }
+					<a href="https://wordpress.com/tos/" target={ '_blank' } rel="noreferrer">
+						WordPress.com Terms
+					</a>{ ' ' }
+					and{ ' ' }
+					<a href="https://automattic.com/privacy/" target={ 'blank' }>
+						Advertising Terms
+					</a>
+					.
+				</p>
+			</div>
 		</Main>
 	);
 }

--- a/client/my-sites/promote-post/style.scss
+++ b/client/my-sites/promote-post/style.scss
@@ -11,3 +11,13 @@
 		flex: 1;
 	}
 }
+
+.promote-post__footer {
+	text-align: center;
+	margin: 24px 0;
+
+	a {
+		color: var( --studio-gray-60 );
+		text-decoration: underline;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

1. Changes the page title to "Advertising" Rather than remote See: (pdtkmj-pb-p2) - specifically `#comment-676`
2. Bring the Advertising page more inline with the posts page - the styles here aren't as polished
3. Adds the links to the footer containing T's and C's
4. Remove the $ from impressions 
5. Empty post titles show "Untitled" instead of being blank

Ticket for items 1 - 3: ( 599-gh-Tumblr/wordads-picard )
Ticket for items 4: ( 617-gh-Tumblr/wordads-picard )

**Before**
**Point 2**
![Screenshot 2022-09-05 at 15 04 38](https://user-images.githubusercontent.com/6440498/188467814-59676713-2564-4be5-a618-f5a935ce0ebd.png)

**Point 4**
![Screenshot 2022-09-05 at 15 43 55](https://user-images.githubusercontent.com/6440498/188474440-1f791ff4-e664-4d58-8cdc-3db4d02659c6.png)



**After - this is now a closer match to the posts page**
![Screenshot 2022-09-05 at 15 01 06](https://user-images.githubusercontent.com/6440498/188467009-c47b28ac-3148-4039-8f28-f8261b0c6896.png)
![Screenshot 2022-09-05 at 15 44 11](https://user-images.githubusercontent.com/6440498/188474424-d8cd5732-4f7e-44ed-9df5-f45bf2d97e62.png)




#### Testing Instructions

- [ ] Visit http://calypso.localhost:3000/advertising/yoursite.co.uk
- [ ] We expect this page to be a much closer match to `/posts`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
