### PR TITLE
E2E: add generated site URL verification to onboarding specs.

### DIFF
--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -30,7 +30,6 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );
-	const blogName = DataHelper.getBlogName();
 	const blogTagLine = DataHelper.getRandomPhrase();
 
 	let page: Page;
@@ -147,7 +146,7 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 		} );
 
 		it( 'Enter blog name', async function () {
-			await startSiteFlow.enterBlogName( blogName );
+			await startSiteFlow.enterBlogName( testUser.siteName );
 		} );
 
 		it( 'Enter blog tagline', async function () {
@@ -178,6 +177,14 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 			await page.waitForURL(
 				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
 			);
+		} );
+
+		it( 'Site URL matches selected domain', async function () {
+			const url = page.url();
+			// If domain selection is skipped during onboarding, the first (default) site
+			// is created with the user's username.
+			// See https://github.com/Automattic/wp-calypso/pull/67517.
+			expect( url ).toContain( testUser.username );
 		} );
 	} );
 

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -87,6 +87,11 @@ describe(
 				const plan = await sidebarComponent.getCurrentPlanName();
 				expect( plan ).toBe( 'Free' );
 			} );
+
+			it( 'Site URL matches selected domain', async function () {
+				const url = page.url();
+				expect( url ).toContain( testUser.siteName );
+			} );
 		} );
 
 		afterAll( async function () {

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -87,11 +87,6 @@ describe(
 				const plan = await sidebarComponent.getCurrentPlanName();
 				expect( plan ).toBe( 'Free' );
 			} );
-
-			it( 'Site URL matches selected domain', async function () {
-				const url = page.url();
-				expect( url ).toContain( testUser.siteName );
-			} );
 		} );
 
 		afterAll( async function () {


### PR DESCRIPTION
#### Proposed Changes

This PR adds verification steps when a site is created in the spec.

Context:
- https://github.com/Automattic/wp-calypso/pull/67506
- p1662563176125549-slack-C025Q5RK2

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/67506.