### PR TITLE
Hosting Config: Show SSH panel for Free sites too

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -1,4 +1,4 @@
-import { FEATURE_SSH } from '@automattic/calypso-products';
+import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
 import { Card, Button, Gridicon, Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { PanelBody, ToggleControl } from '@wordpress/components';
@@ -51,6 +51,7 @@ export const SftpCard = ( {
 	requestSftpUsers,
 	createSftpUser,
 	resetSftpPassword,
+	siteHasSftpFeature,
 	siteHasSshFeature,
 	isSshAccessEnabled,
 	requestSshAccess,
@@ -227,6 +228,7 @@ export const SftpCard = ( {
 	};
 
 	const displayQuestionsAndButton = ! ( username || isLoading );
+	const showSshPanel = ! siteHasSftpFeature || siteHasSshFeature;
 
 	const featureExplanation = siteHasSshFeature
 		? translate(
@@ -284,7 +286,7 @@ export const SftpCard = ( {
 							}
 						) }
 					</PanelBody>
-					{ siteHasSshFeature && (
+					{ showSshPanel && (
 						<PanelBody title={ translate( 'What is SSH?' ) } initialOpen={ false }>
 							{ translate(
 								'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. ' +
@@ -452,6 +454,7 @@ export default connect(
 			currentUserId,
 			username,
 			password,
+			siteHasSftpFeature: siteHasFeature( state, siteId, FEATURE_SFTP ),
 			siteHasSshFeature: siteHasFeature( state, siteId, FEATURE_SSH ),
 			isSshAccessEnabled: 'ssh' === getAtomicHostingSshAccess( state, siteId ),
 		};


### PR DESCRIPTION
From p1662564174874959-slack-C03TP5Z3MPD

## Proposed Changes

Shows the SSH panel:
* When a site _doesn't_ have SFTP as a part of their plan (e.g. Free or Premium)
* When a site _does_ have SSH as a part of their plan (e.g. Business or eCommerce)

The panel doesn't show for Pro, which has SFTP but doesn't have SSH.

### Free

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/36432/188993045-e1dbb9d1-4327-47c1-9ca0-b935ee8de7a3.png">

### Pro

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/36432/188993024-7776cf75-f6e2-42e0-896b-65abe95f8cb2.png">

### Business

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/36432/188993323-ccf7c951-c99f-4a31-8fea-545441cebc9b.png">

## Testing Instructions

1. View `/hosting-config` on a Free site and verify the SSH panel appears.
2. View `/hosting-config` on a Pro site and verify the SSH panel doesn't appear.
3. View `/hosting-config` on a Business site and verify the SSH panel appears.