### PR TITLE
Checkout: move sidebar email support message logic to getPlanFeatures

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -13,7 +13,6 @@ import {
 	isWpComPersonalPlan,
 	isWpComPlan,
 	isWpComPremiumPlan,
-	isStarterPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -184,9 +183,6 @@ function CheckoutSummaryFeaturesList( props: {
 
 	const translate = useTranslate();
 
-	const hasOnlyStarterPlan =
-		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
-
 	const hasNoAdsAddOn = responseCart.products.some( ( product ) => isNoAds( product ) );
 
 	return (
@@ -206,13 +202,6 @@ function CheckoutSummaryFeaturesList( props: {
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-text" />
 					{ translate( 'Remove ads from your site with the No Ads add-on' ) }
-				</CheckoutSummaryFeaturesListItem>
-			) }
-
-			{ ! hasOnlyStarterPlan && (
-				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="features-list-support-text" />
-					{ translate( 'Customer support via email' ) }
 				</CheckoutSummaryFeaturesListItem>
 			) }
 

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -27,6 +27,7 @@ export default function getPlanFeatures(
 	}
 
 	const isMonthlyPlan = isMonthly( productSlug );
+	const emailSupport = String( translate( 'Customer support via email' ) );
 	const liveChatSupport = String( translate( 'Live chat support' ) );
 	const freeOneYearDomain = showFreeDomainFeature
 		? String( translate( 'Free domain for one year' ) )
@@ -36,6 +37,7 @@ export default function getPlanFeatures(
 	if ( isWpComPersonalPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
+			emailSupport,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
 		].filter( isValueTruthy );
@@ -44,6 +46,7 @@ export default function getPlanFeatures(
 	if ( isStarterPlan( productSlug ) ) {
 		return [
 			freeOneYearDomain,
+			emailSupport,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
 			String( translate( 'Track your stats with Google Analytics' ) ),
@@ -53,6 +56,7 @@ export default function getPlanFeatures(
 	if ( isWpComPremiumPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
+			isMonthlyPlan && emailSupport,
 			! isMonthlyPlan && liveChatSupport,
 			isEnabled( 'themes/premium' )
 				? String( translate( 'Unlimited access to our library of Premium Themes' ) )
@@ -67,6 +71,7 @@ export default function getPlanFeatures(
 	if ( isWpComBusinessPlan( productSlug ) || isWpComProPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
+			isMonthlyPlan && emailSupport,
 			! isMonthlyPlan && liveChatSupport,
 			String( translate( 'Install custom plugins and themes' ) ),
 			String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
@@ -78,6 +83,7 @@ export default function getPlanFeatures(
 	if ( isWpComEcommercePlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
+			isMonthlyPlan && emailSupport,
 			! isMonthlyPlan && liveChatSupport,
 			String( translate( 'Install custom plugins and themes' ) ),
 			String( translate( 'Accept payments in 60+ countries' ) ),


### PR DESCRIPTION
#### Proposed Changes
The logic introduced with #63813 causes "Customer support via email" to be displayed for all carts now that Starter and Pro plans have been reverted. This PR moves the plan support logic to the `getPlanFeatures` helper, and displayed "Customer support via email" for all plans that don't support live chat.

#### Testing Instructions
- Add an annual plan Premium or above to your cart
- Visit Checkout
- Verify that "Live chat support" is shown in the sidebar feature list
- Verify that "Customer support via email" is not shown in the sidebar feature list
- Remove the plan
- Add a monthly plan Premium or above to your cart
- Visit Checkout
- Verify that "Live chat support" is not shown in the sidebar feature list
- Verify that "Customer support via email" is shown in the sidebar feature list
- Remove the plan
- Add a Personal plan to your cart
- Visit Checkout
- Verify that "Live chat support" is not shown in the sidebar feature list
- Verify that "Customer support via email" is shown in the sidebar feature list
