### PR TITLE
Tailored Flows: Leaving checkout brings you to launchpad

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -1,7 +1,12 @@
+import { isTailoredSignupFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
-import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import {
+	clearSignupDestinationCookie,
+	getSignupCompleteFlowName,
+	retrieveSignupDestination,
+} from 'calypso/signup/storageUtils';
 
 const debug = debugFactory( 'calypso:leave-checkout' );
 
@@ -25,6 +30,16 @@ export const leaveCheckout = ( {
 		previousPath,
 		createUserAndSiteBeforeTransaction,
 	} );
+
+	const signupFlowName = getSignupCompleteFlowName();
+	const isTailoredSignup = isTailoredSignupFlow( signupFlowName );
+
+	if ( isTailoredSignup ) {
+		const urlFromCookie = retrieveSignupDestination();
+		if ( urlFromCookie ) {
+			window.location.assign( urlFromCookie );
+		}
+	}
 
 	if ( jetpackCheckoutBackUrl ) {
 		window.location.href = jetpackCheckoutBackUrl;

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -32,9 +32,8 @@ export const leaveCheckout = ( {
 	} );
 
 	const signupFlowName = getSignupCompleteFlowName();
-	const isTailoredSignup = isTailoredSignupFlow( signupFlowName );
 
-	if ( isTailoredSignup ) {
+	if ( isTailoredSignupFlow( signupFlowName ) ) {
 		const urlFromCookie = retrieveSignupDestination();
 		if ( urlFromCookie ) {
 			window.location.assign( urlFromCookie );


### PR DESCRIPTION
#### Proposed Changes

When leaving the checkout pages, users are brought to '/plans', so leaving the tailored flows. Now they remain in the flow and are sent to launchpad.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch and `yarn start`
* Try leaving checkout in LiB and Newsletter flow
* You should land in `launchpad`
* Verify that you can proceed with checkout

Related to #67441
Fixes #67441
