### PR TITLE
Domains: Redirect the `/domain/manage/all/edit-contact-info` route

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -21,7 +21,6 @@ import {
 	domainManagementManageConsent,
 	domainManagementDomainConnectMapping,
 	domainManagementRoot,
-	domainManagementAllEditContactInfo,
 } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -51,20 +50,6 @@ export default {
 				analyticsTitle="Domain Management > All Domains"
 				component={ DomainManagement.AllDomains }
 				context={ pageContext }
-			/>
-		);
-		next();
-	},
-
-	domainManagementBulkEditContactInfo( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementAllEditContactInfo() }
-				analyticsTitle="Domain Management > All Domains > Edit Contact Info"
-				component={ DomainManagement.BulkEditContactInfo }
-				context={ pageContext }
-				needsDomains
-				selectedDomainName={ pageContext.params.domain }
 			/>
 		);
 		next();

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -49,6 +49,11 @@ export default function () {
 	// successful site address change shows a continuous placeholder state... #23929 for details.
 	page.redirect( '/domains/manage/edit', paths.domainManagementRoot() );
 	page.redirect( '/domains/manage/edit/:site', paths.domainManagementRoot() );
+	// This redirect should remain until we implement the `/domains/manage/all/edit-contact-info` route
+	page.redirect(
+		paths.domainManagementAllEditContactInfo(),
+		paths.domainManagementRoot() + '?site=all&action=edit-contact-email'
+	);
 
 	registerMultiPage( {
 		paths: [
@@ -128,14 +133,6 @@ export default function () {
 		paths.domainManagementRoot(),
 		...getCommonHandlers( { noSitePath: false } ),
 		domainManagementController.domainManagementListAllSites,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		paths.domainManagementAllEditContactInfo(),
-		...getCommonHandlers( { noSitePath: false } ),
-		domainManagementController.domainManagementBulkEditContactInfo,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
#### Proposed Changes

This PR redirects the `/domain/manage/all/edit-contact-info` route to `/domains/manage?site=all&action=edit-contact-email` until we implement the functionality for bulk editing full contact info (currently we only update emails in bulk).

That route was added in #53481 but led to a broken page because `DomainManagement.BulkEditContactInfo` wasn't defined (see https://github.com/Automattic/wp-calypso/blob/1ff4a6d7eb8a9f1065b6d9649674bf7e5ae2a318/client/my-sites/domains/domain-management/index.jsx).

#### Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to `/domains/manage/all/edit-contact-info` and ensure you are redirected to `/domains/manage?site=all&action=edit-contact-email`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
