### PR TITLE
E2E: remove extraneous teardown processing in the framework to prevent hangs with newer Playwright versions.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -147,10 +147,10 @@ open class E2EBuildType(
 					set -x
 
 					mkdir -p screenshots
-					find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+					find test/e2e/results -type f \( -iname \*.webm -o -iname \*.png \) -print0 | xargs -r -0 mv -t screenshots
 
 					mkdir -p logs
-					find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+					find test/e2e/results -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
 
 					mkdir -p trace
 					find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace


### PR DESCRIPTION
#### Proposed Changes

This PR streamlines the handling of video and screenshot artifacts when the entire spec file has passed (ie. no failures).

Key changes:
- change the `find` command when collecting video/screenshots to not look within the `/screenshots` dir.
- when writing video and screenshots, write to the top-level artifacts dir instead of `/screenshots`.
- remove handling for `page.close()` and video deletion for when no tests have failed.

Reason:
As noted in [this comment](https://github.com/Automattic/wp-calypso/issues/67616#issuecomment-1242467304), with Playwright versions 1.24 and above due to some change to either the tool or the bundled browser versions, our suite of E2E tests permanently hangs when executed in CI or locally.

After much debugging I've narrowed it down to the way `calypso-e2e/jest-playwright-config/environment.ts` handles the `teardown` event, specifically when tests have all passed. Specifically, [these lines](https://github.com/Automattic/wp-calypso/blob/bb6793074f514c1183314109a7022fd51f240211/packages/calypso-e2e/src/jest-playwright-config/environment.ts#L251-L257) are responsible for the hang.

Under specific circumstances the way the offending code likely results in either too much I/O to the disk or an attempt to delete a file that does not exist. Either way, the result is that Jest hangs and does not exit unless CTRL+C is sent or the `--forceExit` flag is set.

Fixes https://github.com/Automattic/wp-calypso/issues/67616

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
