### PR TITLE
DomainPicker: enable newsletter vendor for newsletter flow

### DIFF
--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -1,4 +1,8 @@
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
+
+type NEWSLETTER_FLOW = typeof NEWSLETTER_FLOW;
+type LINK_IN_BIO_FLOW = typeof LINK_IN_BIO_FLOW;
 
 export function mockDomainSuggestion(
 	domainName: string | undefined
@@ -34,7 +38,7 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: 'link-in-bio' | 'newsletter';
+	flowName?: NEWSLETTER_FLOW | LINK_IN_BIO_FLOW;
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
@@ -46,11 +50,11 @@ type DomainSuggestionsVendor =
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
 ): DomainSuggestionsVendor {
-	if ( options.flowName === 'link-in-bio' ) {
-		return options.flowName;
+	if ( options.flowName === LINK_IN_BIO_FLOW ) {
+		return 'link-in-bio';
 	}
-	if ( options.flowName === 'newsletter' ) {
-		return options.flowName;
+	if ( options.flowName === NEWSLETTER_FLOW ) {
+		return 'newsletter';
 	}
 	if ( options.isSignup && ! options.isDomainOnly ) {
 		return 'variation4_front';

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -1,9 +1,6 @@
 import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
-type NEWSLETTER_FLOW = typeof NEWSLETTER_FLOW;
-type LINK_IN_BIO_FLOW = typeof LINK_IN_BIO_FLOW;
-
 export function mockDomainSuggestion(
 	domainName: string | undefined
 ): DomainSuggestions.DomainSuggestion | undefined {
@@ -38,7 +35,7 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: NEWSLETTER_FLOW | LINK_IN_BIO_FLOW;
+	flowName?: typeof NEWSLETTER_FLOW | typeof LINK_IN_BIO_FLOW;
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -34,18 +34,22 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: 'link-in-bio';
+	flowName?: 'link-in-bio' | 'newsletter';
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
 	| 'variation4_front'
 	| 'variation8_front'
-	| 'link-in-bio';
+	| 'link-in-bio'
+	| 'newsletter';
 
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
 ): DomainSuggestionsVendor {
 	if ( options.flowName === 'link-in-bio' ) {
+		return options.flowName;
+	}
+	if ( options.flowName === 'newsletter' ) {
 		return options.flowName;
 	}
 	if ( options.isSignup && ! options.isDomainOnly ) {


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| <img width="1163" alt="Screenshot 2022-09-05 at 17 47 25" src="https://user-images.githubusercontent.com/7000684/188484507-0616e135-87fb-4fd6-93ca-726295c3ca9a.png"> |  <img width="1162" alt="Screenshot 2022-09-05 at 17 46 19" src="https://user-images.githubusercontent.com/7000684/188484544-7074c8a0-f2da-44e3-85c9-8b9d28d08c10.png"> |

#### Proposed Changes

* We need to update the domain suggestion vendor to be newsletter for newsletter flow

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Follow the newsletter flow and compare the domain suggestions for the same domain on this branch and trunk

Related to #67368
