### PR TITLE
Pattern Assembler: Pattern selector features

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -1,1 +1,4 @@
 export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
+export const STYLE_SHEET = 'pub/blank-canvas';
+export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
+export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -61,31 +61,12 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		setShowPatternSelectorType( null );
 	};
 
-	const onDeselect = ( pattern: Pattern | null ) => {
-		if ( pattern ) {
-			if ( 'header' === showPatternSelectorType ) setHeader( null );
-			if ( 'footer' === showPatternSelectorType ) setFooter( null );
-			// if ( 'section' === showPatternSelectorType ) deleteSection( pattern );
-		}
-
-		setShowPatternSelectorType( null );
-	};
-
-	const getPatternSelected = (): Pattern | null => {
-		if ( 'header' === showPatternSelectorType ) return header;
-		if ( 'footer' === showPatternSelectorType ) return footer;
-		// if ( 'section' === showPatternSelectorType ) return section;
-		return null;
-	};
-
 	const stepContent = (
 		<div className="pattern-assembler__wrapper">
 			<div className="pattern-assembler__sidebar">
 				<PatternSelectorLoader
 					showPatternSelectorType={ showPatternSelectorType }
-					pattern={ getPatternSelected() }
 					onSelect={ onSelect }
-					onDeselect={ onDeselect }
 				/>
 				{ ! showPatternSelectorType && (
 					<PatternLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -19,18 +19,18 @@ type PatternLayoutProps = {
 };
 
 const PatternLayout = ( {
-	onContinueClick,
-	onSelectHeader,
-	onSelectSection,
-	onMoveUpSection,
-	onMoveDownSection,
-	onSelectFooter,
-	onDeleteHeader,
-	onDeleteFooter,
-	onDeleteSection,
 	header,
 	sections,
 	footer,
+	onSelectHeader,
+	onDeleteHeader,
+	onSelectSection,
+	onDeleteSection,
+	onMoveUpSection,
+	onMoveDownSection,
+	onSelectFooter,
+	onDeleteFooter,
+	onContinueClick,
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
@@ -14,7 +14,7 @@ const IframeAutoHeight = ( {
 	const [ height, setHeight ] = useState( 300 );
 
 	useEffect( () => {
-		window.addEventListener( 'message', ( { data, origin } ) => {
+		const handleMessage = ( { data, origin }: MessageEvent ) => {
 			if (
 				publicApiUrl === origin &&
 				'preview-auto-height' === data?.source &&
@@ -22,7 +22,11 @@ const IframeAutoHeight = ( {
 			) {
 				setHeight( data.height );
 			}
-		} );
+		};
+
+		window.addEventListener( 'message', handleMessage );
+
+		return () => window.removeEventListener( 'message', handleMessage );
 	}, [ patternId ] );
 
 	const iframe = cloneElement( children.props.children, { style: { height } } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
@@ -1,35 +1,48 @@
+import { addQueryArgs } from '@wordpress/url';
 import { cloneElement, ReactElement, useEffect, useState } from 'react';
-import { publicApiUrl } from './utils';
 
 // Same ratio as in the CSS transform in .pattern-selector__block-list iframe
 const iframeScaleRatio = 0.2705;
 
 const IframeAutoHeight = ( {
 	children,
+	url,
 	patternId,
 }: {
 	children: ReactElement;
+	url: string;
 	patternId: number;
 } ) => {
 	const [ height, setHeight ] = useState( 300 );
+	const calypso_token = patternId;
 
 	useEffect( () => {
-		const handleMessage = ( { data, origin }: MessageEvent ) => {
-			if (
-				publicApiUrl === origin &&
-				'preview-auto-height' === data?.source &&
-				patternId === data?.patternId
-			) {
-				setHeight( data.height );
+		const handleMessage = ( event: MessageEvent ) => {
+			let data;
+			try {
+				data = JSON.parse( event.data );
+			} catch ( err ) {
+				return;
+			}
+
+			if ( ! data || data.channel !== 'preview-' + calypso_token ) {
+				return;
+			}
+
+			if ( 'page-dimensions-on-load' === data.type ) {
+				setHeight( data.payload.height );
 			}
 		};
 
 		window.addEventListener( 'message', handleMessage );
 
 		return () => window.removeEventListener( 'message', handleMessage );
-	}, [ patternId ] );
+	}, [ calypso_token ] );
 
-	const iframe = cloneElement( children.props.children, { style: { height } } );
+	const iframe = cloneElement( children.props.children, {
+		style: { height },
+		src: addQueryArgs( url, { calypso_token } ),
+	} );
 	const wrapper = cloneElement(
 		children,
 		{ style: { minHeight: height * iframeScaleRatio } },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
@@ -4,13 +4,15 @@ import { cloneElement, ReactElement, useEffect, useState } from 'react';
 // Same ratio as in the CSS transform in .pattern-selector__block-list iframe
 const iframeScaleRatio = 0.2705;
 
-const IframeAutoHeight = ( {
+const PatternPreviewAutoHeight = ( {
 	children,
 	url,
+	patternName,
 	patternId,
 }: {
 	children: ReactElement;
 	url: string;
+	patternName: string;
 	patternId: number;
 } ) => {
 	const [ height, setHeight ] = useState( 300 );
@@ -39,17 +41,20 @@ const IframeAutoHeight = ( {
 		return () => window.removeEventListener( 'message', handleMessage );
 	}, [ calypso_token ] );
 
-	const iframe = cloneElement( children.props.children, {
-		style: { height },
-		src: addQueryArgs( url, { calypso_token } ),
-	} );
 	const wrapper = cloneElement(
 		children,
 		{ style: { minHeight: height * iframeScaleRatio } },
-		iframe
+		<iframe
+			title={ patternName }
+			frameBorder="0"
+			aria-hidden
+			tabIndex={ -1 }
+			style={ { height } }
+			src={ addQueryArgs( url, { calypso_token } ) }
+		/>
 	);
 
 	return wrapper;
 };
 
-export default IframeAutoHeight;
+export default PatternPreviewAutoHeight;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
@@ -1,0 +1,38 @@
+import { cloneElement, ReactElement, useEffect, useState } from 'react';
+import { publicApiUrl } from './utils';
+
+// Same ratio as in the CSS transform in .pattern-selector__block-list iframe
+const iframeScaleRatio = 0.2705;
+
+const IframeAutoHeight = ( {
+	children,
+	patternId,
+}: {
+	children: ReactElement;
+	patternId: number;
+} ) => {
+	const [ height, setHeight ] = useState( 300 );
+
+	useEffect( () => {
+		window.addEventListener( 'message', ( { data, origin } ) => {
+			if (
+				publicApiUrl === origin &&
+				'preview-auto-height' === data?.source &&
+				patternId === data?.patternId
+			) {
+				setHeight( data.height );
+			}
+		} );
+	}, [ patternId ] );
+
+	const iframe = cloneElement( children.props.children, { style: { height } } );
+	const wrapper = cloneElement(
+		children,
+		{ style: { minHeight: height * iframeScaleRatio } },
+		iframe
+	);
+
+	return wrapper;
+};
+
+export default IframeAutoHeight;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -5,7 +5,6 @@ import type { Pattern } from './types';
 
 type PatternSelectorLoaderProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
-	onDeselect: ( selectedPattern: Pattern | null ) => void;
 	pattern: Pattern | null;
 	showPatternSelectorType: string | null;
 };
@@ -14,7 +13,6 @@ const PatternSelectorLoader = ( {
 	showPatternSelectorType,
 	pattern,
 	onSelect,
-	onDeselect,
 }: PatternSelectorLoaderProps ) => {
 	const translate = useTranslate();
 
@@ -24,7 +22,6 @@ const PatternSelectorLoader = ( {
 				show={ showPatternSelectorType === 'header' }
 				patterns={ headerPatterns }
 				onSelect={ onSelect }
-				onDeselect={ onDeselect }
 				title={ translate( 'Choose a header' ) }
 				pattern={ pattern }
 			/>
@@ -32,7 +29,6 @@ const PatternSelectorLoader = ( {
 				show={ showPatternSelectorType === 'footer' }
 				patterns={ footerPatterns }
 				onSelect={ onSelect }
-				onDeselect={ onDeselect }
 				title={ translate( 'Choose a footer' ) }
 				pattern={ pattern }
 			/>
@@ -40,7 +36,6 @@ const PatternSelectorLoader = ( {
 				show={ showPatternSelectorType === 'section' }
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
-				onDeselect={ onDeselect }
 				title={ translate( 'Choose a section' ) }
 				pattern={ pattern }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -5,13 +5,11 @@ import type { Pattern } from './types';
 
 type PatternSelectorLoaderProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
-	pattern: Pattern | null;
 	showPatternSelectorType: string | null;
 };
 
 const PatternSelectorLoader = ( {
 	showPatternSelectorType,
-	pattern,
 	onSelect,
 }: PatternSelectorLoaderProps ) => {
 	const translate = useTranslate();
@@ -23,21 +21,18 @@ const PatternSelectorLoader = ( {
 				patterns={ headerPatterns }
 				onSelect={ onSelect }
 				title={ translate( 'Choose a header' ) }
-				pattern={ pattern }
 			/>
 			<PatternSelector
 				show={ showPatternSelectorType === 'footer' }
 				patterns={ footerPatterns }
 				onSelect={ onSelect }
 				title={ translate( 'Choose a footer' ) }
-				pattern={ pattern }
 			/>
 			<PatternSelector
 				show={ showPatternSelectorType === 'section' }
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
 				title={ translate( 'Choose a section' ) }
-				pattern={ pattern }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
 import type { Pattern } from './types';
 
@@ -8,21 +8,12 @@ type PatternSelectorProps = {
 	patterns: Pattern[] | null;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	title: string | null;
-	pattern: Pattern | null;
 	show: boolean;
 };
 
-const PatternSelector = ( { patterns, onSelect, title, pattern, show }: PatternSelectorProps ) => {
+const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorProps ) => {
 	const [ selectedPattern, setSelectedPattern ] = useState< Pattern | null >( null );
 	const translate = useTranslate();
-
-	useEffect( () => {
-		setSelectedPattern( pattern );
-	}, [ pattern ] );
-
-	useEffect( () => {
-		setSelectedPattern( pattern );
-	}, [ pattern ] );
 
 	const handleContinueClick = () => {
 		onSelect( selectedPattern );
@@ -33,10 +24,7 @@ const PatternSelector = ( { patterns, onSelect, title, pattern, show }: PatternS
 		setSelectedPattern( null );
 	};
 
-	const isSelected = ( id: number ) => id === ( selectedPattern?.id || pattern?.id );
-
 	const handleSelectedPattern = ( item: Pattern ) => {
-		if ( isSelected( item.id ) ) return setSelectedPattern( null );
 		setSelectedPattern( item );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -29,6 +29,10 @@ const PatternSelector = ( {
 		setSelectedPattern( pattern );
 	}, [ pattern ] );
 
+	useEffect( () => {
+		setSelectedPattern( pattern );
+	}, [ pattern ] );
+
 	const handleContinueClick = () => {
 		onSelect( selectedPattern );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import PatternPreviewAutoHeight from './pattern-preview-auto-height';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
 import type { Pattern } from './types';
 
@@ -25,23 +26,24 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 			<div className="pattern-selector__body">
 				<div className="pattern-selector__block-list" role="listbox">
 					{ patterns?.map( ( item: Pattern ) => (
-						<div
-							key={ item.id }
-							aria-label={ item.name }
-							tabIndex={ 0 }
-							role="option"
-							aria-selected={ false }
-							onClick={ () => onSelect( item ) }
-							onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
-						>
-							<iframe
-								title={ item.name }
-								src={ getPatternPreviewUrl( item.id ) }
-								frameBorder="0"
-								aria-hidden
-								tabIndex={ -1 }
-							></iframe>
-						</div>
+						<PatternPreviewAutoHeight key={ item.id } patternId={ item.id }>
+							<div
+								aria-label={ item.name }
+								tabIndex={ 0 }
+								role="option"
+								aria-selected={ false }
+								onClick={ () => onSelect( item ) }
+								onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
+							>
+								<iframe
+									title={ item.name }
+									src={ getPatternPreviewUrl( item.id ) }
+									frameBorder="0"
+									aria-hidden
+									tabIndex={ -1 }
+								></iframe>
+							</div>
+						</PatternPreviewAutoHeight>
 					) ) }
 				</div>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
 import type { Pattern } from './types';
 
@@ -12,19 +11,10 @@ type PatternSelectorProps = {
 };
 
 const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorProps ) => {
-	const [ selectedPattern, setSelectedPattern ] = useState< Pattern | null >( null );
 	const translate = useTranslate();
-
-	const handleContinueClick = () => {
-		onSelect( selectedPattern );
-	};
 
 	const handleBackClick = () => {
 		onSelect( null );
-	};
-
-	const handleSelectedPattern = ( item: Pattern ) => {
-		setSelectedPattern( item );
 	};
 
 	return (
@@ -41,8 +31,8 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 							tabIndex={ 0 }
 							role="option"
 							aria-selected={ false }
-							onClick={ () => handleSelectedPattern( item ) }
-							onKeyUp={ handleKeyboard( () => setSelectedPattern( item ) ) }
+							onClick={ () => onSelect( item ) }
+							onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
 						>
 							<iframe
 								title={ item.name }
@@ -59,11 +49,6 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 				<Button className="pattern-assembler__button" onClick={ handleBackClick }>
 					{ translate( 'Back' ) }
 				</Button>
-				{ selectedPattern && (
-					<Button className="pattern-assembler__button" onClick={ handleContinueClick } primary>
-						{ translate( 'Choose' ) }
-					</Button>
-				) }
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -32,6 +32,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 							key={ `${ index }-${ item.id }` }
 							url={ getPatternPreviewUrl( item.id, locale ) }
 							patternId={ item.id }
+							patternName={ item.name }
 						>
 							<div
 								aria-label={ item.name }
@@ -40,9 +41,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 								aria-selected={ false }
 								onClick={ () => onSelect( item ) }
 								onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
-							>
-								<iframe title={ item.name } frameBorder="0" aria-hidden tabIndex={ -1 }></iframe>
-							</div>
+							/>
 						</PatternPreviewAutoHeight>
 					) ) }
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -21,7 +21,6 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 
 	const handleBackClick = () => {
 		onSelect( null );
-		setSelectedPattern( null );
 	};
 
 	const handleSelectedPattern = ( item: Pattern ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
@@ -13,6 +14,7 @@ type PatternSelectorProps = {
 
 const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorProps ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
 
 	const handleBackClick = () => {
 		onSelect( null );
@@ -37,7 +39,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 							>
 								<iframe
 									title={ item.name }
-									src={ getPatternPreviewUrl( item.id ) }
+									src={ getPatternPreviewUrl( item.id, locale ) }
 									frameBorder="0"
 									aria-hidden
 									tabIndex={ -1 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -7,6 +7,7 @@ import type { Pattern } from './types';
 type PatternSelectorProps = {
 	patterns: Pattern[] | null;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
+	onDeselect: ( selectedPattern: Pattern | null ) => void;
 	title: string | null;
 	show: boolean;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -25,8 +25,8 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 			</div>
 			<div className="pattern-selector__body">
 				<div className="pattern-selector__block-list" role="listbox">
-					{ patterns?.map( ( item: Pattern ) => (
-						<PatternPreviewAutoHeight key={ item.id } patternId={ item.id }>
+					{ patterns?.map( ( item: Pattern, index: number ) => (
+						<PatternPreviewAutoHeight key={ `${ index }-${ item.id }` } patternId={ item.id }>
 							<div
 								aria-label={ item.name }
 								tabIndex={ 0 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -7,7 +7,6 @@ import type { Pattern } from './types';
 type PatternSelectorProps = {
 	patterns: Pattern[] | null;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
-	onDeselect: ( selectedPattern: Pattern | null ) => void;
 	title: string | null;
 	show: boolean;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -28,7 +28,11 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 			<div className="pattern-selector__body">
 				<div className="pattern-selector__block-list" role="listbox">
 					{ patterns?.map( ( item: Pattern, index: number ) => (
-						<PatternPreviewAutoHeight key={ `${ index }-${ item.id }` } patternId={ item.id }>
+						<PatternPreviewAutoHeight
+							key={ `${ index }-${ item.id }` }
+							url={ getPatternPreviewUrl( item.id, locale ) }
+							patternId={ item.id }
+						>
 							<div
 								aria-label={ item.name }
 								tabIndex={ 0 }
@@ -37,13 +41,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 								onClick={ () => onSelect( item ) }
 								onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
 							>
-								<iframe
-									title={ item.name }
-									src={ getPatternPreviewUrl( item.id, locale ) }
-									frameBorder="0"
-									aria-hidden
-									tabIndex={ -1 }
-								></iframe>
+								<iframe title={ item.name } frameBorder="0" aria-hidden tabIndex={ -1 }></iframe>
 							</div>
 						</PatternPreviewAutoHeight>
 					) ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
@@ -8,20 +7,12 @@ import type { Pattern } from './types';
 type PatternSelectorProps = {
 	patterns: Pattern[] | null;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
-	onDeselect: ( selectedPattern: Pattern | null ) => void;
 	title: string | null;
 	pattern: Pattern | null;
 	show: boolean;
 };
 
-const PatternSelector = ( {
-	patterns,
-	onSelect,
-	onDeselect,
-	title,
-	pattern,
-	show,
-}: PatternSelectorProps ) => {
+const PatternSelector = ( { patterns, onSelect, title, pattern, show }: PatternSelectorProps ) => {
 	const [ selectedPattern, setSelectedPattern ] = useState< Pattern | null >( null );
 	const translate = useTranslate();
 
@@ -42,12 +33,7 @@ const PatternSelector = ( {
 		setSelectedPattern( null );
 	};
 
-	const handleDeleteClick = () => {
-		onDeselect( pattern );
-		setSelectedPattern( null );
-	};
-
-	const isSelected = ( id: number ) => id === selectedPattern?.id;
+	const isSelected = ( id: number ) => id === ( selectedPattern?.id || pattern?.id );
 
 	const handleSelectedPattern = ( item: Pattern ) => {
 		if ( isSelected( item.id ) ) return setSelectedPattern( null );
@@ -67,8 +53,7 @@ const PatternSelector = ( {
 							aria-label={ item.name }
 							tabIndex={ 0 }
 							role="option"
-							aria-selected={ isSelected( item.id ) }
-							className={ classNames( { '--pattern-selected': isSelected( item.id ) } ) }
+							aria-selected={ false }
 							onClick={ () => handleSelectedPattern( item ) }
 							onKeyUp={ handleKeyboard( () => setSelectedPattern( item ) ) }
 						>
@@ -90,11 +75,6 @@ const PatternSelector = ( {
 				{ selectedPattern && (
 					<Button className="pattern-assembler__button" onClick={ handleContinueClick } primary>
 						{ translate( 'Choose' ) }
-					</Button>
-				) }
-				{ ! selectedPattern && pattern && (
-					<Button className="pattern-assembler__button" onClick={ handleDeleteClick } primary>
-						{ translate( 'Delete' ) }
 					</Button>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -124,7 +124,7 @@ const sectionPatterns: Pattern[] = [
 		name: 'Header and Three Images',
 	},
 	{
-		id: 687,
+		id: 678,
 		name: 'Images with Titles',
 	},
 ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -96,84 +96,8 @@ const sectionPatterns: Pattern[] = [
 		name: 'Contact',
 	},
 	{
-		id: 4691,
-		name: 'Payment Block Media and Text',
-	},
-	{
-		id: 3759,
-		name: 'Coming Soon',
-	},
-	{
-		id: 1400,
-		name: 'Contact',
-	},
-	{
-		id: 4691,
-		name: 'Payment Block Media and Text',
-	},
-	{
-		id: 3759,
-		name: 'Coming Soon',
-	},
-	{
-		id: 1400,
-		name: 'Contact',
-	},
-	{
 		id: 3856,
 		name: 'Organic Gallery With Intro Text',
-	},
-	{
-		id: 1930,
-		name: 'Intro Section With Text and Spot Images',
-	},
-	{
-		id: 3862,
-		name: 'Alternating Image and Text',
-	},
-	{
-		id: 1826,
-		name: 'Two Images, Text, and Buttons',
-	},
-	{
-		id: 5564,
-		name: 'Contact',
-	},
-	{
-		id: 1046,
-		name: 'Subscription',
-	},
-	{
-		id: 3856,
-		name: 'Organic Gallery With Intro Text',
-	},
-	{
-		id: 1930,
-		name: 'Intro Section With Text and Spot Images',
-	},
-	{
-		id: 3862,
-		name: 'Alternating Image and Text',
-	},
-	{
-		id: 1826,
-		name: 'Two Images, Text, and Buttons',
-	},
-	{
-		id: 5564,
-		name: 'Contact',
-	},
-	{
-		id: 1046,
-		name: 'Subscription',
-	},
-	{
-		id: 1593,
-		name: 'Header and Three Images',
-	},
-	{
-		id: 678,
-		name: 'Images with Titles',
 	},
 	{
 		id: 1930,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -155,8 +155,8 @@ const sectionPatterns: Pattern[] = [
 		name: 'Two Images, Text, and Buttons',
 	},
 	{
-		id: 4691,
-		name: 'Payment Block Media and Text',
+		id: 5564,
+		name: 'Contact',
 	},
 	{
 		id: 1046,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -82,6 +82,21 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 3880,
 		name: 'About me',
+<<<<<<< HEAD
+=======
+	},
+	{
+		id: 4691,
+		name: 'Payment Block Media and Text',
+	},
+	{
+		id: 3759,
+		name: 'Coming Soon',
+	},
+	{
+		id: 1400,
+		name: 'Contact',
+>>>>>>> 663114251d (Add section patterns list for testing)
 	},
 	{
 		id: 4691,
@@ -126,6 +141,26 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 678,
 		name: 'Images with Titles',
+	},
+	{
+		id: 1930,
+		name: 'Intro Section With Text and Spot Images',
+	},
+	{
+		id: 3862,
+		name: 'Alternating Image and Text',
+	},
+	{
+		id: 1826,
+		name: 'Two Images, Text, and Buttons',
+	},
+	{
+		id: 4691,
+		name: 'Payment Block Media and Text',
+	},
+	{
+		id: 1046,
+		name: 'Subscription',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -82,8 +82,6 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 3880,
 		name: 'About me',
-<<<<<<< HEAD
-=======
 	},
 	{
 		id: 4691,
@@ -96,7 +94,6 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 1400,
 		name: 'Contact',
->>>>>>> 663114251d (Add section patterns list for testing)
 	},
 	{
 		id: 4691,
@@ -109,6 +106,42 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 1400,
 		name: 'Contact',
+	},
+	{
+		id: 4691,
+		name: 'Payment Block Media and Text',
+	},
+	{
+		id: 3759,
+		name: 'Coming Soon',
+	},
+	{
+		id: 1400,
+		name: 'Contact',
+	},
+	{
+		id: 3856,
+		name: 'Organic Gallery With Intro Text',
+	},
+	{
+		id: 1930,
+		name: 'Intro Section With Text and Spot Images',
+	},
+	{
+		id: 3862,
+		name: 'Alternating Image and Text',
+	},
+	{
+		id: 1826,
+		name: 'Two Images, Text, and Buttons',
+	},
+	{
+		id: 5564,
+		name: 'Contact',
+	},
+	{
+		id: 1046,
+		name: 'Subscription',
 	},
 	{
 		id: 3856,
@@ -161,6 +194,14 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 1046,
 		name: 'Subscription',
+	},
+	{
+		id: 1593,
+		name: 'Header and Three Images',
+	},
+	{
+		id: 687,
+		name: 'Images with Titles',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,16 +1,12 @@
 import { addQueryArgs } from '@wordpress/url';
-import { PATTERN_SOURCE_SITE_ID } from './constants';
-
-const stylesheet = 'pub/blank-canvas';
-const publicApiUrl = 'https://public-api.wordpress.com';
-const patternPreviewUrl = publicApiUrl + '/wpcom/v2/block-previews/pattern';
+import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL, STYLE_SHEET } from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
 
 export const getPatternPreviewUrl = ( id: number, language: string ) => {
-	return addQueryArgs( patternPreviewUrl, {
-		stylesheet,
+	return addQueryArgs( PREVIEW_PATTERN_URL, {
+		stylesheet: STYLE_SHEET,
 		pattern_id: encodePatternId( id ),
 		language,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -8,11 +8,12 @@ const patternPreviewUrl = publicApiUrl + '/wpcom/v2/block-previews/pattern';
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
 
-export const getPatternPreviewUrl = ( id: number ) => {
+export const getPatternPreviewUrl = ( id: number, language: string ) => {
 	return addQueryArgs( patternPreviewUrl, {
 		stylesheet,
 		preview_auto_height: true,
 		pattern_id: encodePatternId( id ),
+		language,
 	} );
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -11,7 +11,6 @@ export const encodePatternId = ( patternId: number ) =>
 export const getPatternPreviewUrl = ( id: number, language: string ) => {
 	return addQueryArgs( patternPreviewUrl, {
 		stylesheet,
-		preview_auto_height: true,
 		pattern_id: encodePatternId( id ),
 		language,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,13 +1,20 @@
+import { addQueryArgs } from '@wordpress/url';
 import { PATTERN_SOURCE_SITE_ID } from './constants';
 
-const patternPreviewUrl =
-	'https://public-api.wordpress.com/wpcom/v2/block-previews/pattern?stylesheet=pub/blank-canvas&pattern_id=';
+const stylesheet = 'pub/blank-canvas';
+const publicApiUrl = 'https://public-api.wordpress.com';
+const patternPreviewUrl = publicApiUrl + '/wpcom/v2/block-previews/pattern';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
 
-export const getPatternPreviewUrl = ( id: number ) =>
-	`${ patternPreviewUrl }${ encodePatternId( id ) }`;
+export const getPatternPreviewUrl = ( id: number ) => {
+	return addQueryArgs( patternPreviewUrl, {
+		stylesheet,
+		preview_auto_height: true,
+		pattern_id: encodePatternId( id ),
+	} );
+};
 
 // Runs the callback if the keys Enter or Spacebar are in the keyboard event
 export const handleKeyboard =


### PR DESCRIPTION
#### Proposed Changes

* Remove the `Choose` button to select patterns with one click
* Created the component `IframeAutoHeight` to dynamically adjust the height of the pattern preview by listening to a `postMessage` passing a `calypso_token` to the preview endpoint.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Click on the Calypso Live (direct link) in the comment below.
- Type the URL /setup/patternAssembler?siteSlug={Site slug} in the Calypso Live domain

- In the pattern assembler check that the pattern selector uses one click to add patterns:
  - Click on choose a header
  - Click on a pattern
  - Check that is added to the list

- To test the pattern preview height:
  - Click on choose a header to check that the patterns have different heights

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66787