### PR TITLE
Newsletter: fix start URL for newsletter

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -32,8 +32,8 @@ export const newsletter: Flow = {
 
 		const getStartUrl = () => {
 			return locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ name }&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=${ name }`
-				: `/start/account/user?variationName=${ name }&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=${ name }`;
+				? `/start/account/user/${ locale }?variationName=${ name }&pageTitle=Newsletter&redirect_to=/setup/newsletterSetup?flow=${ name }`
+				: `/start/account/user?variationName=${ name }&pageTitle=Newsletter&redirect_to=/setup/newsletterSetup?flow=${ name }`;
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {


### PR DESCRIPTION
#### Proposed Changes

* The start URL in the newsletter flow is wrong.
* This results to a redirect after login to a step that doesn't exist for the newsletter flow and redirects back to the intro step.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Logout in case you have an active session
- Visit the [newsletter flow](http://calypso.localhost:3000/setup?flow=newsletter)
- After logging in, check if you are redirected back to the newsletterSetup step

Related to #67519
