### PR TITLE
Pattern Assembler: Go back to the main screen when clicking on the “Back” button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -61,6 +61,14 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		setShowPatternSelectorType( null );
 	};
 
+	const onBack = () => {
+		if ( showPatternSelectorType ) {
+			setShowPatternSelectorType( null );
+		} else {
+			goBack();
+		}
+	};
+
 	const stepContent = (
 		<div className="pattern-assembler__wrapper">
 			<div className="pattern-assembler__sidebar">
@@ -111,7 +119,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	return (
 		<StepContainer
 			stepName={ 'pattern-assembler' }
-			goBack={ goBack }
+			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			isWideLayout={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,6 +1,4 @@
-import { Button } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
 import type { Pattern } from './types';
@@ -13,12 +11,7 @@ type PatternSelectorProps = {
 };
 
 const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorProps ) => {
-	const translate = useTranslate();
 	const locale = useLocale();
-
-	const handleBackClick = () => {
-		onSelect( null );
-	};
 
 	return (
 		<div className="pattern-selector" style={ show ? {} : { height: 0, overflow: 'hidden' } }>
@@ -45,11 +38,6 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 						</PatternPreviewAutoHeight>
 					) ) }
 				</div>
-			</div>
-			<div className="pattern-selector__footer">
-				<Button className="pattern-assembler__button" onClick={ handleBackClick }>
-					{ translate( 'Back' ) }
-				</Button>
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -41,9 +41,9 @@ $font-family: "SF Pro Text", $sans;
 
 	.pattern-assembler__sidebar {
 		width: 280px;
-		margin-bottom: 0;
 		box-sizing: border-box;
 		margin-top: 50px;
+		margin-bottom: 32px;
 	}
 
 	.pattern-layout {
@@ -179,20 +179,14 @@ $font-family: "SF Pro Text", $sans;
 		}
 
 		.pattern-selector__body {
-			margin: 32px 0;
+			margin-top: 32px;
 			padding: 2px;
-			max-height: calc(100vh - 298px);
 			overflow-y: scroll;
 			scrollbar-width: none;
 
 			&::-webkit-scrollbar {
 				display: none;
 			}
-		}
-
-		.pattern-selector__footer {
-			margin-top: auto;
-			margin-bottom: 32px;
 		}
 
 		.pattern-selector__block-list {
@@ -207,7 +201,6 @@ $font-family: "SF Pro Text", $sans;
 			}
 
 			div {
-				margin-bottom: 16px;
 				border: 1px solid rgba(0, 0, 0, 0.05);
 				border-radius: 4px;
 				min-height: 140px;
@@ -215,6 +208,10 @@ $font-family: "SF Pro Text", $sans;
 				overflow: hidden;
 				user-select: none;
 				cursor: pointer;
+
+				&:not(:last-child) {
+					margin-bottom: 16px;
+				}
 
 				&:focus,
 				&:hover {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -162,7 +162,6 @@ $font-family: "SF Pro Text", $sans;
 
 		.pattern-layout__footer {
 			margin-top: auto;
-			margin-bottom: 32px;
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* According to https://github.com/Automattic/wp-calypso/issues/67630, the behavior of the “Back” button at the top-left corner is incorrect, so this PR changes its behavior and let the user go back to the main screen instead of the previous step.
* As we can use the “Back” button at the top-left corner to go back to the main screen, I remove the “Back” button at the bottom to avoid confusion

https://user-images.githubusercontent.com/13596067/189605771-3dc4cb5e-5994-4257-a2de-ecbe57f62476.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/patternAssembler?siteSlug=<your_site>`
* Select “Choose a header”, “Add a first section”, or “Choose a footer” to go to the pattern selector
* On the pattern selector, you won't see the “Back” button at the bottom
* Click the “Back” button at the top-left corner, and you will go back to the main screen
* On the main screen, click the “Back” button again and you will go back to the Design Picker step

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67630
