### PR TITLE
Tailored flow: Fix line height problem in setup textarea

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -56,7 +56,7 @@ $font-family: "SF Pro Text", $sans;
 		textarea,
 		pre {
 			min-height: 44px;
-			line-height: 1.5;
+			line-height: 2;
 			padding-top: 7px;
 			padding-bottom: 7px;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -62,7 +62,7 @@ $border-radius: 4px;
 			color: var(--studio-gray-100);
 			font-size: $font-body-small;
 			padding: 12px 16px;
-			height: $input-height;
+			min-height: $input-height;
 			border-radius: $border-radius;
 			background-repeat: no-repeat;
 			background-position: 95%;


### PR DESCRIPTION
#### Proposed Changes

We added a textarea in the flow setup steps, but text was slighty off. Updating `line-height` fixed it:

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/52076348/189702630-b619773b-96a2-4021-83e3-dc13095d6a03.png)  |![image](https://user-images.githubusercontent.com/52076348/189702677-e06dbf18-c719-4c70-9c8e-400e41a7ae6e.png) |



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch and `yarn start`
* Check the design in the setup steps in both Link in Bio and Newsletter