### PR TITLE
E2E: separate steps in FSE: Smoke Test spec for better reliability.

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -10,7 +10,6 @@ import {
 	TestAccount,
 	getTestAccountByFeature,
 	envToFeatureKey,
-	ElementHelper,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
@@ -43,18 +42,18 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await sidebarComponent.navigate( 'Appearance', 'Editor' );
 	} );
 
-	it( 'Editor content loads', async function () {
+	it( 'Editor endpoint loads', async function () {
+		await page.waitForURL( /.*site-editor.*/ );
+	} );
+
+	it( 'Editor canvas loads', async function () {
 		// Because this is a temporary smoke test, adding the needed FSE selectors here instead of
 		// spinning up a POM class that we will later needed to redo.
 		// This should ensure the editor hasn't done a WSoD.
-		const editorLoadedClosure = async () => {
-			const locator = page
-				.frameLocator( '.calypsoify.is-iframe iframe.is-loaded' )
-				.frameLocator( 'iframe[name="editor-canvas"]' )
-				.locator( '[aria-label="Block: Post Title"]:has-text("Home"):visible' );
-			await locator.waitFor( { timeout: 90 * 1000 } );
-		};
+		const topFrameLocator = page.frameLocator( '.calypsoify.is-iframe iframe.is-loaded' );
+		await topFrameLocator.locator( '[aria-label="Editor top bar"]' ).waitFor();
 
-		await ElementHelper.reloadAndRetry( page, editorLoadedClosure );
+		const editorFrameLocator = topFrameLocator.frameLocator( 'iframe[title="Editor canvas"]' );
+		await editorFrameLocator.locator( '.edit-site-block-editor__block-list' ).waitFor();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR separates out the steps within FSE: Smoke Test steps into smaller, focused steps that are better sequenced.

Key changes:
- split up validation into two steps
- split up the wait for locators into two separate calls for better ordering.

After triggering it multiple times in the branch, it looks like this change has helped.
![image](https://user-images.githubusercontent.com/6549265/189774194-96034659-b5d5-400a-b553-f2ac895f54c2.png)

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/67350.
