### PR TITLE
Add bulk action warning notices

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -199,11 +199,7 @@ export class PluginsListHeader extends PureComponent {
 					compact
 					key="plugin-list-header__buttons-deactivate"
 					disabled={ isWpcom ? ! this.props.haveActiveSelected : ! this.hasSelectedPlugins() }
-					onClick={
-						isJetpackSelected
-							? this.props.deactiveAndDisconnectSelected
-							: this.props.deactivatePluginNotice
-					}
+					onClick={ this.props.deactivatePluginNotice }
 				>
 					{ translate( 'Deactivate' ) }
 				</Button>
@@ -338,11 +334,7 @@ export class PluginsListHeader extends PureComponent {
 				{ isJetpackOnlySelected && (
 					<SelectDropdown.Item
 						disabled={ isWpcom ? ! this.props.haveActiveSelected : ! this.hasSelectedPlugins() }
-						onClick={
-							isJetpackSelected
-								? this.props.deactiveAndDisconnectSelected
-								: this.props.deactivatePluginNotice
-						}
+						onClick={ this.props.deactivatePluginNotice }
 					>
 						{ translate( 'Deactivate' ) }
 					</SelectDropdown.Item>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -54,6 +54,7 @@ export class PluginsListHeader extends PureComponent {
 		deactivatePluginNotice: PropTypes.func.isRequired,
 		autoupdateEnablePluginNotice: PropTypes.func.isRequired,
 		autoupdateDisablePluginNotice: PropTypes.func.isRequired,
+		updatePluginNotice: PropTypes.func.isRequired,
 		haveActiveSelected: PropTypes.bool,
 		haveInactiveSelected: PropTypes.bool,
 		plugins: PropTypes.array.isRequired,
@@ -168,7 +169,7 @@ export class PluginsListHeader extends PureComponent {
 					compact
 					disabled={ isWpcom ? ! this.props.haveUpdatesSelected : ! this.hasSelectedPlugins() }
 					primary={ isWpcom }
-					onClick={ this.props.updateSelected }
+					onClick={ this.props.updatePluginNotice }
 				>
 					{ ! isWpcom ? translate( 'Update Plugins' ) : translate( 'Update' ) }
 				</Button>
@@ -320,7 +321,7 @@ export class PluginsListHeader extends PureComponent {
 
 				<SelectDropdown.Item
 					disabled={ isWpcom ? ! this.props.haveUpdatesSelected : ! this.hasSelectedPlugins() }
-					onClick={ this.props.updateSelected }
+					onClick={ this.props.updatePluginNotice }
 				>
 					{ ! isWpcom ? translate( 'Update Plugins' ) : translate( 'Update' ) }
 				</SelectDropdown.Item>
@@ -329,7 +330,7 @@ export class PluginsListHeader extends PureComponent {
 				{ isJetpackOnlySelected && (
 					<SelectDropdown.Item
 						disabled={ isWpcom ? ! this.props.haveInactiveSelected : ! this.hasSelectedPlugins() }
-						onClick={ this.props.activateSelected }
+						onClick={ this.props.activatePluginNotice }
 					>
 						{ translate( 'Activate' ) }
 					</SelectDropdown.Item>
@@ -340,7 +341,7 @@ export class PluginsListHeader extends PureComponent {
 						onClick={
 							isJetpackSelected
 								? this.props.deactiveAndDisconnectSelected
-								: this.props.deactivateSelected
+								: this.props.deactivatePluginNotice
 						}
 					>
 						{ translate( 'Deactivate' ) }
@@ -351,14 +352,14 @@ export class PluginsListHeader extends PureComponent {
 
 				<SelectDropdown.Item
 					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
-					onClick={ this.props.setAutoupdateSelected }
+					onClick={ this.props.autoupdateEnablePluginNotice }
 				>
 					{ translate( 'Autoupdate' ) }
 				</SelectDropdown.Item>
 
 				<SelectDropdown.Item
 					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
-					onClick={ this.props.unsetAutoupdateSelected }
+					onClick={ this.props.autoupdateDisablePluginNotice }
 				>
 					{ ! isWpcom ? translate( 'Disable' ) : translate( 'Disable Autoupdates' ) }
 				</SelectDropdown.Item>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -50,6 +50,10 @@ export class PluginsListHeader extends PureComponent {
 		setSelectionState: PropTypes.func.isRequired,
 		unsetAutoupdateSelected: PropTypes.func.isRequired,
 		removePluginNotice: PropTypes.func.isRequired,
+		activatePluginNotice: PropTypes.func.isRequired,
+		deactivatePluginNotice: PropTypes.func.isRequired,
+		autoupdateEnablePluginNotice: PropTypes.func.isRequired,
+		autoupdateDisablePluginNotice: PropTypes.func.isRequired,
 		haveActiveSelected: PropTypes.bool,
 		haveInactiveSelected: PropTypes.bool,
 		plugins: PropTypes.array.isRequired,
@@ -182,7 +186,7 @@ export class PluginsListHeader extends PureComponent {
 				<Button
 					key="plugin-list-header__buttons-activate"
 					disabled={ isWpcom ? ! this.props.haveInactiveSelected : ! this.hasSelectedPlugins() }
-					onClick={ this.props.activateSelected }
+					onClick={ this.props.activatePluginNotice }
 					compact
 				>
 					{ translate( 'Activate' ) }
@@ -197,7 +201,7 @@ export class PluginsListHeader extends PureComponent {
 					onClick={
 						isJetpackSelected
 							? this.props.deactiveAndDisconnectSelected
-							: this.props.deactivateSelected
+							: this.props.deactivatePluginNotice
 					}
 				>
 					{ translate( 'Deactivate' ) }
@@ -217,7 +221,7 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-autoupdate-on"
 					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					compact
-					onClick={ this.props.setAutoupdateSelected }
+					onClick={ this.props.autoupdateEnablePluginNotice }
 				>
 					{ translate( 'Autoupdate' ) }
 				</Button>
@@ -227,7 +231,7 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-autoupdate-off"
 					disabled={ isWpcom ? ! this.canUpdatePlugins() : ! this.hasSelectedPlugins() }
 					compact
-					onClick={ this.props.unsetAutoupdateSelected }
+					onClick={ this.props.autoupdateDisablePluginNotice }
 				>
 					{ ! isWpcom ? translate( 'Disable' ) : translate( 'Disable Autoupdates' ) }
 				</Button>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -366,7 +366,6 @@ export class PluginsList extends Component {
 					{
 						components: {
 							em: <em />,
-							p: <p />,
 						},
 						args: {
 							actionText: actionText,
@@ -383,7 +382,6 @@ export class PluginsList extends Component {
 					{
 						components: {
 							em: <em />,
-							p: <p />,
 						},
 						args: {
 							actionText: actionText,
@@ -400,7 +398,6 @@ export class PluginsList extends Component {
 					{
 						components: {
 							em: <em />,
-							p: <p />,
 						},
 						args: {
 							actionText: actionText,
@@ -417,7 +414,6 @@ export class PluginsList extends Component {
 					{
 						components: {
 							em: <em />,
-							p: <p />,
 						},
 						args: {
 							actionText: actionText,
@@ -434,8 +430,13 @@ export class PluginsList extends Component {
 		const { plugins, translate } = this.props;
 		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
 		const pluginsCount = selectedPlugins.length;
-		const pluginsSize = pluginsCount === 1 ? 'plugin' : 'plugins';
+
 		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
+
+		const translationArgs = {
+			args: { pluginsCount },
+			count: pluginsCount,
+		};
 
 		switch ( actionName ) {
 			case 'activate':
@@ -444,12 +445,11 @@ export class PluginsList extends Component {
 						<span>{ this.getConfirmationText( selectedPlugins, 'activate', 'on' ) }</span>
 					</div>,
 					( accepted ) => this.activateSelected( accepted ),
-					translate( 'Activate %(numberOfPlugins)d %(plugins)s', {
-						args: {
-							numberOfPlugins: pluginsCount,
-							plugins: pluginsSize,
-						},
-					} )
+					translate(
+						'Activate %(pluginsCount)d plugin',
+						'Activate %(pluginsCount)d plugins',
+						translationArgs
+					)
 				);
 				break;
 			case 'deactivate':
@@ -460,12 +460,11 @@ export class PluginsList extends Component {
 					isJetpackIncluded
 						? ( accepted ) => this.deactiveAndDisconnectSelected( accepted )
 						: ( accepted ) => this.deactivateSelected( accepted ),
-					translate( 'Deactivate %(numberOfPlugins)d %(plugins)s', {
-						args: {
-							numberOfPlugins: pluginsCount,
-							plugins: pluginsSize,
-						},
-					} )
+					translate(
+						'Deactivate %(pluginsCount)d plugin',
+						'Deactivate %(pluginsCount)d plugins',
+						translationArgs
+					)
 				);
 				break;
 			case 'enableAutoupdates':
@@ -476,12 +475,11 @@ export class PluginsList extends Component {
 						</span>
 					</div>,
 					( accepted ) => this.setAutoupdateSelected( accepted ),
-					translate( 'Enable autoupdates for %(numberOfPlugins)d %(plugins)s', {
-						args: {
-							numberOfPlugins: pluginsCount,
-							plugins: pluginsSize,
-						},
-					} )
+					translate(
+						'Enable autoupdates for %(pluginsCount)d plugin',
+						'Enable autoupdates for %(pluginsCount)d plugins',
+						translationArgs
+					)
 				);
 				break;
 			case 'disableAutoupdates':
@@ -492,12 +490,11 @@ export class PluginsList extends Component {
 						</span>
 					</div>,
 					( accepted ) => this.unsetAutoupdateSelected( accepted ),
-					translate( 'Disable autoupdates for %(numberOfPlugins)d %(plugins)s', {
-						args: {
-							numberOfPlugins: pluginsCount,
-							plugins: pluginsSize,
-						},
-					} )
+					translate(
+						'Disable autoupdates for %(pluginsCount)d plugin',
+						'Disable autoupdates for %(pluginsCount)d plugins',
+						translationArgs
+					)
 				);
 				break;
 			case 'update':
@@ -506,12 +503,11 @@ export class PluginsList extends Component {
 						<span>{ this.getConfirmationText( selectedPlugins, 'update', 'on' ) }</span>
 					</div>,
 					( accepted ) => this.updateSelected( accepted ),
-					translate( 'Update %(numberOfPlugins)d %(plugins)s', {
-						args: {
-							numberOfPlugins: pluginsCount,
-							plugins: pluginsSize,
-						},
-					} )
+					translate(
+						'Update %(pluginsCount)d plugin',
+						'Update %(pluginsCount)d plugins',
+						translationArgs
+					)
 				);
 		}
 	};

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -301,19 +301,21 @@ export class PluginsList extends Component {
 		}
 	};
 
-	deactiveAndDisconnectSelected = () => {
-		let waitForDeactivate = false;
+	deactiveAndDisconnectSelected = ( accepted ) => {
+		if ( accepted ) {
+			let waitForDeactivate = false;
 
-		this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
-			waitForDeactivate = true;
-			this.props.deactivatePlugin( site, plugin );
-		} );
+			this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
+				waitForDeactivate = true;
+				this.props.deactivatePlugin( site, plugin );
+			} );
 
-		if ( waitForDeactivate && this.props.selectedSite ) {
-			this.setState( { disconnectJetpackNotice: true } );
+			if ( waitForDeactivate && this.props.selectedSite ) {
+				this.setState( { disconnectJetpackNotice: true } );
+			}
+
+			this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
 		}
-
-		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
 	};
 
 	setAutoupdateSelected = ( accepted ) => {
@@ -433,6 +435,7 @@ export class PluginsList extends Component {
 		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
 		const pluginsCount = selectedPlugins.length;
 		const pluginsSize = pluginsCount === 1 ? 'plugin' : 'plugins';
+		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
 
 		switch ( actionName ) {
 			case 'activate':
@@ -454,7 +457,9 @@ export class PluginsList extends Component {
 					<div>
 						<span>{ this.getConfirmationText( selectedPlugins, 'deactivate', 'on' ) }</span>
 					</div>,
-					( accepted ) => this.deactivateSelected( accepted ),
+					isJetpackIncluded
+						? ( accepted ) => this.deactiveAndDisconnectSelected( accepted )
+						: ( accepted ) => this.deactivateSelected( accepted ),
 					translate( 'Deactivate %(numberOfPlugins)d %(plugins)s', {
 						args: {
 							numberOfPlugins: pluginsCount,


### PR DESCRIPTION
Adding warning notice modals for bulk actions in the Edit All view when managing multiple plugins

#### Proposed Changes

* Adding a modal with a warning notice whenever bulk actions are being done using the Edit All view when managing plugins.

**Screenshots**

![image](https://user-images.githubusercontent.com/1749918/188801259-58cb265e-dd3f-43c4-8eee-e63a60fbd8a8.png)

![image](https://user-images.githubusercontent.com/1749918/188800867-ca226ade-ccc4-458f-b701-54065ae5bc34.png)

![image](https://user-images.githubusercontent.com/1749918/188800906-bddd2a43-bc21-4872-93c8-8512047f1361.png)

![image](https://user-images.githubusercontent.com/1749918/188800944-daf5171d-cdee-48e8-8397-35b48b8fee02.png)

![image](https://user-images.githubusercontent.com/1749918/188800977-7a0b34fc-d0e2-487c-8fd0-bf0aa3220cd0.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and run `yarn start` and `yarn start-jetpack-cloud-p`
* Navigate to the plugins management page at `http://calypso.localhost:3000/plugins/active` and `http://jetpack.cloud.localhost:3001/plugins/active` and verify the following actions produce a warning modal
* Verify the modal is shown for each bulk action condition (Update, Activate, Deactivate, Enable Autoupdates, Disable Autoupdates) on a single site for both 1 plugin and multiple plugins. 
* Verify the modal is shown when managing the same bulk actions across multiple sites for 1 plugin and multiple plugins.
* Verify the modal text for each condition is correct

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
