### PR TITLE
Videopress onboarding v2: domain selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,23 +1,26 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import type { Step } from '../../types';
 
+import './style.scss';
+
 const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } ) {
 	const { goNext, goBack, submit } = navigation;
 	const isVideoPressFlow = 'videopress' === flow;
+
+	const onSkip = () => {
+		submit?.( { domainName: '' } );
+	};
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
 	const getVideoPressFlowStepContent = () => {
 		const onAddDomain = ( { domain_name }: any ) => {
 			submit?.( { domainName: domain_name } );
-		};
-
-		const onSkip = () => {
-			submit?.( { domainName: '' } );
 		};
 
 		const domainSuggestion = data?.domainName ?? data?.siteTitle ?? '';
@@ -39,11 +42,37 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 		);
 	};
 
+	const getFormattedHeader = () => {
+		if ( ! isVideoPressFlow ) {
+			return undefined;
+		}
+
+		return (
+			<FormattedHeader
+				id={ 'choose-a-domain-header' }
+				headerText="Choose a domain"
+				subHeaderText={
+					<>
+						Make your video site shine with a custom domain. Not sure yet ?{ ' ' }
+						<button
+							className="button navigation-link step-container__navigation-link has-underline is-borderless"
+							onClick={ onSkip }
+						>
+							Decide later.
+						</button>
+					</>
+				}
+				align={ 'center' }
+			/>
+		);
+	};
+
 	const stepContent = isVideoPressFlow ? getVideoPressFlowStepContent() : getDefaultStepContent();
 
 	return (
 		<StepContainer
 			stepName={ 'chooseADomain' }
+			shouldHideNavButtons={ isVideoPressFlow }
 			goBack={ goBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
@@ -51,6 +80,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 			isLargeSkipLayout={ false }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
+			formattedHeader={ getFormattedHeader() }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -37,6 +37,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 					showAlreadyOwnADomain={ false }
 					onAddDomain={ onAddDomain }
 					onSkip={ onSkip }
+					promoTlds={ [ 'video', 'studio', 'productions', 'com' ] }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,10 +1,45 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { StepContainer } from 'calypso/../packages/onboarding/src';
+import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import type { Step } from '../../types';
 
-const ChooseADomain: Step = function ChooseADomain( { navigation } ) {
-	const { goNext, goBack } = navigation;
+const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } ) {
+	const { goNext, goBack, submit } = navigation;
+	const isVideoPressFlow = 'videopress' === flow;
+
+	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
+
+	const getVideoPressFlowStepContent = () => {
+		const onAddDomain = ( { domain_name }: any ) => {
+			submit?.( { domainName: domain_name } );
+		};
+
+		const onSkip = () => {
+			submit?.( { domainName: '' } );
+		};
+
+		const domainSuggestion = data?.domainName ?? data?.siteTitle ?? '';
+
+		return (
+			<CalypsoShoppingCartProvider>
+				<RegisterDomainStep
+					basePath={ '' }
+					suggestion={ domainSuggestion }
+					domainsWithPlansOnly={ false }
+					isSignupStep={ true }
+					includeWordPressDotCom={ true }
+					includeDotBlogSubdomain={ true }
+					showAlreadyOwnADomain={ false }
+					onAddDomain={ onAddDomain }
+					onSkip={ onSkip }
+				/>
+			</CalypsoShoppingCartProvider>
+		);
+	};
+
+	const stepContent = isVideoPressFlow ? getVideoPressFlowStepContent() : getDefaultStepContent();
 
 	return (
 		<StepContainer
@@ -14,7 +49,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation } ) {
 			isHorizontalLayout={ false }
 			isWideLayout={ true }
 			isLargeSkipLayout={ false }
-			stepContent={ <h1>Choose a domain step</h1> }
+			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -1,0 +1,10 @@
+.videopress.choose-adomain {
+	.formatted-header__subtitle {
+		text-align: center !important;
+
+		button {
+			font-size: 1rem;
+			line-height: 1.55;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -19,10 +19,10 @@ import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import './style.scss';
 
-const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
+const SiteOptions: Step = function SiteOptions( { navigation, flow, data } ) {
 	const { goBack, goNext, submit } = navigation;
-	const [ siteTitle, setSiteTitle ] = React.useState( '' );
-	const [ tagline, setTagline ] = React.useState( '' );
+	const [ siteTitle, setSiteTitle ] = React.useState( ( data?.siteTitle ?? '' ) as string );
+	const [ tagline, setTagline ] = React.useState( ( data?.tagline ?? '' ) as string );
 	const [ formTouched, setFormTouched ] = React.useState( false );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -36,6 +36,7 @@ export const videopress: Flow = {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const [ _siteTitle, setSiteTitle ] = useState( '' );
 		const [ _tagline, setTagline ] = useState( '' );
+		const [ _domainName, setDomainName ] = useState( '' );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -51,11 +52,14 @@ export const videopress: Flow = {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
 					setTagline( tagline as string );
-					return navigate( 'chooseADomain' );
+					return navigate( 'chooseADomain', { siteTitle: siteTitle } );
 				}
 
-				case 'chooseADomain':
+				case 'chooseADomain': {
+					const { domainName } = providedDependencies;
+					setDomainName( domainName as string );
 					return navigate( 'completingPurchase' );
+				}
 
 				case 'completingPurchase':
 					return navigate( 'processing' );
@@ -72,6 +76,10 @@ export const videopress: Flow = {
 		}
 
 		const goBack = () => {
+			switch ( _currentStep ) {
+				case 'chooseADomain':
+					return navigate( 'options', { siteTitle: _siteTitle, tagline: _tagline } );
+			}
 			return;
 		};
 
@@ -86,7 +94,18 @@ export const videopress: Flow = {
 		};
 
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
-			navigate( step );
+			switch ( step ) {
+				case 'options':
+					return navigate( step, { siteTitle: _siteTitle, tagline: _tagline } );
+				case 'chooseADomain':
+					return navigate( step, {
+						siteTitle: _siteTitle,
+						tagline: _tagline,
+						domainName: _domainName,
+					} );
+				default:
+					return navigate( step );
+			}
 		};
 
 		return { goNext, goBack, goToStep, submit };


### PR DESCRIPTION
#### Proposed Changes

This PR adds the domain selection step in the videopress flow.

#### Testing Instructions
* Apply this PR
* Go to http://calypso.localhost:3000/setup/intro?flow=videopress
* ✅ If you're logged in, you should be redirected to the options step
* ✅ If you're not logged in, you should be redirected to the account creation step, then to the options step
* Add a site title and click continue
* ✅ You should be redirected to the domain selection step, with the site title as suggestion

Fixes 1293-gh-Automattic/greenhouse