### PR TITLE
Jetpack Cloud: Make the "Update Plugins" button only update plugins needing an update

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -271,12 +271,18 @@ export class PluginsList extends Component {
 
 	updateAllPlugins = () => {
 		this.removePluginStatuses();
-		this.props.plugins.forEach( ( plugin ) => {
-			Object.keys( plugin.sites ).forEach( ( siteId ) => {
-				const sitePlugin = this.getSitePlugin( plugin, siteId );
-				return this.props.updatePlugin( siteId, sitePlugin );
+		this.props.plugins
+			// only consider plugins needing an update
+			.filter( ( plugin ) => plugin.update )
+			.forEach( ( plugin ) => {
+				Object.entries( plugin.sites )
+					// only consider the sites where the those plugins are installed
+					.filter( ( [ , sitePlugin ] ) => sitePlugin.update )
+					.forEach( ( [ siteId ] ) => {
+						const sitePlugin = this.getSitePlugin( plugin, siteId );
+						return this.props.updatePlugin( siteId, sitePlugin );
+					} );
 			} );
-		} );
 		this.recordEvent( 'Clicked Update all Plugins', true );
 	};
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -269,20 +269,24 @@ export class PluginsList extends Component {
 		} );
 	};
 
-	updateAllPlugins = () => {
+	handleUpdatePlugins = ( plugins ) => {
 		this.removePluginStatuses();
-		this.props.plugins
+		plugins
 			// only consider plugins needing an update
 			.filter( ( plugin ) => plugin.update )
 			.forEach( ( plugin ) => {
 				Object.entries( plugin.sites )
 					// only consider the sites where the those plugins are installed
-					.filter( ( [ , sitePlugin ] ) => sitePlugin.update )
+					.filter( ( [ , sitePlugin ] ) => sitePlugin.update?.new_version )
 					.forEach( ( [ siteId ] ) => {
 						const sitePlugin = this.getSitePlugin( plugin, siteId );
 						return this.props.updatePlugin( siteId, sitePlugin );
 					} );
 			} );
+	};
+
+	updateAllPlugins = () => {
+		this.handleUpdatePlugins( this.props.plugins );
 		this.recordEvent( 'Clicked Update all Plugins', true );
 	};
 
@@ -294,7 +298,7 @@ export class PluginsList extends Component {
 	};
 
 	updatePlugin = ( selectedPlugin ) => {
-		this.doActionOverSelected( 'updating', this.props.updatePlugin, [ selectedPlugin ] );
+		this.handleUpdatePlugins( [ selectedPlugin ] );
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
 	};
 


### PR DESCRIPTION
#### Proposed Changes

* The `updateAllPlugins` goes through every plugin in the list and through every site that has that plugin installed. Then, for each plugin-site pair, the function triggers an update for every combination. As a result, the app sends many unnecessary requests and produces a suboptimal user experience.
* These changes change how `updateAllPlugins` works by only considering plugins needing an update and the sites where those outdated plugins are installed. In the code changes, you can see I added two `filter` calls to accomplish that.
* As a result, the app will send fewer requests and only the ones the user cares about, which should result in a clearer and smoother experience for users.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/3418513/188970289-e338a35a-41dc-4a8b-986c-57e6dc44ee16.mp4


</td>
<td>

https://user-images.githubusercontent.com/3418513/188970303-07ab6ca8-3253-4175-b27a-2054869b4ebe.mp4


</td>
</tr>
</table>

#### Testing Instructions

##### Pre-requisites
* Make sure you have 2-3 sites with plugins needing an update (the easiest way to do this is to install Jetpack Beta and select an activate an outdated version of the plugin.

##### Replicate the issue
* From `trunk`, run `yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/ (you should be redirected to `/dashboard`).
* Click on the Plugins item located in the sidebar.
* Verify that you see a few indicators of plugins needing an update in the list of plugins.
* Click on the `Update x Plugins` green button.
* Verify that every plugin was attempted to be updated.

##### Test the fix
* Download this PR.
* Run `yarn start-jetpack-cloud`.
* Visit http://jetpack.cloud.localhost:3000/ (you should be redirected to `/dashboard`).
* Click on the Plugins item located in the sidebar.
* Verify that you see a few indicators of plugins needing an update in the list of plugins.
* Click on the `Update x Plugins` green button.
* Verify that only the plugins needing an update were updated.
* Click on the network tab in the dev tool and set the throttling level to `Offline` for the API to fail.

<img width="336" alt="Screenshot 2022-09-08 at 6 10 40 PM" src="https://user-images.githubusercontent.com/10586875/189124325-c4511772-2586-4a87-8861-ba28ce8bdccf.png">

* Click on the {currentVersion} -> Update to {newVersion}` button and verify that only the plugins needing an update were updated.

<img width="266" alt="Screenshot 2022-09-08 at 6 04 33 PM" src="https://user-images.githubusercontent.com/10586875/189124223-859f9d9b-e81c-41e5-8bbc-14b624728815.png">

* Click on the `retry` button and verify that only the plugins needing an update were updated. 

<img width="722" alt="Screenshot 2022-09-08 at 6 07 08 PM" src="https://user-images.githubusercontent.com/10586875/189124288-556b8c23-1583-44cd-b980-7e2844d050ba.png">

* You can go one step further and block the request URL of the update API for one site, set the throttling level to `No Throttling`, and let one plugin update and fail at least once, now clicking on retry should only try to update the failed ones. 

<img width="499" alt="Screenshot 2022-09-08 at 6 10 53 PM" src="https://user-images.githubusercontent.com/10586875/189124393-efdeb636-e6c6-4dd9-a0a4-f362c6a75075.png">


##### Regressions
* Run `yarn start`.
* Visit http://calypso.localhost:3000/plugins/manage.
* Verify the bulk update works as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202938430394628 & 1202518759611394-as-1202940210709799