### PR TITLE
Show marketplace automanaged plugins tootip on Plugin Details page

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -12,7 +12,7 @@ export const PREINSTALLED_PLUGINS = [
 	'full-site-editing',
 	'layout-grid',
 	'page-optimize',
-];
+]; // These plugins auto update but shouldn't be deactivated.
 
 export const PREINSTALLED_PREMIUM_PLUGINS = {
 	'jetpack-search': {
@@ -25,4 +25,21 @@ export const PREINSTALLED_PREMIUM_PLUGINS = {
 	},
 };
 
-export const AUTOMOMANAGED_PLUGINS_ECOM = [ 'woocommerce' ];
+export const AUTOMOMANAGED_PLUGINS = [
+	'woocommerce',
+	'facebook-for-woocommerce',
+	'woocommerce-services',
+	'mailchimp-for-woocommerce',
+	'woocommerce-gateway-stripe',
+	'woocommerce-square',
+	'woocommerce-gateway-paypal-express-checkout',
+	'woocommerce-payfast-gateway',
+	'woocommerce-gateway-eway',
+	'taxjar-simplified-taxes-for-woocommerce',
+	'klarna-payments-for-woocommerce',
+	'klarna-checkout-for-woocommerce',
+	'crowdsignal-forms',
+	'polldaddy',
+	'classic-editor',
+	'wordpress-seo',
+]; // These plugins auto update but can be activated / deactivated.

--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -24,3 +24,5 @@ export const PREINSTALLED_PREMIUM_PLUGINS = {
 		},
 	},
 };
+
+export const AUTOMOMANAGED_PLUGINS_ECOM = [ 'woocommerce' ];

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -10,7 +10,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import { togglePluginAutoUpdate } from 'calypso/state/plugins/installed/actions';
 import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
-import { AUTOMOMANAGED_PLUGINS_ECOM } from '../constants';
+import { AUTOMOMANAGED_PLUGINS, PREINSTALLED_PLUGINS } from '../constants';
 
 const autoUpdateActions = [ ENABLE_AUTOUPDATE_PLUGIN, DISABLE_AUTOUPDATE_PLUGIN ];
 
@@ -56,17 +56,23 @@ export class PluginAutoUpdateToggle extends Component {
 		}
 	};
 
-	getDisabledInfo() {
-		const { site, wporg, translate, isMarketplaceProduct, plugin } = this.props;
-		if ( ! site ) {
-			// we don't have enough info
-			return null;
-		}
+	isAutoManaged = () =>
+		this.props.isMarketplaceProduct ||
+		PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ||
+		AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug );
 
-		if ( isMarketplaceProduct || AUTOMOMANAGED_PLUGINS_ECOM.includes( plugin.slug ) ) {
+	getDisabledInfo() {
+		const { site, wporg, translate } = this.props;
+
+		if ( this.isAutoManaged() ) {
 			return translate(
 				'This plugin is auto managed and therefore will auto update to the latest stable version.'
 			);
+		}
+
+		if ( ! site ) {
+			// we don't have enough info
+			return null;
 		}
 
 		if ( ! wporg ) {
@@ -139,17 +145,8 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const {
-			inProgress,
-			site,
-			plugin,
-			label,
-			disabled,
-			translate,
-			hideLabel,
-			toggleExtraContent,
-			isMarketplaceProduct,
-		} = this.props;
+		const { inProgress, site, plugin, label, disabled, translate, hideLabel, toggleExtraContent } =
+			this.props;
 		if ( ! site.jetpack ) {
 			return null;
 		}
@@ -162,10 +159,10 @@ export class PluginAutoUpdateToggle extends Component {
 
 		return (
 			<PluginAction
-				disabled={ isMarketplaceProduct ? true : disabled } // Marketplace products are auto-managed.
+				disabled={ this.isAutoManaged() ? true : disabled }
 				label={ label || defaultLabel }
 				className="plugin-autoupdate-toggle"
-				status={ isMarketplaceProduct ? true : plugin.autoupdate } // Marketplace products are auto-managed.
+				status={ this.isAutoManaged() ? true : plugin.autoupdate }
 				action={ this.toggleAutoUpdates }
 				inProgress={ inProgress }
 				disabledInfo={ getDisabledInfo }

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -10,6 +10,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import { togglePluginAutoUpdate } from 'calypso/state/plugins/installed/actions';
 import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { AUTOMOMANAGED_PLUGINS_ECOM } from '../constants';
 
 const autoUpdateActions = [ ENABLE_AUTOUPDATE_PLUGIN, DISABLE_AUTOUPDATE_PLUGIN ];
 
@@ -56,13 +57,13 @@ export class PluginAutoUpdateToggle extends Component {
 	};
 
 	getDisabledInfo() {
-		const { site, wporg, translate, isMarketplaceProduct } = this.props;
+		const { site, wporg, translate, isMarketplaceProduct, plugin } = this.props;
 		if ( ! site ) {
 			// we don't have enough info
 			return null;
 		}
 
-		if ( isMarketplaceProduct ) {
+		if ( isMarketplaceProduct || AUTOMOMANAGED_PLUGINS_ECOM.includes( plugin.slug ) ) {
 			return translate(
 				'This plugin is auto managed and therefore will auto update to the latest stable version.'
 			);


### PR DESCRIPTION
#### Proposed Changes

* Create a list of automanaged plugins
* Show the automanage tootip on the update toggle when on the Plugin Details page of those plugins.
* Show the autoupdates toggle as enabled - since we are indeed autoupdating the source code but on different cadence.

#### Testing Instructions
* Go to production version of the WooCommerce page (https://wordpress.com/plugins/woocommerce)
* Install the plugin (if not installed) 
* Check you should be able to click on the autoupdate toggle, but the state won't change
* Go to this branch version of the WooCommerce Plugin Page (`/plugins/woocommerce`)
* Install the plugin (if not install)
* You now should see the tooltip stating the reason you can't change it
* Repeat for Jetpack, Yoast SEO

| Before  | After |
| ------------- | ------------- |
|<img width="1041" alt="Screen Shot 2022-09-06 at 14 20 37" src="https://user-images.githubusercontent.com/5039531/188710605-baf29914-18ea-43a6-8da9-3005dc478041.png">|<img width="1041" alt="Screen Shot 2022-09-06 at 14 21 55" src="https://user-images.githubusercontent.com/5039531/188710632-001d0d00-cb7b-403c-8a44-8b268f97d13a.png">|




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65463
