### PR TITLE
E2E: add retry mechanism to the domain search and selection step.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -3,7 +3,6 @@ import { reloadAndRetry } from '../../element-helper';
 
 const selectors = {
 	searchInput: `.search-component__input`,
-	resultPlaceholder: `.is-placeholder`,
 	resultItem: ( keyword: string ) => `.domain-suggestion__content:has-text("${ keyword }")`,
 };
 


### PR DESCRIPTION
#### Proposed Changes

This PR aims to add resiliency to the domain search and selection step during signup by adding a retry mechanism.

Key changes:
- replace wait for the placeholder selector with a `waitForResponse` for queries to complete.
- add retry mechanism in a closure to re-attempt up to 3 times.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/67403.
Closes https://github.com/Automattic/wp-calypso/issues/67400.
