### PR TITLE
/plugins: Set the h1 tag for main /plugins page and individual plugins #1064

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -33,7 +33,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 			<div className="plugin-details-header__main-info">
 				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
 				<div className="plugin-details-header__title-container">
-					<div className="plugin-details-header__name">{ plugin.name }</div>
+					<h1 className="plugin-details-header__name">{ plugin.name }</h1>
 					<div className="plugin-details-header__subtitle">
 						<span className="plugin-details-header__author">
 							{ translate( 'By {{author/}}', {
@@ -113,7 +113,7 @@ function LegacyPluginDetailsHeader( { plugin, isJetpackCloud } ) {
 			<div className="plugin-details-header__main-info">
 				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
 				<div className="plugin-details-header__title-container">
-					<div className="plugin-details-header__name">{ plugin.name }</div>
+					<h1 className="plugin-details-header__name">{ plugin.name }</h1>
 					<div className="plugin-details-header__description">
 						{ preventWidows( plugin.short_description || plugin.description ) }
 					</div>
@@ -192,7 +192,7 @@ function PluginDetailsHeaderPlaceholder() {
 		<div className="plugin-details-header__wrapper is-placeholder">
 			<div className="plugin-details-header__tags">...</div>
 			<div className="plugin-details-header__container">
-				<div className="plugin-details-header__name">...</div>
+				<h1 className="plugin-details-header__name">...</h1>
 				<div className="plugin-details-header__description">...</div>
 				<div className="plugin-details-header__additional-info">...</div>
 			</div>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -149,6 +149,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				isSearching={ isFetchingPluginsBySearchTerm }
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
+				renderTitleInH1={ ! category }
 			/>
 
 			{ ! search && <Categories selected={ category } /> }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -98,8 +98,16 @@ const PopularSearches = ( props ) => {
 };
 
 const SearchBoxHeader = ( props ) => {
-	const { searchTerm, title, searchTerms, isSticky, popularSearchesRef, isSearching, searchRef } =
-		props;
+	const {
+		searchTerm,
+		title,
+		searchTerms,
+		isSticky,
+		popularSearchesRef,
+		isSearching,
+		searchRef,
+		renderTitleInH1,
+	} = props;
 
 	// Clear the keyword in search box on PluginsBrowser load if required.
 	// Required when navigating to a new plugins browser location
@@ -113,7 +121,8 @@ const SearchBoxHeader = ( props ) => {
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>
-			<h1 className="search-box-header__header">{ title }</h1>
+			{ renderTitleInH1 && <h1 className="search-box-header__header">{ title }</h1> }
+			{ ! renderTitleInH1 && <div className="search-box-header__header">{ title }</div> }
 			<div className="search-box-header__search">
 				<SearchBox
 					searchTerm={ searchTerm }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -113,7 +113,7 @@ const SearchBoxHeader = ( props ) => {
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>
-			<div className="search-box-header__header">{ title }</div>
+			<h1 className="search-box-header__header">{ title }</h1>
 			<div className="search-box-header__search">
 				<SearchBox
 					searchTerm={ searchTerm }


### PR DESCRIPTION
#### Proposed Changes

* Add correct H1 tags to plugin page title and plugin listing page titles. 
* 1064-gh-Automattic/martech

#### Testing Instructions

* Log out
* Navigate to /plugins
* Ensure that the page header "Plugins you need to get your projects done" is in a H1 tag and NOT a DIV.
* Navigate to a plugin detail page (eg. http://calypso.localhost:3000/plugins/wordpress-seo-premium) and ensure that the page header - "Yoast SEO Premium" is in a H1 tag and NOT a DIV.
* Navigate to a plugin category page (eg. http://calypso.localhost:3000/plugins/browse/seo) and ensure that the page header - "Plugins you need to get your projects done" is NOT a H1 tag and in a DIV. For this page the page Header is located below "Search Engine Optimzation" and it should be in a H1 Tag.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
