### PR TITLE
Hosting Configuration: Remove beta notice for SSH access

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -186,10 +186,9 @@ export const SftpCard = ( {
 					checked={ isSshAccessEnabled }
 					onChange={ () => toggleSshAccess() }
 					label={ translate(
-						'Enable SSH access for this site. {{em}}This feature is currently in beta.{{/em}} For more information see {{supportLink}}SSH on WordPress.com{{/supportLink}}.',
+						'Enable SSH access for this site. For more information see {{supportLink}}Connect to SSH on WordPress.com{{/supportLink}}.',
 						{
 							components: {
-								em: <em />,
 								supportLink: (
 									<ExternalLink
 										icon
@@ -289,7 +288,7 @@ export const SftpCard = ( {
 						<PanelBody title={ translate( 'What is SSH?' ) } initialOpen={ false }>
 							{ translate(
 								'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. ' +
-									'For more information see {{supportLink}}SSH on WordPress.com{{/supportLink}}. {{em}}This feature is currently in beta.{{/em}}',
+									'For more information see {{supportLink}}Connect to SSH on WordPress.com{{/supportLink}}.',
 								{
 									components: {
 										supportLink: (
@@ -301,7 +300,6 @@ export const SftpCard = ( {
 												) }
 											/>
 										),
-										em: <em />,
 									},
 								}
 							) }

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -186,7 +186,7 @@ export const SftpCard = ( {
 					checked={ isSshAccessEnabled }
 					onChange={ () => toggleSshAccess() }
 					label={ translate(
-						'Enable SSH access for this site. For more information see {{supportLink}}Connect to SSH on WordPress.com{{/supportLink}}.',
+						'Enable SSH access for this site. {{supportLink}}Learn more{{/supportLink}}.',
 						{
 							components: {
 								supportLink: (


### PR DESCRIPTION
From p1662552753600149-slack-C03TP5Z3MPD

## Proposed Changes

Removes the beta notice from the SSH access fields. Notably, I tweaked the strings to avoid a wrapping issue where the period ended up widowed on a new line.

The fields now look like this:

<img width="759" alt="image" src="https://user-images.githubusercontent.com/36432/188885355-1f38e5ee-9b9a-4e18-a68c-88b218804f14.png">

<img width="755" alt="image" src="https://user-images.githubusercontent.com/36432/188885723-b18bc252-29da-43cd-9beb-ae207e9f22f3.png">

## Testing Instructions

1. Create a new Business site.
2. Navigate to `/hosting-configuration`
3. Verify the `<PanelBody>` field appears as expected.
4. Enable SFTP access.
5. Verify the `<ToggleControl>` field appears as expected.