### PR TITLE
Remove checks for Quick Start banner translations

### DIFF
--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -46,22 +46,15 @@ class ConciergeBanner extends Component {
 	}
 
 	getBannerContent() {
-		const { bannerType, locale, translate } = this.props;
+		const { bannerType, translate } = this.props;
 
 		let title;
 		let description;
 		let buttonText;
 		let event;
-		let hasTranslations = locale.startsWith( 'en' );
 
 		switch ( bannerType ) {
 			case CONCIERGE_HAS_UPCOMING_APPOINTMENT:
-				hasTranslations =
-					hasTranslations ||
-					( i18n.hasTranslation( 'Your Quick Start session is coming up soon' ) &&
-						i18n.hasTranslation(
-							'Your {{supportLink}}Quick Start support session{{/supportLink}} is approaching. Get ready for your one-to-one with our Happiness Engineer.'
-						) );
 				title = translate( 'Your Quick Start session is coming up soon' );
 				description = translate(
 					'Your {{supportLink}}Quick Start support session{{/supportLink}} is approaching. Get ready for your one-to-one with our Happiness Engineer.',
@@ -81,12 +74,6 @@ class ConciergeBanner extends Component {
 				event = 'view-concierge-dashboard';
 				break;
 			case CONCIERGE_HAS_AVAILABLE_SESSION:
-				hasTranslations =
-					hasTranslations ||
-					( i18n.hasTranslation( 'You still have a Quick Start session available' ) &&
-						i18n.hasTranslation(
-							'Schedule your {{supportLink}}Quick Start support session{{/supportLink}} and get one-on-one guidance from our expert Happiness Engineers to kickstart your site.'
-						) );
 				title = translate( 'You still have a Quick Start session available' );
 				description = translate(
 					`Schedule your {{supportLink}}Quick Start support session{{/supportLink}} and get one-on-one guidance from our expert Happiness Engineers to kickstart your site.`,
@@ -107,7 +94,7 @@ class ConciergeBanner extends Component {
 				break;
 		}
 
-		return { title, description, buttonText, event, hasTranslations };
+		return { title, description, buttonText, event };
 	}
 
 	render() {
@@ -117,11 +104,7 @@ class ConciergeBanner extends Component {
 			return this.placeholder();
 		}
 
-		const { buttonText, description, title, event, hasTranslations } = this.getBannerContent();
-
-		if ( ! hasTranslations ) {
-			return null;
-		}
+		const { buttonText, description, title, event } = this.getBannerContent();
 
 		return (
 			<>


### PR DESCRIPTION
#### Proposed Changes

* This PR removes the translation checks added in https://github.com/Automattic/wp-calypso/pull/67024, as the [translation of the strings has now been completed](https://github.com/Automattic/wp-calypso/pull/67024#issuecomment-1241802716).

#### Testing Instructions

* You will need to set up a back end server to do two things:
  a. Mock an upcoming appointment; which you can do using the steps documented here: 2d8ef-pb
  b. Mock a user who has one or more available Quick Start sessions
* Run this branch via the live branch, or locally
* Sandbox `public-api.wordpress.com` and enable the upcoming appointment mocking
* Visit `/me/purchases` and verify that the correct Quick Start banner is displayed
* Visit `/me/account` and change your UI language to another language
* Visit `/me/purchases` and verify that the Quick Start banner is displayed -- if you're using one of the languages listed in the [main translation page](https://translate.wordpress.com/deliverables/overview/7511588/), you should see translated test, but you may still see the untranslated English text if you picked another language
* Update the back end to disable the upcoming appointment mock, and switch to mock a user with available/unused Quick Start sessions
* Visit `/me/purchases` again, and verify that you see the Quick Start banner mentioning that you still have unused sessions - this should be in your non-English language
* Visit `/me/account` and switch back to your default language
* Visit `/me/purchases` and verify that you see the Quick Start banner

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ x ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #67024