### PR TITLE
Extract selector: doesThemeBundleUsableSoftwareSet

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -1,4 +1,3 @@
-import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { Button, Dialog, Gridicon, ScreenReaderText } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -10,13 +9,12 @@ import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customiz
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import { clearActivated } from 'calypso/state/themes/actions';
 import {
-	doesThemeBundleSoftwareSet,
+	doesThemeBundleUsableSoftwareSet,
 	getActiveTheme,
 	getCanonicalTheme,
 	getThemeDetailsUrl,
@@ -319,21 +317,16 @@ const ConnectedThanksModal = connect(
 				  )
 				: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId, isFSEActive );
 
-		// Does the theme have sofware bundled?
-		const doesThemeBundleSoftware = doesThemeBundleSoftwareSet( state, currentThemeId );
-		// Are we allowed to use bundled software if it exists?
-		const isEligibleForBundledSoftware =
-			siteHasFeature( state, siteId, FEATURE_WOOP ) &&
-			siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
-		// Check both conditions before redirecting for bundled software.
-		const doesThemeBundleUsableSoftware = doesThemeBundleSoftware && isEligibleForBundledSoftware;
-
 		return {
 			siteId,
 			siteUrl,
 			siteSlug: getSiteSlug( state, siteId ),
 			currentTheme,
-			doesThemeBundleUsableSoftware,
+			doesThemeBundleUsableSoftware: doesThemeBundleUsableSoftwareSet(
+				state,
+				currentThemeId,
+				siteId
+			),
 			shouldEditHomepageWithGutenberg,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
 			customizeUrl,

--- a/client/state/themes/selectors/does-theme-bundle-software-set.js
+++ b/client/state/themes/selectors/does-theme-bundle-software-set.js
@@ -3,6 +3,13 @@ import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 
 import 'calypso/state/themes/init';
 
+/**
+ * Returns true if the theme contains a software bundle (like woo-on-plans).
+ *
+ * @param {object} state Global state tree
+ * @param {string} themeId Theme ID
+ * @returns {boolean} True if the theme contains a software bundle.
+ */
 export function doesThemeBundleSoftwareSet( state, themeId ) {
 	const theme = getTheme( state, 'wpcom', themeId );
 	const theme_software_set = theme?.taxonomies?.theme_software_set;

--- a/client/state/themes/selectors/does-theme-bundle-usable-software-set.js
+++ b/client/state/themes/selectors/does-theme-bundle-usable-software-set.js
@@ -1,5 +1,5 @@
 import { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
-import { isSiteEligibleForBundledSoftare } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
+import { isSiteEligibleForBundledSoftware } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
 
 import 'calypso/state/themes/init';
 
@@ -14,6 +14,7 @@ import 'calypso/state/themes/init';
  */
 export function doesThemeBundleUsableSoftwareSet( state, themeId, siteId ) {
 	return (
-		doesThemeBundleSoftwareSet( state, themeId ) && isSiteEligibleForBundledSoftare( state, siteId )
+		doesThemeBundleSoftwareSet( state, themeId ) &&
+		isSiteEligibleForBundledSoftware( state, siteId )
 	);
 }

--- a/client/state/themes/selectors/does-theme-bundle-usable-software-set.js
+++ b/client/state/themes/selectors/does-theme-bundle-usable-software-set.js
@@ -1,0 +1,19 @@
+import { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
+import { isSiteEligibleForBundledSoftare } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Returns true if the theme contains a software bundle (like woo-on-plans) and
+ * the site specified has the features needed to use the software.
+ *
+ * @param {object} state Global state tree
+ * @param {string} themeId Theme ID
+ * @param {number} siteId Site ID
+ * @returns {boolean} True if the theme contains a software bundle that is usable by the specified site.
+ */
+export function doesThemeBundleUsableSoftwareSet( state, themeId, siteId ) {
+	return (
+		doesThemeBundleSoftwareSet( state, themeId ) && isSiteEligibleForBundledSoftare( state, siteId )
+	);
+}

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -50,7 +50,7 @@ export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-reque
 export { isRequestingTheme } from 'calypso/state/themes/selectors/is-requesting-theme';
 export { isRequestingThemesForQuery } from 'calypso/state/themes/selectors/is-requesting-themes-for-query';
 export { isRequestingThemesForQueryIgnoringPage } from 'calypso/state/themes/selectors/is-requesting-themes-for-query-ignoring-page';
-export { isSiteEligibleForBundledSoftare } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
+export { isSiteEligibleForBundledSoftware } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
 export { isThemeActive } from 'calypso/state/themes/selectors/is-theme-active';
 export { isThemeGutenbergFirst } from 'calypso/state/themes/selectors/is-theme-gutenberg-first';
 export { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -2,6 +2,7 @@ export { arePremiumThemesEnabled } from 'calypso/state/themes/selectors/are-prem
 export { areRecommendedThemesLoading } from 'calypso/state/themes/selectors/are-recommended-themes-loading';
 export { areTrendingThemesLoading } from 'calypso/state/themes/selectors/are-trending-themes-loading';
 export { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
+export { doesThemeBundleUsableSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-usable-software-set';
 export { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 export { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme';
 export { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';
@@ -49,6 +50,7 @@ export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-reque
 export { isRequestingTheme } from 'calypso/state/themes/selectors/is-requesting-theme';
 export { isRequestingThemesForQuery } from 'calypso/state/themes/selectors/is-requesting-themes-for-query';
 export { isRequestingThemesForQueryIgnoringPage } from 'calypso/state/themes/selectors/is-requesting-themes-for-query-ignoring-page';
+export { isSiteEligibleForBundledSoftare } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
 export { isThemeActive } from 'calypso/state/themes/selectors/is-theme-active';
 export { isThemeGutenbergFirst } from 'calypso/state/themes/selectors/is-theme-gutenberg-first';
 export { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';

--- a/client/state/themes/selectors/is-site-eligible-for-bundled-software.js
+++ b/client/state/themes/selectors/is-site-eligible-for-bundled-software.js
@@ -1,0 +1,19 @@
+import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Returns true if the site specified has the features needed to use
+ * software bundled with themes (like woo-on-plans).
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} True if the site is able to used bundled software.
+ */
+export function isSiteEligibleForBundledSoftare( state, siteId ) {
+	return (
+		siteHasFeature( state, siteId, FEATURE_WOOP ) &&
+		siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
+	);
+}

--- a/client/state/themes/selectors/is-site-eligible-for-bundled-software.js
+++ b/client/state/themes/selectors/is-site-eligible-for-bundled-software.js
@@ -11,7 +11,7 @@ import 'calypso/state/themes/init';
  * @param {number} siteId Site ID
  * @returns {boolean} True if the site is able to used bundled software.
  */
-export function isSiteEligibleForBundledSoftare( state, siteId ) {
+export function isSiteEligibleForBundledSoftware( state, siteId ) {
 	return (
 		siteHasFeature( state, siteId, FEATURE_WOOP ) &&
 		siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )


### PR DESCRIPTION
#### Proposed Changes

* In #67342, the thanks-modal does calculations to see if a site is able to use themes with bundled software.
  * ATOMIC and WOOP features are required.
* This PR moves that calculation to its own selector, so components outside the thanks-modal can reuse the same definition of requirements.

#### Testing Instructions


* Have two sites, a (premium) site and a (business or ecommerce) site. Both should be simple.
* Use calypso localhost or an environment where the `themes/plugin-bundling` flag is on.
* Visit the theme showcase `http://calypso.localhost:3000/themes/YOURSITE`
* Switch themes to baxter
* On the free or premium site, you should see the thank you modal render.
* On the business or commerce site, the thank you modal should redirect you to the bundle plugin flow.
* Behavior should be the same before and after the PR
