### PR TITLE
Tailored Flows: Multiline description in setup step

### DIFF
--- a/client/blocks/comments/autoresizing-form-textarea.jsx
+++ b/client/blocks/comments/autoresizing-form-textarea.jsx
@@ -8,7 +8,18 @@ import withPasteToLink from 'calypso/lib/paste-to-link';
 import './autoresizing-form-textarea.scss';
 
 const AutoresizingFormTextarea = (
-	{ hasFocus, value, placeholder, onKeyUp, onKeyDown, onFocus, onBlur, onChange, enableAutoFocus },
+	{
+		hasFocus,
+		value,
+		placeholder,
+		onKeyUp,
+		onKeyDown,
+		onFocus,
+		onBlur,
+		onChange,
+		enableAutoFocus,
+		...otherProps
+	},
 	forwardedRef
 ) => {
 	const classes = classnames( 'expanding-area', { focused: hasFocus } );
@@ -21,6 +32,7 @@ const AutoresizingFormTextarea = (
 			</pre>
 			<AutoDirection>
 				<FormTextarea
+					{ ...otherProps }
 					value={ value }
 					placeholder={ placeholder }
 					onKeyUp={ onKeyUp }
@@ -37,4 +49,6 @@ const AutoresizingFormTextarea = (
 	);
 };
 
-export default withPasteToLink( withUserMentions( forwardRef( AutoresizingFormTextarea ) ) );
+export const ForwardedAutoresizingFormTextarea = forwardRef( AutoresizingFormTextarea );
+
+export default withPasteToLink( withUserMentions( ForwardedAutoresizingFormTextarea ) );

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -192,7 +192,8 @@ button {
 			color: var(--studio-gray-60);
 		}
 
-		input[type="text"].form-text-input {
+		input[type="text"].form-text-input,
+		textarea.form-textarea {
 			font-size: $font-body-small;
 			border-radius: 4px;
 			border: 1px solid var(--studio-gray-10);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
 import greenCheckmarkImg from 'calypso/assets/images/onboarding/green-checkmark.svg';
+import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -134,19 +135,20 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 
 			<FormFieldset>
 				<FormLabel htmlFor="link-in-bio-input-description">{ __( 'Brief description' ) }</FormLabel>
-				<FormInput
+				<ForwardedAutoresizingFormTextarea
 					name="link-in-bio-input-description"
 					id="link-in-bio-input-description"
 					value={ tagline }
-					onChange={ onChange }
 					placeholder={ __( 'Add a short biography here' ) }
+					enableAutoFocus={ false }
+					onChange={ onChange }
 					style={ {
 						backgroundImage: tagline.trim() ? `url(${ greenCheckmarkImg })` : 'unset',
 						backgroundRepeat: 'no-repeat',
 						backgroundPosition: '95%',
 						paddingRight: ' 40px',
+						paddingLeft: '14px',
 					} }
-					isError={ false }
 				/>
 			</FormFieldset>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -51,10 +51,11 @@ $font-family: "SF Pro Text", $sans;
 			font-weight: 400;
 		}
 
+
 		input,
 		textarea,
 		pre {
-			height: 44px;
+			min-height: 44px;
 			line-height: 1.5;
 			padding-top: 7px;
 			padding-bottom: 7px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -45,13 +45,19 @@ $font-family: "SF Pro Text", $sans;
 		}
 
 		label,
-		input {
+		input,
+		textarea {
 			font-family: $font-family;
 			font-weight: 400;
 		}
 
-		input {
+		input,
+		textarea,
+		pre {
 			height: 44px;
+			line-height: 1.5;
+			padding-top: 7px;
+			padding-bottom: 7px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
 import greenCheckmarkImg from 'calypso/assets/images/onboarding/green-checkmark.svg';
+import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -188,15 +189,20 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel htmlFor="tagline">{ __( 'Brief description' ) }</FormLabel>
-				<FormInput
-					value={ tagline }
-					placeholder={ __( 'Describe your Newsletter in a line or two' ) }
+				<ForwardedAutoresizingFormTextarea
 					name="tagline"
 					id="tagline"
+					value={ tagline }
+					placeholder={ __( 'Describe your Newsletter in a line or two' ) }
+					enableAutoFocus={ false }
+					onChange={ onChange }
 					style={ {
 						backgroundImage: getBackgroundImage( tagline ),
+						backgroundRepeat: 'no-repeat',
+						backgroundPosition: '95%',
+						paddingRight: ' 40px',
+						paddingLeft: '14px',
 					} }
-					onChange={ onChange }
 				/>
 			</FormFieldset>
 			<FormFieldset>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -45,7 +45,8 @@ $border-radius: 4px;
 		}
 
 		label,
-		input {
+		input,
+		textarea {
 			font-family: $font-family;
 			font-weight: 400;
 		}
@@ -55,7 +56,9 @@ $border-radius: 4px;
 			font-size: $font-body;
 		}
 
-		input {
+		input,
+		textarea,
+		pre {
 			color: var(--studio-gray-100);
 			font-size: $font-body-small;
 			padding: 12px 16px;


### PR DESCRIPTION
#### Proposed Changes

Make the description field multiline, in the setup step. In both Link in Bio and Newsletter flows.

![image](https://user-images.githubusercontent.com/52076348/189384894-087cb972-cdc6-4fb7-9bd8-19aaf0eb99ff.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch and `yarn start`
* Check both link in bio flow ( `/setup?flow=link-in-bio` ) and newsletter ( `/setup?flow=newsletter` )
* Description should become multiline if is enough words are used


Related to #67602
Fixes #67602
