### PR TITLE
Promote posts design updates

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -3,6 +3,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/account-settings/',
 		post_id: 80368,
 	},
+	advertising: {
+		link: 'https://wordpress.com/advertising/',
+		post_id: 213203,
+	},
 	autorenewal: {
 		link: 'https://wordpress.com/support/manage-purchases/#automatic-renewal',
 		post_id: 111349,

--- a/client/my-sites/promote-post/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post/components/campaign-item/style.scss
@@ -94,7 +94,8 @@
 		margin-bottom: 10px;
 	}
 
-	.campaign-item__target-value {
+	.campaign-item__target-value a {
 		word-break: break-all;
+		color: var( --color-text );
 	}
 }

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import SitePreview from 'calypso/blocks/site-preview';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
@@ -40,18 +41,37 @@ export default function PromotedPosts( { tab }: Props ) {
 		page( '/' );
 	}
 
+	const learnMoreLink = <InlineSupportLink supportContext="advertising" showIcon={ false } />;
+
+	const subtitle = campaignsData?.length
+		? translate(
+				'Reach more people promoting a post or a page to the larger WordPress.com community of blogs and sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: learnMoreLink,
+					},
+				}
+		  )
+		: translate(
+				'Promote a post to attract high-quality traffic to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: learnMoreLink,
+					},
+				}
+		  );
+
 	return (
 		<Main wideLayout className="promote-post">
 			<DocumentHead title={ translate( 'Advertising' ) } />
 			<SitePreview />
 			<FormattedHeader
 				brandFont
-				className="advertising-page-heading"
+				className="advertising__page-header"
 				headerText={ translate( 'Advertising' ) }
+				subHeaderText={ subtitle }
 				align="left"
-				hasScreenOptions
 			/>
-			<DocumentHead title={ translate( 'Advertising' ) } />
 			<SitePreview />
 			{ ! campaignsData?.length && ! campaignsIsLoading && <PostsListBanner /> }
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />


### PR DESCRIPTION
1. Ad destination colour didn't match the design ( 680-gh-Tumblr/wordads-picard )
2. Add subtitle ( 628-gh-Tumblr/wordads-picard )
3. Adds learn more pop out support article ( 628-gh-Tumblr/wordads-picard )

#### Proposed Changes
These are the parts that needed addressing

![Screenshot 2022-09-06 at 18 19 38](https://user-images.githubusercontent.com/6440498/188833314-ec5dac16-2f26-438e-b44d-21727c5eb925.png)


#### Testing Instructions

- [ ] visit http://calypso.localhost:3000/advertising/
- [ ] Check the subtitle appears when no campaigns and click "learn more"
- [ ] check the subtitle for when there are campaigns and click "learn more"
- [ ] Check the campaigns tab, that the link no longer has any colour

Screenshots of all scenarios can be found below:

![Screenshot 2022-09-06 at 18 14 03](https://user-images.githubusercontent.com/6440498/188833407-8d9bcf59-aecd-49ba-ae24-1927de4715a4.png)
![Screenshot 2022-09-06 at 18 15 19](https://user-images.githubusercontent.com/6440498/188833411-3b12178c-fb83-4056-83f0-f6c31d4dc5f9.png)
![Screenshot 2022-09-06 at 18 16 08](https://user-images.githubusercontent.com/6440498/188833374-ba0f824a-2cfe-4c6a-8b09-7ccd577596d8.png)

![Screenshot 2022-09-06 at 18 18 46](https://user-images.githubusercontent.com/6440498/188833274-71d39dc3-882c-4fe7-8876-160fd4de1130.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
