### PR TITLE
Pricing page rework: Improve naming of functions inside useStoreItemInfo

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -57,12 +57,12 @@ const ProductLightbox: React.FC< Props > = ( {
 	const { getCheckoutURL } = useStoreItemInfoContext();
 
 	const isMobile = useMobileBreakpoint();
-	const { isMultisiteCompatible, isMultisite } = useStoreItemInfo( {
+	const { getIsMultisiteCompatible, isMultisite } = useStoreItemInfo( {
 		siteId,
 		duration,
 	} );
 
-	const isMultiSiteIncompatible = isMultisite && ! isMultisiteCompatible( product );
+	const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( product );
 
 	return (
 		<Modal

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -24,9 +24,9 @@ import productButtonLabel from '../../product-card/product-button-label';
 import { SelectorProduct } from '../../types';
 import { UseStoreItemInfoProps } from '../types';
 
-const isDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
+const getIsDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
-const isMultisiteCompatible = ( item: SelectorProduct ) => {
+const getIsMultisiteCompatible = ( item: SelectorProduct ) => {
 	if ( isJetpackPlanSlug( item.productSlug ) ) {
 		// plans containing Jetpack Backup and/or Jetpack Scan are incompatible with multisite installs
 		return ! [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ].filter( ( productSlug ) =>
@@ -55,7 +55,7 @@ export const useStoreItemInfo = ( {
 	const translate = useTranslate();
 
 	// Determine whether product is owned.
-	const isOwned = useCallback(
+	const getIsOwned = useCallback(
 		( item: SelectorProduct ) => {
 			if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
 				return true;
@@ -70,31 +70,31 @@ export const useStoreItemInfo = ( {
 		[ sitePlan, siteProducts ]
 	);
 
-	const isUpgradeableToYearly = useCallback(
+	const getIsUpgradeableToYearly = useCallback(
 		( item: SelectorProduct ) =>
-			isOwned( item ) && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY,
-		[ isOwned, selectedTerm ]
+			getIsOwned( item ) && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY,
+		[ getIsOwned, selectedTerm ]
 	);
 
-	const isPlanFeature = useCallback(
+	const getIsPlanFeature = useCallback(
 		( item: SelectorProduct ) =>
 			!! ( sitePlan && planHasFeature( sitePlan.product_slug, item.productSlug ) ),
 		[ sitePlan ]
 	);
 
-	const isIncludedInPlan = useCallback(
+	const getIsIncludedInPlan = useCallback(
 		( item: SelectorProduct ) => {
-			return ! isOwned( item ) && isPlanFeature( item );
+			return ! getIsOwned( item ) && getIsPlanFeature( item );
 		},
-		[ isOwned, isPlanFeature ]
+		[ getIsOwned, getIsPlanFeature ]
 	);
 
-	const isSuperseded = useCallback(
+	const getIsSuperseded = useCallback(
 		( item: SelectorProduct ) => {
 			return !! (
-				! isDeprecated( item ) &&
-				! isOwned( item ) &&
-				! isIncludedInPlan( item ) &&
+				! getIsDeprecated( item ) &&
+				! getIsOwned( item ) &&
+				! getIsIncludedInPlan( item ) &&
 				sitePlan &&
 				item &&
 				isSupersedingJetpackItem(
@@ -103,46 +103,46 @@ export const useStoreItemInfo = ( {
 				)
 			);
 		},
-		[ isIncludedInPlan, isOwned, sitePlan ]
+		[ getIsIncludedInPlan, getIsOwned, sitePlan ]
 	);
 
-	const isIncludedInPlanOrSuperseded = useCallback(
-		( item: SelectorProduct ) => isIncludedInPlan( item ) || isSuperseded( item ),
-		[ isIncludedInPlan, isSuperseded ]
+	const getIsIncludedInPlanOrSuperseded = useCallback(
+		( item: SelectorProduct ) => getIsIncludedInPlan( item ) || getIsSuperseded( item ),
+		[ getIsIncludedInPlan, getIsSuperseded ]
 	);
 
 	const getPurchase = useCallback(
 		( item: SelectorProduct ) => {
-			const isItemPlanFeature = isPlanFeature( item );
+			const isPlanFeature = getIsPlanFeature( item );
 
-			const isItemSuperseded = isSuperseded( item );
+			const isSuperseded = getIsSuperseded( item );
 
 			// If item is a plan feature, use the plan purchase object.
 			const purchase =
-				isItemPlanFeature || isItemSuperseded
+				isPlanFeature || isSuperseded
 					? getPurchaseByProductSlug( purchases, sitePlan?.product_slug || '' )
 					: getPurchaseByProductSlug( purchases, item.productSlug );
 
 			return purchase;
 		},
-		[ isPlanFeature, isSuperseded, purchases, sitePlan?.product_slug ]
+		[ getIsPlanFeature, getIsSuperseded, purchases, sitePlan?.product_slug ]
 	);
 
 	const getCheckoutURL = useCallback(
 		( item: SelectorProduct ) => {
-			return createCheckoutURL?.( item, isUpgradeableToYearly( item ), getPurchase( item ) );
+			return createCheckoutURL?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );
 		},
-		[ createCheckoutURL, getPurchase, isUpgradeableToYearly ]
+		[ createCheckoutURL, getPurchase, getIsUpgradeableToYearly ]
 	);
 
 	const getOnClickPurchase = useCallback(
 		( item: SelectorProduct ) => () => {
-			return onClickPurchase?.( item, isUpgradeableToYearly( item ), getPurchase( item ) );
+			return onClickPurchase?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );
 		},
-		[ getPurchase, isUpgradeableToYearly, onClickPurchase ]
+		[ getPurchase, getIsUpgradeableToYearly, onClickPurchase ]
 	);
 
-	const isUserPurchaseOwner = useCallback(
+	const getIsUserPurchaseOwner = useCallback(
 		( item: SelectorProduct ) => {
 			const purchase = getPurchase( item );
 			return isCurrentUserPurchaseOwner( purchase );
@@ -154,17 +154,17 @@ export const useStoreItemInfo = ( {
 		( item: SelectorProduct ) => {
 			const ctaLabel = productButtonLabel( {
 				product: item,
-				isOwned: isOwned( item ),
-				isUpgradeableToYearly: isUpgradeableToYearly( item ),
-				isDeprecated: isDeprecated( item ),
-				isSuperseded: isSuperseded( item ),
+				isOwned: getIsOwned( item ),
+				isUpgradeableToYearly: getIsUpgradeableToYearly( item ),
+				isDeprecated: getIsDeprecated( item ),
+				isSuperseded: getIsSuperseded( item ),
 				currentPlan: sitePlan,
 				fallbackLabel: translate( 'Get' ),
 			} );
 
 			const purchase = getPurchase( item );
 
-			if ( ! purchase ) {
+			if ( ! purchase || isCurrentUserPurchaseOwner( purchase ) ) {
 				return ctaLabel;
 			}
 
@@ -176,41 +176,47 @@ export const useStoreItemInfo = ( {
 				</>
 			);
 		},
-		[ getPurchase, isOwned, isSuperseded, isUpgradeableToYearly, sitePlan, translate ]
+		[
+			getIsOwned,
+			getIsUpgradeableToYearly,
+			getIsSuperseded,
+			sitePlan,
+			translate,
+			getPurchase,
+			isCurrentUserPurchaseOwner,
+		]
 	);
 
 	return useMemo(
 		() => ( {
 			getCheckoutURL,
 			getCtaLabel,
+			getIsDeprecated,
+			getIsIncludedInPlan,
+			getIsIncludedInPlanOrSuperseded,
+			getIsMultisiteCompatible,
+			getIsOwned,
+			getIsPlanFeature,
+			getIsSuperseded,
+			getIsUpgradeableToYearly,
+			getIsUserPurchaseOwner,
 			getOnClickPurchase,
 			getPurchase,
-			isDeprecated,
-			isIncludedInPlan,
-			isIncludedInPlanOrSuperseded,
-			isOwned,
-			isPlanFeature,
-			isSuperseded,
-			isUpgradeableToYearly,
-			isUserPurchaseOwner,
-			isMultisiteCompatible,
 			isMultisite,
-			sitePlan,
 		} ),
 		[
 			getCheckoutURL,
 			getCtaLabel,
+			getIsIncludedInPlan,
+			getIsIncludedInPlanOrSuperseded,
+			getIsOwned,
+			getIsPlanFeature,
+			getIsSuperseded,
+			getIsUpgradeableToYearly,
+			getIsUserPurchaseOwner,
 			getOnClickPurchase,
 			getPurchase,
-			isIncludedInPlan,
-			isIncludedInPlanOrSuperseded,
-			isOwned,
-			isPlanFeature,
-			isSuperseded,
-			isUpgradeableToYearly,
-			isUserPurchaseOwner,
 			isMultisite,
-			sitePlan,
 		]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -18,16 +18,16 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 	const {
 		getCheckoutURL,
 		getCtaLabel,
+		getIsDeprecated,
+		getIsIncludedInPlan,
+		getIsIncludedInPlanOrSuperseded,
+		getIsMultisiteCompatible,
+		getIsOwned,
+		getIsPlanFeature,
+		getIsSuperseded,
+		getIsUserPurchaseOwner,
 		getOnClickPurchase,
-		isIncludedInPlan,
-		isIncludedInPlanOrSuperseded,
-		isMultisiteCompatible,
 		isMultisite,
-		isOwned,
-		isPlanFeature,
-		isSuperseded,
-		isDeprecated,
-		isUserPurchaseOwner,
 	} = useStoreItemInfoContext();
 
 	const wrapperClassName = classNames( 'jetpack-product-store__all-items', className );
@@ -38,27 +38,26 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 
 			<div className="jetpack-product-store__all-items--grid">
 				{ items.map( ( item ) => {
-					const isItemOwned = isOwned( item );
-					const isItemSuperseded = isSuperseded( item );
-					const isItemDeprecated = isDeprecated( item );
-					const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
-					const isItemIncludedInPlan = isIncludedInPlan( item );
-					const isMultiSiteIncompatible = isMultisite && ! isMultisiteCompatible( item );
+					const isOwned = getIsOwned( item );
+					const isSuperseded = getIsSuperseded( item );
+					const isDeprecated = getIsDeprecated( item );
+					const isIncludedInPlanOrSuperseded = getIsIncludedInPlanOrSuperseded( item );
+					const isIncludedInPlan = getIsIncludedInPlan( item );
+					const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( item );
 
 					const isCtaDisabled =
 						isMultiSiteIncompatible ||
-						( ( isItemOwned || isItemIncludedInPlan ) && ! isUserPurchaseOwner( item ) );
+						( ( isOwned || isIncludedInPlan ) && ! getIsUserPurchaseOwner( item ) );
 
 					const ctaLabel = getCtaLabel( item );
 
-					const hideMoreInfoLink =
-						isItemDeprecated || isItemOwned || isItemIncludedInPlanOrSuperseded;
+					const hideMoreInfoLink = isDeprecated || isOwned || isIncludedInPlanOrSuperseded;
 
 					const price = (
 						<ItemPrice
 							isMultiSiteIncompatible={ isMultiSiteIncompatible }
-							isIncludedInPlan={ isItemIncludedInPlan }
-							isOwned={ isItemOwned }
+							isIncludedInPlan={ isIncludedInPlan }
+							isOwned={ isOwned }
 							item={ item }
 							siteId={ siteId }
 						/>
@@ -73,7 +72,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						</>
 					);
 
-					const ctaAsPrimary = ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
+					const ctaAsPrimary = ! ( isOwned || getIsPlanFeature( item ) || isSuperseded );
 
 					return (
 						<SimpleItemCard

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -21,16 +21,16 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 	const {
 		getCheckoutURL,
 		getCtaLabel,
+		getIsDeprecated,
+		getIsIncludedInPlan,
+		getIsIncludedInPlanOrSuperseded,
+		getIsMultisiteCompatible,
+		getIsOwned,
+		getIsPlanFeature,
+		getIsSuperseded,
+		getIsUserPurchaseOwner,
 		getOnClickPurchase,
-		isIncludedInPlan,
-		isIncludedInPlanOrSuperseded,
-		isMultisiteCompatible,
 		isMultisite,
-		isOwned,
-		isPlanFeature,
-		isSuperseded,
-		isDeprecated,
-		isUserPurchaseOwner,
 	} = useStoreItemInfoContext();
 
 	return (
@@ -38,27 +38,26 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 			<h3 className="jetpack-product-store__most-popular--heading">{ heading }</h3>
 			<div className="jetpack-product-store__most-popular--items">
 				{ items.map( ( item ) => {
-					const isItemOwned = isOwned( item );
-					const isItemSuperseded = isSuperseded( item );
-					const isItemDeprecated = isDeprecated( item );
-					const isItemIncludedInPlanOrSuperseded = isIncludedInPlanOrSuperseded( item );
-					const isItemIncludedInPlan = isIncludedInPlan( item );
-					const isMultiSiteIncompatible = isMultisite && ! isMultisiteCompatible( item );
+					const isOwned = getIsOwned( item );
+					const isSuperseded = getIsSuperseded( item );
+					const isDeprecated = getIsDeprecated( item );
+					const isIncludedInPlanOrSuperseded = getIsIncludedInPlanOrSuperseded( item );
+					const isIncludedInPlan = getIsIncludedInPlan( item );
+					const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( item );
 
 					const isCtaDisabled =
 						isMultiSiteIncompatible ||
-						( ( isItemOwned || isItemIncludedInPlan ) && ! isUserPurchaseOwner( item ) );
+						( ( isOwned || isIncludedInPlan ) && ! getIsUserPurchaseOwner( item ) );
 
 					const ctaLabel = getCtaLabel( item );
 
-					const hideMoreInfoLink =
-						isItemDeprecated || isItemOwned || isItemIncludedInPlanOrSuperseded;
+					const hideMoreInfoLink = isDeprecated || isOwned || isIncludedInPlanOrSuperseded;
 
 					const price = (
 						<ItemPrice
 							isMultiSiteIncompatible={ isMultiSiteIncompatible }
-							isIncludedInPlan={ isItemIncludedInPlan }
-							isOwned={ isItemOwned }
+							isIncludedInPlan={ isIncludedInPlan }
+							isOwned={ isOwned }
 							item={ item }
 							siteId={ siteId }
 						/>
@@ -75,7 +74,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 						</p>
 					);
 
-					const ctaAsPrimary = ! ( isItemOwned || isPlanFeature( item ) || isItemSuperseded );
+					const ctaAsPrimary = ! ( isOwned || getIsPlanFeature( item ) || isSuperseded );
 
 					return (
 						<div key={ item.productSlug } className="jetpack-product-store__most-popular--item">


### PR DESCRIPTION
Names of the functions inside `useStoreItemInfo` may be confusing for other developers. For example, `isOwned`, `isSuperseded` etc. sound more like boolean flags instead of factory functions which should be called with the item/product as the only argument.

#### Proposed Changes

* Improve naming of functions inside `useStoreItemInfo`

#### Testing Instructions

- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing?flags=jetpack/pricing-page-rework-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout update/jp-pricing-rework/improve-use-store-item-info`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1)
- Confirm that everything is the same as before

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related: p1662703287766229-slack-C03RCHNVC0H