### PR TITLE
ProcessBar: update styles to match wordpress blue

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -1,4 +1,5 @@
-@import 'calypso/assets/stylesheets/shared/_loading.scss';
+/* stylelint-disable-next-line scss/at-import-no-partial-leading-underscore */
+@import 'calypso/assets/stylesheets/shared/_loading';
 @import '@automattic/onboarding/styles/mixins';
 
 $progress-duration: 800ms;
@@ -35,10 +36,11 @@ $progress-duration: 800ms;
 	height: 6px;
 	margin-top: 1em;
 	background: var( --studio-gray-10 );
+
 	--progress: 0;
 
 	&::before {
-		background: var( --studio-blue-40 );
+		background: var( --studio-blue-50 );
 		transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
 		position: absolute;
 		content: '';
@@ -49,6 +51,7 @@ $progress-duration: 800ms;
 		transition: transform $progress-duration ease-out;
 	}
 }
+
 .site-setup.processing .step-container__content,
 .anchor-fm.processing .step-container__content {
 	width: 100%;

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -25,10 +25,11 @@ $progress-duration: 800ms;
 		height: 6px;
 		margin-top: 1em;
 		background: var( --studio-gray-10 );
+
 		--progress: 0;
 
 		&::before {
-			background: var( --studio-blue-40 );
+			background: var( --studio-blue-50 );
 			transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
 			position: absolute;
 			content: '';

--- a/packages/components/src/progress-bar/style.scss
+++ b/packages/components/src/progress-bar/style.scss
@@ -4,6 +4,7 @@
 	position: relative;
 	height: 9px;
 	background-color: var( --color-neutral-10 );
+	/* stylelint-disable-next-line scales/radii */
 	border-radius: 4.5px;
 
 	&.is-compact {
@@ -17,33 +18,13 @@
 	top: 0;
 	left: 0;
 	height: 100%;
-	background-color: var( --color-primary );
+	background-color: var( --studio-blue-50 );
+	/* stylelint-disable-next-line scales/radii */
 	border-radius: 4.5px;
 	transition: width 200ms;
-	@media ( prefers-reduced-motion: reduce ) {
+
+	@media (prefers-reduced-motion: reduce) {
 		transition: none;
-	}
-}
-
-.progress-bar.is-pulsing .progress-bar__progress {
-	animation: progress-bar-animation 3300ms infinite linear;
-	background-size: 50px 100%;
-	background-image: linear-gradient(
-		-45deg,
-		var( --color-primary ) 28%,
-		var( --color-primary-light ) 28%,
-		var( --color-primary-light ) 72%,
-		var( --color-primary ) 72%
-	);
-
-	@media ( prefers-reduced-motion: reduce ) {
-		animation: none;
-	}
-}
-
-@keyframes progress-bar-animation {
-	0% {
-		background-position: 100px 0;
 	}
 }
 
@@ -52,7 +33,31 @@
 	border-radius: 0;
 	height: 8px;
 	width: 150px;
+
 	.progress-bar__progress {
 		border-radius: 0;
+	}
+}
+
+.progress-bar.is-pulsing .progress-bar__progress {
+	animation: progress-bar-animation 3300ms infinite linear;
+	background-size: 50px 100%;
+	background-image:
+		linear-gradient(
+			-45deg,
+			var( --studio-blue-50 ) 28%,
+			var( --studio-blue-30 ) 28%,
+			var( --studio-blue-30 ) 72%,
+			var( --studio-blue-50 ) 72%
+		);
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}
+
+@keyframes progress-bar-animation {
+	0% {
+		background-position: 100px 0;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Instead of using the primary color for the progress bar we need to switch to the wordpress blue color

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Compare the local http://calypso.localhost:3000/devdocs/design/progress-bar against https://wpcalypso.wordpress.com/devdocs/design/progress-bar
- Follow the newletter or link in bio flow to check the progress bar color on the top progress bar and on the one in the middle

Related to #67373
