### PR TITLE
Fix available designs missing recipe property

### DIFF
--- a/packages/design-picker/src/utils/available-designs-config.ts
+++ b/packages/design-picker/src/utils/available-designs-config.ts
@@ -5,4 +5,12 @@ export interface AvailableDesigns {
 	featured: Design[];
 }
 
-export const availableDesignsConfig = rawAvailableDesignsConfig as Readonly< AvailableDesigns >;
+export const availableDesignsConfig = {
+	...rawAvailableDesignsConfig,
+	featured: rawAvailableDesignsConfig.featured.map( ( design ) => ( {
+		...design,
+		recipe: {
+			stylesheet: `${ design.is_premium ? 'premium' : 'pub' }/${ design.theme }`,
+		},
+	} ) ),
+} as Readonly< AvailableDesigns >;


### PR DESCRIPTION
#### Proposed Changes

* There are still some users who enter our deprecated Gutenboarding flow.  However, the designs in that flow missing the `recipe.stylesheet` property and it causes `block-previews/site` endpoint to be broken. See p1662593198198819-slack-C4N88L95W

![image](https://user-images.githubusercontent.com/13596067/189023318-3557e788-b2ba-4f8f-be87-064c44194501.png)

TODO

- [ ] The `block-previews/site` might need to make `stylesheet` required to avoid potential error

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new/design` and you have to see the preview of designs show as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1662593198198819-slack-C4N88L95W