### PR TITLE
Sites Management Page: Use consistent casing for launch status dropdown

### DIFF
--- a/packages/components/src/sites-table/use-sites-table-filtering.tsx
+++ b/packages/components/src/sites-table/use-sites-table-filtering.tsx
@@ -51,7 +51,7 @@ export function useSitesTableFiltering< T extends SiteObjectWithBasicInfo >(
 
 	const filterableSiteLaunchStatuses = useMemo( () => {
 		return {
-			all: __( 'All Sites' ),
+			all: __( 'All sites' ),
 			...translatedSiteLaunchStatuses,
 		};
 	}, [ __, translatedSiteLaunchStatuses ] );


### PR DESCRIPTION
## Proposed Changes

Switches 'All Sites' to 'All sites' for consistency with 'Coming soon'.

### Before

<img width="767" alt="image" src="https://user-images.githubusercontent.com/36432/189751273-cbfc5d2b-a9d2-4d4f-90d1-fb9393b2a6d0.png">

### After

<img width="659" alt="image" src="https://user-images.githubusercontent.com/36432/189751010-49b76209-ca3f-4c38-89da-26b685695461.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Verify launch status dropdown behaves as expected.