### PR TITLE
Update ImportSubscribersResponse response

### DIFF
--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -48,7 +48,7 @@ export function createActions() {
 				formData: [ [ 'import', file, file.name ] ],
 			} );
 
-			yield importCsvSubscribersStartSuccess( siteId, data.id );
+			yield importCsvSubscribersStartSuccess( siteId, data.upload_id );
 		} catch ( error ) {
 			yield importCsvSubscribersStartFailed( siteId, error as ImportSubscribersError );
 		}

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -40,8 +40,9 @@ export type AddSubscribersResponse = {
 export type ImportSubscribersError = Record< string, unknown > | GenericError;
 
 export type ImportSubscribersResponse = {
-	id: number;
-	success: boolean;
+	upload_id: number;
+	errors: string[];
+	subscribed: number;
 };
 
 export type GetSubscribersImportResponse = ImportJob;


### PR DESCRIPTION
#### Proposed Changes

* Updated import subscriber response object and took `upload_id` property instead of obsolete `id`.

#### Testing Instructions

* Go to `/setup/subscribers?flow=newsletter&complete-setup=true&siteSlug={SLUG}`
* Select a CSV file
* Click on the 'Continue' button

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
