### PR TITLE
Pattern Assembler: Implement large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,7 +1,7 @@
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/component';
-import PreviewToolbar from 'calypso/signup/steps/design-picker/preview-toolbar';
+import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -1,0 +1,1 @@
+export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
+import PatternAssemblerPreview from './pattern-assembler-preview';
 import type { Step } from '../../types';
 import type { Pattern } from './types';
 import './style.scss';
@@ -122,9 +123,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 					/>
 				) }
 			</div>
-			<div className="pattern-assembler__preview">
-				<h3> Web preview placeholder </h3>
-			</div>
+			<PatternAssemblerPreview header={ header } sections={ sections } footer={ footer } />
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,9 +1,9 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
-import PatternAssemblerPreview from './pattern-assembler-preview';
 import type { Step } from '../../types';
 import type { Pattern } from './types';
 import './style.scss';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -1,0 +1,31 @@
+.pattern-assembler-preview {
+	flex: 1;
+	height: 100vh;
+	padding: 32px 0;
+	margin-top: -60px;
+	margin-inline-start: 32px;
+	box-sizing: border-box;
+
+	.preview-toolbar__browser-header,
+	.spinner-line {
+		display: none;
+	}
+
+	.web-preview__frame-wrapper {
+		background-color: transparent;
+	}
+
+	iframe {
+		padding: 12px;
+		border: none;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 20px;
+		box-shadow:
+			0 15px 20px rgba( 0 0 0 / 4% ),
+			0 13px 10px rgba( 0 0 0 / 3% ),
+			0 6px 6px rgba( 0 0 0 / 2% );
+		box-sizing: border-box;
+		background: #f8f8f8;
+		opacity: 1;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -11,6 +11,10 @@
 		display: none;
 	}
 
+	.web-preview__placeholder {
+		overflow-y: unset;
+	}
+
 	.web-preview__frame-wrapper {
 		background-color: transparent;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -20,12 +20,38 @@
 		border: none;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 20px;
-		box-shadow:
-			0 15px 20px rgba( 0 0 0 / 4% ),
-			0 13px 10px rgba( 0 0 0 / 3% ),
-			0 6px 6px rgba( 0 0 0 / 2% );
 		box-sizing: border-box;
-		background: #f8f8f8;
-		opacity: 1;
+		opacity: 0;
 	}
+
+	&--has-selected-patterns {
+		iframe {
+			opacity: 1;
+		}
+	}
+}
+
+.pattern-assembler-preview__placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 20px;
+	box-shadow:
+		0 15px 20px rgba( 0 0 0 / 4% ),
+		0 13px 10px rgba( 0 0 0 / 3% ),
+		0 6px 6px rgba( 0 0 0 / 2% );
+	color: var( --studio-gray-60 );
+	background-color: #f8f8f8;
+	opacity: 1;
+	z-index: -1;
+}
+
+.pattern-assembler-preview__spinner {
+	transform: scale( 2.5 );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -12,6 +12,7 @@
 	}
 
 	.web-preview__placeholder {
+		margin-top: -15px;
 		overflow-y: unset;
 	}
 
@@ -44,12 +45,14 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
+	padding: 0 16px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 20px;
 	box-shadow:
 		0 15px 20px rgba( 0 0 0 / 4% ),
 		0 13px 10px rgba( 0 0 0 / 3% ),
 		0 6px 6px rgba( 0 0 0 / 2% );
+	box-sizing: border-box;
 	color: var( --studio-gray-60 );
 	background-color: #f8f8f8;
 	opacity: 1;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -17,9 +17,9 @@ import type { Design } from '@automattic/design-picker';
 import './pattern-assembler-preview.scss';
 
 interface Props {
-	header?: Pattern;
+	header: Pattern | null;
 	sections?: Pattern[];
-	footer?: Pattern;
+	footer: Pattern | null;
 }
 
 const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -37,8 +37,11 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 		...selectedDesign,
 		recipe: {
 			...selectedDesign?.recipe,
-			pattern_ids: sections.map( ( pattern ) => encodePatternId( pattern.id ) ),
-			header_pattern_ids: header ? [ encodePatternId( header.id ) ] : undefined,
+			// The blank canvas blocks demo site doesn't have the header, so we inject the header into the first pattern
+			// of the content.
+			pattern_ids: [ header, ...sections ]
+				.filter( Boolean )
+				.map( ( pattern ) => encodePatternId( pattern!.id ) ),
 			footer_pattern_ids: footer ? [ encodePatternId( footer.id ) ] : undefined,
 		},
 	} as Design;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -1,0 +1,55 @@
