### PR TITLE
Fix: First breadcrumb item on logged out Plugin Details page not translated after refresh

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAllJetpackSitesPlugins from 'calypso/components/data/query-all-jetpack-sites-plugins';
@@ -34,7 +34,7 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
-import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
+import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
@@ -77,6 +77,8 @@ function PluginDetails( props ) {
 	const translate = useTranslate();
 
 	const breadcrumbs = useSelector( getBreadcrumbs );
+	const [ initialBreadcrumbs ] = useState( breadcrumbs );
+
 	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
 	// Site information.
@@ -216,37 +218,28 @@ function PluginDetails( props ) {
 	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( fullPlugin.slug );
 
 	useEffect( () => {
-		if ( breadcrumbs.length === 0 ) {
-			dispatch(
-				appendBreadcrumb( {
-					label: translate( 'Plugins' ),
-					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
-					id: 'plugins',
-					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins.'
-					),
-				} )
-			);
+		const items = initialBreadcrumbs ? [ ...initialBreadcrumbs ] : [];
+		if ( ! items.length ) {
+			items.push( {
+				label: translate( 'Plugins' ),
+				href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
+				id: 'plugins',
+				helpBubble: translate(
+					'Add new functionality and integrations to your site with plugins.'
+				),
+			} );
 		}
 
 		if ( fullPlugin.name && props.pluginSlug ) {
-			dispatch(
-				appendBreadcrumb( {
-					label: fullPlugin.name,
-					href: localizePath( `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }` ),
-					id: `plugin-${ props.pluginSlug }`,
-				} )
-			);
+			items.push( {
+				label: fullPlugin.name,
+				href: localizePath( `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }` ),
+				id: `plugin-${ props.pluginSlug }`,
+			} );
 		}
-	}, [
-		fullPlugin.name,
-		props.pluginSlug,
-		selectedSite,
-		breadcrumbs.length,
-		dispatch,
-		translate,
-		localizePath,
-	] );
+
+		dispatch( updateBreadcrumbs( items ) );
+	}, [ fullPlugin.name, props.pluginSlug, selectedSite, dispatch, translate, localizePath ] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {


### PR DESCRIPTION
#### Proposed Changes

This fixes the issue where the `Plugin` part of the breadcrumb on the logged-out Plugin Details page doesn't get translated after refreshing the page (brought [up here](https://github.com/Automattic/wp-calypso/pull/67140#issuecomment-1236962444)).
The issue is caused by the translation chunks arriving after the page's initial render. There's a check which doesn't allow for part of the breadcrumb items to be rendered.
This addresses the issue by ensuring the whole breadcrumb chain gets re-rendered.

#### Testing Instructions

* If you're running this locally, make sure you env uses translation chunks
* While logged out, go to `/ja/plugins`
* Click on one of the plugins
* The first breadcrumb item (Plugins) should be translated
<img width="320" alt="Screenshot on 2022-09-06 at 15-45-19" src="https://user-images.githubusercontent.com/2749938/188638707-3420522b-2116-4168-a456-472cfb324f5e.png">

* Refresh the page
* The first breadcrumb item (Plugins) should still be translated


