### PR TITLE
E2E: skip domain selection for Plans: Business flow.

### DIFF
--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -48,7 +48,7 @@ describe(
 				await page.goto( DataHelper.getCalypsoURL( 'start' ) );
 			} );
 
-			it( 'Select a .wordpres.com domain name', async function () {
+			it( 'Skip domain selection', async function () {
 				const signupDomainPage = new SignupDomainPage( page );
 				await signupDomainPage.skipDomainSelection();
 			} );

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -11,7 +11,7 @@ import {
 	RestAPIClient,
 	CartCheckoutPage,
 	TestAccount,
-	DomainSearchComponent,
+	SignupDomainPage,
 	MediaPage,
 	NewSiteResponse,
 } from '@automattic/calypso-e2e';
@@ -23,7 +23,6 @@ declare const browser: Browser;
 describe(
 	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Business site as exising user' ),
 	function () {
-		const blogName = DataHelper.getBlogName();
 		const planName = 'Business';
 
 		let testAccount: TestAccount;
@@ -50,9 +49,8 @@ describe(
 			} );
 
 			it( 'Select a .wordpres.com domain name', async function () {
-				const domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.search( blogName );
-				await domainSearchComponent.selectDomain( '.wordpress.com' );
+				const signupDomainPage = new SignupDomainPage( page );
+				await signupDomainPage.skipDomainSelection();
 			} );
 
 			it( `Select WordPress.com ${ planName } plan`, async function () {


### PR DESCRIPTION
#### Proposed Changes

This PR skips the domain search and selection step for Plans: Business flow to reduce dependence on the potentially flaky third party domain lookup service.

#### Testing Instructions
Ensure the following build configurations are passing:
  - [ ] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67400
