### PR TITLE
Enhance Button component with renderAs prop

### DIFF
--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -18,15 +18,16 @@ export default function RockOnButton() {
 
 ### Props
 
-| Name         | Type     | Default | Description                                                                        |
-| ------------ | -------- | ------- | ---------------------------------------------------------------------------------- |
-| `plain`      | `bool`   | false   | Renders a button with no user-agent styles                                         |
-| `compact`    | `bool`   | false   | Decreases the size of the button                                                   |
-| `primary`    | `bool`   | false   | Provides extra visual weight and identifies the primary action in a set of buttons |
-| `borderless` | `bool`   | false   | Renders a button without borders                                                   |
-| `scary`      | `bool`   | false   | Indicates a dangerous or potentially negative action                               |
-| `busy`       | `bool`   | false   | Indicates activity while a background action is being performed                    |
-| `href`       | `string` | null    | If provided, renders `a` instead of `button`                                       |
+| Name         | Type              | Default   | Description                                                                                 |
+| ------------ | ----------------- | --------- | ------------------------------------------------------------------------------------------- |
+| `plain`      | `bool`            | false     | Renders a button with no user-agent styles                                                  |
+| `compact`    | `bool`            | false     | Decreases the size of the button                                                            |
+| `primary`    | `bool`            | false     | Provides extra visual weight and identifies the primary action in a set of buttons          |
+| `borderless` | `bool`            | false     | Renders a button without borders                                                            |
+| `scary`      | `bool`            | false     | Indicates a dangerous or potentially negative action                                        |
+| `busy`       | `bool`            | false     | Indicates activity while a background action is being performed                             |
+| `href`       | `string`          | null      | If provided, renders `a` instead of `button`                                                |
+| `renderAs`   | `'a' \| 'button'` | undefined | If provided, renders as the given type. Useful if you want to render as `a` with empty href |
 
 ### Button types
 

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -17,6 +17,7 @@ export interface OwnProps {
 	busy?: boolean;
 	borderless?: boolean;
 	plain?: boolean;
+	renderAs?: Extract< React.ElementType, 'a' | 'button' >;
 }
 
 type AnchorElementProps = AnchorHTMLAttributes< HTMLAnchorElement >;
@@ -40,6 +41,7 @@ const cleanAnchorProps = ( {
 	primary,
 	scary,
 	plain,
+	renderAs,
 	...anchorProps
 }: ButtonProps | AnchorProps ): AnchorProps => anchorProps as AnchorProps;
 
@@ -52,6 +54,7 @@ const cleanButtonProps = ( {
 	primary,
 	scary,
 	plain,
+	renderAs,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore Clean incorrect usage of the component
 	rel,
@@ -78,7 +81,7 @@ const Button: ForwardRefRenderFunction<
 				'is-borderless': props.borderless,
 		  } );
 
-	if ( isAnchor( props ) ) {
+	if ( isAnchor( props ) || props.renderAs === 'a' ) {
 		const anchorProps = cleanAnchorProps( props );
 		// block referrers when external link
 		const rel: string | undefined = anchorProps.target


### PR DESCRIPTION
When using `Button` from `@automattic/components`, we often want all our buttons to have the same styles. Many times we want to use the same component as `<a />` which is decided whether an non-emty `href` is passed.

The problem arises when we want to disable a button and at the same time want to remove the `href` attribute to avoid manipulation via browser devtools. When we pass `href` to be an empty string, it's rendered as `<button />` thus making our components look different.
Now, to overcome this issue, we often use `href='#'` to ensure that it's rendered as `<a />` and not as a `<button />`, but it has some other consequences with the UI. For example the click result in scroll to the top of the page.



https://user-images.githubusercontent.com/18226415/189117241-bcae7d08-f9fb-4295-8bcc-5f1b8b901b51.mov



This PR tried to fix this issue by adding an explicit prop `renderAs` which can be `'a'` or `'button'`. It is backward compatible and only opt-in.

#### Proposed Changes

* Add a `renderAs` prop to button component in `@automattic/components`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to consume the component and pass `renderAs` prop with appropriate value.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
