### PR TITLE
Remove jetpack logo for LiB

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -1,3 +1,4 @@
+import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import cx from 'classnames';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -15,14 +16,14 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 	return (
 		<StepContainer
 			stepName={ 'intro' }
-			className={ cx( { 'is-newsletter': flow === 'newsletter' } ) }
+			className={ cx( { 'is-newsletter': flow === NEWSLETTER_FLOW } ) }
 			goBack={ goBack }
 			isHorizontalLayout={ false }
 			isWideLayout={ true }
 			isLargeSkipLayout={ false }
 			stepContent={ <IntroStep flowName={ flow as string } onSubmit={ handleSubmit } /> }
 			recordTracksEvent={ recordTracksEvent }
-			showJetpackPowered={ flow === 'newsletter' }
+			showJetpackPowered={ flow === NEWSLETTER_FLOW }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -22,7 +22,7 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 			isLargeSkipLayout={ false }
 			stepContent={ <IntroStep flowName={ flow as string } onSubmit={ handleSubmit } /> }
 			recordTracksEvent={ recordTracksEvent }
-			showJetpackPowered
+			showJetpackPowered={ flow === 'newsletter' }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -161,7 +161,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 			}
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
-			showJetpackPowered
 		/>
 	);
 };

--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -91,9 +91,11 @@ export default function TailoredFlowProcessingScreen( { flowName } ) {
 				/>
 			</div>
 
-			<div className="reskinned-processing-screen__jetpack-powered">
-				<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
-			</div>
+			{ flowName === 'newsletter' && (
+				<div className="reskinned-processing-screen__jetpack-powered">
+					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -91,7 +91,7 @@ export default function TailoredFlowProcessingScreen( { flowName } ) {
 				/>
 			</div>
 
-			{ flowName === 'newsletter' && (
+			{ flowName === NEWSLETTER_FLOW && (
 				<div className="reskinned-processing-screen__jetpack-powered">
 					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
 				</div>


### PR DESCRIPTION
## Proposed Changes

Remove Jetpack logo for LiB flow

## Testing Instructions

- Pull this branch and run `yarn start`
- Navigate to` /setup/intro?flow=link-in-bio` and go until the end of the flow
- You **should not** see the Jetpack Powered logo on the whole **LiB flow**
- It should still br visible on Newsletter flow
<img width="138" alt="image" src="https://user-images.githubusercontent.com/2653810/188848152-ddb2eff8-f372-49f3-9dc1-64ab5a7b90c7.png">


Related to #67442
Fixes #67442