### PR TITLE
Added hasCredentials condition in addition to testCredentialsResult

### DIFF
--- a/client/components/advanced-credentials/index.tsx
+++ b/client/components/advanced-credentials/index.tsx
@@ -115,12 +115,12 @@ const AdvancedCredentials: FunctionComponent< Props > = ( { action, host, role }
 			return StatusState.Loading;
 		}
 
-		if ( testCredentialsResult ) {
+		if ( hasCredentials && testCredentialsResult ) {
 			return StatusState.Connected;
 		}
 
 		return StatusState.Disconnected;
-	}, [ testCredentialsResult, isRequestingCredentials ] );
+	}, [ hasCredentials, testCredentialsResult, isRequestingCredentials ] );
 
 	const currentStep = useMemo( (): Step => {
 		if ( 'unsubmitted' !== formSubmissionStatus ) {


### PR DESCRIPTION
#### Proposed Changes

* Fixes a bug introduced by the changes in #66468 that omitted the `hasCredentials` condition, resulting in sites with no credentials displaying as connected.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new Jurassic Ninja site (or use an existing self hosted site), connect Jetpack, and add a Jetpack Backup plan
* Add server credentials at cloud.jetpack.com > Settings, or follow the steps here: https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/
* Navigate to cloud.jetpack.com > Settings, or to WPCOM > Settings > Jetpack, and confirm that it shows connected (results should match test from RWDB)
* SSH into your site and change password, then navigate back to cloud.jetpack.com > Settings or to WPCOM > Settings > Jetpack, and Calypso should show Disconnected prompting user to re-enter credentials
* Delete credentials, either from RWDB or Calypso, and then reload the Jetpack settings in Calypso, which should continue to show Disconnected and prompt to enter credentials

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66468
