### PR TITLE
Theme Showcase: Detect when a WooCommerce theme is included in plan

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -277,7 +277,7 @@ export class Theme extends Component {
 		const isUsableBundledTheme =
 			doesThemeBundleSoftwareSet && hasPremiumThemesFeature && isSiteEligibleForBundledSoftware;
 
-		if ( didPurchaseTheme && ! hasPremiumThemesFeature ) {
+		if ( didPurchaseTheme && ! isUsablePremiumTheme && ! isUsableBundledTheme ) {
 			return translate( 'You have purchased an annual subscription for this theme' );
 		} else if ( isUsablePremiumTheme ) {
 			return translate( 'The premium theme is included in your plan.' );


### PR DESCRIPTION
#### Proposed Changes

* Update the popover text in the theme showcase to reflect the new rules around bundled themes
  * Business plan = Access to premium+bundled themes, Premium plan = Access to premium themes but not bundled, Free plan = access to neither
  * Right now it thinks that Premium plan can access bundled themes, which isn't correct

**Before PR: Premium Plan sees Bundled Theme (Incorrect)**
![2022-09-06_15-04](https://user-images.githubusercontent.com/937354/188729638-73b815e2-576a-4f08-bd7c-ed3f16f014d8.png)

**After PR: Premium Plan sees Bundled Theme**
![2022-09-06_15-05](https://user-images.githubusercontent.com/937354/188729708-0bba0735-4466-4562-9e42-54824c7d66fc.png)

**After PR: Business plan sees bundled theme**
![2022-09-06_15-12](https://user-images.githubusercontent.com/937354/188729767-e6e16180-de89-493e-af5a-c19e51ccf981.png)

I realize the star should not be green when premium plan sees bundled theme, but fixing that was going to make this PR too complicated, so that can be a separate step.

#### Testing Instructions

* Use free, premium, and business simple sites
* Ensure the `themes/plugin-bundling` flag is on (use calypso localhost)
* Ensure the `signup/seller-upgrade-modal` flag is on (edit config/development.json or use `?flags=signup/seller-upgrade-modal`
* Visit the theme showcase
* Find baxter (baxter should not be active)
* Move your mouse over the star and check that the tooltip makes sense (free and premium are told they need business, business is told it's included in plan)
* Also check a non-bundled theme, check that the tooltip makes sense (free is told they need premium, premium and business are told it's included in plan)

