### PR TITLE
Help Center (1min review) - make contact button sticky

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -15,7 +15,7 @@
 	img {
 		width: 32px;
 		height: 32px;
-		border: 2px solid white;
+		border: 2px solid #fff;
 		border-radius: 50%; // stylelint-disable-line declaration-property-unit-allowed-list
 	}
 
@@ -56,6 +56,20 @@
 	.site-picker__site-item {
 		padding: 12px 8px;
 	}
+
+	.popover.is-top-left {
+		z-index: 9999;
+
+		.popover__arrow {
+			z-index: 1;
+		}
+
+		.popover__inner span {
+			display: block;
+			padding: 16px;
+		}
+	}
+
 }
 
 .help-center-contact-form__message,
@@ -74,21 +88,39 @@
 	}
 }
 
-.button.help-center-contact-form__site-picker-cta.is-primary {
-	background-color: var(--color-accent);
-	border-color: var(--color-accent);
-	color: var(--color-text-inverted);
+section.contact-form-submit {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	background: #fff;
+	padding: 16px;
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
 
-	&:hover {
+	.button.help-center-contact-form__site-picker-cta.is-primary {
+		background-color: var(--color-accent);
+		border-color: var(--color-accent);
 		color: var(--color-text-inverted);
-		background-color: var(--color-accent-60);
-		border-color: var(--color-accent-60);
-	}
 
-	&:disabled {
-		background-color: var(--color-surface) !important;
-		border-color: var(--color-neutral-5) !important;
-		color: var(--color-neutral-20) !important;
+		&:hover,
+		&:focus {
+			color: var(--color-text-inverted);
+			background-color: var(--color-accent-60);
+			border-color: var(--color-accent-60);
+		}
+
+		&:focus {
+			border: none;
+			box-shadow: none;
+			outline: solid 2px var(--color-accent-60);
+			outline-offset: 2px;
+		}
+
+		&:disabled {
+			background-color: var(--color-surface) !important;
+			border-color: var(--color-neutral-5) !important;
+			color: var(--color-neutral-20) !important;
+		}
 	}
 }
 
@@ -151,21 +183,6 @@
 	}
 }
 
-.help-center-contact-form {
-	.popover.is-top-left {
-		z-index: 9999;
-
-		.popover__arrow {
-			z-index: 1;
-		}
-
-		.popover__inner span {
-			display: block;
-			padding: 16px;
-		}
-	}
-}
-
 .help-center-contact-form__domain-sharing .components-checkbox-control {
 	display: flex;
 
@@ -180,7 +197,7 @@
 }
 
 .form-input-validation {
-	line-height: 1.5rem;
+	line-height: 1.5;
 
 	.gridicon {
 		fill: currentColor;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -421,7 +421,7 @@ export const HelpCenterContactForm = () => {
 				</section>
 			) }
 
-			<section>
+			<section className="contact-form-submit">
 				<Button
 					disabled={ isCTADisabled() }
 					onClick={ handleCTA }

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -142,14 +142,14 @@ $head-foot-height: 50px;
 			background: var(--studio-pink-50);
 			border-radius: 20px; /* stylelint-disable-line scales/radii */
 			font-size: $font-body-extra-small;
-			color: white;
+			color: #000;
 		}
 
 		.help-center-header__a8c-only-badge {
 			display: inline-block;
 			margin-left: 8px;
 			padding: 2px 6px;
-			background: lightgray;
+			background: #d3d3d3;
 			border-radius: 4px;
 			font-size: $font-body-extra-small;
 			color: var(--studio-gray-50);
@@ -196,7 +196,7 @@ $head-foot-height: 50px;
 	button.button.back-button__help-center.is-borderless {
 		display: flex;
 		align-items: center;
-		color: black;
+		color: #000;
 		font-size: $font-body-small;
 		padding-right: 5px;
 
@@ -214,12 +214,17 @@ $head-foot-height: 50px;
 		> *:not(iframe) {
 			padding: 16px;
 		}
+
+		.help-center-contact-form {
+			margin-bottom: 87px;
+		}
 	}
 
 	.help-center-sibyl-articles__list {
 		list-style: none;
 		box-sizing: border-box;
 		padding: 0;
+		margin: 0;
 
 		> li {
 			padding: 0;
@@ -332,10 +337,6 @@ $head-foot-height: 50px;
 	.help-center-contact-form__label,
 	.site-picker__label {
 		font-size: $font-body-small;
-	}
-
-	.help-center-sibyl-articles__list {
-		margin: 0;
 	}
 
 	.help-center-header__text {


### PR DESCRIPTION
## Proposed Changes

On small screens the Help Center contact form CTA button is hidden unless the user scrolls. This changes the button to be fixed to the bottom.

| Small Screen | Big Screen |
| - | - |
| <img width="439" alt="Markup 2022-09-11 at 21 11 22" src="https://user-images.githubusercontent.com/33258733/189550740-da5d4da2-149a-4104-bad6-f6941a216fc1.png"> | <img width="443" alt="Markup 2022-09-11 at 21 23 28" src="https://user-images.githubusercontent.com/33258733/189550752-061f6341-d233-4981-8970-51afb06f9101.png"> |


## Testing Instructions

1. Pull branch, `cd apps/editing-toolkit && yarn dev --sync`, sandbox
2. Open up Help Center and go to the support contact form.
3. Check the the button is showing properly.