### PR TITLE
Tailored Flows: empty the store after submitting info

### DIFF
--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -44,6 +44,7 @@ interface SetupOnboardingSiteOptions {
 export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSiteOptions ) {
 	const { getState, getPatternContent } = select( ONBOARD_STORE );
 	const state = getState();
+	const { resetOnboardStore } = dispatch( ONBOARD_STORE );
 	const { saveSiteSettings, setIntentOnSite, setStaticHomepageOnSite } = dispatch( SITE_STORE );
 	const selectedPatternContent = getPatternContent();
 
@@ -109,6 +110,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 				has_site_title: !! state.siteTitle,
 				has_tagline: !! state.siteDescription,
 			} );
+			resetOnboardStore();
 		} );
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Subscribers step and Launchpad come after the site info. I'm concerned deleting the store might have some consequences there. 

#### Testing Instructions

1. Go to /setup?flow=newsletter
2. Go through the flow.
3. All should work.
4. Repeat, you should **not** get pre-filled fields in the setup step.
5. Repeat for LiB.
