### PR TITLE
Domains: Remove unused properties from the `resolveDomainStatus` function

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -37,7 +37,6 @@ export type ResolveDomainStatusReturn =
 			status: ReactChild;
 			icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
 			listStatusText?: ReactChild | Array< ReactChild >;
-			listStatusClass?: 'alert' | 'warning' | 'verifying' | 'info' | 'premium' | 'transfer-warning';
 			listStatusWeight?: number;
 			noticeText?: ReactChild | Array< ReactChild > | null;
 	  }
@@ -141,7 +140,6 @@ export function resolveDomainStatus(
 					status: status,
 					icon: 'info',
 					listStatusText: expiresMessage,
-					listStatusClass: domain.autoRenewing ? 'info' : 'alert',
 					listStatusWeight: isExpiringSoon( domain, 7 ) ? 1000 : 800,
 					noticeText,
 				};
@@ -178,7 +176,6 @@ export function resolveDomainStatus(
 							"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
 							{ components: mappingSetupComponents }
 						),
-						listStatusClass: 'alert',
 						listStatusWeight: 1000,
 					};
 				}
@@ -204,7 +201,6 @@ export function resolveDomainStatus(
 							},
 						}
 					),
-					listStatusClass: 'verifying',
 					listStatusWeight: 600,
 				};
 			}
@@ -242,7 +238,6 @@ export function resolveDomainStatus(
 							},
 						}
 					),
-					listStatusClass: 'warning',
 					listStatusWeight: 400,
 				};
 			}
@@ -256,7 +251,6 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: pendingRenewalMessage,
 					noticeText: translate( 'Attempting to get it renewed for you.' ),
-					listStatusClass: 'warning',
 					listStatusWeight: 400,
 				};
 			}
@@ -415,7 +409,6 @@ export function resolveDomainStatus(
 							'timeSinceExpiry is of the form "[number] [time-period] ago" e.g. "3 days ago"',
 					} ),
 					noticeText,
-					listStatusClass: 'alert',
 					listStatusWeight: 1000,
 				};
 			}
@@ -456,7 +449,6 @@ export function resolveDomainStatus(
 						icon: 'info',
 						listStatusText: domainExpirationMessage,
 						noticeText: expiresMessage,
-						listStatusClass: 'alert',
 						listStatusWeight: 1000,
 					};
 				}
@@ -468,7 +460,6 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: expiresMessage,
 					noticeText: expiresMessage,
-					listStatusClass: 'warning',
 					listStatusWeight: 800,
 				};
 			}
@@ -510,7 +501,6 @@ export function resolveDomainStatus(
 					icon: 'cloud_upload',
 					listStatusText: translate( 'Activating' ),
 					noticeText,
-					listStatusClass: 'info',
 					listStatusWeight: 400,
 				};
 			}
@@ -530,7 +520,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-premium',
 					status: translate( 'Active' ),
 					icon: 'check_circle',
-					listStatusClass: 'premium',
 				};
 			}
 
@@ -563,7 +552,6 @@ export function resolveDomainStatus(
 							},
 						}
 					),
-					listStatusClass: 'transfer-warning',
 					listStatusWeight: 600,
 				};
 			}
@@ -589,7 +577,6 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusText: noticeText,
 					noticeText: noticeText,
-					listStatusClass: 'warning',
 					listStatusWeight: 400,
 				};
 			}
@@ -667,7 +654,6 @@ export function resolveDomainStatus(
 							},
 						}
 					),
-					listStatusClass: 'transfer-warning',
 					listStatusWeight: 600,
 				};
 			} else if ( domain.transferStatus === transferStatus.CANCELLED ) {
@@ -684,7 +670,6 @@ export function resolveDomainStatus(
 						'Transfer failed. Learn the possible {{a}}reasons why{{/a}}.',
 						transferOptions
 					),
-					listStatusClass: 'alert',
 					listStatusWeight: 1000,
 				};
 			} else if ( domain.transferStatus === transferStatus.PENDING_REGISTRY ) {
@@ -702,7 +687,6 @@ export function resolveDomainStatus(
 							'The transfer should complete by {{strong}}%(transferFinishDate)s{{/strong}}. We are waiting for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 							transferOptions
 						),
-						listStatusClass: 'verifying',
 						listStatusWeight: 200,
 					};
 				}
