### PR TITLE
HelpCenter: disable Happychatif HelpCenter is loaded

### DIFF
--- a/client/components/happychat/connection-connected.jsx
+++ b/client/components/happychat/connection-connected.jsx
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
+import { shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { connect } from 'react-redux';
 import { HappychatConnection } from 'calypso/components/happychat/connection';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { initConnection } from 'calypso/state/happychat/connection/actions';
 import isHappychatConnectionUninitialized from 'calypso/state/happychat/selectors/is-happychat-connection-uninitialized';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
@@ -9,7 +11,8 @@ export default connect(
 	( state, ownProps ) => ( {
 		getAuth: ownProps.getAuth || getHappychatAuth( state ),
 		isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
-		isHappychatEnabled: config.isEnabled( 'happychat' ),
+		isHappychatEnabled:
+			config.isEnabled( 'happychat' ) && ! shouldShowHelpCenterToUser( getCurrentUserId( state ) ),
 	} ),
 	{ initConnection }
 )( HappychatConnection );


### PR DESCRIPTION
## Proposed Changes

This adds logic to the Happychat connection to disable the `initConnection` if the user should be seeing HelpCenter

**Here is the BUG** we are addressing with this PR

https://user-images.githubusercontent.com/33258733/189176423-da457236-11c0-4ce2-9bf2-80444a9fb63e.mov

## Testing Instructions

1. Pull branch and run 'yarn start'
2. Login to https://hud-staging.happychat.io/
3. Place an item in your cart and go to checkout (or anywhere else HelpCenter and FAB loaded)
4. Check to first make sure FAB allows you to start a chat
5. [Edit this line](https://github.com/Automattic/wp-calypso/blob/36180329dcc1455aea926664f1c40bbc7f54fffc/packages/help-center/src/utils.ts#L8) to `return true`
6. Now refresh and start a chat from HelpCenter and make sure the Happychat button doesn't popup.