### PR TITLE
Plugin Management: plugin details page enhancements

### DIFF
--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
@@ -4,8 +4,13 @@
 .plugins-overview__container {
 	.current-section {
 		padding: 0 16px;
+
+		button {
+			padding: 12px 8px;
+		}
 	}
 }
+
 .plugins-overview__logo {
 	fill: var( --color-neutral-10 );
 	color: var( --color-neutral-10 );

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -84,35 +84,39 @@ export default function PluginDetailsV2( {
 				sites={ sitesWithPlugins }
 				plugins={ [ fullPlugin ] }
 			/>
-			<div className="plugin-details__page legacy">
-				<div className="plugin-details__layout plugin-details__top-section">
-					<div className="plugin-details__layout-col-left">
-						<PluginDetailsHeader
-							isJetpackCloud
-							plugin={ fullPlugin }
-							isPlaceholder={ showPlaceholder }
-						/>
+			<div className="plugin-details-v2__top-container">
+				<div className="plugin-details__page legacy">
+					<div className="plugin-details__layout plugin-details__top-section">
+						<div className="plugin-details__layout-col-left">
+							<PluginDetailsHeader
+								isJetpackCloud
+								plugin={ fullPlugin }
+								isPlaceholder={ showPlaceholder }
+							/>
+						</div>
 					</div>
 				</div>
-			</div>
-			<SitesWithInstalledPluginsList
-				sites={ sitesWithPlugin }
-				selectedSite={ selectedSite }
-				isLoading={ isLoading }
-				plugin={ fullPlugin }
-			/>
-			<PluginAvailableOnSitesList
-				sites={ sitesWithoutPlugin }
-				selectedSite={ selectedSite }
-				isLoading={ isLoading }
-				plugin={ fullPlugin }
-			/>
-			{ fullPlugin.fetched && (
-				<PluginDetailsBody
-					fullPlugin={ fullPlugin }
-					isMarketplaceProduct={ isMarketplaceProduct }
-					isWpcom={ isWpcom }
+				<SitesWithInstalledPluginsList
+					sites={ sitesWithPlugin }
+					selectedSite={ selectedSite }
+					isLoading={ isLoading }
+					plugin={ fullPlugin }
 				/>
+				<PluginAvailableOnSitesList
+					sites={ sitesWithoutPlugin }
+					selectedSite={ selectedSite }
+					isLoading={ isLoading }
+					plugin={ fullPlugin }
+				/>
+			</div>
+			{ fullPlugin.fetched && (
+				<div className="plugin-details-v2__body-container">
+					<PluginDetailsBody
+						fullPlugin={ fullPlugin }
+						isMarketplaceProduct={ isMarketplaceProduct }
+						isWpcom={ isWpcom }
+					/>
+				</div>
 			) }
 		</div>
 	);

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -3,11 +3,25 @@
 
 .plugin-details-v2 {
 	padding: 0 16px;
-	max-width: 1500px;
-	margin: auto;
 
 	p {
 		font-size: inherit;
+	}
+
+	.plugin-details-v2__top-container {
+		max-width: 1500px;
+		margin: auto;
+	}
+
+	.plugin-details-v2__body-container {
+		padding-block-start: 0;
+		background: var( --color-surface );
+		margin: 32px -180px -32px;
+		padding: 0 180px;
+
+		@include break-xlarge {
+			margin-top: 72px;
+		}
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
@@ -84,10 +98,9 @@
 	}
 
 	.plugin-details__body {
-		padding-block-start: 0;
-		background: var( --color-surface );
-		margin: 72px -180px -32px;
-		padding: 0 180px;
+		padding-top: 0;
+		max-width: 1500px;
+		margin: auto;
 
 		.section-nav-tabs__list {
 			box-shadow: none;
@@ -98,7 +111,11 @@
 		}
 
 		.plugin-details__layout-col-left {
-			padding-block-start: 48px;
+			padding-block-start: 12px;
+
+			@include break-xlarge {
+				padding-block-start: 48px;
+			}
 
 			.section-nav__mobile-header {
 				padding: 10px 0;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -2,11 +2,13 @@
 @import '@wordpress/base-styles/mixins';
 
 .plugin-details-v2 {
+	padding: 0 16px;
+	max-width: 1500px;
+	margin: auto;
+
 	p {
 		font-size: inherit;
 	}
-
-	padding: 0 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
@@ -84,15 +86,19 @@
 	.plugin-details__body {
 		padding-block-start: 0;
 		background: var( --color-surface );
-		margin: 16px -72px -32px;
-		padding: 0 72px;
+		margin: 72px -180px -32px;
+		padding: 0 180px;
 
 		.section-nav-tabs__list {
 			box-shadow: none;
 		}
 
+		.plugin-details__plugins-sections .card {
+			padding-top: 24px;
+		}
+
 		.plugin-details__layout-col-left {
-			padding-block-start: 10px;
+			padding-block-start: 48px;
 
 			.section-nav__mobile-header {
 				padding: 10px 0;
@@ -141,6 +147,11 @@
 
 	@include break-xlarge {
 		padding-inline-start: 70px !important;
+
+		> div {
+			max-width: 1530px;
+			margin: auto;
+		}
 	}
 }
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -1,85 +1,149 @@
-@import '@wordpress/base-styles/_breakpoints.scss';
-@import '@wordpress/base-styles/_mixins.scss';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .plugin-details-v2 {
+	p {
+		font-size: inherit;
+	}
+
 	padding: 0 16px;
+
 	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
 	}
-	@include break-xlarge() {
+
+	@include break-xlarge {
 		padding: 0 38px;
 	}
+
 	.plugin-details-sidebar__plugin-details-content {
 		border: none;
 		margin: 0;
 		padding: 0;
 	}
+
 	.current-section button {
 		padding: 12px 8px !important;
 	}
+
 	.legacy .plugin-details__layout {
 		grid-template-columns: unset;
 		max-width: 800px;
 		background: var( --color-surface );
 		margin: 0 -16px;
 		padding: 0 16px 16px;
+
 		@include breakpoint-deprecated( '>660px' ) {
 			background: unset;
 			margin: 0;
 			padding: 0;
 		}
 	}
+
 	.legacy .plugin-details-header__container {
 		@include breakpoint-deprecated( '>660px' ) {
 			padding: 20px 0;
 		}
-		@include break-xlarge() {
+
+		@include break-xlarge {
 			padding: 30px 0;
 		}
 	}
+
 	.legacy .plugin-details-header__additional-info {
 		.plugin-details-header__info {
 			padding: 0;
-			@media screen and ( max-width: 1040px ) {
+
+			@media screen and (max-width: 1040px) {
 				padding-block-end: 12px;
 			}
 		}
+
 		.plugin-details-header__info-value {
 			font-size: 0.875rem;
 		}
 	}
+
 	.plugin-ratings__rating-stars {
 		display: flex;
 		margin: 10px 0;
+
 		@include breakpoint-deprecated( '>660px' ) {
 			margin: 0;
 		}
 	}
+
 	.plugin-details__page {
 		padding: 0;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			padding: 30px 0 0;
+		}
 	}
+
 	.plugin-details__body {
 		padding-block-start: 0;
 		background: var( --color-surface );
 		margin: 16px -72px -32px;
 		padding: 0 72px;
+
+		.section-nav-tabs__list {
+			box-shadow: none;
+		}
+
+		.plugin-details__layout-col-left {
+			padding-block-start: 10px;
+
+			.section-nav__mobile-header {
+				padding: 10px 0;
+			}
+
+			.section-nav-tab {
+				&:first-child .section-nav-tab__link {
+					padding: 8px 8px 12px;
+
+					@include breakpoint-deprecated( '>660px' ) {
+						padding-left: 0;
+					}
+				}
+
+				&.is-selected .section-nav-tab__link {
+					color: var( --color-text-inverted );
+
+					.section-nav-tab__text {
+						padding-bottom: 0;
+						font-weight: 500;
+						border-bottom: none;
+					}
+
+					@include breakpoint-deprecated( '>660px' ) {
+						color: initial;
+					}
+				}
+			}
+		}
 	}
 }
+
 .plugin-details-v2__header {
 	border-bottom: none !important;
 	background-color: var( --color-surface-backdrop ) !important;
+
 	@include breakpoint-deprecated( '>660px' ) {
 		inset-inline-start: calc( var( --sidebar-width-min ) + 1px ) !important;
 		padding-inline-start: 24px !important;
 	}
-	@include break-large() {
+
+	@include break-large {
 		inset-inline-start: calc( var( --sidebar-width-min ) + 45px ) !important;
 		padding-inline-start: 39px !important;
 	}
-	@include break-xlarge() {
+
+	@include break-xlarge {
 		padding-inline-start: 70px !important;
 	}
 }
+
 .plugin-details-v2__title {
 	font-size: 0.875rem;
 	color: var( --color-text );


### PR DESCRIPTION
#### Proposed Changes

This PR makes some UI enhancements to the plugin details page.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/plugin-details-page-enhancements` and `yarn start-jetpack-cloud-p`
2. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
3. Click on **Plugins** in the sidebar -> Click on any plugin -> Verify that the plugin details are loaded as shown below. 

Before

<img width="1660" alt="Screenshot 2022-09-06 at 10 59 29 AM" src="https://user-images.githubusercontent.com/10586875/188554518-219918e6-2687-43bd-b146-f4b327ae2f63.png">
<img width="1519" alt="Screenshot 2022-09-06 at 10 59 39 AM" src="https://user-images.githubusercontent.com/10586875/188554721-1d3e3468-337d-4fb1-b98a-a3af08ecd6d7.png">
<img width="1595" alt="Screenshot 2022-09-06 at 10 59 50 AM" src="https://user-images.githubusercontent.com/10586875/188554734-34571e0b-e975-4625-89be-364affa3c5aa.png">
<img width="1599" alt="Screenshot 2022-09-06 at 10 59 57 AM" src="https://user-images.githubusercontent.com/10586875/188554741-cdb1f49b-2445-4b59-b7e4-79dac4e8f356.png">
<img width="370" alt="Screenshot 2022-09-06 at 11 00 23 AM" src="https://user-images.githubusercontent.com/10586875/188554756-630670a9-5f93-4851-b4a4-3c9f56a8d1aa.png">

After

<img width="1655" alt="Screenshot 2022-09-06 at 11 01 58 AM" src="https://user-images.githubusercontent.com/10586875/188554790-41fdc36d-9b6b-48bf-8163-383ed51e1697.png">
<img width="1661" alt="Screenshot 2022-09-06 at 11 02 06 AM" src="https://user-images.githubusercontent.com/10586875/188554814-819ddb91-89a3-41c0-ab07-930c61fafe03.png">
<img width="1597" alt="Screenshot 2022-09-06 at 11 02 13 AM" src="https://user-images.githubusercontent.com/10586875/188554817-024fb3da-7bbd-44d2-91cd-f64cdc5d94fb.png">
<img width="1577" alt="Screenshot 2022-09-06 at 11 02 18 AM" src="https://user-images.githubusercontent.com/10586875/188554819-8fb27f76-3176-41a6-af99-e90e5f3cce4b.png">
<img width="375" alt="Screenshot 2022-09-06 at 11 01 36 AM" src="https://user-images.githubusercontent.com/10586875/188554869-9db66a57-40e4-45d5-b3fb-774e46922c0f.png">




#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202698250096175