### PR TITLE
Test API for disabling site preview interactions [do not merge]

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -274,9 +274,11 @@ export default class WebPreviewContent extends Component {
 		if ( this.props.previewMarkup ) {
 			debug( 'preview loaded with markup' );
 			this.props.onLoad( this.iframe.contentDocument );
-		} else {
-			debug( 'preview loaded for url:', this.state.iframeUrl );
+			this.setState( { loaded: true, isLoadingSubpage: false } );
+			return;
 		}
+		debug( 'preview loaded for url:', this.state.iframeUrl );
+
 		if ( this.checkForIframeLoadFailure( caller ) ) {
 			debug( `preview not loaded yet, waiting ${ loadingTimeout }ms` );
 			clearTimeout( this.loadingTimeoutTimer );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -5,7 +5,9 @@ import PreviewToolbar from 'calypso/signup/steps/design-picker/preview-toolbar';
 
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
-	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
+	const previewUrl = siteSlug
+		? `https://public-api.wordpress.com/wpcom/v2/web-previews/site/${ siteSlug }`
+		: null;
 	const defaultDevice = 'phone';
 
 	function formatPreviewUrl() {
@@ -13,14 +15,11 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 			return null;
 		}
 
-		return addQueryArgs(
-			`https://public-api.wordpress.com/rest/v1/site-preview/demo/${ siteSlug }`,
-			{
-				iframe: true,
-				// hide the "Create your website with WordPress.com" banner
-				hide_banners: true,
-			}
-		);
+		return addQueryArgs( previewUrl, {
+			iframe: true,
+			// hide the "Create your website with WordPress.com" banner
+			hide_banners: true,
+		} );
 	}
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -13,12 +13,14 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 			return null;
 		}
 
-		return addQueryArgs( previewUrl, {
-			iframe: true,
-			theme_preview: true,
-			// hide the "Create your website with WordPress.com" banner
-			hide_banners: true,
-		} );
+		return addQueryArgs(
+			`https://public-api.wordpress.com/rest/v1/site-preview/demo/${ siteSlug }`,
+			{
+				iframe: true,
+				// hide the "Create your website with WordPress.com" banner
+				hide_banners: true,
+			}
+		);
 	}
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Testing changes to use API that fetches site preview page and disables links/forms/actions etc.

**Will merge after backend changes are merged: D87462-code**

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and run `yarn start`
* Sandbox and setup backend changes following the instructions from: D87462-code
* Load the launchpad page: http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug={SITE_SLUG_HERE}
* Ensure the site preview is loading and that links within the site preview no longer redirect the user.

![image](https://user-images.githubusercontent.com/10482592/188753416-706a0f41-4d2c-4f25-8c3b-08f163266a4d.png)




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66574