### PR TITLE
Pricing page rework: Enable compact mode for Item price component when viewed in tight space.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -197,6 +197,10 @@
 		line-height: 1.2;
 	}
 
+	&__billing-time-frame .compact {
+		display: none;
+	}
+
 	&__expiration-date {
 		color: var(--studio-pink-50);
 	}

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -1,7 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { TERM_MONTHLY } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { createElement, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { Moment } from 'moment';
@@ -18,25 +17,17 @@ const TimeFrame: React.FC< TimeFrameProps > = ( { expiryDate, billingTerm } ) =>
 		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
 
 	const billingTermText = useMemo( () => {
-		const isNewFormat = isEnabled( 'jetpack/pricing-page-rework-v1' ); // TO-DO remove this flag once we have the new translation in production
-
 		if ( billingTerm === TERM_MONTHLY ) {
-			return isNewFormat
-				? translate( '/mo{{span}}nth{{/span}}, billed monthly', {
-						components: {
-							span: createElement( 'span' ),
-						},
-				  } )
-				: translate( '/month, billed monthly' );
+			return {
+				normal: translate( '/month, billed monthly' ),
+				compact: translate( '/mo, billed monthly' ),
+			};
 		}
 
-		return isNewFormat
-			? translate( '/mo{{span}}nth{{/span}}, billed yearly', {
-					components: {
-						span: createElement( 'span' ),
-					},
-			  } )
-			: translate( '/month, billed yearly' );
+		return {
+			normal: translate( '/month, billed yearly' ),
+			compact: translate( '/mo, billed yearly' ),
+		};
 	}, [ billingTerm, translate ] );
 
 	return productExpiryDate ? (
@@ -54,7 +45,10 @@ const TimeFrame: React.FC< TimeFrameProps > = ( { expiryDate, billingTerm } ) =>
 		</div>
 	) : (
 		<div>
-			<span className="display-price__billing-time-frame">{ billingTermText }</span>
+			<span className="display-price__billing-time-frame">
+				<span className="normal">{ billingTermText.normal }</span>
+				<span className="compact">{ billingTermText.compact }</span>
+			</span>
 		</div>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -1,6 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { TERM_MONTHLY } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { createElement, useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { Moment } from 'moment';
@@ -17,11 +18,25 @@ const TimeFrame: React.FC< TimeFrameProps > = ( { expiryDate, billingTerm } ) =>
 		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
 
 	const billingTermText = useMemo( () => {
+		const isNewFormat = isEnabled( 'jetpack/pricing-page-rework-v1' ); // TO-DO remove this flag once we have the new translation in production
+
 		if ( billingTerm === TERM_MONTHLY ) {
-			return translate( '/month, billed monthly' );
+			return isNewFormat
+				? translate( '/mo{{span}}nth{{/span}}, billed monthly', {
+						components: {
+							span: createElement( 'span' ),
+						},
+				  } )
+				: translate( '/month, billed monthly' );
 		}
 
-		return translate( '/month, billed yearly' );
+		return isNewFormat
+			? translate( '/mo{{span}}nth{{/span}}, billed yearly', {
+					components: {
+						span: createElement( 'span' ),
+					},
+			  } )
+			: translate( '/month, billed yearly' );
 	}, [ billingTerm, translate ] );
 
 	return productExpiryDate ? (

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -20,13 +20,17 @@ const TimeFrame: React.FC< TimeFrameProps > = ( { expiryDate, billingTerm } ) =>
 		if ( billingTerm === TERM_MONTHLY ) {
 			return {
 				normal: translate( '/month, billed monthly' ),
-				compact: translate( '/mo, billed monthly' ),
+				compact: translate( '/mo, billed monthly', {
+					comment: '/mo should be as compact as possible',
+				} ),
 			};
 		}
 
 		return {
 			normal: translate( '/month, billed yearly' ),
-			compact: translate( '/mo, billed yearly' ),
+			compact: translate( '/mo, billed yearly', {
+				comment: '/mo should be as compact as possible',
+			} ),
 		};
 	}, [ billingTerm, translate ] );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-price-compact.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-price-compact.ts
@@ -15,7 +15,9 @@ export const useItemPriceCompact = () => {
 
 		onResize();
 		window.addEventListener( 'resize', onResize );
-	}, [] );
+
+		return () => window.removeEventListener( 'resize', onResize );
+	}, [ containerRef ] );
 
 	return useMemo(
 		() => ( {

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-price-compact.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-item-price-compact.ts
@@ -1,0 +1,27 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const ITEM_PRICE_COMPACT_WIDTH_THRESHOLD = 270;
+
+export const useItemPriceCompact = () => {
+	const [ isCompact, setIsCompact ] = useState( false );
+	const containerRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		const onResize = () => {
+			if ( containerRef && containerRef.current ) {
+				setIsCompact( containerRef.current.offsetWidth < ITEM_PRICE_COMPACT_WIDTH_THRESHOLD );
+			}
+		};
+
+		onResize();
+		window.addEventListener( 'resize', onResize );
+	}, [] );
+
+	return useMemo(
+		() => ( {
+			isCompact,
+			containerRef,
+		} ),
+		[ isCompact ]
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -1,8 +1,10 @@
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import useItemPrice from '../../use-item-price';
+import { useItemPriceCompact } from '../hooks/use-item-price-compact';
 import { ItemPriceProps } from '../types';
 import ItemPriceMessage from './item-price-message';
 import './style.scss';
@@ -21,6 +23,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	);
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const translate = useTranslate();
+	const { containerRef, isCompact } = useItemPriceCompact();
 
 	if ( isMultiSiteIncompatible ) {
 		return (
@@ -33,7 +36,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	}
 
 	return (
-		<div className="item-price">
+		<div className={ classNames( 'item-price', { 'is-compact': isCompact } ) } ref={ containerRef }>
 			<DisplayPrice
 				isFree={ item.isFree }
 				isOwned={ isOwned }

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -85,10 +85,12 @@
 	}
 }
 
-.item-price.is-compact .display-price .display-price__billing-time-frame span {
-	@include break-medium {
-		display: none;
-	}
+.item-price.is-compact .display-price .display-price__billing-time-frame .normal {
+	display: none;
+}
+
+.item-price.is-compact .display-price .display-price__billing-time-frame .compact {
+	display: inline-block;
 }
 
 .item-price__message {

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -85,6 +85,11 @@
 	}
 }
 
+.item-price.is-compact .display-price .display-price__billing-time-frame span {
+	@include break-medium {
+		display: none;
+	}
+}
 
 .item-price__message {
 	font-size: $font-body-extra-small;

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -18,7 +18,7 @@
 	background: linear-gradient(159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53%);
 	border-radius: 4px;
 
-	@media only screen and (min-width: 821px) {
+	@media only screen and ( min-width: 821px ) {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -38,6 +38,10 @@
 	font-size: $font-body-small;
 	justify-content: space-between;
 	align-items: flex-start;
+}
+
+.simple-item-card__header > :first-child {
+	flex-grow: 1;
 }
 
 .simple-item-card__title {


### PR DESCRIPTION
### Description
When we display the pricing page on the Ipad air (portrait) screen, the item price component looks crammed into the simple card.

<img width="366" alt="Screen Shot 2022-09-12 at 3 57 29 PM" src="https://user-images.githubusercontent.com/56598660/189602330-cba11ee1-c70f-4482-b397-f2015d7895d0.png">

The [prototype](https://codesandbox.io/s/jpop-pricing-2-el9kqn?file=/src/layouts.css) provided by design team shows that the billing time frame description is shorten to allow more spacing.

<img width="397" alt="Screen Shot 2022-09-12 at 4 02 29 PM" src="https://user-images.githubusercontent.com/56598660/189602879-1eb35471-690c-4717-bb29-6d518abf5c52.png">


#### Proposed Changes
1. Update existing translation to allow easier CSS manipulation for shortening billing time frame description.
2. Create a custom `useItemPriceCompact` hook for handling container size changes and inserting/removing Item price `is-compact` class modifier.


#### Testing Instructions

1. * Run `git fetch && git checkout add/item-price-compact-functionality`
    * Run `yarn start-jetpack-cloud`
3. Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
4. Using chrome browser, open device tool and set device view to Ipad Air (portrait).
5. Confirm that billing time frame descriptions is shorten for the simple cards.
<img width="840" alt="Screen Shot 2022-09-12 at 4 05 30 PM" src="https://user-images.githubusercontent.com/56598660/189603518-d1162b44-7cee-41da-8687-4998043f5f6b.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202936358291323