### PR TITLE
i18n: Make onboarding course details strings reactive

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -7,9 +7,9 @@ import Notice from 'calypso/components/notice';
 import {
 	COURSE_SLUGS,
 	useCourseData,
+	useCourseDetails,
 	useUpdateUserCourseProgressionMutation,
 } from 'calypso/data/courses';
-import { COURSE_DETAILS } from 'calypso/data/courses/constants';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import VideoChapters from './video-chapters';
 import VideoPlayer from './video-player';
@@ -97,6 +97,7 @@ const VideosUi = ( {
 			} );
 		}
 	}, [ course ] );
+	const { headerTitle, headerSubtitle, headerSummary } = useCourseDetails( courseSlug );
 
 	return (
 		<div className="videos-ui">
@@ -119,12 +120,12 @@ const VideosUi = ( {
 				) }
 				<div className="videos-ui__header-content">
 					<div className="videos-ui__titles">
-						<h2>{ COURSE_DETAILS[ courseSlug ].headerTitle }</h2>
-						<h2>{ COURSE_DETAILS[ courseSlug ].headerSubtitle }</h2>
+						<h2>{ headerTitle }</h2>
+						<h2>{ headerSubtitle }</h2>
 					</div>
 					<div className="videos-ui__summary">
 						<ul>
-							{ COURSE_DETAILS[ courseSlug ].headerSummary.map( ( text ) => {
+							{ headerSummary.map( ( text ) => {
 								return (
 									<li>
 										<Gridicon icon="checkmark" size={ 18 } /> { text }

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -127,7 +127,7 @@ const VideosUi = ( {
 						<ul>
 							{ headerSummary.map( ( text ) => {
 								return (
-									<li>
+									<li key={ text }>
 										<Gridicon icon="checkmark" size={ 18 } /> { text }
 									</li>
 								);

--- a/client/components/videos-ui/test/index.jsx
+++ b/client/components/videos-ui/test/index.jsx
@@ -31,11 +31,20 @@ const useUpdateUserCourseProgressionMutation = () => {
 	};
 };
 
+const useCourseDetails = () => {
+	return {
+		headerTitle: '',
+		headerSubtitle: '',
+		headerSummary: [ '' ],
+	};
+};
+
 jest.mock( 'calypso/data/courses', () => ( {
 	COURSE_SLUGS: {
 		BLOGGING_QUICK_START: 'blogging-quick-start',
 	},
 	useCourseData,
+	useCourseDetails,
 	useUpdateUserCourseProgressionMutation,
 } ) );
 

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,30 +1,5 @@
-import i18n from 'i18n-calypso';
-
 export const COURSE_SLUGS: Readonly< { PAYMENTS_FEATURES: string; BLOGGING_QUICK_START: string } > =
 	Object.freeze( {
 		BLOGGING_QUICK_START: 'blogging-quick-start',
 		PAYMENTS_FEATURES: 'payments-features',
 	} );
-
-export const COURSE_DETAILS = {
-	[ COURSE_SLUGS.BLOGGING_QUICK_START ]: {
-		headerTitle: i18n.translate( 'Watch five videos.' ),
-		headerSubtitle: i18n.translate( 'Save yourself hours.' ),
-		headerSummary: [
-			i18n.translate( 'Learn the basics of blogging' ),
-			i18n.translate( 'Familiarize yourself with WordPress' ),
-			i18n.translate( 'Upskill and save hours' ),
-			i18n.translate( 'Set yourself up for blogging success' ),
-		],
-	},
-	[ COURSE_SLUGS.PAYMENTS_FEATURES ]: {
-		headerTitle: i18n.translate( 'Make money from your website.' ),
-		headerSubtitle: i18n.translate( 'Watch our tutorial videos to get started.' ),
-		headerSummary: [
-			i18n.translate( 'Accept one-time or recurring payments' ),
-			i18n.translate( 'Accept donations or sell services' ),
-			i18n.translate( 'Setup paid, subscriber-only content' ),
-			i18n.translate( 'Run a fully featured ecommerce store' ),
-		],
-	},
-};

--- a/client/data/courses/index.ts
+++ b/client/data/courses/index.ts
@@ -1,4 +1,5 @@
 export { COURSE_SLUGS } from './constants';
 export { default as useCourseData } from './use-course-data';
+export { default as useCourseDetails } from './use-course-details';
 export { default as useCourseQuery } from './use-course-query';
 export { default as useUpdateUserCourseProgressionMutation } from './use-update-user-course-progression-mutation';

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -1,0 +1,46 @@
+/**
+ * External Dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+/**
+ * Internal Dependencies
+ */
+import { COURSE_SLUGS } from './constants';
+
+type CourseSlug = keyof typeof COURSE_SLUGS;
+
+interface CourseDetails {
+	headerTitle: string;
+	headerSubtitle: string;
+	headerSummary: string[];
+}
+
+const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined => {
+	const translate = useTranslate();
+
+	if ( courseSlug === COURSE_SLUGS.BLOGGING_QUICK_START ) {
+		return {
+			headerTitle: translate( 'Watch five videos.' ),
+			headerSubtitle: translate( 'Save yourself hours.' ),
+			headerSummary: [
+				translate( 'Learn the basics of blogging' ),
+				translate( 'Familiarize yourself with WordPress' ),
+				translate( 'Upskill and save hours' ),
+				translate( 'Set yourself up for blogging success' ),
+			],
+		};
+	} else if ( courseSlug === COURSE_SLUGS.PAYMENTS_FEATURES ) {
+		return {
+			headerTitle: translate( 'Make money from your website.' ),
+			headerSubtitle: translate( 'Watch our tutorial videos to get started.' ),
+			headerSummary: [
+				translate( 'Accept one-time or recurring payments' ),
+				translate( 'Accept donations or sell services' ),
+				translate( 'Setup paid, subscriber-only content' ),
+				translate( 'Run a fully featured ecommerce store' ),
+			],
+		};
+	}
+};
+
+export default useCourseDetails;


### PR DESCRIPTION
#### Proposed Changes

* Currently, the `i18n.translate` calls will be fired upon initializing the `COURSE_DETAILS` object. Since we load translations asynchronously, it's very likely that translation data will not be loaded and therefore strings would remain untranslated.
* This PR moves the course details into a custom hook that's using `useTranslate` so that it's subscribed to i18n changes and makes it that the course details object would be re-computed whenever i18n change event occurs (i.e. translation data is being loaded).

**Before:**
![CleanShot 2022-09-06 at 11 04 24](https://user-images.githubusercontent.com/2722412/188583234-ada21121-6126-4c09-b888-4a372ba22e62.png)

**After:**
![CleanShot 2022-09-06 at 11 04 01](https://user-images.githubusercontent.com/2722412/188583260-adecc59e-3bd7-4ce6-94bf-94b09d17f61d.png)

#### Testing Instructions

* Change UI to a Mag-16 language.
* Checkout locally or use calypso.live build.
* Go to `/start`.
  * Choose domain and plan
  * On goals selection, choose "Write and Publish" (first option).
  * Enter blog name.
  * On the next screen, select "Video courses" (second option).
* Confirm strings in the heading section are being rendered translated correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 510-gh-Automattic/i18n-issues
