### PR TITLE
TailoredFlowProcessingScreen: remove checkout related messages

### DIFF
--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -19,7 +19,6 @@ const useSteps = ( flowName ) => {
 				{ title: __( 'Great choices. Nearly there!' ) },
 				{ title: __( 'Shining and polishing your Bio' ) },
 				{ title: __( 'Mounting it on a marble pedestal' ) },
-				{ title: __( 'Looking good. Time for checkout!' ) },
 			];
 			break;
 		case NEWSLETTER_FLOW:
@@ -27,7 +26,6 @@ const useSteps = ( flowName ) => {
 				{ title: __( 'Excellent choices. Nearly there!' ) },
 				{ title: __( 'Smoothing down the stationery' ) },
 				{ title: __( 'Embossing all the envelopes' ) },
-				{ title: __( 'Let’s head to the checkout' ) },
 			];
 			break;
 		default:


### PR DESCRIPTION
#### Proposed Changes

* This PR removes the checkout related messages from the `TailoredFlowProcessingScreen`
* This removes the necessity to add checkout related logic to the processing screen component.
* This bumps the interval duration for the steps from 1500ms to 2000ms which results in a smoother experience.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Go through the newsletter and LiB flow
- Ensure that the checkout related messages are not part of the processing step and that the loader is smoother

Related to #67439
