### PR TITLE
Videopress onboarding: plan selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,26 +1,23 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import type { Step } from '../../types';
 
-import './style.scss';
-
 const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } ) {
 	const { goNext, goBack, submit } = navigation;
 	const isVideoPressFlow = 'videopress' === flow;
-
-	const onSkip = () => {
-		submit?.( { domainName: '' } );
-	};
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
 	const getVideoPressFlowStepContent = () => {
 		const onAddDomain = ( { domain_name }: any ) => {
 			submit?.( { domainName: domain_name } );
+		};
+
+		const onSkip = () => {
+			submit?.( { domainName: '' } );
 		};
 
 		const domainSuggestion = data?.domainName ?? data?.siteTitle ?? '';
@@ -37,34 +34,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 					showAlreadyOwnADomain={ false }
 					onAddDomain={ onAddDomain }
 					onSkip={ onSkip }
-					promoTlds={ [ 'video', 'studio', 'productions', 'com' ] }
 				/>
 			</CalypsoShoppingCartProvider>
-		);
-	};
-
-	const getFormattedHeader = () => {
-		if ( ! isVideoPressFlow ) {
-			return undefined;
-		}
-
-		return (
-			<FormattedHeader
-				id={ 'choose-a-domain-header' }
-				headerText="Choose a domain"
-				subHeaderText={
-					<>
-						Make your video site shine with a custom domain. Not sure yet ?{ ' ' }
-						<button
-							className="button navigation-link step-container__navigation-link has-underline is-borderless"
-							onClick={ onSkip }
-						>
-							Decide later.
-						</button>
-					</>
-				}
-				align={ 'center' }
-			/>
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,29 +1,40 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { useSelect, useDispatch } from '@wordpress/data';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import type { Step } from '../../types';
 
 import './style.scss';
 
-const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } ) {
+const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
 	const isVideoPressFlow = 'videopress' === flow;
+	const [ siteTitle, domain ] = useSelect( ( select ) => {
+		return [
+			select( ONBOARD_STORE ).getSelectedSiteTitle(),
+			select( ONBOARD_STORE ).getSelectedDomain(),
+		];
+	} );
+	const { setDomain } = useDispatch( ONBOARD_STORE );
 
 	const onSkip = () => {
-		submit?.( { domainName: '' } );
+		setDomain( domain );
+		submit?.( { domain: domain } );
 	};
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
 	const getVideoPressFlowStepContent = () => {
-		const onAddDomain = ( { domain_name }: any ) => {
-			submit?.( { domainName: domain_name } );
+		const onAddDomain = ( selectedDomain: any ) => {
+			setDomain( selectedDomain );
+			submit?.( { domain: selectedDomain } );
 		};
 
-		const domainSuggestion = data?.domainName ?? data?.siteTitle ?? '';
+		const domainSuggestion = domain ? domain.domain_name : siteTitle;
 
 		return (
 			<CalypsoShoppingCartProvider>
@@ -37,7 +48,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 					showAlreadyOwnADomain={ false }
 					onAddDomain={ onAddDomain }
 					onSkip={ onSkip }
-					promoTlds={ [ 'video', 'studio', 'productions', 'com' ] }
+					promoTlds={ [ 'video', 'studio', 'productions', 'film', 'tv', 'com' ] }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -37,6 +37,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 					showAlreadyOwnADomain={ false }
 					onAddDomain={ onAddDomain }
 					onSkip={ onSkip }
+					promoTlds={ [ 'video', 'studio', 'productions', 'com' ] }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,23 +1,26 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import type { Step } from '../../types';
 
+import './style.scss';
+
 const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } ) {
 	const { goNext, goBack, submit } = navigation;
 	const isVideoPressFlow = 'videopress' === flow;
+
+	const onSkip = () => {
+		submit?.( { domainName: '' } );
+	};
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
 	const getVideoPressFlowStepContent = () => {
 		const onAddDomain = ( { domain_name }: any ) => {
 			submit?.( { domainName: domain_name } );
-		};
-
-		const onSkip = () => {
-			submit?.( { domainName: '' } );
 		};
 
 		const domainSuggestion = data?.domainName ?? data?.siteTitle ?? '';
@@ -36,6 +39,31 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow, data } )
 					onSkip={ onSkip }
 				/>
 			</CalypsoShoppingCartProvider>
+		);
+	};
+
+	const getFormattedHeader = () => {
+		if ( ! isVideoPressFlow ) {
+			return undefined;
+		}
+
+		return (
+			<FormattedHeader
+				id={ 'choose-a-domain-header' }
+				headerText="Choose a domain"
+				subHeaderText={
+					<>
+						Make your video site shine with a custom domain. Not sure yet ?{ ' ' }
+						<button
+							className="button navigation-link step-container__navigation-link has-underline is-borderless"
+							onClick={ onSkip }
+						>
+							Decide later.
+						</button>
+					</>
+				}
+				align={ 'center' }
+			/>
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -35,6 +35,25 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		};
 
 		const domainSuggestion = domain ? domain.domain_name : siteTitle;
+		const promoTlds = [
+			'video',
+			'tube',
+			'movie',
+			'live',
+			'network',
+			'news',
+			'show',
+			'watch',
+			'media',
+			'productions',
+			'digital',
+			'plus',
+			'online',
+			'film',
+			'tv',
+			'studio',
+			'com',
+		];
 
 		return (
 			<CalypsoShoppingCartProvider>
@@ -48,7 +67,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					showAlreadyOwnADomain={ false }
 					onAddDomain={ onAddDomain }
 					onSkip={ onSkip }
-					promoTlds={ [ 'video', 'studio', 'productions', 'film', 'tv', 'com' ] }
+					promoTlds={ promoTlds }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -12,6 +13,7 @@ import './style.scss';
 
 const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
+	const { __ } = useI18n();
 	const isVideoPressFlow = 'videopress' === flow;
 	const [ siteTitle, domain ] = useSelect( ( select ) => {
 		return [
@@ -84,12 +86,12 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 				headerText="Choose a domain"
 				subHeaderText={
 					<>
-						Make your video site shine with a custom domain. Not sure yet ?{ ' ' }
+						{ __( 'Make your video site shine with a custom domain. Not sure yet ?' ) }
 						<button
 							className="button navigation-link step-container__navigation-link has-underline is-borderless"
 							onClick={ onSkip }
 						>
-							Decide later.
+							{ __( 'Decide later.' ) }
 						</button>
 					</>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -25,13 +25,12 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow, data } ) {
 		return (
 			<CalypsoShoppingCartProvider>
 				<PlansGrid
-					header={ <h1>Test</h1> }
 					currentDomain={ undefined }
 					onPlanSelect={ onPlanSelect }
 					currentPlanProductId={ undefined }
 					onPickDomainClick={ undefined }
 					isAccordion={ false }
-					selectedFeatures={ undefined }
+					selectedFeatures={ [ 'video-storage' ] }
 					locale={ locale }
 					onBillingPeriodChange={ undefined }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
+import { StepContainer } from 'calypso/../packages/onboarding/src';
+import PlansGrid from 'calypso/../packages/plans-grid/src/plans-grid';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import type { Step } from '../../types';
+
+const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow, data } ) {
+	const { goNext, goBack, submit } = navigation;
+	const isVideoPressFlow = 'videopress' === flow;
+	const { __ } = useI18n();
+	const locale = useLocale();
+
+	const onSkip = () => {};
+
+	const getDefaultStepContent = () => <h1>Choose a plan step</h1>;
+
+	const getVideoPressFlowStepContent = () => {
+		const domainName = data?.domainName ?? '';
+		const onPlanSelect = () => {};
+
+		return (
+			<CalypsoShoppingCartProvider>
+				<PlansGrid
+					header={ <h1>Test</h1> }
+					currentDomain={ undefined }
+					onPlanSelect={ onPlanSelect }
+					currentPlanProductId={ undefined }
+					onPickDomainClick={ undefined }
+					isAccordion={ false }
+					selectedFeatures={ undefined }
+					locale={ locale }
+					onBillingPeriodChange={ undefined }
+				/>
+			</CalypsoShoppingCartProvider>
+		);
+	};
+
+	const getFormattedHeader = () => {
+		if ( ! isVideoPressFlow ) {
+			return undefined;
+		}
+
+		return (
+			<FormattedHeader
+				id={ 'choose-a-plan-header' }
+				headerText="Choose a plan"
+				subHeaderText={
+					<>
+						{ __( 'Unlock a powerful bundle of features for your video site.' ) }
+						<button
+							className="button navigation-link step-container__navigation-link has-underline is-borderless"
+							onClick={ onSkip }
+						>
+							{ __( 'Or start with a free plan.' ) }
+						</button>
+					</>
+				}
+				align={ 'center' }
+			/>
+		);
+	};
+
+	const stepContent = isVideoPressFlow ? getVideoPressFlowStepContent() : getDefaultStepContent();
+
+	return (
+		<StepContainer
+			stepName={ 'chooseAPlan' }
+			shouldHideNavButtons={ isVideoPressFlow }
+			goBack={ goBack }
+			goNext={ goNext }
+			isHorizontalLayout={ false }
+			isWideLayout={ true }
+			isLargeSkipLayout={ false }
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+			formattedHeader={ getFormattedHeader() }
+		/>
+	);
+};
+
+export default ChooseAPlan;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -37,6 +37,7 @@ export { default as intro } from './intro';
 export { default as linkInBioSetup } from './link-in-bio-setup';
 export { default as completingPurchase } from './completing-purchase';
 export { default as chooseADomain } from './choose-a-domain';
+export { default as chooseAPlan } from './choose-a-plan';
 export { default as launchpad } from './launchpad';
 export { default as subscribers } from './subscribers';
 export { default as patterns } from './patterns';
@@ -87,4 +88,5 @@ export type StepPath =
 	| 'launchpad'
 	| 'subscribers'
 	| 'promote'
-	| 'getCurrentThemeSoftwareSets';
+	| 'getCurrentThemeSoftwareSets'
+	| 'chooseAPlan';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -21,8 +21,8 @@ import './style.scss';
 
 const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 	const { goBack, goNext, submit } = navigation;
-	const [ siteTitle, setSiteTitle ] = React.useState( ( data?.siteTitle ?? '' ) as string );
-	const [ tagline, setTagline ] = React.useState( ( data?.tagline ?? '' ) as string );
+	const [ siteTitle, setSiteTitle ] = React.useState( '' );
+	const [ tagline, setTagline ] = React.useState( '' );
 	const [ formTouched, setFormTouched ] = React.useState( false );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -19,7 +19,7 @@ import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import './style.scss';
 
-const SiteOptions: Step = function SiteOptions( { navigation, flow, data } ) {
+const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 	const { goBack, goNext, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( ( data?.siteTitle ?? '' ) as string );
 	const [ tagline, setTagline ] = React.useState( ( data?.tagline ?? '' ) as string );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,6 +1,6 @@
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
@@ -27,13 +27,11 @@ export const videopress: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const name = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const { setStepProgress, setSiteTitle, setSiteDescription } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
-		const [ _siteTitle, setSiteTitle ] = useState( '' );
-		const [ _tagline, setTagline ] = useState( '' );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -48,13 +46,11 @@ export const videopress: Flow = {
 				case 'options': {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
-					setTagline( tagline as string );
+					setSiteDescription( tagline as string );
 					return navigate( 'chooseADomain' );
 				}
 
 				case 'chooseADomain': {
-					const { domainName } = providedDependencies;
-					setDomainName( domainName as string );
 					return navigate( 'chooseAPlan' );
 				}
 
@@ -75,7 +71,7 @@ export const videopress: Flow = {
 		const goBack = () => {
 			switch ( _currentStep ) {
 				case 'chooseADomain':
-					return navigate( 'options', { siteTitle: _siteTitle, tagline: _tagline } );
+					return navigate( 'options' );
 			}
 			return;
 		};
@@ -91,18 +87,7 @@ export const videopress: Flow = {
 		};
 
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
-			switch ( step ) {
-				case 'options':
-					return navigate( step, { siteTitle: _siteTitle, tagline: _tagline } );
-				case 'chooseADomain':
-					return navigate( step, {
-						siteTitle: _siteTitle,
-						tagline: _tagline,
-						domainName: _domainName,
-					} );
-				default:
-					return navigate( step );
-			}
+			return navigate( step );
 		};
 
 		return { goNext, goBack, goToStep, submit };

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -19,9 +19,7 @@ export const videopress: Flow = {
 			'intro',
 			'options',
 			'chooseADomain',
-			// 'videopressSetup',
-			// 'patterns',
-			'completingPurchase',
+			'chooseAPlan',
 			'processing',
 			'launchpad',
 		] as StepPath[];
@@ -54,10 +52,13 @@ export const videopress: Flow = {
 					return navigate( 'chooseADomain' );
 				}
 
-				case 'chooseADomain':
-					return navigate( 'completingPurchase' );
+				case 'chooseADomain': {
+					const { domainName } = providedDependencies;
+					setDomainName( domainName as string );
+					return navigate( 'chooseAPlan' );
+				}
 
-				case 'completingPurchase':
+				case 'chooseAPlan':
 					return navigate( 'processing' );
 
 				case 'processing': {

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -36,7 +36,6 @@ export const videopress: Flow = {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const [ _siteTitle, setSiteTitle ] = useState( '' );
 		const [ _tagline, setTagline ] = useState( '' );
-		const [ _domainName, setDomainName ] = useState( '' );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -52,14 +51,11 @@ export const videopress: Flow = {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
 					setTagline( tagline as string );
-					return navigate( 'chooseADomain', { siteTitle: siteTitle } );
+					return navigate( 'chooseADomain' );
 				}
 
-				case 'chooseADomain': {
-					const { domainName } = providedDependencies;
-					setDomainName( domainName as string );
+				case 'chooseADomain':
 					return navigate( 'completingPurchase' );
-				}
 
 				case 'completingPurchase':
 					return navigate( 'processing' );


### PR DESCRIPTION
#### Proposed Changes

This PR adds the plan selection step in the videopress flow.
Design and plan validation are still to be done, this PR is adding the basic feature to the flow.

#### Testing Instructions
* Apply this PR
* Go to http://calypso.localhost:3000/setup/intro?flow=videopress
* ✅ If you're logged in, you should be redirected to the options step
* ✅ If you're not logged in, you should be redirected to the account creation step, then to the options step
* Add a site title and click continue
* ✅ You should be redirected to the domain selection step, with the site title as suggestion
* Select a domain
* ✅ You should be redirected to the plan selection page
* ✅ Only premium and business should be displayed
* ✅ The page shouldn't be skippable and no free plan should be selectable here

Related to 1296-gh-Automattic/greenhouse