### PR TITLE
[Jetpack App Migration] Design Updates to App Banners

### DIFF
--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -35,6 +35,7 @@ body.app-banner-is-visible {
 		color: var(--color-neutral-100);
 		padding: 30px 24px;
 		text-align: center;
+		font-family: "SF Pro Text", $sans;
 	}
 }
 
@@ -80,7 +81,7 @@ body.app-banner-is-visible {
 
 	&.jetpack {
 		letter-spacing: -0.4px;
-		margin: 30px auto 0;
+		margin: 36px auto 0;
 	}
 }
 
@@ -91,7 +92,7 @@ body.app-banner-is-visible {
 
 	&.jetpack {
 		font-size: rem(28px); //typography-exception
-		font-weight: bold;
+		font-weight: 500;
 		max-width: 18em;
 		margin-left: auto;
 		margin-right: auto;
@@ -108,12 +109,13 @@ body.app-banner-is-visible {
 		max-width: 18em;
 		margin-left: auto;
 		margin-right: auto;
+		margin-top: 18px;
 	}
 }
 
 .app-banner__buttons {
 	width: 100%;
-	margin-top: 20px;
+	margin-top: 36px;
 }
 
 .button.app-banner__open-button {
@@ -124,6 +126,7 @@ body.app-banner-is-visible {
 
 	&.jetpack {
 		background-color: var(--color-jetpack);
+		margin-bottom: 5px;
 	}
 }
 
@@ -139,7 +142,10 @@ body.app-banner-is-visible {
 
 .button.jetpack {
 	width: 100%;
+	min-width: 110px;
 	max-width: 366px;
 	margin: auto;
 	display: block;
+	padding: 15px 18px;
+	font-size: rem(18px); //typography-exception;
 }

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -126,7 +126,7 @@ body.app-banner-is-visible {
 
 	&.jetpack {
 		background-color: var(--color-jetpack);
-		margin-bottom: 5px;
+		margin-bottom: 12px;
 	}
 }
 

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -96,6 +96,7 @@ body.app-banner-is-visible {
 		max-width: 18em;
 		margin-left: auto;
 		margin-right: auto;
+		@extend .wp-brand-font;
 	}
 }
 

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -96,6 +96,9 @@ body.app-banner-is-visible {
 		max-width: 18em;
 		margin-left: auto;
 		margin-right: auto;
+		-webkit-font-smoothing: auto;
+		-moz-osx-font-smoothing: initial;
+		text-rendering: auto;
 		@extend .wp-brand-font;
 	}
 }


### PR DESCRIPTION
Following the updates to the app banners in https://github.com/Automattic/wp-calypso/pull/67013, this PR addresses design feedback.

#### Proposed Changes

Some necessary tweaks to various styles have been made, such as padding, font sizes, etc. The following screenshots display a comparison between the design and the actual implementation followed by a before/after comparison.

<details>
 <summary>Design/actual Comparison ⤵️</summary>

Note, the "actual" screenshot is from an emulation of the Pixel 5 (_393 x 851_).

| Design  | Actual |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/189378205-2c0e1acb-27e0-46dc-9f2a-c56c55b217e7.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/191116564-b3f17d0b-b0e0-4643-89be-82e6270ccf17.png" width="100%"> |
</details>

<details>
 <summary>Before/after ⤵️</summary>

As with the design comparison, the both screenshots are from an emulation of the Pixel 5 (_393 x 851_).

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/189378730-604410cc-9d93-4c2d-ae9e-ddd8dc48a80a.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/191116564-b3f17d0b-b0e0-4643-89be-82e6270ccf17.png" width="100%"> |
</details>

#### Testing Instructions

_Prerequisite:_ The app banner can be viewed via the mobile web (which can also be [emulated using browser tools](https://developer.chrome.com/docs/devtools/device-mode/#viewport)) when navigating directly to the Reader, Stats, Notifications, or the editor. Note, if the banner has previously been dismissed in your browser, it'll be necessary to clear your cache.

The following should be confirmed for both iOS and Android:

* Verify that the banner appears as expected when navigating to the Reader, Stats, Notifications, and the editor.
* For now, the banner's "open" link won't open the Jetpack app (see deep links section above for further details). We should, however, confirm that the links to the WordPress app continue to function as before for users.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?