### PR TITLE
NewsletterSetup: remove outline on focus of Accent Color Popover

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -155,6 +155,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			/>
 			<Popover
 				isVisible={ colorPickerOpen }
+				className="newsletter-setup__accent-color-popover"
 				context={ accentColorRef.current }
 				position="top left"
 				onClose={ () => setColorPickerOpen( false ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -105,3 +105,9 @@ $border-radius: 4px;
 		width: unset !important;
 	}
 }
+
+.newsletter-setup__accent-color-popover {
+	&:focus {
+		outline: none;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -107,7 +107,8 @@ $border-radius: 4px;
 }
 
 .newsletter-setup__accent-color-popover {
-	&:focus {
+	&:focus,
+	&:focus-visible {
 		outline: none;
 	}
 }


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
|  <img width="546" alt="Screenshot 2022-09-12 at 18 04 24" src="https://user-images.githubusercontent.com/7000684/189702209-c7ca98d5-68df-4f6a-b553-3fda29b13142.png"> | <img width="527" alt="Screenshot 2022-09-12 at 18 03 55" src="https://user-images.githubusercontent.com/7000684/189702305-00de75fa-5d60-44b5-adc0-f576b7840e64.png">  |

#### Proposed Changes

* This PR fixes the popover outline that happens on focus of the accent color picker

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Follow the newsletter flow and reach the setup step
- Click on the description field
- Press the `Tab` key
- Expected: the picker popover to open without an outline

Related to #
