### PR TITLE
Domains: Fix missing domain name in availability error notice

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -177,7 +177,7 @@ function UseMyDomain( props ) {
 
 			const availabilityErrorMessage = getAvailabilityErrorMessage( {
 				availabilityData,
-				filteredDomainName,
+				domainName: filteredDomainName,
 				selectedSite,
 			} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes a wrong parameter name when showing the domain availability error message, which led to the domain name not being shown in the error message.

- Before

![Markup on 2022-09-06 at 18:50:35](https://user-images.githubusercontent.com/5324818/188747913-3e08a847-9433-4e64-b700-6004b0b4b527.png)

- After

![Markup on 2022-09-06 at 18:51:16](https://user-images.githubusercontent.com/5324818/188747937-a384a22f-ee3b-45c3-9084-bed332acccef.png)

#### Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select "+ Add a domain > Use a domain I own"
- Type a domain that can't be mapped nor transferred, e.g. `leotaba.blog` (which is mapped to another site)
- Ensure the domain name appears in the error notice as shown in the screenshot above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
