### PR TITLE
Tailored flows: Fix mobile scroll for LiB

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -11,6 +11,7 @@ $font-family: 'SF Pro Text', $sans;
 		display: flex;
 		justify-content: center;
 		margin-bottom: 30px;
+		min-height: unset;
 	}
 
 	.link-in-bio-setup .step-container__header {


### PR DESCRIPTION
## Proposed Changes

On small devices, on the setup step for LiB there is an unwanted vertical scroll, this PR removes it.

## Testing Instructions

-  Pull this branch and run yarn start
-  Open the browser `devtools` and simulate a small device ( IPhone SE for instance )
-  Navigate to `/setup/intro?flow=link-in-bio`
-  Go to the setup step and check if there is an vertical scroll, **it should not**


Fixes #67592
Related to #67592