### PR TITLE
Add more formatting commits to the blame-ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,8 @@
-# Ignore prettier format done in #62969
+# Prettier format in #18282
+b855b7a8a7e9f6a24e4fc87e8fe251cfd10603fd
+# Prettier format in #41114
+4537033c6794449ce0a10b69d72daf5fa658d553
+# Prettier format in #45291
+5948dacb721fd61e06e193757b066eab21a43cbd
+# Prettier format in #62969
 9fb7ac149e55361c0c3a9639ad0caa5e15fc88b0


### PR DESCRIPTION
Adds a few more Prettier formatting commits to the `.git-blame-ignore-revs` file originally created in #63072.

**How to test:**
Make sure your local Git repo is configured to use the ignore file. By default only the GitHub web UI uses it:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
Then check that formatting commits are ignored when showing blame with:
- `git blame` on command line
- blame tools in your text editor (I tested in VS Code)
- online on GitHub