### PR TITLE
Checkout: update domain bundling message in Checkout summary

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -267,17 +267,18 @@ function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
 
 function CheckoutSummaryFeaturesListDomainItem( { domain }: { domain: ResponseCartProduct } ) {
 	const translate = useTranslate();
-	const bundledText = translate( 'free for one year' );
-	const bundledDomain = translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
-		components: {
-			strong: <strong />,
-		},
-		args: {
-			domain: domain.meta,
-			bundled: bundledText,
-		},
-		comment: 'domain name and bundling message, separated by a dash',
-	} );
+	const bundledDomain = translate(
+		'{{strong}}%(domain)s{{/strong}} domain registration free for one year',
+		{
+			components: {
+				strong: <strong />,
+			},
+			args: {
+				domain: domain.meta,
+			},
+			comment: 'domain name and bundling message',
+		}
+	);
 
 	// If domain is using existing credit or bundled with cart, show bundled text.
 	if ( domain.is_bundled ) {


### PR DESCRIPTION
#### Proposed Changes
To address confusion around what exactly is free for one year, this updates the bundled domain message in the "Include with your purchase" section of the Checkout summary.

<img width="360" alt="Screen Shot 2022-09-05 at 11 50 09 AM" src="https://user-images.githubusercontent.com/942359/188484719-432ed178-933b-4f28-b629-01ee7e4e1020.png">

See: p1662159504020409/1661257502.340709-slack-C03D472D64C

#### Testing Instructions
- Add an annual plan and domain to your cart
- Visit Checkout
- Verify that the top item in the sidebar reads "{domainName} domain registration free for one year"