### PR TITLE
Correctly redirect from Titan set up mailbox page

### DIFF
--- a/client/my-sites/email/titan-set-up-mailbox/index.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/index.tsx
@@ -71,7 +71,7 @@ const TitanSetUpMailbox = ( { selectedDomainName, source }: TitanSetUpMailboxPro
 			const configuredMailboxCount = getConfiguredTitanMailboxCount( selectedDomain );
 			const maxMailboxCount = getMaxTitanMailboxCount( selectedDomain );
 
-			if ( configuredMailboxCount < maxMailboxCount ) {
+			if ( configuredMailboxCount === maxMailboxCount ) {
 				page.redirect( emailManagement( selectedSiteSlug ?? '', selectedDomainName ) );
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

Fixes minor fault in redirect logic introduced in #67505

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a domain with an unconfigured mailbox (go to `/start/onboarding-with-email` to get one)
2. Go to the Homepage in Calypso (important because we need to query data in the right order)
3. Click on Upgrades > Emails in the sidebar
4. You should automatically be redirected to the "Set Up Mailbox" view
5. Submit the form
6. Click on Upgrades > Emails in the sidebar
7. Ensure that you are directed to the email management page (potentially after an extra redirect) and not the "Set Up Mailbox" view again

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
