### PR TITLE
Stylelint: properly scope all disable comments

### DIFF
--- a/client/assets/stylesheets/_p2-extends.scss
+++ b/client/assets/stylesheets/_p2-extends.scss
@@ -78,7 +78,7 @@
 	background-color: var( --p2-color-button );
 	color: var( --p2-color-text );
 	border: none;
-	border-radius: 50px; /* stylelint-disable-line */
+	border-radius: 50px; /* stylelint-disable-line scales/radii */
 	display: flex;
 	align-items: center;
 	font-family: var( --p2-font-inter );

--- a/client/assets/stylesheets/_videopress-extends.scss
+++ b/client/assets/stylesheets/_videopress-extends.scss
@@ -78,7 +78,7 @@
 	background-color: var( --videopress-color-button );
 	color: var( --videopress-color-text );
 	border: none;
-	border-radius: 50px; /* stylelint-disable-line */
+	border-radius: 50px; /* stylelint-disable-line scales/radii */
 	display: flex;
 	align-items: center;
 	font-family: var( --videopress-font-inter );

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -85,13 +85,11 @@ body.app-banner-is-visible {
 }
 
 .app-banner__title {
-	/* stylelint-disable-next-line */
 	font-size: rem( 22px ); //typography-exception
 	font-family: $brand-serif;
 	line-height: 30px;
 
 	&.jetpack {
-		/* stylelint-disable-next-line */
 		font-size: rem( 28px ); //typography-exception
 		font-weight: bold;
 		max-width: 18em;
@@ -102,11 +100,9 @@ body.app-banner-is-visible {
 
 .app-banner__copy {
 	margin-top: 12px;
-	/* stylelint-disable-next-line */
 	font-size: rem( 15px ); //typography-exception
 
 	&.jetpack {
-		/* stylelint-disable-next-line */
 		font-size: rem( 16px ); //typography-exception
 		line-height: 21px;
 		max-width: 18em;

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -41,7 +41,7 @@ body.app-banner-is-visible {
 .app-banner__circle {
 	position: absolute;
 	border: 2px solid;
-	border-radius: 50%; /* stylelint-disable-line */
+	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	z-index: z-index( 'root', '.app-banner__circle' );
 
 	&.is-blue {
@@ -123,7 +123,7 @@ body.app-banner-is-visible {
 .button.app-banner__open-button {
 	background-color: var( --color-accent-40 );
 	border: 0;
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 	margin-right: 10px;
 
 	&.jetpack {

--- a/client/blocks/import-light/capture/style.scss
+++ b/client/blocks/import-light/capture/style.scss
@@ -1,6 +1,6 @@
 .import-light__capture {
 	.form-label {
-		font-size: 1em; /* stylelint-disable-line */
+		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		font-weight: 500;
 		color: var( --studio-gray-60 );
 

--- a/client/blocks/import-light/summary/style.scss
+++ b/client/blocks/import-light/summary/style.scss
@@ -1,10 +1,10 @@
 .import-light__summary {
 	.onboarding-title {
-		font-size: 3em; /* stylelint-disable-line */
+		font-size: 3em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 
 	.onboarding-subtitle {
-		font-size: 1.125em; /* stylelint-disable-line */
+		font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin-bottom: 1.5em;
 	}
 }

--- a/client/blocks/import/capture-retired/style.scss
+++ b/client/blocks/import/capture-retired/style.scss
@@ -65,7 +65,7 @@ $placeholder-color: #909398;
 		}
 
 		@include break-medium {
-			font-size: 2.75rem; /* stylelint-disable-line */
+			font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
 		}
 
 		&::placeholder {

--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -1,6 +1,6 @@
 .import-light__capture {
 	.form-label {
-		font-size: 1em; /* stylelint-disable-line */
+		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		font-weight: 500;
 		color: var( --studio-gray-60 );
 

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -41,7 +41,7 @@ html[dir='rtl'] {
 		}
 
 		h3 {
-			font-size: 1.125em; /* stylelint-disable-line */
+			font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: var( --studio-gray-90 );
 			margin-bottom: 1em;
 		}
@@ -65,8 +65,8 @@ html[dir='rtl'] {
 
 			a, button {
 				padding: 0;
-				font-size: 0.875em; /* stylelint-disable-line */
-				font-weight: 500; /* stylelint-disable-line */
+				font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 500;
 				line-height: 20px;
 				text-decoration: underline;
 				color: var( --studio-gray-100 );
@@ -79,7 +79,7 @@ html[dir='rtl'] {
 			margin-top: 10px;
 			margin-right: 0;
 			margin-inline-end: 1.5em !important;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 		}
 
 		.list__importers-primary {

--- a/client/blocks/import/ready/style.scss
+++ b/client/blocks/import/ready/style.scss
@@ -16,7 +16,7 @@
 		.import__preview-wrapper {
 			background: var( --studio-white );
 			border: 1px solid rgba( 0, 0, 0, 0.12 );
-			border-radius: 6px; /* stylelint-disable-line */
+			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			overflow: hidden;
 			position: relative;
 
@@ -56,7 +56,7 @@
 			background: var( --studio-gray-5 );
 			width: 4px;
 			height: 4px;
-			border-radius: 50%; /* stylelint-disable-line */
+			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			margin: 0 2px;
 
 			@include break-small {
@@ -77,10 +77,10 @@
 				padding: 2px;
 				margin: 0 auto;
 				font-size: $font-body-extra-small;
-				font-weight: 500; /* stylelint-disable-line */
+				font-weight: 500;
 				line-height: 1.6667em;
 				background: var( --studio-gray-0 );
-				border-radius: 8px; /* stylelint-disable-line */
+				border-radius: 8px; /* stylelint-disable-line scales/radii */
 
 				@include break-small {
 					display: block;
@@ -122,8 +122,8 @@
 
 	.import__details-learn-more {
 		display: inline-block;
-		font-size: 1.125em; /* stylelint-disable-line */
-		font-weight: 500; /* stylelint-disable-line */
+		font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
 		text-decoration: underline;
 		color: var( --studio-gray-100 );
 		margin-bottom: 2em;
@@ -135,18 +135,18 @@
 
 	.import__details-features {
 		p {
-			font-size: 1em; /* stylelint-disable-line */
+			font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 
 		strong {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			color: var( --studio-gray-100 );
 		}
 	}
 
 	.import__details-footer {
-		font-weight: 300; /* stylelint-disable-line */
-		font-size: 0.875em; /* stylelint-disable-line */
+		font-weight: 300; /* stylelint-disable-line scales/font-weights */
+		font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		color: var( --studio-gray-80 );
 	}
 }

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -8,8 +8,8 @@
 .import__onboarding-page {
 	.components-button.action-buttons__next.is-primary {
 		padding: 9px 40px;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		border-radius: 4px;
+		font-weight: 500;
 		line-height: 20px;
 
 		// override unnecessary super specificity added by another class
@@ -48,7 +48,7 @@
 		}
 
 		strong {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			color: var( --studio-gray-100 );
 		}
 
@@ -58,7 +58,7 @@
 		}
 
 		.onboarding-subtitle {
-			font-size: 1.125rem; /* stylelint-disable-line */
+			font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 			line-height: 1.4444em;
 
 			@include break-small {
@@ -80,7 +80,7 @@
 
 		.components-button.action-buttons__back {
 			color: var( --studio-gray-100 );
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 
 			&:hover {
 				color: var( --color-neutral-70 );
@@ -96,8 +96,8 @@
 		.import__heading {
 			.onboarding-title {
 				font-family: var( --font-base, var( --font-base-default ) );
-				font-size: 1.75em; /* stylelint-disable-line */
-				margin-bottom: 0.5em /* stylelint-disable-line */;
+				font-size: 1.75em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				margin-bottom: 0.5em;
 			}
 
 			.onboarding-subtitle {

--- a/client/blocks/import/style/components.scss
+++ b/client/blocks/import/style/components.scss
@@ -24,7 +24,7 @@
 
 	.action-card__main p {
 		color: var( --studio-gray-40 );
-		font-size: 0.875em; /* stylelint-disable-line */
+		font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin-bottom: 0;
 	}
 
@@ -48,21 +48,21 @@
 
 // Modal component
 .components-modal__frame.components-modal-new__frame {
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 
 	p {
-		font-size: 1rem; /* stylelint-disable-line */
+		font-size: 1rem;
 		color: var( --studio-gray-70 );
 		margin-bottom: 1em;
 
 		@include break-small {
-			font-size: 1.125rem; /* stylelint-disable-line */
+			font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 			line-height: 1.4444em;
 		}
 	}
 
 	strong {
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 	}
 
 	.components-modal__content {

--- a/client/blocks/import/style/mixins.scss
+++ b/client/blocks/import/style/mixins.scss
@@ -2,12 +2,12 @@
 
 @mixin onboarding-import-heading-text {
 	@include onboarding-font-recoleta;
-	font-size: 2.25rem; // 36px /* stylelint-disable-line */
-	line-height: 1.0833em; // 52px
+	font-size: 2.25rem; // 36px
+	line-height: 1.0833em; /* stylelint-disable-line declaration-property-unit-allowed-list */ // 52px
 	letter-spacing: 0.2px;
 	color: var( --studio-gray-100 );
 
 	@include break-small {
-		font-size: 3rem; // 48px /* stylelint-disable-line */
+		font-size: 3rem; // 48px
 	}
 }

--- a/client/blocks/importer/components/getting-started-video/style.scss
+++ b/client/blocks/importer/components/getting-started-video/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	strong {
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		color: var( --studio-gray-100 );
 	}
 }

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -20,7 +20,7 @@
 	.onboarding-title {
 		font-family: var( --font-base, var( --font-base-default ) );
 		color: var( --studio-gray-100 );
-		font-size: 1.25rem; /* stylelint-disable-line */
+		font-size: 1.25rem;
 		line-height: 1.5rem;
 		margin-bottom: 1.5rem;
 	}
@@ -118,7 +118,7 @@
 
 		.plan-title {
 			font-weight: 500;
-			font-size: 1.25em; /* stylelint-disable-line */
+			font-size: 1.25em;
 			line-height: 1.25em;
 			color: var( --studio-gray-60 );
 		}
@@ -138,7 +138,7 @@
 		}
 
 		.plan-time-frame {
-			font-size: 0.75em; /* stylelint-disable-line */
+			font-size: 0.75em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: var( --studio-gray-40 );
 		}
 	}

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -19,7 +19,7 @@
 
 		& > a.button {
 			margin: 0 20px;
-			border-radius: 4px; /* stylelint-disable scales/radii */
+			border-radius: 4px;
 		}
 	}
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -334,7 +334,7 @@
 	.login__form label {
 		font-size: var( --p2-font-size-form-xxs );
 		color: var( --p2-color-text );
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		margin-bottom: 0.5em;
 		line-height: 1.8;
 	}
@@ -355,7 +355,7 @@
 	.login__form-header {
 		color: var( --p2-color-text );
 		font-size: var( --p2-font-size-form-xxl );
-		font-weight: 900; /* stylelint-disable-line */
+		font-weight: 900; /* stylelint-disable-line scales/font-weights */
 		text-align: center;
 		line-height: 1.3;
 		margin-top: 0;

--- a/client/blocks/signup-form/p2.scss
+++ b/client/blocks/signup-form/p2.scss
@@ -25,7 +25,7 @@
 
 	.form-label {
 		font-size: var( --p2-font-size-form-xxs );
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		margin-bottom: 0.5em;
 	}
 

--- a/client/components/domains/connect-domain-step/style.scss
+++ b/client/components/domains/connect-domain-step/style.scss
@@ -48,8 +48,8 @@ body.connect-domain-setup__body-white {
 			justify-content: center;
 			align-items: center;
 			margin: 16px 0 0 8px;
-			border-radius: 4px; /* stylelint-disable-line */
-			font-weight: 500; /* stylelint-disable-line */
+			border-radius: 4px;
+			font-weight: 500;
 			font-size: $font-body-extra-small;
 			background: rgba( 220, 220, 222, 0.6 );
 			color: var( --studio-gray-80 );
@@ -62,13 +62,13 @@ body.connect-domain-setup__body-white {
 
 	& &__heading {
 		font-size: $font-title-medium;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		margin: 0 0 16px;
 	}
 
 	& &__sub-heading {
 		font-size: $font-title-small;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 
 		&-icon {
 			fill: var( --color-text );
@@ -148,7 +148,7 @@ body.connect-domain-setup__body-white {
 			font-size: $font-body-small;
 			color: var( --color-text-subtle );
 			box-sizing: border-box;
-			border-radius: 50%; /* stylelint-disable-line */
+			border-radius: 50%;
 			flex-shrink: 0;
 
 			&.current-step {
@@ -171,7 +171,7 @@ body.connect-domain-setup__body-white {
 
 		&-step-name {
 			font-size: $font-body-small;
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			color: var( --color-text-subtle );
 			margin-left: 8px;
 			position: relative;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -74,7 +74,7 @@
 
 	.domain-product-price__free-price {
 		color: var( --studio-green-60 );
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		font-size: $font-body-small;
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -33,16 +33,16 @@
 		}
 
 		.domain-registration-suggestion__domain-title-tld {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			color: var( --studio-gray-90 );
 		}
 	}
 
 	.badge {
 		margin-left: 0;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		font-size: 0.75rem;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		margin-right: 4px;
 
 		&.badge--warning {
@@ -325,9 +325,9 @@ body.is-section-signup.is-white-signup {
 		margin-bottom: 10px;
 
 		.badge {
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			font-size: 0.75rem;
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			white-space: nowrap;
 		}
 
@@ -410,7 +410,7 @@ body.is-section-signup.is-white-signup {
 			letter-spacing: 0.2px;
 
 			@include break-mobile {
-				font-weight: 500; /* stylelint-disable-line */
+				font-weight: 500;
 			}
 		}
 
@@ -430,7 +430,7 @@ body.is-section-signup.is-white-signup {
 				}
 
 				.domain-registration-suggestion__domain-title-tld {
-					font-weight: 500; /* stylelint-disable-line */
+					font-weight: 500;
 				}
 			}
 
@@ -451,8 +451,8 @@ body.is-section-signup.is-white-signup {
 				height: auto;
 				line-height: 20px;
 				padding: 0.57em 1.17em;
-				font-weight: 500; /* stylelint-disable-line */
-				border-radius: 4px; /* stylelint-disable-line */
+				font-weight: 500;
+				border-radius: 4px;
 				box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 				border: 1px solid #c3c4c7;
 				letter-spacing: 0.32px;

--- a/client/components/domains/domain-transfer-recommendation/style.scss
+++ b/client/components/domains/domain-transfer-recommendation/style.scss
@@ -21,9 +21,9 @@
 
 	.badge {
 		margin-left: 0.8em;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		font-size: $font-body-extra-small;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		position: relative;
 		bottom: 2px;
 	}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -173,7 +173,7 @@
 
 body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion.card {
 	border: none;
-	border-radius: 0; /* stylelint-disable-line */
+	border-radius: 0; /* stylelint-disable-line scales/radii */
 	margin: 0;
 	align-items: center;
 	background: #ffffff;
@@ -181,7 +181,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	padding: 16px 20px;
 
 	@include break-mobile {
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		margin-bottom: 12px;
 		box-sizing: border-box;
 		border: 1px solid #e2e4e7;
@@ -198,9 +198,9 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	}
 
 	.button.domain-suggestion__action {
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		padding: 0.57em 1.17em;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 		font-size: 0.875rem;
 		height: auto;
@@ -212,11 +212,11 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	}
 
 	.domain-registration-suggestion__domain-title {
-		font-size: 1.375rem; /* stylelint-disable-line */
+		font-size: 1.375rem; /* stylelint-disable-line scales/font-sizes */
 		line-height: 30px;
 
 		@include break-mobile {
-			font-size: 1.625rem; /* stylelint-disable-line */
+			font-size: 1.625rem; /* stylelint-disable-line scales/font-sizes */
 		}
 	}
 
@@ -247,12 +247,12 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	&.featured-domain-suggestion--is-placeholder {
 		margin-bottom: 1px;
 		margin-top: 0;
-		border-radius: 0; /* stylelint-disable-line */
+		border-radius: 0; /* stylelint-disable-line scales/radii */
 		border-bottom: none;
 
 		@include break-mobile {
 			margin-bottom: 12px;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			border: none;
 		}
 	}
@@ -275,19 +275,19 @@ body.is-section-signup.is-white-signup .featured-domain-suggestions {
 @include breakpoint-deprecated( '>660px' ) {
 	.domain-registration-suggestion__title {
 		.featured-domain-suggestions--title-in-18em & {
-			font-size: 1.8em; /* stylelint-disable-line */
+			font-size: 1.8em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 		.featured-domain-suggestions--title-in-16em & {
-			font-size: 1.6em; /* stylelint-disable-line */
+			font-size: 1.6em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 		.featured-domain-suggestions--title-in-14em & {
 			font-size: $font-title-small;
 		}
 		.featured-domain-suggestions--title-in-12em & {
-			font-size: 1.2em; /* stylelint-disable-line */
+			font-size: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 		.featured-domain-suggestions--title-in-10em & {
-			font-size: 1em; /* stylelint-disable-line */
+			font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		}
 	}
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -60,12 +60,12 @@
 
 	.search-component {
 		border: 1px solid var( --color-border-subtle );
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 	}
 
 	.search-component.is-open {
 		border: 1px solid #a7aaad;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		height: 48px;
 	}
 
@@ -217,7 +217,7 @@
 
 button.register-domain-step__next-page-button {
 	font-size: 0.875rem;
-	font-weight: 500; /* stylelint-disable-line */
+	font-weight: 500;
 }
 
 body.is-section-domains {
@@ -259,7 +259,7 @@ body.is-section-signup.is-white-signup {
 
 		button.register-domain-step__next-page-button {
 			padding: 0.57em 1.17em;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 
 			letter-spacing: 0.32px;
 			line-height: 1.25rem;

--- a/client/components/domains/reskin-side-explainer/style.scss
+++ b/client/components/domains/reskin-side-explainer/style.scss
@@ -33,7 +33,7 @@
         .reskin-side-explainer__cta-text {
             text-decoration: underline;
             cursor: pointer;
-            font-weight: 500; /* stylelint-disable-line */
+            font-weight: 500;
         }
     }
 	.is-loading {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -25,7 +25,7 @@
 		background-color: var( --studio-white );
 
 		border: 1px solid var( --color-neutral-20 );
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 
 		&.is-borderless {
 			&:hover,
@@ -213,13 +213,13 @@ body.is-section-signup.is-white-signup {
 		margin-left: 1em;
 		background: #fdfdfd;
 		border: 1px solid #d5d5d7;
-		border-radius: 4px; /* stylelint-disable-line */
-		font-weight: 500; /* stylelint-disable-line */
+		border-radius: 4px;
+		font-weight: 500;
 		color: var( --studio-gray-60 );
 
 		&.is-active {
 			background: initial;
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			border-color: var( --studio-gray-50 );
 			color: #2b2d2f;
 		}

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -48,14 +48,14 @@
 				}
 
 				h2 {
-					font-weight: 500; /* stylelint-disable-line */
+					font-weight: 500;
 					font-size: $font-title-small;
 				}
 
 				.badge {
-					border-radius: 4px; /* stylelint-disable-line */
+					border-radius: 4px;
 					font-size: $font-body-extra-small;
-					font-weight: 500; /* stylelint-disable-line */
+					font-weight: 500;
 					margin-top: 8px;
 
 					@include break-mobile {
@@ -109,7 +109,7 @@
 					font-size: $font-body-small;
 
 					&-text {
-						font-weight: 500; /* stylelint-disable-line */
+						font-weight: 500;
 						color: var( --color-text );
 
 						&.is-free {
@@ -131,8 +131,8 @@
 
 							.badge {
 								font-size: $font-body-extra-small;
-								font-weight: 500; /* stylelint-disable-line */
-								border-radius: 4px; /* stylelint-disable-line */
+								font-weight: 500;
+								border-radius: 4px;
 								margin: 0 0 0 4px;
 							}
 						}

--- a/client/components/emails/email-product-price/style.scss
+++ b/client/components/emails/email-product-price/style.scss
@@ -48,7 +48,7 @@
 		color: var( --studio-green-60 );
 
 		@include break-mobile {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 		}
 	}
 

--- a/client/components/emails/email-signup-titan-card/style.scss
+++ b/client/components/emails/email-signup-titan-card/style.scss
@@ -32,7 +32,7 @@
 }
 
 .email-signup-titan-card__title {
-	font-size: 1.375rem; /* stylelint-disable-line */
+	font-size: 1.375rem; /* stylelint-disable-line scales/font-sizes */
 	line-height: 30px;
 	max-width: 100%;
 	padding-right: 0.2em;
@@ -40,7 +40,7 @@
 	word-break: break-all;
 
 	@include break-mobile {
-		font-size: 1.625rem; /* stylelint-disable-line */
+		font-size: 1.625rem; /* stylelint-disable-line scales/font-sizes */
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
@@ -85,7 +85,7 @@ body.is-section-signup.is-white-signup {
 
 		@include break-mobile {
 			border: 1px solid #e2e4e7;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			margin: 0 20px;
 		}
 
@@ -113,10 +113,10 @@ body.is-section-signup.is-white-signup {
 
 		.email-signup-titan-card__suggestion-action {
 			border: 1px solid #c3c4c7;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 			font-size: 0.875rem;
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			padding: 0.57em 1.17em;
 			width: 100%;
 

--- a/client/components/happychat/button.scss
+++ b/client/components/happychat/button.scss
@@ -5,7 +5,7 @@
 	z-index: z-index( 'root', '.floating-help' );
 	line-height: 0;
 	padding: 1px;
-	border-radius: 100%; /* stylelint-disable-line */
+	border-radius: 100%; /* stylelint-disable-line scales/radii */
 	background: var( --color-primary );
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
 

--- a/client/components/happychat/timeline.scss
+++ b/client/components/happychat/timeline.scss
@@ -31,7 +31,7 @@
 	font-size: $font-body-small;
 	flex: 1;
 	padding: 8px 12px;
-	border-radius: 8px 8px 8px 0; /* stylelint-disable-line */
+	border-radius: 8px 8px 8px 0; /* stylelint-disable-line scales/radii */
 	color: var( --color-neutral-70 );
 	background: var( --color-surface );
 	position: relative;
@@ -70,7 +70,7 @@
 	.is-user-message & {
 		color: var( --color-primary-dark );
 		background: var( --color-primary-5 );
-		border-radius: 8px 8px 0; /* stylelint-disable-line */
+		border-radius: 8px 8px 0; /* stylelint-disable-line scales/radii */
 
 		&::after {
 			left: auto;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -106,7 +106,7 @@
 	&__no-savings {
 		display: inline-block;
 		margin-block-start: 24px;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
 		padding: 4px 8px;
 
 		font-size: $font-body-small;

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -81,7 +81,7 @@
 				color: white;
 				background-color: var( --studio-jetpack-green-40 );
 				text-align: center;
-				border-radius: 50%; /* stylelint-disable-line */
+				border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 				font-size: $font-title-small;
 				font-weight: 600;
 				width: rem( 32px );

--- a/client/components/jetpack/licensing-activation/style.scss
+++ b/client/components/jetpack/licensing-activation/style.scss
@@ -60,7 +60,7 @@
 	display: flex;
 	flex-direction: column;
 	padding: 0;
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 	box-shadow: 0 0 40px 0 #00000014;
 
 	width: 100%;

--- a/client/components/plans/plan-pill/style.scss
+++ b/client/components/plans/plan-pill/style.scss
@@ -24,6 +24,6 @@
 	left: unset;
 	text-transform: none;
 	padding: 4px 10px;
-	border-radius: 10px; /* stylelint-disable-line */
+	border-radius: 10px; /* stylelint-disable-line scales/radii */
 	background-color: var( --color-neutral-100 );
 }

--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -18,7 +18,7 @@ $screen-options-icon-border-y: 7px;
 
 .screen-options-tab__button {
 	border: 1px solid var( --color-neutral-5 );
-	border-radius: 0 0 4px 4px; /* stylelint-disable-line */
+	border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
 	background-color: #ffffff;
 	font-size: $default-font-size;
 	padding: 3px 16px;
@@ -77,7 +77,7 @@ $screen-options-icon-border-y: 7px;
 	background-color: #ffffff;
 	box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.1 );
 	width: 215px;
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 }
 
 /*
@@ -98,7 +98,7 @@ $screen-options-icon-border-y: 7px;
 .screen-switcher__button,
 a.screen-switcher__button {
 	cursor: pointer;
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 	padding: 8px;
 	text-align: left;
 	border: 1px solid transparent;
@@ -110,7 +110,7 @@ a.screen-switcher__button {
 	// When the user sees this component they are going to be in Calypso
 	// so it's safe to assume the Calypso option is always going to be active.
 	&:first-child {
-		margin-bottom: 4px; /* stylelint-disable-line */
+		margin-bottom: 4px;
 		border-color: var( --color-accent );
 	}
 

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -22,7 +22,7 @@
 .facebook-share-preview__title {
 	color: #1d2129;
 	font-family: Georgia, serif;
-	font-size: 18px; /* stylelint-disable-line */
+	font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	font-weight: 600;
 	line-height: 22px;
 	max-height: 100px;
@@ -161,7 +161,7 @@
 .twitter-share-preview__body {
 	padding: 0.75em;
 	text-decoration: none;
-	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: $font-body-small;
 	color: black;
 	text-align: left;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -232,7 +232,7 @@
 	.videos-ui__button,
 	.videos-ui__button:visited {
 		border: 0;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
 		color: #101517;
 		padding: 10px 28px;
 		span {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -223,7 +223,7 @@
 	inset-inline-end: 42px;
 	inset-block-start: 50%;
 	transform: translateY( -50% );
-	border-radius: 50%; /* stylelint-disable-line */
+	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	border-width: 2px;
 	border-style: solid;
 	width: 24px;

--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/style.scss
@@ -31,7 +31,7 @@
 .add-stored-credit-card__title {
 	display: flex;
 	align-items: center;
-	font-size: 1.125rem; /* stylelint-disable-line */
+	font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 	color: var( --studio-gray-100 );
 
 	span {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -29,7 +29,7 @@
         width: 20px;
         height: 20px;
         display: flex;
-        border-radius: 50%; /* stylelint-disable */
+        border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
         justify-content: center;
         align-content: center;
         align-items: center;

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/style.scss
@@ -53,7 +53,7 @@
 	&__input-field label {
 		display: block;
 		margin-bottom: 0.5rem;
-		font-size: 1.125rem; /* stylelint-disable-line */
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		font-weight: 400;
 		color: var( --studio-gray-80 );
 	}

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -62,7 +62,7 @@
 	width: 20px;
 	height: 20px;
 	border: 2px solid var( --studio-black );
-	border-radius: 12px; /* stylelint-disable-line */
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
 	text-align: center;
 
 	@include license-product-card-block__radio;

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/style.scss
@@ -27,7 +27,7 @@
 	&__heading {
 		margin: -16px -16px 16px;
 		padding: 9px 16px;
-		font-size: 1.125rem; /* stylelint-disable */
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		font-weight: 600;
 		line-height: 20px;
 		border-bottom: 1px solid var( --studio-gray-5 );

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/style.scss
@@ -74,7 +74,7 @@
 	&__heading {
 		margin: -16px -16px 16px;
 		padding: 24px;
-		font-size: 1.125rem; /* stylelint-disable */
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		font-weight: 600;
 		line-height: 20px;
 		color: var( --studio-gray-60 );

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
@@ -88,7 +88,7 @@
 }
 
 .stored-credit-card__name {
-	font-size: 1.125rem; /* stylelint-disable-line */
+	font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 	color: var( --studio-gray-80 );
 	margin-bottom: 1rem;
 }

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/style.scss
@@ -74,7 +74,7 @@
 	&__heading {
 		margin: -16px -16px 16px;
 		padding: 24px;
-		font-size: 1.125rem; /* stylelint-disable */
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		font-weight: 600;
 		line-height: 20px;
 		color: var( --studio-gray-60 );

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -34,7 +34,7 @@
 
 			color: var( --color-text );
 
-			font-size: rem( 21px ); /* stylelint-disable declaration-property-unit-allowed-list */
+			font-size: rem( 21px ); /* stylelint-disable-line declaration-property-unit-allowed-list */
 
 			@include break-medium {
 				margin: 1.5rem 0 40px;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -29,7 +29,7 @@
 	border: 1px solid var( --color-accent );
 	border-radius: var( --jetpack-corners-soft );
 	box-sizing: border-box;
-	font-weight: 500; /* stylelint-disable-line scales/font-weights */
+	font-weight: 500;
 	transition: background-color 0.1s;
 
 	&:hover {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -123,7 +123,6 @@ button {
 
 			.flow-progress-indicator {
 				font-weight: 500;
-				/* stylelint-disable-line */
 				font-size: 0.875rem;
 				color: var( --studio-gray-30 );
 			}
@@ -165,7 +164,7 @@ button {
 			border-radius: 4px;
 
 			&.site-icon-with-picker__upload-button {
-				border-radius: 50%; /* stylelint-disable-line */
+				border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 				font-family: 'SF Pro Text', $sans;
 				transition: ease 300ms;
 				border: 1px solid var( --studio-gray-10 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -66,14 +66,14 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				@include onboarding-font-recoleta;
 				color: $gray-100;
 				letter-spacing: 0.2px;
-				font-size: 2.15rem; /* stylelint-disable-line */
+				font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
 				font-weight: 400;
 				padding: 0;
 				text-align: start;
 				margin: 0;
 
 				@include break-xlarge {
-					font-size: 2.75rem; /* stylelint-disable-line */
+					font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.scss
@@ -15,7 +15,6 @@
 		font-family: 'Inter';
 		font-style: normal;
 		font-weight: 500;
-		/* stylelint-disable scales/font-weights */
 		font-display: swap;
 		src: url('https://s0.wp.com/i/fonts/inter/Inter-Medium.woff2?v=3.19') format('woff2'),
 			url('https://s0.wp.com/i/fonts/inter/Inter-Medium.woff?v=3.19') format('woff');

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -181,7 +181,7 @@
 		background: none;
 		color: #101517;
 		text-decoration: underline;
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		text-align: start;
 
 		@include break-small {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -35,13 +35,13 @@
 		@include onboarding-font-recoleta;
 		color: var( --studio-gray-100 );
 		letter-spacing: 0.2px;
-		font-size: 2.15rem; /* stylelint-disable-line */
+		font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
 		font-weight: 400;
 		padding: 0;
 		margin: 0;
 
 		@include break-xlarge {
-			font-size: 2.75rem; /* stylelint-disable-line */
+			font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -40,9 +40,9 @@
 			.form-label {
 				line-height: 1.5;
 				margin-bottom: 8px;
-				font-weight: 500; /* stylelint-disable-line scales/font-weights */
+				font-weight: 500;
 				color: var( --studio-gray-60 );
-				border-radius: 4px; /* stylelint-disable-line scales/radii */
+				border-radius: 4px;
 
 				.form-label__optional {
 					font-size: inherit;
@@ -66,7 +66,7 @@
 			input.form-text-input {
 				height: 44px;
 				line-height: 44px;
-				border-radius: 4px; /* stylelint-disable-line scales/radii */
+				border-radius: 4px;
 
 				&:focus,
 				&:focus:hover {
@@ -100,8 +100,8 @@
 
 	.button.site-options__submit-button.is-primary {
 		padding: 9px 48px;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		border-radius: 4px;
+		font-weight: 500;
 
 		// override unnecessary super specificity added by another class
 		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -168,7 +168,6 @@ body {
 		text-shadow: none !important;
 	}
 
-	/* stylelint-disable selector-max-id */
 	#notices,
 	.environment-badge,
 	.community-translator,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -326,10 +326,10 @@ $image-height: 47px;
 		background-color: #117ac9;
 		border-color: #0e64a5;
 		color: var( --color-text-inverted );
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		box-shadow: none;
 		border: 0;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		letter-spacing: 0.32px;
 		line-height: 17px;
 		min-width: 100%;
@@ -361,7 +361,7 @@ $image-height: 47px;
 		button {
 			/* Note: Same as `button.signup-form__submit, .signup-form__input.form-text-input` */
 			height: 44px;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			border: 1px solid var( --studio-gray-10 );
 			font-size: $font-body-small;
 
@@ -400,14 +400,14 @@ $image-height: 47px;
 		text-overflow: ellipsis;
 		text-decoration: none;
 		box-sizing: border-box;
-		font-size: 14px; /* stylelint-disable-line */
+		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		-webkit-appearance: none;
 		-moz-appearance: none;
 		appearance: none;
 		background-color: var( --color-surface );
 		color: var( --color-neutral-70 );
 		border: 1px solid var( --color-neutral-10 );
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		letter-spacing: 0.32px;
 		line-height: 17px;
 		height: 44px;

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -194,15 +194,15 @@
 	.DayPicker-Day.DayPicker-Day--start {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
-		border-top-left-radius: 50%; /* stylelint-disable-line */
-		border-bottom-left-radius: 50%; /* stylelint-disable-line */
+		border-top-left-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-bottom-left-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 
 	.DayPicker-Day.DayPicker-Day--end {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
-		border-top-right-radius: 50%; /* stylelint-disable-line */
-		border-bottom-right-radius: 50%; /* stylelint-disable-line */
+		border-top-right-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-bottom-right-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 
 	.DayPicker-Day.DayPicker-Day--today .date-picker__day {
@@ -222,7 +222,7 @@
 		position: absolute;
 		display: block;
 		background-color: var( --color-neutral-70 );
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line scales/radii */
 		width: 26px;
 		height: 26px;
 		left: 6px;
@@ -242,7 +242,7 @@
 
 	.DayPicker-Day.DayPicker-Day--start .date-picker__day,
 	.DayPicker-Day.DayPicker-Day--end .date-picker__day {
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line scales/radii */
 		color: var( --color-text-inverted );
 		padding: 0;
 		position: relative;
@@ -281,7 +281,7 @@
 		right: auto;
 		z-index: -1;
 		background-color: var( --color-primary );
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line scales/radii */
 	}
 
 	.DayPicker-Day--start:hover .date-picker__day::after,

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -757,7 +757,7 @@
 
 	background-color: var( --studio-jetpack-green-40 );
 
-	border-radius: 24px; /* stylelint-disable-line */
+	border-radius: 24px; /* stylelint-disable-line scales/radii */
 
 	width: 28px;
 	height: 28px;
@@ -822,7 +822,7 @@
 		.jetpack-checkout-thank-you__sub-message-loading,
 		.jetpack-checkout-thank-you__sub-message {
 			font-size: $font-title-medium;
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			margin-bottom: 64px;
 		}
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -22,7 +22,7 @@
 		.segmented-control {
 			background-color: var( --studio-gray-0 );
 			border: 1px solid var( --studio-gray-5 );
-			border-radius: 6px; /* stylelint-disable-line */
+			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			color: var( --color-text );
 
 			&.is-compact {
@@ -31,7 +31,7 @@
 			}
 
 			.segmented-control__item {
-				border-radius: 6px; /* stylelint-disable-line */
+				border-radius: 6px; /* stylelint-disable-line scales/radii */
 				border: 1px solid var( --studio-gray-0 );
 				padding: 2px;
 
@@ -59,7 +59,7 @@
 				}
 
 				&.is-selected .segmented-control__link {
-					border-radius: 5px; /* stylelint-disable-line */
+					border-radius: 5px; /* stylelint-disable-line scales/radii */
 					background-color: var( --studio-white );
 					border-color: var( --studio-white );
 					box-shadow: 0 4px 4px rgba( 0, 0, 0, 0.25 ), 0 3px 8px rgba( 0, 0, 0, 0.12 ),

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -81,7 +81,7 @@ body.dns__body-white {
 
 			&.is-header {
 				border-bottom: 1px solid $gray-20;
-				font-weight: 600; /* stylelint-disable-line */
+				font-weight: 600;
 				display: none;
 
 				@include break-mobile {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -18,8 +18,8 @@
 	/* div. for increased specificity */
 	div.domain-row__primary-badge {
 		font-size: $font-body-extra-small;
-		border-radius: 4px; /* stylelint-disable-line */
-		font-weight: 500; /* stylelint-disable-line */
+		border-radius: 4px;
+		font-weight: 500;
 		margin: 4px 0;
 
 		@include break-mobile {
@@ -50,7 +50,7 @@
 		width: 8px;
 		height: 8px;
 		margin-right: 8px;
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		background-color: var( --studio-green-50 );
 	}
 
@@ -198,7 +198,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		font-size: $font-body;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 
 		button {
 			color: var( --studio-gray-90 );

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -27,8 +27,8 @@
 
 	& &__primary-badge {
 		font-size: $font-body-extra-small;
-		border-radius: 4px; /* stylelint-disable-line */
-		font-weight: 500; /* stylelint-disable-line */
+		border-radius: 4px;
+		font-weight: 500;
 		margin-top: 8px;
 
 		svg {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -279,7 +279,7 @@
 		display: flex;
 		width: 20px;
 		background: #d67709;
-		border-radius: 16px; /* stylelint-disable-line */
+		border-radius: 16px; /* stylelint-disable-line scales/radii */
 		justify-content: center;
 		align-items: center;
 		color: #ffffff;

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -56,8 +56,8 @@
 				justify-content: center;
 				align-items: center;
 				font-size: $font-body-extra-small;
-				border-radius: 4px; /* stylelint-disable-line */
-				font-weight: 500; /* stylelint-disable-line */
+				border-radius: 4px;
+				font-weight: 500;
 
 				.settings-header__badge-indicator {
 					display: flex;

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -26,6 +26,6 @@
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 17px; /* stylelint-disable-line */
+		font-size: 17px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 }

--- a/client/my-sites/invites/p2/style.scss
+++ b/client/my-sites/invites/p2/style.scss
@@ -62,7 +62,7 @@
 
 	.invite-accept-header__join-site-title {
 		font-size: var( --p2-font-size-form-xl );
-		font-weight: 900; /* stylelint-disable-line */
+		font-weight: 900; /* stylelint-disable-line scales/font-weights */
 		margin: 0 0 1rem;
 		letter-spacing: -0.02em;
 		line-height: 1.35;

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -4,7 +4,7 @@ $plan-features-sidebar-width: 272px;
 .plan-pill.is-in-signup {
 	right: 52%;
 	transform: translate( 50% );
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 	background-color: var( --studio-green-5 );
 	color: var( --studio-gray-80 );
 	font-size: $font-body-small;
@@ -300,7 +300,7 @@ $plan-features-sidebar-width: 272px;
 				& .plan-features-comparison__item-annual-plan {
 					font-weight: 600;
 					color: var( --color-error );
-					font-size: 0.6rem; /* stylelint-disable-line */
+					font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
 					text-transform: uppercase;
 				}
 			}
@@ -364,13 +364,13 @@ $plan-features-sidebar-width: 272px;
 .notouch .plans .segmented-control.price-toggle {
 	background-color: var( --studio-gray-5 );
 	border-color: var( --studio-gray-5 );
-	border-radius: 6px; /* stylelint-disable-line */
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
 	color: var( --color-text );
 	margin-top: 16px;
 
 	.segmented-control__item {
 		border: 1px solid;
-		border-radius: 6px; /* stylelint-disable-line */
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		border-color: var( --studio-gray-5 );
 
 		&.is-selected {
@@ -395,7 +395,7 @@ $plan-features-sidebar-width: 272px;
 		}
 
 		&.is-selected .segmented-control__link {
-			border-radius: 5px; /* stylelint-disable-line */
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
 			background-color: var( --studio-white );
 			border-color: var( --studio-white );
 			box-shadow: 0 4px 4px rgba( 0, 0, 0, 0.25 ), 0 3px 8px rgba( 0, 0, 0, 0.12 ),
@@ -412,7 +412,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__actions-button {
-	border-radius: 4px; /* stylelint-disable-line */
+	border-radius: 4px;
 }
 
 .plan-features-comparison__header-price-group {
@@ -447,26 +447,26 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.plan-features--signup .is-premium-plan .plan-features-comparison__header-title {
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 	}
 
 	.plan-features--signup .plan-features-comparison__pricing {
 		.plan-price {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 
 			.plan-price__integer {
-				font-weight: 500; /* stylelint-disable-line */
+				font-weight: 500;
 			}
 		}
 
 		.plan-features-comparison__header-billing-info {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 		}
 	}
 
 	.plan-pill.is-in-signup {
 		font-size: 0.75rem;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 		letter-spacing: 0.2px;
 		line-height: 1.25rem;
 		padding: 0 8px;
@@ -502,14 +502,14 @@ body.is-section-signup.is-white-signup {
 			&:hover {
 				border: 1px solid var( --studio-gray-10 );
 				background-color: unset;
-				border-radius: 5px; /* stylelint-disable-line */
+				border-radius: 5px; /* stylelint-disable-line scales/radii */
 			}
 		}
 
 		&.is-selected .segmented-control__link {
 			border: 0.5px solid rgba( 0, 0, 0, 0.04 );
 			box-shadow: 0 3px 8px rgba( 0, 0, 0, 0.12 ), 0 3px 1px rgba( 0, 0, 0, 0.04 );
-			border-radius: 5px; /* stylelint-disable-line */
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
 
 			&:hover {
 				background-color: #fff;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -433,7 +433,7 @@ $plan-features-sidebar-width: 272px;
 	font-size: $font-body-extra-small;
 	line-height: 20px;
 	height: 20px;
-	border-radius: 10px; /* stylelint-disable-line */
+	border-radius: 10px; /* stylelint-disable-line scales/radii */
 	color: var( --color-text-inverted );
 	background: var( --color-success );
 	font-weight: 400;
@@ -1063,7 +1063,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	}
 
 	tr:last-child .plan-features__table-item {
-		border-radius: 0 0 5px 5px; /* stylelint-disable-line */
+		border-radius: 0 0 5px 5px; /* stylelint-disable-line scales/radii */
 	}
 
 	.plan-features__actions {
@@ -1135,7 +1135,7 @@ button.plan-features__scroll-button {
 	padding: 0;
 	background-color: var( --color-neutral );
 	border: 0;
-	border-radius: 15px; /* stylelint-disable-line */
+	border-radius: 15px; /* stylelint-disable-line scales/radii */
 	color: var( --color-text-inverted );
 	cursor: pointer;
 
@@ -1225,7 +1225,7 @@ button.plan-features__scroll-button {
 
 .plans-wrapper {
 	.plan-features__item-annual-plan {
-		font-size: 0.6rem; /* stylelint-disable-line */
+		font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
 		text-transform: uppercase;
 	}
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -726,7 +726,6 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		}
 	}
 }
-/* stylelint-enable */
 
 .plans-wrapper {
 	margin: 0 auto;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -683,7 +683,6 @@ $plan-features-sidebar-width: 272px;
 // The #primary id is included to increase specificity
 // and override some of the segmented-control styles.
 // This UI should really use buttons instead.
-/* stylelint-disable selector-max-id */
 body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	margin: 0 auto 16px;
 	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.14 ), 0 2px 1px -1px rgba( 0, 0, 0, 0.12 ),

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -65,7 +65,7 @@
 
 .plans-features-main__heading {
 	margin: 0 0 12px;
-	font-size: 17px; /* stylelint-disable-line */
+	font-size: 17px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	line-height: 1;
 	font-weight: 600;
 	color: var( --color-text );
@@ -110,7 +110,7 @@ body.is-section-signup.is-white-signup {
 			padding: 20px;
 
 			.plan-features__header-title {
-				font-size: 18px; /* stylelint-disable-line */
+				font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			}
 
 			.plan-features__audience {
@@ -121,7 +121,7 @@ body.is-section-signup.is-white-signup {
 			.plan-pill {
 				background: var( --color-text );
 				color: var( --color-text-inverted );
-				font-size: 13px; /* stylelint-disable-line */
+				font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 				top: unset;
 				bottom: -10px;
 				left: 20px;
@@ -173,20 +173,20 @@ body.is-section-signup.is-white-signup {
 
 					.plan-price {
 						text-align: left;
-						font-size: 32px; /* stylelint-disable-line */
+						font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 						color: var( --color-neutral-100 );
 						margin-top: 15px;
 
 						.plan-price__currency-symbol {
 							vertical-align: initial;
-							font-size: 32px; /* stylelint-disable-line */
+							font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 							color: var( --color-neutral-100 );
 						}
 					}
 
 					.plan-features__header-billing-info {
 						text-align: left;
-						font-size: 10px; /* stylelint-disable-line */
+						font-size: 10px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 						color: var( --color-neutral-50 );
 						font-weight: 400;
 					}

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -72,7 +72,7 @@
 
 	p {
 		display: inline-block;
-		max-width: 55ch; // stylelint-disable unit-allowed-list
+		max-width: 55ch; // stylelint-disable-line unit-allowed-list
 		margin: 0;
 		font-style: normal;
 		font-weight: 400;

--- a/client/my-sites/plans/jetpack-plans/product-store/view-filter/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/view-filter/style.scss
@@ -6,7 +6,7 @@
 	height: 33px;
 	background-color: #f2f2f2;
 	border-color: var( --studio-gray-5 );
-	border-radius: 8px; /* stylelint-disable-line */
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
 	color: var( --color-text );
 	margin: 0 auto;
 	max-width: 21.4375em;

--- a/client/my-sites/plans/jetpack-plans/style.scss
+++ b/client/my-sites/plans/jetpack-plans/style.scss
@@ -22,7 +22,7 @@
 @font-face {
 	font-family: 'Inter';
 	font-style: normal;
-	font-weight: 500; /* stylelint-disable scales/font-weights */
+	font-weight: 500;
 	font-display: swap;
 	src: url( 'https://s0.wp.com/i/fonts/inter/Inter-Medium.woff2?v=3.19' ) format( 'woff2' ),
 		url( 'https://s0.wp.com/i/fonts/inter/Inter-Medium.woff?v=3.19' ) format( 'woff' );

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -38,7 +38,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
-		font-weight: 500; /* stylelint-disable-line */
+		font-weight: 500;
 	}
 
 	.plugin-action {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -190,7 +190,7 @@
 	.gridicon {
 		margin-top: 3px;
 		margin-right: 6px;
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 
 	.gridicon.checkmark--active {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -116,9 +116,7 @@
 
 .theme__sheet-action-bar-cost-upgrade {
 	text-transform: uppercase;
-	/* stylelint-disable declaration-property-unit-allowed-list */
-	font-size: 90%;
-	/*stylelint-enable declaration-property-unit-allowed-list */
+	font-size: 90%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 }
 
 .theme__sheet-screenshot {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -122,7 +122,6 @@
  */
 .themes-magic-search-card__token {
 	/* These are required to make token alignment work */
-	/* stylelint-disable-next-line */
 	font: inherit;
 	pointer-events: none;
 	position: relative;
@@ -169,7 +168,6 @@
 
 .themes-magic-search-card__search-text {
 	/* These are required to make token alignment work */
-	/* stylelint-disable-next-line */
 	font: inherit;
 	pointer-events: none;
 	color: transparent;
@@ -177,7 +175,6 @@
 
 .themes-magic-search-card__search-white-space {
 	/* These are required to make token alignment work */
-	/* stylelint-disable-next-line */
 	font: inherit;
 	pointer-events: none;
 	white-space: pre;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable selector-max-id */
-
 /**
  * Notifications
  */

--- a/client/signup/p2-step-wrapper/style-p2v1.scss
+++ b/client/signup/p2-step-wrapper/style-p2v1.scss
@@ -104,7 +104,7 @@
 
 	.p2-step-wrapper__header-text {
 		font-size: var( --p2-font-size-form-xxl );
-		font-weight: 900; /* stylelint-disable-line */
+		font-weight: 900; /* stylelint-disable-line scales/font-weights */
 		text-align: center;
 		line-height: 1.3;
 	}

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -69,7 +69,7 @@
 
 .p2-step-wrapper__header-text {
 	font-size: var( --p2-font-size-form-xxl );
-	font-weight: 900; /* stylelint-disable-line */
+	font-weight: 900; /* stylelint-disable-line scales/font-weights */
 	text-align: center;
 	line-height: 1.3;
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -75,7 +75,7 @@ body.is-section-signup.is-white-signup {
 
 		.search-component.is-open {
 			border: 1px solid #a7aaad;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			height: 48px;
 		}
 
@@ -166,7 +166,7 @@ body.is-section-signup.is-white-signup {
 		.register-domain-step__search-card {
 			background: var( --color-surface );
 			box-shadow: none;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			margin: 20px 0 0;
 			border: 1px solid #a7aaad;
 
@@ -187,7 +187,7 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 		.search-component__input {
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 
 			&::placeholder {
 				color: var( --color-neutral-50 );

--- a/client/signup/steps/p2-confirm-email/style.scss
+++ b/client/signup/steps/p2-confirm-email/style.scss
@@ -19,7 +19,7 @@
 		width: 36px;
 		height: 36px;
 		border: 1px solid var( --p2-color-link );
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line scales/radii */
 		padding: 8px;
 	}
 

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -137,7 +137,7 @@
 	width: 100%;
 	background-color: var( --p2-color-link );
 	border: none;
-	border-radius: 50px; /* stylelint-disable-line */
+	border-radius: 50px; /* stylelint-disable-line scales/radii */
 	font-weight: normal;
 	font-size: var( --p2-font-size-form-s );
 	color: var( --p2-color-white );
@@ -160,7 +160,7 @@
 
 .p2-site__form .form-label {
 	color: var( --p2-color-text );
-	font-weight: 500; /* stylelint-disable-line */
+	font-weight: 500;
 	font-size: var( --p2-font-size-form-xxs );
 	letter-spacing: -0.01em;
 	margin-bottom: 8px;

--- a/client/signup/steps/site-options/site-options.scss
+++ b/client/signup/steps/site-options/site-options.scss
@@ -13,9 +13,9 @@
 
 	.form-label {
 		margin-bottom: 8px;
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		color: $gray-60;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
 
 		.form-label__optional {
 			font-size: inherit;
@@ -39,7 +39,7 @@
 	input.form-text-input {
 		height: 44px;
 		line-height: 44px;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
 
 		&:focus,
 		&:focus:hover {
@@ -71,8 +71,8 @@
 
 .button.site-options__submit-button.is-primary {
 	padding: 9px 48px;
-	border-radius: 4px; /* stylelint-disable-line scales/radii */
-	font-weight: 500; /* stylelint-disable-line scales/font-weights */
+	border-radius: 4px;
+	font-weight: 500;
 
 	// override unnecessary super specificity added by another class
 	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;

--- a/client/signup/steps/site-picker/style.scss
+++ b/client/signup/steps/site-picker/style.scss
@@ -23,7 +23,7 @@ body.is-section-signup.is-white-signup {
 		}
 		.search-component.is-open {
 			border: 1px solid #a7aaad;
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			height: 48px;
 			box-sizing: border-box;
 		}

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -13,7 +13,7 @@ body.is-section-signup.is-white-signup .signup {
 
 		.form-label {
 			color: var( --studio-gray-60 );
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			margin-bottom: 8px;
 			line-height: 20px;
 			letter-spacing: -0.16px;

--- a/client/signup/steps/videopress-site/style.scss
+++ b/client/signup/steps/videopress-site/style.scss
@@ -137,7 +137,7 @@
 	width: 100%;
 	background-color: var( --p2-color-link );
 	border: none;
-	border-radius: 50px; /* stylelint-disable-line */
+	border-radius: 50px; /* stylelint-disable-line scales/radii*/
 	font-weight: normal;
 	font-size: var( --p2-font-size-form-s );
 	color: var( --p2-color-white );
@@ -160,7 +160,7 @@
 
 .videopress-site__form .form-label {
 	color: var( --videopress-color-text );
-	font-weight: 500; /* stylelint-disable-line */
+	font-weight: 500;
 	font-size: var( --p2-font-size-form-xxs );
 	letter-spacing: -0.01em;
 	margin-bottom: 8px;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -168,7 +168,7 @@ body.is-section-signup .layout.gravatar {
 			background: var( --color-surface );
 			padding-bottom: 16px;
 			margin-bottom: 24px;
-			border-radius: 6px; /* stylelint-disable-line */
+			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			@include elevation( 3dp );
 		}
 
@@ -398,7 +398,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			inset-inline-end: 20px;
 
 			.flow-progress-indicator {
-				font-weight: 500; /* stylelint-disable-line */
+				font-weight: 500;
 				font-size: 0.875rem;
 				color: var( --studio-gray-30 );
 			}
@@ -466,10 +466,10 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			@include onboarding-font-recoleta;
 			color: $gray-100;
 			letter-spacing: 0.2px;
-			font-size: 2.15rem; /* stylelint-disable-line */
+			font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
 
 			@include break-xlarge {
-				font-size: 2.75rem; /* stylelint-disable-line */
+				font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
 			}
 		}
 
@@ -516,7 +516,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 				@include break-small {
 					max-width: inherit;
-					font-size: 3.25rem; /* stylelint-disable-line */
+					font-size: 3.25rem; /* stylelint-disable-line scales/font-sizes */
 					line-height: 3.5rem;
 				}
 			}
@@ -533,7 +533,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 				@include break-small {
 					max-width: inherit;
-					font-size: 1.125rem; /* stylelint-disable-line */
+					font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 					line-height: 1.625rem;
 					letter-spacing: 0.24px;
 				}
@@ -548,11 +548,11 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		button.signup-form__submit {
-			border-radius: 4px; /* stylelint-disable-line */
+			border-radius: 4px;
 			max-width: 408px;
 			height: 44px;
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			letter-spacing: 0.32px;
 			line-height: 17px;
 		}
@@ -697,7 +697,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 				margin-bottom: 16px;
 				height: 44px;
 				max-width: 408px;
-				border-radius: 4px; /* stylelint-disable-line */
+				border-radius: 4px;
 				border: 1px solid var( --studio-gray-10 );
 			}
 
@@ -788,11 +788,11 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-plans {
 		.formatted-header {
 			.formatted-header__title {
-				font-size: 2.25rem; /* stylelint-disable-line */
+				font-size: 2.25rem;
 				line-height: 2.5rem;
 
 				@include break-mobile {
-					font-size: 2.75rem; /* stylelint-disable-line */
+					font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
 					line-height: 3rem;
 				}
 			}
@@ -826,11 +826,11 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans {
 		.formatted-header__title {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 		}
 
 		.formatted-header__subtitle button.is-borderless {
-			font-weight: 500; /* stylelint-disable-line */
+			font-weight: 500;
 			color: var( --studio-gray-90 );
 		}
 	}
@@ -848,7 +848,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			margin-top: 40px;
 
 			.formatted-header__title {
-				font-size: 2rem; /* stylelint-disable-line */
+				font-size: 2rem;
 			}
 
 			@include break-mobile {

--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -169,7 +169,7 @@
 
 .videopress-step-wrapper__header-text {
 	font-size: var( --videopress-font-size-form-xxl );
-	font-weight: 900; /* stylelint-disable-line */
+	font-weight: 900; /* stylelint-disable-line scales/font-weights */
 	text-align: center;
 	line-height: 1.3;
 }

--- a/packages/components/src/pagination-control/style.scss
+++ b/packages/components/src/pagination-control/style.scss
@@ -24,7 +24,7 @@
 		padding: 0;
 		width: 6px;
 		height: 6px;
-		border-radius: 50%; /* stylelint-disable-line */
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		cursor: pointer;
 		transition: all 0.2s ease-in-out;
 		background-color: var( --color-neutral-10 );

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -31,7 +31,7 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 		&.is-pressed {
 			.design-picker-category-filter__item-name {
 				text-decoration: underline;
-				font-weight: 500; /* stylelint-disable-line scales/font-weights */
+				font-weight: 500;
 				color: $design-picker-category-filter-text-color-active;
 
 				&:hover:not( :disabled ) {

--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -15,7 +15,7 @@
 		cursor: pointer;
 		display: inline-flex;
 		font-size: 11px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		height: 100%;
 		justify-content: center;
 		width: 100%;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -193,7 +193,7 @@
 
 	.design-picker__image-frame-blank-canvas__title {
 		color: var( --studio-gray-80 );
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		font-size: $font-title-small;
 	}
 
@@ -223,7 +223,7 @@
 		align-items: center;
 		display: inline-flex;
 		font-size: $font-body;
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		margin-top: -0.1em;
 	}
 
@@ -375,9 +375,9 @@
 
 	.design-button-cover__button {
 		justify-content: center;
-		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
 		font-size: inherit;
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		line-height: 20px;
 
 		&:not( .is-primary ) {

--- a/packages/onboarding/src/notice/style.scss
+++ b/packages/onboarding/src/notice/style.scss
@@ -1,7 +1,7 @@
 .onboarding-notice {
 	display: flex;
 	color: var( --studio-gray-50 );
-	font-size: 0.875em; /* stylelint-disable-line */
+	font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	margin-bottom: 1.5em;
 
 	svg {

--- a/packages/onboarding/src/progress/style.scss
+++ b/packages/onboarding/src/progress/style.scss
@@ -14,7 +14,7 @@
 
 	.onboarding-title {
 		color: var( --studio-gray-100 );
-		font-size: 2rem; /* stylelint-disable-line */
+		font-size: 2rem;
 		line-height: 1em;
 		margin-bottom: 1.5rem;
 	}

--- a/packages/onboarding/src/select-items-alt/style.scss
+++ b/packages/onboarding/src/select-items-alt/style.scss
@@ -54,7 +54,7 @@
 		background: none;
 		color: #101517;
 		text-decoration: underline;
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 		text-align: end;
 
 		@include break-mobile {

--- a/packages/onboarding/src/select-items/style.scss
+++ b/packages/onboarding/src/select-items/style.scss
@@ -78,12 +78,12 @@
 
 	button.select-items__item-button {
 		margin-top: 24px;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		min-width: 130px;
 		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 		border: 1px solid rgb( 195, 196, 199 );
 		color: #101517;
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 500;
 
 		@include break-mobile {
 			margin-top: 0;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -85,13 +85,13 @@
 				@include onboarding-font-recoleta;
 				color: var( --studio-gray-100 );
 				letter-spacing: 0.2px;
-				font-size: 2.15rem; /* stylelint-disable-line */
+				font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
 				font-weight: 400;
 				padding: 0;
 				margin: 0;
 
 				@include break-xlarge {
-					font-size: 2.75rem; /* stylelint-disable-line */
+					font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
 				}
 			}
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -9,19 +9,19 @@
 
 @mixin onboarding-heading-text {
 	@include onboarding-font-recoleta;
-	font-size: 42px; /* stylelint-disable-line */
+	font-size: 42px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	line-height: 57px;
 }
 
 @mixin onboarding-heading-text-tablet {
 	@include onboarding-font-recoleta;
-	font-size: 36px; /* stylelint-disable-line */
+	font-size: 36px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	line-height: 40px;
 }
 
 @mixin onboarding-heading-text-mobile {
 	@include onboarding-font-recoleta;
-	font-size: 32px; /* stylelint-disable-line */
+	font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	line-height: 40px;
 }
 
@@ -39,7 +39,7 @@
 }
 
 @mixin onboarding-large-text {
-	font-size: 16px; /* stylelint-disable-line */
+	font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	line-height: 24px;
 }
 

--- a/packages/plans-grid/src/plans-interval-toggle/style.scss
+++ b/packages/plans-grid/src/plans-interval-toggle/style.scss
@@ -64,7 +64,7 @@
 	.segmented-control__text {
 		font-family: $default-font;
 		font-size: $font-body-small;
-		font-weight: 500; /* stylelint-disable-line scales/font-weight */
+		font-weight: 500;
 		letter-spacing: 0.16px;
 		color: var( --studio-gray-90 );
 	}

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -38,19 +38,19 @@
 	max-width: 376px;
 
 	.add-subscriber__title-emoji {
-		font-size: 2.5rem; /* stylelint-disable-line */
+		font-size: 2.5rem; /* stylelint-disable-line scales/font-sizes */
 		margin-bottom: 0.75em;
 	}
 
 	.onboarding-title {
 		margin-bottom: 1.5rem;
-		font-size: 2.75rem; /* stylelint-disable-line */
-		line-height: 3.5rem; /* stylelint-disable-line */
+		font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+		line-height: 3.5rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 
 	.onboarding-subtitle {
 		margin-bottom: 1.5rem;
-		font-size: 1.125rem; /* stylelint-disable-line */
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 	}
 }
 
@@ -63,7 +63,7 @@
 	.components-button {
 		height: auto;
 		padding: 0;
-		font-size: 1em; /* stylelint-disable-line */
+		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		color: var( --color-text );
 		text-decoration: underline;
 

--- a/packages/tour-kit/src/variants/wpcom/styles.scss
+++ b/packages/tour-kit/src/variants/wpcom/styles.scss
@@ -34,7 +34,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 }
 
 .wpcom-tour-kit-step-card__heading {
-	font-size: 1.125rem; /* stylelint-disable-line */
+	font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 	margin: 0.5rem 0;
 }
 
@@ -67,7 +67,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 
 	&.components-card {
 		border: none;
-		border-radius: 4px; /* stylelint-disable-line */
+		border-radius: 4px;
 		box-shadow: none;
 	}
 
@@ -90,7 +90,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 
 		.wpcom-tour-kit-rating__end-icon.components-button.has-icon {
 			background-color: #f6f7f7;
-			border-radius: 50%; /* stylelint-disable-line */
+			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: $gray-600;
 			margin-left: 8px;
 


### PR DESCRIPTION
### Proposed Changes
Work towards #67467. For every unscoped `stylelint-disable`, scope it to a specific rule. Additionally, replace uses of `stylelint-disable` with `stylelint-disable-line`. Unfortunately, there is [no built-in way to enforce this](https://github.com/stylelint/stylelint/issues/2292) going forward, but `--fix` [does not work correctly](https://github.com/stylelint/stylelint/issues/2643) if rules are unscoped. (E.g. if you write `/* stylelint-disable-line */`, the **entire file** cannot be autofixed. Autofix only works for the rest of the file if the line is scoped to a rule.)

It will be very important moving forward to make sure that autofix works, and therefore forbid the use of disable lines which break it. Maybe we can write a basic shell script or plugin that can do that without too much trouble, but it's out of scope for this PR.

The specific motivation for this PR is that we cannot autofix the 88 impacted files if they use unscoped disable rules.

### Testing Instructions
There's no easy way to divide this up and review it other than just looking at the files and making sure I didn't make egregious syntax errors. It's also not crucial for every rule to be exact -- as we move forward with fixing style issues, any problems with these changes will be discovered and fixed.

You can also test by:
- `yarn lint:css` on trunk vs on this branch and verify there are no regressions.
- Search across the code base for unscoped rules and make sure I didn't miss any. (e.g. "/* stylelint-disable-line */")
