### PR TITLE
Tailored Flows: Error state to use wordpress/icons

### DIFF
--- a/packages/components/src/forms/form-input-validation/index.tsx
+++ b/packages/components/src/forms/form-input-validation/index.tsx
@@ -39,7 +39,11 @@ const FormInputValidation: React.FC< Props > = ( {
 	return (
 		<div className={ classes } role="alert">
 			<span id={ id }>
-				{ icon ? <Gridicon size={ 24 } icon={ icon } /> : <Icon icon={ defaultIcon } /> }
+				{ icon ? (
+					<Gridicon size={ 24 } icon={ icon } />
+				) : (
+					<Icon size={ 24 } icon={ defaultIcon } />
+				) }
 				{ text }
 				{ children }
 			</span>

--- a/packages/components/src/forms/form-input-validation/index.tsx
+++ b/packages/components/src/forms/form-input-validation/index.tsx
@@ -1,3 +1,4 @@
+import { Icon, info, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
 import { Gridicon } from '../..';
@@ -33,12 +34,13 @@ const FormInputValidation: React.FC< Props > = ( {
 		'is-hidden': isHidden,
 	} );
 
-	const defaultIcon = isError || isWarning ? 'notice-outline' : 'checkmark';
+	const defaultIcon = isError || isWarning ? info : check;
 
 	return (
 		<div className={ classes } role="alert">
 			<span id={ id }>
-				<Gridicon size={ 24 } icon={ icon ? icon : defaultIcon } /> { text }
+				{ icon ? <Gridicon size={ 24 } icon={ icon } /> : <Icon icon={ defaultIcon } /> }
+				{ text }
 				{ children }
 			</span>
 		</div>

--- a/packages/components/src/forms/form-input-validation/style.scss
+++ b/packages/components/src/forms/form-input-validation/style.scss
@@ -4,11 +4,11 @@
 	color: var( --color-success );
 	position: relative;
 	padding: 6px 24px 11px 34px;
-	border-radius: 1px;
+	border-radius: 2px;
 	box-sizing: border-box;
 	font-size: $font-body-small;
 	animation: appear 0.3s ease-in-out;
-	font-weight: normal;
+	font-weight: 400;
 
 	&.is-error {
 		color: var( --color-error );
@@ -23,8 +23,9 @@
 		visibility: hidden;
 	}
 
-	.gridicon {
-		fill: currentColor;
+	.gridicon,
+	svg {
+		fill: currentcolor;
 		float: left;
 		margin-left: -34px;
 	}


### PR DESCRIPTION
#### Proposed Changes

In `linkInBioSetup` step in the link in bio flow, use `@wordpress/icons` instead of gridicon in the error state

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn start`
* Follow the link in bio flow: http://calypso.localhost:3000/setup?flow=link-in-bio
* Error state in step `linkInBioSetup` should use wordpress icon and not gridicon

Related to #67453
Fixes #67453
