### PR TITLE
Remove feature flag guard from WP.org plugin search

### DIFF
--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -15,10 +15,6 @@ jest.mock( 'calypso/blocks/upsell-nudge', () => ( { plan } ) => (
 let mockPlugins = [];
 jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
 	useWPORGPlugins: jest.fn( () => ( { data: { plugins: mockPlugins } } ) ),
-	useWPORGInfinitePlugins: jest.fn( () => ( {
-		data: { plugins: mockPlugins },
-		fetchNextPage: jest.fn(),
-	} ) ),
 } ) );
 
 jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
@@ -28,6 +24,10 @@ jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
 
 jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
 	useSiteSearchPlugins: jest.fn( () => ( {
+		data: { plugins: mockPlugins },
+		fetchNextPage: jest.fn(),
+	} ) ),
+	useESPluginsInfinite: jest.fn( () => ( {
 		data: { plugins: mockPlugins },
 		fetchNextPage: jest.fn(),
 	} ) ),

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -31,6 +31,10 @@ jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
 		data: { plugins: mockPlugins },
 		fetchNextPage: jest.fn(),
 	} ) ),
+	useESPluginsInfinite: jest.fn( () => ( {
+		data: { plugins: mockPlugins },
+		fetchNextPage: jest.fn(),
+	} ) ),
 } ) );
 
 jest.mock( '@automattic/languages', () => [

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -15,6 +15,10 @@ jest.mock( 'calypso/blocks/upsell-nudge', () => ( { plan } ) => (
 let mockPlugins = [];
 jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
 	useWPORGPlugins: jest.fn( () => ( { data: { plugins: mockPlugins } } ) ),
+	useWPORGInfinitePlugins: jest.fn( () => ( {
+		data: { plugins: mockPlugins },
+		fetchNextPage: jest.fn(),
+	} ) ),
 } ) );
 
 jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
@@ -24,10 +28,6 @@ jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
 
 jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
 	useSiteSearchPlugins: jest.fn( () => ( {
-		data: { plugins: mockPlugins },
-		fetchNextPage: jest.fn(),
-	} ) ),
-	useESPluginsInfinite: jest.fn( () => ( {
 		data: { plugins: mockPlugins },
 		fetchNextPage: jest.fn(),
 	} ) ),

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Plugin } from 'calypso/data/marketplace/types';
@@ -6,7 +7,10 @@ import {
 	useWPCOMFeaturedPlugins,
 	useWPCOMPlugins,
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query';
+import {
+	useWPORGInfinitePlugins,
+	useWPORGPlugins,
+} from 'calypso/data/marketplace/use-wporg-plugin-query';
 import { useCategories } from '../categories/use-categories';
 
 interface WPORGResponse {
@@ -70,6 +74,11 @@ const usePlugins = ( {
 	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
+	const searchHook =
+		isEnabled( 'marketplace-jetpack-plugin-search' ) && search
+			? useESPluginsInfinite
+			: useWPORGInfinitePlugins;
+
 	const { localeSlug = '' } = useTranslate();
 	const wporgPluginsOptions = {
 		locale: locale || localeSlug,
@@ -93,7 +102,7 @@ const usePlugins = ( {
 		isLoading: isFetchingWPORGInfinite,
 		fetchNextPage,
 		hasNextPage,
-	} = useESPluginsInfinite( wporgPluginsOptions, {
+	} = searchHook( wporgPluginsOptions, {
 		enabled:
 			infinite &&
 			!! ( search || ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) ) &&

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Plugin } from 'calypso/data/marketplace/types';
@@ -7,10 +6,7 @@ import {
 	useWPCOMFeaturedPlugins,
 	useWPCOMPlugins,
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import {
-	useWPORGInfinitePlugins,
-	useWPORGPlugins,
-} from 'calypso/data/marketplace/use-wporg-plugin-query';
+import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import { useCategories } from '../categories/use-categories';
 
 interface WPORGResponse {
@@ -74,11 +70,6 @@ const usePlugins = ( {
 	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
-	const searchHook =
-		isEnabled( 'marketplace-jetpack-plugin-search' ) && search
-			? useESPluginsInfinite
-			: useWPORGInfinitePlugins;
-
 	const { localeSlug = '' } = useTranslate();
 	const wporgPluginsOptions = {
 		locale: locale || localeSlug,
@@ -102,7 +93,7 @@ const usePlugins = ( {
 		isLoading: isFetchingWPORGInfinite,
 		fetchNextPage,
 		hasNextPage,
-	} = searchHook( wporgPluginsOptions, {
+	} = useESPluginsInfinite( wporgPluginsOptions, {
 		enabled:
 			infinite &&
 			!! ( search || ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) ) &&

--- a/config/development.json
+++ b/config/development.json
@@ -101,7 +101,7 @@
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,
 		"marketplace-domain-bundle": true,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -65,7 +65,7 @@
 		"legal-updates-banner": false,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -71,7 +71,7 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -69,7 +69,7 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,7 +60,7 @@
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
 		"mailchimp": true,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,


### PR DESCRIPTION
#### Proposed Changes

* Remove the feature flag guard in plugins browser
* This change makes ElasticSearch based plugin search for WP.org plugins generally available

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins`
* Search for any plugin
* Verify that the search request is made to this endpoint: https://public-api.wordpress.com/rest/v1.3/marketplace/search?http_envelope=1&fields[]=blog_icon_url&fields[]=comment_count&fields[]=plugin.excerpt&fields[]=like_count&fields[]=modified&fields[]=modified_gmt&fields[]=plugin.title&fields[]=author&fields[]=plugin.author&fields[]=author_login&fields[]=blog_id&fields[]=date&fields[]=date_gmt&fields[]=permalink.url.raw&fields[]=post_id&fields[]=post_type&fields[]=slug&fields[]=plugin.tested&fields[]=plugin.stable_tag&fields[]=plugin.active_installs&fields[]=plugin.support_threads&fields[]=plugin.support_threads_resolved&fields[]=plugin.rating&fields[]=plugin.num_ratings&fields[]=plugin.icons&page_handle=1&query=newsletter&sort=score_default&size=20&lang=en&group_id=wporg

Before | After
--- | ---
![CleanShot 2022-09-07 at 18 08 16](https://user-images.githubusercontent.com/11555574/188927112-ef24dab0-db3d-4c68-adda-a463e9f77286.png) | ![CleanShot 2022-09-07 at 18 06 32](https://user-images.githubusercontent.com/11555574/188926655-f3c6f82b-8700-449c-bd66-0474832bf54c.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #66089
