### PR TITLE
Pricing page rework: Prevent interaction with disabled buttons

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -12,6 +12,10 @@
 	p {
 		margin-bottom: 0.5rem;
 	}
+
+	:is(.button[disabled], .button:disabled, .button.disabled) {
+		background-color: var(--studio-gray-5);
+	}
 }
 
 .product-lightbox__modal-overlay {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -26,7 +26,12 @@
 
 	.info-popover.owner-info__pop-over {
 		line-height: inherit;
+		pointer-events: all;
 	}
+}
+
+:is(.product-lightbox__modal, .jetpack-product-store) :is(.button[disabled], .button:disabled, .button.disabled) {
+	pointer-events: none;
 }
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .jetpack-product-store .header .header__main-title .formatted-header__title {

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -13,9 +13,7 @@ $wpcom-menu-collapse: 783px;
 
 :is(.is-group-sites.is-section-plans, .is-section-jetpack-connect) .jetpack-product-store {
 
-	.button[disabled],
-	.button:disabled,
-	.button.disabled {
+	:is(.button[disabled], .button:disabled, .button.disabled) {
 		background-color: var(--studio-gray-5);
 	}
 


### PR DESCRIPTION
Currently, our disabled buttons have `href` set to `#` which allows the users to interact with the buttons even though they are disabled.

#### Proposed Changes

* Prevent interaction with disabled buttons by using `pointer-events: none;` for disabled buttons
* Retain interaction with Owner info buttons inside disabled buttons
* Fix disabled button background inside lightbox on WPCOM

#### Testing Instructions

- Create a JN multi-site
- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing/:site?flags=jetpack/pricing-page-rework-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout fix/jp-pricing-rework/disabled-btns-prevent-interaction`
        * Run `yarn start-jetpack-cloud`
        * Goto `http://jetpack.cloud.localhost:3000/pricing/:site?flags=jetpack/pricing-page-rework-v1`
- Confirm that the disabled buttons are no longer clickable
- Goto Calypso Blue for the same site and confirm the same behavior with the disabled buttons.
- Create a normal JN site and connect Jetpack with a product for example Backup (yearly)
- Add a secondary admin to the site and log in to the new admin account.
- Confirm that the info icon inside CTA button shows tooltip on hover.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Before

https://user-images.githubusercontent.com/18226415/189279814-6cd9d7b6-d71f-41cb-91e9-74d444409f33.mov

After

https://user-images.githubusercontent.com/18226415/189279878-4b077852-43fb-4b32-8901-e2802305488d.mov


| BEFORE | AFTER |
|-|-|
| <img width="1357" alt="Screenshot 2022-09-09 at 11 07 02 AM" src="https://user-images.githubusercontent.com/18226415/189279982-7367dd94-5ef3-49f0-9c3f-37d52863cd68.png"> | <img width="1391" alt="Screenshot 2022-09-09 at 11 07 34 AM" src="https://user-images.githubusercontent.com/18226415/189279988-de050d8d-a834-490e-90ab-fe945675304e.png"> |

<img width="1270" alt="Screenshot 2022-09-09 at 11 24 04 AM" src="https://user-images.githubusercontent.com/18226415/189280827-7cea53f8-d474-4115-8367-d58438aa3987.png">

