### PR TITLE
PR: Remove search bar from following (all) page layout

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,59 +1,18 @@
-import { CompactCard, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { trim } from 'lodash';
-import page from 'page';
-import SearchInput from 'calypso/components/search';
 import SectionHeader from 'calypso/components/section-header';
-import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
-import Suggestion from 'calypso/reader/search-stream/suggestion';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
-import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
-import { recordTrack } from 'calypso/reader/stats';
 import Stream from 'calypso/reader/stream';
 import FollowingIntro from './intro';
 import './style.scss';
 
-function handleSearch( query ) {
-	recordTrack( 'calypso_reader_search_from_following', {
-		query,
-	} );
-
-	if ( trim( query ) !== '' ) {
-		page( '/read/search?q=' + encodeURIComponent( query ) + '&focus=1' );
-	}
-}
-
-function FollowingStream( { suggestions, ...props } ) {
+function FollowingStream( { ...props } ) {
 	const translate = useTranslate();
-
-	const suggestionList =
-		suggestions &&
-		suggestions
-			.flatMap( ( query ) => [
-				<Suggestion
-					key={ query.railcar.railcar }
-					suggestion={ query.text }
-					source="following"
-					railcar={ query.railcar }
-				/>,
-				', ',
-			] )
-			.slice( 0, -1 );
-	const placeholderText = getSearchPlaceholderText();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
 			<FollowingIntro />
-			<CompactCard className="following__search">
-				<SearchInput
-					onSearch={ handleSearch }
-					delaySearch={ true }
-					delayTimeout={ 500 }
-					placeholder={ placeholderText }
-				/>
-			</CompactCard>
-			<BlankSuggestions suggestions={ suggestionList } />
 			<SectionHeader label={ translate( 'Followed Sites' ) }>
 				<Button primary compact className="following__manage" href="/following/manage">
 					{ translate( 'Manage' ) }


### PR DESCRIPTION
## Details

We're in the process of updating the look and feel of our Calypso Reader Cards. As a part of this, we'd like to remove the search bar and the search suggestions from the default following page:

### Before

<img width="1154" alt="CleanShot 2022-08-30 at 11 58 24@2x" src="https://user-images.githubusercontent.com/5634774/187484868-def71535-026d-4ff4-a646-96b421f0b3ee.png">

### After

<img width="511" alt="CleanShot 2022-08-30 at 12 00 13@2x" src="https://user-images.githubusercontent.com/5634774/187485113-fd6b0a06-a0c2-44f7-8ca8-b9482fd8b7cb.png">

### Related to
#66650, #67164
