### PR TITLE
Style selection: Implement button to submit selected design and variation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
@@ -67,7 +67,7 @@ const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 				return;
 			}
 
-			return setDesignOnSite( newSite.site_slug, _selectedDesign, '' ).then( () =>
+			return setDesignOnSite( newSite.site_slug, _selectedDesign, undefined, '' ).then( () =>
 				reduxDispatch( requestActiveTheme( newSite.blogid ) )
 			);
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
@@ -67,7 +67,7 @@ const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 				return;
 			}
 
-			return setDesignOnSite( newSite.site_slug, _selectedDesign, undefined, '' ).then( () =>
+			return setDesignOnSite( newSite.site_slug, _selectedDesign ).then( () =>
 				reduxDispatch( requestActiveTheme( newSite.blogid ) )
 			);
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -260,7 +260,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 				: -1;
 
 			setPendingAction( () =>
-				setDesignOnSite( siteSlugOrId, _selectedDesign, siteVerticalId ).then( () =>
+				setDesignOnSite( siteSlugOrId, _selectedDesign, undefined, siteVerticalId ).then( () =>
 					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
 				)
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -260,7 +260,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 				: -1;
 
 			setPendingAction( () =>
-				setDesignOnSite( siteSlugOrId, _selectedDesign, undefined, siteVerticalId ).then( () =>
+				setDesignOnSite( siteSlugOrId, _selectedDesign, { verticalId: siteVerticalId } ).then( () =>
 					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
 				)
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -244,12 +244,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				);
 			}
 			setPendingAction( () =>
-				setDesignOnSite(
-					siteSlugOrId,
-					_selectedDesign,
-					selectedStyleVariation,
-					siteVerticalId
-				).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
+				setDesignOnSite( siteSlugOrId, _selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					verticalId: siteVerticalId,
+				} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -146,7 +146,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		setIsPreviewingDesign( true );
 	}
 
-	// ********** Logic for fetching the details of a selected design with style variations
+	// ********** Logic for selecting a style variation of the selected design
 
 	const isEnabledStyleSelection =
 		selectedDesign &&
@@ -156,6 +156,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
 		enabled: isPreviewingDesign && isEnabledStyleSelection,
 	} );
+
+	const selectedStyleVariation = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getSelectedStyleVariation()
+	);
+	const { setSelectedStyleVariation } = useDispatch( ONBOARD_STORE );
 
 	// ********** Logic for unlocking a selected premium design
 
@@ -239,9 +244,12 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				);
 			}
 			setPendingAction( () =>
-				setDesignOnSite( siteSlugOrId, _selectedDesign, siteVerticalId ).then( () =>
-					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
-				)
+				setDesignOnSite(
+					siteSlugOrId,
+					_selectedDesign,
+					selectedStyleVariation,
+					siteVerticalId
+				).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign ),
@@ -282,6 +290,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			);
 
 			setSelectedDesign( undefined );
+			setSelectedStyleVariation( undefined );
 			setIsPreviewingDesign( false );
 			return;
 		}
@@ -336,6 +345,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 						title={ designTitle }
 						description={ selectedDesign.description }
 						variations={ selectedDesignDetails?.style_variations }
+						selectedVariation={ selectedStyleVariation }
+						onSelectVariation={ setSelectedStyleVariation }
 					/>
 				) : (
 					<WebPreview
@@ -362,7 +373,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		);
 
 		const pickDesignText =
-			selectedDesign?.design_type === 'vertical'
+			selectedDesign?.design_type === 'vertical' || isEnabledStyleSelection
 				? translate( 'Select and continue' )
 				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
 
@@ -386,7 +397,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				stepContent={ stepContent }
 				hideSkip
 				className="design-setup__preview design-setup__preview__has-more-info"
+				nextLabelText={ pickDesignText }
 				goBack={ handleBackClick }
