### PR TITLE
Add bulk action warning notices

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -50,6 +50,10 @@ export class PluginsListHeader extends PureComponent {
 		setSelectionState: PropTypes.func.isRequired,
 		unsetAutoupdateSelected: PropTypes.func.isRequired,
 		removePluginNotice: PropTypes.func.isRequired,
+		activatePluginNotice: PropTypes.func.isRequired,
+		deactivatePluginNotice: PropTypes.func.isRequired,
+		autoupdateEnablePluginNotice: PropTypes.func.isRequired,
+		autoupdateDisablePluginNotice: PropTypes.func.isRequired,
 		haveActiveSelected: PropTypes.bool,
 		haveInactiveSelected: PropTypes.bool,
 		plugins: PropTypes.array.isRequired,
@@ -178,7 +182,7 @@ export class PluginsListHeader extends PureComponent {
 				<Button
 					key="plugin-list-header__buttons-activate"
 					disabled={ ! this.props.haveInactiveSelected }
-					onClick={ this.props.activateSelected }
+					onClick={ this.props.activatePluginNotice }
 					compact
 				>
 					{ translate( 'Activate' ) }
@@ -193,7 +197,7 @@ export class PluginsListHeader extends PureComponent {
 					onClick={
 						isJetpackSelected
 							? this.props.deactiveAndDisconnectSelected
-							: this.props.deactivateSelected
+							: this.props.deactivatePluginNotice
 					}
 				>
 					{ translate( 'Deactivate' ) }
@@ -213,7 +217,7 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-autoupdate-on"
 					disabled={ ! this.canUpdatePlugins() }
 					compact
-					onClick={ this.props.setAutoupdateSelected }
+					onClick={ this.props.autoupdateEnablePluginNotice }
 				>
 					{ translate( 'Autoupdate' ) }
 				</Button>
@@ -223,7 +227,7 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-autoupdate-off"
 					disabled={ ! this.canUpdatePlugins() }
 					compact
-					onClick={ this.props.unsetAutoupdateSelected }
+					onClick={ this.props.autoupdateDisablePluginNotice }
 				>
 					{ ! isWpcom ? translate( 'Disable' ) : translate( 'Disable Autoupdates' ) }
 				</Button>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -126,6 +126,14 @@ export class PluginsList extends Component {
 		return !! this.state.selectedPlugins[ slug ];
 	};
 
+	isJetpackSelected = ( selectedPlugin ) => {
+		const { plugins } = this.props;
+
+		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
+
+		return selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
+	};
+
 	togglePlugin = ( plugin ) => {
 		const { slug } = plugin;
 		const { selectedPlugins } = this.state;
@@ -161,7 +169,7 @@ export class PluginsList extends Component {
 
 	filterSelection = {
 		active( plugin ) {
-			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
+			if ( this.isSelected( plugin ) ) {
 				return Object.keys( plugin.sites ).some( ( siteId ) => {
 					const sitePlugin = this.getSitePlugin( plugin, siteId );
 					return sitePlugin?.active;
@@ -285,14 +293,18 @@ export class PluginsList extends Component {
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
 	};
 
-	activateSelected = () => {
-		this.doActionOverSelected( 'activating', this.props.activatePlugin );
-		this.recordEvent( 'Clicked Activate Plugin(s)', true );
+	activateSelected = ( accepted ) => {
+		if ( accepted ) {
+			this.doActionOverSelected( 'activating', this.props.activatePlugin );
+			this.recordEvent( 'Clicked Activate Plugin(s)', true );
+		}
 	};
 
-	deactivateSelected = () => {
-		this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
-		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
+	deactivateSelected = ( accepted ) => {
+		if ( accepted ) {
+			this.doActionOverSelected( 'deactivating', this.props.deactivatePlugin );
+			this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
+		}
 	};
 
 	deactiveAndDisconnectSelected = () => {
@@ -310,17 +322,21 @@ export class PluginsList extends Component {
 		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
 	};
 
-	setAutoupdateSelected = () => {
-		this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
-		this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
+	setAutoupdateSelected = ( accepted ) => {
+		if ( accepted ) {
+			this.doActionOverSelected( 'enablingAutoupdates', this.props.enableAutoupdatePlugin );
+			this.recordEvent( 'Clicked Enable Autoupdate Plugin(s)', true );
+		}
 	};
 
-	unsetAutoupdateSelected = () => {
-		this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
-		this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
+	unsetAutoupdateSelected = ( accepted ) => {
+		if ( accepted ) {
+			this.doActionOverSelected( 'disablingAutoupdates', this.props.disableAutoupdatePlugin );
+			this.recordEvent( 'Clicked Disable Autoupdate Plugin(s)', true );
+		}
 	};
 
-	getConfirmationText( selectedPlugins ) {
+	getConfirmationText( selectedPlugins, actionName ) {
 		const pluginsList = {};
 		const sitesList = {};
 		let pluginName;
@@ -350,14 +366,14 @@ export class PluginsList extends Component {
 		switch ( combination ) {
 			case '1 site 1 plugin':
 				return translate(
-					'You are about to remove {{em}}%(plugin)s from %(site)s{{/em}}.{{p}}' +
-						'This will deactivate the plugin and delete all associated files and data.{{/p}}',
+					'You are about to %(actionName)s {{em}}%(plugin)s from %(site)s{{/em}}.',
 					{
 						components: {
 							em: <em />,
 							p: <p />,
 						},
 						args: {
+							actionName: actionName,
 							plugin: pluginName,
 							site: siteName,
 						},
@@ -366,14 +382,14 @@ export class PluginsList extends Component {
 
 			case '1 site n plugins':
 				return translate(
-					'You are about to remove {{em}}%(numberOfPlugins)d plugins from %(site)s{{/em}}.{{p}}' +
-						'This will deactivate the plugins and delete all associated files and data.{{/p}}',
+					'You are about to %(actionName)s {{em}}%(numberOfPlugins)d plugins from %(site)s{{/em}}.',
 					{
 						components: {
 							em: <em />,
 							p: <p />,
 						},
 						args: {
+							actionName: actionName,
 							numberOfPlugins: pluginsListSize,
 							site: siteName,
 						},
@@ -382,14 +398,14 @@ export class PluginsList extends Component {
 
 			case 'n sites 1 plugin':
 				return translate(
-					'You are about to remove {{em}}%(plugin)s from %(numberOfSites)d sites{{/em}}.{{p}}' +
-						'This will deactivate the plugin and delete all associated files and data.{{/p}}',
+					'You are about to %(actionName)s {{em}}%(plugin)s from %(numberOfSites)d sites{{/em}}.',
 					{
 						components: {
 							em: <em />,
 							p: <p />,
 						},
 						args: {
+							actionName: actionName,
 							plugin: pluginName,
 							numberOfSites: siteListSize,
 						},
@@ -398,14 +414,14 @@ export class PluginsList extends Component {
 
 			case 'n sites n plugins':
 				return translate(
-					'You are about to remove {{em}}%(numberOfPlugins)d plugins from %(numberOfSites)d sites{{/em}}.{{p}}' +
-						'This will deactivate the plugins and delete all associated files and data.{{/p}}',
+					'You are about to %(actionName)s {{em}}%(numberOfPlugins)d plugins from %(numberOfSites)d sites{{/em}}.',
 					{
 						components: {
 							em: <em />,
 							p: <p />,
 						},
 						args: {
+							actionName: actionName,
 							numberOfPlugins: pluginsListSize,
 							numberOfSites: siteListSize,
 						},
@@ -414,6 +430,70 @@ export class PluginsList extends Component {
 		}
 	}
 
+	bulkActionDialog = ( actionName, selectedPlugin ) => {
+		const { plugins, translate } = this.props;
+		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
+
+		const message = (
+			<div>
+				<span>{ this.getConfirmationText( selectedPlugins, actionName ) }</span>
+			</div>
+		);
+
+		const pluginsCount = selectedPlugins.length;
+		const pluginsSize = pluginsCount === 1 ? 'plugin' : 'plugins';
+
+		switch ( actionName ) {
+			case 'activate':
+				acceptDialog(
+					message,
+					( accepted ) => this.activateSelected( accepted ),
+					translate( 'Activate %(numberOfPlugins)d %(plugins)s', {
+						args: {
+							numberOfPlugins: pluginsCount,
+							plugins: pluginsSize,
+						},
+					} )
+				);
+				break;
+			case 'deactivate':
+				acceptDialog(
+					message,
+					( accepted ) => this.deactivateSelected( accepted ),
+					translate( 'Deactivate %(numberOfPlugins)d %(plugins)s', {
+						args: {
+							numberOfPlugins: pluginsCount,
+							plugins: pluginsSize,
+						},
+					} )
+				);
+				break;
+			case 'enableAutoupdates':
+				acceptDialog(
+					message,
+					( accepted ) => this.setAutoupdateSelected( accepted ),
+					translate( 'Enable Autoupdates on %(numberOfPlugins)d %(plugins)s', {
+						args: {
+							numberOfPlugins: pluginsCount,
+							plugins: pluginsSize,
+						},
+					} )
+				);
+				break;
+			case 'disableAutoupdates':
+				acceptDialog(
+					message,
+					( accepted ) => this.unsetAutoupdateSelected( accepted ),
+					translate( 'Disable Autoupdates on %(numberOfPlugins)d %(plugins)s', {
+						args: {
+							numberOfPlugins: pluginsCount,
+							plugins: pluginsSize,
+						},
+					} )
+				);
+		}
+	};
+
 	removePluginDialog = ( selectedPlugin ) => {
 		const { plugins, translate } = this.props;
 
@@ -421,16 +501,24 @@ export class PluginsList extends Component {
 
 		const message = (
 			<div>
-				<span>{ this.getConfirmationText( selectedPlugins ) }</span>
+				<span>{ this.getConfirmationText( selectedPlugins, 'remove' ) }</span>
+				<span>
+					{ translate(
+						'{{p}}This will deactivate the plugins and delete all associated files and data.{{/p}}',
+						{
+							components: {
+								p: <p />,
+							},
+						}
+					) }
+				</span>
 				<span>{ translate( 'Do you want to continue?' ) }</span>
 			</div>
 		);
 
-		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
-
 		acceptDialog(
 			message,
-			isJetpackIncluded
+			this.isJetpackSelected
 				? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
 				: ( accepted ) => this.removeSelected( accepted, selectedPlugins ),
 			translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } )
@@ -558,6 +646,10 @@ export class PluginsList extends Component {
 					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
 					removePluginNotice={ () => this.removePluginDialog() }
 					setSelectionState={ this.setBulkSelectionState }
+					activatePluginNotice={ () => this.bulkActionDialog( 'activate' ) }
+					deactivatePluginNotice={ () => this.bulkActionDialog( 'deactivate' ) }
+					autoupdateEnablePluginNotice={ () => this.bulkActionDialog( 'enableAutoupdates' ) }
+					autoupdateDisablePluginNotice={ () => this.bulkActionDialog( 'disableAutoupdates' ) }
 					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
 					haveInactiveSelected={ this.props.plugins.some(
 						this.filterSelection.inactive.bind( this )


### PR DESCRIPTION
Adding warning notice modals for bulk actions in the Edit All view when managing multiple plugins

#### Proposed Changes

* Adding a modal with a warning notice whenever bulk actions are being done using the Edit All view when managing plugins.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
