### PR TITLE
Change tabname if there is a feature flag

### DIFF
--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -74,7 +74,9 @@ class PeopleSectionNav extends Component {
 				id: 'viewers',
 			},
 			{
-				title: translate( 'Invites' ),
+				title: isEnabled( 'subscriber-importer' )
+					? translate( 'User Invites' )
+					: translate( 'Invites' ),
 				path: '/people/invites/' + siteFilter,
 				id: 'invites',
 			},

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright';
 import { clickNavTab, reloadAndRetry } from '../../element-helper';
 import { NoticeComponent } from '../components';
 
-export type PeoplePageTabs = 'Team' | 'Followers' | 'Email Followers' | 'Invites';
+export type PeoplePageTabs = 'Team' | 'Followers' | 'Email Followers' | 'User Invites';
 
 const selectors = {
 	// Navigation tabs
@@ -54,7 +54,7 @@ export class PeoplePage {
 	 */
 	async clickTab( name: PeoplePageTabs ): Promise< void > {
 		// For Invites tab, wait for the full request to be completed.
-		if ( name === 'Invites' ) {
+		if ( name === 'User Invites' ) {
 			await Promise.all( [
 				this.page.waitForNavigation( { url: '**/people/invites/**', waitUntil: 'networkidle' } ),
 				clickNavTab( this.page, name ),

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -60,7 +60,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 
 		it( 'Confirm invite is pending', async function () {
 			await sidebarComponent.navigate( 'Users', 'All Users' );
-			await peoplePage.clickTab( 'Invites' );
+			await peoplePage.clickTab( 'User Invites' );
 			await peoplePage.selectInvitedUser( testUser.email );
 		} );
 	} );

--- a/test/e2e/specs/users/invite__revoke.ts
+++ b/test/e2e/specs/users/invite__revoke.ts
@@ -74,7 +74,7 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 
 		it( 'View pending invites', async function () {
 			peoplePage = new PeoplePage( page );
-			await peoplePage.clickTab( 'Invites' );
+			await peoplePage.clickTab( 'User Invites' );
 		} );
 
 		it( 'Revoke the invite for test user', async function () {


### PR DESCRIPTION
#### Proposed Changes

The same change has been introduced through [this PR](https://github.com/Automattic/wp-calypso/pull/67160), but pre-release tests were failing, and I did a quick revert [here](https://github.com/Automattic/wp-calypso/pull/67309).

This is a revert of revert with the pre-release test updated this time. I've [double-checked pre-release tests this time and everything seems fine](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Pre_Release/8561432?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true).

#### Testing Instructions

Don't need to test anything, it is a simple tab rename depending on the feature flag.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67309
