### PR TITLE
Launchpad: Add checklist item test

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -37,6 +37,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				) : null }
 				{ ! taskDisabled && (
 					<Gridicon
+						aria-label={ translate( 'Task enabled' ) }
 						className="launchpad__checklist-item-chevron"
 						icon={ `chevron-${ isRtl ? 'left' : 'right' }` }
 						size={ 18 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ChecklistItem from '../checklist-item';
+import { Task } from '../types';
+
+function getTask( taskData = {} ) {
+	const task: Task = {
+		id: 'foo_task',
+		isCompleted: false,
+		actionUrl: '#',
+		taskType: 'blog',
+		displayBadge: false,
+	};
+
+	return { ...task, ...taskData };
+}
+
+describe( 'ChecklistItem', () => {
+	describe( 'when the task requires a badge', () => {
+		it( 'displays a badge', () => {
+			const badgeText = 'Badge Text';
+			render( <ChecklistItem task={ getTask( { displayBadge: true, badgeText } ) } /> );
+			expect( screen.getByText( badgeText ) ).toBeTruthy();
+		} );
+	} );
+
+	// describe( 'when the task depends on the completion of other tasks', () => {
+	// 	describe( 'and the other tasks are not completed', () => {
+	// 		it( 'disables the task', () => {
+	// 			const { getByText } = render(
+	// 				<ChecklistItem task={ getTask( { displayBadge: true } ) } />
+	// 			);
+	// 		} );
+	// 	} );
+	// 	describe( 'and the other tasks are completed', () => {
+	// 		it( 'enables the task', () => {
+	// 			const { getByText } = render(
+	// 				<ChecklistItem task={ getTask( { displayBadge: true } ) } />
+	// 			);
+	// 		} );
+	// 	} );
+	// } );
+	// describe( 'when the task is complete', () => {
+	// 	it( 'disables the task', () => {
+	// 		render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+	// 		screen.debug();
+	// 		const checkmark = screen.queryByRole( 'svg' );
+	// 		console.log( { checkmark } );
+	// 		// expect( actual ).toBeFalsy();
+	// 	} );
+	// } );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -13,6 +13,7 @@ function getTask( taskData = {} ) {
 		actionUrl: '#',
 		taskType: 'blog',
 		displayBadge: false,
+		title: 'Foo Task',
 	};
 
 	return { ...task, ...taskData };
@@ -27,29 +28,42 @@ describe( 'ChecklistItem', () => {
 		} );
 	} );
 
-	// describe( 'when the task depends on the completion of other tasks', () => {
-	// 	describe( 'and the other tasks are not completed', () => {
-	// 		it( 'disables the task', () => {
-	// 			const { getByText } = render(
-	// 				<ChecklistItem task={ getTask( { displayBadge: true } ) } />
-	// 			);
-	// 		} );
-	// 	} );
-	// 	describe( 'and the other tasks are completed', () => {
-	// 		it( 'enables the task', () => {
-	// 			const { getByText } = render(
-	// 				<ChecklistItem task={ getTask( { displayBadge: true } ) } />
-	// 			);
-	// 		} );
-	// 	} );
-	// } );
-	// describe( 'when the task is complete', () => {
-	// 	it( 'disables the task', () => {
-	// 		render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
-	// 		screen.debug();
-	// 		const checkmark = screen.queryByRole( 'svg' );
-	// 		console.log( { checkmark } );
-	// 		// expect( actual ).toBeFalsy();
-	// 	} );
-	// } );
+	describe( 'when the task is complete', () => {
+		it( 'shows the task complete icon', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			const taskCompleteIcon = screen.queryByLabelText( 'Task complete' );
+			expect( taskCompleteIcon ).toBeTruthy();
+		} );
+		it( 'hides the task enabled icon', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
+			expect( taskEnabledIcon ).toBeFalsy();
+		} );
+		it( 'disables the task', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			const taskButton = screen.queryByRole( 'link' );
+			expect( taskButton ).toHaveAttribute( 'disabled' );
+		} );
+	} );
+
+	describe( 'when the task depends on the completion of other tasks', () => {
+		describe( 'and some of the other tasks are not completed', () => {
+			it( 'disables the task', () => {
+				const otherTaskCompleted = true;
+
+				render( <ChecklistItem task={ getTask( { dependencies: [ ! otherTaskCompleted ] } ) } /> );
+				const taskButton = screen.queryByRole( 'link' );
+				expect( taskButton ).toHaveAttribute( 'disabled' );
+			} );
+		} );
+		describe( 'and the other tasks are completed', () => {
+			it( 'enables the task', () => {
+				const otherTaskCompleted = true;
+
+				render( <ChecklistItem task={ getTask( { dependencies: [ otherTaskCompleted ] } ) } /> );
+				const taskButton = screen.queryByRole( 'link' );
+				expect( taskButton ).not.toHaveAttribute( 'disabled' );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* Add unit testing to launchpad task helper methods

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn test-client launchpad/test/checklist-item`
* Verify that unit tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
