### PR TITLE
Checkout: Convert CountrySelectMenu to TypeScript

### DIFF
--- a/client/components/advanced-credentials/credentials-form/index.tsx
+++ b/client/components/advanced-credentials/credentials-form/index.tsx
@@ -42,7 +42,9 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	const [ interactions, setFormInteractions ] = useState( INITIAL_FORM_INTERACTION );
 	const hostInfo = getHostInfoFromId( host );
 
-	const handleFormChange: FormEventHandler< HTMLInputElement > = ( { currentTarget } ) => {
+	const handleFormChange: FormEventHandler< HTMLInputElement | HTMLSelectElement > = ( {
+		currentTarget,
+	} ) => {
 		switch ( currentTarget.name ) {
 			case 'protocol':
 				onFormStateChange( {

--- a/client/components/forms/form-country-select/index.tsx
+++ b/client/components/forms/form-country-select/index.tsx
@@ -1,22 +1,29 @@
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { useTranslate, localize } from 'i18n-calypso';
 import { isEmpty, omit } from 'lodash';
-import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormSelect from 'calypso/components/forms/form-select';
+import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { HTMLProps } from 'react';
 
 import './style.scss';
 
-export class FormCountrySelect extends Component {
-	static propTypes = {
-		countriesList: PropTypes.array.isRequired,
-		className: PropTypes.string,
-		disabled: PropTypes.bool,
-		onChange: PropTypes.func,
-		translate: PropTypes.func.isRequired,
-	};
+export interface FormCountrySelectProps {
+	countriesList: CountryListItem[];
+	translate: ReturnType< typeof useTranslate >;
+}
 
-	getOptions() {
+interface OptionObject {
+	key: string | number;
+	label: string;
+	code?: string;
+	disabled?: boolean;
+}
+
+export class FormCountrySelect extends Component<
+	FormCountrySelectProps & Omit< HTMLProps< HTMLSelectElement >, 'ref' >
+> {
+	getOptions(): OptionObject[] {
 		const { countriesList, translate } = this.props;
 
 		if ( isEmpty( countriesList ) ) {

--- a/client/components/forms/form-select/index.tsx
+++ b/client/components/forms/form-select/index.tsx
@@ -1,9 +1,18 @@
 import classNames from 'classnames';
 import { Component } from 'react';
+import type { LegacyRef, HTMLProps } from 'react';
 
 import './style.scss';
 
-class FormSelect extends Component {
+interface FormSelectProps {
+	inputRef?: LegacyRef< HTMLSelectElement >;
+	className?: string;
+	isError?: boolean;
+}
+
+class FormSelect extends Component<
+	FormSelectProps & Omit< HTMLProps< HTMLSelectElement >, 'ref' >
+> {
 	static defaultProps = {
 		isError: false,
 	};

--- a/client/components/phone-input/index.tsx
+++ b/client/components/phone-input/index.tsx
@@ -379,7 +379,7 @@ function getCountrySelectionHandler(
 	setFreezeSelection: ( shouldFreeze: boolean ) => void,
 	enableStickyCountry: boolean
 ) {
-	return function handleCountrySelection( event: ChangeEvent< HTMLInputElement > ) {
+	return function handleCountrySelection( event: ChangeEvent< HTMLSelectElement > ) {
 		const newCountryCode = event.target.value;
 		if ( newCountryCode === countryCode ) {
 			return;

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -84,7 +84,7 @@ function VatForm() {
 					name="country"
 					disabled={ isUpdating || isVatAlreadySet }
 					value={ currentVatDetails.country ?? vatDetails.country ?? '' }
-					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+					onChange={ ( event: React.ChangeEvent< HTMLSelectElement > ) =>
 						setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
 					}
 				/>
@@ -158,7 +158,7 @@ function CountryCodeInput( {
 	name: string;
 	disabled?: boolean;
 	value: string;
-	onChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
+	onChange: ( event: React.ChangeEvent< HTMLSelectElement > ) => void;
 } ) {
 	const countries = [
 		'AT',

--- a/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
@@ -1,5 +1,8 @@
+import { useTranslate } from 'i18n-calypso';
 import FormCountrySelect from 'calypso/components/forms/form-country-select';
 import FormFieldAnnotation from 'calypso/my-sites/checkout/composite-checkout/components/form-field-annotation';
+import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { HTMLProps } from 'react';
 
 export default function CountrySelectMenu( {
 	translate,
@@ -9,6 +12,14 @@ export default function CountrySelectMenu( {
 	errorMessage,
 	currentValue,
 	countriesList,
+}: {
+	translate: ReturnType< typeof useTranslate >;
+	onChange: HTMLProps< HTMLSelectElement >[ 'onChange' ];
+	isDisabled?: boolean;
+	isError?: boolean;
+	errorMessage?: string;
+	currentValue: HTMLProps< HTMLSelectElement >[ 'value' ];
+	countriesList: CountryListItem[];
 } ) {
 	const countrySelectorId = 'country-selector';
 	const countrySelectorLabelId = 'country-selector-label';
@@ -27,8 +38,8 @@ export default function CountrySelectMenu( {
 			<FormCountrySelect
 				id={ countrySelectorId }
 				countriesList={ [
-					{ code: '', name: translate( 'Select Country' ) },
-					{ code: null, name: '' },
+					{ code: '', name: translate( 'Select Country' ), has_postal_codes: false },
+					{ code: '', name: '', has_postal_codes: false },
 					...countriesList,
 				] }
 				onChange={ onChange }

--- a/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormCountrySelect from 'calypso/components/forms/form-country-select';
 import FormFieldAnnotation from 'calypso/my-sites/checkout/composite-checkout/components/form-field-annotation';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
-import type { HTMLProps } from 'react';
+import type { HTMLProps, ReactChild } from 'react';
 
 export default function CountrySelectMenu( {
 	translate,
@@ -17,7 +17,7 @@ export default function CountrySelectMenu( {
 	onChange: HTMLProps< HTMLSelectElement >[ 'onChange' ];
 	isDisabled?: boolean;
 	isError?: boolean;
-	errorMessage?: string;
+	errorMessage?: ReactChild;
 	currentValue: HTMLProps< HTMLSelectElement >[ 'value' ];
 	countriesList: CountryListItem[];
 } ) {

--- a/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent, ReactChild } from 'react';
 
 type FormFieldWrapperProps = {
 	isError: boolean;
@@ -49,7 +49,7 @@ type FormFieldAnnotationProps = {
 	// Semantic props
 	labelText: string;
 	normalDescription?: string;
-	errorDescription?: string;
+	errorDescription?: ReactChild;
 
 	// Functional props
 	isError?: boolean; // default false
@@ -115,7 +115,7 @@ type RenderedDescriptionProps = {
 	descriptionText?: string;
 	descriptionId?: string;
 	isError?: boolean;
-	errorMessage?: string;
+	errorMessage?: ReactChild;
 };
 
 type DescriptionProps = {

--- a/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/form-field-annotation.tsx
@@ -49,7 +49,7 @@ type FormFieldAnnotationProps = {
 	// Semantic props
 	labelText: string;
 	normalDescription?: string;
-	errorDescription: string;
+	errorDescription?: string;
 
 	// Functional props
 	isError?: boolean; // default false

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -58,7 +58,7 @@ export default function TaxFields( {
 			<LeftColumn>
 				<CountrySelectMenu
 					translate={ translate }
-					onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+					onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
 						onChange( {
 							countryCode: { value: event.target.value, errors: [], isTouched: true },
 							postalCode: updatePostalCodeForCountry( postalCode, countryCode, countriesList ),


### PR DESCRIPTION
#### Proposed Changes

This PR converts the `CountrySelectMenu` component used by checkout to TypeScript. As part of this conversion, this also converts the components `FormSelect` and `FormCountrySelect` which are used by `CountrySelectMenu`.

#### Testing Instructions

A visual inspection of the changes should be sufficient. The changes are nearly all types and so will be covered by the TS compiler.