### PR TITLE
E2E: validate selected free domain

### DIFF
--- a/test/e2e/specs/onboarding/ftme__write.ts
+++ b/test/e2e/specs/onboarding/ftme__write.ts
@@ -25,6 +25,7 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 	let siteCreatedFlag: boolean;
 	let newSiteDetails: NewSiteResponse;
 	let page: Page;
+	let selectedFreeDomain: string;
 
 	beforeAll( async function () {
 		page = await browser.newPage();
@@ -41,7 +42,7 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 		it( 'Select a .wordpress.com domain name', async function () {
 			const domainSearchComponent = new DomainSearchComponent( page );
 			await domainSearchComponent.search( blogName );
-			await domainSearchComponent.selectDomain( '.wordpress.com' );
+			selectedFreeDomain = await domainSearchComponent.selectDomain( '.wordpress.com' );
 		} );
 
 		it( `Select WordPress.com Free plan`, async function () {
@@ -59,8 +60,11 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 			startSiteFlow = new StartSiteFlow( page );
 		} );
 
-		it( 'Enter Onboarding flow', async function () {
+		it( 'Enter Onboarding flow for the selected domain', async function () {
 			await expect( page.waitForURL( /setup\/goals\?/ ) ).resolves.not.toThrow();
+
+			const urlRegex = `/setup/goals?siteSlug=${ selectedFreeDomain }`;
+			expect( page.url() ).toMatch( urlRegex );
 		} );
 
 		it( 'Select "Write" goal', async function () {

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -28,6 +28,7 @@ describe(
 		let page: Page;
 		let userDetails: NewUserResponse;
 		let userCreatedFlag = false;
+		let selectedFreeDomain: string;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
@@ -56,7 +57,7 @@ describe(
 			it( 'Select a free .wordpress.com domain', async function () {
 				const domainSearchComponent = new DomainSearchComponent( page );
 				await domainSearchComponent.search( testUser.siteName );
-				await domainSearchComponent.selectDomain( '.wordpress.com' );
+				selectedFreeDomain = await domainSearchComponent.selectDomain( '.wordpress.com' );
 			} );
 
 			it( 'Select WordPress.com Free plan', async function () {
@@ -75,6 +76,11 @@ describe(
 
 		describe( 'Validate WordPress.com Free functionality', function () {
 			let sidebarComponent: SidebarComponent;
+
+			it( 'User has the selected free domain', async function () {
+				const urlRegex = `/home/${ selectedFreeDomain }`;
+				expect( page.url() ).toMatch( urlRegex );
+			} );
 
 			it( 'User is on WordPress.com Free plan', async function () {
 				sidebarComponent = new SidebarComponent( page );


### PR DESCRIPTION
#### Proposed Changes

* Recent changes required for tailored signup flows [caused an issue](p58i-d6T-p2) where the value of the preselected free `.wordpress.com` domain was not respected. A site with different domain was created at the end of the signup.
* This PR modifies existing tests to verify the created site, so that this issue is prevented in the future.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Run the e2e tests. Follow the [e2e instructions if needed](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)
- Or run the changed tests one by one:
```
yarn jest specs/onboarding/ftme__write
yarn jest specs/plans/plans__signup-free
```

Related to #67549