### PR TITLE
Style selection: Style preview UI/UX polish

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -136,16 +136,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		};
 	}
 
-	function previewDesign( _selectedDesign: Design, positionIndex?: number ) {
-		recordTracksEvent( 'calypso_signup_design_preview_select', {
-			...getEventPropsByDesign( _selectedDesign ),
-			...( positionIndex && { position_index: positionIndex } ),
-		} );
-
-		setSelectedDesign( _selectedDesign );
-		setIsPreviewingDesign( true );
-	}
-
 	// ********** Logic for selecting a style variation of the selected design
 
 	const isEnabledStyleSelection =
@@ -161,6 +151,20 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		select( ONBOARD_STORE ).getSelectedStyleVariation()
 	);
 	const { setSelectedStyleVariation } = useDispatch( ONBOARD_STORE );
+
+	function previewDesign( _selectedDesign: Design, variation?: StyleVariation ) {
+		recordTracksEvent(
+			'calypso_signup_design_preview_select',
+			getEventPropsByDesign( _selectedDesign )
+		);
+
+		setSelectedDesign( _selectedDesign );
+		if ( variation ) {
+			setSelectedStyleVariation( variation );
+		}
+
+		setIsPreviewingDesign( true );
+	}
 
 	// ********** Logic for unlocking a selected premium design
 
@@ -442,10 +446,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			verticalId={ siteVerticalId }
 			locale={ locale }
 			onSelect={ pickDesign }
-			onPreview={ ( design: Design, variation?: StyleVariation ) => {
-				setSelectedStyleVariation( variation );
-				previewDesign( design );
-			} }
+			onPreview={ previewDesign }
 			onUpgrade={ upgradePlan }
 			onCheckout={ goToCheckout }
 			heading={ heading }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -35,7 +35,7 @@ import UpgradeModal from './upgrade-modal';
 import getThemeIdFromDesign from './util/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
-import type { Design } from '@automattic/design-picker';
+import type { Design, StyleVariation } from '@automattic/design-picker';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -442,7 +442,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			verticalId={ siteVerticalId }
 			locale={ locale }
 			onSelect={ pickDesign }
