### PR TITLE
Style selection: Show old preview for themes that don't have style variations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -151,6 +151,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const isEnabledStyleSelection =
 		selectedDesign &&
 		selectedDesign.design_type !== 'vertical' &&
+		selectedDesign.style_variations?.length > 0 &&
 		isEnabled( 'signup/design-picker-style-selection' );
 
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -151,7 +151,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const isEnabledStyleSelection =
 		selectedDesign &&
 		selectedDesign.design_type !== 'vertical' &&
-		selectedDesign.style_variations?.length > 0 &&
+		selectedDesign.style_variations &&
+		selectedDesign.style_variations.length > 0 &&
 		isEnabled( 'signup/design-picker-style-selection' );
 
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -74,9 +74,10 @@ export const siteSetupFlow: Flow = {
 		] as StepPath[];
 	},
 	useSideEffect() {
+		// Prefetch designs for a smooth design picker UX.
+		// Except for Unified Design Picker which uses a separate API endpoint (wpcom/v2/starter-designs).
 		const site = useSite();
-		// prefetch designs for a smooth design picker UX
-		useDesignsBySite( site );
+		useDesignsBySite( site, { enabled: !! site && ! isEnabled( 'signup/design-picker-unified' ) } );
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );

--- a/packages/design-picker/src/hooks/use-designs-by-site.ts
+++ b/packages/design-picker/src/hooks/use-designs-by-site.ts
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores/src/site';
 import { useMemo } from 'react';
+import { UseQueryOptions } from 'react-query';
 import { useThemeDesignsQuery } from './use-theme-designs-query';
 
 /**
@@ -9,7 +10,7 @@ import { useThemeDesignsQuery } from './use-theme-designs-query';
  *
  * @param site the site
  */
-export function useDesignsBySite( site: SiteDetails | null ) {
+export function useDesignsBySite( site: SiteDetails | null, queryOptions?: UseQueryOptions = {} ) {
 	const sitePlanSlug = site?.plan?.product_slug;
 
 	const isPremiumThemeAvailable = Boolean(
@@ -29,6 +30,9 @@ export function useDesignsBySite( site: SiteDetails | null ) {
 	return useThemeDesignsQuery(
 		{ filter: themeFilters, tier },
 		// Wait until FSS eligibility is loaded to load themes
-		{ enabled: !! site }
+		{
+			enabled: !! site,
+			...queryOptions,
+		}
 	);
 }

--- a/packages/design-picker/src/hooks/use-designs-by-site.ts
+++ b/packages/design-picker/src/hooks/use-designs-by-site.ts
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores/src/site';
 import { useMemo } from 'react';
-import { UseQueryOptions } from 'react-query';
 import { useThemeDesignsQuery } from './use-theme-designs-query';
 
 /**
@@ -10,7 +9,7 @@ import { useThemeDesignsQuery } from './use-theme-designs-query';
  *
  * @param site the site
  */
-export function useDesignsBySite( site: SiteDetails | null, queryOptions?: UseQueryOptions = {} ) {
+export function useDesignsBySite( site: SiteDetails | null, queryOptions = {} ) {
 	const sitePlanSlug = site?.plan?.product_slug;
 
 	const isPremiumThemeAvailable = Boolean(


### PR DESCRIPTION
#### Proposed Changes

This PR updates the new full-screen theme preview behavior so that it is only shown when previewing themes that have style variations. Themes that don't have style variations will continue seeing the old full-screen theme preview. See discussion here https://github.com/Automattic/wp-calypso/issues/67388#issuecomment-1238807936. For reference:

New full-screen theme preview: 
![Screen Shot 2022-09-12 at 1 20 49 PM](https://user-images.githubusercontent.com/797888/189579108-a1309a6e-dc63-4a61-9406-4083e12bf27b.png)

Old full-screen theme preview:
![Screen Shot 2022-09-12 at 1 20 59 PM](https://user-images.githubusercontent.com/797888/189579146-6d80b10c-4417-401e-b7b0-0593728f9bda.png)

Also, this PR removes previous design picker prefetch optimization, since the unified design picker doesn't use that endpoint.


![Screen Shot 2022-09-12 at 2 09 46 PM](https://user-images.githubusercontent.com/797888/189584988-22938549-f1db-4b73-91b3-293753e396ed.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the unified design picker `setup/designSetup?siteSlug=${site_slug}`
* Click on a theme that has style variations, and ensure that the new full-screen preview is shown.
* Click on a theme that doesn't have style variations, and ensure that the old full-screen preview is shown.
* Click on a generated design, and ensure that the old full-screen preview is shown.
* To test the removal of prefetch optimization, ensure that the endpoint `v1.2/themes` isn't called on page load.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

