### PR TITLE
Always show back button in `EmailProvidersStackedComparison`

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -170,6 +170,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		return (
 			<EmailProvidersStackedComparisonPage
 				comparisonContext="email-home-single-domain"
+				hideNavigation
 				selectedDomainName={ domainsWithNoEmail[ 0 ].name }
 				selectedEmailProviderSlug={ selectedEmailProviderSlug }
 				selectedIntervalLength={ selectedIntervalLength }

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -44,6 +44,7 @@ import './style.scss';
 export type EmailProvidersStackedComparisonProps = {
 	cartDomainName?: string;
 	comparisonContext: string;
+	hideNavigation?: boolean;
 	isDomainInCart?: boolean;
 	selectedDomainName: string;
 	selectedEmailProviderSlug?: string;
@@ -53,6 +54,7 @@ export type EmailProvidersStackedComparisonProps = {
 
 const EmailProvidersStackedComparison = ( {
 	comparisonContext,
+	hideNavigation = false,
 	isDomainInCart = false,
 	selectedDomainName,
 	selectedEmailProviderSlug,
@@ -218,14 +220,16 @@ const EmailProvidersStackedComparison = ( {
 
 			{ ! isDomainInCart && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
-			<EmailUpsellNavigation
-				backUrl={
-					isDomainInCart
-						? domainAddNew( selectedSite?.slug )
-						: emailManagement( selectedSite?.slug, null )
-				}
-				skipUrl={ isDomainInCart ? `/checkout/${ selectedSite?.slug }` : '' }
-			/>
+			{ ! hideNavigation && (
+				<EmailUpsellNavigation
+					backUrl={
+						isDomainInCart
+							? domainAddNew( selectedSite?.slug )
+							: emailManagement( selectedSite?.slug, null )
+					}
+					skipUrl={ isDomainInCart ? `/checkout/${ selectedSite?.slug }` : '' }
+				/>
+			) }
 
 			<h1 className="email-providers-stacked-comparison__header">
 				{ isDomainInCart

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -222,7 +222,7 @@ const EmailProvidersStackedComparison = ( {
 				backUrl={
 					isDomainInCart
 						? domainAddNew( selectedSite?.slug )
-						: emailManagement( selectedSite?.slug )
+						: emailManagement( selectedSite?.slug, null )
 				}
 				skipUrl={ isDomainInCart ? `/checkout/${ selectedSite?.slug }` : '' }
 			/>

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'calypso/lib/domains/email-forwarding';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
+import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
@@ -30,7 +31,7 @@ import { IntervalLength } from 'calypso/my-sites/email/email-providers-compariso
 import EmailUpsellNavigation from 'calypso/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation';
 import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-comparison/stacked/provider-cards/google-workspace-card';
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card';
-import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
+import { emailManagement, emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
@@ -216,7 +217,15 @@ const EmailProvidersStackedComparison = ( {
 			<QueryProductsList />
 
 			{ ! isDomainInCart && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
-			{ isDomainInCart && <EmailUpsellNavigation siteSlug={ selectedSite?.slug ?? '' } /> }
+
+			<EmailUpsellNavigation
+				backUrl={
+					isDomainInCart
+						? domainAddNew( selectedSite?.slug )
+						: emailManagement( selectedSite?.slug )
+				}
+				skipUrl={ isDomainInCart ? `/checkout/${ selectedSite?.slug }` : '' }
+			/>
 
 			<h1 className="email-providers-stacked-comparison__header">
 				{ isDomainInCart

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation.scss
@@ -3,13 +3,18 @@
 .email-upsell-navigation {
 	display: flex;
 	justify-content: space-between;
+	margin-bottom: 18px;
+
+	&.is-hiding-skip {
+		margin-bottom: 0;
+	}
 
 	.button {
 		@include onboarding-medium-text;
+
 		align-items: center;
 		display: inline-flex;
 		padding: 0;
-		margin-bottom: 18px;
 	}
 
 	.button.is-borderless .gridicon {

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation.tsx
@@ -1,22 +1,34 @@
 import { Button, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { domainAddNew } from 'calypso/my-sites/domains/paths';
 
 import './email-upsell-navigation.scss';
 
-const EmailUpsellNavigation = ( { siteSlug }: { siteSlug: string } ) => {
+type Props = {
+	backUrl: string;
+	skipUrl?: string;
+};
+
+const EmailUpsellNavigation = ( { backUrl, skipUrl }: Props ) => {
 	const translate = useTranslate();
 
 	return (
-		<div className="email-upsell-navigation">
-			<Button borderless href={ domainAddNew( siteSlug ) }>
+		<div
+			className={ classNames( 'email-upsell-navigation', {
+				'is-hiding-skip': ! skipUrl,
+			} ) }
+		>
+			<Button borderless href={ backUrl }>
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{ translate( 'Back' ) }
 			</Button>
-			<Button borderless href={ `/checkout/${ siteSlug }` }>
-				{ translate( 'Skip' ) }
-				<Gridicon icon="arrow-right" size={ 18 } />
-			</Button>
+
+			{ skipUrl && (
+				<Button borderless href={ skipUrl }>
+					{ translate( 'Skip' ) }
+					<Gridicon icon="arrow-right" size={ 18 } />
+				</Button>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

We don't display a back button if a user goes to purchase email for a previously registered domain. Since we do display a back button on the domain email management pages (`/email/:domain/manage/:site_slug`), it seemed like a nice thing to add.

I wasn't entirely content with the way this looks, but I still think this would be a nice thing to add. We do have the larger **Update email UI to align with domains** project in the pipeline, which should help us achieve more consistent header styling and that would also be a boon for the unsatisfactory visual balance on this page.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/1101677/189096029-3d11c595-e5ae-4c11-9a78-967352a573d8.png) | ![after](https://user-images.githubusercontent.com/1101677/189096044-0b942b73-3e17-449e-8484-989237d7dca7.png) |

#### Testing Instructions for multi domain sites

1. Have a site with at least two domains, where at least one lacks email
2. Navigate to `/email/:domain/purchase/:site_slug`
3. Ensure that a back button is visible

#### Testing Instructions for single domain sites

1. Have a site with a single domain, without email
2. Navigate to `/email/:site_slug`
3. Ensure that no back button is visible

#### Testing Instructions for new domains

1. Go to `/domains/add/:site_slug`
2. Select a domain
3. In the email upsell step, ensure that both the back button and the skip button are displayed (and work properly)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
