### PR TITLE
Marketplace: Discover page title and margin fixes

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -5,6 +5,7 @@ import './style.scss';
 
 interface SectionProps {
 	header: ReactChild;
+	subheader?: ReactChild;
 	children: ReactChild | ReactChild[];
 	dark?: boolean;
 }
@@ -28,36 +29,49 @@ const SectionContainer = styled.div< SectionContainerProps >`
 		width: 200vw;
 		left: -100vw;
 		z-index: -1;
-		margin-top: -96px;
+		margin-top: -56px;
 	}
-	padding: 96px 0;
+	padding: 56px 0;
 `;
 
 const SectionHeader = styled.div< SectionHeaderProps >`
-	@media ( max-width: 660px ) {
-		padding: 0 16px;
-	}
-
 	color: var( --${ ( props ) => ( props.dark ? 'color-text-inverted' : 'color-text' ) } );
 	font-weight: 400;
 	letter-spacing: -0.4px;
 	text-align: left;
-	margin-bottom: 25px;
 	font-size: var( --scss-font-title-large );
-	max-width: 377px;
 	line-height: 40px;
+`;
+
+const SectionSubHeader = styled.div< SectionHeaderProps >`
+	color: var( --${ ( props ) => ( props.dark ? 'color-text-inverted' : 'color-text' ) } );
+	font-weight: 400;
+	text-align: left;
+	font-size: var( --scss-font-body-small );
+	margin-top: 8px;
+`;
+
+const SectionHeaderContainer = styled.div< SectionHeaderProps >`
+	@media ( max-width: 660px ) {
+		padding: 0 16px;
+	}
+	margin-bottom: 25px;
+	max-width: 377px;
 `;
 
 const SectionContent = styled.div``;
 
 const Section = ( props: SectionProps ) => {
-	const { children, header, dark } = props;
+	const { children, header, subheader, dark } = props;
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<SectionContainer dark={ dark }>
-			<SectionHeader dark={ dark } className="wp-brand-font">
-				{ header }
-			</SectionHeader>
+			<SectionHeaderContainer>
+				<SectionHeader dark={ dark } className="wp-brand-font">
+					{ header }
+				</SectionHeader>
+				{ subheader && <SectionSubHeader>{ subheader }</SectionSubHeader> }
+			</SectionHeaderContainer>
 			<SectionContent>{ children }</SectionContent>
 		</SectionContainer>
 	);

