### PR TITLE
Learn More links: Post-content and Table-of-Contents

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -89,6 +89,12 @@ const blockLinks: { [ key: string ]: string } = {
 
 	'core/gallery': 'https://wordpress.com/support/wordpress-editor/blocks/gallery-block/',
 
+	'core/post-content':
+		'https://wordpress.com/support/full-site-editing/theme-blocks/post-content-block/',
+
+	'core/table-of-contents':
+		'https://wordpress.com/support/wordpress-editor/table-of-contents-block/',
+
 	/**
 	 * A8C and CO Blocks
 	 */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
@@ -1,8 +1,15 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { ReactElement, JSXElementConstructor } from 'react';
 import blockLinks from './block-links-map';
 import DescriptionSupportLink from './inline-support-link';
+
+declare global {
+	interface Window {
+		wpcomBlockDescriptionLinksLocale: string;
+	}
+}
 
 const addBlockSupportLinks = (
 	settings: {
@@ -15,9 +22,13 @@ const addBlockSupportLinks = (
 	const blockName = isChild ? settings[ 'parent' ].toString() : name;
 
 	if ( blockLinks[ blockName ] ) {
+		const localizedUrl = localizeUrl(
+			blockLinks[ blockName ],
+			window.wpcomBlockDescriptionLinksLocale
+		);
 		const descriptionWithLink = createInterpolateElement( '<InlineSupportLink />', {
 			InlineSupportLink: (
-				<DescriptionSupportLink title={ String( settings.title ) } url={ blockLinks[ blockName ] }>
+				<DescriptionSupportLink title={ String( settings.title ) } url={ localizedUrl }>
 					{ settings.description }
 				</DescriptionSupportLink>
 			),


### PR DESCRIPTION
#### Proposed Changes

 Add new documentation links to two blocks:

- Post Content `https://wordpress.com/support/full-site-editing/theme-blocks/post-content-block/`
- Table of Contents `https://wordpress.com/support/wordpress-editor/table-of-contents-block/`

![image](https://user-images.githubusercontent.com/52076348/188628546-a4d18df9-f749-4032-ae3c-4bca4c65a25d.png)
![image](https://user-images.githubusercontent.com/52076348/188628594-f242eff1-96d8-438f-a5ff-267f0713b6b0.png)

Manage support links localizatIon: support articles were always in English, now the url is localized
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn dev --sync` from `apps/editing-toolkit`
* Check that the two blocks have the `Learn more` link and it points to the correct destination.
* Check that support articles are localized.

Related to #67293
Fixes #67293
