### PR TITLE
Stepper: remove WordPress logo stroke

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,6 +2,7 @@
 	"extends": [ "stylelint-config-standard-scss", "@wordpress/stylelint-config/scss" ],
 	"plugins": [ "@signal-noise/stylelint-scales" ],
 	"rules": {
+		"media-feature-parentheses-space-inside": "always",
 		"at-rule-empty-line-before": [
 			"always",
 			{
@@ -26,7 +27,7 @@
 		"scales/font-weights": [ 400, 500, 600, 700 ],
 		"scales/font-sizes": [
 			{
-				"scale": [ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ],
+				"scale": [ 0.75, 0.875, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.75, 3, 3.375 ],
 				"units": [ "rem" ]
 			}
 		],

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -118,15 +118,6 @@ button {
 			}
 		}
 
-		// Courses has a dark background
-		@at-root .courses#{&} {
-			color: var( --color-text-inverted );
-
-			.wordpress-logo {
-				fill: var( --color-text-inverted );
-			}
-		}
-
 		@include break-small {
 			.wordpress-logo {
 				inset-inline-start: 24px;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -12,9 +12,8 @@
  */
 body,
 button {
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
-		'Cantarell', 'Helvetica Neue', sans-serif;
-	text-rendering: optimizeLegibility;
+	font-family: $sans;
+	text-rendering: optimizelegibility;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 
@@ -26,8 +25,7 @@ button {
 	h2,
 	h3,
 	p {
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
-			'Cantarell', 'Helvetica Neue', sans-serif;
+		font-family: $sans;
 		font-weight: 400;
 		margin: 0;
 	}
@@ -59,8 +57,8 @@ button {
 .completing-purchase,
 .anchor-fm,
 .subscribers,
-.blazepress {
-	position: relative;
+.blazepress,
+.intro {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 
@@ -71,16 +69,6 @@ button {
 
 	&.courses {
 		padding: 0;
-
-		.signup-header {
-			z-index: 1;
-			color: #fff;
-
-			svg path {
-				fill: #fff;
-				stroke: #fff;
-			}
-		}
 	}
 
 	.flow-progress {
@@ -108,12 +96,13 @@ button {
  	 * Signup Header
  	 */
 	.signup-header {
+		z-index: 1;
+
 		.wordpress-logo {
 			position: absolute;
-			inset-inline-start: 20px;
 			inset-block-start: 20px;
+			inset-inline-start: 24px;
 			fill: var( --color-text );
-			stroke: var( --color-text );
 			transform-origin: 0 0;
 		}
 
@@ -126,6 +115,15 @@ button {
 				/* stylelint-disable-line */
 				font-size: 0.875rem;
 				color: var( --studio-gray-30 );
+			}
+		}
+
+		// Courses has a dark background
+		@at-root .courses#{&} {
+			color: var( --color-text-inverted );
+
+			.wordpress-logo {
+				fill: var( --color-text-inverted );
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/style.scss
@@ -1,17 +1,21 @@
-@import '@wordpress/base-styles/_breakpoints.scss';
-@import '@wordpress/base-styles/_mixins.scss';
-
 $grey-header: #151b1e;
-$grey-footer: #101517;
 
 .courses {
+	.signup-header {
+		color: var( --color-text-inverted );
+
+		svg.wordpress-logo {
+			fill: var( --color-text-inverted );
+		}
+	}
+
 	.step-container__content {
 		padding-top: 60px;
 		background-color: $grey-header;
 	}
 
 	.step-container .step-container__navigation.action-buttons {
-		background-color: $grey-footer;
+		background-color: var( --studio-gray-100 );
 		border: 0;
 		box-shadow: 0 -1px 0 #2c3234;
 
@@ -66,6 +70,7 @@ $grey-footer: #101517;
 		box-shadow: 0 -1px 0 #2c3234;
 		background-color: var( --studio-gray-100 );
 		animation: appear 0.3s ease-in-out;
+
 		@include reduce-motion( 'animation' );
 
 		.courses__footer-content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+
 $grey-header: #151b1e;
 
 .courses {
@@ -9,52 +12,54 @@ $grey-header: #151b1e;
 		}
 	}
 
-	.step-container__content {
-		padding-top: 60px;
-		background-color: $grey-header;
-	}
+	.step-container {
+		.step-container__navigation.action-buttons {
+			background-color: var( --studio-gray-100 );
+			border: 0;
+			box-shadow: 0 -1px 0 #2c3234;
 
-	.step-container .step-container__navigation.action-buttons {
-		background-color: var( --studio-gray-100 );
-		border: 0;
-		box-shadow: 0 -1px 0 #2c3234;
+			button.navigation-link.is-borderless {
+				color: #fff;
 
-		button.navigation-link.is-borderless {
-			color: #fff;
+				svg {
+					fill: #fff;
+				}
+			}
 
-			svg {
-				fill: #fff;
+			@include break-small {
+				background-color: $grey-header;
+				box-shadow: none;
 			}
 		}
 
-		@include break-small {
+		.step-container__content {
+			padding-top: 60px;
 			background-color: $grey-header;
-			box-shadow: none;
-		}
-	}
 
-	.videos-ui {
-		position: relative;
-		width: 100%;
-		min-height: calc( 100vh - 60px );
+			.videos-ui {
+				position: relative;
+				width: 100%;
+				min-height: calc( 100vh - 60px );
 
-		span,
-		p {
-			font-size: 0.875rem;
-		}
-
-		.videos-ui__header .videos-ui__header-content .videos-ui__summary svg {
-			fill: #fff9;
-		}
-
-		.videos-ui__body {
-			svg use {
-				fill: #fff;
-			}
-
-			.videos-ui__active-video-content {
+				span,
 				p {
-					padding-bottom: 1.5em;
+					font-size: 0.875rem;
+				}
+
+				.videos-ui__header .videos-ui__header-content .videos-ui__summary svg {
+					fill: #fff9;
+				}
+
+				.videos-ui__body {
+					svg use {
+						fill: #fff;
+					}
+
+					.videos-ui__active-video-content {
+						p {
+							padding-bottom: 1.5em;
+						}
+					}
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -3,14 +3,15 @@
 
 .intro {
 	&.newsletter {
-		background-color: rgb( 162, 218, 254 );
-		background-image: url( 'calypso/assets/images/onboarding/newsletter-intro-left.png' ),
-		url( 'calypso/assets/images/onboarding/newsletter-intro-right.png' );
+		background-color: rgb( 162 218 254 );
+		background-image:
+			url( calypso/assets/images/onboarding/newsletter-intro-left.png ),
+			url( calypso/assets/images/onboarding/newsletter-intro-right.png );
 		background-repeat: no-repeat, no-repeat;
 		background-attachment: fixed;
-    	background-position-x: 0%, 100%;
-    	background-position-y: 100%, 100px;
-    	background-size: auto 30%, auto 50%;
+		background-position-x: 0%, 100%;
+		background-position-y: 100%, 100px;
+		background-size: auto 30%, auto 50%;
 
 		@include break-large {
 			background-size: auto 55%, auto 80%;
@@ -20,9 +21,9 @@
 
 	&.link-in-bio {
 		background-color: #d0cce3;
-
-		background-image: url( 'calypso/assets/images/onboarding/link-in-bio-intro-left.png' ),
-		url( 'calypso/assets/images/onboarding/link-in-bio-intro-right.png' );
+		background-image:
+			url( calypso/assets/images/onboarding/link-in-bio-intro-left.png ),
+			url( calypso/assets/images/onboarding/link-in-bio-intro-right.png );
 		background-position-y: 85%, 15%;
 		background-position-x: 0, 100%;
 		background-repeat: no-repeat, no-repeat;
@@ -47,15 +48,6 @@
 
 	.signup-header {
 		z-index: 1;
-
-		.wordpress-logo {
-			inset-block-start: 20px;
-			inset-inline-start: 24px;
-			position: absolute;
-			transform-origin: 0 0;
-			fill: var( --color-text );
-			stroke: var( --color-text );
-		}
 	}
 
 	.progress-bar {
@@ -94,19 +86,19 @@
 		transform: translateY( -50% );
 	}
 
-
 	.intro__title {
 		@include onboarding-font-recoleta;
-		/* stylelint-disable-next-line scales/font-size, declaration-property-unit-allowed-list */
-		font-size: 28px;
+
+		font-size: 1.75rem;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 130%;
 		padding-bottom: 32px;
 
 		@include break-large {
-			/* stylelint-disable-next-line scales/font-size, declaration-property-unit-allowed-list */
-			font-size: 44px;
+			font-size: 2.75rem;
 			line-height: 52px;
 		}
+
 		span {
 			display: block;
 		}


### PR DESCRIPTION
## Proposed Changes

This was a little tricky because stylelint got mad at me. Ultimately removed the svg stroke applied to the log and consolidated some of the styles that were duplicated.

## Testing Instructions

1. Pull branch and yarn start
2. Check for regressions on `http://calypso.localhost:3000/setup/courses?siteSlug=[YOUR-SITE]` and `http://calypso.localhost:3000/setup/intro`
3. Click through signup flow to make sure the stroke is gone and there are no regressions.

Closes #67445 