### PR TITLE
Theme showcase: Restrict bundled themes on premium plans

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -23,6 +23,7 @@ import { updateThemes } from 'calypso/state/themes/actions/theme-update';
 import {
 	doesThemeBundleSoftwareSet as getDoesThemeBundleSoftwareSet,
 	isSiteEligibleForBundledSoftware as getIsSiteEligibleForBundledSoftware,
+	isPremiumThemeAvailable as getIsPremiumThemeAvailable,
 } from 'calypso/state/themes/selectors';
 import { isThemePremium as getIsThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
@@ -319,6 +320,7 @@ export class Theme extends Component {
 			isPremiumTheme,
 			didPurchaseTheme,
 			doesThemeBundleSoftwareSet,
+			isPremiumThemeAvailable,
 		} = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
@@ -340,7 +342,7 @@ export class Theme extends Component {
 		 * Only show the Premium badge if we're not already showing the price
 		 * and the theme isn't the active theme.
 		 */
-		const showPremiumBadge = isPremiumTheme && ! themeNeedsPurchase && ! active;
+		const showPremiumBadge = isPremiumTheme && isPremiumThemeAvailable && ! active;
 
 		const themeDescription = decodeEntities( description );
 
@@ -392,7 +394,7 @@ export class Theme extends Component {
 						! isEnabled( 'signup/seller-upgrade-modal' )
 							? 'theme__upsell-icon'
 							: 'theme__upsell-popover',
-						hasPremiumThemesFeature || showPremiumBadge ? 'active' : null
+						isPremiumThemeAvailable || showPremiumBadge ? 'active' : null
 					) }
 					position={ ! isEnabled( 'signup/seller-upgrade-modal' ) ? 'top left' : 'top' }
 				>
@@ -506,6 +508,7 @@ export default connect(
 			isSiteEligibleForBundledSoftware: getIsSiteEligibleForBundledSoftware( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 			didPurchaseTheme: isThemePurchased( state, theme.id, siteId ),
+			isPremiumThemeAvailable: getIsPremiumThemeAvailable( state, theme.id, siteId ),
 		};
 	},
 	{ recordTracksEvent, setThemesBookmark, updateThemes }


### PR DESCRIPTION
#### Proposed Changes

* When viewing the theme showcase on a premium plan, bundled themes will no longer show a green star (because their plan does not grant automatic access to the bundled theme)
  * A bundled theme is a theme that contains software, like woo-on-plans, that requires features ATOMIC and WOO to make the most of.
* The "activate" menu item will now be replaced with "Upgrade to activate"

**AFTER PR: Bundled Theme on Premium Plan**
![2022-09-06_16-43](https://user-images.githubusercontent.com/937354/188748421-e1d73daf-cd6a-4ae6-814a-79eae015250f.png)

**AFTER PR: Bundled Theme on Business Plan**
![2022-09-06_16-44](https://user-images.githubusercontent.com/937354/188748537-22902a08-7e9f-46c4-8b7b-783895527573.png)

#### Testing Instructions


* Use free, premium, and business simple sites
* Ensure the `themes/plugin-bundling` flag is on (use calypso localhost)
* Ensure the `signup/seller-upgrade-modal` flag is on (edit config/development.json or use `?flags=signup/seller-upgrade-modal`
* Visit the theme showcase
* Find baxter (baxter should not be active)
* **Bundled Themes**: Check the star coloring and the options available on the three dot menu
  * Business Plan: Activate, Green star
  * Free+Premium Plans: Upgrade to activate, grey star
* **Non-bundled themes** should continue to act the same:
  * Business+Premium Plans: Activate, Green star
  * Free Plan: Upgrade to activate, grey star



Related to #
