### PR TITLE
Troubleshooting: Update the troubleshooting guide for fatal errors from Chromium missing

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,8 @@ path-to-project/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserFetcher.js:
             throw new Error();
 ```
 
+#### Solution
+
 You may need to manually install `Chromium`. There are instructons on how to do that via `Homebrew` here: <https://linguinecode.com/post/how-to-fix-m1-mac-puppeteer-chromium-arm64-bug>
 
 ### EMFILE - too many open files

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,7 +3,23 @@
 ## Building
 
 This section lists known problems you can encounter while building the project.
-If you have a problem when running `yarn start` - this is the proper section to look for a solution.
+If you have a problem when running `yarn` or `yarn start` - this is the proper section to look for a solution.
+
+### Puppeteer throws a fatal error
+
+If running `yarn` fails and the log file for `Puppeteer` show an error like this: 
+
+```
+The chromium binary is not available for arm64:
+If you are on Ubuntu, you can install with:
+
+ apt-get install chromium-browser
+
+path-to-project/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserFetcher.js:112
+            throw new Error();
+```
+
+You may need to manually install `Chromium`. There are instructons on how to do that via `Homebrew` here: <https://linguinecode.com/post/how-to-fix-m1-mac-puppeteer-chromium-arm64-bug>
 
 ### EMFILE - too many open files
 


### PR DESCRIPTION
…Calypso build

#### Proposed Changes

* New M1 Apple machines don't include the Chromium binary by default. This causes a fatal error when running `yarn` to start the local build of Calypso

This change adds a small section to address the error that the user sees and a link to documentation that helped me resolve the issue on my own machine. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull this branch
* Navigate to `docs/troubleshooting.md`
* Review the section `#### Puppeteer throws a fatal error`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [NA] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # NA
