### PR TITLE
Add stylelint format to ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,5 @@ b855b7a8a7e9f6a24e4fc87e8fe251cfd10603fd
 5948dacb721fd61e06e193757b066eab21a43cbd
 # Prettier format in #62969
 9fb7ac149e55361c0c3a9639ad0caa5e15fc88b0
+# Stylelint format in #67568
+b7a4a072ae2a13785fb6ccbf9c34ed8e65739705


### PR DESCRIPTION
#### Proposed Changes
I formatted the repo for stylelint in #67568. This adds the commit to the ignore-revs file.

#### Testing Instructions
None
