### PR TITLE
Launchpad: Reintroduce loading screen styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -323,3 +323,61 @@
 		display: none;
 	}
 }
+
+// Launchpad - Processing Screens
+.processing {
+	.wordpress-logo {
+		position: absolute;
+		inset-inline-start: 20px;
+		inset-block-start: 20px;
+		fill: var(--color-text);
+		stroke: var(--color-text);
+		transform-origin: 0 0;
+	}
+
+	.processing-step__progress-bar {
+		background-color: #fff;
+	}
+
+	&.link-in-bio {
+		position: fixed;
+		width: 100%;
+		height: 100%;
+		background-color: #d0cce3;
+		background-image:
+			url(calypso/assets/images/onboarding/link-in-bio-processing-left.png),
+			url(calypso/assets/images/onboarding/link-in-bio-processing-right.png);
+		background-repeat: no-repeat, no-repeat;
+		background-attachment: fixed;
+		background-size: auto 30%, auto 30%;
+		background-position-x: 0%, 100%;
+		background-position-y: 90%, 10%;
+
+		@include break-large {
+			background-size: auto 50%, auto 50%;
+		}
+	}
+
+	.step-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin-top: 25vh;
+	}
+
+	.step-container__content {
+		width: 100%;
+	}
+
+	.progress-bar {
+		display: none;
+	}
+
+	h1.processing-step__progress-step {
+		font-size: $font-title-medium;
+
+		@include break-medium {
+			font-size: $font-title-large;
+		}
+	}
+}


### PR DESCRIPTION
#### Context

The completing purchase step and its subsequent loading screens were recently moved **_outside_** the context of tailored onboarding in stepper. They were then lumped together with traditional onboarding flows in https://github.com/Automattic/wp-calypso/pull/67399.

The changes migrated styling for the loading screens [elsewhere](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/tailored-flow-processing-screen/style.scss), but, unfortunately, the launchpad still relies on said styles and expects them to exist in stepper. To address this, we duplicate the styles ( for now ) when the launchpad screen is set up. @alshakero wondering if you have thoughts about how to consolidate the styling from this PR and your changes in `/signup/tailored-flow-processing-screen`

#### Proposed Changes

* Reintroduce styles removed in https://github.com/Automattic/wp-calypso/pull/67399

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Step through tailored onboarding flow for link in bio
  * Navigate to https://wordpress.com/hp-2022-tailored-flows/
  * Click on the link in bio link
* When at the launchpad screen, complete the edit links task
* Navigate back to the launchpad
* Click on the the launch site task
* Verify that the loading screen has correct styling as seen in the gif below

![2022-09-12 15 07 36](https://user-images.githubusercontent.com/5414230/189768553-fc0738c3-145a-45a9-a94b-c211c4f4ec68.gif)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67659
