### PR TITLE
Refactor Unified Design Picker step by grouping blocks of related logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -39,42 +39,35 @@ import type { Design } from '@automattic/design-picker';
 
 const SiteIntent = Onboard.SiteIntent;
 
-/**
- * The unified design picker
- */
 const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
-	const [ isPreviewingDesign, setIsPreviewingDesign ] = useState( false );
-	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
-	// CSS breakpoints are set at 600px for mobile
-	const isMobile = ! useViewportMatch( 'small' );
 	const { goBack, submit, exitFlow } = navigation;
+
+	const reduxDispatch = useReduxDispatch();
+
 	const translate = useTranslate();
 	const locale = useLocale();
-	const site = useSite();
-	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
-	const { setDesignOnSite } = useDispatch( SITE_STORE );
-	const reduxDispatch = useReduxDispatch();
-	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+
+	// CSS breakpoints are set at 600px for mobile
+	const isMobile = ! useViewportMatch( 'small' );
+
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+
+	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
+	const siteVerticalId = useSelect(
+		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || ''
+	);
+
 	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
 	useEffect( () => {
 		if ( isAtomic ) {
 			exitFlow?.( `/site-editor/${ siteSlugOrId }` );
 		}
 	}, [ isAtomic ] );
-
-	const isEligibleForProPlan = useSelect(
-		( select ) => site && select( SITE_STORE ).isEligibleForProPlan( site.ID )
-	);
-
-	const siteVerticalId = useSelect(
-		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || ''
-	);
 
 	const isPremiumThemeAvailable = Boolean(
 		useSelect(
@@ -83,17 +76,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		)
 	);
 