@@ -719,7 +703,6 @@ export function resolveDomainStatus(
 						'We are waiting for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 						transferOptions
 					),
-					listStatusClass: 'verifying',
 					listStatusWeight: 200,
 				};
 			}
@@ -739,7 +722,6 @@ export function resolveDomainStatus(
 							transferOptions
 					  )
 					: null,
-				listStatusClass: 'verifying',
 				listStatusWeight: 200,
 			};
 

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -36,7 +36,6 @@ export type ResolveDomainStatusReturn =
 				| 'status-premium';
 			status: ReactChild;
 			icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
-			listStatusText?: ReactChild | Array< ReactChild >;
 			listStatusWeight?: number;
 			noticeText?: ReactChild | Array< ReactChild > | null;
 	  }
@@ -139,7 +138,6 @@ export function resolveDomainStatus(
 					statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
 					status: status,
 					icon: 'info',
-					listStatusText: expiresMessage,
 					listStatusWeight: isExpiringSoon( domain, 7 ) ? 1000 : 800,
 					noticeText,
 				};
@@ -154,24 +152,11 @@ export function resolveDomainStatus(
 					moment.utc().isAfter( registrationDatePlus3Days );
 
 				if ( hasMappingError ) {
-					let status;
-					if ( domain?.connectionMode === 'advanced' ) {
-						status = translate(
-							'{{strong}}Connection error:{{/strong}} The A records are incorrect. Please {{a}}try this step{{/a}} again.',
-							{ components: mappingSetupComponents }
-						);
-					} else {
-						status = translate(
-							'{{strong}}Connection error:{{/strong}} The name servers are incorrect. Please {{a}}try this step{{/a}} again.',
-							{ components: mappingSetupComponents }
-						);
-					}
 					return {
 						statusText: translate( 'Connection error' ),
 						statusClass: 'status-alert',
 						status: translate( 'Error' ),
 						icon: 'info',
-						listStatusText: status,
 						noticeText: translate(
 							"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
 							{ components: mappingSetupComponents }
@@ -182,16 +167,11 @@ export function resolveDomainStatus(
 			}
 
 			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
-				const status = translate(
-					'{{strong}}Verifying connection:{{/strong}} You can continue to work on your site, but your domain won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
-					{ components: mappingSetupComponents }
-				);
 				return {
 					statusText: translate( 'Verifying' ),
 					statusClass: 'status-success',
 					status: translate( 'Verifying' ),
 					icon: 'verifying',
-					listStatusText: status,
 					noticeText: translate(
 						'It can take between a few minutes to 72 hours to verify the connection. You can continue to work on your site, but {{strong}}%(domainName)s{{/strong}} won’t be reachable just yet. You can review the {{a}}setup instructions{{/a}} to ensure everything is correct.',
 						{
@@ -249,7 +229,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-success',
 					status: translate( 'Renewing' ),
 					icon: 'info',
-					listStatusText: pendingRenewalMessage,
 					noticeText: translate( 'Attempting to get it renewed for you.' ),
 					listStatusWeight: 400,
 				};
@@ -401,13 +380,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Expired' ),
 					icon: 'info',
-					listStatusText: translate( 'Expired %(timeSinceExpiry)s', {
-						args: {
-							timeSinceExpiry: moment.utc( domain.expiry ).fromNow(),
-						},
-						comment:
-							'timeSinceExpiry is of the form "[number] [time-period] ago" e.g. "3 days ago"',
-					} ),
 					noticeText,
 					listStatusWeight: 1000,
 				};
@@ -447,7 +419,6 @@ export function resolveDomainStatus(
 						statusClass: 'status-error',
 						status: translate( 'Expiring soon' ),
 						icon: 'info',
-						listStatusText: domainExpirationMessage,
 						noticeText: expiresMessage,
 						listStatusWeight: 1000,
 					};
@@ -458,7 +429,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-warning',
 					status: translate( 'Expiring soon' ),
 					icon: 'info',
-					listStatusText: expiresMessage,
 					noticeText: expiresMessage,
 					listStatusWeight: 800,
 				};
@@ -499,7 +469,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-success',
 					status: translate( 'Activating' ),
 					icon: 'cloud_upload',
-					listStatusText: translate( 'Activating' ),
 					noticeText,
 					listStatusWeight: 400,
 				};
@@ -529,20 +498,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-success',
 					status: translate( 'Active' ),
 					icon: 'info',
-					listStatusText: translate(
-						'{{strong}}Point to WordPress.com:{{/strong}} To point this domain to your WordPress.com site, you need to update the name servers. {{a}}Update now{{/a}} or do this later.',
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ domainManagementEdit( siteSlug as string, domain.domain ) }
-										onClick={ ( e ) => e.stopPropagation() }
-									/>
-								),
-							},
-						}
-					),
 					noticeText: translate(
 						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
 						{
@@ -575,7 +530,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-warning',
 					status: translate( 'Pending' ),
 					icon: 'info',
-					listStatusText: noticeText,
 					noticeText: noticeText,
 					listStatusWeight: 400,
 				};
@@ -621,25 +575,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-warning',
 					status: translate( 'Complete setup' ),
 					icon: 'info',
-					listStatusText: translate(
-						'{{strong}}Transfer waiting:{{/strong}} Follow {{a}}these steps{{/a}} by %(beginTransferUntilDate)s to start the transfer.',
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_STATUSES ) }
-										rel="noopener noreferrer"
-										target="_blank"
-										onClick={ ( e ) => e.stopPropagation() }
-									/>
-								),
-							},
-							args: {
-								beginTransferUntilDate: moment.utc( domain.beginTransferUntilDate ).format( 'LL' ),
-							},
-						}
-					),
 					noticeText: translate(
 						'Please follow {{a}}these instructions{{/a}} to start the transfer.',
 						{
@@ -662,10 +597,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Failed' ),
 					icon: 'info',
-					listStatusText: translate(
-						'{{strong}}Transfer failed:{{/strong}} this transfer has failed. {{a}}Learn more{{/a}}',
-						transferOptions
-					),
 					noticeText: translate(
 						'Transfer failed. Learn the possible {{a}}reasons why{{/a}}.',
 						transferOptions
@@ -679,10 +610,6 @@ export function resolveDomainStatus(
 						statusClass: 'status-success',
 						status: translate( 'In progress' ),
 						icon: 'info',
-						listStatusText: translate(
-							'{{strong}}Transfer in progress:{{/strong}} the transfer should be completed by %(transferFinishDate)s. We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
-							transferOptions
-						),
 						noticeText: translate(
 							'The transfer should complete by {{strong}}%(transferFinishDate)s{{/strong}}. We are waiting for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 							transferOptions
@@ -695,10 +622,6 @@ export function resolveDomainStatus(
 					statusClass: 'status-success',
 					status: translate( 'In progress' ),
 					icon: 'info',
-					listStatusText: translate(
-						'{{strong}}Transfer in progress:{{/strong}} We are waiting for approval from your current domain provider to proceed. {{a}}Learn more{{/a}}',
-						transferOptions
-					),
 					noticeText: translate(
 						'We are waiting for authorization from your current domain provider to proceed. {{a}}Learn more{{/a}}',
 						transferOptions
@@ -712,10 +635,6 @@ export function resolveDomainStatus(
 				statusClass: 'status-success',
 				status: translate( 'In progress' ),
 				icon: 'cached',
-				listStatusText: translate(
-					'{{strong}}Transfer in progress.{{/strong}} {{a}}Learn more{{/a}}',
-					transferOptions
-				),
 				noticeText: domain.transferEndDate
 					? translate(
 							'The transfer should complete by {{strong}}%(transferFinishDate)s{{/strong}}. {{a}}Learn more{{/a}}',


### PR DESCRIPTION
#### Proposed Changes

This PR removes the unused `listStatusClass` and `listStatusText` properties from the `resolveDomainStatus` function. PR #60005 removed the `DomainItem` component which used these properties, but they remained in `resolveDomainStatus` until now.

#### Testing Instructions

Code inspection should be enough because the properties weren't being used anywhere anymore. But it's a good idea to take a look at the domain list page and ensure everything looks right.

#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
