### PR TITLE
Use react-query to load domains in `TitanSetUpMailbox`

### DIFF
--- a/client/lib/titan/get-configured-titan-mailbox-count.js
+++ b/client/lib/titan/get-configured-titan-mailbox-count.js
@@ -1,3 +1,0 @@
-export function getConfiguredTitanMailboxCount( domain ) {
-	return domain.titanMailSubscription?.numberOfMailboxes ?? 0;
-}

--- a/client/lib/titan/get-configured-titan-mailbox-count.ts
+++ b/client/lib/titan/get-configured-titan-mailbox-count.ts
@@ -1,0 +1,5 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+export function getConfiguredTitanMailboxCount( domain: ResponseDomain | undefined ): number {
+	return domain?.titanMailSubscription?.numberOfMailboxes ?? 0;
+}

--- a/client/lib/titan/get-configured-titan-mailbox-count.ts
+++ b/client/lib/titan/get-configured-titan-mailbox-count.ts
@@ -1,5 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function getConfiguredTitanMailboxCount( domain: ResponseDomain | undefined ): number {
-	return domain?.titanMailSubscription?.numberOfMailboxes ?? 0;
+export function getConfiguredTitanMailboxCount( domain: ResponseDomain ): number {
+	return domain.titanMailSubscription?.numberOfMailboxes ?? 0;
 }

--- a/client/lib/titan/get-max-titan-mailbox-count.js
+++ b/client/lib/titan/get-max-titan-mailbox-count.js
@@ -1,3 +1,0 @@
-export function getMaxTitanMailboxCount( domain ) {
-	return domain.titanMailSubscription?.maximumMailboxCount ?? 1;
-}

--- a/client/lib/titan/get-max-titan-mailbox-count.ts
+++ b/client/lib/titan/get-max-titan-mailbox-count.ts
@@ -1,5 +1,10 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function getMaxTitanMailboxCount( domain: ResponseDomain | undefined ): number {
-	return domain?.titanMailSubscription?.maximumMailboxCount ?? 1;
+/**
+ * Returns the maximum number of mailboxes that can be provisioned for a domain. Because a Titan
+ * subscription must have at least one mailbox, `1` is the default return value even for domains
+ * without an active Titan subscription.
+ */
+export function getMaxTitanMailboxCount( domain: ResponseDomain ): number {
+	return domain.titanMailSubscription?.maximumMailboxCount ?? 1;
 }

--- a/client/lib/titan/get-max-titan-mailbox-count.ts
+++ b/client/lib/titan/get-max-titan-mailbox-count.ts
@@ -1,0 +1,5 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+export function getMaxTitanMailboxCount( domain: ResponseDomain | undefined ): number {
+	return domain?.titanMailSubscription?.maximumMailboxCount ?? 1;
+}

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -10,11 +10,7 @@ import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
-import {
-	getConfiguredTitanMailboxCount,
-	getMaxTitanMailboxCount,
-	hasTitanMailWithUs,
-} from 'calypso/lib/titan';
+import { getConfiguredTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
@@ -184,7 +180,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 
 	if ( isSingleDomainThatHasEmail ) {
 		if (
-			getMaxTitanMailboxCount( domainsWithEmail[ 0 ] ) > 0 &&
+			( domainsWithEmail[ 0 ].titanMailSubscription?.maximumMailboxCount ?? 0 ) > 0 &&
 			getConfiguredTitanMailboxCount( domainsWithEmail[ 0 ] ) === 0
 		) {
 			page.redirect(

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -10,7 +10,11 @@ import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
-import { hasTitanMailWithUs } from 'calypso/lib/titan';
+import {
+	getConfiguredTitanMailboxCount,
+	getMaxTitanMailboxCount,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
@@ -180,8 +184,8 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 
 	if ( isSingleDomainThatHasEmail ) {
 		if (
-			( domainsWithEmail[ 0 ].titanMailSubscription?.maximumMailboxCount ?? 0 ) > 0 &&
-			domainsWithEmail[ 0 ].titanMailSubscription?.numberOfMailboxes === 0
+			getMaxTitanMailboxCount( domainsWithEmail[ 0 ] ) > 0 &&
+			getConfiguredTitanMailboxCount( domainsWithEmail[ 0 ] ) === 0
 		) {
 			page.redirect(
 				emailManagementTitanSetUpMailbox( selectedSite.slug, domainsWithEmail[ 0 ].domain )

--- a/client/my-sites/email/titan-set-up-mailbox/index.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/index.tsx
@@ -48,10 +48,6 @@ const TitanSetUpMailbox = ( { selectedDomainName, source }: TitanSetUpMailboxPro
 
 	const hasTitanSubscription = hasTitanMailWithUs( selectedDomain );
 
-	const configuredMailboxCount = getConfiguredTitanMailboxCount( selectedDomain );
-	const maxMailboxCount = getMaxTitanMailboxCount( selectedDomain );
-	const hasUnconfiguredMailboxes = configuredMailboxCount < maxMailboxCount;
-
 	const handleBack = useCallback( () => {
 		page( previousRoute );
 	}, [ previousRoute ] );
@@ -69,13 +65,19 @@ const TitanSetUpMailbox = ( { selectedDomainName, source }: TitanSetUpMailboxPro
 					source
 				)
 			);
-		} else if ( selectedDomain && ! hasUnconfiguredMailboxes ) {
-			page.redirect( emailManagement( selectedSiteSlug ?? '', selectedDomainName ) );
+		}
+
+		if ( selectedDomain && hasTitanSubscription ) {
+			const configuredMailboxCount = getConfiguredTitanMailboxCount( selectedDomain );
+			const maxMailboxCount = getMaxTitanMailboxCount( selectedDomain );
+
+			if ( configuredMailboxCount < maxMailboxCount ) {
+				page.redirect( emailManagement( selectedSiteSlug ?? '', selectedDomainName ) );
+			}
 		}
 	}, [
 		currentRoute,
 		hasTitanSubscription,
-		hasUnconfiguredMailboxes,
 		selectedDomain,
 		selectedDomainName,
 		selectedSiteSlug,

--- a/client/my-sites/email/titan-set-up-mailbox/index.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/index.tsx
@@ -10,9 +10,17 @@ import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { getSelectedDomain } from 'calypso/lib/domains';
-import { hasTitanMailWithUs, getTitanProductName } from 'calypso/lib/titan';
+import {
+	getConfiguredTitanMailboxCount,
+	getMaxTitanMailboxCount,
+	getTitanProductName,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
+import {
+	emailManagementPurchaseNewEmailAccount,
+	emailManagement,
+} from 'calypso/my-sites/email/paths';
 import TitanSetUpMailboxForm from 'calypso/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -40,6 +48,10 @@ const TitanSetUpMailbox = ( { selectedDomainName, source }: TitanSetUpMailboxPro
 
 	const hasTitanSubscription = hasTitanMailWithUs( selectedDomain );
 
+	const configuredMailboxCount = getConfiguredTitanMailboxCount( selectedDomain );
+	const maxMailboxCount = getMaxTitanMailboxCount( selectedDomain );
+	const hasUnconfiguredMailboxes = configuredMailboxCount < maxMailboxCount;
+
 	const handleBack = useCallback( () => {
 		page( previousRoute );
 	}, [ previousRoute ] );
@@ -57,11 +69,14 @@ const TitanSetUpMailbox = ( { selectedDomainName, source }: TitanSetUpMailboxPro
 					source
 				)
 			);
+		} else if ( selectedDomain && ! hasUnconfiguredMailboxes ) {
+			page.redirect( emailManagement( selectedSiteSlug ?? '', selectedDomainName ) );
 		}
 	}, [
-		selectedDomain,
 		currentRoute,
 		hasTitanSubscription,
+		hasUnconfiguredMailboxes,
+		selectedDomain,
 		selectedDomainName,
 		selectedSiteSlug,
 		source,

--- a/client/my-sites/email/titan-set-up-mailbox/index.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/index.tsx
@@ -8,6 +8,7 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasTitanMailWithUs, getTitanProductName } from 'calypso/lib/titan';
 import EmailHeader from 'calypso/my-sites/email/email-header';
@@ -15,7 +16,7 @@ import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/p
 import TitanSetUpMailboxForm from 'calypso/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 interface TitanSetUpMailboxProps {
@@ -30,9 +31,10 @@ const TitanSetUpMailbox = ( { selectedDomainName, source }: TitanSetUpMailboxPro
 
 	const previousRoute = useSelector( getPreviousRoute );
 
-	const domains = useSelector( ( state ) =>
-		getDomainsBySiteId( state, selectedSiteId ?? undefined )
-	);
+	const { data: allDomains = [] } = useGetDomainsQuery( selectedSiteId, {
+		retry: false,
+	} );
+	const domains = allDomains.map( createSiteDomainObject );
 
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 


### PR DESCRIPTION
#### Proposed Changes

In the `TitanSetUpMailbox` component, we rely on Redux rather than react-query for looking up domains. This isn't ideal, because `EmailHome` and other email management components tend to rely on react-query, and when we don't have a unified approach, state invalidation doesn't work properly.

This sometimes resulted in an issue where users would "get stuck" in the "Set Up Mailbox" view. I.e. after they submitted the form and tried to go to the email management page, they would be taken straight back to the "Set Up Mailbox" view. See screencasts below for clarification.

In this PR, I've updated the logic in `TitanSetUpMailbox` for retrieving the current site's domains to use a react-query based hook. I also took the opportunity to convert `getConfiguredTitanMailboxCount` and `getMaxTitanMailboxCount` to Typescript.

| Before | After |
|-|-|
| <video src="https://user-images.githubusercontent.com/1101677/189056685-2cd39262-97ac-4132-a0a9-d7be6b1a8f02.mp4" /> | <video src="https://user-images.githubusercontent.com/1101677/189056699-e8a0fb0a-8e21-4463-8c29-855c4f48722a.mp4" /> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a domain with an unconfigured mailbox (go to `/start/onboarding-with-email` to get one)
2. Go to the Homepage in Calypso (important because we need to query data in the right order)
3. Click on Upgrades > Emails in the sidebar
4. You should automatically be redirected to the "Set Up Mailbox" view
5. Submit the form
6. Click on Upgrades > Emails in the sidebar
7. Ensure that you are directed to the email management page (potentially after an extra redirect) and not the "Set Up Mailbox" view again

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
