### PR TITLE
Google Workspace Regional Discount: Add new pricing information for products with an introductory offer

### DIFF
--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -97,7 +97,7 @@ function getPriceMessageExplanation( {
 		if ( hasGoogleWorkspaceOffer ) {
 			return isMonthlyBilling
 				? translate(
-						'This is less than the first month discounted price because you are only charged for the remainder of the current month.'
+						'This is less than the first year discounted price because you are only charged for the remainder of the current month.'
 				  )
 				: translate(
 						'This is less than the first year discounted price because you are only charged for the remainder of the current year.'


### PR DESCRIPTION
This set of changes updates the messaging that users see when attempting to add new mailboxes, so that it more aptly describes the offer we provide for Google Workspace subscriptions

#### Proposed Changes

* Detect when an offer is in place for Google Workspace
* Change the messaging to reflect the current offer correctly

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a Google Workspace subscriptions as described [here](2d832-pb/#plain)
* Attempt to add new mailboxes by bringing up the `Add New Mailboxes` view i.e. `/email/<domain>/google-workspace/add-users/<site>`
* Confirm that the new pricing message better describes the offer being presented

|  Before |  After |
|---|---|
|  <img width="700" alt="Screenshot 2022-09-06 at 12 41 27 AM" src="https://user-images.githubusercontent.com/277661/188521075-65c53714-c849-4799-87b7-8bb5dcce82f0.png"> | <img width="700" alt="Screenshot 2022-09-06 at 12 40 56 AM" src="https://user-images.githubusercontent.com/277661/188673357-ec1c2db4-fc24-445f-ac0e-812aff6b4c5e.png">  |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #