### PR TITLE
Fix header text on domain/plans step

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,7 +5,7 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
 import {
 	clone,
@@ -729,10 +729,9 @@ class Signup extends Component {
 	}
 
 	getPageTitle() {
-		if ( this.props.flowName.toLowerCase() === LINK_IN_BIO_FLOW ) {
-			return 'Link in Bio';
+		if ( isNewsletterOrLinkInBioFlow( this.props.flowName ) ) {
+			return this.props.pageTitle;
 		}
-		return this.props.flowName;
 	}
 	render() {
 		// Prevent rendering a step if in the middle of performing a redirect or resuming progress.

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,7 +5,7 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import debugModule from 'debug';
 import {
 	clone,
@@ -728,6 +728,12 @@ class Signup extends Component {
 		}
 	}
 
+	getPageTitle() {
+		if ( this.props.flowName.toLowerCase() === LINK_IN_BIO_FLOW ) {
+			return 'Link in Bio';
+		}
+		return this.props.flowName;
+	}
 	render() {
 		// Prevent rendering a step if in the middle of performing a redirect or resuming progress.
 		if (
@@ -762,6 +768,7 @@ class Signup extends Component {
 								flowName: this.props.flowName,
 								stepName: this.props.stepName,
 							} }
+							pageTitle={ this.getPageTitle() }
 							shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
 							isReskinned={ isReskinned }
 							rightComponent={

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -683,7 +683,7 @@ class DomainsStep extends Component {
 	}
 
 	isTailoredFlow() {
-		return [ 'newsletter', 'link-in-bio' ].includes( this.props.flowName );
+		return isNewsletterOrLinkInBioFlow( this.props.flowName );
 	}
 
 	renderContent() {
@@ -829,6 +829,7 @@ class DomainsStep extends Component {
 				isExternalBackUrl={ isExternalBackUrl }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
+				shouldHideNavButtons={ this.isTailoredFlow() }
 				stepContent={
 					<div>
 						{ ! this.props.productsLoaded && <QueryProductsList /> }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -7,7 +7,11 @@ import {
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import { englishLocales } from '@automattic/i18n-utils';
-import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
+import {
+	LINK_IN_BIO_FLOW,
+	NEWSLETTER_FLOW,
+	isNewsletterOrLinkInBioFlow,
+} from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -372,7 +376,9 @@ export class PlansStep extends Component {
 
 		return subHeaderText || translate( 'Choose a plan. Upgrade as you grow.' );
 	}
-
+	isTailoredFlow() {
+		return isNewsletterOrLinkInBioFlow( this.props.flowName );
+	}
 	plansFeaturesSelection() {
 		const { flowName, stepName, positionInFlow, translate, hasInitializedSitesBackUrl, steps } =
 			this.props;
@@ -416,6 +422,7 @@ export class PlansStep extends Component {
 					stepName={ stepName }
 					positionInFlow={ positionInFlow }
 					headerText={ headerText }
+					shouldHideNavButtons={ this.isTailoredFlow() }
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -7,6 +7,10 @@
 		.signup-header {
 			z-index: 1;
 
+			h1 {
+				text-transform: capitalize;
+			}
+
 			.signup-header__right {
 				visibility: hidden;
 			}

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -7,10 +7,6 @@
 		.signup-header {
 			z-index: 1;
 
-			h1 {
-				text-transform: capitalize;
-			}
-
 			.signup-header__right {
 				visibility: hidden;
 			}


### PR DESCRIPTION
## Proposed Changes

Add Tailored flow header on domain and plans step

Before:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/2653810/189348109-40571f25-7c0f-4879-bfe2-92f3c940b803.png">

Now:
<img width="737" alt="image" src="https://user-images.githubusercontent.com/2653810/189348167-2b2a9e4e-a959-4270-93c8-eec5f22fe383.png">


## Testing Instructions

- Pull this branch and run yarn start
- Go to `/setup/intro?flow=link-in-bio` or `/setup/intro?flow=newsletter`
- Navigate until the domain step 
- Check if the Flow name is present as the header 

Related to #67599
Fixes #67599
