### PR TITLE
SSR: Avoid setting up route multiple times

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -490,19 +490,13 @@ function setUpCSP( req, res, next ) {
 
 function setUpRoute( req, res, next ) {
 	if ( req.context.isRouteSetup === true ) {
-		try {
-			req.logger.warn(
-				{
-					isLoggedIn: req.context.isLoggedIn,
-					path: req.context.path,
-				},
-				'Route already set up. Ambiguous route definition likely.'
-			);
-		} catch ( err ) {
-			if ( process.env.NODE_ENV === 'development' ) {
-				console.warn( 'Route already set up. Ambiguous route definition likely.' );
-			}
-		}
+		req.logger.warn(
+			{
+				isLoggedIn: req.context.isLoggedIn,
+				path: req.context.path,
+			},
+			'Route already set up. Ambiguous route definition likely.'
+		);
 
 		return next();
 	}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -489,6 +489,13 @@ function setUpCSP( req, res, next ) {
 }
 
 function setUpRoute( req, res, next ) {
+	if ( req.context.isRouteSetup === true ) {
+		console.log( '\nRoute already setup. Ambiguous route definition detected.' );
+		return next();
+	}
+	// Prevents function from being called twice.
+	req.context.isRouteSetup = true;
+
 	setUpCSP( req, res, () =>
 		req.context.isLoggedIn
 			? setUpLoggedInRoute( req, res, next )

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -490,7 +490,20 @@ function setUpCSP( req, res, next ) {
 
 function setUpRoute( req, res, next ) {
 	if ( req.context.isRouteSetup === true ) {
-		console.log( '\nRoute already setup. Ambiguous route definition detected.' );
+		try {
+			req.logger.warn(
+				{
+					isLoggedIn: req.context.isLoggedIn,
+					path: req.context.path,
+				},
+				'Route already set up. Ambiguous route definition likely.'
+			);
+		} catch ( err ) {
+			if ( process.env.NODE_ENV === 'development' ) {
+				console.warn( 'Route already set up. Ambiguous route definition likely.' );
+			}
+		}
+
 		return next();
 	}
 	// Prevents function from being called twice.


### PR DESCRIPTION
### Proposed Changes
Isomorphic routes differ from normal routes in that there are multiple server-side route definitions per section. For non-isomorphic routes, there is one server-side route definition per section and other routing happens on the client.

As a result, it is possible for ambiguous route definitions to call the router function multiple times, executing multiple middleware chains per matching route until a request is resolved. When this happens, `setUpRoute` is called in each middleware chain. Since `setUpRoute` does async work like fetching the bootstrapped user object, this has a negative performance impact.

This simple fix calls `next()` immediately if the request was already setup, as there should be no need to set it up again.

### Testing Instructions
1. Enable logged-in user bootstrapping with these instructions: PCYsg-5YE-p2. (under "Force login cookie on the server")
2. Run `yarn start`
3. Visit the URL `http://calypso.localhost:3000/themes/$site`, where $site is one of your wpcom sites.
4. Observe the message "WARN calypso: Route already setup" in the console.
5. Also observe that the debug message about the user object being fetched is only printed once.