### PR TITLE
Integrate lightbox component to feature and simple card

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -1,11 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { SVG, Path } from '@wordpress/components';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { createElement, ReactNode, useEffect, useRef } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
-import HintButton from 'calypso/my-sites/plans/jetpack-plans/product-lightbox/hint-button';
 import DisplayPrice from './display-price';
 import JetpackProductCardFeatures from './features';
 import type {
@@ -48,7 +46,6 @@ type OwnProps = {
 	showAbovePriceText?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
-	onLearnMoreClick?: React.MouseEventHandler;
 };
 
 type HeaderLevel = 1 | 2 | 3 | 4 | 5 | 6;
@@ -90,7 +87,6 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	aboveButtonText = null,
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
-	onLearnMoreClick,
 } ) => {
 	const isFree = item.isFree;
 
@@ -236,9 +232,6 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				) }
 				{ item.disclaimer && (
 					<span className="jetpack-product-card__disclaimer">{ item.disclaimer }</span>
-				) }
-				{ isEnabled( 'jetpack/pricing-page-product-lightbox' ) && (
-					<HintButton onClick={ onLearnMoreClick } />
 				) }
 			</div>
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	planHasFeature,
 	TERM_MONTHLY,
@@ -26,7 +25,6 @@ import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import PlanRenewalMessage from '../plan-renewal-message';
-import ProductLightbox from '../product-lightbox';
 import useItemPrice from '../use-item-price';
 import productAboveButtonText from './product-above-button-text';
 import productButtonLabel from './product-button-label';
@@ -210,56 +208,39 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 		buttonLabel
 	);
 
