### PR TITLE
Turn on the subscriber role when the subscriber/importer feature flag is off

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -405,6 +405,7 @@ class InvitePeople extends Component {
 	renderInviteForm = () => {
 		const { site, translate, needsVerification, isJetpack, showSSONotice } = this.props;
 		let includeFollower;
+		const includeSubscriber = ! isEnabled( 'subscriber-importer' );
 
 		if ( ! isEnabled( 'subscriber-importer' ) ) {
 			// Atomic private sites don't support Viewers/Followers.
@@ -450,6 +451,7 @@ class InvitePeople extends Component {
 							value={ this.state.role }
 							disabled={ this.state.sendingInvites }
 							includeFollower={ includeFollower }
+							includeSubscriber={ includeSubscriber }
 							explanation={ this.renderRoleExplanation() }
 						/>
 


### PR DESCRIPTION
#### Proposed Changes

- Turn on the subscriber role when the subscriber/importer feature flag is off

#### Screenshot
<img width="745" alt="Screenshot 2022-09-12 at 10 22 24" src="https://user-images.githubusercontent.com/1241413/189606830-ffc131f9-7032-4812-9135-1d9ac9b89afd.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/new/{SLUG}.wpcomstaging.com?flags=-subscriber-importer`
* Check if there is a subscriber role

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #67531