-	useQuerySitePurchases( site ? site.ID : -1 );
-
-	const purchasedThemes = useSelector( ( state ) =>
-		site ? getPurchasedThemes( state, site.ID ) : []
-	);
-	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
-	const didPurchaseSelectedTheme = useSelector( ( state ) =>
-		site && selectedDesignThemeId
-			? isThemePurchased( state, selectedDesignThemeId, site.ID )
-			: false
-	);
+	// ********** Logic for fetching designs
 
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
 		{
@@ -108,15 +91,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const generatedDesigns = allDesigns?.generated?.designs || [];
 	const staticDesigns = allDesigns?.static?.designs || [];
 
-	const isEnabledStyleSelection =
-		selectedDesign &&
-		selectedDesign.design_type !== 'vertical' &&
-		isEnabled( 'signup/design-picker-style-selection' );
-
-	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
-		enabled: isPreviewingDesign && isEnabledStyleSelection,
-	} );
-
 	const hasTrackedView = useRef( false );
 	useEffect( () => {
 		if ( ! hasTrackedView.current && staticDesigns.length > 0 ) {
@@ -129,80 +103,37 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	}, [ hasTrackedView, generatedDesigns, staticDesigns ] );
 
-	const getEventPropsByDesign = ( design: Design ) => ( {
-		slug: design?.slug,
-		theme: design?.recipe?.stylesheet,
-		flow,
-		intent,
-		is_premium: design?.is_premium,
-		design_type: design.design_type,
-		...( design?.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
-		...( design?.recipe?.header_pattern_ids && {
-			header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
-		} ),
-		...( design?.recipe?.footer_pattern_ids && {
-			footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
-		} ),
-	} );
-
 	const categorizationOptions = getCategorizationOptions( intent, true );
-
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 
-	const handleSubmit = ( providedDependencies?: ProvidedDependencies ) => {
-		const _selectedDesign = providedDependencies?.selectedDesign as Design;
+	// ********** Logic for selecting a design
 
-		recordTracksEvent( 'calypso_signup_design_type_submit', {
+	const [ isPreviewingDesign, setIsPreviewingDesign ] = useState( false );
+
+	// Make sure people is at the top when entering/leaving preview mode.
+	useEffect( () => {
+		window.scrollTo( { top: 0 } );
+	}, [ isPreviewingDesign ] );
+
+	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+
+	function getEventPropsByDesign( design: Design ) {
+		return {
+			slug: design?.slug,
+			theme: design?.recipe?.stylesheet,
 			flow,
 			intent,
-			design_type: _selectedDesign?.design_type ?? 'default',
-		} );
-
-		submit?.( providedDependencies );
-	};
-
-	const closeUpgradeModal = () => {
-		recordTracksEvent( 'calypso_signup_design_upgrade_modal_close_button_click', {
-			theme: selectedDesign?.slug,
-		} );
-		setShowUpgradeModal( false );
-	};
-
-	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
-		setSelectedDesign( _selectedDesign );
-		if ( siteSlugOrId && _selectedDesign ) {
-			let positionIndex = generatedDesigns.findIndex(
-				( design ) => design.slug === _selectedDesign.slug
-			);
-			if ( positionIndex === -1 ) {
-				positionIndex = staticDesigns.findIndex(
-					( design ) => design.slug === _selectedDesign.slug
-				);
-			}
-			// Send vertical_id only if the current design is generated design or we enabled the v13n of standard themes.
-			// We cannot check the config inside `setDesignOnSite` action. See https://github.com/Automattic/wp-calypso/pull/65531#issuecomment-1190850273
-			setPendingAction( () =>
-				setDesignOnSite( siteSlugOrId, _selectedDesign, siteVerticalId ).then( () =>
-					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
-				)
-			);
-			recordTracksEvent( 'calypso_signup_select_design', {
-				...getEventPropsByDesign( _selectedDesign ),
-				...( positionIndex >= 0 && { position_index: positionIndex } ),
-			} );
-
-			if ( _selectedDesign.verticalizable ) {
-				recordTracksEvent(
-					'calypso_signup_select_verticalized_design',
-					getEventPropsByDesign( _selectedDesign )
-				);
-			}
-
-			handleSubmit( {
-				selectedDesign: _selectedDesign,
-				selectedSiteCategory: categorization.selection,
-			} );
-		}
+			is_premium: design?.is_premium,
+			design_type: design.design_type,
+			...( design?.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
+			...( design?.recipe?.header_pattern_ids && {
+				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
+			} ),
+			...( design?.recipe?.footer_pattern_ids && {
+				footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
+			} ),
+		};
 	}
 
 	function previewDesign( _selectedDesign: Design, positionIndex?: number ) {
@@ -215,6 +146,39 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		setIsPreviewingDesign( true );
 	}
 
+	// ********** Logic for fetching the details of a selected design with style variations
+
+	const isEnabledStyleSelection =
+		selectedDesign &&
+		selectedDesign.design_type !== 'vertical' &&
+		isEnabled( 'signup/design-picker-style-selection' );
+
+	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
+		enabled: isPreviewingDesign && isEnabledStyleSelection,
+	} );
+
+	// ********** Logic for unlocking a selected premium design
+
+	useQuerySitePurchases( site ? site.ID : -1 );
+
+	const purchasedThemes = useSelector( ( state ) =>
+		site ? getPurchasedThemes( state, site.ID ) : []
+	);
+	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
+	const didPurchaseSelectedTheme = useSelector( ( state ) =>
+		site && selectedDesignThemeId
+			? isThemePurchased( state, selectedDesignThemeId, site.ID )
+			: false
+	);
+	const shouldUpgrade =
+		selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme;
+
+	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
+
+	const isEligibleForProPlan = useSelect(
+		( select ) => site && select( SITE_STORE ).isEligibleForProPlan( site.ID )
+	);
+
 	function upgradePlan() {
 		if ( ! isEnabled( 'signup/seller-upgrade-modal' ) ) {
 			return goToCheckout();
@@ -224,6 +188,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			theme: selectedDesign?.slug,
 		} );
 		setShowUpgradeModal( true );
+	}
+
+	function closeUpgradeModal() {
+		recordTracksEvent( 'calypso_signup_design_upgrade_modal_close_button_click', {
+			theme: selectedDesign?.slug,
+		} );
+		setShowUpgradeModal( false );
 	}
 
 	function goToCheckout() {
@@ -251,16 +222,59 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	}
 
