### PR TITLE
Pricing page rework: Change feature cards breakpoint from break_medium to 821px and set border radius to 8px.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -3,8 +3,8 @@
 
 .featured-item-card {
 	background: linear-gradient( 159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53% );
-	border-start-end-radius: 4px;
-	border-start-start-radius: 4px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 8px;
 	color: var( --gray-100 );
 	display: flex;
 	flex-direction: column;

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
@@ -4,8 +4,8 @@
 .features-list {
 	padding: 1.5rem;
 	/* stylelint-disable scales/radii */
-	border-bottom-left-radius: 8px;
-	border-bottom-right-radius: 8px;
+	border-end-start-radius: 8px;
+	border-end-end-radius: 8px;
 	/* stylelint-enable scales/radii */
 
 	@include break-mobile {

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
@@ -3,6 +3,10 @@
 
 .features-list {
 	padding: 1.5rem;
+	/* stylelint-disable scales/radii */
+	border-bottom-left-radius: 8px;
+	border-bottom-right-radius: 8px;
+	/* stylelint-enable scales/radii */
 
 	@include break-mobile {
 		padding-bottom: 2.5rem;

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/bundles-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/bundles-list.tsx
@@ -6,6 +6,8 @@ import { AllItems } from './all-items';
 import { MostPopular } from './most-popular';
 import type { BundlesListProps } from '../types';
 
+import './style-bundle-list.scss';
+
 export const BundlesList: React.FC< BundlesListProps > = ( {
 	createCheckoutURL,
 	duration,

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-bundle-list.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-bundle-list.scss
@@ -1,0 +1,4 @@
+.jetpack-product-store__bundles-list .featured-item-card {
+	border-bottom-left-radius: 0;
+	border-bottom-right-radius: 0;
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-bundle-list.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-bundle-list.scss
@@ -1,4 +1,4 @@
 .jetpack-product-store__bundles-list .featured-item-card {
-	border-bottom-left-radius: 0;
-	border-bottom-right-radius: 0;
+	border-end-start-radius: 0;
+	border-end-end-radius: 0;
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -24,7 +24,7 @@
 	grid-template-columns: 1fr;
 	grid-gap: 24px;
 
-	@include break-medium {
+	@media only screen and (min-width: 821px) {
 		grid-template-columns: 1fr 1fr;
 		margin: 32px auto 0;
 		gap: 24px;


### PR DESCRIPTION
### Description
Currently the feature cards do not stack properly when viewed in Ipad Air (portrait) screen. Border radius is also not correct base on the figma design.
![container-beautiful-lamarr calypso live_pricing_flags=jetpack%2Fpricing-page-rework-v1 view=bundles(iPad Air) (1)](https://user-images.githubusercontent.com/56598660/188866779-6e3af4e3-edeb-4777-ba21-49f569d193f8.png)

#### Proposed Changes

* Change feature cards' breakpoint from `break_medium` to `821px` to fix issue w/ Ipad air (portrait) screen not properly stacking the cards.
* Fix featured cards and items border radius to 8px to match design.

#### Testing Instructions

1. * Run `git fetch && git checkout fix/pricing-page-feature-cards-breakpoint`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
3. Using chrome browser, open device tool and set device view to Ipad Air (portrait).
4. Confirm that the feature cards stacks correctly.

<img width="801" alt="Screen Shot 2022-09-08 at 2 28 00 PM" src="https://user-images.githubusercontent.com/56598660/189050242-337f6518-a4b2-4745-88a5-0a0b1ae066c2.png">


5. Confirm borders is 8px for featured cards and featured cards + featured items.
<img width="1205" alt="Screen Shot 2022-09-08 at 2 21 29 PM" src="https://user-images.githubusercontent.com/56598660/189049687-e71c4430-86b2-4bc2-9cf1-f4f5a1b67728.png">

<img width="625" alt="Screen Shot 2022-09-08 at 2 28 47 PM" src="https://user-images.githubusercontent.com/56598660/189050593-3e261412-ba41-47d5-af34-a3937d63b389.png"> <img width="625" alt="Screen Shot 2022-09-08 at 2 28 52 PM" src="https://user-images.githubusercontent.com/56598660/189050932-2217c449-3c31-44c7-8612-69bf49219db9.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202936358291314

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202936358291314