### PR TITLE
Newsletter Accent Color: Default input state should be blue

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -1,5 +1,11 @@
 import { Button, FormInputValidation, Popover } from '@automattic/components';
-import { hasMinContrast, StepContainer, RGB, base64ImageToBlob } from '@automattic/onboarding';
+import {
+	hasMinContrast,
+	hexToRgb,
+	StepContainer,
+	RGB,
+	base64ImageToBlob,
+} from '@automattic/onboarding';
 import { ColorPicker } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -71,10 +77,10 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 
 	useEffect( () => {
 		const { siteAccentColor, siteTitle, siteDescription, siteLogo } = state;
-		if ( defaultAccentColor.hex === siteAccentColor ) {
-			setAccentColor( defaultAccentColor );
+		if ( siteAccentColor && siteAccentColor !== '' && siteAccentColor !== defaultAccentColor.hex ) {
+			setAccentColor( { hex: siteAccentColor, rgb: hexToRgb( siteAccentColor ) } );
 		} else {
-			setAccentColor( { ...defaultAccentColor, hex: siteAccentColor } );
+			setAccentColor( defaultAccentColor );
 		}
 
 		setTagline( siteDescription );

--- a/packages/onboarding/src/utils/contrastChecker.ts
+++ b/packages/onboarding/src/utils/contrastChecker.ts
@@ -32,3 +32,18 @@ export const hasMinContrast = (
 	const contrast = colorContrastRatio( textColorLuminance, bgColorLuminance );
 	return contrast <= minContrastRatio;
 };
+
+// Works also with shorthand hex triplets such as "#03F"
+export const hexToRgb = ( hex: string ) => {
+	const rgbHex = hex
+		.replace( /^#?([a-f\d])([a-f\d])([a-f\d])$/i, ( _m, r, g, b ) => '#' + r + r + g + g + b + b )
+		.substring( 1 )
+		.match( /.{2}/g );
+
+	if ( rgbHex?.length !== 3 ) {
+		throw 'Unexpected RGB hex value';
+	}
+
+	const [ r, g, b ] = rgbHex.map( ( x ) => parseInt( x, 16 ) );
+	return { r, g, b };
+};


### PR DESCRIPTION
#### The Issue
![Screen Shot 2022-09-09 at 15 00 55](https://user-images.githubusercontent.com/2019970/189610522-eeea6fbd-42e4-4b00-8e6f-e419be6b3f2a.png)

This is a regression that was introduced with: https://github.com/Automattic/wp-calypso/pull/67275

#### Proposed Changes

* If the initial store's value for site accent color is empty string - set the input's value to default

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear local storage for http://calypso.localhost:3000
![Screen Shot 2022-09-12 at 10 40 24](https://user-images.githubusercontent.com/2019970/189610450-5c0d6c65-5ae6-4197-a46d-e7d8539377d4.png)

* Go to http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter
* Check that the default color is set correctly once page loads
* Play around with the color picker to ensure contrast checker works as expected too

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #67603