+				goNext={ () => pickDesign() }
+				customizedActionButtons={ actionButtons }
 				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		) : (

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -8,7 +8,7 @@ import { FeatureId } from '../wpcom-features/types';
 import { SiteGoal, STORE_KEY } from './constants';
 import type { State } from '.';
 // somewhat hacky, but resolves the circular dependency issue
-import type { Design, FontPair } from '@automattic/design-picker/src/types';
+import type { Design, FontPair, StyleVariation } from '@automattic/design-picker/src/types';
 
 // copied from design picker to avoid a circular dependency
 function isBlankCanvasDesign( design: { slug: string } | undefined ): boolean {
@@ -177,6 +177,13 @@ export const setSelectedDesign = ( selectedDesign: Design | undefined ) => ( {
 	selectedDesign,
 } );
 
+export const setSelectedStyleVariation = (
+	selectedStyleVariation: StyleVariation | undefined
+) => ( {
+	type: 'SET_SELECTED_STYLE_VARIATION' as const,
+	selectedStyleVariation,
+} );
+
 export const setSelectedSite = ( selectedSite: number | undefined ) => ( {
 	type: 'SET_SELECTED_SITE' as const,
 	selectedSite,
@@ -325,6 +332,7 @@ export type OnboardAction = ReturnType<
 	| typeof setPlanProductId
 	| typeof setRandomizedDesigns
 	| typeof setSelectedDesign
+	| typeof setSelectedStyleVariation
 	| typeof setSelectedSite
 	| typeof setShowSignupDialog
 	| typeof setPatternContent

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -4,7 +4,7 @@ import type { DomainSuggestion } from '../domain-suggestions/types';
 import type { FeatureId } from '../wpcom-features/types';
 import type { OnboardAction } from './actions';
 // somewhat hacky, but resolves the circular dependency issue
-import type { Design, FontPair } from '@automattic/design-picker/src/types';
+import type { Design, FontPair, StyleVariation } from '@automattic/design-picker/src/types';
 import type { Reducer } from 'redux';
 
 const domain: Reducer< DomainSuggestion | undefined, OnboardAction > = ( state, action ) => {
@@ -117,6 +117,19 @@ const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, ac
 		return action.selectedDesign;
 	}
 	if ( [ 'RESET_SELECTED_DESIGN', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+		return undefined;
+	}
+	return state;
+};
+
+const selectedStyleVariation: Reducer< StyleVariation | undefined, OnboardAction > = (
+	state,
+	action
+) => {
+	if ( action.type === 'SET_SELECTED_STYLE_VARIATION' ) {
+		return action.selectedStyleVariation;
+	}
+	if ( [ 'RESET_SELECTED_STYLE_VARIATION', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return undefined;
 	}
 	return state;
@@ -379,6 +392,7 @@ const reducer = combineReducers( {
 	storeType,
 	selectedFonts,
 	selectedDesign,
+	selectedStyleVariation,
 	selectedSite,
 	siteTitle,
 	showSignupDialog,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -8,6 +8,7 @@ export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getLastLocation = ( state: State ) => state.lastLocation;
 export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
+export const getSelectedStyleVariation = ( state: State ) => state.selectedStyleVariation;
 export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,4 +1,4 @@
-import { Design, StyleVariation } from '@automattic/design-picker/src/types';
+import { Design, DesignOptions } from '@automattic/design-picker/src/types';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
 import {
@@ -294,12 +294,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 	}
 
-	function* setDesignOnSite(
-		siteSlug: string,
-		selectedDesign: Design,
-		selectedStyleVariation?: StyleVariation,
-		siteVerticalId?: string
-	) {
+	function* setDesignOnSite( siteSlug: string, selectedDesign: Design, options?: DesignOptions ) {
 		const { theme, recipe } = selectedDesign;
 
 		yield wpcomRequest( {
@@ -307,7 +302,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			apiVersion: '1.1',
 			body: {
 				theme: recipe?.stylesheet?.split( '/' )[ 1 ] || theme,
-				style_variation_slug: selectedStyleVariation?.slug,
+				style_variation_slug: options?.styleVariation?.slug,
 				dont_change_homepage: true,
 			},
 			method: 'POST',
@@ -324,7 +319,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			};
 
 			if ( selectedDesign.verticalizable ) {
-				themeSetupOptions.vertical_id = siteVerticalId;
+				themeSetupOptions.vertical_id = options?.verticalId;
 			}
 
 			if ( recipe?.pattern_ids ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,4 +1,4 @@
-import { Design } from '@automattic/design-picker/src/types';
+import { Design, StyleVariation } from '@automattic/design-picker/src/types';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
 import {
@@ -294,13 +294,22 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 	}
 
-	function* setDesignOnSite( siteSlug: string, selectedDesign: Design, siteVerticalId?: string ) {
+	function* setDesignOnSite(
+		siteSlug: string,
+		selectedDesign: Design,
+		selectedStyleVariation?: StyleVariation,
+		siteVerticalId?: string
+	) {
 		const { theme, recipe } = selectedDesign;
 
 		yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine`,
 			apiVersion: '1.1',
-			body: { theme: recipe?.stylesheet?.split( '/' )[ 1 ] || theme, dont_change_homepage: true },
+			body: {
+				theme: recipe?.stylesheet?.split( '/' )[ 1 ] || theme,
+				style_variation_slug: selectedStyleVariation?.slug,
+				dont_change_homepage: true,
+			},
 			method: 'POST',
 		} );
 

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -410,7 +410,7 @@ describe( 'Site Actions', () => {
 			request: {
 				path: `/sites/${ siteSlug }/themes/mine`,
 				apiVersion: '1.1',
-				body: { theme: 'zoologist', dont_change_homepage: true },
+				body: { theme: 'zoologist', style_variation_slug: 'default', dont_change_homepage: true },
 				method: 'POST',
 			},
 		};
@@ -452,6 +452,7 @@ describe( 'Site Actions', () => {
 					...mockedDesign,
 					verticalizable: true,
 				},
+				undefined,
 				mockedSiteVerticalId
 			);
 
@@ -476,6 +477,7 @@ describe( 'Site Actions', () => {
 					...mockedDesign,
 					verticalizable: true,
 				},
+				undefined,
 				mockedSiteVerticalId
 			);
 

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -404,16 +404,29 @@ describe( 'Site Actions', () => {
 			features: [],
 			recipe: mockedRecipe,
 		};
+		const mockedStyleVariation = {
+			slug: 'default',
+			settings: {
+				color: {
+					palette: {
+						theme: [],
+					},
+				},
+			},
+			styles: {
+				color: {},
+			},
+		};
 
-		const mockedThemeSwitchApiRequest = {
+		const createMockedThemeSwitchApiRequest = ( payload ) => ( {
 			type: 'WPCOM_REQUEST',
 			request: {
 				path: `/sites/${ siteSlug }/themes/mine`,
 				apiVersion: '1.1',
-				body: { theme: 'zoologist', style_variation_slug: 'default', dont_change_homepage: true },
+				body: payload,
 				method: 'POST',
 			},
-		};
+		} );
 
 		const createMockedThemeSetupApiRequest = ( payload ) => ( {
 			type: 'WPCOM_REQUEST',
@@ -425,7 +438,21 @@ describe( 'Site Actions', () => {
 			},
 		} );
 
-		it( 'should not send vertical_id if the design is not verticalizable', () => {
+		it( 'should send style_variation_slug to themes/mine API if the design has style variation', () => {
+			const { setDesignOnSite } = createActions( mockedClientCredentials );
+			const generator = setDesignOnSite( siteSlug, mockedDesign, mockedStyleVariation );
+
+			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					style_variation_slug: 'default',
+					dont_change_homepage: true,
+				} )
+			);
+		} );
+
+		it( 'should not send vertical_id to theme-setup API if the design is not verticalizable', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
 			const generator = setDesignOnSite( siteSlug, {
 				...mockedDesign,
@@ -433,7 +460,12 @@ describe( 'Site Actions', () => {
 			} );
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					dont_change_homepage: true,
+				} )
+			);
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
 			expect( generator.next().value ).toEqual(
@@ -443,7 +475,7 @@ describe( 'Site Actions', () => {
 			);
 		} );
 
-		it( 'should send vertical_id if the design is verticalizable but the vertical id is empty string', () => {
+		it( 'should send vertical_id to theme-setup API if the design is verticalizable and vertical id is passed', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
 			const mockedSiteVerticalId = '1';
 			const generator = setDesignOnSite(
@@ -457,7 +489,12 @@ describe( 'Site Actions', () => {
 			);
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					dont_change_homepage: true,
+				} )
+			);
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
 			expect( generator.next().value ).toEqual(
@@ -468,32 +505,7 @@ describe( 'Site Actions', () => {
 			);
 		} );
 
-		it( 'should send vertical_id if the design is verticalizable and vertical id is not empty string', () => {
-			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const mockedSiteVerticalId = '1';
-			const generator = setDesignOnSite(
-				siteSlug,
-				{
-					...mockedDesign,
-					verticalizable: true,
-				},
-				undefined,
-				mockedSiteVerticalId
-			);
-
-			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
-
-			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSetupApiRequest( {
-					trim_content: true,
-					vertical_id: mockedSiteVerticalId,
-				} )
-			);
-		} );
-
-		it( 'should send pattern_ids if the recipe of the design has this property', () => {
+		it( 'should send pattern_ids to theme-setup API if the recipe of the design has this property', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
 			const patternIds = [ 1, 2, 3 ];
 			const generator = setDesignOnSite( siteSlug, {
@@ -505,7 +517,12 @@ describe( 'Site Actions', () => {
 			} );
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					dont_change_homepage: true,
+				} )
+			);
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
 			expect( generator.next().value ).toEqual(
@@ -516,7 +533,7 @@ describe( 'Site Actions', () => {
 			);
 		} );
 
-		it( 'should send header_pattern_ids if the recipe of the design has this property', () => {
+		it( 'should send header_pattern_ids to theme-setup API if the recipe of the design has this property', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
 			const headerPatternIds = [ 1, 2, 3 ];
 			const generator = setDesignOnSite( siteSlug, {
@@ -528,7 +545,12 @@ describe( 'Site Actions', () => {
 			} );
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					dont_change_homepage: true,
+				} )
+			);
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
 			expect( generator.next().value ).toEqual(
@@ -539,7 +561,7 @@ describe( 'Site Actions', () => {
 			);
 		} );
 
-		it( 'should send footer_pattern_ids if the recipe of the design has this property', () => {
+		it( 'should send footer_pattern_ids to theme-setup API if the recipe of the design has this property', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
 			const footerPatternIds = [ 1, 2, 3 ];
 			const generator = setDesignOnSite( siteSlug, {
@@ -551,7 +573,12 @@ describe( 'Site Actions', () => {
 			} );
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					dont_change_homepage: true,
+				} )
+			);
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
 			expect( generator.next().value ).toEqual(
@@ -570,7 +597,12 @@ describe( 'Site Actions', () => {
 			} );
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual( mockedThemeSwitchApiRequest );
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+					dont_change_homepage: true,
+				} )
+			);
 
 			// Second iteration: Complete the cycle
 			expect( generator.next().done ).toEqual( true );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -440,7 +440,9 @@ describe( 'Site Actions', () => {
 
 		it( 'should send style_variation_slug to themes/mine API if the design has style variation', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const generator = setDesignOnSite( siteSlug, mockedDesign, mockedStyleVariation );
+			const generator = setDesignOnSite( siteSlug, mockedDesign, {
+				styleVariation: mockedStyleVariation,
+			} );
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
 			expect( generator.next().value ).toEqual(
@@ -484,8 +486,7 @@ describe( 'Site Actions', () => {
 					...mockedDesign,
 					verticalizable: true,
 				},
-				undefined,
-				mockedSiteVerticalId
+				{ verticalId: mockedSiteVerticalId }
 			);
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -105,6 +105,11 @@ export interface Design {
 	hide?: boolean;
 }
 
+export interface DesignOptions {
+	styleVariation?: StyleVariation;
+	verticalId?: string;
+}
+
 export interface DesignPreviewOptions {
 	language?: string;
 	vertical_id?: string;

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import Sidebar from './sidebar';
 import SitePreview from './site-preview';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
@@ -9,6 +9,8 @@ interface PreviewProps {
 	title?: string;
 	description?: string;
 	variations?: StyleVariation[];
+	selectedVariation?: StyleVariation;
+	onSelectVariation: ( variation: StyleVariation ) => void;
 }
 
 const Preview: React.FC< PreviewProps > = ( {
@@ -16,14 +18,14 @@ const Preview: React.FC< PreviewProps > = ( {
 	title,
 	description,
 	variations = [],
+	selectedVariation,
+	onSelectVariation,
 } ) => {
-	const [ activeVariation, setActiveVariation ] = useState< StyleVariation | undefined >();
-
 	useEffect( () => {
-		if ( variations.length > 0 && ! activeVariation ) {
-			setActiveVariation( variations[ 0 ] );
+		if ( variations.length > 0 && ! selectedVariation ) {
+			onSelectVariation( variations[ 0 ] );
 		}
-	}, [ variations, activeVariation ] );
+	}, [ variations, selectedVariation, onSelectVariation ] );
 
 	return (
 		<div className="design-preview">
@@ -31,10 +33,10 @@ const Preview: React.FC< PreviewProps > = ( {
 				title={ title }
 				description={ description }
 				variations={ variations }
-				activeVariation={ activeVariation }
-				onVariationClick={ setActiveVariation }
+				selectedVariation={ selectedVariation }
+				onSelectVariation={ onSelectVariation }
 			/>
-			<SitePreview url={ previewUrl } inlineCss={ activeVariation?.inline_css || '' } />
+			<SitePreview url={ previewUrl } inlineCss={ selectedVariation?.inline_css || '' } />
 		</div>
 	);
 };

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -6,16 +6,16 @@ interface SidebarProps {
 	title?: string;
 	description?: string;
 	variations: StyleVariation[];
-	activeVariation?: StyleVariation;
-	onVariationClick: ( variation: StyleVariation ) => void;
+	selectedVariation?: StyleVariation;
+	onSelectVariation: ( variation: StyleVariation ) => void;
 }
 
 const Sidebar: React.FC< SidebarProps > = ( {
 	title,
 	description,
 	variations = [],
-	activeVariation,
-	onVariationClick,
+	selectedVariation,
+	onSelectVariation,
 } ) => {
 	return (
 		<div className="design-preview__sidebar">
@@ -35,8 +35,8 @@ const Sidebar: React.FC< SidebarProps > = ( {
 					<div className="design-preview__sidebar-variations-grid">
 						<StyleVariationPreviews
 							variations={ variations }
-							activeVariation={ activeVariation }
-							onClick={ onVariationClick }
+							activeVariation={ selectedVariation }
+							onClick={ onSelectVariation }
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
#### Proposed Changes

This PR handles the submission of a design with the corresponding selected style variation. This works by passing the variation slug to the `style_variation_slug` field of the `/themes/mine` endpoint. The endpoint will then set the correct global style variation to the site.

**NOTE**: Currently the button is located at the top-right corner, following the existing implementation in the `<StepContainer>` component. I will implement moving the button to the sidebar later / in a follow-up PR.

#### Testing Instructions

1. Go to `/setup?siteSlug=<your-site-slug>`
2. Select any goal and click Continue.
3. Select any vertical and click Continue.
4. Select Pendant theme.
5. Select the Electric Blue style variation.
6. Click "Select and continue" button.
7. Go to the site editor.
8. Verify that you see the homepage with the same look-and-feel as you saw in the design picker preview step.
9. Click the Styles icon on the top-right corner to open the Styles sidebar.
10. Click "Browse styles".
11. Verify that the Electric Blue style variation is active (highlighted / has black border).


#### Pre-merge Checklist


- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66842 
