### PR TITLE
Disable buttons correctly in EmailPlan when purchase is null

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -21,7 +21,12 @@ import {
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
-import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import {
+	getTitanProductName,
+	getTitanProductSlug,
+	getTitanSubscriptionId,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
@@ -90,7 +95,9 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	const currentRoute = useSelector( getCurrentRoute );
 
 	const canAddMailboxes =
-		getGSuiteSubscriptionStatus( domain ) !== 'suspended' && canCurrentUserAddEmail( domain );
+		( getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) ) &&
+		getGSuiteSubscriptionStatus( domain ) !== 'suspended' &&
+		canCurrentUserAddEmail( domain );
 	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -21,12 +21,7 @@ import {
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
-import {
-	getTitanProductName,
-	getTitanProductSlug,
-	getTitanSubscriptionId,
-	hasTitanMailWithUs,
-} from 'calypso/lib/titan';
+import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
@@ -95,9 +90,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	const currentRoute = useSelector( getCurrentRoute );
 
 	const canAddMailboxes =
-		( getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) ) &&
-		getGSuiteSubscriptionStatus( domain ) !== 'suspended' &&
-		canCurrentUserAddEmail( domain );
+		getGSuiteSubscriptionStatus( domain ) !== 'suspended' && canCurrentUserAddEmail( domain );
 	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {
@@ -117,6 +110,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	function getAddMailboxProps() {
 		if ( hasGSuiteWithUs( domain ) ) {
 			return {
+				disabled: ! canAddMailboxes,
 				path: emailManagementAddGSuiteUsers(
 					selectedSite.slug,
 					domain.name,
@@ -150,11 +144,13 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 
 			return {
 				external: showExternalControlPanelLink,
+				disabled: ! canAddMailboxes,
 				path: controlPanelUrl,
 			};
 		}
 
 		return {
+			disabled: ! canAddMailboxes,
 			path: emailManagementAddEmailForwards( selectedSite.slug, domain.name, currentRoute ),
 		};
 	}
@@ -185,18 +181,12 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	}
 
 	function renderViewBillingAndPaymentSettingsNavItem() {
-		if ( ! hasSubscription || ! purchase ) {
-			return (
-				<VerticalNavItem disabled>
-					{ translate( 'View billing and payment settings' ) }
-				</VerticalNavItem>
-			);
-		}
-
-		const managePurchaseUrl = getManagePurchaseUrlFor( selectedSite.slug, purchase.id );
+		const managePurchaseUrl = purchase
+			? getManagePurchaseUrlFor( selectedSite.slug, purchase.id )
+			: '';
 
 		return (
-			<VerticalNavItem path={ managePurchaseUrl }>
+			<VerticalNavItem path={ managePurchaseUrl } disabled={ ! hasSubscription || ! purchase }>
 				{ translate( 'View billing and payment settings' ) }
 			</VerticalNavItem>
 		);
@@ -233,7 +223,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 		}
 
 		return (
-			<VerticalNavItem { ...manageAllNavItemProps } disabled={ ! hasSubscription || ! purchase }>
+			<VerticalNavItem { ...manageAllNavItemProps } disabled={ ! purchase }>
 				{ translate( 'Manage all mailboxes', {
 					comment:
 						'This is the text for a link to manage all email accounts/mailboxes for a subscription',
@@ -243,14 +233,6 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	}
 
 	function renderAddNewMailboxesOrRenewNavItem() {
-		if ( hasTitanMailWithUs( domain ) && ! hasSubscription ) {
-			return (
-				<VerticalNavItem { ...getAddMailboxProps() }>
-					{ translate( 'Add new mailboxes' ) }
-				</VerticalNavItem>
-			);
-		}
-
 		if ( hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) ) {
 			if ( purchase && isExpired( purchase ) ) {
 				return (
@@ -261,7 +243,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			}
 
 			return (
-				<VerticalNavItem { ...getAddMailboxProps() } disabled={ ! canAddMailboxes }>
+				<VerticalNavItem { ...getAddMailboxProps() }>
 					{ translate( 'Add new mailboxes' ) }
 				</VerticalNavItem>
 			);

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -185,12 +185,12 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	}
 
 	function renderViewBillingAndPaymentSettingsNavItem() {
-		if ( ! hasSubscription ) {
-			return null;
-		}
-
-		if ( ! purchase ) {
-			return <VerticalNavItem isPlaceholder />;
+		if ( ! hasSubscription || ! purchase ) {
+			return (
+				<VerticalNavItem disabled>
+					{ translate( 'View billing and payment settings' ) }
+				</VerticalNavItem>
+			);
 		}
 
 		const managePurchaseUrl = getManagePurchaseUrlFor( selectedSite.slug, purchase.id );
@@ -233,7 +233,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 		}
 
 		return (
-			<VerticalNavItem { ...manageAllNavItemProps }>
+			<VerticalNavItem { ...manageAllNavItemProps } disabled={ ! hasSubscription || ! purchase }>
 				{ translate( 'Manage all mailboxes', {
 					comment:
 						'This is the text for a link to manage all email accounts/mailboxes for a subscription',
@@ -252,11 +252,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 		}
 
 		if ( hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) ) {
-			if ( ! purchase ) {
-				return <VerticalNavItem isPlaceholder />;
-			}
-
-			if ( isExpired( purchase ) ) {
+			if ( purchase && isExpired( purchase ) ) {
 				return (
 					<VerticalNavItem onClick={ handleRenew } path="#">
 						{ translate( 'Renew to add new mailboxes' ) }


### PR DESCRIPTION
#### Proposed Changes

Sometimes, users are able to access email subscriptions without being the subscription owner. This can happen under the following circumstances:

- User A has a mapped domain: example.com
- User A purchases Professional Email for that domain
- User A removes the example.com domain from their account
- User B adds example.com as a mapped domain to their account
- The Professional Email subscription will now show up in Calypso for User B, but they will not be able to manage it

In this scenario, two buttons in the email management view `/email/:domain/manage/:site_slug` would render incorrectly. Instead of showing any text, they would just show perpetual loading animations.

This happened because the purchase for the email subscription couldn't load (since the current user doesn't have access to it). This PR fixes that by rendering disabled buttons instead of a loading placeholder.

**Please note** that the `Add new mailboxes` button will render as disabled after D87509-code is merged.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/1101677/189863631-55c6b947-8351-438b-a9da-e8d46d1c846b.png) | ![after](https://user-images.githubusercontent.com/1101677/189863648-a357c7f8-916f-468c-908c-0756f4ad9494.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Follow the steps outlined above to get access to an email subscription without being the owner (you do need an external domain that you can add as a mapped domain 😫)
2. Navigate to `/email/:domain/manage/:site_slug` in Calypso
3. Ensure that the `Add new mailboxes` button renders (not as a loading placeholder) and is enabled
4. Ensure that the `Manage all mailboxes` button is disabled
5. Ensure that the `View billing and payment settings` button renders (not as a loading placeholder) and is disabled

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67723