### PR TITLE
v13n: Turn on signup/standard-theme-v13n flag (second try)

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -128,7 +128,7 @@
 		"signup/seller-upgrade-modal": false,
 		"signup/site-vertical-step": true,
 		"signup/social": true,
-		"signup/standard-theme-v13n": false,
+		"signup/standard-theme-v13n": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
 		"signup/theme-preview-screen": true,


### PR DESCRIPTION
#### Proposed Changes

We enabled the flag via https://github.com/Automattic/wp-calypso/pull/67077 but encountered an issue and reverted. This is a second try and we have added some test cases via https://github.com/Automattic/wp-calypso/pull/67296

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Any selected vertical excludes "Something else"**

* Go to /setup/vertical?siteSlug=<your_site>
* Select a vertical
* Go to /setup/designSetup?siteSlug=<your_site>
* Preview one of the following themes and you have to see the images are verticalized
  * Geologist
  * Stewart
  * Arbutus
  * Zoologist
* Continue with that theme and you have to see the `calypso_signup_select_verticalized_design` is sent
* You will land on My Home successfully

**No selected vertical**

* Go to /setup/vertical?siteSlug=<your_site>
* Don't select a vertical or select "Something else"
* Go to /setup/designSetup?siteSlug=<your_site>
* The following themes won't be verticalized
  * Geologist
  * Stewart
  * Arbutus
  * Zoologist
* Select any of the above themes and you have to land on My Home successfully

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/66680, https://github.com/Automattic/wp-calypso/issues/66835
