### PR TITLE
Add changes from stepper signup preview toolbar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.tsx
@@ -23,6 +23,10 @@ type PreviewToolbarProps = {
 	// Called when a device button is clicked
 	setDeviceViewport: ( device: Device ) => void;
 	translate: ( word: string ) => string;
+	// Show iframe site address bar
+	showSiteAddressBar?: boolean;
+	// Filter devices to show in device switcher
+	devicesToShow?: Device[];
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -35,6 +39,8 @@ const DesignPickerPreviewToolbar = ( {
 	isSticky,
 	setDeviceViewport,
 	translate,
+	showSiteAddressBar = true,
+	devicesToShow,
 }: PreviewToolbarProps ) => {
 	const devices = React.useRef( {
 		computer: { title: translate( 'Desktop' ), icon: computer, iconSize: 36 },
@@ -78,11 +84,25 @@ const DesignPickerPreviewToolbar = ( {
 		};
 	}, [ isSticky, setStickyStyle ] );
 
+	function filterDevices( selectedDevices: Device[] | undefined ) {
+		// If invalid inputs, display all possible devices
+		// If at least one valid input, Will filter out any devices that do not exist in the 'possibleDevices' array above
+		let filteredPossibleDevices: Device[] = [];
+		if ( Array.isArray( selectedDevices ) && selectedDevices.length > 0 ) {
+			filteredPossibleDevices = selectedDevices.filter( ( device ) => {
+				return possibleDevices.includes( device );
+			} );
+		}
+		return filteredPossibleDevices.length === 0 ? possibleDevices : filteredPossibleDevices;
+	}
+
+	const filteredPossibleDevices = filterDevices( devicesToShow );
+
 	return (
 		<div className="preview-toolbar__toolbar">
 			{ showDeviceSwitcher && (
 				<div className="preview-toolbar__devices">
-					{ possibleDevices.map( ( device ) => (
+					{ filteredPossibleDevices.map( ( device ) => (
 						<Button
 							key={ device }
 							borderless
@@ -100,22 +120,24 @@ const DesignPickerPreviewToolbar = ( {
 					) ) }
 				</div>
 			) }
-			<div className="preview-toolbar__browser-header" ref={ headerRef }>
-				<div
-					className="preview-toolbar__browser-header-content"
-					style={ stickyStyle }
-					ref={ headerContentRef }
-				>
-					<svg width="40" height="8">
-						<g>
-							<rect width="8" height="8" rx="4" />
-							<rect x="16" width="8" height="8" rx="4" />
-							<rect x="32" width="8" height="8" rx="4" />
-						</g>
-					</svg>
-					{ externalUrl && <span className="preview-toolbar__browser-url">{ externalUrl }</span> }
+			{ showSiteAddressBar && (
+				<div className="preview-toolbar__browser-header" ref={ headerRef }>
+					<div
+						className="preview-toolbar__browser-header-content"
+						style={ stickyStyle }
+						ref={ headerContentRef }
+					>
+						<svg width="40" height="8">
+							<g>
+								<rect width="8" height="8" rx="4" />
+								<rect x="16" width="8" height="8" rx="4" />
+								<rect x="32" width="8" height="8" rx="4" />
+							</g>
+						</svg>
+						{ externalUrl && <span className="preview-toolbar__browser-url">{ externalUrl }</span> }
+					</div>
 				</div>
-			</div>
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,5 +1,6 @@
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
@@ -7,6 +8,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const defaultDevice = 'phone';
+	const devicesToShow: Device[] = [ 'computer', 'phone' ];
 
 	function formatPreviewUrl() {
 		if ( ! previewUrl ) {
@@ -40,7 +42,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 				} ) }
 				translate={ translate }
 				defaultViewportDevice={ defaultDevice }
-				devicesToShow={ [ 'computer', 'phone' ] }
+				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
 			/>
 		</div>


### PR DESCRIPTION
#### Proposed Changes

* Add changing to signup flow preview toolbar from discussion: https://github.com/Automattic/wp-calypso/pull/66670#issuecomment-1219107656

These changes are for filtering devices to show in the `<WebPreview />` preview toolbar and for displaying/hiding the site address bar. The import for the preview toolbar has been changed to be more consistent with the stepper framework/component, so I decided to add these changes to the preview toolbar as well.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and run `yarn start`
* Navigate to `http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=SITE_SLUG_HERE`
* Ensure the site preview is not displaying a site address bar and only displaying two devices above the site preview (desktop and phone icon)
* Repeat the previous step for the newsletter flow `Navigate to `http://calypso.localhost:3000/setup/newsletter?flow=link-in-bio&siteSlug=SITE_SLUG_HERE`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
