### PR TITLE
Promoted Posts style tweak: center align labels, update font size

### DIFF
--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -59,9 +59,13 @@ export default function PostItem( { post }: Props ) {
 				<div className="post-item__body">
 					<div className="post-item__title">{ post.title }</div>
 					<div className="post-item__subtitle">
-						<PostRelativeTimeStatus showPublishedStatus={ false } post={ post } />
+						<PostRelativeTimeStatus
+							showPublishedStatus={ false }
+							post={ post }
+							gridiconSize={ 12 }
+						/>
 						<span className="post-item__posttype">{ getPostType( post.type ) }</span>
-						<Button isLink href={ post.URL }>
+						<Button className="post-item__view-link" isLink href={ post.URL } size={ 12 }>
 							{ __( 'View' ) }
 						</Button>
 					</div>

--- a/client/my-sites/promote-post/components/post-item/style.scss
+++ b/client/my-sites/promote-post/components/post-item/style.scss
@@ -1,4 +1,3 @@
-
 .post-item__card {
 	display: flex;
 	align-items: center;
@@ -32,9 +31,16 @@
 			font-size: 1.25rem;
 		}
 
-		.post-item__subtitle, .post-item__posttype {
+		.post-item__subtitle,
+		.post-item__posttype {
 			color: var( --color-neutral-50 );
-			font-size: 0.875rem;
+			font-size: 0.75rem;
+			display: flex;
+			align-items: center;
+		}
+
+		.post-item__view-link {
+			font-size: 0.75rem;
 		}
 
 		.post-item__posttype {
@@ -42,5 +48,3 @@
 		}
 	}
 }
-
-


### PR DESCRIPTION
#### Proposed Changes

* Update the post tab to match Post page styles.
* Also center align the labels.

![Screen Shot 2022-09-06 at 12 47 36](https://user-images.githubusercontent.com/6070516/188525144-7c8e7bb1-5581-4793-a0e7-a35f1acb3092.jpg)

#### Testing Instructions
Compare the Promoted Posts page, post tab with the Post page.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