--- a/client/components/spotlight/index.tsx
+++ b/client/components/spotlight/index.tsx
@@ -57,7 +57,7 @@ const Spotlight: React.FunctionComponent< SpotlightProps > = ( props: SpotlightP
 	const { taglineText, illustrationSrc, onClick, titleText, ctaText } = props;
 
 	return (
-		<SpotlightContainer onClick={ onClick }>
+		<SpotlightContainer onClick={ onClick } className={ 'spotlight' }>
 			<SpotlightContent>
 				<SpotlightIllustration alt="Spotlight Logo" src={ illustrationSrc } />
 				<SpotlightTextContainer>

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -54,18 +54,23 @@ export function useCategories(
 	const categories = {
 		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
 		paid: {
-			name: __( 'Top premium plugins' ),
-			categoryDescription: __( 'A collection of the most popular premium plugins on offer.' ),
+			name: __( 'Must-have premium plugins' ),
+			categoryDescription: __( 'Add the best-loved plugins on WordPress.com' ),
 			slug: 'paid',
 			tags: [],
 		},
 		popular: {
-			name: __( 'Top free plugins' ),
-			categoryDescription: __( 'The most popular free plugins to extend your WordPress site.' ),
+			name: __( 'The free essentials' ),
+			categoryDescription: __( 'Add and install the very best free plugins' ),
 			slug: 'popular',
 			tags: [],
 		},
-		featured: { name: __( 'Editor’s pick' ), slug: 'featured', tags: [] },
+		featured: {
+			name: __( 'Our developers’ favorites' ),
+			categoryDescription: __( 'Start fast with these WordPress.com team picks' ),
+			slug: 'featured',
+			tags: [],
+		},
 		seo: {
 			name: __( 'Search Engine Optimization' ),
 			description: __( 'Search Optimization' ),

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -25,7 +25,7 @@ const ThreeColumnContainer = styled.div`
 `;
 
 const EducationFooterContainer = styled.div`
-	margin-top: 96px;
+	margin-top: 48px;
 `;
 
 const EducationFooter = () => {
@@ -44,7 +44,10 @@ const EducationFooter = () => {
 
 	return (
 		<EducationFooterContainer>
-			<Section header={ __( 'Learn more' ) }>
+			<Section
+				header={ __( 'Get started with plugins' ) }
+				subheader={ __( 'Our favorite how-to guides to get you started with plugins' ) }
+			>
 				<ThreeColumnContainer>
 					<LinkCard
 						external
@@ -82,9 +85,7 @@ const EducationFooter = () => {
 				</ThreeColumnContainer>
 			</Section>
 			<Section
-				header={ preventWidows(
-					__( 'Add additional features to your WordPress site. Risk free.' )
-				) }
+				header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
 				dark
 			>
 				<ThreeColumnContainer>
@@ -95,12 +96,12 @@ const EducationFooter = () => {
 					</FeatureItem>
 					<FeatureItem header={ __( 'Thousands of plugins' ) }>
 						{ __(
-							'Along with our hand curated collection of premium plugins, you also have thousands of community developed plugins at your disposal.'
+							'From WordPress.com premium plugins to thousands more community-authored plugins, we’ve got you covered.'
 						) }
 					</FeatureItem>
 					<FeatureItem header={ __( 'Flexible pricing' ) }>
 						{ __(
-							'WordPress.com offers monthly and annual premium plugin pricing for extra flexibility.'
+							'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
 						) }
 					</FeatureItem>
 				</ThreeColumnContainer>

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -7,7 +7,7 @@
 	cursor: pointer;
 	display: block;
 	float: left;
-	margin: 10px 0;
+	margin: 20px 0 0 0;
 	position: relative;
 	overflow: hidden;
 
@@ -16,18 +16,13 @@
 	}
 
 	.plugin-icon {
-		width: 48px;
-		height: 48px;
+		width: 60px;
+		height: 60px;
 		margin-right: 0;
 
 		&.is-placeholder {
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
-	}
-
-	.plugin-icon {
-		width: 60px;
-		height: 60px;
 	}
 
 	.plugins-browser-item__title,
@@ -51,11 +46,11 @@
 		}
 	}
 
-	@include breakpoint-deprecated( ">960px" ) {
+	@include breakpoint-deprecated(">960px") {
 		width: calc(50% - 10px); // 2 column grid with 20px gutter
 	}
 
-	@include breakpoint-deprecated( "<960px" ) {
+	@include breakpoint-deprecated("<960px") {
 		width: 100%;
 	}
 

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -87,22 +87,22 @@ const PluginsBrowserList = ( {
 
 	return (
 		<div className="plugins-browser-list">
-			<div className="plugins-browser-list__header">
-				{ ( title || subtitle ) && (
+			{ ( title || subtitle ) && (
+				<div className="plugins-browser-list__header">
 					<div className="plugins-browser-list__titles">
 						<div className={ classnames( 'plugins-browser-list__title', listName ) }>{ title }</div>
 						<div className="plugins-browser-list__subtitle">{ subtitle }</div>
 					</div>
-				) }
-				<div className="plugins-browser-list__actions">
-					{ expandedListLink && (
-						<a className="plugins-browser-list__browse-all" href={ expandedListLink }>
-							{ __( 'Browse All' ) }
-							<Gridicon icon="arrow-right" size="18" />
-						</a>
-					) }
+					<div className="plugins-browser-list__actions">
+						{ expandedListLink && (
+							<a className="plugins-browser-list__browse-all" href={ expandedListLink }>
+								{ __( 'Browse All' ) }
+								<Gridicon icon="arrow-right" size="18" />
+							</a>
+						) }
+					</div>
 				</div>
-			</div>
+			) }
 			{ listName === 'paid' && (
 				<AsyncLoad
 					require="calypso/blocks/jitm"

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -3,7 +3,6 @@
 
 .plugins-browser-list {
 	margin-bottom: 8px; // 32 + 8 = 40 gap
-	margin-top: 32px;
 
 	.feature-example & {
 		margin: 0;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -25,6 +25,10 @@
 	@include breakpoint-deprecated("<660px") {
 		padding: 0 16px;
 	}
+
+	.spotlight {
+		margin-top: 20px;
+	}
 }
 
 .plugins-browser-list__header {
@@ -35,6 +39,7 @@
 	flex-wrap: wrap;
 
 	padding-top: 32px;
+
 	.plugins-browser-list__titles {
 		margin-bottom: 4px; // +20 from elements = 24 gap
 

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,5 +1,9 @@
+@import "@automattic/onboarding/styles/base-styles.scss";
+@import "@automattic/onboarding/styles/mixins.scss";
+
 .plugins-browser-list {
-	margin-bottom: 16px;
+	margin-bottom: 8px; // 32 + 8 = 40 gap
+	margin-top: 32px;
 
 	.feature-example & {
 		margin: 0;
@@ -33,10 +37,11 @@
 
 	padding-top: 32px;
 	.plugins-browser-list__titles {
-		padding-bottom: 10px;
+		margin-bottom: 4px; // +20 from elements = 24 gap
 
 		.plugins-browser-list__title {
-			font-size: $font-title-small;
+			@include onboarding-font-recoleta;
+			font-size: $font-title-medium;
 			font-weight: 500;
 
 			&[class*="plugins-browser-list__search-for"] {
@@ -53,9 +58,10 @@
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: space-between;
+		margin-top: auto;
+		margin-bottom: 4px; // +20 from elements = 24 gap
 
 		> div {
-			padding-bottom: 10px;
 			flex-grow: 4;
 
 			.select-dropdown__container {
@@ -64,12 +70,10 @@
 		}
 
 		.plugins-browser-list__browse-all {
-			font-size: $font-body;
+			font-size: $font-body-small;
 			display: flex;
 			justify-content: flex-end;
 			align-items: center;
-			padding-bottom: 10px;
-			margin-left: 1.5rem;
 			flex-grow: 4;
 			svg {
 				margin-left: 2px;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,5 +1,5 @@
-@import "@automattic/onboarding/styles/base-styles.scss";
-@import "@automattic/onboarding/styles/mixins.scss";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .plugins-browser-list {
 	margin-bottom: 8px; // 32 + 8 = 40 gap
@@ -39,7 +39,7 @@
 		margin-bottom: 4px; // +20 from elements = 24 gap
 
 		.plugins-browser-list__title {
-			@include onboarding-font-recoleta;
+			@extend .wp-brand-font;
 			font-size: $font-title-medium;
 			font-weight: 500;
 
@@ -49,6 +49,7 @@
 		}
 
 		.plugins-browser-list__subtitle {
+			margin-top: 4px;
 			font-size: $font-body-small;
 		}
 	}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -147,7 +147,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				isSticky={ isAboveElement }
 				searchTerm={ search }
 				isSearching={ isFetchingPluginsBySearchTerm }
-				title={ translate( 'Plugins you need to get your projects done' ) }
+				title={ translate( 'Flex your site’s features with plugins' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,5 @@
-import { useTranslate } from 'i18n-calypso';
+import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -75,10 +76,11 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const siteId = useSelector( getSelectedSiteId );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
 
-	const translate = useTranslate();
+	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
 
 	const categories = useCategories();
-	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
+	const categoryName = categories[ category ]?.name || __( 'Plugins' );
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {
@@ -113,7 +115,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	};
 
 	if ( ! isRequestingSitesData && noPermissionsError ) {
-		return <NoPermissionsError title={ translate( 'Plugins', { textOnly: true } ) } />;
+		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
 
 	return (
@@ -129,7 +131,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				selectedSiteId={ selectedSite?.ID }
 				trackPageViews={ trackPageViews }
 			/>
-			<DocumentHead title={ translate( 'Plugins' ) } />
+			<DocumentHead title={ __( 'Plugins' ) } />
 
 			<PluginsAnnouncementModal />
 			{ ! hideHeader && (
@@ -147,7 +149,11 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				isSticky={ isAboveElement }
 				searchTerm={ search }
 				isSearching={ isFetchingPluginsBySearchTerm }
-				title={ translate( 'Flex your site’s features with plugins' ) }
+				title={
+					'en' === locale || hasTranslation( 'Flex your site’s features with plugins' )
+						? __( 'Flex your site’s features with plugins' )
+						: __( 'Plugins you need to get your projects done' )
+				}
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
 

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -40,6 +40,8 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) =>
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
+	const categoryDescription = categories[ category ]?.categoryDescription || null;
+
 	const { localizePath } = useLocalizedPlugins();
 
 	const installedPlugins = useSelector( ( state ) =>
@@ -64,6 +66,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) =>
 			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
 			listName={ category }
 			title={ categoryName }
+			subtitle={ categoryDescription }
 			site={ siteSlug }
 			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? localizePath( listLink ) : false }
 			size={ SHORT_LIST_LENGTH }

--- a/client/my-sites/plugins/plugins-category-results-page/header.scss
+++ b/client/my-sites/plugins/plugins-category-results-page/header.scss
@@ -3,10 +3,9 @@
 
 .plugin-category-results-header {
 	position: relative;
-	top: 36px;
-	padding: 12px 16px 0;
+	padding: 32px 16px 0 16px;
 
-	@include breakpoint-deprecated( ">660px" ) {
+	@include breakpoint-deprecated(">660px") {
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/client/my-sites/plugins/plugins-category-results-page/header.scss
+++ b/client/my-sites/plugins/plugins-category-results-page/header.scss
@@ -3,7 +3,7 @@
 
 .plugin-category-results-header {
 	position: relative;
-	padding: 32px 16px 0 16px;
+	padding: 32px 16px 4px 16px;
 
 	@include breakpoint-deprecated(">660px") {
 		padding-left: 0;
@@ -13,17 +13,19 @@
 
 .plugin-category-results-header__title {
 	@extend .wp-brand-font;
-	font-size: $font-title-large;
+	font-size: $font-title-medium;
 }
 
 .plugin-category-results-header__count {
 	color: var(--studio-gray-60);
-	margin-top: 8px;
+	font-size: $font-body-small;
+	margin-top: 4px;
 }
 
 .plugin-category-results-header__subtitle {
 	color: var(--studio-gray-80);
-	margin: 8px 0;
+	font-size: $font-body-small;
+	margin-top: 4px;
 
 	@include break-small {
 		width: 527px;

--- a/client/my-sites/plugins/plugins-category-results-page/header.tsx
+++ b/client/my-sites/plugins/plugins-category-results-page/header.tsx
@@ -13,7 +13,7 @@ const Header = ( {
 		<div className="plugin-category-results-header">
 			<h1 className="plugin-category-results-header__title">{ title }</h1>
 			{ subtitle && <h2 className="plugin-category-results-header__subtitle">{ subtitle }</h2> }
-			<p className="plugin-category-results-header__count">{ count }</p>
+			<div className="plugin-category-results-header__count">{ count }</div>
 		</div>
 	);
 };

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -57,6 +57,10 @@ const selectors = {
 export class PluginsPage {
 	private page: Page;
 
+	static paidSection = 'Must-have premium plugins';
+	static featuredSection = 'Our developers’ favorites';
+	static freeSection = 'The free essentials';
+
 	/**
 	 * Constructs an instance.
 	 */

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit();
 		} );
 
-		it.each( [ 'Top premium plugins', 'Editor’s pick', 'Top free plugins' ] )(
+		it.each( [ 'Must-have premium plugins', 'Our developers’ favorites', 'The free essentials' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 
 		it( 'Can browse all free plugins', async function () {
 			await pluginsPage.clickBrowseAllFreePlugins();
-			await pluginsPage.validateHasHeaderTitle( 'Top free plugins' );
+			await pluginsPage.validateHasHeaderTitle( 'The free essentials' );
 		} );
 
 		it( 'Can return via breadcrumb', async function () {
@@ -48,11 +48,11 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Top premium plugins' );
+			await pluginsPage.validateHasSection( 'Must-have premium plugins' );
 		} );
 		it( 'Can browse all premium plugins', async function () {
 			await pluginsPage.clickBrowseAllPaidPlugins();
-			await pluginsPage.validateHasHeaderTitle( 'Top premium plugins' );
+			await pluginsPage.validateHasHeaderTitle( 'Must-have premium plugins' );
 		} );
 
 		it( 'Can return via breadcrumb from premium plugins', async function () {
@@ -61,7 +61,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Top premium plugins' );
+			await pluginsPage.validateHasSection( 'Must-have premium plugins' );
 		} );
 
 		it.each( [
@@ -96,7 +96,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit( credentials.testSites?.primary.url as string );
 		} );
 
-		it.each( [ 'Top premium plugins', 'Editor’s pick', 'Top free plugins' ] )(
+		it.each( [ 'Must-have premium plugins', 'Our developers’ favorites', 'The free essentials' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit();
 		} );
 
-		it.each( [ 'Must-have premium plugins', 'Our developers’ favorites', 'The free essentials' ] )(
+		it.each( [ PluginsPage.paidSection, PluginsPage.featuredSection, PluginsPage.freeSection ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 
 		it( 'Can browse all free plugins', async function () {
 			await pluginsPage.clickBrowseAllFreePlugins();
-			await pluginsPage.validateHasHeaderTitle( 'The free essentials' );
+			await pluginsPage.validateHasHeaderTitle( PluginsPage.freeSection );
 		} );
 
 		it( 'Can return via breadcrumb', async function () {
@@ -48,11 +48,11 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Must-have premium plugins' );
+			await pluginsPage.validateHasSection( PluginsPage.paidSection );
 		} );
 		it( 'Can browse all premium plugins', async function () {
 			await pluginsPage.clickBrowseAllPaidPlugins();
-			await pluginsPage.validateHasHeaderTitle( 'Must-have premium plugins' );
+			await pluginsPage.validateHasHeaderTitle( PluginsPage.paidSection );
 		} );
 
 		it( 'Can return via breadcrumb from premium plugins', async function () {
@@ -61,7 +61,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Must-have premium plugins' );
+			await pluginsPage.validateHasSection( PluginsPage.paidSection );
 		} );
 
 		it.each( [
@@ -96,7 +96,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit( credentials.testSites?.primary.url as string );
 		} );
 
-		it.each( [ 'Must-have premium plugins', 'Our developers’ favorites', 'The free essentials' ] )(
+		it.each( [ PluginsPage.paidSection, PluginsPage.featuredSection, PluginsPage.freeSection ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );

--- a/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
+++ b/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		await pluginsPage.visit( siteUrl );
 	} );
 
-	it.each( [ 'Editor’s pick', 'Top free plugins' ] )(
+	it.each( [ 'Our developers’ favorites', 'The free essentials' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
 			await pluginsPage.validateHasSection( section );
@@ -39,6 +39,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 
 	// We don't support marketplace plugin purchases on self hosted sites. (Source code download restrictions)
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
-		await pluginsPage.validateNotHasSection( 'Top premium plugins' );
+		await pluginsPage.validateNotHasSection( 'Must-have premium plugins' );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
+++ b/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		await pluginsPage.visit( siteUrl );
 	} );
 
-	it.each( [ 'Our developers’ favorites', 'The free essentials' ] )(
+	it.each( [ PluginsPage.featuredSection, PluginsPage.freeSection ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
 			await pluginsPage.validateHasSection( section );
@@ -39,6 +39,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 
 	// We don't support marketplace plugin purchases on self hosted sites. (Source code download restrictions)
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
-		await pluginsPage.validateNotHasSection( 'Must-have premium plugins' );
+		await pluginsPage.validateNotHasSection( PluginsPage.paidSection );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -50,7 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		await pluginsPage.clickSearchResult( 'Royal Mail' );
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await pluginsPage.clickPluginsBreadcrumb();
-			await pluginsPage.validateHasSection( 'Top premium plugins' );
+			await pluginsPage.validateHasSection( 'Must-have premium plugins' );
 		} else {
 			await pluginsPage.clickBackBreadcrumb();
 			await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -50,7 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		await pluginsPage.clickSearchResult( 'Royal Mail' );
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await pluginsPage.clickPluginsBreadcrumb();
-			await pluginsPage.validateHasSection( 'Must-have premium plugins' );
+			await pluginsPage.validateHasSection( PluginsPage.paidSection );
 		} else {
 			await pluginsPage.clickBackBreadcrumb();
 			await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );


### PR DESCRIPTION
#### Proposed Changes

* Replaces discover page category titles and subheadings
* Updates misc discover page whitespace / margins / placements

#### Testing Instructions

* Load http://calypso.localhost:3000/plugins/
* Should see matching design updates per [this comment](https://github.com/Automattic/wp-calypso/issues/65574#issuecomment-1238156028) and new titles / subtitles per [this comment](https://github.com/Automattic/wp-calypso/issues/65574#issuecomment-1237461756).

Before
![Screenshot 2022-09-12 at 18-07-45 Plugins ‹ Business Atomic — WordPress com](https://user-images.githubusercontent.com/811776/189603889-3123d4bf-44b8-4c03-ad68-c1f5d0fd83b4.png)

After
![Screenshot 2022-09-12 at 18-07-39 Plugins ‹ Business Atomic — WordPress com](https://user-images.githubusercontent.com/811776/189603882-5ad86a8c-b125-4dd7-a6ac-c8b6ee761162.png)



Fixes https://github.com/Automattic/wp-calypso/issues/65574
