### PR TITLE
Make product lightbox url accessible using hash fragment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import { ItemPrice } from '../item-price';
+import { MoreInfoLink } from '../more-info-link';
 import { FeaturedItemCardProps } from '../types';
 
 import './style.scss';
@@ -19,7 +19,6 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 	onClickPurchase,
 	siteId,
 } ) => {
-	const translate = useTranslate();
 	const { displayName: title, featuredDescription } = item;
 
 	return (
@@ -42,20 +41,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 							<span>{ featuredDescription }</span>
 							<br />
 
-							{ ! hideMoreInfoLink && (
-								<Button
-									className="featured-item-card--learn-more"
-									onClick={ onClickMore }
-									href="#"
-									plain
-								>
-									{ translate( 'More about {{productName/}}', {
-										components: {
-											productName: <>{ title }</>,
-										},
-									} ) }
-								</Button>
-							) }
+							{ ! hideMoreInfoLink && <MoreInfoLink item={ item } onClickMore={ onClickMore } /> }
 						</p>
 					</div>
 				</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -81,17 +81,6 @@
 	}
 }
 
-.featured-item-card--learn-more {
-	color: var( --gray-100 );
-	display: inline-block;
-	margin-top: 4px;
-	text-decoration-line: underline;
-
-	@include break-medium {
-		padding-bottom: 0;
-	}
-}
-
 .featured-item-card--footer {
 	align-items: center;
 	display: flex;

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -6,9 +6,9 @@ import { SelectorProduct } from '../../types';
 import { sanitizeLocationHash } from '../utils/sanitize-location-hash';
 
 export const useItemLightbox = () => {
-	const item = slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) );
-
-	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( item );
+	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( () =>
+		slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) )
+	);
 
 	const clearCurrentItem = useCallback( () => {
 		setCurrentItem( null );

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import { SelectorProduct } from '../../types';
 
 export const useItemLightbox = () => {
@@ -9,7 +10,10 @@ export const useItemLightbox = () => {
 			recordTracksEvent( 'calypso_product_more_about_product_click', {
 				product: item.productSlug,
 			} );
-			setCurrentItem( item );
+
+			if ( ! EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) ) {
+				setCurrentItem( item );
+			}
 		};
 	}, [] );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -1,10 +1,19 @@
 import { useCallback, useMemo, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
+import slugToSelectorProduct from '../../slug-to-selector-product';
 import { SelectorProduct } from '../../types';
 
 export const useItemLightbox = () => {
-	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( null );
+	const item = slugToSelectorProduct( window.location.hash.substring( 1 ) );
+
+	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( item );
+
+	const clearCurrentItem = () => {
+		setCurrentItem( null );
+		window.location.hash = '';
+	};
+
 	const onClickMoreInfoFactory = useCallback( ( item: SelectorProduct ): VoidFunction => {
 		return () => {
 			recordTracksEvent( 'calypso_product_more_about_product_click', {
@@ -20,7 +29,7 @@ export const useItemLightbox = () => {
 	return useMemo(
 		() => ( {
 			currentItem,
-			setCurrentItem,
+			clearCurrentItem,
 			onClickMoreInfoFactory,
 		} ),
 		[ currentItem, onClickMoreInfoFactory ]

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -3,9 +3,10 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import slugToSelectorProduct from '../../slug-to-selector-product';
 import { SelectorProduct } from '../../types';
+import { sanitizeLocationHash } from '../utils/sanitize-location-hash';
 
 export const useItemLightbox = () => {
-	const item = slugToSelectorProduct( window.location.hash.substring( 1 ) );
+	const item = slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) );
 
 	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( item );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-lightbox.ts
@@ -9,10 +9,10 @@ export const useItemLightbox = () => {
 
 	const [ currentItem, setCurrentItem ] = useState< SelectorProduct | null >( item );
 
-	const clearCurrentItem = () => {
+	const clearCurrentItem = useCallback( () => {
 		setCurrentItem( null );
 		window.location.hash = '';
-	};
+	}, [] );
 
 	const onClickMoreInfoFactory = useCallback( ( item: SelectorProduct ): VoidFunction => {
 		return () => {
@@ -32,6 +32,6 @@ export const useItemLightbox = () => {
 			clearCurrentItem,
 			onClickMoreInfoFactory,
 		} ),
-		[ currentItem, onClickMoreInfoFactory ]
+		[ currentItem, onClickMoreInfoFactory, clearCurrentItem ]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-list/index.tsx
@@ -18,7 +18,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 	onClickPurchase,
 	siteId,
 } ) => {
-	const { currentItem, setCurrentItem, onClickMoreInfoFactory } = useItemLightbox();
+	const { currentItem, clearCurrentItem, onClickMoreInfoFactory } = useItemLightbox();
 	const Component = components[ currentView ];
 
 	if ( ! Component ) {
@@ -31,9 +31,7 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 				<ProductLightbox
 					product={ currentItem }
 					isVisible={ !! currentItem }
-					onClose={ () => {
-						setCurrentItem( null );
-					} }
+					onClose={ clearCurrentItem }
 				/>
 			) }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
+import { MoreInfoLinkProps } from '../types';
+
+import './style.scss';
+
+export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClickMore } ) => {
+	const translate = useTranslate();
+
+	const isExternalProduct = useMemo(
+		() => EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ),
+		[ item ]
+	);
+
+	const href = isExternalProduct && item.externalUrl ? item.externalUrl : '#';
+
+	return (
+		<Button className="more-info-link" onClick={ onClickMore } href={ href } plain>
+			{ translate( 'More about {{productName/}}', {
+				components: { productName: <>{ item.shortName }</> },
+			} ) }
+		</Button>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -14,7 +14,7 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClickMore
 		[ item ]
 	);
 
-	const href = isExternalProduct && item.externalUrl ? item.externalUrl : '#';
+	const href = isExternalProduct && item.externalUrl ? item.externalUrl : `#${ item.productSlug }`;
 
 	return (
 		<Button className="more-info-link" onClick={ onClickMore } href={ href } plain>

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import { MoreInfoLinkProps } from '../types';
 
@@ -9,10 +8,7 @@ import './style.scss';
 export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClickMore } ) => {
 	const translate = useTranslate();
 
-	const isExternalProduct = useMemo(
-		() => EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ),
-		[ item ]
-	);
+	const isExternalProduct = EXTERNAL_PRODUCTS_LIST.includes( item.productSlug );
 
 	const href = isExternalProduct && item.externalUrl ? item.externalUrl : `#${ item.productSlug }`;
 

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/style.scss
@@ -1,0 +1,13 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.more-info-link {
+	display: inline-block;
+	color: var( --color-neutral-100 ) !important;
+	text-decoration: underline;
+	margin-top: 4px;
+
+	@include break-medium {
+		padding-bottom: 0;
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import { ItemPrice } from '../item-price';
+import { MoreInfoLink } from '../more-info-link';
 import { SimpleProductCardProps } from '../types';
 import getProductIcon from '../utils/get-product-icon';
 
@@ -19,8 +19,6 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 	onClickPurchase,
 	siteId,
 } ) => {
-	const translate = useTranslate();
-
 	const { shortName: name } = item;
 	const productDescription = item?.shortDescription || item.description;
 
@@ -52,21 +50,8 @@ const SimpleProductCard: React.FC< SimpleProductCardProps > = ( {
 					</Button>
 				</div>
 				<div className="simple-product-card__info-content">
-					{ productDescription }
-					{ ! hideMoreInfoLink && (
-						<Button
-							className="simple-product-card__info-more-link"
-							onClick={ onClickMore }
-							href="#"
-							plain
-						>
-							{ translate( 'More about {{productName/}}', {
-								components: {
-									productName: <>{ name }</>,
-								},
-							} ) }
-						</Button>
-					) }
+					{ productDescription } <br />
+					{ ! hideMoreInfoLink && <MoreInfoLink onClickMore={ onClickMore } item={ item } /> }
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-product-card/style.scss
@@ -75,10 +75,3 @@
 	line-height: rem( 24px );
 	padding: 8px 0 16px;
 }
-
-.simple-product-card__info-more-link {
-	display: block;
-	color: var( --color-neutral-100 ) !important;
-	text-decoration: underline;
-	margin-top: 4px;
-}

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -90,3 +90,5 @@ export type FeaturedItemCardProps = ItemPriceProps & {
 };
 
 export type SimpleProductCardProps = Omit< FeaturedItemCardProps, 'hero' >;
+
+export type MoreInfoLinkProps = Pick< FeaturedItemCardProps, 'item' | 'onClickMore' >;

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/sanitize-location-hash.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/sanitize-location-hash.ts
@@ -1,0 +1,4 @@
+export const sanitizeLocationHash = ( value: string ) => {
+	// Location hash value can contain only english alphanumeric characters and underscores
+	return value.replace( /[^a-z0-9_]/gi, '' );
+};


### PR DESCRIPTION
#### Proposed Changes

* Create a separate MoreInfoLink component to handle more complicated logic such as redirecting page for external products or setting location hash to product slug.
* Update useItemLightbox to set default item base on the location hash value.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. * Run `git fetch && git checkout add/url-supported-lightbox-functionality`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
3. Press 'more about Search' link or any other 'more info' links except `Jetpack CRM` on either the simple card or featured card in the pricing page.
<img width="573" alt="Screen Shot 2022-09-06 at 9 37 28 PM" src="https://user-images.githubusercontent.com/56598660/188649516-e619b5e7-f2de-4ebf-8dd5-cc2d01fb778a.png">

4. Confirm while the lightbox is displayed and the url is updated w/ hash value equivalent to the product slug of the current item.
<img width="1066" alt="Screen Shot 2022-09-06 at 9 40 37 PM" src="https://user-images.githubusercontent.com/56598660/188650315-985719cf-6083-4a1d-8fa4-fd8be8750963.png">

5. Copy the current url in your browser, open another tab and paste the url.
6. Confirm that the lightbox shows up when the page loads
<img width="1102" alt="Screen Shot 2022-09-06 at 9 39 07 PM" src="https://user-images.githubusercontent.com/56598660/188649885-54670c44-0899-45f6-a7fa-9fbb7461aa98.png">

7. Close the current lightbox and confirm the hash value is cleared
8. Click on 'more about CRM Enterprenuer' link under the Product list page and confirm the page is redirected to https://jetpackcrm.com/pricing/
9. 
<img width="605" alt="Screen Shot 2022-09-06 at 9 42 02 PM" src="https://user-images.githubusercontent.com/56598660/188650613-725195c9-308d-4d31-bb67-8162b6fb482e.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202796695664081

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664081