+import { getDesignPreviewUrl } from '@automattic/design-picker';
+import { useLocale } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import WebPreview from 'calypso/components/web-preview/content';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../../../../hooks/use-site';
+import { ONBOARD_STORE } from '../../../../stores';
+import PreviewToolbar from '../design-setup/preview-toolbar';
+import { encodePatternId } from './utils';
+import type { Pattern } from './types';
+import type { Design } from '@automattic/design-picker';
+import './pattern-assembler-preview.scss';
+
+interface Props {
+	header?: Pattern;
+	sections?: Pattern[];
+	footer?: Pattern;
+}
+
+const PatternAssemblerPreview = ( { header, sections, footer }: Props ) => {
+	const locale = useLocale();
+	const translate = useTranslate();
+	const site = useSite();
+	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const mergedDesign = {
+		...selectedDesign,
+		recipe: {
+			...selectedDesign?.recipe,
+			pattern_ids: sections ? sections.map( ( pattern ) => encodePatternId( pattern.id ) ) : [],
+			header_pattern_ids: header ? [ encodePatternId( header.id ) ] : undefined,
+			footer_pattern_ids: footer ? [ encodePatternId( footer.id ) ] : undefined,
+		},
+	} as Design;
+
+	return (
+		<div className="pattern-assembler-preview">
+			<WebPreview
+				showPreview
+				showClose={ false }
+				showEdit={ false }
+				previewUrl={ getDesignPreviewUrl( mergedDesign, {
+					language: locale,
+				} ) }
+				toolbarComponent={ PreviewToolbar }
+				siteId={ site?.ID }
+				url={ site?.URL }
+				translate={ translate }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</div>
+	);
+};
+
+export default PatternAssemblerPreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -8,6 +8,10 @@
 $font-family: 'SF Pro Text', $sans;
 
 .pattern-assembler {
+    .step-container {
+        max-width: 1440px;
+    }
+
     display: flex;
     height: calc( 100vh - 60px );
     width: 100%;
@@ -40,19 +44,6 @@ $font-family: 'SF Pro Text', $sans;
         margin-bottom: 0;
         box-sizing: border-box;
         margin-top: 50px;
-    }
-    
-    .pattern-assembler__preview {
-        flex-basis: 100%;
-        margin-inline-start: 32px;
-        background: #f6f6f6;
-        box-shadow: 0 0 2px rgba( 0, 0, 0, 0.1 );
-        border-radius: 4px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin-bottom: 32px;
-        margin-top: -25px;
     }
 
     .pattern-layout {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -40,7 +40,7 @@ $font-family: 'SF Pro Text', $sans;
     }
     
     .pattern-assembler__sidebar {
-        min-width: 280px;
+        width: 280px;
         margin-bottom: 0;
         box-sizing: border-box;
         margin-top: 50px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,14 +1,17 @@
-const sourceSiteId = 174455321; // dotcompatterns
+import { PATTERN_SOURCE_SITE_ID } from './constants';
+
 const patternPreviewUrl =
 	'https://public-api.wordpress.com/wpcom/v2/block-previews/pattern?stylesheet=pub/blank-canvas&pattern_id=';
 
-const getPatternPreviewUrl = ( id: number ) => `${ patternPreviewUrl }${ id }-${ sourceSiteId }`;
+export const encodePatternId = ( patternId: number ) =>
+	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
 
-// Runs the callbakc if the keys Enter or Spacebar are in the keyboard event
-const handleKeyboard =
+export const getPatternPreviewUrl = ( id: number ) =>
+	`${ patternPreviewUrl }${ encodePatternId( id ) }`;
+
+// Runs the callback if the keys Enter or Spacebar are in the keyboard event
+export const handleKeyboard =
 	( callback: () => void ) =>
 	( { key }: { key: string } ) => {
 		if ( key === 'Enter' || key === ' ' ) callback();
 	};
-
-export { getPatternPreviewUrl, handleKeyboard };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -451,7 +451,7 @@ export interface LaunchPadCheckListTasksStatuses {
 export interface ThemeSetupOptions {
 	trim_content?: boolean;
 	vertical_id?: string;
-	pattern_ids?: number[];
-	header_pattern_ids?: number[];
-	footer_pattern_ids?: number[];
+	pattern_ids?: number[] | string[];
+	header_pattern_ids?: number[] | string[];
+	footer_pattern_ids?: number[] | string[];
 }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -56,9 +56,9 @@ export interface StyleVariationStylesColor {
 
 export interface DesignRecipe {
 	stylesheet?: string;
-	pattern_ids?: number[];
-	header_pattern_ids?: number[];
-	footer_pattern_ids?: number[];
+	pattern_ids?: number[] | string[];
+	header_pattern_ids?: number[] | string[];
+	footer_pattern_ids?: number[] | string[];
 }
 
 export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'


### PR DESCRIPTION
#### Proposed Changes

* Implement the `PatternAssemblerPreview` component to show the large preview of the selected patterns
* Use `createPortal` to append the empty placeholder into the `WebPreview` component so that it could be responsive according to the current device. Any thoughts? 🤔
* The demo site of the blank canvas doesn't have the header, so we inject the header into the first pattern of the sections to preview the result
* If we want to use [ThemePreview](https://github.com/Automattic/wp-calypso/blob/6266364d9f35ea2587d7393c532297c8ec61be4b/packages/design-picker/src/components/theme-preview/index.tsx#L27) to show the large preview, we might need to make a change to support showing loading message whenever the URL is changed, disable the loading placeholder, and etc. So, we keep using the `<WebPreview />` component

https://user-images.githubusercontent.com/13596067/188633070-757b1c40-ae42-45a0-97df-b9129a9f99cd.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?siteSlug=<your_site>`
* Select "Blank Canvas"
* Select any pattern
* See the web preview is rendered

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66589, https://github.com/Automattic/wp-calypso/issues/66786
