### PR TITLE
Domains: Update dot color of expiring auto-renewing domain connections to green

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -135,27 +135,14 @@ export function resolveDomainStatus(
 						: translate( 'Expiring soon' );
 				}
 
-				if ( isExpiringSoon( domain, 7 ) ) {
-					return {
-						statusText: expiresMessage,
-						statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
-						status: status,
-						icon: 'info',
-						listStatusText: expiresMessage,
-						listStatusClass: domain.autoRenewing ? 'info' : 'alert',
-						listStatusWeight: 1000,
-						noticeText,
-					};
-				}
-
 				return {
 					statusText: expiresMessage,
-					statusClass: 'status-warning',
+					statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
 					status: status,
 					icon: 'info',
 					listStatusText: expiresMessage,
-					listStatusClass: 'warning',
-					listStatusWeight: 800,
+					listStatusClass: domain.autoRenewing ? 'info' : 'alert',
+					listStatusWeight: isExpiringSoon( domain, 7 ) ? 1000 : 800,
 					noticeText,
 				};
 			}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the color of the dot of auto-renewing domain connections in the domains list page. The status is correct ("Active") but the dot color is yellow when it should be green. We overlooked this detail in #63450 and #63692.

See p2MSmN-9If-p2#comment-48932

#### Screenshots

- Before

![Markup on 2022-09-09 at 21:00:47](https://user-images.githubusercontent.com/5324818/189460635-3ca12a25-a212-4be8-a208-a35d7d2dfe1d.png)

- After

![Markup on 2022-09-09 at 21:02:08](https://user-images.githubusercontent.com/5324818/189460638-b9405e02-4a91-4d5d-aa06-e176e3640ea4.png)

#### Testing Instructions

- Build this branch locally or open the live Calypso link
- Select a site that has a domain connection that will expire in less than 30 days
- Go to "Upgrades > Domains" and ensure the status and dot color are correct in the domain list

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
