### PR TITLE
Sites Management Dashboard: Add dropdown to choose between alphabetical and last publish sorting

### DIFF
--- a/client/data/sites/site-excerpt-types.ts
+++ b/client/data/sites/site-excerpt-types.ts
@@ -14,7 +14,9 @@ export type SiteExcerptNetworkData = Pick<
 
 export type SiteExcerptData = Pick<
 	SiteDetails,
-	typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] | typeof SITE_EXCERPT_COMPUTED_FIELDS[ number ]
+	| Exclude< typeof SITE_EXCERPT_REQUEST_FIELDS[ number ], 'name' >
+	| typeof SITE_EXCERPT_COMPUTED_FIELDS[ number ]
 > & {
+	name: string;
 	options?: Pick< SiteDetailsOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
 };

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -81,7 +81,8 @@ type SitesContentControlsProps = {
 	initialSearch?: string;
 	statuses: Statuses;
 	selectedStatus: Statuses[ number ];
-} & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher >;
+} & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher > &
+	ComponentPropsWithoutRef< typeof SitesListSortingDropdown >;
 
 export const SitesContentControls = ( {
 	initialSearch,
@@ -89,6 +90,8 @@ export const SitesContentControls = ( {
 	selectedStatus,
 	displayMode,
 	onDisplayModeChange,
+	sitesListSorting,
+	onSitesListSortingChange,
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 
@@ -116,7 +119,10 @@ export const SitesContentControls = ( {
 					) ) }
 				</ControlsSelectDropdown>
 				<VisibilityControls>
-					<SitesListSortingDropdown />
+					<SitesListSortingDropdown
+						sitesListSorting={ sitesListSorting }
+						onSitesListSortingChange={ onSitesListSortingChange }
+					/>
 					<SitesDisplayModeSwitcher
 						displayMode={ displayMode }
 						onDisplayModeChange={ onDisplayModeChange }

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -41,24 +41,36 @@ const DisplayControls = styled.div( {
 	alignItems: 'center',
 	alignSelf: 'stretch',
 	flex: 1,
+
+	[ MEDIA_QUERIES.small ]: {
+		flexDirection: 'column',
+	},
 } );
 
 const VisibilityControls = styled.div( {
 	display: 'flex',
 	gap: '10px',
-	marginInlineStart: 'auto',
 	flexShrink: 0,
 	alignItems: 'center',
+
+	[ MEDIA_QUERIES.small ]: {
+		width: '100%',
+		justifyContent: 'space-between',
+	},
+
+	[ MEDIA_QUERIES.mediumOrLarger ]: {
+		marginInlineStart: 'auto',
+	},
 } );
 
 const ControlsSelectDropdown = styled( SelectDropdown )( {
 	width: '100%',
 
 	'.select-dropdown__container': {
-		width: '100%',
+		minWidth: '100%',
 
 		[ MEDIA_QUERIES.mediumOrLarger ]: {
-			width: 'auto',
+			minWidth: 'fit-content',
 		},
 	},
 } );

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -7,6 +7,7 @@ import { ComponentPropsWithoutRef } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { MEDIA_QUERIES } from '../utils';
 import { SitesDisplayModeSwitcher } from './sites-display-mode-switcher';
+import { SitesListSortingDropdown } from './sites-list-sorting-dropdown';
 import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
 
@@ -40,6 +41,14 @@ const DisplayControls = styled.div( {
 	alignItems: 'center',
 	alignSelf: 'stretch',
 	flex: 1,
+} );
+
+const VisibilityControls = styled.div( {
+	display: 'flex',
+	gap: '10px',
+	marginInlineStart: 'auto',
+	flexShrink: 0,
+	alignItems: 'center',
 } );
 
 const ControlsSelectDropdown = styled( SelectDropdown )( {
@@ -94,10 +103,13 @@ export const SitesContentControls = ( {
 						</SelectDropdown.Item>
 					) ) }
 				</ControlsSelectDropdown>
-				<SitesDisplayModeSwitcher
-					displayMode={ displayMode }
-					onDisplayModeChange={ onDisplayModeChange }
-				/>
+				<VisibilityControls>
+					<SitesListSortingDropdown />
+					<SitesDisplayModeSwitcher
+						displayMode={ displayMode }
+						onDisplayModeChange={ onDisplayModeChange }
+					/>
+				</VisibilityControls>
 			</DisplayControls>
 		</FilterBar>
 	);

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -18,6 +18,7 @@ import { NoSitesMessage } from './no-sites-message';
 import { SitesDashboardQueryParams, SitesContentControls } from './sites-content-controls';
 import { useSitesDisplayMode } from './sites-display-mode-switcher';
 import { SitesGrid } from './sites-grid';
+import { useSitesListSorting } from './sites-list-sorting-dropdown';
 import { SitesTable } from './sites-table';
 
 interface SitesDashboardProps {
@@ -140,6 +141,7 @@ export function SitesDashboard( {
 	const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
+	const [ sitesListSorting, onSitesListSortingChange ] = useSitesListSorting();
 
 	const elementRef = useRef( window );
 
@@ -175,6 +177,8 @@ export function SitesDashboard( {
 							selectedStatus={ selectedStatus }
 							displayMode={ displayMode }
 							onDisplayModeChange={ setDisplayMode }
+							sitesListSorting={ sitesListSorting }
+							onSitesListSortingChange={ onSitesListSortingChange }
 						/>
 					) }
 					{ filteredSites.length > 0 || isLoading ? (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -18,7 +18,7 @@ import { NoSitesMessage } from './no-sites-message';
 import { SitesDashboardQueryParams, SitesContentControls } from './sites-content-controls';
 import { useSitesDisplayMode } from './sites-display-mode-switcher';
 import { SitesGrid } from './sites-grid';
-import { useSitesListSorting } from './sites-list-sorting-dropdown';
+import { parseSorting, useSitesListSorting } from './sites-list-sorting-dropdown';
 import { SitesTable } from './sites-table';
 
 interface SitesDashboardProps {
@@ -127,21 +127,22 @@ export function SitesDashboard( {
 
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 
-	const { sortedSites } = useSitesTableSorting( allSites, {
-		sortKey: 'updated-at',
-		sortOrder: 'desc',
-	} );
-
-	const { filteredSites, statuses } = useSitesTableFiltering( sortedSites, {
+	const { filteredSites, statuses } = useSitesTableFiltering( allSites, {
 		search,
 		showHidden: search ? true : showHidden,
 		status,
 	} );
 
+	const [ sitesListSorting, onSitesListSortingChange ] = useSitesListSorting();
+
+	const { sortedSites } = useSitesTableSorting(
+		sitesListSorting === 'none' ? [] : filteredSites,
+		parseSorting( sitesListSorting )
+	);
+
 	const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
-	const [ sitesListSorting, onSitesListSortingChange ] = useSitesListSorting();
 
 	const elementRef = useRef( window );
 
@@ -181,19 +182,19 @@ export function SitesDashboard( {
 							onSitesListSortingChange={ onSitesListSortingChange }
 						/>
 					) }
-					{ filteredSites.length > 0 || isLoading ? (
+					{ sortedSites.length > 0 || isLoading ? (
 						<>
 							{ displayMode === 'list' && (
 								<SitesTable
 									isLoading={ isLoading }
-									sites={ filteredSites }
+									sites={ sortedSites }
 									className={ sitesMargin }
 								/>
 							) }
 							{ displayMode === 'tile' && (
 								<SitesGrid
 									isLoading={ isLoading }
-									sites={ filteredSites }
+									sites={ sortedSites }
 									className={ sitesMargin }
 								/>
 							) }

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -2,10 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector, useStore } from 'react-redux';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 
 const container = css( {
 	marginInlineStart: 'auto',
@@ -13,43 +10,17 @@ const container = css( {
 	gap: '10px',
 } );
 
-type SitesDisplayMode = 'tile' | 'list' | 'none';
+type SitesDisplayMode = 'tile' | 'list';
 
-const PREFERENCE_NAME = 'sites-management-dashboard-display-mode';
-
-export const useSitesDisplayMode = () => {
-	const store = useStore();
-	const dispatch = useDispatch();
-	const remotePreferencesLoaded = useSelector( hasReceivedRemotePreferences );
-
-	const [ displayMode, setLocalDisplayMode ] = useState< SitesDisplayMode >( () => {
-		if ( ! remotePreferencesLoaded ) {
-			return 'none';
-		}
-
-		return getPreference( store.getState(), PREFERENCE_NAME ) ?? 'tile';
+export const useSitesDisplayMode = () =>
+	useAsyncPreference< SitesDisplayMode >( {
+		defaultValue: 'tile',
+		preferenceName: 'sites-management-dashboard-display-mode',
 	} );
-
-	useEffect( () => {
-		if ( remotePreferencesLoaded ) {
-			setLocalDisplayMode( getPreference( store.getState(), PREFERENCE_NAME ) ?? 'tile' );
-		}
-	}, [ remotePreferencesLoaded, store ] );
-
-	const setDisplayMode = useCallback(
-		( newValue: SitesDisplayMode ) => {
-			setLocalDisplayMode( newValue );
-			dispatch( savePreference( PREFERENCE_NAME, newValue ) );
-		},
-		[ dispatch ]
-	);
-
-	return [ displayMode, setDisplayMode ] as const;
-};
 
 interface SitesDisplayModeSwitcherProps {
 	onDisplayModeChange( newValue: SitesDisplayMode ): void;
-	displayMode: SitesDisplayMode;
+	displayMode: ReturnType< typeof useSitesDisplayMode >[ 0 ];
 }
 
 export const SitesDisplayModeSwitcher = ( {

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -5,7 +5,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 
 const container = css( {
-	marginInlineStart: 'auto',
 	display: 'flex',
 	gap: '10px',
 } );

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -65,10 +65,10 @@ export const SitesListSortingDropdown = ( {
 
 		switch ( sitesListSorting ) {
 			case `alphabetically${ SEPARATOR }asc`:
-				return __( 'Sorting: alphabetically' );
+				return __( 'Sorted alphabetically' );
 
 			case `updatedAt${ SEPARATOR }desc`:
-				return __( 'Sorting: last publish date' );
+				return __( 'Sorted by last published' );
 
 			default:
 				throw new Error( `invalid sort value ${ sitesListSorting }` );

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -1,9 +1,11 @@
 import { Gridicon, SitesTableSortKey, SitesTableSortOrder } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { useMediaQuery } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
+import { SMALL_MEDIA_QUERY } from '../utils';
 
 const SortingButton = styled( Button )( {
 	alignSelf: 'stretch',
@@ -53,6 +55,7 @@ export const SitesListSortingDropdown = ( {
 	onSitesListSortingChange,
 	sitesListSorting,
 }: SitesListSortingDropdownProps ) => {
+	const isSmallScreen = useMediaQuery( SMALL_MEDIA_QUERY );
 	const { __ } = useI18n();
 
 	const label = useMemo( () => {
@@ -78,7 +81,7 @@ export const SitesListSortingDropdown = ( {
 
 	return (
 		<Dropdown
-			position="bottom center"
+			position={ isSmallScreen ? 'bottom left' : 'bottom center' }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<SortingButton
 					icon={ <SortingButtonIcon icon={ isOpen ? 'chevron-up' : 'chevron-down' } /> }

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -84,7 +84,7 @@ export const SitesListSortingDropdown = ( {
 			position="bottom center"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<SortingButton
-					icon={ <SortingButtonIcon icon={ isOpen ? 'arrow-up' : 'arrow-down' } /> }
+					icon={ <SortingButtonIcon icon={ isOpen ? 'chevron-up' : 'chevron-down' } /> }
 					iconSize={ 16 }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -62,13 +62,13 @@ export const SitesListSortingDropdown = ( {
 
 		switch ( sitesListSorting ) {
 			case `alphabetically${ SEPARATOR }asc`:
-				return __( 'Sorted alphabetically (A-Z)' );
+				return __( 'Sorting: alphabetically (A-Z)' );
 
 			case `alphabetically${ SEPARATOR }desc`:
-				return __( 'Sorted alphabetically (Z-A)' );
+				return __( 'Sorting: alphabetically (Z-A)' );
 
 			case `updatedAt${ SEPARATOR }desc`:
-				return __( 'Sorted by last publish date' );
+				return __( 'Sorting: last publish date' );
 
 			default:
 				throw new Error( `invalid sort value ${ sitesListSorting }` );

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -1,7 +1,9 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, SitesTableSortKey, SitesTableSortOrder } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useMemo } from 'react';
+import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 
 const SortingButton = styled( Button )( {
 	alignSelf: 'stretch',
@@ -14,8 +16,48 @@ const SortingButtonIcon = styled( Gridicon )( {
 	marginRight: '0 !important',
 } );
 
-export const SitesListSortingDropdown = () => {
+type SitesListSorting = `${ SitesTableSortKey }-${ SitesTableSortOrder }`;
+
+export const useSitesListSorting = () =>
+	useAsyncPreference< SitesListSorting >( {
+		defaultValue: 'updated-at-desc',
+		preferenceName: 'sites-list-sorting',
+	} );
+
+interface SitesListSortingDropdownProps {
+	onSitesListSortingChange( newValue: SitesListSorting ): void;
+	sitesListSorting: ReturnType< typeof useSitesListSorting >[ 0 ];
+}
+
+export const SitesListSortingDropdown = ( {
+	onSitesListSortingChange,
+	sitesListSorting,
+}: SitesListSortingDropdownProps ) => {
 	const { __ } = useI18n();
+
+	const label = useMemo( () => {
+		if ( sitesListSorting === 'none' ) {
+			return null;
+		}
+
+		switch ( sitesListSorting ) {
+			case 'alphabetically-asc':
+				return __( 'Sorted alphabetically (A-Z)' );
+
+			case 'alphabetically-desc':
+				return __( 'Sorted alphabetically (Z-A)' );
+
+			case 'updated-at-desc':
+				return __( 'Sorted by last publish date' );
+
+			default:
+				throw new Error( 'invalid sort key' );
+		}
+	}, [ __, sitesListSorting ] );
+
+	if ( sitesListSorting === 'none' ) {
+		return null;
+	}
 
 	return (
 		<Dropdown
@@ -27,14 +69,35 @@ export const SitesListSortingDropdown = () => {
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 				>
-					{ __( 'Sorted alphabetically (A-Z)' ) }
+					{ label }
 				</SortingButton>
 			) }
-			renderContent={ () => (
+			renderContent={ ( { onClose } ) => (
 				<MenuGroup>
-					<MenuItem>{ __( 'Alphabetically (A-Z)' ) }</MenuItem>
-					<MenuItem>{ __( 'Alphabetically (Z-A)' ) }</MenuItem>
-					<MenuItem>{ __( 'Last published' ) }</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							onSitesListSortingChange( 'alphabetically-asc' );
+							onClose();
+						} }
+					>
+						{ __( 'Alphabetically (A-Z)' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							onSitesListSortingChange( 'alphabetically-desc' );
+							onClose();
+						} }
+					>
+						{ __( 'Alphabetically (Z-A)' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							onSitesListSortingChange( 'updated-at-desc' );
+							onClose();
+						} }
+					>
+						{ __( 'Last published' ) }
+					</MenuItem>
 				</MenuGroup>
 			) }
 		/>

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -62,10 +62,7 @@ export const SitesListSortingDropdown = ( {
 
 		switch ( sitesListSorting ) {
 			case `alphabetically${ SEPARATOR }asc`:
-				return __( 'Sorting: alphabetically (A-Z)' );
-
-			case `alphabetically${ SEPARATOR }desc`:
-				return __( 'Sorting: alphabetically (Z-A)' );
+				return __( 'Sorting: alphabetically' );
 
 			case `updatedAt${ SEPARATOR }desc`:
 				return __( 'Sorting: last publish date' );
@@ -100,15 +97,7 @@ export const SitesListSortingDropdown = ( {
 							onClose();
 						} }
 					>
-						{ __( 'Alphabetically (A-Z)' ) }
-					</MenuItem>
-					<MenuItem
-						onClick={ () => {
-							onSitesListSortingChange( `alphabetically${ SEPARATOR }desc` );
-							onClose();
-						} }
-					>
-						{ __( 'Alphabetically (Z-A)' ) }
+						{ __( 'Alphabetically' ) }
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -7,6 +7,7 @@ const SortingButton = styled( Button )( {
 	alignSelf: 'stretch',
 	flexDirection: 'row-reverse',
 	gap: '4px',
+	whiteSpace: 'nowrap',
 } );
 
 const SortingButtonIcon = styled( Gridicon )( {

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -16,11 +16,31 @@ const SortingButtonIcon = styled( Gridicon )( {
 	marginRight: '0 !important',
 } );
 
-type SitesListSorting = `${ SitesTableSortKey }-${ SitesTableSortOrder }`;
+const SEPARATOR = '-' as const;
+
+type SitesListSorting = `${ SitesTableSortKey }${ typeof SEPARATOR }${ SitesTableSortOrder }`;
+
+const DEFAULT_LIST_SORTING = {
+	sortKey: 'updatedAt',
+	sortOrder: 'desc',
+} as const;
+
+export const parseSorting = ( sorting: SitesListSorting | 'none' ) => {
+	if ( sorting === 'none' ) {
+		return DEFAULT_LIST_SORTING;
+	}
+
+	const [ sortKey, sortOrder ] = sorting.split( SEPARATOR );
+
+	return {
+		sortKey: sortKey as SitesTableSortKey,
+		sortOrder: sortOrder as SitesTableSortOrder,
+	};
+};
 
 export const useSitesListSorting = () =>
 	useAsyncPreference< SitesListSorting >( {
-		defaultValue: 'updated-at-desc',
+		defaultValue: `${ DEFAULT_LIST_SORTING.sortKey }-${ DEFAULT_LIST_SORTING.sortOrder }`,
 		preferenceName: 'sites-list-sorting',
 	} );
 
@@ -41,17 +61,17 @@ export const SitesListSortingDropdown = ( {
 		}
 
 		switch ( sitesListSorting ) {
-			case 'alphabetically-asc':
+			case `alphabetically${ SEPARATOR }asc`:
 				return __( 'Sorted alphabetically (A-Z)' );
 
-			case 'alphabetically-desc':
+			case `alphabetically${ SEPARATOR }desc`:
 				return __( 'Sorted alphabetically (Z-A)' );
 
-			case 'updated-at-desc':
+			case `updatedAt${ SEPARATOR }desc`:
 				return __( 'Sorted by last publish date' );
 
 			default:
-				throw new Error( 'invalid sort key' );
+				throw new Error( `invalid sort value ${ sitesListSorting }` );
 		}
 	}, [ __, sitesListSorting ] );
 
@@ -76,7 +96,7 @@ export const SitesListSortingDropdown = ( {
 				<MenuGroup>
 					<MenuItem
 						onClick={ () => {
-							onSitesListSortingChange( 'alphabetically-asc' );
+							onSitesListSortingChange( `alphabetically${ SEPARATOR }asc` );
 							onClose();
 						} }
 					>
@@ -84,7 +104,7 @@ export const SitesListSortingDropdown = ( {
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {
-							onSitesListSortingChange( 'alphabetically-desc' );
+							onSitesListSortingChange( `alphabetically${ SEPARATOR }desc` );
 							onClose();
 						} }
 					>
@@ -92,7 +112,7 @@ export const SitesListSortingDropdown = ( {
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {
-							onSitesListSortingChange( 'updated-at-desc' );
+							onSitesListSortingChange( `updatedAt${ SEPARATOR }desc` );
 							onClose();
 						} }
 					>

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -1,0 +1,41 @@
+import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+const SortingButton = styled( Button )( {
+	alignSelf: 'stretch',
+	flexDirection: 'row-reverse',
+	gap: '4px',
+} );
+
+const SortingButtonIcon = styled( Gridicon )( {
+	marginRight: '0 !important',
+} );
+
+export const SitesListSortingDropdown = () => {
+	const { __ } = useI18n();
+
+	return (
+		<Dropdown
+			position="bottom center"
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<SortingButton
+					icon={ <SortingButtonIcon icon={ isOpen ? 'arrow-up' : 'arrow-down' } /> }
+					iconSize={ 16 }
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+				>
+					{ __( 'Sorted alphabetically (A-Z)' ) }
+				</SortingButton>
+			) }
+			renderContent={ () => (
+				<MenuGroup>
+					<MenuItem>{ __( 'Alphabetically (A-Z)' ) }</MenuItem>
+					<MenuItem>{ __( 'Alphabetically (Z-A)' ) }</MenuItem>
+					<MenuItem>{ __( 'Last published' ) }</MenuItem>
+				</MenuGroup>
+			) }
+		/>
+	);
+};

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -22,8 +22,10 @@ export const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
 };
 
+export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';
+
 export const MEDIA_QUERIES = {
-	small: '@media screen and ( max-width: 600px )',
+	small: `@media ${ SMALL_MEDIA_QUERY }`,
 	mediumOrSmaller: '@media screen and ( max-width: 781px )',
 	mediumOrLarger: '@media screen and ( min-width: 660px )',
 	large: '@media screen and ( min-width: 960px )',

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -23,6 +23,7 @@ export const displaySiteUrl = ( siteUrl: string ) => {
 };
 
 export const MEDIA_QUERIES = {
+	small: '@media screen and ( max-width: 600px )',
 	mediumOrSmaller: '@media screen and ( max-width: 781px )',
 	mediumOrLarger: '@media screen and ( min-width: 660px )',
 	large: '@media screen and ( min-width: 960px )',

--- a/client/state/preferences/use-async-preference.ts
+++ b/client/state/preferences/use-async-preference.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector, useStore } from 'react-redux';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+
+interface UseAsyncPreferenceOptions< T > {
+	defaultValue: T;
+	preferenceName: string;
+}
+
+export const useAsyncPreference = < T extends string >( {
+	defaultValue,
+	preferenceName,
+}: UseAsyncPreferenceOptions< T > ) => {
+	const store = useStore();
+	const dispatch = useDispatch();
+	const remotePreferencesLoaded = useSelector( hasReceivedRemotePreferences );
+
+	const [ localValue, setLocalValue ] = useState< T | 'none' >( () => {
+		if ( ! remotePreferencesLoaded ) {
+			return 'none';
+		}
+
+		return getPreference( store.getState(), preferenceName ) ?? defaultValue;
+	} );
+
+	useEffect( () => {
+		if ( remotePreferencesLoaded ) {
+			setLocalValue( getPreference( store.getState(), preferenceName ) ?? defaultValue );
+		}
+	}, [ remotePreferencesLoaded, store, preferenceName, defaultValue ] );
+
+	const setValue = useCallback(
+		( newValue: T ) => {
+			setLocalValue( newValue );
+			dispatch( savePreference( preferenceName, newValue ) );
+		},
+		[ dispatch, preferenceName ]
+	);
+
+	return [ localValue, setValue ] as const;
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -29,6 +29,7 @@ export {
 } from './sites-table/use-sites-table-filtering';
 export type { FilterableSiteLaunchStatuses } from './sites-table/use-sites-table-filtering';
 export { useSitesTableSorting } from './sites-table/use-sites-table-sorting';
+export type { SitesTableSortKey, SitesTableSortOrder } from './sites-table/use-sites-table-sorting';
 export { getSiteLaunchStatus, useSiteLaunchStatusLabel } from './sites-table/site-status';
 export { SitesTableTabPanel } from './sites-table/sites-table-tab-panel';
 export { LoadingPlaceholder } from './loading-placeholder';

--- a/packages/components/src/sites-table/test/use-sites-table-sorting.jsx
+++ b/packages/components/src/sites-table/test/use-sites-table-sorting.jsx
@@ -41,10 +41,10 @@ describe( 'useSitesTableSorting', () => {
 		expect( result.current.sortedSites[ 2 ].ID ).toBe( 3 );
 	} );
 
-	test( 'should sort sites by updated-at descending', () => {
+	test( 'should sort sites by updatedAt descending', () => {
 		const { result } = renderHook( () =>
 			useSitesTableSorting( filteredSites, {
-				sortKey: 'updated-at',
+				sortKey: 'updatedAt',
 				sortOrder: 'desc',
 			} )
 		);
@@ -55,10 +55,10 @@ describe( 'useSitesTableSorting', () => {
 		expect( result.current.sortedSites[ 2 ].ID ).toBe( 1 );
 	} );
 
-	test( 'should sort sites by updated-at ascending', () => {
+	test( 'should sort sites by updatedAt ascending', () => {
 		const { result } = renderHook( () =>
 			useSitesTableSorting( filteredSites, {
-				sortKey: 'updated-at',
+				sortKey: 'updatedAt',
 				sortOrder: 'asc',
 			} )
 		);
@@ -74,7 +74,7 @@ describe( 'useSitesTableSorting', () => {
 
 		const { result, rerender } = renderHook(
 			( { sortOrder } ) =>
-				useSitesTableSorting( filteredSites, { sortKey: 'updated-at', sortOrder } ),
+				useSitesTableSorting( filteredSites, { sortKey: 'updatedAt', sortOrder } ),
 			{ initialProps: { sortOrder: 'asc' } }
 		);
 

--- a/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
@@ -3,24 +3,31 @@
  */
 
 import { renderHook } from '@testing-library/react-hooks';
-import { useSitesTableSorting } from '../use-sites-table-sorting';
+import {
+	SitesTableSortKey,
+	SitesTableSortOrder,
+	useSitesTableSorting,
+} from '../use-sites-table-sorting';
 
 describe( 'useSitesTableSorting', () => {
 	const filteredSites = [
 		{
 			ID: 1,
+			name: 'B',
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
 		},
 		{
 			ID: 2,
+			name: 'A',
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 			},
 		},
 		{
 			ID: 3,
+			name: 'C',
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
@@ -30,7 +37,7 @@ describe( 'useSitesTableSorting', () => {
 	test( 'should not sort sites if unsupported sortKey is provided', () => {
 		const { result } = renderHook( () =>
 			useSitesTableSorting( filteredSites, {
-				sortKey: 'sort-that-is-not-supported',
+				sortKey: 'sort-that-is-not-supported' as SitesTableSortKey,
 				sortOrder: 'asc',
 			} )
 		);
@@ -39,6 +46,34 @@ describe( 'useSitesTableSorting', () => {
 		expect( result.current.sortedSites[ 0 ].ID ).toBe( 1 );
 		expect( result.current.sortedSites[ 1 ].ID ).toBe( 2 );
 		expect( result.current.sortedSites[ 2 ].ID ).toBe( 3 );
+	} );
+
+	test( 'should sort sites alphabetically ascending', () => {
+		const { result } = renderHook( () =>
+			useSitesTableSorting( filteredSites, {
+				sortKey: 'alphabetically',
+				sortOrder: 'asc',
+			} )
+		);
+
+		expect( result.current.sortedSites.length ).toBe( 3 );
+		expect( result.current.sortedSites[ 0 ].name ).toBe( 'A' );
+		expect( result.current.sortedSites[ 1 ].name ).toBe( 'B' );
+		expect( result.current.sortedSites[ 2 ].name ).toBe( 'C' );
+	} );
+
+	test( 'should sort sites alphabetically descending', () => {
+		const { result } = renderHook( () =>
+			useSitesTableSorting( filteredSites, {
+				sortKey: 'alphabetically',
+				sortOrder: 'desc',
+			} )
+		);
+
+		expect( result.current.sortedSites.length ).toBe( 3 );
+		expect( result.current.sortedSites[ 0 ].name ).toBe( 'C' );
+		expect( result.current.sortedSites[ 1 ].name ).toBe( 'B' );
+		expect( result.current.sortedSites[ 2 ].name ).toBe( 'A' );
 	} );
 
 	test( 'should sort sites by updatedAt descending', () => {
@@ -75,7 +110,7 @@ describe( 'useSitesTableSorting', () => {
 		const { result, rerender } = renderHook(
 			( { sortOrder } ) =>
 				useSitesTableSorting( filteredSites, { sortKey: 'updatedAt', sortOrder } ),
-			{ initialProps: { sortOrder: 'asc' } }
+			{ initialProps: { sortOrder: 'asc' as SitesTableSortOrder } }
 		);
 
 		expect( result.current.sortedSites ).toHaveLength( 3 );

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 export interface SiteDetailsForSorting {
+	name: string;
 	options?: {
 		updated_at?: string;
 	};
@@ -24,12 +25,34 @@ export function useSitesTableSorting< T extends SiteDetailsForSorting >(
 ): UseSitesTableSortingResult< T > {
 	return useMemo( () => {
 		switch ( sortKey ) {
+			case 'alphabetically':
+				return { sortedSites: sortSitesAlphabetically( allSites, sortOrder ) };
 			case 'updated-at':
 				return { sortedSites: sortSitesByLastPublish( allSites, sortOrder ) };
 			default:
 				return { sortedSites: allSites };
 		}
 	}, [ allSites, sortKey, sortOrder ] );
+}
+
+function sortSitesAlphabetically< T extends SiteDetailsForSorting >(
+	sites: T[],
+	sortOrder: SitesTableSortOrder
+): T[] {
+	return [ ...sites ].sort( ( a, b ) => {
+		const normalizedA = a.name.toLocaleLowerCase();
+		const normalizedB = b.name.toLocaleLowerCase();
+
+		if ( normalizedA > normalizedB ) {
+			return sortOrder === 'asc' ? 1 : -1;
+		}
+
+		if ( normalizedA < normalizedB ) {
+			return sortOrder === 'asc' ? -1 : 1;
+		}
+
+		return 0;
+	} );
 }
 
 function sortSitesByLastPublish< T extends SiteDetailsForSorting >(

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -6,9 +6,12 @@ export interface SiteDetailsForSorting {
 	};
 }
 
+export type SitesTableSortKey = 'updated-at' | 'alphabetically';
+export type SitesTableSortOrder = 'asc' | 'desc';
+
 interface SitesTableSortOptions {
-	sortKey?: string;
-	sortOrder?: 'asc' | 'desc';
+	sortKey?: SitesTableSortKey;
+	sortOrder?: SitesTableSortOrder;
 }
 
 interface UseSitesTableSortingResult< T extends SiteDetailsForSorting > {
@@ -31,7 +34,7 @@ export function useSitesTableSorting< T extends SiteDetailsForSorting >(
 
 function sortSitesByLastPublish< T extends SiteDetailsForSorting >(
 	sites: T[],
-	sortOrder: string
+	sortOrder: SitesTableSortOrder
 ): T[] {
 	return [ ...sites ].sort( ( a, b ) => {
 		if ( ! a.options?.updated_at || ! b.options?.updated_at ) {

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -7,7 +7,7 @@ export interface SiteDetailsForSorting {
 	};
 }
 
-export type SitesTableSortKey = 'updated-at' | 'alphabetically';
+export type SitesTableSortKey = 'updatedAt' | 'alphabetically';
 export type SitesTableSortOrder = 'asc' | 'desc';
 
 interface SitesTableSortOptions {
@@ -27,7 +27,7 @@ export function useSitesTableSorting< T extends SiteDetailsForSorting >(
 		switch ( sortKey ) {
 			case 'alphabetically':
 				return { sortedSites: sortSitesAlphabetically( allSites, sortOrder ) };
-			case 'updated-at':
+			case 'updatedAt':
 				return { sortedSites: sortSitesByLastPublish( allSites, sortOrder ) };
 			default:
 				return { sortedSites: allSites };


### PR DESCRIPTION
#### Proposed Changes

Part of https://github.com/Automattic/wp-calypso/issues/67043.

This PR adds a sorting select to the UI and adds alphabetical sorting. When the user switches between sorting order, a preference is saved.

| Large screens | Small screens |
| -------------- | -------------- |
| <img width="387" alt="image" src="https://user-images.githubusercontent.com/36432/189753315-49ef38c2-d060-4501-8e13-6c54c3b5f998.png"> | <img width="496" alt="image" src="https://user-images.githubusercontent.com/36432/189753383-84b7fce8-446d-4b61-aff5-0bfe737941e1.png"> |

#### Testing Instructions

1. Open SMD;
2. Check that the sorting select box is showing left to the display mode switcher;
3. Check that by default it sorts by last published date, descending;
4. Try opening the dropdown and selecting `Alphabetically` and checking that the sites are now sorted alphabetically, ascending;
6. Check that the sorting order is persisted by refreshing the page and viewing the list with the same sorting order.