### PR TITLE
Limit Global Styles: Add gate selector

### DIFF
--- a/client/state/selectors/site-has-full-global-styles.tsx
+++ b/client/state/selectors/site-has-full-global-styles.tsx
@@ -1,0 +1,27 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { WPCOM_FEATURES_GLOBAL_STYLES } from '@automattic/calypso-products';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks if Global Styles are fully available to the given site.
+ *
+ * @param  {object}  state       Global state tree
+ * @param  {number}  siteId      The ID of the site we're querying
+ * @returns {boolean} Whether Global Styles are fully available (true) or restricted (false).
+ */
+export default function siteHasFullGlobalStyles( state: AppState, siteId: number ) {
+	// Grant the full feature to sites created before we started to restrict it.
+	// This cutoff blog ID needs to be updated once we launch the limited global styles to the public.
+	if ( siteId < 210494207 ) {
+		return true;
+	}
+
+	// Limit the full feature to sites that have an eligible purchase.
+	if ( siteHasFeature( state, siteId, WPCOM_FEATURES_GLOBAL_STYLES ) ) {
+		return true;
+	}
+
+	// Rest of sites are restricted if the feature flag is enabled. This check should be removed before launch.
+	return ! isEnabled( 'limit-global-styles' );
+}

--- a/client/state/selectors/test/site-has-full-global-styles.js
+++ b/client/state/selectors/test/site-has-full-global-styles.js
@@ -1,0 +1,51 @@
+import { WPCOM_FEATURES_GLOBAL_STYLES } from '@automattic/calypso-products';
+import siteHasFullGlobalStyles from 'calypso/state/selectors/site-has-full-global-styles';
+
+describe( 'selectors', () => {
+	describe( '#siteHasFullGlobalStyles()', () => {
+		test( 'should return true for legacy sites', () => {
+			const state = {
+				sites: {
+					features: {
+						210494206: {
+							data: {
+								active: [],
+							},
+						},
+					},
+				},
+			};
+			expect( siteHasFullGlobalStyles( state, 210494206 ) ).toEqual( true );
+		} );
+
+		test( 'should return true for sites with eligible purchases', () => {
+			const state = {
+				sites: {
+					features: {
+						210494207: {
+							data: {
+								active: [ WPCOM_FEATURES_GLOBAL_STYLES ],
+							},
+						},
+					},
+				},
+			};
+			expect( siteHasFullGlobalStyles( state, 210494207 ) ).toEqual( true );
+		} );
+
+		test( 'should return false for non-legacy sites without eligible purchases', () => {
+			const state = {
+				sites: {
+					features: {
+						210494207: {
+							data: {
+								active: [],
+							},
+						},
+					},
+				},
+			};
+			expect( siteHasFullGlobalStyles( state, 210494207 ) ).toEqual( false );
+		} );
+	} );
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -96,6 +96,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
+		"limit-global-styles": true,
 		"login/magic-login": true,
 		"logmein": true,
 		"mailchimp": true,

--- a/config/test.json
+++ b/config/test.json
@@ -59,6 +59,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
+		"limit-global-styles": true,
 		"mailchimp": true,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,


### PR DESCRIPTION
Part of 800-gh-Automattic/dotcom-forge

#### Proposed Changes

Adds a new selector to limit the Global Styles on free sites created after today since we want to grant the full functionality of Global Styles to existing sites (note that the cutoff blog ID used in the check needs to be updated once we're ready to launch the limited global styles to the public).

Because we want the development behind a feature flag, the feature is only limited when the `limit-global-styles` feature flag is enabled.

#### Testing Instructions

Everything should be covered by the new unit test: 

```
yarn run test-client client/state/selectors/test/site-has-full-global-styles.js
```

Alternatively, you can play around with the new `siteHasFullGlobalStyles` selector with your sites to check that you get the expected values.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?