### PR TITLE
i18n: Add context for site launch statuses strings

### DIFF
--- a/packages/components/src/sites-table/site-status.tsx
+++ b/packages/components/src/sites-table/site-status.tsx
@@ -30,16 +30,16 @@ export const getSiteLaunchStatus = ( site: SiteObjectWithStatus ): SiteLaunchSta
 };
 
 export const useTranslatedSiteLaunchStatuses = (): { [ K in SiteLaunchStatus ]: string } => {
-	const { __ } = useI18n();
+	const { _x } = useI18n();
 
 	return useMemo(
 		() => ( {
-			'coming-soon': __( 'Coming soon' ),
-			private: __( 'Private' ),
-			public: __( 'Public' ),
-			redirect: __( 'Redirect' ),
+			'coming-soon': _x( 'Coming soon', 'site' ),
+			private: _x( 'Private', 'site' ),
+			public: _x( 'Public', 'site' ),
+			redirect: _x( 'Redirect', 'site' ),
 		} ),
-		[ __ ]
+		[ _x ]
 	);
 };
 


### PR DESCRIPTION
#### Proposed Changes

* Add `site` context for `Coming soon`, `Private`, `Public`, and `Redirect` launch site status strings.

![CleanShot 2022-09-06 at 13 57 41](https://user-images.githubusercontent.com/2722412/188618615-dcced305-cd58-43e1-9ef5-da0b2ce821c4.png)


#### Testing Instructions

* Code review.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to 512-gh-Automattic/i18n-issues