-	const [ isDialogVisible, setDialogVisible ] = React.useState( false );
-
 	return (
-		<>
-			{ isEnabled( 'jetpack/pricing-page-product-lightbox' ) && (
-				<ProductLightbox
-					product={ item }
-					isVisible={ isDialogVisible }
-					onClose={ () => {
-						setDialogVisible( false );
-					} }
-				/>
-			) }
-
-			<JetpackProductCard
-				item={ item }
-				headerLevel={ 3 }
-				description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
-				originalPrice={ originalPrice }
-				discountedPrice={ discountedPrice }
-				buttonLabel={ buttonLabel }
-				buttonPrimary={ ! ( isOwned || isItemPlanFeature || isSuperseded ) }
-				onButtonClick={ () => {
-					onClick( item, isUpgradeableToYearly, purchase );
-				} }
-				buttonURL={
-					createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
-				}
-				buttonDisabled={ isDisabled || buttonDisabled || isLoadingUpsellPageExperiment }
-				expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
-				isFeatured={ isFeatured }
-				isOwned={ isOwned }
-				isIncludedInPlan={ isIncludedInPlan || isSuperseded }
-				isDeprecated={ isDeprecated }
-				isAligned={ isAligned }
-				displayFrom={ ! siteId && priceTierList.length > 0 }
-				tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
-				aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
-				isDisabled={ isDisabled }
-				disabledMessage={ disabledMessage }
-				featuredLabel={ featuredLabel }
-				hideSavingLabel={ hideSavingLabel }
-				scrollCardIntoView={ scrollCardIntoView }
-				collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
-				pricesAreFetching={ pricesAreFetching }
-				onLearnMoreClick={ () => {
-					setDialogVisible( true );
-				} }
-			/>
-		</>
+		<JetpackProductCard
+			item={ item }
+			headerLevel={ 3 }
+			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
+			originalPrice={ originalPrice }
+			discountedPrice={ discountedPrice }
+			buttonLabel={ buttonLabel }
+			buttonPrimary={ ! ( isOwned || isItemPlanFeature || isSuperseded ) }
+			onButtonClick={ () => {
+				onClick( item, isUpgradeableToYearly, purchase );
+			} }
+			buttonURL={
+				createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
+			}
+			buttonDisabled={ isDisabled || buttonDisabled || isLoadingUpsellPageExperiment }
+			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
+			isFeatured={ isFeatured }
+			isOwned={ isOwned }
+			isIncludedInPlan={ isIncludedInPlan || isSuperseded }
+			isDeprecated={ isDeprecated }
+			isAligned={ isAligned }
+			displayFrom={ ! siteId && priceTierList.length > 0 }
+			tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
+			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
+			isDisabled={ isDisabled }
+			disabledMessage={ disabledMessage }
+			featuredLabel={ featuredLabel }
+			hideSavingLabel={ hideSavingLabel }
+			scrollCardIntoView={ scrollCardIntoView }
+			collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
+			pricesAreFetching={ pricesAreFetching }
+		/>
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/product-store/bundle-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/bundle-list/index.tsx
@@ -16,7 +16,7 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 	createCheckoutURL,
 	duration,
 	onClickPurchase,
-	clickMoreHandlerFactory,
+	onClickMoreInfoFactory,
 	siteId,
 } ) => {
 	const [ popularItems ] = useBundlesToDisplay( { duration, siteId } );
@@ -79,7 +79,7 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 					isIncludedInPlan={ isIncludedInPlanOrSuperseded( item ) }
 					isOwned={ isItemOwned }
 					item={ item }
-					onClickMore={ clickMoreHandlerFactory( item ) }
+					onClickMore={ onClickMoreInfoFactory( item ) }
 					onClickPurchase={ getOnClickPurchase( item ) }
 					siteId={ siteId }
 				/>

--- a/client/my-sites/plans/jetpack-plans/product-store/bundle-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/bundle-list/index.tsx
@@ -44,13 +44,15 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 	const mostPopularItems = popularItems.map( ( item ) => {
 		const isItemOwned = isOwned( item );
 		const isItemSuperseded = isSuperseded( item );
+		const isItemDeprecated = isDeprecated( item );
+		const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
 		const purchase = getPurchase( item );
 
 		const buttonLabelOptions = {
 			product: item,
 			isOwned: isItemOwned,
 			isUpgradeableToYearly: isUpgradeableToYearly( item ),
-			isDeprecated: isDeprecated( item ),
+			isDeprecated: isItemDeprecated,
 			isSuperseded: isItemSuperseded,
 			currentPlan: sitePlan,
 			fallbackLabel: translate( 'Get' ),
@@ -68,6 +70,8 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 			</>
 		);
 
+		const hideMoreInfoLink = isItemDeprecated || isItemOwned || isItemIncludedInPlanOrSuperseded;
+
 		return (
 			<div key={ item.productSlug } className="jetpack-product-store__bundles-list--featured-item">
 				<FeaturedItemCard
@@ -76,7 +80,8 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 					ctaLabel={ ctaLabel }
 					hero={ <HeroImage item={ item } /> }
 					isCtaDisabled={ isItemOwned && ! isUserPurchaseOwner( item ) }
-					isIncludedInPlan={ isIncludedInPlanOrSuperseded( item ) }
+					isIncludedInPlan={ isItemIncludedInPlanOrSuperseded }
+					hideMoreInfoLink={ hideMoreInfoLink }
 					isOwned={ isItemOwned }
 					item={ item }
 					onClickMore={ onClickMoreInfoFactory( item ) }

--- a/client/my-sites/plans/jetpack-plans/product-store/bundle-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/bundle-list/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import productButtonLabel from '../../product-card/product-button-label';
 import { FeaturedItemCard } from '../featured-item-card';
@@ -17,6 +16,7 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 	createCheckoutURL,
 	duration,
 	onClickPurchase,
+	clickMoreHandlerFactory,
 	siteId,
 } ) => {
 	const [ popularItems ] = useBundlesToDisplay( { duration, siteId } );
@@ -79,12 +79,7 @@ export const BundlesList: React.FC< BundlesListProps > = ( {
 					isIncludedInPlan={ isIncludedInPlanOrSuperseded( item ) }
 					isOwned={ isItemOwned }
 					item={ item }
-					onClickMore={ () => {
-						recordTracksEvent( 'calypso_product_more_about_product_click', {
-							product: item.productSlug,
-						} );
-						// TODO: Open modal
-					} }
+					onClickMore={ clickMoreHandlerFactory( item ) }
 					onClickPurchase={ getOnClickPurchase( item ) }
 					siteId={ siteId }
 				/>

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -10,10 +10,10 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 	ctaAsPrimary,
 	ctaLabel,
 	hero,
+	hideMoreInfoLink,
 	isCtaDisabled,
 	isIncludedInPlan,
 	isOwned,
-	isDeprecated,
 	item,
 	onClickMore,
 	onClickPurchase,
@@ -21,7 +21,6 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const { displayName: title, featuredDescription } = item;
-	const hasMoreInfoLink = ! isDeprecated && ! isOwned && ! isIncludedInPlan;
 
 	return (
 		<div className="featured-item-card">
@@ -43,7 +42,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 							<span>{ featuredDescription }</span>
 							<br />
 
-							{ hasMoreInfoLink && (
+							{ ! hideMoreInfoLink && (
 								<Button
 									className="featured-item-card--learn-more"
 									onClick={ onClickMore }

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -40,18 +40,21 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 						<p>
 							<span>{ featuredDescription }</span>
 							<br />
-							<Button
-								className="featured-item-card--learn-more"
-								onClick={ onClickMore }
-								href="#"
-								plain
-							>
-								{ translate( 'More about %(product)s', {
-									args: {
-										product: title,
-									},
-								} ) }
-							</Button>
+
+							{ onClickMore && (
+								<Button
+									className="featured-item-card--learn-more"
+									onClick={ onClickMore }
+									href="#"
+									plain
+								>
+									{ translate( 'More about %(product)s', {
+										args: {
+											product: title,
+										},
+									} ) }
+								</Button>
+							) }
 						</p>
 					</div>
 				</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -13,6 +13,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 	isCtaDisabled,
 	isIncludedInPlan,
 	isOwned,
+	isDeprecated,
 	item,
 	onClickMore,
 	onClickPurchase,
@@ -20,6 +21,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const { displayName: title, featuredDescription } = item;
+	const hasMoreInfoLink = ! isDeprecated && ! isOwned && ! isIncludedInPlan;
 
 	return (
 		<div className="featured-item-card">
@@ -41,7 +43,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 							<span>{ featuredDescription }</span>
 							<br />
 
-							{ onClickMore && (
+							{ hasMoreInfoLink && (
 								<Button
 									className="featured-item-card--learn-more"
 									onClick={ onClickMore }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-bundles-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-bundles-to-display.ts
@@ -3,10 +3,10 @@ import { useSelector } from 'react-redux';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { MOST_POPULAR_BUNDLES } from '../../constants';
 import { getPlansToDisplay } from '../../product-grid/utils';
-import { itemToDisplayProps } from '../types';
+import { ItemToDisplayProps } from '../types';
 import { isolatePopularItems } from '../utils/isolate-popular-items';
 
-export const useBundlesToDisplay = ( { siteId, duration }: itemToDisplayProps ) => {
+export const useBundlesToDisplay = ( { siteId, duration }: ItemToDisplayProps ) => {
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 
 	const currentPlanSlug = currentPlan?.product_slug || null;

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-bundles-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-bundles-to-display.ts
@@ -3,10 +3,10 @@ import { useSelector } from 'react-redux';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { MOST_POPULAR_BUNDLES } from '../../constants';
 import { getPlansToDisplay } from '../../product-grid/utils';
-import { ProductsListProps } from '../types';
+import { itemToDisplayProps } from '../types';
 import { isolatePopularItems } from '../utils/isolate-popular-items';
 
-export const useBundlesToDisplay = ( { siteId, duration }: ProductsListProps ) => {
+export const useBundlesToDisplay = ( { siteId, duration }: itemToDisplayProps ) => {
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 
 	const currentPlanSlug = currentPlan?.product_slug || null;

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -1,0 +1,24 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { SelectorProduct } from '../../types';
+
+export const useItemLightbox = () => {
+	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( null );
+	const clickMoreHandlerFactory = ( item: SelectorProduct ): VoidFunction | undefined => {
+		return isEnabled( 'jetpack/pricing-page-product-lightbox' )
+			? () => {
+					recordTracksEvent( 'calypso_product_more_about_product_click', {
+						product: item.productSlug,
+					} );
+					setCurrentItem( item );
+			  }
+			: undefined;
+	};
+
+	return {
+		currentItem,
+		setCurrentItem,
+		clickMoreHandlerFactory,
+	};
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -1,17 +1,20 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SelectorProduct } from '../../types';
 
 export const useItemLightbox = () => {
 	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( null );
-	const clickMoreHandlerFactory = ( item: SelectorProduct ): VoidFunction | undefined => {
-		return () => {
-			recordTracksEvent( 'calypso_product_more_about_product_click', {
-				product: item.productSlug,
-			} );
-			setCurrentItem( item );
-		};
-	};
+	const clickMoreHandlerFactory = useCallback(
+		( item: SelectorProduct ): VoidFunction | undefined => {
+			return () => {
+				recordTracksEvent( 'calypso_product_more_about_product_click', {
+					product: item.productSlug,
+				} );
+				setCurrentItem( item );
+			};
+		},
+		[]
+	);
 
 	return {
 		currentItem,

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -4,24 +4,21 @@ import { SelectorProduct } from '../../types';
 
 export const useItemLightbox = () => {
 	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( null );
-	const clickMoreHandlerFactory = useCallback(
-		( item: SelectorProduct ): VoidFunction | undefined => {
-			return () => {
-				recordTracksEvent( 'calypso_product_more_about_product_click', {
-					product: item.productSlug,
-				} );
-				setCurrentItem( item );
-			};
-		},
-		[]
-	);
+	const onClickMoreInfoFactory = useCallback( ( item: SelectorProduct ): VoidFunction => {
+		return () => {
+			recordTracksEvent( 'calypso_product_more_about_product_click', {
+				product: item.productSlug,
+			} );
+			setCurrentItem( item );
+		};
+	}, [] );
 
 	return useMemo(
 		() => ( {
 			currentItem,
 			setCurrentItem,
-			clickMoreHandlerFactory,
+			onClickMoreInfoFactory,
 		} ),
-		[ currentItem, clickMoreHandlerFactory ]
+		[ currentItem, onClickMoreInfoFactory ]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SelectorProduct } from '../../types';
 
@@ -16,9 +16,12 @@ export const useItemLightbox = () => {
 		[]
 	);
 
-	return {
-		currentItem,
-		setCurrentItem,
-		clickMoreHandlerFactory,
-	};
+	return useMemo(
+		() => ( {
+			currentItem,
+			setCurrentItem,
+			clickMoreHandlerFactory,
+		} ),
+		[ currentItem, clickMoreHandlerFactory ]
+	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SelectorProduct } from '../../types';
@@ -6,14 +5,12 @@ import { SelectorProduct } from '../../types';
 export const useItemLightbox = () => {
 	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( null );
 	const clickMoreHandlerFactory = ( item: SelectorProduct ): VoidFunction | undefined => {
-		return isEnabled( 'jetpack/pricing-page-product-lightbox' )
-			? () => {
-					recordTracksEvent( 'calypso_product_more_about_product_click', {
-						product: item.productSlug,
-					} );
-					setCurrentItem( item );
-			  }
-			: undefined;
+		return () => {
+			recordTracksEvent( 'calypso_product_more_about_product_click', {
+				product: item.productSlug,
+			} );
+			setCurrentItem( item );
+		};
 	};
 
 	return {

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
@@ -5,10 +5,10 @@ import { getProductsToDisplay } from '../../product-grid/utils';
 import slugToSelectorProduct from '../../slug-to-selector-product';
 import { SelectorProduct } from '../../types';
 import useGetPlansGridProducts from '../../use-get-plans-grid-products';
-import { ProductsListProps } from '../types';
+import { itemToDisplayProps } from '../types';
 import { isolatePopularItems } from '../utils/isolate-popular-items';
 
-export const useProductsToDisplay = ( { siteId, duration }: ProductsListProps ) => {
+export const useProductsToDisplay = ( { siteId, duration }: itemToDisplayProps ) => {
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =
 		useGetPlansGridProducts( siteId );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
@@ -5,10 +5,10 @@ import { getProductsToDisplay } from '../../product-grid/utils';
 import slugToSelectorProduct from '../../slug-to-selector-product';
 import { SelectorProduct } from '../../types';
 import useGetPlansGridProducts from '../../use-get-plans-grid-products';
-import { itemToDisplayProps } from '../types';
+import { ItemToDisplayProps } from '../types';
 import { isolatePopularItems } from '../utils/isolate-popular-items';
 
-export const useProductsToDisplay = ( { siteId, duration }: itemToDisplayProps ) => {
+export const useProductsToDisplay = ( { siteId, duration }: ItemToDisplayProps ) => {
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =
 		useGetPlansGridProducts( siteId );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
@@ -13,7 +13,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 	onClickPurchase,
 	siteId,
 } ) => {
-	const { currentItem, setCurrentItem, clickMoreHandlerFactory } = useItemLightbox();
+	const { currentItem, setCurrentItem, onClickMoreInfoFactory } = useItemLightbox();
 
 	return (
 		<div className="jetpack-product-store__items-list">
@@ -33,7 +33,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 					siteId={ siteId }
 					createCheckoutURL={ createCheckoutURL }
 					onClickPurchase={ onClickPurchase }
-					clickMoreHandlerFactory={ clickMoreHandlerFactory }
+					onClickMoreInfoFactory={ onClickMoreInfoFactory }
 				/>
 			) }
 			{ currentView === 'bundles' && (
@@ -42,7 +42,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 					siteId={ siteId }
 					createCheckoutURL={ createCheckoutURL }
 					onClickPurchase={ onClickPurchase }
-					clickMoreHandlerFactory={ clickMoreHandlerFactory }
+					onClickMoreInfoFactory={ onClickMoreInfoFactory }
 				/>
 			) }
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
@@ -2,9 +2,14 @@ import ProductLightbox from '../../product-lightbox';
 import { BundlesList } from '../bundle-list';
 import { useItemLightbox } from '../hooks/use-item-lightbox';
 import { ProductsList } from '../product-list';
-import type { ItemsListProps } from '../types';
+import type { ItemsListProps, ProductsListProps, ViewType } from '../types';
 
 import './style.scss';
+
+const components: Record< ViewType, React.ComponentType< ProductsListProps > > = {
+	products: ProductsList,
+	bundles: BundlesList,
+};
 
 export const ItemsList: React.FC< ItemsListProps > = ( {
 	createCheckoutURL,
@@ -14,6 +19,11 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 	siteId,
 } ) => {
 	const { currentItem, setCurrentItem, onClickMoreInfoFactory } = useItemLightbox();
+	const Component = components[ currentView ];
+
+	if ( ! Component ) {
+		return null;
+	}
 
 	return (
 		<div className="jetpack-product-store__items-list">
@@ -27,24 +37,13 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 				/>
 			) }
 
-			{ currentView === 'products' && (
-				<ProductsList
-					duration={ duration }
-					siteId={ siteId }
-					createCheckoutURL={ createCheckoutURL }
-					onClickPurchase={ onClickPurchase }
-					onClickMoreInfoFactory={ onClickMoreInfoFactory }
-				/>
-			) }
-			{ currentView === 'bundles' && (
-				<BundlesList
-					duration={ duration }
-					siteId={ siteId }
-					createCheckoutURL={ createCheckoutURL }
-					onClickPurchase={ onClickPurchase }
-					onClickMoreInfoFactory={ onClickMoreInfoFactory }
-				/>
-			) }
+			<Component
+				duration={ duration }
+				siteId={ siteId }
+				createCheckoutURL={ createCheckoutURL }
+				onClickPurchase={ onClickPurchase }
+				onClickMoreInfoFactory={ onClickMoreInfoFactory }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import ProductLightbox from '../../product-lightbox';
 import { BundlesList } from '../bundle-list';
 import { useItemLightbox } from '../hooks/use-item-lightbox';
@@ -18,7 +17,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 
 	return (
 		<div className="jetpack-product-store__items-list">
-			{ isEnabled( 'jetpack/pricing-page-product-lightbox' ) && currentItem && (
+			{ currentItem && (
 				<ProductLightbox
 					product={ currentItem }
 					isVisible={ !! currentItem }

--- a/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
@@ -1,4 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
+import ProductLightbox from '../../product-lightbox';
 import { BundlesList } from '../bundle-list';
+import { useItemLightbox } from '../hooks/use-item-lightbox';
 import { ProductsList } from '../product-list';
 import type { ItemsListProps } from '../types';
 
@@ -11,14 +14,27 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 	onClickPurchase,
 	siteId,
 } ) => {
+	const { currentItem, setCurrentItem, clickMoreHandlerFactory } = useItemLightbox();
+
 	return (
 		<div className="jetpack-product-store__items-list">
+			{ isEnabled( 'jetpack/pricing-page-product-lightbox' ) && currentItem && (
+				<ProductLightbox
+					product={ currentItem }
+					isVisible={ !! currentItem }
+					onClose={ () => {
+						setCurrentItem( null );
+					} }
+				/>
+			) }
+
 			{ currentView === 'products' && (
 				<ProductsList
 					duration={ duration }
 					siteId={ siteId }
 					createCheckoutURL={ createCheckoutURL }
 					onClickPurchase={ onClickPurchase }
+					clickMoreHandlerFactory={ clickMoreHandlerFactory }
 				/>
 			) }
 			{ currentView === 'bundles' && (
@@ -27,6 +43,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 					siteId={ siteId }
 					createCheckoutURL={ createCheckoutURL }
 					onClickPurchase={ onClickPurchase }
+					clickMoreHandlerFactory={ clickMoreHandlerFactory }
 				/>
 			) }
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/product-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/product-list/index.tsx
@@ -85,6 +85,8 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 	const mostPopularItems = popularItems.map( ( item ) => {
 		const isItemOwned = isOwned( item );
 		const isItemSuperseded = isSuperseded( item );
+		const isItemDeprecated = isDeprecated( item );
+		const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
 		const purchase = getPurchase( item );
 
 		const ctaLabel = getCtaLabel( { item, isItemOwned, isItemSuperseded, purchase } );
@@ -92,14 +94,17 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 		const isCtaDisabled =
 			( isItemOwned || isIncludedInPlan( item ) ) && ! isUserPurchaseOwner( item );
 
+		const hideMoreInfoLink = isItemDeprecated || isItemOwned || isItemIncludedInPlanOrSuperseded;
+
 		return (
 			<FeaturedItemCard
 				checkoutURL={ getCheckoutURL( item ) }
 				ctaAsPrimary={ ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded ) }
 				ctaLabel={ ctaLabel }
 				hero={ <HeroImage item={ item } /> }
+				hideMoreInfoLink={ hideMoreInfoLink }
 				isCtaDisabled={ isCtaDisabled }
-				isIncludedInPlan={ isIncludedInPlanOrSuperseded( item ) }
+				isIncludedInPlan={ isItemIncludedInPlanOrSuperseded }
 				isOwned={ isItemOwned }
 				item={ item }
 				key={ item.productSlug }
@@ -128,19 +133,26 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 					{ allItems.map( ( item ) => {
 						const isItemOwned = isOwned( item );
 						const isItemSuperseded = isSuperseded( item );
+						const isItemDeprecated = isDeprecated( item );
+						const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
 						const purchase = getPurchase( item );
 
 						const isCtaDisabled =
 							( isItemOwned || isIncludedInPlan( item ) ) && ! isUserPurchaseOwner( item );
 
 						const ctaLabel = getCtaLabel( { item, isItemOwned, isItemSuperseded, purchase } );
+
+						const hideMoreInfoLink =
+							isItemDeprecated || isItemOwned || isItemIncludedInPlanOrSuperseded;
+
 						return (
 							<SimpleProductCard
 								checkoutURL={ getCheckoutURL( item ) }
 								ctaAsPrimary={ ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded ) }
 								ctaLabel={ ctaLabel }
 								isCtaDisabled={ isCtaDisabled }
-								isIncludedInPlan={ isIncludedInPlanOrSuperseded( item ) }
+								isIncludedInPlan={ isItemIncludedInPlanOrSuperseded }
+								hideMoreInfoLink={ hideMoreInfoLink }
 								isOwned={ isItemOwned }
 								item={ item }
 								key={ item.productSlug }

--- a/client/my-sites/plans/jetpack-plans/product-store/product-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/product-list/index.tsx
@@ -19,7 +19,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 	createCheckoutURL,
 	duration,
 	onClickPurchase,
-	clickMoreHandlerFactory,
+	onClickMoreInfoFactory,
 	siteId,
 } ) => {
 	const [ popularItems, otherItems ] = useProductsToDisplay( { duration, siteId } );
@@ -103,7 +103,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 				isOwned={ isItemOwned }
 				item={ item }
 				key={ item.productSlug }
-				onClickMore={ clickMoreHandlerFactory( item ) }
+				onClickMore={ onClickMoreInfoFactory( item ) }
 				onClickPurchase={ getOnClickPurchase( item ) }
 				siteId={ siteId }
 			/>
@@ -144,7 +144,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 								isOwned={ isItemOwned }
 								item={ item }
 								key={ item.productSlug }
-								onClickMore={ clickMoreHandlerFactory( item ) }
+								onClickMore={ onClickMoreInfoFactory( item ) }
 								onClickPurchase={ getOnClickPurchase( item ) }
 								siteId={ siteId }
 							/>

--- a/client/my-sites/plans/jetpack-plans/product-store/product-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/product-list/index.tsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Purchase } from 'calypso/lib/purchases/types';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import productButtonLabel from '../../product-card/product-button-label';
@@ -20,6 +19,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 	createCheckoutURL,
 	duration,
 	onClickPurchase,
+	clickMoreHandlerFactory,
 	siteId,
 } ) => {
 	const [ popularItems, otherItems ] = useProductsToDisplay( { duration, siteId } );
@@ -103,12 +103,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 				isOwned={ isItemOwned }
 				item={ item }
 				key={ item.productSlug }
-				onClickMore={ () => {
-					recordTracksEvent( 'calypso_product_more_about_product_click', {
-						product: item.productSlug,
-					} );
-					// TODO: Open modal
-				} }
+				onClickMore={ clickMoreHandlerFactory( item ) }
 				onClickPurchase={ getOnClickPurchase( item ) }
 				siteId={ siteId }
 			/>
@@ -149,12 +144,7 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 								isOwned={ isItemOwned }
 								item={ item }
 								key={ item.productSlug }
-								onClickMore={ () => {
-									recordTracksEvent( 'calypso_product_more_about_product_click', {
-										product: item.productSlug,
-									} );
-									// TODO: Open modal
-								} }
+								onClickMore={ clickMoreHandlerFactory( item ) }
 								onClickPurchase={ getOnClickPurchase( item ) }
 								siteId={ siteId }
 							/>

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
@@ -13,6 +13,7 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 	isIncludedInPlan,
 	isOwned,
 	isCtaDisabled,
+	isDeprecated,
 	item,
 	onClickMore,
 	onClickPurchase,
@@ -22,6 +23,7 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 
 	const { shortName: name } = item;
 	const productDescription = item?.shortDescription || item.description;
+	const hasMoreInfoLink = ! isDeprecated && ! isOwned && ! isIncludedInPlan;
 
 	return (
 		<div className="simple-product-card">
@@ -52,7 +54,7 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 				</div>
 				<div className="simple-product-card__info-content">
 					{ productDescription }
-					{ onClickMore && (
+					{ hasMoreInfoLink && (
 						<Button
 							className="simple-product-card__info-more-link"
 							onClick={ onClickMore }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
@@ -13,8 +13,8 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 	isIncludedInPlan,
 	isOwned,
 	isCtaDisabled,
-	isDeprecated,
 	item,
+	hideMoreInfoLink,
 	onClickMore,
 	onClickPurchase,
 	siteId,
@@ -23,7 +23,6 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 
 	const { shortName: name } = item;
 	const productDescription = item?.shortDescription || item.description;
-	const hasMoreInfoLink = ! isDeprecated && ! isOwned && ! isIncludedInPlan;
 
 	return (
 		<div className="simple-product-card">
@@ -54,7 +53,7 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 				</div>
 				<div className="simple-product-card__info-content">
 					{ productDescription }
-					{ hasMoreInfoLink && (
+					{ ! hideMoreInfoLink && (
 						<Button
 							className="simple-product-card__info-more-link"
 							onClick={ onClickMore }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
@@ -52,14 +52,16 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 				</div>
 				<div className="simple-product-card__info-content">
 					{ productDescription }
-					<Button
-						className="simple-product-card__info-more-link"
-						onClick={ onClickMore }
-						href="#"
-						plain
-					>
-						{ translate( 'More about %(name)s', { args: { name } } ) }
-					</Button>
+					{ onClickMore && (
+						<Button
+							className="simple-product-card__info-more-link"
+							onClick={ onClickMore }
+							href="#"
+							plain
+						>
+							{ translate( 'More about %(name)s', { args: { name } } ) }
+						</Button>
+					) }
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -23,6 +23,7 @@ export interface ProductStoreProps {
 	duration: Duration;
 	createCheckoutURL?: PurchaseURLCallback;
 	onClickPurchase?: PurchaseCallback;
+	clickMoreHandlerFactory: ( item: SelectorProduct ) => VoidFunction | undefined;
 	urlQueryArgs: ProductStoreQueryArgs;
 	header: React.ReactNode;
 }
@@ -42,6 +43,8 @@ export interface ViewFilterProps {
 
 export type ProductsListProps = ProductStoreBaseProps &
 	Omit< ProductStoreProps, 'urlQueryArgs' | 'header' >;
+
+export type itemToDisplayProps = Omit< ProductsListProps, 'clickMoreHandlerFactory' >;
 
 export type BundlesListProps = ProductsListProps;
 

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -42,12 +42,12 @@ export interface ViewFilterProps {
 
 export type ProductsListProps = ProductStoreBaseProps &
 	Omit< ProductStoreProps, 'urlQueryArgs' | 'header' > & {
-		clickMoreHandlerFactory: ( item: SelectorProduct ) => VoidFunction | undefined;
+		onClickMoreInfoFactory: ( item: SelectorProduct ) => VoidFunction;
 	};
 
 export type BundlesListProps = ProductsListProps;
 
-export type ItemToDisplayProps = Omit< ProductsListProps, 'clickMoreHandlerFactory' >;
+export type ItemToDisplayProps = Omit< ProductsListProps, 'onClickMoreInfoFactory' >;
 
 export interface ItemsListProps extends ItemToDisplayProps {
 	currentView: ViewType;

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -47,9 +47,9 @@ export type ProductsListProps = ProductStoreBaseProps &
 
 export type BundlesListProps = ProductsListProps;
 
-export type itemToDisplayProps = Omit< ProductsListProps, 'clickMoreHandlerFactory' >;
+export type ItemToDisplayProps = Omit< ProductsListProps, 'clickMoreHandlerFactory' >;
 
-export interface ItemsListProps extends itemToDisplayProps {
+export interface ItemsListProps extends ItemToDisplayProps {
 	currentView: ViewType;
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -80,7 +80,7 @@ export type FeaturedItemCardProps = ItemPriceProps & {
 	hero: React.ReactNode;
 	isCtaDisabled?: boolean;
 	item: SelectorProduct;
-	onClickMore: VoidFunction;
+	onClickMore?: VoidFunction;
 	onClickPurchase?: VoidFunction;
 };
 

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -23,7 +23,6 @@ export interface ProductStoreProps {
 	duration: Duration;
 	createCheckoutURL?: PurchaseURLCallback;
 	onClickPurchase?: PurchaseCallback;
-	clickMoreHandlerFactory: ( item: SelectorProduct ) => VoidFunction | undefined;
 	urlQueryArgs: ProductStoreQueryArgs;
 	header: React.ReactNode;
 }
@@ -42,13 +41,15 @@ export interface ViewFilterProps {
 }
 
 export type ProductsListProps = ProductStoreBaseProps &
-	Omit< ProductStoreProps, 'urlQueryArgs' | 'header' >;
-
-export type itemToDisplayProps = Omit< ProductsListProps, 'clickMoreHandlerFactory' >;
+	Omit< ProductStoreProps, 'urlQueryArgs' | 'header' > & {
+		clickMoreHandlerFactory: ( item: SelectorProduct ) => VoidFunction | undefined;
+	};
 
 export type BundlesListProps = ProductsListProps;
 
-export interface ItemsListProps extends ProductsListProps {
+export type itemToDisplayProps = Omit< ProductsListProps, 'clickMoreHandlerFactory' >;
+
+export interface ItemsListProps extends itemToDisplayProps {
 	currentView: ViewType;
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -74,6 +74,7 @@ export type UseStoreItemInfoProps = ProductStoreBaseProps & {
 export type ItemPriceProps = ProductStoreBaseProps &
 	HeroImageProps & {
 		isOwned?: boolean;
+		isDeprecated?: boolean;
 		isIncludedInPlan?: boolean;
 	};
 

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -74,7 +74,6 @@ export type UseStoreItemInfoProps = ProductStoreBaseProps & {
 export type ItemPriceProps = ProductStoreBaseProps &
 	HeroImageProps & {
 		isOwned?: boolean;
-		isDeprecated?: boolean;
 		isIncludedInPlan?: boolean;
 	};
 
@@ -85,6 +84,7 @@ export type FeaturedItemCardProps = ItemPriceProps & {
 	hero: React.ReactNode;
 	isCtaDisabled?: boolean;
 	item: SelectorProduct;
+	hideMoreInfoLink?: boolean;
 	onClickMore?: VoidFunction;
 	onClickPurchase?: VoidFunction;
 };

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,7 +45,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -39,7 +39,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -42,7 +42,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -42,7 +42,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-product-lightbox": false,
 		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,


### PR DESCRIPTION
#### Proposed Changes

* Create `useItemLightbox` custom hook for managing lightbox state.
* Integrate lightbox component to featured card and simple card using `useItemLightbox`.
* Remove temporary hint button for displaying lightboxes.

#### Testing Instructions
* Run `git fetch && git checkout add/lightbox-to-feature-and-product-card`
  * Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
* Confirm that all 'more ***' buttons in feature and simple cards works by clicking the button and confirming the lightbox shows up with correct product name on the header. (Except for CRM which will redirect user to the 
<img width="391" alt="Screen Shot 2022-09-05 at 9 49 00 PM" src="https://user-images.githubusercontent.com/56598660/188465510-01fc023d-b43d-474f-a649-fa6157b951ad.png">

* To confirm if the 'more info' is not visible when the product is not purchasable, go to site specific pricing page that has active jetpack plan.

   eg: [Jurassic Ninja](http://jetpack.cloud.localhost:3000/pricing/jurassic.ninja?flags=jetpack/pricing-page-rework-v1)
 * Confirm that the more info link is not visible for some products that are active to the current plan.
 
<img width="614" alt="Screen Shot 2022-09-06 at 7 09 51 PM" src="https://user-images.githubusercontent.com/56598660/188621638-9873c110-cda0-415e-87f5-359675ae294a.png">





#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202923891228306

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202923891228306