### PR TITLE
Domains: Remove broken route `/domains/manage/all/edit-contact-info`

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -21,7 +21,6 @@ import {
 	domainManagementManageConsent,
 	domainManagementDomainConnectMapping,
 	domainManagementRoot,
-	domainManagementAllEditContactInfo,
 } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -51,20 +50,6 @@ export default {
 				analyticsTitle="Domain Management > All Domains"
 				component={ DomainManagement.AllDomains }
 				context={ pageContext }
-			/>
-		);
-		next();
-	},
-
-	domainManagementBulkEditContactInfo( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementAllEditContactInfo() }
-				analyticsTitle="Domain Management > All Domains > Edit Contact Info"
-				component={ DomainManagement.BulkEditContactInfo }
-				context={ pageContext }
-				needsDomains
-				selectedDomainName={ pageContext.params.domain }
 			/>
 		);
 		next();

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -133,14 +133,6 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementAllEditContactInfo(),
-		...getCommonHandlers( { noSitePath: false } ),
-		domainManagementController.domainManagementBulkEditContactInfo,
-		makeLayout,
-		clientRender
-	);
-
-	page(
 		paths.domainManagementList( ':site' ),
 		...getCommonHandlers(),
 		domainManagementController.domainManagementList,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -106,10 +106,6 @@ export function domainManagementEditContactInfo( siteName, domainName, relativeT
 	return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
 }
 
-export function domainManagementAllEditContactInfo() {
-	return domainManagementAllRoot() + '/edit-contact-info';
-}
-
 /**
  * @param {string} siteName
  * @param {string} domainName


### PR DESCRIPTION
#### Proposed Changes

This PR removes the broken route `/domains/manage/all/edit-contact-info`.

That route was added in #53481 but led to a broken page because `DomainManagement.BulkEditContactInfo` wasn't defined (see https://github.com/Automattic/wp-calypso/blob/1ff4a6d7eb8a9f1065b6d9649674bf7e5ae2a318/client/my-sites/domains/domain-management/index.jsx).

The correct URL for that action should be `/domains/manage?site=all&action=edit-contact-email`.

#### Testing Instructions

Code inspection should be enough because this wasn't being used, but it would be nice to take a look at the bulk contact edit page:

- Build this branch locally or open the live Calypso link
- Go to `/domains/manage/all/edit-contact-info` and ensure no error is shown, only a blank page
- Go to `/domains/manage?site=all&action=edit-contact-email` and ensure everything is normal

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
