### PR TITLE
Show the blank canvas cta on 'All' category only

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -15,6 +15,7 @@ import {
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
+	SHOW_ALL_SLUG,
 } from '../constants';
 import {
 	getDesignPreviewUrl,
@@ -397,7 +398,10 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 
 		result.sort( sortDesigns );
 
-		if ( isEnabled( 'signup/design-picker-pattern-assembler' ) ) {
+		if (
+			isEnabled( 'signup/design-picker-pattern-assembler' ) &&
+			categorization?.selection === SHOW_ALL_SLUG
+		) {
 			const blankCanvasDesign = {
 				recipe: {
 					stylesheet: 'pub/blank-canvas-blocks',


### PR DESCRIPTION
## Proposed Changes

* Show the blank canvas CTA on 'All' category on UDP

## Testing Instructions

* Head to /designSetup step
* Confirm that the blank canvas CTA is only shown on the 'Show All' option

## Reference

Related to #67073

