### PR TITLE
Newsletter & LinkInBio Setup: validate site title on submit instead of change

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -54,6 +54,12 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 		setTagline( site.description );
 	}, [ site ] );
 
+	useEffect( () => {
+		if ( siteTitle.trim().length && invalidSiteTitle ) {
+			setInvalidSiteTitle( false );
+		}
+	}, [ siteTitle, invalidSiteTitle ] );
+
 	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
 		switch ( event.currentTarget.name ) {
 			case 'link-in-bio-input-name':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -26,21 +26,19 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 	const site = useSite();
 
 	const usesSite = !! useSiteSlugParam();
-	const [ formTouched, setFormTouched ] = React.useState( false );
+	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const [ base64Image, setBase64Image ] = React.useState< string | null >();
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
 	const { setSiteTitle, setSiteDescription, setSiteLogo } = useDispatch( ONBOARD_STORE );
-
-	const siteTitleError = formTouched && ! siteTitle.trim();
-
 	const state = useSelect( ( select ) => select( ONBOARD_STORE ) ).getState();
 
 	useEffect( () => {
 		const { siteTitle, siteDescription, siteLogo } = state;
 		setTagline( siteDescription );
 		setComponentSiteTitle( siteTitle );
+
 		if ( siteLogo ) {
 			const file = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
 			setSelectedFile( file );
@@ -52,15 +50,11 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 			return;
 		}
 
-		if ( formTouched ) {
-			return;
-		}
 		setComponentSiteTitle( site.name || '' );
 		setTagline( site.description );
-	}, [ site, formTouched ] );
+	}, [ site ] );
 
 	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
-		setFormTouched( true );
 		switch ( event.currentTarget.name ) {
 			case 'link-in-bio-input-name':
 				return setComponentSiteTitle( event.currentTarget.value );
@@ -78,7 +72,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		setFormTouched( true );
+		setInvalidSiteTitle( ! siteTitle.trim().length );
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
@@ -122,9 +116,9 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 						backgroundPosition: '95%',
 						paddingRight: ' 40px',
 					} }
-					isError={ siteTitleError }
+					isError={ invalidSiteTitle }
 				/>
-				{ siteTitleError && (
+				{ invalidSiteTitle && (
 					<FormInputValidation
 						isError
 						text={ __( `Oops. Looks like your Link in Bio doesn't have a name yet.` ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -48,6 +48,10 @@ $font-family: 'SF Pro Text', $sans;
 			font-family: $font-family;
 			font-weight: 400;
 		}
+
+		input {
+			height: 44px;
+		}
 	}
 
 	.link-in-bio-setup-form__submit {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -60,18 +60,13 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const { setSiteTitle, setSiteAccentColor, setSiteDescription, setSiteLogo } =
 		useDispatch( ONBOARD_STORE );
 
-	const [ formTouched, setFormTouched ] = React.useState( false );
+	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
 	const [ accentColor, setAccentColor ] = React.useState< AccentColor >( defaultAccentColor );
 	const [ base64Image, setBase64Image ] = React.useState< string | null >();
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
-	const siteTitleError =
-		formTouched && ! siteTitle.trim()
-			? __( `Oops. Looks like your Newsletter doesn't have a name yet.` )
-			: '';
-
 	const state = useSelect( ( select ) => select( ONBOARD_STORE ) ).getState();
 
 	useEffect( () => {
@@ -95,13 +90,9 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			return;
 		}
 
-		if ( formTouched ) {
-			return;
-		}
-
 		setComponentSiteTitle( site.name || '' );
 		setTagline( site.description );
-	}, [ site, formTouched ] );
+	}, [ site ] );
 
 	const imageFileToBase64 = ( file: Blob ) => {
 		const reader = new FileReader();
@@ -112,7 +103,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		setFormTouched( true );
+		setInvalidSiteTitle( ! siteTitle.trim().length );
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
@@ -132,7 +123,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	};
 
 	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
-		setFormTouched( true );
 		switch ( event.currentTarget.name ) {
 			case 'siteTitle':
 				return setComponentSiteTitle( event.currentTarget.value );
@@ -180,10 +170,15 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					style={ {
 						backgroundImage: getBackgroundImage( siteTitle ),
 					} }
-					isError={ !! siteTitleError }
+					isError={ invalidSiteTitle }
 					onChange={ onChange }
 				/>
-				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
+				{ invalidSiteTitle && (
+					<FormInputValidation
+						isError
+						text={ __( `Oops. Looks like your Newsletter doesn't have a name yet.` ) }
+					/>
+				) }
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel htmlFor="tagline">{ __( 'Brief description' ) }</FormLabel>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -94,6 +94,12 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		setTagline( site.description );
 	}, [ site ] );
 
+	useEffect( () => {
+		if ( siteTitle.trim().length && invalidSiteTitle ) {
+			setInvalidSiteTitle( false );
+		}
+	}, [ siteTitle, invalidSiteTitle ] );
+
 	const imageFileToBase64 = ( file: Blob ) => {
 		const reader = new FileReader();
 		reader.readAsDataURL( file );


### PR DESCRIPTION
#### Proposed Changes

* This PR moves the siteTitle validation to happen on submit instead of change

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Test on the newsletter and link in bio flows
- Try submitting with empty title, and check if the error message is shown


Related to #67452