### PR TITLE
Agency Dashboard: remove the chevron icon from agency dashboard actions

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -74,7 +74,6 @@ export default function SiteActions( {
 							onClick={ () => handleClickMenuItem( 'issue_license' ) }
 							href={ `/partner-portal/issue-license/?site_id=${ siteId }&source=dashboard` }
 							className="site-actions__menu-item"
-							icon="chevron-right"
 						>
 							{ translate( 'Issue new license' ) }
 						</PopoverMenuItem>
@@ -82,7 +81,6 @@ export default function SiteActions( {
 							onClick={ () => handleClickMenuItem( 'view_activity' ) }
 							href={ `/activity-log/${ siteUrl }` }
 							className="site-actions__menu-item"
-							icon="chevron-right"
 						>
 							{ translate( 'View activity' ) }
 						</PopoverMenuItem>


### PR DESCRIPTION
#### Proposed Changes

This PR removes the chevron-right icons from actions such as `Issue new license` & `View activity`.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/remove-icons-from-agency-dashboard-actions` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on any site actions(`...` icon) and verify that no icons are visible for actions such as `Issue new license` & `View activity`.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="498" alt="Screenshot 2022-09-09 at 9 30 25 AM" src="https://user-images.githubusercontent.com/10586875/189271086-6a791433-867f-429b-9119-cdbb0c54ccaa.png">
</td>
<td>
<img width="514" alt="Screenshot 2022-09-09 at 9 29 49 AM" src="https://user-images.githubusercontent.com/10586875/189271647-483b77d9-ea6d-469f-9923-2097d1c31688.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202619025189113-as-1202950216197309