### PR TITLE
VideoPress Onboarding v2: Account Step

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -44,7 +44,7 @@ export const videopress: Flow = {
 						return navigate( 'options' );
 					}
 					return window.location.replace(
-						`/start/account/user?variationName=${ name }&pageTitle=Link%20in%20Bio&redirect_to=/setup/options?flow=${ name }`
+						`/start/account/user?variationName=${ name }&pageTitle=Video%20Portfolio&redirect_to=/setup/options?flow=${ name }`
 					);
 
 				case 'options': {

--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -20,6 +20,7 @@ interface Props {
 const VARIATION_TITLES: Record< string, string > = {
 	newsletter: 'Newsletter',
 	'link-in-bio': 'Link in Bio',
+	videopress: 'Video Portfolio',
 };
 
 const SignupHeader = ( {

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -22,6 +22,13 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		plans: 5,
 		launchpad: 6,
 	},
+	videopress: {
+		intro: 0,
+		user: 1,
+		domains: 2,
+		plans: 3,
+		launchpad: 4,
+	},
 };
 
 export const useFlowProgress = ( { stepName, flowName }: FlowProgress = {} ) => {


### PR DESCRIPTION
#### Proposed Changes

* Adds The VideoPress title and progress bar to account create
* See also pxWta-1z5-p2


#### Testing Instructions

* go to http://calypso.localhost:3000/setup/intro?flow=videopress and click to start flow
* You are taken to the account creation step and you can see a progress bar and "Video Portfolio"

refs #67539