### PR TITLE
Marketplace: Reskin plugins discover upsell nudge

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -58,6 +58,7 @@ export const UpsellNudge = ( {
 	primaryButton,
 	selectedSiteHasFeature,
 	showIcon = false,
+	icon = 'star',
 	site,
 	siteSlug,
 	target,
@@ -129,7 +130,7 @@ export const UpsellNudge = ( {
 			forceHref={ forceHref }
 			horizontal={ horizontal }
 			href={ href }
-			icon="star"
+			icon={ icon }
 			jetpack={ isJetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 			isAtomic={ isAtomic }
 			list={ list }

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,5 +1,6 @@
 .plugins-browser-list {
 	margin-bottom: 16px;
+	margin-top: 32px;
 
 	.feature-example & {
 		margin: 0;
@@ -19,7 +20,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated("<660px") {
 		padding: 0 16px;
 	}
 }
@@ -31,7 +32,6 @@
 	justify-content: space-between;
 	flex-wrap: wrap;
 
-	padding-top: 48px;
 	.plugins-browser-list__titles {
 		padding-bottom: 10px;
 

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,6 +1,5 @@
 .plugins-browser-list {
 	margin-bottom: 16px;
-	margin-top: 32px;
 
 	.feature-example & {
 		margin: 0;
@@ -32,6 +31,7 @@
 	justify-content: space-between;
 	flex-wrap: wrap;
 
+	padding-top: 32px;
 	.plugins-browser-list__titles {
 		padding-bottom: 10px;
 

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -18,6 +18,8 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import SingleListView from '../plugins-browser/single-list-view';
 import usePlugins from '../use-plugins';
 
+import './style.scss';
+
 /**
  * Module variables
  */
@@ -83,6 +85,9 @@ const UpgradeNudge = ( {
 		return (
 			<UpsellNudge
 				event="calypso_plugins_browser_upgrade_nudge"
+				className={ 'plugins-discovery-page__upsell' }
+				callToAction={ translate( 'Upgrade now' ) }
+				icon={ 'notice-outline' }
 				showIcon={ true }
 				href={ `/checkout/${ siteSlug }/${ requiredPlan.getPathSlug() }` }
 				feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
@@ -103,6 +108,9 @@ const UpgradeNudge = ( {
 		return (
 			<UpsellNudge
 				event="calypso_plugins_browser_upgrade_nudge"
+				className={ 'plugins-discovery-page__upsell' }
+				callToAction={ translate( 'Upgrade now' ) }
+				icon={ 'notice-outline' }
 				showIcon={ true }
 				href={ `/checkout/${ siteSlug }/pro` }
 				feature={ FEATURE_INSTALL_PLUGINS }
@@ -116,6 +124,9 @@ const UpgradeNudge = ( {
 	return (
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
+			className={ 'plugins-discovery-page__upsell' }
+			callToAction={ translate( 'Upgrade now' ) }
+			icon={ 'notice-outline' }
 			showIcon={ true }
 			href={ `/checkout/${ siteSlug }/business` }
 			feature={ FEATURE_INSTALL_PLUGINS }

--- a/client/my-sites/plugins/plugins-discovery-page/style.scss
+++ b/client/my-sites/plugins/plugins-discovery-page/style.scss
@@ -1,0 +1,26 @@
+.plugins-discovery-page__upsell.card.banner.upsell-nudge {
+	background-color: #f0f7fc;
+	border: none;
+	box-shadow: none;
+	margin-top: 32px;
+	margin-bottom: 0;
+	padding: 24px 30px;
+	border-radius: 4px;
+
+	.banner__title {
+		font-weight: 500;
+	}
+
+	.banner__icon-circle {
+		background-color: #0675c4;
+	}
+
+	.banner__action .button {
+		background-color: #0675c4;
+		font-weight: 400;
+		border: none;
+		padding: 8px 14px;
+		font-size: 0.875rem;
+		line-height: 22px;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* Reskin plugins discover upsell nudge

#### Testing Instructions

* View /plugins/:site page http://calypso.localhost:3000/plugins without a business plan.
* Confirm the new banner design is shown

Before

![Screenshot 2022-09-12 at 16-32-32 Plugins ‹ Premium - Simple Site — WordPress com](https://user-images.githubusercontent.com/811776/189588185-683fb930-0ab7-4c11-8fce-17fd30105073.png)

After

![Screenshot 2022-09-12 at 16-31-55 Plugins ‹ Premium - Simple Site — WordPress com](https://user-images.githubusercontent.com/811776/189588214-7bafdab7-e314-4047-aca3-8e9ba145c54e.png)


Fixes #67223