### PR TITLE
Update/subscriber combine endpoint

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -4,7 +4,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
@@ -130,7 +129,7 @@ class Followers extends Component {
 									siteId={ this.props.site.ID }
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 									onImportFinished={ () => {
-										page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+										this.props?.refetch?.();
 									} }
 								/>
 							</EmailVerificationGate>

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -130,7 +130,7 @@ class Followers extends Component {
 									siteId={ this.props.site.ID }
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 									onImportFinished={ () => {
-										page.redirect( `/people/invites/${ this.props.site.slug }` );
+										page.redirect( `/people/email-followers/${ this.props.site.slug }` );
 									} }
 								/>
 							</EmailVerificationGate>

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -52,6 +52,7 @@ const FollowersList = ( { site, search, type = 'wpcom' } ) => {
 			isFetching={ isLoading }
 			isFetchingNextPage={ isFetchingNextPage }
 			totalFollowers={ data?.total }
+			refetch={ refetch }
 			fetchNextPage={ fetchNextPage }
 			hasNextPage={ hasNextPage }
 			removeFollower={ removeFollower }

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -75,7 +75,7 @@ class PeopleInvites extends PureComponent {
 							siteId={ this.props.site.ID }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							onImportFinished={ () => {
-								page.redirect( `/people/invites/${ this.props.site.slug }` );
+								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
 							} }
 						/>
 					</EmailVerificationGate>

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -34,7 +34,7 @@ export function createActions() {
 		job,
 	} );
 
-	function* importCsvSubscribers( siteId: number, file: File ) {
+	function* importCsvSubscribers( siteId: number, file?: File, emails: string[] = [] ) {
 		yield importCsvSubscribersStart( siteId );
 
 		try {
@@ -44,7 +44,8 @@ export function createActions() {
 				apiNamespace: 'wpcom/v2',
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
-				formData: [ [ 'import', file, file.name ] ],
+				formData: file && [ [ 'import', file, file.name ] ],
+				body: { emails },
 			} );
 
 			yield importCsvSubscribersStartSuccess( siteId, data.upload_id );

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -1,6 +1,5 @@
 import { wpcomRequest } from '../wpcom-request-controls';
 import {
-	AddSubscribersResponse,
 	GetSubscribersImportResponse,
 	GetSubscribersImportsResponse,
 	ImportJob,
@@ -55,47 +54,6 @@ export function createActions() {
 	}
 
 	/**
-	 * ↓ Add subscribers
-	 */
-	const addSubscribersStart = ( siteId: number ) => ( {
-		type: 'ADD_SUBSCRIBERS_START' as const,
-		siteId,
-	} );
-
-	const addSubscribersSuccess = ( siteId: number, response: AddSubscribersResponse ) => ( {
-		type: 'ADD_SUBSCRIBERS_SUCCESS' as const,
-		siteId,
-		response,
-	} );
-
-	const addSubscribersFailed = ( siteId: number ) => ( {
-		type: 'ADD_SUBSCRIBERS_FAILED' as const,
-		siteId,
-	} );
-
-	function* addSubscribers( siteId: number, emails: string[] ) {
-		yield addSubscribersStart( siteId );
-
-		try {
-			const data: AddSubscribersResponse = yield wpcomRequest( {
-				path: `/sites/${ encodeURIComponent( siteId ) }/invites/new`,
-				method: 'POST',
-				apiNamespace: 'rest/v1.1',
-				body: {
-					invitees: emails,
-					role: 'follower',
-					source: 'calypso',
-					is_external: false,
-				},
-			} );
-
-			yield addSubscribersSuccess( siteId, data );
-		} catch ( err ) {
-			yield addSubscribersFailed( siteId );
-		}
-	}
-
-	/**
 	 * ↓ Get import
 	 */
 	const getSubscribersImportSuccess = ( siteId: number, importJob: ImportJob ) => ( {
@@ -145,10 +103,6 @@ export function createActions() {
 		importCsvSubscribersStartFailed,
 		importCsvSubscribersUpdate,
 		importCsvSubscribers,
-		addSubscribersStart,
-		addSubscribersSuccess,
-		addSubscribersFailed,
-		addSubscribers,
 		getSubscribersImport,
 		getSubscribersImportSuccess,
 		getSubscribersImports,
@@ -163,9 +117,6 @@ export type Action = ReturnType<
 	| ActionCreators[ 'importCsvSubscribersStartSuccess' ]
 	| ActionCreators[ 'importCsvSubscribersStartFailed' ]
 	| ActionCreators[ 'importCsvSubscribersUpdate' ]
-	| ActionCreators[ 'addSubscribersStart' ]
-	| ActionCreators[ 'addSubscribersSuccess' ]
-	| ActionCreators[ 'addSubscribersFailed' ]
 	| ActionCreators[ 'getSubscribersImportSuccess' ]
 	| ActionCreators[ 'getSubscribersImportsSuccess' ]
 >;

--- a/packages/data-stores/src/subscriber/reducers.ts
+++ b/packages/data-stores/src/subscriber/reducers.ts
@@ -51,26 +51,6 @@ export const subscriber: Reducer< SubscriberState, Action > = ( state = {}, acti
 	}
 
 	/**
-	 * ↓ Add subscribers
-	 */
-	if ( action.type === 'ADD_SUBSCRIBERS_START' ) {
-		return Object.assign( {}, state, {
-			add: { inProgress: true },
-		} );
-	} else if ( action.type === 'ADD_SUBSCRIBERS_SUCCESS' ) {
-		return Object.assign( {}, state, {
-			add: {
-				inProgress: false,
-				response: action.response,
-			},
-		} );
-	} else if ( action.type === 'ADD_SUBSCRIBERS_FAILED' ) {
-		return Object.assign( {}, state, {
-			add: { inProgress: false },
-		} );
-	}
-
-	/**
 	 * ↓ Get import
 	 */
 	if ( action.type === 'GET_SUBSCRIBERS_IMPORT_SUCCESS' ) {

--- a/packages/data-stores/src/subscriber/selectors.ts
+++ b/packages/data-stores/src/subscriber/selectors.ts
@@ -2,6 +2,5 @@ import type { State } from './reducers';
 
 export const getState = ( state: State ) => state.subscriber;
 export const getHydrationStatus = ( state: State ) => state.subscriber.hydrated;
-export const getAddSubscribersSelector = ( state: State ) => state.subscriber.add;
 export const getImportSubscribersSelector = ( state: State ) => state.subscriber.import;
 export const getImportJobsSelector = ( state: State ) => state.subscriber.imports;

--- a/packages/data-stores/src/subscriber/test/reducers.ts
+++ b/packages/data-stores/src/subscriber/test/reducers.ts
@@ -59,43 +59,6 @@ describe( 'Subscriber reducer', () => {
 	} );
 
 	/**
-	 * ↓ Add subscribers
-	 */
-	it( 'manually add subscribers start', () => {
-		const state = subscriber( EMPTY_STATE, {
-			type: 'ADD_SUBSCRIBERS_START',
-			siteId: 1,
-		} );
-
-		const expectedState = { add: { inProgress: true } };
-
-		expect( state ).toEqual( expectedState );
-	} );
-
-	it( 'manually add subscribers start success', () => {
-		const state = subscriber( EMPTY_STATE, {
-			type: 'ADD_SUBSCRIBERS_SUCCESS',
-			siteId: 1,
-			response: {
-				subscribed: 2,
-				errors: [],
-			},
-		} );
-
-		const expectedState = {
-			add: {
-				inProgress: false,
-				response: {
-					subscribed: 2,
-					errors: [],
-				},
-			},
-		};
-
-		expect( state ).toEqual( expectedState );
-	} );
-
-	/**
 	 * ↓ Get import
 	 */
 	it( 'get import job, add to `imports` array', () => {

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -2,10 +2,6 @@ import * as actions from './actions';
 import type { DispatchFromMap } from '../mapped-types';
 
 export interface SubscriberState {
-	add?: {
-		inProgress: boolean;
-		response: AddSubscribersResponse;
-	};
 	import?: {
 		inProgress: boolean;
 		job?: ImportJob;
@@ -31,11 +27,6 @@ export type GenericError = {
 };
 
 export type AddSubscriberError = { email: string } | GenericError;
-
-export type AddSubscribersResponse = {
-	subscribed: number;
-	errors: AddSubscriberError[];
-};
 
 export type ImportSubscribersError = Record< string, unknown > | GenericError;
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -103,8 +103,8 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			} )
 			.filter( ( x ) => !! x ) as string[];
 
-		// validEmails.length && addSubscribers( siteId, validEmails );
-		selectedFile && importCsvSubscribers( siteId, selectedFile );
+		( validEmails.length || selectedFile ) &&
+			importCsvSubscribers( siteId, selectedFile, validEmails );
 
 		! validEmails.length && ! selectedFile && allowEmptyFormSubmit && onImportFinished?.();
 	}

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -47,8 +47,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		onImportFinished,
 	} = props;
 
-	const { addSubscribers, importCsvSubscribers, getSubscribersImports } =
-		useDispatch( SUBSCRIBER_STORE );
+	const { importCsvSubscribers, getSubscribersImports } = useDispatch( SUBSCRIBER_STORE );
 
 	/**
 	 * ↓ Fields
@@ -104,7 +103,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			} )
 			.filter( ( x ) => !! x ) as string[];
 
-		validEmails.length && addSubscribers( siteId, validEmails );
+		// validEmails.length && addSubscribers( siteId, validEmails );
 		selectedFile && importCsvSubscribers( siteId, selectedFile );
 
 		! validEmails.length && ! selectedFile && allowEmptyFormSubmit && onImportFinished?.();

--- a/packages/subscriber/src/hooks/use-in-progress-state.ts
+++ b/packages/subscriber/src/hooks/use-in-progress-state.ts
@@ -4,9 +4,8 @@ import { IMPORT_PROGRESS_SIMULATION_DURATION } from '../config';
 import { SUBSCRIBER_STORE } from '../store';
 
 export function useInProgressState( simulationDuration = IMPORT_PROGRESS_SIMULATION_DURATION ) {
-	const addSelector = useSelect( ( s ) => s( SUBSCRIBER_STORE ).getAddSubscribersSelector() );
 	const importSelector = useSelect( ( s ) => s( SUBSCRIBER_STORE ).getImportSubscribersSelector() );
-	const IN_PROGRESS = addSelector?.inProgress || importSelector?.inProgress;
+	const IN_PROGRESS = importSelector?.inProgress;
 	const [ inProgress, setInProgress ] = useState( IN_PROGRESS );
 
 	useEffect( () => {


### PR DESCRIPTION
#### Proposed Changes

* Removed manually add subscriber action from the data store
* Updated UI to consume combined endpoint for adding manual email list and CSV upload

#### Testing Instructions

* Go to `/setup/subscribers?flow=newsletter&complete-setup=true&siteSlug={SLUG}`
* Manually add emails
* Select a CSV file
* Click on the 'Continue' button
* Check if there is only one single call for adding combined payload (CSV file and email list)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #67438
