### PR TITLE
Pricing page rework: Show "Jetpack successfully installed" only after connection.

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -3,6 +3,7 @@ import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
@@ -48,7 +49,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 
 	let titleToRender =
 		isEnabled( 'jetpack/pricing-page-rework-v1' ) &&
-		window.location.pathname.startsWith( '/jetpack/connect/plans' )
+		window.location.pathname.startsWith( JPC_PATH_PLANS )
 			? translate( 'Jetpack is successfully installed' )
 			: '';
 

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -46,9 +46,11 @@ function LicensingPromptDialog( { siteId }: Props ) {
 		dispatch( recordTracksEvent( 'calypso_user_license_modal_view' ) );
 	}, [ dispatch ] );
 
-	let titleToRender = isEnabled( 'jetpack/pricing-page-rework-v1' )
-		? translate( 'Jetpack is successfully installed' )
-		: '';
+	let titleToRender =
+		isEnabled( 'jetpack/pricing-page-rework-v1' ) &&
+		window.location.pathname.startsWith( '/jetpack/connect/plans' )
+			? translate( 'Jetpack is successfully installed' )
+			: '';
 
 	if ( ! titleToRender ) {
 		if ( hasOneDetachedLicense ) {

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -2,6 +2,7 @@ import { TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 import JetpackBoostWelcomePage from 'calypso/components/jetpack/jetpack-boost-welcome';
 import JetpackFreeWelcomePage from 'calypso/components/jetpack/jetpack-free-welcome';
 import JetpackSocialWelcomePage from 'calypso/components/jetpack/jetpack-social-welcome';
+import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -64,7 +65,7 @@ export const productSelect =
 
 		const enableUserLicensesDialog = !! (
 			siteId &&
-			( isJetpackCloud() || context.path.startsWith( '/jetpack/connect/plans' ) )
+			( isJetpackCloud() || context.path.startsWith( JPC_PATH_PLANS ) )
 		);
 
 		context.primary = (

--- a/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
@@ -11,7 +11,9 @@ export const UserLicensesDialog: React.FC< ProductStoreBaseProps > = ( { siteId 
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( successNotice( translate( 'Jetpack is successfully installed' ) ) );
+		if ( window.location.pathname.startsWith( '/jetpack/connect/plans' ) ) {
+			dispatch( successNotice( translate( 'Jetpack is successfully installed' ) ) );
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import LicensingActivationBanner from 'calypso/components/jetpack/licensing-activation-banner';
 import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
+import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
 import { successNotice } from 'calypso/state/notices/actions';
 import { ProductStoreBaseProps } from './types';
 
@@ -11,7 +12,7 @@ export const UserLicensesDialog: React.FC< ProductStoreBaseProps > = ( { siteId 
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		if ( window.location.pathname.startsWith( '/jetpack/connect/plans' ) ) {
+		if ( window.location.pathname.startsWith( JPC_PATH_PLANS ) ) {
 			dispatch( successNotice( translate( 'Jetpack is successfully installed' ) ) );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
#### Proposed Changes

Prior to this PR the "Jetpack successfully installed" notice (and heading in the licensing dialog prompt, (if the user has licenses available)) was showing on the new pricing page on `cloud.jetpack.com/pricing/:site`, however the "Jetpack successfully installed" messages should only show immediately after plugin connection when the user is redirected to `wordpress.com/jetpack/connect/plans/:site`. (See screenshot in "Showing the issue:", below)

**Showing the issue:**
Here, the "_Jetpack successfully installed_" message is showing on the `cloud.jetpack.com/pricing/:site`page, **which it should _not_ be**. This page is **not** shown immediately after plugin connection. This page is usually viewed by clicking on the "Plans" link in the Jetpack plugin dashboard after the plugin has already been connected:

![Markup 2022-09-05 at 18 48 00](https://user-images.githubusercontent.com/11078128/188518762-acc680df-e1d2-429c-970a-de4ec2ee93d4.png)

This PR fixes this issue so that the "_Jetpack successfully installed_" message (and in the licensing dialog) only appears immediately after successful plugin connection, when the user is redirected to 'wordpress.com/jetpack/connect/plans/:site`.

Asana task: 1202796695664022-as-1202925210357632/f


#### Testing Instructions

- First go to `cloud.jetpack.com/pricing/:site?flags=jetpack/pricing-page-rework-v1`, where `:site` is a Jetpack site you own, or a Jurassic Ninja site that you have connected to your account.
- See that the "_Jetpack successfully installed_" notice is showing. (if you have and un-activated licenses then you will see the licensing dialog too, and it will also say, "_Jetpack successfully installed_". It should look like the screenshot above in "_Showing the issue_:" This is the regression, "_Jetpack successfully installed_" should not be showing here.
- Now spin up this PR: `git fetch && git checkout fix/pricing-rework-licensing-prompt && yarn start`.
- and in a new command line window, also run `yarn start-jetpack-cloud-p` (to also spin up jetpack cloud)
- Create a new Jurassic Ninja site.
- Connect Jetpack. Click Authorize.
- After connection you will be redirected to the pricing page. (`wordpress.com/jetpack/connect/plans/:site?....`)
- Copy the URL, replace `https://wordpress.com` with `http://calypso.localhost:3000` and then append `&flags=jetpack/pricing-page-rework-v1` to the end of the URL.
- Paste the new URL back into the browser address bar and press enter (to load the page).
- See/verify that the "_Jetpack successfully installed_" message is here showing correctly here on `/jetpack/connect/plans` after connection.
- Now in a new tab, got to `jetapck.cloud.localhost:3000/pricing/:site`, where `:site` is the JN site you created.
- See/verify that the "_Jetpack successfully installed_" message, is no longer showing on this page.

#### Screenshots

The `jetpack/connect/plans/:site` page immediately after plugin connection (With available licenses):

![Markup 2022-09-05 at 18 08 19](https://user-images.githubusercontent.com/11078128/188520379-9c7578ad-cfc1-4615-8c33-ed6a90e2e9ec.png)
.

The `jetpack/connect/plans/:site` page immediately after plugin connection (Without any available licenses):

![Markup 2022-09-05 at 18 24 21](https://user-images.githubusercontent.com/11078128/188520481-5e4cf539-49cc-4012-b2ea-45766abdcfd8.png)
.

The `cloud.jetpack.com/pricing:site` page (With available licenses):

![Markup 2022-09-05 at 18 10 29](https://user-images.githubusercontent.com/11078128/188520581-fb83b229-fa5f-4cac-b5be-fb582e823060.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #