### PR TITLE
Theme Sheet: Hide upsell banner for bundled premium themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -658,6 +658,7 @@ class ThemeSheet extends Component {
 			hasUnlimitedPremiumThemes,
 			isAtomic,
 			isPremium,
+			isBundledSoftwareSet,
 			isJetpack,
 			isWpcomTheme,
 			isVip,
@@ -711,13 +712,22 @@ class ThemeSheet extends Component {
 
 		// Show theme upsell banner on Simple sites.
 		const hasWpComThemeUpsellBanner =
-			! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired;
+			! isJetpack &&
+			isPremium &&
+			! isBundledSoftwareSet &&
+			! hasUnlimitedPremiumThemes &&
+			! isVip &&
+			! retired;
 		// Show theme upsell banner on Jetpack sites.
 		const hasWpOrgThemeUpsellBanner =
 			! isAtomic && ! isWpcomTheme && ( ! siteId || ( ! isJetpack && ! canUserUploadThemes ) );
 		// Show theme upsell banner on Atomic sites.
 		const hasThemeUpsellBannerAtomic =
-			isAtomic && isPremium && ! canUserUploadThemes && ! hasUnlimitedPremiumThemes;
+			isAtomic &&
+			isPremium &&
+			! isBundledSoftwareSet &&
+			! canUserUploadThemes &&
+			! hasUnlimitedPremiumThemes;
 
 		const hasUpsellBanner =
 			hasWpComThemeUpsellBanner || hasWpOrgThemeUpsellBanner || hasThemeUpsellBannerAtomic;


### PR DESCRIPTION
#### Proposed Changes

* When viewing a bundled premium theme's info page (The "theme sheet"), hide the upsell banner.
  * The upsell banner mentions `'Access this theme for FREE with a Premium or Business plan!` which is incorrect, since premium plans can't access bundled themes.
  * We can make a new upsell banner for these later, but I don't have the copy/specs.

#### Testing Instructions

* Use a free site
* Ensure the `themes/plugin-bundling` flag is on (use calypso localhost)
* Ensure the `signup/seller-upgrade-modal` flag is on (edit config/development.json or use `?flags=signup/seller-upgrade-modal`
* Visit the theme showcase
* Find baxter and click on 'info'
* Examine the upsell banner at the top. Before PR: It exists. After PR: It is gone, but remains on the other premium themes that aren't bundled.

![2022-09-06_10-06](https://user-images.githubusercontent.com/937354/188671537-311c7bc4-de9d-4fb4-adf4-cae26d298c4b.png)



Related to #
