### PR TITLE
A11y: Add aria-label to Theme__more-button

### DIFF
--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -53,7 +53,7 @@ class NavItem extends PureComponent {
 		}
 
 		return (
-			<li className={ itemClassName }>
+			<li className={ itemClassName } role="none">
 				<a
 					href={ this.props.path }
 					target={ target }
@@ -62,8 +62,8 @@ class NavItem extends PureComponent {
 					onMouseEnter={ this.preload }
 					tabIndex={ this.props.tabIndex || 0 }
 					aria-current={ this.props.selected }
-					disabled={ this.props.disabled }
 					role="menuitem"
+					disabled={ this.props.disabled }
 					rel={ this.props.isExternalLink ? 'external' : null }
 					onKeyPress={ this.props.onKeyPress }
 				>

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -38,7 +38,7 @@ class SegmentedControlItem extends Component {
 		} );
 
 		return (
-			<li className={ itemClassName }>
+			<li className={ itemClassName } role="none">
 				<a
 					href={ this.props.path }
 					className={ linkClassName }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -478,6 +478,7 @@ export class Theme extends Component {
 							<ThemeMoreButton
 								index={ this.props.index }
 								themeId={ this.props.theme.id }
+								themeName={ this.props.theme.name }
 								active={ this.props.active }
 								onMoreButtonClick={ this.props.onMoreButtonClick }
 								options={ this.props.buttonContents }

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -107,7 +107,6 @@ class ThemeMoreButton extends Component {
 }
 
 ThemeMoreButton.propTypes = {
-	'aria-label': PropTypes.string,
 	themeId: PropTypes.string,
 	// Index of theme in results list
 	index: PropTypes.number,

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -54,7 +54,11 @@ class ThemeMoreButton extends Component {
 
 		return (
 			<span className={ classes }>
-				<button ref={ this.moreButtonRef } onClick={ this.togglePopover }>
+				<button
+					aria-label={ `More options for theme ${ this.props.themeName }` }
+					ref={ this.moreButtonRef }
+					onClick={ this.togglePopover }
+				>
 					<Gridicon icon="ellipsis" size={ 24 } />
 				</button>
 
@@ -103,6 +107,7 @@ class ThemeMoreButton extends Component {
 }
 
 ThemeMoreButton.propTypes = {
+	'aria-label': PropTypes.string,
 	themeId: PropTypes.string,
 	// Index of theme in results list
 	index: PropTypes.number,

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -107,8 +107,8 @@ class ThemeMoreButton extends Component {
 }
 
 ThemeMoreButton.propTypes = {
-	themeName: PropTypes.string,
 	// Name of theme to give image context.
+	themeName: PropTypes.string,
 	themeId: PropTypes.string,
 	// Index of theme in results list
 	index: PropTypes.number,

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -107,6 +107,8 @@ class ThemeMoreButton extends Component {
 }
 
 ThemeMoreButton.propTypes = {
+	themeName: PropTypes.string,
+	// Name of theme to give image context.
 	themeId: PropTypes.string,
 	// Index of theme in results list
 	index: PropTypes.number,

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -36,7 +36,9 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       <span
         class="theme__more-button"
       >
-        <button>
+        <button
+          aria-label="More options for theme Twenty Seventeen"
+        >
           <svg
             class="gridicon gridicons-ellipsis"
             height="24"


### PR DESCRIPTION
#### Proposed Changes

* Adding an aria-label to the more button that displays on the theme cards on /themes so that screen readers can have some context for what the button does and which theme the button applies to. This resolves 50 a11y audit violations on /themes.
* Adding role='none' to a list item in section-nav and segmented-control because its child has the actual menu item role [as used in this example from Mozilla](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role). This resolves 75 a11y audit violations on 19 pages/screens.
* Updating the unit test snapshot for theme component tests to reflect the more button change.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With a screen reader, the /themes page should now have a named more button for each theme card. Nothing else should change. [Don't have a screen reader and want to test this PR? If you have an Apple device you can use VoiceOver for free](https://www.apple.com/accessibility/vision/).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
