### PR TITLE
Plugin Management: Design fixes and improvements

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -152,7 +152,11 @@ export class PluginsListHeader extends PureComponent {
 			}
 			rightSideButtons.push(
 				<ButtonGroup key="plugin-list-header__buttons-bulk-management">
-					<Button compact onClick={ this.toggleBulkManagement }>
+					<Button
+						className="plugin-list-header__buttons-action-button"
+						compact
+						onClick={ this.toggleBulkManagement }
+					>
 						{ translate( 'Edit All', { context: 'button label' } ) }
 					</Button>
 				</ButtonGroup>
@@ -161,6 +165,7 @@ export class PluginsListHeader extends PureComponent {
 			const updateButton = (
 				<Button
 					key="plugin-list-header__buttons-update"
+					className="plugin-list-header__buttons-action-button"
 					compact
 					disabled={ isWpcom ? ! this.props.haveUpdatesSelected : ! this.hasSelectedPlugins() }
 					primary={ isWpcom }
@@ -181,6 +186,7 @@ export class PluginsListHeader extends PureComponent {
 			activateButtons.push(
 				<Button
 					key="plugin-list-header__buttons-activate"
+					className="plugin-list-header__buttons-action-button"
 					disabled={ isWpcom ? ! this.props.haveInactiveSelected : ! this.hasSelectedPlugins() }
 					onClick={ this.props.activateSelected }
 					compact
@@ -193,6 +199,7 @@ export class PluginsListHeader extends PureComponent {
 				<Button
 					compact
 					key="plugin-list-header__buttons-deactivate"
+					className="plugin-list-header__buttons-action-button"
 					disabled={ isWpcom ? ! this.props.haveActiveSelected : ! this.hasSelectedPlugins() }
 					onClick={
 						isJetpackSelected
@@ -215,6 +222,7 @@ export class PluginsListHeader extends PureComponent {
 			autoupdateButtons.push(
 				<Button
 					key="plugin-list-header__buttons-autoupdate-on"
+					className="plugin-list-header__buttons-action-button"
 					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					compact
 					onClick={ this.props.setAutoupdateSelected }
@@ -225,6 +233,7 @@ export class PluginsListHeader extends PureComponent {
 			autoupdateButtons.push(
 				<Button
 					key="plugin-list-header__buttons-autoupdate-off"
+					className="plugin-list-header__buttons-action-button"
 					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					compact
 					onClick={ this.props.unsetAutoupdateSelected }

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -85,8 +85,10 @@
 }
 
 .plugin-list-header-new {
+	height: 60px;
 	margin-block-start: 8px;
 	&.section-header.card {
+		align-items: center;
 		margin-inline-start: 0;
 		margin-inline-end: 0;
 		padding-inline-start: 16px;
@@ -170,5 +172,11 @@
 	}
 	.plugin-list-header__bulk-select-label {
 		margin-inline-end: 16px;
+	}
+
+	.plugin-list-header__action-buttons {
+		button.plugin-list-header__buttons-action-button {
+			color: var( --studio-gray-80 );
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -17,11 +17,11 @@
 		font-size: 0.75rem;
 		color: var( --studio-gray-50 );
 		font-weight: 400;
-		height: 50px;
+		height: 60px;
 	}
 	td {
 		font-size: 0.875rem;
-		height: 50px;
+		height: 60px;
 		width: 175px;
 		box-sizing: border-box;
 		&:nth-child( 1 ) {
@@ -104,6 +104,7 @@ td.plugin-common-table__actions {
 			margin-inline-end: 8px;
 		}
 		button {
+			color: var( --studio-gray-80 );
 			&:first-child,
 			&:last-child {
 				border-radius: 4px;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -9,7 +9,7 @@
 	max-width: 32px;
 	height: 32px;
 	vertical-align: middle;
-	margin-inline-end: 16px;
+	margin-inline-end: 12px;
 }
 .row-data-common-style {
 	display: inline-block;


### PR DESCRIPTION
#### Proposed Changes

This PR will make style adjustments to ensure that the implemented UI components match the design (typography, color, spacing, etc.)

**Note:** Table layout enhancements will be fixed in 1202619025189113-as-1202935480301806

#### Testing Instructions
- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/plugins/manage
- Verify that the UI matches the design
- Visit http://jetpack.cloud.localhost:3000/plugins/manage/:site (i.e. the single site view)
- Verify that the UI matches the design

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202860364241326