### PR TITLE
Add a modal for the update all plugins notice

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -55,6 +55,7 @@ export class PluginsListHeader extends PureComponent {
 		autoupdateEnablePluginNotice: PropTypes.func.isRequired,
 		autoupdateDisablePluginNotice: PropTypes.func.isRequired,
 		updatePluginNotice: PropTypes.func.isRequired,
+		updateAllPluginsNotice: PropTypes.func.isRequired,
 		haveActiveSelected: PropTypes.bool,
 		haveInactiveSelected: PropTypes.bool,
 		plugins: PropTypes.array.isRequired,
@@ -143,7 +144,7 @@ export class PluginsListHeader extends PureComponent {
 			if ( 0 < this.props.pluginUpdateCount ) {
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-update-all">
-						<Button compact primary onClick={ this.props.updateAllPlugins }>
+						<Button compact primary onClick={ this.props.updateAllPluginsNotice }>
 							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
 								context: 'button label',
 								count: this.props.pluginUpdateCount,

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -269,15 +269,17 @@ export class PluginsList extends Component {
 		} );
 	};
 
-	updateAllPlugins = () => {
-		this.removePluginStatuses();
-		this.props.plugins.forEach( ( plugin ) => {
-			Object.keys( plugin.sites ).forEach( ( siteId ) => {
-				const sitePlugin = this.getSitePlugin( plugin, siteId );
-				return this.props.updatePlugin( siteId, sitePlugin );
+	updateAllPlugins = ( accepted ) => {
+		if ( accepted ) {
+			this.removePluginStatuses();
+			this.props.plugins.forEach( ( plugin ) => {
+				Object.keys( plugin.sites ).forEach( ( siteId ) => {
+					const sitePlugin = this.getSitePlugin( plugin, siteId );
+					return this.props.updatePlugin( siteId, sitePlugin );
+				} );
 			} );
-		} );
-		this.recordEvent( 'Clicked Update all Plugins', true );
+			this.recordEvent( 'Clicked Update all Plugins', true );
+		}
 	};
 
 	updateSelected = ( accepted ) => {
@@ -514,6 +516,15 @@ export class PluginsList extends Component {
 						translationArgs
 					)
 				);
+				break;
+			case 'update_all':
+				acceptDialog(
+					<div>
+						<span>{ translate( 'You are about to update all plugins on all sites.' ) }</span>
+					</div>,
+					( accepted ) => this.updateAllPlugins( accepted ),
+					translate( 'Update all plugins' )
+				);
 		}
 	};
 
@@ -677,6 +688,7 @@ export class PluginsList extends Component {
 					autoupdateEnablePluginNotice={ () => this.bulkActionDialog( 'enableAutoupdates' ) }
 					autoupdateDisablePluginNotice={ () => this.bulkActionDialog( 'disableAutoupdates' ) }
 					updatePluginNotice={ () => this.bulkActionDialog( 'update' ) }
+					updateAllPluginsNotice={ () => this.bulkActionDialog( 'update_all' ) }
 					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
 					haveInactiveSelected={ this.props.plugins.some(
 						this.filterSelection.inactive.bind( this )


### PR DESCRIPTION
Adding a modal for the button used to update all plugins with pending updates across all sites.

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
