### PR TITLE
Site Switcher: Fix Add new site closing switcher and rendering empty state before navigating 

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -10,13 +10,17 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const recordAddNewSite = useCallback( () => {
-		const event = isJetpackCloud()
-			? 'calypso_add_new_jetpack_click'
-			: 'calypso_add_new_wordpress_click';
+	const recordAddNewSite = useCallback(
+		( e ) => {
+			e.stopPropagation();
+			const event = isJetpackCloud()
+				? 'calypso_add_new_jetpack_click'
+				: 'calypso_add_new_wordpress_click';
 
-		dispatch( recordTracksEvent( event ) );
-	}, [ dispatch ] );
+			dispatch( recordTracksEvent( event ) );
+		},
+		[ dispatch ]
+	);
 
 	return (
 		<Button


### PR DESCRIPTION
#### Proposed Changes
Clicking `Add new site` from the site site switcher results in an empty state page being rendered just before the page is redirected to the onboarding url. This happens because the when loading the onboarding component the global `siteid` is set to null https://github.com/Automattic/wp-calypso/blob/dfb08c7b07c7bf6fe1377bb71e9b35b48a01fdfb/client/signup/controller.js#L288
The click event then bubbles up to the parent result in the layout focus being changed re-renders my-sites home but now with an empty siteId. The issue is exasperated because the domain step component that we are mounting is an async component that's not pre-loaded, this caused the empty page to be seen before the `stepComponent` is shown. https://github.com/Automattic/wp-calypso/blob/dfb08c7b07c7bf6fe1377bb71e9b35b48a01fdfb/client/signup/controller.js#L256

This PR fixes the issue 
* Preventing the click event from bubbling up to it's parent and re-rendering the component.

#### Testing Instructions

- From site switcher select the `Add new site` button
- Verify site switcher is not re-rendered and redirects to domain page.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67497
