### PR TITLE
Plugin Management: UI enhancements based on CFT feedback

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -318,10 +318,6 @@ export class PluginsListHeader extends PureComponent {
 				className="plugin-list-header__actions-dropdown"
 				selectedText={ translate( 'Actions' ) }
 			>
-				<SelectDropdown.Item selected value="Actions">
-					{ translate( 'Actions' ) }
-				</SelectDropdown.Item>
-
 				<SelectDropdown.Separator />
 
 				<SelectDropdown.Item

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -1,5 +1,5 @@
-@import "@wordpress/base-styles/_breakpoints.scss";
-@import "@wordpress/base-styles/_mixins.scss";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .plugin-list-header.section-header.card {
 	.section-header__actions {
@@ -15,6 +15,7 @@
 
 	.button-group {
 		margin-left: 8px;
+		display: inherit;
 	}
 
 	&.is-placeholder {
@@ -25,11 +26,6 @@
 
 	&.is-bulk-editing .section-header__label {
 		display: none;
-	}
-
-	.button-group {
-		margin-left: 8px;
-		display: inherit;
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
@@ -138,18 +134,16 @@
 		}
 		.form-checkbox {
 			&:checked::before {
-				content: url("/calypso/images/checkbox-icons/checkmark-jetpack.svg");
+				content: url(/calypso/images/checkbox-icons/checkmark-jetpack.svg);
 			}
 		}
-	}
-	.plugin-list-header__action-buttons {
-		justify-content: end;
 	}
 	.plugin-list-header__bulk-select-wrapper {
 		display: flex;
 		align-items: center;
 	}
 	.plugin-list-header__bulk-select-label {
+		margin-inline-end: 16px;
 		font-size: 0.75rem;
 		font-weight: bold;
 
@@ -163,6 +157,7 @@
 	.plugin-list-header__actions-dropdown {
 		margin-inline-start: auto;
 	}
+
 	.plugin-list-header__mode-buttons {
 		flex-grow: 0;
 		margin-inline-start: 16px;
@@ -170,13 +165,24 @@
 			margin-inline-start: 32px;
 		}
 	}
-	.plugin-list-header__bulk-select-label {
-		margin-inline-end: 16px;
-	}
 
 	.plugin-list-header__action-buttons {
+		justify-content: end;
+
 		button.plugin-list-header__buttons-action-button {
 			color: var(--studio-gray-80);
+		}
+
+		button {
+			&:disabled {
+				background: var(--studio-gray-5);
+				color: var(--studio-gray-30);
+				border: none;
+			}
+
+			&:not(:first-child):disabled {
+				border-left: 1px solid  var(--studio-gray-10);
+			}
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/style.scss
@@ -1,14 +1,15 @@
-@import "@wordpress/base-styles/_breakpoints.scss";
-@import "@wordpress/base-styles/_mixins.scss";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .plugin-common-list__mobile-view {
-	@include break-xlarge() {
+	@include break-xlarge {
 		display: none;
 	}
 }
 .plugin-common-list__content-header {
 	margin-block-end: 0;
 	height: 50px;
+
 	> div {
 		color: var(--color-text);
 		font-size: 0.75rem;
@@ -19,7 +20,6 @@
 }
 .plugin-common-multi-site-table {
 	.plugin-common-table__table td:nth-child(1) {
-		max-width: fit-content;
+		width: auto;
 	}
-
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -133,6 +133,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 }
 
 .plugin-row-formatter__last-updated {
+	font-size: 0.75rem;
 	color: var(--color-text-subtle);
 
 	@include break-xlarge {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -140,6 +140,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 		text-align: right;
 		width: 100%;
 		display: inline-block;
+		white-space: pre;
 	}
 
 	// Cut off the "Updated on" part when there's no enough space.

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -133,6 +133,8 @@ a.button.plugin-row-formatter__plugin-name-card {
 }
 
 .plugin-row-formatter__last-updated {
+	color: var(--color-text-subtle);
+
 	@include break-xlarge {
 		// Align right when there's no enough space.
 		text-align: right;

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/style.scss
@@ -63,3 +63,10 @@ button.update-plugin__retry-button {
 		}
 	}
 }
+
+.has-bulk-management-active {
+	.update-plugin__plugin-update-wrapper {
+		opacity: 0.3;
+		pointer-events: none;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

This PR makes some UI enhancements to the plugin management based on CFT feedback.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/plugin-management-cft-enhancements` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Visit any single-site view and verify the `Updated x days ago` text color is updated to gray-60(`--color-text-subtle`) and doesn't break the text into 2 lines when the text is `Updated x months ago`

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="320" alt="Screenshot 2022-09-12 at 1 41 37 PM" src="https://user-images.githubusercontent.com/10586875/189632102-8027486d-267b-4841-b916-dd2a6329aa6e.png">
</td>
<td>
<img width="358" alt="Screenshot 2022-09-12 at 3 53 15 PM" src="https://user-images.githubusercontent.com/10586875/189631995-dc5682a8-9752-483f-874d-ad846109270b.png">
</td>
</tr>
<tr>
<td>
<img width="396" alt="Screenshot 2022-09-12 at 1 40 36 PM" src="https://user-images.githubusercontent.com/10586875/189604410-4ee899b5-79bb-480b-ae8c-c6c849e79239.png">
</td>
<td>
<img width="332" alt="Screenshot 2022-09-12 at 3 53 24 PM" src="https://user-images.githubusercontent.com/10586875/189632026-35fe8621-60e9-4fc6-82c9-9a9baba5572f.png">
</td>
</tr>
</table>


4. Click on the `Edit all` and verify the `Update to X` button to update the plugin is disabled.

<img width="1533" alt="Screenshot 2022-09-12 at 1 39 53 PM" src="https://user-images.githubusercontent.com/10586875/189604310-1064236e-b2a8-4b9a-ad2f-272792a2b892.png">

5. Unselect all the selected plugins when bulk action is active and verify the disabled button look as below.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="598" alt="Screenshot 2022-09-12 at 1 43 09 PM" src="https://user-images.githubusercontent.com/10586875/189605041-2cf3c666-62f5-496c-b08d-0b5ba7444007.png">
</td>
<td>
<img width="677" alt="Screenshot 2022-09-12 at 1 34 42 PM" src="https://user-images.githubusercontent.com/10586875/189603343-2de2d77f-7c1f-4c17-99aa-369b56a4f298.png">
</td>
</tr>
</table>

6. Go to mobile view and verify `Actions` item on mobile view is repeated in bulk actions

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="490" alt="Screenshot 2022-09-12 at 1 38 52 PM" src="https://user-images.githubusercontent.com/10586875/189604078-d74c1dc2-8759-47c8-af2c-588444a78adf.png">
</td>
<td>
<img width="422" alt="Screenshot 2022-09-12 at 1 15 11 PM" src="https://user-images.githubusercontent.com/10586875/189603924-989c2a2d-f9e0-4304-8a7b-6ddc8a278fdb.png">
</td>
</tr>
</table>

7. Switch to 1080px using the dev tool on a multi-single plugin view, verify the `Update to x plugin(s)` and `Edit all` buttons are not breaking into 2 lines.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="389" alt="Screenshot 2022-09-12 at 4 20 07 PM" src="https://user-images.githubusercontent.com/10586875/189636848-20822041-6932-4057-87f0-13aee4a39af3.png">
</td>
<td>
<img width="514" alt="Screenshot 2022-09-12 at 4 21 45 PM" src="https://user-images.githubusercontent.com/10586875/189636902-7cbcc991-b4f2-4f07-a202-f675089f9dc5.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202956254773512, 1202518759611394-as-1202956254773500, 1202518759611394-as-1202956254773489, 1202518759611394-as-1202956254773522, 1202518759611394-as-1202960604185800 & 1202518759611394-as-1202960604185794