### PR TITLE
Style selection: Move the submit button to bottom-left on desktop resolution

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -329,6 +329,25 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			vertical_id: selectedDesign.verticalizable ? siteVerticalId : undefined,
 		} );
 
+		const pickDesignText =
+			selectedDesign?.design_type === 'vertical' || isEnabledStyleSelection
+				? translate( 'Select and continue' )
+				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
+
+		const actionButtons = (
+			<div>
+				{ shouldUpgrade ? (
+					<Button primary borderless={ false } onClick={ upgradePlan }>
+						{ translate( 'Unlock theme' ) }
+					</Button>
+				) : (
+					<Button primary borderless={ false } onClick={ () => pickDesign() }>
+						{ pickDesignText }
+					</Button>
+				) }
+			</div>
+		);
+
 		const stepContent = (
 			<>
 				<UpgradeModal
@@ -347,6 +366,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 						variations={ selectedDesignDetails?.style_variations }
 						selectedVariation={ selectedStyleVariation }
 						onSelectVariation={ setSelectedStyleVariation }
+						actionButtons={ actionButtons }
 					/>
 				) : (
 					<WebPreview
@@ -372,35 +392,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			</>
 		);
 
-		const pickDesignText =
-			selectedDesign?.design_type === 'vertical' || isEnabledStyleSelection
-				? translate( 'Select and continue' )
-				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
-
-		const actionButtons = (
-			<div>
-				{ shouldUpgrade ? (
-					<Button primary borderless={ false } onClick={ upgradePlan }>
-						{ translate( 'Unlock theme' ) }
-					</Button>
-				) : (
-					<Button primary borderless={ false } onClick={ () => pickDesign() }>
-						{ pickDesignText }
-					</Button>
-				) }
-			</div>
-		);
-
 		return isEnabledStyleSelection ? (
 			<StepContainer
 				stepName={ STEP_NAME }
 				stepContent={ stepContent }
 				hideSkip
 				className="design-setup__preview design-setup__preview__has-more-info"
-				nextLabelText={ pickDesignText }
 				goBack={ handleBackClick }
-				goNext={ () => pickDesign() }
-				customizedActionButtons={ actionButtons }
+				customizedActionButtons={ isMobile ? actionButtons : undefined }
 				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		) : (

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -11,6 +11,7 @@ interface PreviewProps {
 	variations?: StyleVariation[];
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
+	actionButtons: React.ReactNode;
 }
 
 const Preview: React.FC< PreviewProps > = ( {
@@ -20,6 +21,7 @@ const Preview: React.FC< PreviewProps > = ( {
 	variations = [],
 	selectedVariation,
 	onSelectVariation,
+	actionButtons,
 } ) => {
 	useEffect( () => {
 		if ( variations.length > 0 && ! selectedVariation ) {
@@ -35,6 +37,7 @@ const Preview: React.FC< PreviewProps > = ( {
 				variations={ variations }
 				selectedVariation={ selectedVariation }
 				onSelectVariation={ onSelectVariation }
+				actionButtons={ actionButtons }
 			/>
 			<SitePreview url={ previewUrl } inlineCss={ selectedVariation?.inline_css || '' } />
 		</div>

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarProps {
 	variations: StyleVariation[];
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
+	actionButtons: React.ReactNode;
 }
 
 const Sidebar: React.FC< SidebarProps > = ( {
@@ -16,6 +17,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	variations = [],
 	selectedVariation,
 	onSelectVariation,
+	actionButtons,
 } ) => {
 	return (
 		<div className="design-preview__sidebar">
@@ -40,6 +42,10 @@ const Sidebar: React.FC< SidebarProps > = ( {
 						/>
 					</div>
 				</div>
+			) }
+
+			{ actionButtons && (
+				<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>
 			) }
 		</div>
 	);

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -78,6 +78,16 @@
 		}
 	}
 
+	.design-preview__sidebar-action-buttons {
+		position: absolute;
+		bottom: 0;
+
+		&,
+		button {
+			width: 100%;
+		}
+	}
+
 	@include break-small {
 		border: 0;
 		box-shadow: none;

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -81,10 +81,12 @@
 	.design-preview__sidebar-action-buttons {
 		position: absolute;
 		bottom: 0;
+		width: 100%;
 
-		&,
 		button {
 			width: 100%;
+			border-radius: 4px;
+			box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

Moved the button to the sidebar as per the latest design:

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/1525580/189612879-2fcd59c6-6cdb-4da6-b937-af67ee01eed4.png">

I'm not sure if it's the best approach as it renders the navigation button outside `<StepContainer/>`. Any idea or is it good enough?

#### Testing Instructions

1. Go to `/setup?siteSlug=<your-site-slug>`
2. Select any goal and click Continue.
3. Select any vertical and click Continue.
4. Select Pendant theme.
5. Verify that the submission button is now in the sidebar, at the bottom.
6. Resize the browser to the mobile resolution.
7. Verify that the submission button is still the same (bottom-right)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66842
