### PR TITLE
Jetpack Agency Dashboard: set container element's height to 100%

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -7,6 +7,7 @@
 	}
 }
 .sites-overview__container {
+	height: 100vh;
 	padding: 16px 0;
 	@include break-large() {
 		padding: 6px 0;
@@ -33,7 +34,7 @@
 	// but our element is inside a limited-width parent.
 	margin: 0 -32px;
 	padding: 8px 48px;
-	min-height: 100vh;
+	height: 100%;
 	@include breakpoint-deprecated( '>660px' ) {
     	padding: 16px 48px;
 		background: rgba( 255, 255, 255, 0.5 );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -7,8 +7,10 @@
 	}
 }
 .sites-overview__container {
+	display: flex;
+	flex-direction: column;
 	// The -123px is to undo the padding of .layout__content (79px + 32px) and .sites-overview_container ( 8px + 8px )
-	height: calc( 100vh - 123px );
+	min-height: calc( 100vh - 123px );
 	padding: 16px 0;
 	@include break-large() {
 		padding: 6px 0;
@@ -33,12 +35,13 @@
 .sites-overview__content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
-	margin: 0 -32px;
+	margin: 0 -32px -32px;
 	padding: 8px 48px;
-	height: 100%;
+	flex: 1 1 100%;
 	@include breakpoint-deprecated( '>660px' ) {
-    	padding: 16px 48px;
+		padding: 16px 48px;
 		background: rgba( 255, 255, 255, 0.5 );
+		margin: 0 -32px -38px;
 	}
 }
 .sites-overview__page-title-container {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -7,7 +7,8 @@
 	}
 }
 .sites-overview__container {
-	height: 100vh;
+	// The -123px is to undo the padding of .layout__content (79px + 32px) and .sites-overview_container ( 8px + 8px )
+	height: calc( 100vh - 123px );
 	padding: 16px 0;
 	@include break-large() {
 		padding: 6px 0;

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
@@ -2,6 +2,11 @@
 @import '@wordpress/base-styles/mixins';
 
 .plugins-overview__container {
+	display: flex;
+	flex-direction: column;
+	// The -111px is to undo the padding of .layout__content (79px + 32px)
+	min-height: calc( 100vh - 111px );
+
 	.current-section {
 		padding: 0 16px;
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -390,10 +390,11 @@ body.is-section-plugins header .select-dropdown__item {
 	// but our element is inside a limited-width parent.
 	margin: 0 -32px;
 	padding: 0 48px;
-	min-height: 100vh;
+	flex: 1 1 100%;
 	@include breakpoint-deprecated( '>660px' ) {
     	padding: 16px 48px;
 		background: rgba( 255, 255, 255, 0.5 );
+		margin-bottom: -32px; 
 	}
 }
 .plugins__search {


### PR DESCRIPTION
#### Proposed Changes

* Currently, a div's height is set to `100vh`, which extends the page's height unnecessarily (we end up with a vertical scroll bar). These changes fix that by setting its parent component's height to `100vh` and replacing the child's height from `100vh` to `100%`. As a result, the page no longer shows the vertical scroll bar.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1462" alt="Screen Shot 2022-09-05 at 11 50 43" src="https://user-images.githubusercontent.com/3418513/188485572-870660b0-5c35-4e61-9053-017d77381347.png">
</td>
<td>
<img width="1462" alt="Screen Shot 2022-09-05 at 11 50 53" src="https://user-images.githubusercontent.com/3418513/188485532-fe91dc44-d026-47bd-8386-2aca5042236c.png">
</td>
</tr>
</table>


#### Testing Instructions

##### Replicate the issue
* Visit https://cloud.jetpack.com/dashboard.
* On the desktop, confirm you see the vertical scroll bar on the right of the page (this happens regardless of the amounts of sites shown in the dashboard).

##### Test the fix
* Download this PR.
* Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
* On the desktop, confirm you don't see the vertical scroll bar on the right of the page.
* Verify that everything still looks correct under different viewport sizes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202781858630727