### PR TITLE
Add Global Styles feature to Calypso

### DIFF
--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -264,6 +264,7 @@ export const WPCOM_FEATURES_VIDEOPRESS_UNLIMITED_STORAGE = 'videopress-unlimited
 export const WPCOM_FEATURES_VIDEO_HOSTING = 'video-hosting';
 export const WPCOM_FEATURES_WORDADS = 'wordads';
 export const WPCOM_FEATURES_CUSTOM_DESIGN = 'custom-design';
+export const WPCOM_FEATURES_GLOBAL_STYLES = 'global-styles';
 
 // Signup flow related features
 export const FEATURE_UNLIMITED_EMAILS = 'unlimited-emails';


### PR DESCRIPTION
Part of 800-gh-Automattic/dotcom-forge and counterpart of D87421-code

#### Proposed Changes

Add a new `WPCOM_FEATURES_GLOBAL_STYLES` feature to the `@automattic/calypso-products` package that will be used to limit to limit the Global Styles to paid plans.

#### Testing Instructions

- Apply D87421-code to your WP.com sandbox
- Sandbox the API
- Start Calypso locally
- Apply these changes:
```diff
diff --git a/client/layout/index.jsx b/client/layout/index.jsx
index a412cbd4de..70cbdfc9a3 100644
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -49,6 +49,9 @@ import { handleScroll } from './utils';
 import 'calypso/components/environment-badge/style.scss';
 
 import './style.scss';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { WPCOM_FEATURES_GLOBAL_STYLES } from '@automattic/calypso-products';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
@@ -379,6 +382,10 @@ export default withCurrentRoute(
 			config.isEnabled( 'calypso/help-center' ) &&
 			shouldShowHelpCenterToUser( getCurrentUserId( state ) );
 
+		if ( siteId && ! isRequestingSiteFeatures( state, siteId ) ) {
+			console.log( siteHasFeature( state, siteId, WPCOM_FEATURES_GLOBAL_STYLES ) );
+		}
+
 		return {
 			masterbarIsHidden,
 			sidebarIsHidden,

```
- Open the Calypso local instance on a browser
- Open the browser dev tools
- The trace log should return true only for WP.com sites that have a paid plan

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?