### PR TITLE
Fix: Logged-out Plugins CTA doesn't redirect to /pricing

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -295,6 +295,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						type="a"
 						className="plugin-details-CTA__install-button"
 						primary
+						onClick={ ( e ) => e.stopPropagation() }
 						href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
 					>
 						{ translate( 'View plans' ) }
@@ -471,6 +472,7 @@ function LegacyPluginDetailsCTA( {
 						type="a"
 						className="plugin-details-CTA__install-button"
 						primary
+						onClick={ ( e ) => e.stopPropagation() }
 						href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
 					>
 						{ translate( 'View plans' ) }


### PR DESCRIPTION
#### Proposed Changes

This ensures that the Plugins CTA button for logged-out users by preventing the click event from bubbling up and getting canceled.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run your calypso instance on the `wordpress.com` hostname
* While logged out, go to `/plugins/wordpress-seo-premium`
* Click the `View Plans` button on the right
* You should be redirected to the https://wordpress.com/pricing page

