### PR TITLE
update wording for cancel/stop campaign

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -110,6 +110,19 @@ export default function CampaignItem( { campaign }: Props ) {
 		</div>
 	);
 
+	const cancelCampaignButtonText =
+		campaignStatus === 'active' ? __( 'Stop campaign' ) : __( 'Cancel campaign' );
+	const cancelCampaignConfirmButtonText =
+		campaignStatus === 'active' ? __( 'Yes, stop' ) : __( 'Yes, cancel' );
+	const cancelCampaignTitle =
+		campaignStatus === 'active' ? __( 'Stop the campaign' ) : __( 'Cancel the campaign' );
+	const cancelCampaignMessage =
+		campaignStatus === 'active'
+			? __( 'If you continue your campaign will immediately stop running.' )
+			: __(
+					"If you continue an approval request for your ad will be canceled, and the campaign won't start."
+			  );
+
 	const buttons = [
 		{
 			action: 'cancel',
@@ -118,7 +131,7 @@ export default function CampaignItem( { campaign }: Props ) {
 		{
 			action: 'remove',
 			isPrimary: true,
-			label: __( 'Yes, cancel' ),
+			label: cancelCampaignConfirmButtonText,
 			onClick: async () => {
 				setShowDeleteDialog( false );
 				cancelCampaign( siteId, campaign.campaign_id );
@@ -133,12 +146,8 @@ export default function CampaignItem( { campaign }: Props ) {
 				buttons={ buttons }
 				onClose={ () => setShowDeleteDialog( false ) }
 			>
-				<h1>{ __( 'Cancel the campaign' ) }</h1>
-				<p>
-					{ __(
-						"If you continue an approval request for your ad will be canceled, and the campaign won't start"
-					) }
-				</p>
+				<h1>{ cancelCampaignTitle }</h1>
+				<p>{ cancelCampaignMessage }</p>
 			</Dialog>
 
 			<FoldableCard header={ header } hideSummary={ true } className="campaign-item__foldable-card">
@@ -246,7 +255,7 @@ export default function CampaignItem( { campaign }: Props ) {
 				<div className="campaign-item__payment-and-action">
 					{ canCancelCampaign( campaignStatus ) && (
 						<Button isLink isDestructive onClick={ () => setShowDeleteDialog( true ) }>
-							{ __( 'Cancel campaign' ) }
+							{ cancelCampaignButtonText }
 						</Button>
 					) }
 				</div>


### PR DESCRIPTION
#### Proposed Changes

* issues/631, cancel/stop campaign should use different wording:

|  cancel |  stop |
|---|---|
|  ![Screen Shot 2022-09-12 at 12 32 12](https://user-images.githubusercontent.com/6070516/189556226-aff94b13-3ff1-4b2b-a31f-81132e9f6d2a.jpg) |  ![Screen Shot 2022-09-12 at 11 57 01](https://user-images.githubusercontent.com/6070516/189556237-c77c3718-a69c-4496-9496-c7f8b4edf960.jpg) | 

#### Testing Instructions
Check the campaigns page and compare the cancel/stop campaign wording against the design.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
