### PR TITLE
E2E: try fixing e2e tests by not waiting for past requests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -43,6 +43,7 @@ const selectors = {
  */
 export class PlansPage {
 	private page: Page;
+	public receivedActivePromotions = false;
 
 	/**
 	 * Constructs an instance of the Plans POM.
@@ -51,6 +52,11 @@ export class PlansPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		page.on( 'response', ( res ) => {
+			if ( res.url().includes( 'active-promotions' ) ) {
+				this.receivedActivePromotions = true;
+			}
+		} );
 	}
 
 	/**
@@ -139,9 +145,13 @@ export class PlansPage {
 		// on Desktop viewports.
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
+		this.page.request.get;
 		await Promise.all( [
 			this.page.waitForLoadState( 'networkidle' ),
-			this.page.waitForResponse( /.*active-promotions.*/ ),
+			// don't wait for the response if it's already done in the past
+			this.receivedActivePromotions
+				? Promise.resolve()
+				: this.page.waitForResponse( /.*active-promotions.*/ ),
 		] );
 		await clickNavTab( this.page, targetTab, { force: true } );
 	}

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -145,7 +145,6 @@ export class PlansPage {
 		// on Desktop viewports.
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
-		this.page.request.get;
 		await Promise.all( [
 			this.page.waitForLoadState( 'networkidle' ),
 			// don't wait for the response if it's already done in the past

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -43,7 +43,7 @@ const selectors = {
  */
 export class PlansPage {
 	private page: Page;
-	public receivedActivePromotions = false;
+	private receivedActivePromotions = false;
 
 	/**
 	 * Constructs an instance of the Plans POM.


### PR DESCRIPTION
#### Proposed Changes

* This [line](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/pages/plans-page.ts#L144) waits for active-promotions to go through, but occasionally, it's already through by the time this line runs. 
* This PR keeps a record to see if this request had ever run before, waiting for it.

#### Testing Instructions
It shouldn't fail like [this](https://teamcity.a8c.com/viewLog.html?buildId=8537903&buildTypeId=calypso_Calypso_E2E_Playwright_desktop) build.
