### PR TITLE
Launchpad: Add task helper and checklist unit tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -37,6 +37,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				) : null }
 				{ ! taskDisabled && (
 					<Gridicon
+						aria-label={ translate( 'Task enabled' ) }
 						className="launchpad__checklist-item-chevron"
 						icon={ `chevron-${ isRtl ? 'left' : 'right' }` }
 						size={ 18 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ChecklistItem from '../checklist-item';
+import { Task } from '../types';
+
+function getTask( taskData = {} ) {
+	const task: Task = {
+		id: 'foo_task',
+		isCompleted: false,
+		actionUrl: '#',
+		taskType: 'blog',
+		displayBadge: false,
+		title: 'Foo Task',
+	};
+
+	return { ...task, ...taskData };
+}
+
+describe( 'ChecklistItem', () => {
+	describe( 'when the task requires a badge', () => {
+		it( 'displays a badge', () => {
+			const badgeText = 'Badge Text';
+			render( <ChecklistItem task={ getTask( { displayBadge: true, badgeText } ) } /> );
+			expect( screen.getByText( badgeText ) ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'when the task is complete', () => {
+		it( 'shows the task complete icon', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			const taskCompleteIcon = screen.queryByLabelText( 'Task complete' );
+			expect( taskCompleteIcon ).toBeTruthy();
+		} );
+		it( 'hides the task enabled icon', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
+			expect( taskEnabledIcon ).toBeFalsy();
+		} );
+		it( 'disables the task', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			const taskButton = screen.queryByRole( 'link' );
+			expect( taskButton ).toHaveAttribute( 'disabled' );
+		} );
+	} );
+
+	describe( 'when the task depends on the completion of other tasks', () => {
+		describe( 'and some of the other tasks are not completed', () => {
+			it( 'disables the task', () => {
+				const otherTaskCompleted = true;
+
+				render( <ChecklistItem task={ getTask( { dependencies: [ ! otherTaskCompleted ] } ) } /> );
+				const taskButton = screen.queryByRole( 'link' );
+				expect( taskButton ).toHaveAttribute( 'disabled' );
+			} );
+		} );
+		describe( 'and the other tasks are completed', () => {
+			it( 'enables the task', () => {
+				const otherTaskCompleted = true;
+
+				render( <ChecklistItem task={ getTask( { dependencies: [ otherTaskCompleted ] } ) } /> );
+				const taskButton = screen.queryByRole( 'link' );
+				expect( taskButton ).not.toHaveAttribute( 'disabled' );
+			} );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
@@ -1,10 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import React from 'react';
-import { Task } from '../types';
-import Checklist from '../checklist';
 import { render } from '@testing-library/react';
+import React from 'react';
+import Checklist from '../checklist';
+import { Task } from '../types';
 
 function getTask( taskData = {} ) {
 	const task: Task = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { Task } from '../types';
+import Checklist from '../checklist';
+import { render } from '@testing-library/react';
+
+function getTask( taskData = {} ) {
+	const task: Task = {
+		id: 'foo_task',
+		isCompleted: false,
+		actionUrl: '#',
+		taskType: 'blog',
+		displayBadge: false,
+	};
+
+	return { ...task, ...taskData };
+}
+
+describe( 'Checklist', () => {
+	describe( 'when provided no tasks', () => {
+		it( 'then no tasks are rendered', () => {
+			const { container } = render( <Checklist tasks={ [] } /> );
+			const checklistItems = container.querySelectorAll( '.launchpad__checklist li' );
+			expect( checklistItems.length ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'when a number of tasks are provided', () => {
+		it( 'then the same number of tasks are rendered', () => {
+			const { container } = render(
+				<Checklist tasks={ [ getTask( { id: 'task1' } ), getTask( { id: 'task2' } ) ] } />
+			);
+			const checklistItems = container.querySelectorAll( '.launchpad__checklist li' );
+			expect( checklistItems.length ).toBe( 2 );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Checklist from '../checklist';
 import { Task } from '../types';
@@ -21,18 +21,16 @@ function getTask( taskData = {} ) {
 describe( 'Checklist', () => {
 	describe( 'when provided no tasks', () => {
 		it( 'then no tasks are rendered', () => {
-			const { container } = render( <Checklist tasks={ [] } /> );
-			const checklistItems = container.querySelectorAll( '.launchpad__checklist li' );
-			expect( checklistItems.length ).toBe( 0 );
+			render( <Checklist tasks={ [] } /> );
+			const checklistItems = screen.queryByRole( 'listitem' );
+			expect( checklistItems ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'when a number of tasks are provided', () => {
 		it( 'then the same number of tasks are rendered', () => {
-			const { container } = render(
-				<Checklist tasks={ [ getTask( { id: 'task1' } ), getTask( { id: 'task2' } ) ] } />
-			);
-			const checklistItems = container.querySelectorAll( '.launchpad__checklist li' );
+			render( <Checklist tasks={ [ getTask( { id: 'task1' } ), getTask( { id: 'task2' } ) ] } /> );
+			const checklistItems = screen.getAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 2 );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { getArrayOfFilteredTasks, isTaskDisabled } from '../task-helper';
+import { getArrayOfFilteredTasks, getEnhancedTasks, isTaskDisabled } from '../task-helper';
 import { Task } from '../types';
+import { tasks, launchpadFlowTasks } from '../tasks';
 
 function getTask( taskData = {} ) {
 	const task: Task = {
@@ -17,27 +18,41 @@ function getTask( taskData = {} ) {
 }
 
 describe( 'Task Helpers', () => {
-	// describe( 'getEnhancedTasks', () => {
-	// 	describe( 'when a task is complete', () => {
-	// 		it( 'the task is disabled', () => {
-	// 			expect( isTaskDisabled( task ) ).toBe( true );
-	// 		} );
-	// 	} );
-	// } );
+	describe( 'getEnhancedTasks', () => {
+		describe( 'when a task should not be enhanced', () => {
+			it( 'it is not enhanced', () => {
+				const fakeTasks = [
+					getTask( { id: 'fake-task-1' } ),
+					getTask( { id: 'fake-task-2' } ),
+					getTask( { id: 'fake-task-3' } ),
+				];
+				expect( getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {} ) ).toEqual(
+					fakeTasks
+				);
+			} );
+		} );
+	} );
+
 	describe( 'getArrayOfFilteredTasks', () => {
-		const tasks = [
-			getTask( { id: 'foo_task' } ),
-			getTask( { id: 'bar_task' } ),
-			getTask( { id: 'baz_task' } ),
-		];
+		describe( 'when no flow is provided', () => {
+			it( 'no tasks are found', () => {
+				expect( getArrayOfFilteredTasks( tasks, null ) ).toBe( null );
+			} );
+		} );
 
-		const flow = 'newsletter';
+		describe( 'when a non-existing flow is provided ', () => {
+			it( 'no tasks are found', () => {
+				expect( getArrayOfFilteredTasks( tasks, 'custom-flow' ) ).toBe( undefined );
+			} );
+		} );
 
-		// describe( '', () => {
-		// 	it( 'the task is disabled', () => {
-		// 		expect( getArrayOfFilteredTasks( tasks, flow ) ).toBe( true );
-		// 	} );
-		// } );
+		describe( 'when an existing flow is provided ', () => {
+			it( 'returns found tasks', () => {
+				expect( getArrayOfFilteredTasks( tasks, 'newsletter' ) ).toEqual(
+					tasks.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
+				);
+			} );
+		} );
 	} );
 	describe( 'isTaskDisabled', () => {
 		describe( 'when a task is complete', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getArrayOfFilteredTasks, isTaskDisabled } from '../task-helper';
+import { Task } from '../types';
+
+function getTask( taskData = {} ) {
+	const task: Task = {
+		id: 'foo_task',
+		isCompleted: false,
+		actionUrl: '#',
+		taskType: 'blog',
+		displayBadge: false,
+	};
+
+	return { ...task, ...taskData };
+}
+
+describe( 'Task Helpers', () => {
+	// describe( 'getEnhancedTasks', () => {
+	// 	describe( 'when a task is complete', () => {
+	// 		it( 'the task is disabled', () => {
+	// 			expect( isTaskDisabled( task ) ).toBe( true );
+	// 		} );
+	// 	} );
+	// } );
+	describe( 'getArrayOfFilteredTasks', () => {
+		const tasks = [
+			getTask( { id: 'foo_task' } ),
+			getTask( { id: 'bar_task' } ),
+			getTask( { id: 'baz_task' } ),
+		];
+
+		const flow = 'newsletter';
+
+		// describe( '', () => {
+		// 	it( 'the task is disabled', () => {
+		// 		expect( getArrayOfFilteredTasks( tasks, flow ) ).toBe( true );
+		// 	} );
+		// } );
+	} );
+	describe( 'isTaskDisabled', () => {
+		describe( 'when a task is complete', () => {
+			it( 'the task is disabled', () => {
+				const task = getTask( { isCompleted: true } );
+				expect( isTaskDisabled( task ) ).toBe( true );
+			} );
+		} );
+		describe( 'when a given task has other, dependent tasks that should be completed first', () => {
+			describe( 'and the other tasks are incomplete', () => {
+				it( 'the given task is disabled', () => {
+					const dependencies = [ true, false ];
+					const task = getTask( { dependencies, isCompleted: false } );
+					expect( isTaskDisabled( task ) ).toBe( true );
+				} );
+			} );
+			describe( 'and the other tasks are complete', () => {
+				it( 'the given task is enabled', () => {
+					const dependencies = [ true, true ];
+					const task = getTask( { dependencies, isCompleted: false } );
+					expect( isTaskDisabled( task ) ).toBe( false );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import { getArrayOfFilteredTasks, getEnhancedTasks, isTaskDisabled } from '../task-helper';
-import { Task } from '../types';
 import { tasks, launchpadFlowTasks } from '../tasks';
+import { Task } from '../types';
 
 function getTask( taskData = {} ) {
 	const task: Task = {
@@ -20,12 +20,13 @@ function getTask( taskData = {} ) {
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
 		describe( 'when a task should not be enhanced', () => {
-			it( 'it is not enhanced', () => {
+			it( 'then it is not enhanced', () => {
 				const fakeTasks = [
 					getTask( { id: 'fake-task-1' } ),
 					getTask( { id: 'fake-task-2' } ),
 					getTask( { id: 'fake-task-3' } ),
 				];
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
 				expect( getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {} ) ).toEqual(
 					fakeTasks
 				);
@@ -35,19 +36,19 @@ describe( 'Task Helpers', () => {
 
 	describe( 'getArrayOfFilteredTasks', () => {
 		describe( 'when no flow is provided', () => {
-			it( 'no tasks are found', () => {
+			it( 'then no tasks are found', () => {
 				expect( getArrayOfFilteredTasks( tasks, null ) ).toBe( null );
 			} );
 		} );
 
-		describe( 'when a non-existing flow is provided ', () => {
-			it( 'no tasks are found', () => {
+		describe( 'when a non-existing flow is provided', () => {
+			it( 'then no tasks are found', () => {
 				expect( getArrayOfFilteredTasks( tasks, 'custom-flow' ) ).toBe( undefined );
 			} );
 		} );
 
-		describe( 'when an existing flow is provided ', () => {
-			it( 'returns found tasks', () => {
+		describe( 'when an existing flow is provided', () => {
+			it( 'then it returns found tasks', () => {
 				expect( getArrayOfFilteredTasks( tasks, 'newsletter' ) ).toEqual(
 					tasks.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
 				);
@@ -56,21 +57,21 @@ describe( 'Task Helpers', () => {
 	} );
 	describe( 'isTaskDisabled', () => {
 		describe( 'when a task is complete', () => {
-			it( 'the task is disabled', () => {
+			it( 'then the task is disabled', () => {
 				const task = getTask( { isCompleted: true } );
 				expect( isTaskDisabled( task ) ).toBe( true );
 			} );
 		} );
 		describe( 'when a given task has other, dependent tasks that should be completed first', () => {
 			describe( 'and the other tasks are incomplete', () => {
-				it( 'the given task is disabled', () => {
+				it( 'then the given task is disabled', () => {
 					const dependencies = [ true, false ];
 					const task = getTask( { dependencies, isCompleted: false } );
 					expect( isTaskDisabled( task ) ).toBe( true );
 				} );
 			} );
 			describe( 'and the other tasks are complete', () => {
-				it( 'the given task is enabled', () => {
+				it( 'then the given task is enabled', () => {
 					const dependencies = [ true, true ];
 					const task = getTask( { dependencies, isCompleted: false } );
 					expect( isTaskDisabled( task ) ).toBe( false );


### PR DESCRIPTION
#### Proposed Changes

* Add unit testing to launchpad task helper methods

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn test-client task-helper`
* Verify that unit tests pass
* `yarn test-client launchpad/test/checklist.tsx`
* Verify that unit tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