-	function recordStepContainerTracksEvent( eventName: string ) {
-		const tracksProps = {
-			step: 'design-step',
-			intent: intent,
-		};
+	// ********** Logic for submitting the selected design
 
-		recordTracksEvent( eventName, tracksProps );
+	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+
+	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
+		setSelectedDesign( _selectedDesign );
+		if ( siteSlugOrId && _selectedDesign ) {
+			let positionIndex = generatedDesigns.findIndex(
+				( design ) => design.slug === _selectedDesign.slug
+			);
+			if ( positionIndex === -1 ) {
+				positionIndex = staticDesigns.findIndex(
+					( design ) => design.slug === _selectedDesign.slug
+				);
+			}
+			setPendingAction( () =>
+				setDesignOnSite( siteSlugOrId, _selectedDesign, siteVerticalId ).then( () =>
+					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
+				)
+			);
+			recordTracksEvent( 'calypso_signup_select_design', {
+				...getEventPropsByDesign( _selectedDesign ),
+				...( positionIndex >= 0 && { position_index: positionIndex } ),
+			} );
+
+			if ( _selectedDesign.verticalizable ) {
+				recordTracksEvent(
+					'calypso_signup_select_verticalized_design',
+					getEventPropsByDesign( _selectedDesign )
+				);
+			}
+
+			handleSubmit( {
+				selectedDesign: _selectedDesign,
+				selectedSiteCategory: categorization.selection,
+			} );
+		}
 	}
 
-	const handleBackClick = () => {
+	function handleSubmit( providedDependencies?: ProvidedDependencies ) {
+		const _selectedDesign = providedDependencies?.selectedDesign as Design;
+
+		recordTracksEvent( 'calypso_signup_design_type_submit', {
+			flow,
+			intent,
+			design_type: _selectedDesign?.design_type ?? 'default',
+		} );
+
+		submit?.( providedDependencies );
+	}
+
+	function handleBackClick() {
 		if ( isPreviewingDesign ) {
 			recordTracksEvent(
 				'calypso_signup_design_preview_exit',
@@ -273,12 +287,18 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 
 		goBack();
-	};
+	}
 
-	// Make sure people is at the top when entering/leaving preview mode.
-	useEffect( () => {
-		window.scrollTo( { top: 0 } );
-	}, [ isPreviewingDesign ] );
+	function recordStepContainerTracksEvent( eventName: string ) {
+		const tracksProps = {
+			step: 'design-step',
+			intent: intent,
+		};
+
+		recordTracksEvent( eventName, tracksProps );
+	}
+
+	// ********** Main render logic
 
 	// Don't render until we've fetched the designs from the backend.
 	if ( ! site || isLoadingDesigns ) {
@@ -290,8 +310,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		const headerDesignTitle = (
 			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
 		);
-		const shouldUpgrade =
-			selectedDesign.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme;
+
 		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview
 		const shouldCustomizeText = intent === SiteIntent.Write || intent === SiteIntent.Sell;
 		const previewUrl = getDesignPreviewUrl( selectedDesign, {


### PR DESCRIPTION
#### Proposed Changes

I find that developing a new feature in the existing Unified Design Picker a bit difficult. The main pain point for me is that unrelated logic are tangled all over the place.

This PR does a little bit of refactor of the UDP step by grouping the logic into the following logical groups:

- Getting site properties from the store
- Fetching designs
- Previewing/selecting designs
- Fetching the details of a selected design with style variations
- Unlocking a selected premium design
- Submitting the selected design

Also I changed functions written with arrow/anonymous functions (`const x = () =>`) into `function x()` for consistency.

P.S.: In the future I think we should extract the groups of logic into separate component, but I think this is a good first step towards that.

#### Testing Instructions

There are NO changes in features / behavior whatsoever.

Please help test the happy flows of Unified Design Picker step.

You might have to add `&flags=-signup/design-picker-style-selection` to skip the style selection feature as it will block the flow (for now)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
