### PR TITLE
Onboarding: Redirect /new to /start flow

### DIFF
--- a/client/landing/gutenboarding/section.ts
+++ b/client/landing/gutenboarding/section.ts
@@ -1,7 +1,0 @@
-export const GUTENBOARDING_SECTION_DEFINITION = {
-	name: 'gutenboarding',
-	paths: [ 'new' ],
-	module: 'gutenboarding',
-	group: 'gutenboarding',
-	enableLoggedOut: true,
-};

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -815,11 +815,17 @@ export default function pages() {
 	app.get( [ '/new', '/new/*' ], ( req, res ) => {
 		const lastPathSegment = req.path.substr( req.path.lastIndexOf( '/' ) + 1 );
 		const languageSlugs = getLanguageSlugs();
+		let redirectUrl = '/start';
+
 		if ( languageSlugs.includes( lastPathSegment ) && ! isDefaultLocale( lastPathSegment ) ) {
-			res.redirect( 301, `/start/${ lastPathSegment }` );
-		} else {
-			res.redirect( 301, '/start' );
+			redirectUrl += `/${ lastPathSegment }`;
 		}
+
+		if ( Object.keys( req.query ) > 0 ) {
+			redirectUrl += `?${ stringify( req.query ) }`;
+		}
+
+		res.redirect( 301, redirectUrl );
 	} );
 
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1251,12 +1251,15 @@ describe( 'main app', () => {
 		} );
 	} );
 
-	describe( `Route /new`, () => {
-		assertSection( {
-			url: '/new',
-			sectionName: 'gutenboarding',
-			sectionGroup: 'gutenboarding',
-			entry: 'entry-gutenboarding',
+	describe( `Route deprecated /new`, () => {
+		it( 'redirects to start flow', async () => {
+			const { response } = await app.run( { request: { url: '/new' } } );
+			expect( response.redirect ).toHaveBeenCalledWith( 301, '/start' );
+		} );
+
+		it( 'redirects to start flow with locale', async () => {
+			const { response } = await app.run( { request: { url: '/new/fr' } } );
+			expect( response.redirect ).toHaveBeenCalledWith( 301, '/start/fr' );
 		} );
 	} );
 

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -109,16 +109,6 @@ jest.mock( 'calypso/lib/oauth2-clients', () => ( {
 	isWooOAuth2Client: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/landing/gutenboarding/section', () => ( {
-	GUTENBOARDING_SECTION_DEFINITION: {
-		name: 'gutenboarding',
-		paths: [ '/new' ],
-		module: 'gutenboarding',
-		group: 'gutenboarding',
-		enableLoggedOut: true,
-	},
-} ) );
-
 /**
  * Builds an app for an specific environment.
  *


### PR DESCRIPTION
#### Proposed Changes

* According to p1662606063134259-slack-CRWCHQGUB, we want to redirect the `/new` to `/start` flow as the Gutenboarding flow is deprecated for a long time.
* This PR is focusing on redirection and @Automattic/vertex has their todo list to clean up all the related code (See p1662625585898959/1662606063.134259-slack-CRWCHQGUB)

System request

* pMz3w-fTX-p2

More context
* [Proposal: Redirect existing customers to /start instead of /new](pbxNRc-1eh-p2)
* [Retro: Migrating Anchor from Gutenboarding to Stepper](paYKcK-1Iz-p2)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` and you'll be redirected to `/start`
* Go to `/new/fr` and you'll be redirected to `/start/fr`
* Go to `/new/design/fr` and you'll be redirected to `/start/fr`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1662606063134259-slack-CRWCHQGUB, https://github.com/Automattic/wp-calypso/issues/61818