### PR TITLE
Launchpad: Fix chevron direction for RTL languages

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -1,13 +1,15 @@
 import { Button, Gridicon } from '@automattic/components';
-import { translate } from 'i18n-calypso';
+import { translate, useRtl } from 'i18n-calypso';
 import Badge from 'calypso/components/badge';
 import { isTaskDisabled } from './task-helper';
 import { Task } from './types';
 
 const ChecklistItem = ( { task }: { task: Task } ) => {
+	const isRtl = useRtl();
 	const { id, isCompleted, actionUrl, title, actionDispatch } = task;
 	const action = actionDispatch ? { onClick: actionDispatch } : { href: actionUrl };
 	const taskDisabled = isTaskDisabled( task );
+
 	return (
 		<li className={ `launchpad__task-${ id }` }>
 			<Button
@@ -36,7 +38,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				{ ! taskDisabled && (
 					<Gridicon
 						className="launchpad__checklist-item-chevron"
-						icon="chevron-right"
+						icon={ `chevron-${ isRtl ? 'left' : 'right' }` }
 						size={ 18 }
 					/>
 				) }


### PR DESCRIPTION
#### Proposed Changes

* The launchpad task chevrons were pointing in the wrong direction for RTL languages pdtkmj-rd-p2#comment-886

### Screenshots
#### Before
<img width="1280" alt="Screen Shot 2022-09-06 at 11 27 23 AM" src="https://user-images.githubusercontent.com/5414230/188711139-cf34c99d-6ee3-4129-9465-72b2dfd8ae66.png">

#### After
<img width="1281" alt="Screen Shot 2022-09-06 at 11 12 58 AM" src="https://user-images.githubusercontent.com/5414230/188709902-0f315136-549a-4beb-9ed0-015c77119d83.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to https://wordpress.com/me/account
* Navigate to Interface language
* Select an RTL language ( arabic, hebrew, etc. )
* Navigate to a launchpad page for either the newsletter or link in bio flow http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=YOUR_SITE_SLUG_HERE
* Verify that chevrons point from right to left, instead of from left to right

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/67458