### PR TITLE
i18n: Make infinite scroll options labels translatable

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -32,9 +32,9 @@ function ThemeEnhancements( {
 
 	function RadioOptions() {
 		const options = [
-			{ value: 'default', label: 'Load more posts using the default theme behavior' },
-			{ value: 'button', label: 'Load more posts in page with a button' },
-			{ value: 'scroll', label: 'Load more posts as the reader scrolls down' },
+			{ value: 'default', label: translate( 'Load more posts using the default theme behavior' ) },
+			{ value: 'button', label: translate( 'Load more posts in page with a button' ) },
+			{ value: 'scroll', label: translate( 'Load more posts as the reader scrolls down' ) },
 		];
 		return (
 			<>


### PR DESCRIPTION
#### Proposed Changes

* Wrap infinite scroll options label strings in theme enhancements section with `translate()`.

![CleanShot 2022-09-06 at 14 21 35](https://user-images.githubusercontent.com/2722412/188623643-01413f5a-3b40-4d7b-9159-967b6ebeee1b.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 507-gh-Automattic/i18n-issues
