### PR TITLE
Launchpad: Allows users to go back to Setup from Launchpad 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -20,7 +20,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 		>
 			<Button
 				className="launchpad__checklist-item"
-				disabled={ taskDisabled }
+				disabled={ taskDisabled && ! task.id.includes( 'setup' ) }
 				href={ actionUrl }
 				data-task={ id }
 				{ ...action }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -20,7 +20,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 		>
 			<Button
 				className="launchpad__checklist-item"
-				disabled={ taskDisabled && ! task.id.includes( 'setup' ) }
+				disabled={ taskDisabled }
 				href={ actionUrl }
 				data-task={ id }
 				{ ...action }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -39,14 +39,7 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 				skipLabelText={ translate( 'Go to Admin' ) }
 				skipButtonAlign={ 'bottom' }
 				hideBack={ true }
-				stepContent={
-					<StepContent
-						siteSlug={ siteSlug }
-						submit={ navigation.submit }
-						goNext={ navigation.goNext }
-						goToStep={ navigation.goToStep }
-					/>
-				}
+				stepContent={ <StepContent siteSlug={ siteSlug } navigation={ navigation } /> }
 				formattedHeader={
 					<FormattedHeader
 						id={ 'launchpad-header' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -13,9 +13,7 @@ import { Task } from './types';
 
 type SidebarProps = {
 	siteSlug: string | null;
-	submit: NavigationControls[ 'submit' ];
-	goNext: NavigationControls[ 'goNext' ];
-	goToStep?: NavigationControls[ 'goToStep' ];
+	navigation: NavigationControls;
 };
 
 function getUrlInfo( url: string ) {
@@ -41,7 +39,7 @@ function getChecklistCompletionProgress( tasks: Task[] | null ) {
 	return Math.round( ( totalCompletedTasks / tasks.length ) * 100 );
 }
 
-const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
+const Sidebar = ( { siteSlug, navigation }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	const flow = useFlowParam();
@@ -50,7 +48,7 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 	const translatedStrings = getLaunchpadTranslations( flow );
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
 	const enhancedTasks =
-		site && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site, submit, goToStep );
+		site && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site, navigation );
 
 	const taskCompletionProgress = site && getChecklistCompletionProgress( enhancedTasks );
 
@@ -88,7 +86,7 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 			<div className="launchpad__sidebar-admin-link">
 				<StepNavigationLink
 					direction="forward"
-					handleClick={ goNext }
+					handleClick={ navigation.goNext }
 					label={ translate( 'Go to Admin' ) }
 					borderless={ true }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -4,14 +4,12 @@ import Sidebar from './sidebar';
 
 type StepContentProps = {
 	siteSlug: string | null;
-	submit: NavigationControls[ 'submit' ];
-	goNext: NavigationControls[ 'goNext' ];
-	goToStep?: NavigationControls[ 'goToStep' ];
+	navigation: NavigationControls;
 };
 
-const StepContent = ( { siteSlug, submit, goNext, goToStep }: StepContentProps ) => (
+const StepContent = ( { siteSlug, navigation }: StepContentProps ) => (
 	<div className="launchpad__content">
-		<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } goToStep={ goToStep } />
+		<Sidebar siteSlug={ siteSlug } navigation={ navigation } />
 		<LaunchpadSitePreview siteSlug={ siteSlug } />
 	</div>
 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -31,6 +31,7 @@ export function getEnhancedTasks(
 				case 'setup_newsletter':
 					taskData = {
 						title: translate( 'Set up Newsletter' ),
+						keepActive: true,
 						actionDispatch: () =>
 							navigation.goToStep?.(
 								`newsletterSetup?flow=newsletter&siteSlug=${ siteSlug }&backToStep=launchpad`
@@ -72,6 +73,7 @@ export function getEnhancedTasks(
 							[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 								? translate( 'Set up Link in Bio' )
 								: translate( 'Setup your Link in Bio' ),
+						keepActive: true,
 						actionDispatch: () =>
 							navigation.goToStep?.(
 								`linkInBioSetup?flow=link-in-bio&siteSlug=${ siteSlug }&backToStep=launchpad`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -12,8 +12,7 @@ export function getEnhancedTasks(
 	tasks: Task[] | null,
 	siteSlug: string | null,
 	site: SiteDetails | null,
-	submit: NavigationControls[ 'submit' ],
-	goToStep?: NavigationControls[ 'goToStep' ]
+	navigation: NavigationControls
 ) {
 	const enhancedTaskList: Task[] = [];
 	const productSlug = site?.plan?.product_slug;
@@ -32,6 +31,10 @@ export function getEnhancedTasks(
 				case 'setup_newsletter':
 					taskData = {
 						title: translate( 'Set up Newsletter' ),
+						actionDispatch: () =>
+							navigation.goToStep?.(
+								`newsletterSetup?flow=newsletter&siteSlug=${ siteSlug }&backToStep=launchpad`
+							),
 					};
 					break;
 				case 'plan_selected':
@@ -45,8 +48,8 @@ export function getEnhancedTasks(
 						title: translate( 'Add Subscribers' ),
 						keepActive: true,
 						actionDispatch: () => {
-							if ( goToStep ) {
-								goToStep( 'subscribers' );
+							if ( navigation.goToStep ) {
+								navigation.goToStep( 'subscribers' );
 							}
 						},
 					};
@@ -69,6 +72,10 @@ export function getEnhancedTasks(
 							[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 								? translate( 'Set up Link in Bio' )
 								: translate( 'Setup your Link in Bio' ),
+						actionDispatch: () =>
+							navigation.goToStep?.(
+								`linkInBioSetup?flow=link-in-bio&siteSlug=${ siteSlug }&backToStep=launchpad`
+							),
 					};
 					break;
 				case 'links_added':
@@ -97,7 +104,7 @@ export function getEnhancedTasks(
 									window.location.replace( `/home/${ siteSlug }?forceLoadLaunchpadData=true` );
 								} );
 
-								submit?.();
+								navigation.submit?.();
 							}
 						},
 					};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -15,7 +15,7 @@ import FormInput from 'calypso/components/forms/form-text-input';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
 import type { Step } from '../../types';
@@ -35,6 +35,8 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
 	const { setSiteTitle, setSiteDescription, setSiteLogo } = useDispatch( ONBOARD_STORE );
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
 	const state = useSelect( ( select ) => select( ONBOARD_STORE ) ).getState();
 
 	useEffect( () => {
@@ -76,6 +78,13 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
+
+		if ( site ) {
+			await saveSiteSettings( site.ID, {
+				blogname: siteTitle,
+				blogdescription: tagline,
+			} );
+		}
 
 		if ( selectedFile && base64Image ) {
 			try {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -39,23 +39,14 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 
 	useEffect( () => {
 		const { siteTitle, siteDescription, siteLogo } = state;
-		setTagline( siteDescription );
-		setComponentSiteTitle( siteTitle );
+		setComponentSiteTitle( site?.name || siteTitle );
+		setTagline( site?.description || siteDescription );
 
 		if ( siteLogo ) {
 			const file = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
 			setSelectedFile( file );
 		}
-	}, [ state ] );
-
-	useEffect( () => {
-		if ( ! site ) {
-			return;
-		}
-
-		setComponentSiteTitle( site.name || '' );
-		setTagline( site.description );
-	}, [ site ] );
+	}, [ state, site ] );
 
 	useEffect( () => {
 		if ( siteTitle.trim().length && invalidSiteTitle ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -13,6 +13,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -25,6 +26,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const site = useSite();
+	const urlQueryParams = useQuery();
 
 	const usesSite = !! useSiteSlugParam();
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
@@ -93,7 +95,8 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 		}
 
 		if ( siteTitle.trim().length ) {
-			submit?.( { siteTitle, tagline } );
+			const backToStep = urlQueryParams.get( 'backToStep' );
+			submit?.( { siteTitle, tagline, backToStep } );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -13,6 +13,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -57,7 +58,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 	const site = useSite();
 	const usesSite = !! useSiteSlugParam();
-
+	const urlQueryParams = useQuery();
 	const { setSiteTitle, setSiteAccentColor, setSiteDescription, setSiteLogo } =
 		useDispatch( ONBOARD_STORE );
 
@@ -125,7 +126,8 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 
 		if ( siteTitle.trim().length ) {
-			submit?.( { siteTitle, tagline, siteAccentColor: accentColor.hex } );
+			const backToStep = urlQueryParams.get( 'backToStep' );
+			submit?.( { siteTitle, tagline, siteAccentColor: accentColor.hex, backToStep } );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -15,7 +15,7 @@ import FormInput from 'calypso/components/forms/form-text-input';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import { useSite } from '../../../../hooks/use-site';
@@ -61,6 +61,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const urlQueryParams = useQuery();
 	const { setSiteTitle, setSiteAccentColor, setSiteDescription, setSiteLogo } =
 		useDispatch( ONBOARD_STORE );
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
 	const [ colorPickerOpen, setColorPickerOpen ] = React.useState( false );
@@ -108,6 +109,13 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
 		setSiteAccentColor( accentColor.hex );
+
+		if ( site ) {
+			await saveSiteSettings( site.ID, {
+				blogname: siteTitle,
+				blogdescription: tagline,
+			} );
+		}
 
 		if ( selectedFile && base64Image ) {
 			try {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -73,28 +73,20 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 	useEffect( () => {
 		const { siteAccentColor, siteTitle, siteDescription, siteLogo } = state;
+		setComponentSiteTitle( site?.name || siteTitle );
+		setTagline( site?.description || siteDescription );
+
+		if ( siteLogo ) {
+			const file = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
+			setSelectedFile( file );
+		}
+
 		if ( defaultAccentColor.hex === siteAccentColor ) {
 			setAccentColor( defaultAccentColor );
 		} else {
 			setAccentColor( { ...defaultAccentColor, hex: siteAccentColor } );
 		}
-
-		setTagline( siteDescription );
-		setComponentSiteTitle( siteTitle );
-		if ( siteLogo ) {
-			const file = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
-			setSelectedFile( file );
-		}
-	}, [ state ] );
-
-	useEffect( () => {
-		if ( ! site ) {
-			return;
-		}
-
-		setComponentSiteTitle( site.name || '' );
-		setTagline( site.description );
-	}, [ site ] );
+	}, [ state, site ] );
 
 	useEffect( () => {
 		if ( siteTitle.trim().length && invalidSiteTitle ) {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -48,6 +48,10 @@ export const linkInBio: Flow = {
 					return navigate( 'linkInBioSetup' );
 
 				case 'linkInBioSetup':
+					if ( 'launchpad' === providedDependencies.backToStep ) {
+						return navigate( 'launchpad' );
+					}
+
 					return window.location.assign(
 						`/start/${ name }/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -48,6 +48,10 @@ export const newsletter: Flow = {
 					return window.location.assign( logInUrl );
 
 				case 'newsletterSetup':
+					if ( 'launchpad' === providedDependencies.backToStep ) {
+						return navigate( 'launchpad' );
+					}
+
 					return window.location.assign(
 						`/start/${ name }/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string


### PR DESCRIPTION
### Proposed Changes

Related to #https://github.com/Automattic/wp-calypso/issues/67429

We want to users to return to the site Setup screen from Launchpad, and to return directly to Launchpad after making changes (rather than going through intermediate steps). Changes made: 
- To simplify code, I refactored to pass the 'navigation' object rather than passing its 'submit', 'goNext', and 'goToStep' properties/methods separately. 
- Added 'keepActive' property to the newsletterSetup and linkInBioSetup steps, so they will always remain clickable. 
- Added actionDispatch properties/methods to newsletterSetup and newsletterSetup that will direct users to the relevant setup screens. 
- Updated the Setup screens to look check if backToPage === launchpad. If so, it means they came from launchpad, and we will direct users directly back to launchpad. If not, it means they are on the Setup screen for the first time and we directly them to the next step as before. 

### Testing Instructions

Check out this branch and run yarn and yarn start if needed. You'll then want to test that this works with both Newsletter and Link in Bio flows. 

Test Newsletter flow: 
1) Go to http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=YOUR_SITE_SLUG
2) Confirm that Set up Newsletter is now clickable. It should still show as complete but should highlight blue on hover, and be clickable. 
3) Click that task and confirm it takes you back to the Newsletter setup screen (with site title, description, and icon). 
4) From the Setup screen, click the Continue button, and confirm you are taken directly back to the Launchpad screen. You should not go to the domains screen or any other intermediate steps before Launchpad. 

Test Link in Bio flow: 
1) Go to http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=YOUR_SITE_SLUG
2) Confirm that Set up Link in Bio is now clickable. It should still show as complete but should highlight blue on hover, and be clickable. 
3) Click that task and confirm it takes you back to the Link in Bio setup screen (with site title, description, and icon). 
4) From the Setup screen, click the Continue button, and confirm you are taken directly back to the Launchpad screen. You should not go to the domains screen or any other intermediate steps before Launchpad. 