-			onPreview={ previewDesign }
+			onPreview={ ( design: Design, variation?: StyleVariation ) => {
+				setSelectedStyleVariation( variation );
+				previewDesign( design );
+			} }
 			onUpgrade={ upgradePlan }
 			onCheckout={ goToCheckout }
 			heading={ heading }

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -29,8 +29,10 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 			tabIndex={ 0 }
 			role="button"
 			aria-label={
-				// translators: %(title)s - the style variation title.
-				sprintf( __( 'Style: %(title)s' ), { title: variation.title } )
+				variation.title
+					? // translators: %(title)s - the style variation title.
+					  sprintf( __( 'Style: %(title)s' ), { title: variation.title } )
+					: __( 'Preview with this style' )
 			}
 			onClick={ ( e ) => {
 				// Prevent the event from bubbling to the the parent button.

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { getPreviewStylesFromVariation } from './utils';
 import type { StyleVariation } from '../../types';
@@ -11,6 +12,7 @@ interface BadgeProps {
 }
 
 const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
+	const { __ } = useI18n();
 	const styles = useMemo(
 		() => variation && getPreviewStylesFromVariation( variation ),
 		[ variation ]
@@ -25,12 +27,15 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 			className="style-variation__badge-wrapper"
 			tabIndex={ 0 }
 			role="button"
+			aria-label={ __( 'Preview with this style' ) }
 			onClick={ ( e ) => {
+				// Prevent the event from bubbling to the the parent button.
 				e.stopPropagation();
 				onClick?.( variation );
 			} }
 			onKeyDown={ ( e ) => {
 				if ( e.keyCode === SPACE_BAR_KEYCODE ) {
+					// Prevent the event from bubbling to the the parent button.
 					e.stopPropagation();
 					onClick?.( variation );
 				}

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -3,11 +3,14 @@ import { getPreviewStylesFromVariation } from './utils';
 import type { StyleVariation } from '../../types';
 import './style.scss';
 
+const SPACE_BAR_KEYCODE = 32;
+
 interface BadgeProps {
-	variation?: StyleVariation;
+	variation: StyleVariation;
+	onClick?: ( variation: StyleVariation ) => void;
 }
 
-const Badge: React.FC< BadgeProps > = ( { variation } ) => {
+const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 	const styles = useMemo(
 		() => variation && getPreviewStylesFromVariation( variation ),
 		[ variation ]
@@ -18,7 +21,21 @@ const Badge: React.FC< BadgeProps > = ( { variation } ) => {
 	}
 
 	return (
-		<div className="style-variation__badge-wrapper">
+		<div
+			className="style-variation__badge-wrapper"
+			tabIndex={ 0 }
+			role="button"
+			onClick={ ( e ) => {
+				e.stopPropagation();
+				onClick?.( variation );
+			} }
+			onKeyDown={ ( e ) => {
+				if ( e.keyCode === SPACE_BAR_KEYCODE ) {
+					e.stopPropagation();
+					onClick?.( variation );
+				}
+			} }
+		>
 			<span
 				style={ {
 					backgroundColor: styles.color.background,

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -1,3 +1,4 @@
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { getPreviewStylesFromVariation } from './utils';
@@ -27,7 +28,10 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 			className="style-variation__badge-wrapper"
 			tabIndex={ 0 }
 			role="button"
-			aria-label={ __( 'Preview with this style' ) }
+			aria-label={
+				// translators: %(title)s - the style variation title.
+				sprintf( __( 'Style: %(title)s' ), { title: variation.title } )
+			}
 			onClick={ ( e ) => {
 				// Prevent the event from bubbling to the the parent button.
 				e.stopPropagation();

--- a/packages/design-picker/src/components/style-variation-badges/index.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/index.tsx
@@ -6,9 +6,14 @@ import './style.scss';
 interface BadgesProps {
 	maxVariationsToShow?: number;
 	variations: StyleVariation[];
+	onClick?: ( variation: StyleVariation ) => void;
 }
 
-const Badges: React.FC< BadgesProps > = ( { maxVariationsToShow = 4, variations = [] } ) => {
+const Badges: React.FC< BadgesProps > = ( {
+	maxVariationsToShow = 4,
+	variations = [],
+	onClick,
+} ) => {
 	const variationsToShow = useMemo(
 		() => variations.slice( 0, maxVariationsToShow ),
 		[ variations, maxVariationsToShow ]
@@ -17,7 +22,7 @@ const Badges: React.FC< BadgesProps > = ( { maxVariationsToShow = 4, variations 
 	return (
 		<>
 			{ variationsToShow.map( ( variation ) => (
-				<Badge key={ variation.slug } variation={ variation } />
+				<Badge key={ variation.slug } variation={ variation } onClick={ onClick } />
 			) ) }
 			{ variations.length > variationsToShow.length && (
 				<div className="style-variation__badge-more-wrapper">

--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -24,7 +24,7 @@
 
 		&:hover {
 			&::after {
-				background: rgb(255 255 255 / 72%);
+				background: rgb(255 255 255 / 42%);
 				bottom: 0;
 				content: "";
 				display: block;

--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -10,7 +10,7 @@
 		background: #fff;
 		border: none;
 		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+		box-shadow: inset 0 0 0 1px rgb(0 0 0 / 5%);
 		color: var(--studio-gray-80);
 		cursor: pointer;
 		display: inline-flex;
@@ -18,7 +18,22 @@
 		font-weight: 500;
 		height: 100%;
 		justify-content: center;
+		position: relative;
+		transition: background-color 0.15s ease-in-out;
 		width: 100%;
+
+		&:hover {
+			&::after {
+				background: rgb(255 255 255 / 72%);
+				bottom: 0;
+				content: "";
+				display: block;
+				left: 0;
+				position: absolute;
+				right: 0;
+				top: 0;
+			}
+		}
 	}
 }
 

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -77,15 +77,17 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	}, [ setIsLoaded, setViewport ] );
 
 	useEffect( () => {
-		iframeRef.current?.contentWindow?.postMessage(
-			{
-				channel: `preview-${ calypso_token }`,
-				type: 'inline-css',
-				inline_css: inlineCss,
-			},
-			'*'
-		);
-	}, [ inlineCss ] );
+		if ( isLoaded ) {
+			iframeRef.current?.contentWindow?.postMessage(
+				{
+					channel: `preview-${ calypso_token }`,
+					type: 'inline-css',
+					inline_css: inlineCss,
+				},
+				'*'
+			);
+		}
+	}, [ inlineCss, isLoaded ] );
 
 	return (
 		<div

--- a/packages/design-picker/src/components/theme-preview/style.scss
+++ b/packages/design-picker/src/components/theme-preview/style.scss
@@ -1,5 +1,37 @@
 @import "@automattic/onboarding/styles/mixins";
 
+.theme-preview__frame-wrapper {
+	flex-grow: 1;
+	position: relative;
+
+	.theme-preview__frame-message {
+		bottom: 0;
+		color: var( --color-text-subtle );
+		display: none;
+		font-size: $font-body;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+		z-index: 1;
+
+		strong {
+			color: var( --color-text-subtle );
+			display: block;
+			font-size: $font-title-medium;
+			margin-bottom: 5px;
+		}
+	}
+
+	.theme-preview__frame {
+		border: none;
+		height: 100%;
+		transform-origin: 0 0;
+		transition: opacity 0.2s ease-in-out, max-width 0.2s ease-out;
+		width: 100%;
+	}
+}
+
 .theme-preview__container {
 	bottom: 0;
 	display: flex;
@@ -22,12 +54,14 @@
 	}
 
 	&--loading:not(&--frame-bordered) {
-		@include onboarding-placeholder();
+		@include onboarding-placeholder;
 	}
 
 	&--loading#{ & }--frame-bordered {
-		.theme-preview__frame {
-			@include onboarding-placeholder();
+		.theme-preview__frame-wrapper {
+			.theme-preview__frame {
+				@include onboarding-placeholder;
+			}
 		}
 	}
 
@@ -37,40 +71,46 @@
 		overflow: visible;
 		pointer-events: all;
 
-		.theme-preview__frame {
-			max-width: 100%;
+		.theme-preview__frame-wrapper {
+			.theme-preview__frame {
+				max-width: 100%;
 
-			@include break-small {
-				$frame-border-width: 10px;
+				@include break-small {
+					$frame-border-width: 10px;
 
-				border: $frame-border-width solid var(--color-print);
-				border-radius: 40px; /* stylelint-disable-line scales/radii */
-				box-sizing: border-box;
-				box-shadow:
-					0 5px 15px rgba(0, 0, 0, 0.07),
-					0 3px 10px rgba(0, 0, 0, 0.04);
-
-				@include break-large {
-					border-radius: 20px; /* stylelint-disable-line scales/radii */
+					border: $frame-border-width solid var( --color-print );
+					border-radius: 40px; /* stylelint-disable-line scales/radii */
+					box-sizing: border-box;
 					box-shadow:
-						0 15px 20px rgba(0, 0, 0, 0.04),
-						0 13px 10px rgba(0, 0, 0, 0.03),
-						0 6px 6px rgba(0, 0, 0, 0.02);
-					margin-top: 0;
+						0 5px 15px rgb( 0 0 0 / 7% ),
+						0 3px 10px rgb( 0 0 0 / 4% );
+
+					@include break-large {
+						border-radius: 20px; /* stylelint-disable-line scales/radii */
+						box-shadow:
+							0 15px 20px rgb( 0 0 0 / 4% ),
+							0 13px 10px rgb( 0 0 0 / 3% ),
+							0 6px 6px rgb( 0 0 0 / 2% );
+						margin-top: 0;
+					}
 				}
 			}
 		}
 	}
 
 	&--is-tablet {
-		.theme-preview__frame {
-			max-width: 783px;
+		.theme-preview__frame-wrapper {
+			.theme-preview__frame {
+				max-width: 783px;
+			}
 		}
 	}
 
 	&--is-phone {
-		.theme-preview__frame {
-			max-width: 460px;
+		.theme-preview__frame-wrapper {
+			.theme-preview__frame {
+				max-width: 460px;
+			}
 		}
 	}
 }
@@ -110,37 +150,5 @@
 
 	@include break-small {
 		display: block;
-	}
-}
-
-.theme-preview__frame-wrapper {
-	flex-grow: 1;
-	position: relative;
-
-	.theme-preview__frame-message {
-		bottom: 0;
-		color: var(--color-text-subtle);
-		display: none;
-		font-size: $font-body;
-		left: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-		z-index: 1;
-
-		strong {
-			color: var(--color-text-subtle);
-			display: block;
-			font-size: $font-title-medium;
-			margin-bottom: 5px;
-		}
-	}
-
-	.theme-preview__frame {
-		border: none;
-		height: 100%;
-		transform-origin: 0 0;
-		transition: opacity 0.2s ease-in-out, max-width 0.2s ease-out;
-		width: 100%;
 	}
 }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -30,7 +30,7 @@ import PremiumBadge from './premium-badge';
 import StyleVariationBadges from './style-variation-badges';
 import ThemePreview from './theme-preview';
 import type { Categorization } from '../hooks/use-categorization';
-import type { Design } from '../types';
+import type { Design, StyleVariation } from '../types';
 import './style.scss';
 
 const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;
@@ -68,7 +68,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 interface DesignButtonProps {
 	design: Design;
 	locale: string;
-	onSelect: ( design: Design ) => void;
+	onSelect: ( design: Design, variation?: StyleVariation ) => void;
 	highRes: boolean;
 	disabled?: boolean;
 	hideFullScreenPreview?: boolean;
@@ -206,7 +206,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						) }
 						{ isEnableThemeStyleVariations && style_variations.length > 0 && (
 							<div className="design-picker__options-style-variations">
-								<StyleVariationBadges variations={ style_variations } />
+								<StyleVariationBadges
+									variations={ style_variations }
+									onClick={ ( variation ) => onSelect( design, variation ) }
+								/>
 							</div>
 						) }
 					</span>
@@ -268,7 +271,7 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 interface DesignButtonContainerProps extends DesignButtonProps {
 	isPremiumThemeAvailable?: boolean;
 	hasPurchasedTheme?: boolean;
-	onPreview?: ( design: Design ) => void;
+	onPreview?: ( design: Design, variation?: StyleVariation ) => void;
 	onUpgrade?: () => void;
 	previewOnly?: boolean;
 }
@@ -340,7 +343,7 @@ export interface UnifiedDesignPickerProps {
 	locale: string;
 	verticalId?: string;
 	onSelect: ( design: Design ) => void;
-	onPreview: ( design: Design ) => void;
+	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onUpgrade?: () => void;
 	generatedDesigns: Design[];
 	staticDesigns: Design[];
@@ -357,7 +360,7 @@ interface StaticDesignPickerProps {
 	locale: string;
 	verticalId?: string;
 	onSelect: ( design: Design ) => void;
-	onPreview: ( design: Design ) => void;
+	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onUpgrade?: () => void;
 	designs: Design[];
 	categorization?: Categorization;

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -86,7 +86,6 @@ export interface Design {
 	preview?: 'static';
 	design_type?: DesignType;
 	style_variations?: StyleVariation[];
-	active_style_variation_slug?: string;
 	price?: string;
 	verticalizable?: boolean;
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -86,6 +86,7 @@ export interface Design {
 	preview?: 'static';
 	design_type?: DesignType;
 	style_variations?: StyleVariation[];
+	active_style_variation_slug?: string;
 	price?: string;
 	verticalizable?: boolean;
 

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import Sidebar from './sidebar';
 import SitePreview from './site-preview';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
@@ -13,6 +13,9 @@ interface PreviewProps {
 	onSelectVariation: ( variation: StyleVariation ) => void;
 }
 
+const getVariationBySlug = ( variations: StyleVariation[], slug: string ) =>
+	variations.find( ( variation ) => variation.slug === slug );
+
 const Preview: React.FC< PreviewProps > = ( {
 	previewUrl,
 	title,
@@ -21,11 +24,16 @@ const Preview: React.FC< PreviewProps > = ( {
 	selectedVariation,
 	onSelectVariation,
 } ) => {
-	useEffect( () => {
-		if ( variations.length > 0 && ! selectedVariation ) {
-			onSelectVariation( variations[ 0 ] );
+	const sitePreviewInlineCss = useMemo( () => {
+		if ( selectedVariation ) {
+			return (
+				selectedVariation.inline_css ??
+				( getVariationBySlug( variations, selectedVariation.slug )?.inline_css || '' )
+			);
 		}
-	}, [ variations, selectedVariation, onSelectVariation ] );
+
+		return '';
+	}, [ variations, selectedVariation ] );
 
 	return (
 		<div className="design-preview">
@@ -36,7 +44,7 @@ const Preview: React.FC< PreviewProps > = ( {
 				selectedVariation={ selectedVariation }
 				onSelectVariation={ onSelectVariation }
 			/>
-			<SitePreview url={ previewUrl } inlineCss={ selectedVariation?.inline_css || '' } />
+			<SitePreview url={ previewUrl } inlineCss={ sitePreviewInlineCss } />
 		</div>
 	);
 };

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -35,7 +35,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 					<div className="design-preview__sidebar-variations-grid">
 						<StyleVariationPreviews
 							variations={ variations }
-							activeVariation={ selectedVariation }
+							selectedVariation={ selectedVariation }
 							onClick={ onSelectVariation }
 						/>
 					</div>

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -3,6 +3,7 @@ import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/compo
 import Preview from '@wordpress/edit-site/build-module/components/global-styles/preview';
 import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
 import './style.scss';
 
@@ -40,6 +41,10 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 			} ) }
 			tabIndex={ 0 }
 			role="button"
+			aria-label={ translate( 'Style: %s', {
+				comment: 'Aria label for style preview button',
+				args: variation.title,
+			} ) }
 			onClick={ () => onClick( variation ) }
 			onKeyDown={ ( e ) => e.keyCode === SPACE_BAR_KEYCODE && onClick( variation ) }
 		>

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -7,18 +7,19 @@ import type { StyleVariation } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 const SPACE_BAR_KEYCODE = 32;
+const DEFAULT_VARIATION_SLUG = 'default';
 
 interface StyleVariationPreviewProps {
 	variation: StyleVariation;
-	isActive: boolean;
 	base?: StyleVariation;
+	isSelected: boolean;
 	onClick: ( variation: StyleVariation ) => void;
 }
 
 const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 	variation,
-	isActive,
 	base = {},
+	isSelected,
 	onClick,
 } ) => {
 	const context = useMemo( () => {
@@ -35,12 +36,12 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 	return (
 		<div
 			className={ classnames( 'design-preview__style-variation', {
-				'design-preview__style-variation--is-active': isActive,
+				'design-preview__style-variation--is-selected': isSelected,
 			} ) }
 			tabIndex={ 0 }
 			role="button"
-			onClick={ () => onClick?.( variation ) }
-			onKeyDown={ ( e ) => e.keyCode === SPACE_BAR_KEYCODE && onClick?.( variation ) }
+			onClick={ () => onClick( variation ) }
+			onKeyDown={ ( e ) => e.keyCode === SPACE_BAR_KEYCODE && onClick( variation ) }
 		>
 			<GlobalStylesContext.Provider value={ context }>
 				<Preview label={ variation.title } />
@@ -51,17 +52,18 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 
 interface StyleVariationPreviewsProps {
 	variations: StyleVariation[];
-	activeVariation?: StyleVariation;
+	selectedVariation?: StyleVariation;
 	onClick: ( variation: StyleVariation ) => void;
 }
 
 const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
 	variations = [],
-	activeVariation,
+	selectedVariation,
 	onClick,
 } ) => {
+	const selectedVariationSlug = selectedVariation?.slug ?? DEFAULT_VARIATION_SLUG;
 	const base = useMemo(
-		() => variations.find( ( variation ) => variation.slug === 'default' ),
+		() => variations.find( ( variation ) => variation.slug === DEFAULT_VARIATION_SLUG ),
 		[ variations ]
 	);
 
@@ -72,7 +74,7 @@ const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
 					key={ variation.slug }
 					variation={ variation }
 					base={ base }
-					isActive={ activeVariation?.slug === variation.slug }
+					isSelected={ variation.slug === selectedVariationSlug }
 					onClick={ onClick }
 				/>
 			) ) }

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -41,10 +41,12 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 			} ) }
 			tabIndex={ 0 }
 			role="button"
-			aria-label={ translate( 'Style: %s', {
-				comment: 'Aria label for style preview button',
-				args: variation.title,
-			} ) }
+			aria-label={
+				translate( 'Style: %s', {
+					comment: 'Aria label for style preview buttons',
+					args: variation.title,
+				} ) as string
+			}
 			onClick={ () => onClick( variation ) }
 			onKeyDown={ ( e ) => e.keyCode === SPACE_BAR_KEYCODE && onClick( variation ) }
 		>

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -17,8 +17,8 @@
 .design-preview__sidebar {
 	align-items: center;
 	background: #fff;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-	box-shadow: -4px 0 8px rgba(0, 0, 0, 0.07);
+	border-bottom: 1px solid rgb( 0 0 0 / 5% );
+	box-shadow: -4px 0 8px rgb( 0 0 0 / 7% );
 	box-sizing: border-box;
 	display: flex;
 	height: 96px;
@@ -52,7 +52,7 @@
 			font-family: $brand-serif;
 			font-weight: 400;
 			letter-spacing: -0.4px;
-			line-height: 2rem;
+			line-height: 32px;
 		}
 	}
 
@@ -60,7 +60,7 @@
 		p {
 			color: var(--studio-gray-80);
 			font-size: 0.875rem;
-			line-height: 1.25rem;
+			line-height: 20px;
 		}
 	}
 
@@ -125,13 +125,13 @@
 	transition: border-color 0.15s ease-in-out;
 
 	&:hover,
-	&--is-active {
+	&--is-selected {
 		border-color: var(--studio-blue-50);
 	}
 
 	.edit-site-global-styles-preview__iframe {
 		border-radius: 3px; /* stylelint-disable-line scales/radii */
-		box-shadow: 0 0 1px rgba(0, 0, 0, 0.25);
+		box-shadow: 0 0 1px rgba( 0 0 0 / 25% );
 		border: 0;
 		display: block;
 		max-width: 100%;


### PR DESCRIPTION
#### Proposed Changes

This PR addresses several UI/UX polishes related to the style preview. The list of improvement is as follows:

**Site preview frame border not displayed**
As reported in https://github.com/Automattic/wp-calypso/pull/67306#issuecomment-1237872802, currently the site preview does not show a gray border as per design spec:
![Screen Shot 2022-09-07 at 5 57 03 PM](https://user-images.githubusercontent.com/797888/188850124-9ff2180f-6f7c-453d-a8b0-11b857645459.png)

**Clicking a style indicator from the theme card should open the preview with the corresponding style selected**
See recording for reference:
https://user-images.githubusercontent.com/797888/188855410-c3f443d8-0328-42d4-923a-a915c0f3b690.mp4


Translations:
Strings added in this PR are for `aria-label`. See screenshots for reference:
![Screen Shot 2022-09-13 at 1 57 17 PM](https://user-images.githubusercontent.com/797888/189821307-8620e214-6379-4c50-91c1-9cdc52113a56.png)
![Screen Shot 2022-09-13 at 1 57 55 PM](https://user-images.githubusercontent.com/797888/189821312-5eca7ce9-4618-4df9-bad7-2b503944c3fe.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the unified design picker `setup/designSetup?siteSlug=${site_slug}`
* Ensure that the issue "Site preview frame border not displayed" is no longer reproducible.
* Ensure that the improvement "Clicking on any style indicator from the theme card should open the full-screen theme preview with the corresponding style selected" works as described.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#67388](https://github.com/Automattic/wp-calypso/issues/67388)
