### PR TITLE
Jetpack New Pricing Page - Show not supported message for Multisite

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -4,14 +4,18 @@ import { useCallback, useState } from 'react';
 import Modal from 'react-modal';
 import FoldableCard from 'calypso/components/foldable-card';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
-import { SelectorProduct } from '../types';
+import { useStoreItemInfo } from '../product-store/hooks/use-store-item-info';
+import { ProductStoreBaseProps } from '../product-store/types';
+import { Duration, SelectorProduct } from '../types';
 import { Icons } from './icons/icons';
 import { Tags } from './icons/tags';
+import PaymentPlan from './payment-plan';
 import './style.scss';
 
-type Props = {
+type Props = ProductStoreBaseProps & {
 	product: SelectorProduct;
 	isVisible: boolean;
+	duration: Duration;
 	onClose: () => void;
 };
 
@@ -37,12 +41,24 @@ const Benefits = () => (
 	</ul>
 );
 
-const ProductLightbox: React.FC< Props > = ( { product, isVisible, onClose } ) => {
+const ProductLightbox: React.FC< Props > = ( {
+	product,
+	isVisible,
+	siteId,
+	duration,
+	onClose,
+} ) => {
 	const close = useCallback( () => onClose?.(), [ onClose ] );
 
 	const [ checked, setChecked ] = useState( '10GB' );
 
 	const isMobile = useMobileBreakpoint();
+	const { isMultisiteCompatible, isMultisite } = useStoreItemInfo( {
+		siteId,
+		duration,
+	} );
+
+	const isMultiSiteIncompatible = isMultisite && ! isMultisiteCompatible( product );
 
 	return (
 		<Modal
@@ -125,26 +141,12 @@ const ProductLightbox: React.FC< Props > = ( { product, isVisible, onClose } ) =
 								shouldShuffleAnswers={ false }
 							/>
 						</div>
-
-						<p>Payment plan:</p>
-
-						<div className="product-lightbox__variants-plan-card">
-							<div className="product-lightbox__variants-grey-label">
-								<span className="product-lightbox__variants-plan-card-price">{ '$4.95' }</span>
-								<span className="product-lightbox__variants-plan-card-month-short">/mo</span>
-								<span className="product-lightbox__variants-plan-card-month-long">/month</span>,
-								billed yearly
-							</div>
-							<div className="product-lightbox__variants-grey-label">
-								<span className="product-lightbox__variants-plan-card-old-price">{ '$9.95' }</span>
-								59% off the first year
-							</div>
-						</div>
-
+						<PaymentPlan isMultiSiteIncompatible={ isMultiSiteIncompatible } />
 						<Button
 							primary
 							className="jetpack-product-card__button product-lightbox__checkout-button"
-							href={ 'https://automattic.com' }
+							href={ isMultiSiteIncompatible ? '#' : 'https://automattic.com' }
+							disabled={ isMultiSiteIncompatible }
 						>
 							{ 'Checkout' }
 						</Button>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,0 +1,38 @@
+import { useTranslate } from 'i18n-calypso';
+type PaymentPlanProps = {
+	isMultiSiteIncompatible?: boolean;
+};
+const PaymentPlan: React.FC< PaymentPlanProps > = ( { isMultiSiteIncompatible } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="product-lightbox__variants-plan">
+			{ isMultiSiteIncompatible ? (
+				<div className="product-lightbox__variants-plan-alt-info">
+					<span className="product-lightbox__variants-plan-alt-info--dot"></span>
+					<span className="product-lightbox__variants-plan-alt-info--text">
+						{ translate( 'Not available for multisite WordPress installs' ) }
+					</span>
+				</div>
+			) : (
+				<>
+					<p>Payment plan:</p>
+
+					<div className="product-lightbox__variants-plan-card">
+						<div className="product-lightbox__variants-grey-label">
+							<span className="product-lightbox__variants-plan-card-price">{ '$4.95' }</span>
+							<span className="product-lightbox__variants-plan-card-month-short">/mo</span>
+							<span className="product-lightbox__variants-plan-card-month-long">/month</span>,
+							billed yearly
+						</div>
+						<div className="product-lightbox__variants-grey-label">
+							<span className="product-lightbox__variants-plan-card-old-price">{ '$9.95' }</span>
+							59% off the first year
+						</div>
+					</div>
+				</>
+			) }
+		</div>
+	);
+};
+export default PaymentPlan;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -248,33 +248,55 @@
 	}
 }
 
-.product-lightbox__variants-plan-card {
-	background-color: #fff;
-	border-radius: 8px; /* stylelint-disable-line scales/radii */
-	border: 1px solid #008710;
-	padding: 1rem;
+.product-lightbox__variants-plan {
+	&-alt-info {
+		font-size: $font-body-extra-small;
+		color: var( --studio-jetpack-green-50 );
+		font-weight: 600;
+		display: flex;
+		align-items: center;
+	}
+
+	&-alt-info--dot {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		background: var( --studio-jetpack-green-50 );
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
+		margin-inline-end: 4px;
+	}
+
+	&-card {
+		background-color: #fff;
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		border: 1px solid #008710;
+		padding: 1rem;
+	}
+
+	&-card-price {
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: #000;
+	}
+
+	&-card-old-price {
+		color: #101517;
+		text-decoration: line-through;
+		margin-right: 2px;
+	}
+
+	&-card-month-short {
+		display: none;
+	}
 }
 
-.product-lightbox__variants-plan-card-price {
-	font-size: 1.5rem;
-	font-weight: 700;
-	color: #000;
-}
 
 .product-lightbox__variants-grey-label {
 	font-size: 0.75rem;
 	color: #646970;
 }
 
-.product-lightbox__variants-plan-card-old-price {
-	color: #101517;
-	text-decoration: line-through;
-	margin-right: 2px;
-}
-
-.product-lightbox__variants-plan-card-month-short {
-	display: none;
-}
 
 @media screen and (max-width: 768px) and (orientation: portrait) {
 	.product-lightbox__modal {

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -26,6 +26,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 				</div>
 				<div className="featured-item-card--footer">
 					<Button
+						className="featured-item-card--cta"
 						primary={ ctaAsPrimary }
 						onClick={ onClickCta }
 						disabled={ isCtaDisabled }

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -88,3 +88,7 @@
 	margin-top: 24px;
 }
 
+.featured-item-card--cta {
+	min-width: 5.7em;
+	border-width: 0;
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -26,6 +26,18 @@ import { UseStoreItemInfoProps } from '../types';
 
 const isDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
+const isMultisiteCompatible = ( item: SelectorProduct ) => {
+	if ( isJetpackPlanSlug( item.productSlug ) ) {
+		// plans containing Jetpack Backup and/or Jetpack Scan are incompatible with multisite installs
+		return ! [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ].filter( ( productSlug ) =>
+			planHasFeature( item.productSlug, productSlug )
+		).length;
+	}
+	return ! (
+		[ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ] as ReadonlyArray< string >
+	 ).includes( item.productSlug );
+};
+
 export const useStoreItemInfo = ( {
 	createCheckoutURL,
 	duration: selectedTerm,
@@ -167,18 +179,6 @@ export const useStoreItemInfo = ( {
 		[ getPurchase, isOwned, isSuperseded, isUpgradeableToYearly, sitePlan, translate ]
 	);
 
-	const isMultisiteCompatible = useCallback( ( item: SelectorProduct ) => {
-		if ( isJetpackPlanSlug( item.productSlug ) ) {
-			// plans containing Jetpack Backup and/or Jetpack Scan are incompatible with multisite installs
-			return ! [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ].filter( ( productSlug ) =>
-				planHasFeature( item.productSlug, productSlug )
-			).length;
-		}
-		return ! (
-			[ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ] as ReadonlyArray< string >
-		 ).includes( item.productSlug );
-	}, [] );
-
 	return useMemo(
 		() => ( {
 			getCheckoutURL,
@@ -209,7 +209,6 @@ export const useStoreItemInfo = ( {
 			isSuperseded,
 			isUpgradeableToYearly,
 			isUserPurchaseOwner,
-			isMultisiteCompatible,
 			isMultisite,
 			sitePlan,
 		]

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -4,7 +4,7 @@ import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/d
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import useItemPrice from '../../use-item-price';
 import { ItemPriceProps } from '../types';
-
+import ItemPriceMessage from './item-price-message';
 import './style.scss';
 
 export const ItemPrice: React.FC< ItemPriceProps > = ( {
@@ -22,19 +22,14 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const translate = useTranslate();
 
-	const renderItemPriceAltInfo = ( altText: React.ReactChild ) => (
-		<div className="item-price__alt-info">
-			<span className="item-price__alt-info--dot"></span>
-			<span className="item-price__alt-info--text">{ altText }</span>
-		</div>
-	);
-
 	if ( isMultiSiteIncompatible ) {
-		return renderItemPriceAltInfo( translate( 'Not available for multisite WordPress installs' ) );
+		return (
+			<ItemPriceMessage message={ translate( 'Not available for multisite WordPress installs' ) } />
+		);
 	} else if ( isOwned ) {
-		return renderItemPriceAltInfo( translate( 'Active on your site' ) );
+		return <ItemPriceMessage message={ translate( 'Active on your site' ) } />;
 	} else if ( isIncludedInPlan ) {
-		return renderItemPriceAltInfo( translate( 'Part of the current plan' ) );
+		return <ItemPriceMessage message={ translate( 'Part of the current plan' ) } />;
 	}
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -12,6 +12,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	isOwned,
 	item,
 	siteId,
+	isMultiSiteIncompatible,
 } ) => {
 	const { originalPrice, discountedPrice, isFetching } = useItemPrice(
 		siteId,
@@ -21,15 +22,19 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const translate = useTranslate();
 
-	if ( isOwned || isIncludedInPlan ) {
-		return (
-			<div className="item-price__is-owned">
-				<span className="item-price__is-owned--dot"></span>
-				<span className="item-price__is-owned--text">
-					{ isOwned ? translate( 'Active on your site' ) : translate( 'Part of the current plan' ) }
-				</span>
-			</div>
-		);
+	const renderItemPriceAltInfo = ( altText: React.ReactChild ) => (
+		<div className="item-price__alt-info">
+			<span className="item-price__alt-info--dot"></span>
+			<span className="item-price__alt-info--text">{ altText }</span>
+		</div>
+	);
+
+	if ( isMultiSiteIncompatible ) {
+		return renderItemPriceAltInfo( translate( 'Not available for multisite WordPress installs' ) );
+	} else if ( isOwned ) {
+		return renderItemPriceAltInfo( translate( 'Active on your site' ) );
+	} else if ( isIncludedInPlan ) {
+		return renderItemPriceAltInfo( translate( 'Part of the current plan' ) );
 	}
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/item-price-message.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/item-price-message.tsx
@@ -1,0 +1,8 @@
+const ItemPriceMessage: React.FC< { message: React.ReactNode } > = ( { message } ) => (
+	<div className="item-price__message">
+		<span className="item-price__message--dot"></span>
+		<span className="item-price__message--text">{ message }</span>
+	</div>
+);
+
+export default ItemPriceMessage;

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -86,7 +86,7 @@
 }
 
 
-.item-price__alt-info {
+.item-price__message {
 	font-size: $font-body-extra-small;
 	color: var( --studio-jetpack-green-50 );
 	font-weight: 600;
@@ -94,7 +94,7 @@
 	align-items: center;
 }
 
-.item-price__alt-info--dot {
+.item-price__message--dot {
 	display: inline-block;
 	width: 8px;
 	height: 8px;

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -86,7 +86,7 @@
 }
 
 
-.item-price__is-owned {
+.item-price__alt-info {
 	font-size: $font-body-extra-small;
 	color: var( --studio-jetpack-green-50 );
 	font-weight: 600;
@@ -94,7 +94,7 @@
 	align-items: center;
 }
 
-.item-price__is-owned--dot {
+.item-price__alt-info--dot {
 	display: inline-block;
 	width: 8px;
 	height: 8px;

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -24,6 +24,8 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		getOnClickPurchase,
 		isIncludedInPlan,
 		isIncludedInPlanOrSuperseded,
+		isMultisiteCompatible,
+		isMultisite,
 		isOwned,
 		isPlanFeature,
 		isSuperseded,
@@ -49,9 +51,11 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					const isItemDeprecated = isDeprecated( item );
 					const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
 					const isItemIncludedInPlan = isIncludedInPlan( item );
+					const isMultiSiteIncompatible = isMultisite && ! isMultisiteCompatible( item );
 
 					const isCtaDisabled =
-						( isItemOwned || isItemIncludedInPlan ) && ! isUserPurchaseOwner( item );
+						isMultiSiteIncompatible ||
+						( ( isItemOwned || isItemIncludedInPlan ) && ! isUserPurchaseOwner( item ) );
 
 					const ctaLabel = getCtaLabel( item );
 
@@ -60,6 +64,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 
 					const price = (
 						<ItemPrice
+							isMultiSiteIncompatible={ isMultiSiteIncompatible }
 							isIncludedInPlan={ isItemIncludedInPlan }
 							isOwned={ isItemOwned }
 							item={ item }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -81,9 +81,12 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						</>
 					);
 
+					const ctaAsPrimary =
+						! isCtaDisabled && ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
+
 					return (
 						<SimpleItemCard
-							ctaAsPrimary={ ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded ) }
+							ctaAsPrimary={ ctaAsPrimary }
 							ctaHref={ getCheckoutURL( item ) }
 							ctaLabel={ ctaLabel }
 							description={ description }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -81,8 +81,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						</>
 					);
 
-					const ctaAsPrimary =
-						! isCtaDisabled && ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
+					const ctaAsPrimary = ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
 
 					return (
 						<SimpleItemCard

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/index.tsx
@@ -29,6 +29,8 @@ export const ItemsList: React.FC< ItemsListProps > = ( {
 		<div className="jetpack-product-store__items-list">
 			{ currentItem && (
 				<ProductLightbox
+					siteId={ siteId }
+					duration={ duration }
 					product={ currentItem }
 					isVisible={ !! currentItem }
 					onClose={ clearCurrentItem }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -27,6 +27,8 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 		getOnClickPurchase,
 		isIncludedInPlan,
 		isIncludedInPlanOrSuperseded,
+		isMultisiteCompatible,
+		isMultisite,
 		isOwned,
 		isPlanFeature,
 		isSuperseded,
@@ -49,17 +51,20 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 					const isItemDeprecated = isDeprecated( item );
 					const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
 					const isItemIncludedInPlan = isIncludedInPlan( item );
-
-					const ctaLabel = getCtaLabel( item );
+					const isMultiSiteIncompatible = isMultisite && ! isMultisiteCompatible( item );
 
 					const isCtaDisabled =
-						( isItemOwned || isItemIncludedInPlan ) && ! isUserPurchaseOwner( item );
+						isMultiSiteIncompatible ||
+						( ( isItemOwned || isItemIncludedInPlan ) && ! isUserPurchaseOwner( item ) );
+
+					const ctaLabel = getCtaLabel( item );
 
 					const hideMoreInfoLink =
 						isItemDeprecated || isItemOwned || isItemIncludedInPlanOrSuperseded;
 
 					const price = (
 						<ItemPrice
+							isMultiSiteIncompatible={ isMultiSiteIncompatible }
 							isIncludedInPlan={ isItemIncludedInPlan }
 							isOwned={ isItemOwned }
 							item={ item }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -83,10 +83,13 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 						</p>
 					);
 
+					const ctaAsPrimary =
+						! isCtaDisabled && ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
+
 					return (
 						<div key={ item.productSlug } className="jetpack-product-store__most-popular--item">
 							<FeaturedItemCard
-								ctaAsPrimary={ ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded ) }
+								ctaAsPrimary={ ctaAsPrimary }
 								ctaHref={ getCheckoutURL( item ) }
 								ctaLabel={ ctaLabel }
 								description={ description }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -83,8 +83,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 						</p>
 					);
 
-					const ctaAsPrimary =
-						! isCtaDisabled && ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
+					const ctaAsPrimary = ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
 
 					return (
 						<div key={ item.productSlug } className="jetpack-product-store__most-popular--item">

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
@@ -1,12 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.jetpack-product-store__items-list .button.is-primary {
-	color: var( --color-text-inverted );
-	min-width: 5.7em;
-	border: none;
-}
-
 .jetpack-product-store__all-items--grid {
 	display: grid;
 	column-gap: 80px;

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -48,11 +48,12 @@
 }
 
 .simple-item-card__cta {
+	display: flex;
 	align-items: center;
 	justify-content: center;
 	font-size: $font-body;
-	min-width: 91px;
-	display: flex;
+	min-width: 5.7rem;
+	border-width: 0;
 }
 
 .simple-item-card__footer {

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -78,6 +78,7 @@ export type ItemPriceProps = ProductStoreBaseProps &
 	HeroImageProps & {
 		isOwned?: boolean;
 		isIncludedInPlan?: boolean;
+		isMultiSiteIncompatible?: boolean;
 	};
 
 export type FeaturedItemCardProps = {

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -11,7 +11,7 @@ $wpcom-menu-collapse: 783px;
 	--jetpack-corners-soft: 4px;
 }
 
-.is-group-sites.is-section-plans .jetpack-product-store {
+:is(.is-group-sites.is-section-plans, .is-section-jetpack-connect) .jetpack-product-store {
 
 	h2 {
 		font-size: $font-title-small;

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -13,6 +13,12 @@ $wpcom-menu-collapse: 783px;
 
 :is(.is-group-sites.is-section-plans, .is-section-jetpack-connect) .jetpack-product-store {
 
+	.button[disabled],
+	.button:disabled,
+	.button.disabled {
+		background-color: var( --studio-gray-5 );
+	}
+
 	h2 {
 		font-size: $font-title-small;
 		font-weight: 600;
@@ -33,11 +39,6 @@ $wpcom-menu-collapse: 783px;
 			font-size: $font-title-small;
 			line-height: 23px;
 		}
-	}
-
-
-	:is(.featured-item-card--cta, .simple-item-card__cta):not(.is-primary) {
-		border-width: 1px;
 	}
 
 	// Start after the collapsible admin menu shows up

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -35,6 +35,11 @@ $wpcom-menu-collapse: 783px;
 		}
 	}
 
+
+	:is(.featured-item-card--cta, .simple-item-card__cta):not(.is-primary) {
+		border-width: 1px;
+	}
+
 	// Start after the collapsible admin menu shows up
 	@media (min-width: $wpcom-menu-collapse) {
 		@media (max-width: $break-wide) {


### PR DESCRIPTION
### Proposed Changes

* added `isMultiSIteCompatible` hooks to check if plan is multi-site supported
* Use the hooks in `AllItems` and `MostPopular` card components
* Render the appropriate message in `ItemPrice` component for sites which are multisite in-compatible 
* Rename `classNames` in `ItemPrice` to be more generic
* Use the same hooks for`ProductLightbox`
* Move the pricing plan section to new component and render based on flag

### Testing Instructions
- Login into a multisite WordPress account or spin a new site using [Jurassic Ninja ](https://jurassic.ninja/specialops/)(click on *Launch Multisite on subdomains*)
- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing?flags=jetpack/pricing-page-rework-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout fix/multisite-message`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1)
- Confirm that **Get** button for **Backup** and **Scan** is disabled in both *All Products* section and *Most popular products* section 
- Confirm that message **Not available for multisite WordPress installs** is shown instead of price on unsupported product cards
- Click on *More about Backup* to open lightbox and confirm the same message is displayed instead of the price 
- Close the lightbox and switch to  **Bundles** section 
- Confirm that the same message is displayed for cards in *Most popular bundles* and also confirm message is shown in lightboxes for each of the cards

### Screenshot

#### Products section
![Screenshot 2022-09-07 at 11 07 07 PM](https://user-images.githubusercontent.com/2027003/188943205-d40dd5e9-e23d-4f7f-ac8e-4b9402559c1c.png)

#### Bundles section
![Screenshot 2022-09-07 at 11 08 06 PM](https://user-images.githubusercontent.com/2027003/188943351-46de175e-863c-410c-9fa7-27fe50681fad.png)

#### Lightbox
![Screenshot 2022-09-07 at 11 08 47 PM](https://user-images.githubusercontent.com/2027003/188943444-efd0bd99-e3a7-4878-a247-f6589f06087e.png)

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1202796695664022-as-1202925210357622/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202925210357622