### PR TITLE
Tailored Flow (1 min review): Link in bio intro text to set up

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -31,7 +31,7 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				__( 'You’re 3 minutes away from<br />a stand-out Link in Bio site.<br />Ready? ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Setup your Link in Bio' ),
+			buttonText: __( 'Set up your Link in Bio' ),
 		},
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -25,7 +25,11 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				__( 'You’re 3 minutes away from<br />a launch-ready Newsletter. ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Setup your Newsletter' ),
+			buttonText:
+				hasTranslation( 'Set up your Newsletter' ) ||
+				[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+					? __( 'Set up your Newsletter' )
+					: __( 'Setup your Newsletter' ),
 		},
 		'link-in-bio': {
 			title: createInterpolateElement(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import { getLocaleSlug } from 'i18n-calypso';
 import type { WPElement } from '@wordpress/element';
 
 interface Props {
@@ -16,7 +17,7 @@ interface IntroContent {
 }
 
 const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 
 	const introContent: IntroContent = {
 		newsletter: {
@@ -31,7 +32,11 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				__( 'You’re 3 minutes away from<br />a stand-out Link in Bio site.<br />Ready? ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Set up your Link in Bio' ),
+			buttonText:
+				hasTranslation( 'Set up your Link in Bio' ) ||
+				[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+					? __( 'Set up your Link in Bio' )
+					: __( 'Setup your Link in Bio' ),
 		},
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,6 +1,6 @@
 import { dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { translate } from 'i18n-calypso';
+import { __, hasTranslation } from '@wordpress/i18n';
+import { translate, getLocaleSlug } from 'i18n-calypso';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -64,7 +64,11 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_link_in_bio':
 					taskData = {
-						title: translate( 'Setup Link in bio' ),
+						title:
+							hasTranslation( 'Set up Link in Bio' ) ||
+							[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+								? translate( 'Set up Link in Bio' )
+								: translate( 'Setup Link in Bio' ),
 					};
 					break;
 				case 'links_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -68,7 +68,7 @@ export function getEnhancedTasks(
 							hasTranslation( 'Set up Link in Bio' ) ||
 							[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 								? translate( 'Set up Link in Bio' )
-								: translate( 'Setup Link in Bio' ),
+								: translate( 'Setup your Link in Bio' ),
 					};
 					break;
 				case 'links_added':


### PR DESCRIPTION
#### Proposed Changes

Context: p1663060395372769-slack-C02T4NVL4JJ

Change LinkInBio Intro button text from `Setup your Link in Bio` to `Set up your Link in Bio`.

![image](https://user-images.githubusercontent.com/52076348/189864804-36c5a361-ee83-4e13-9c43-ca678c653ca5.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check Calypso Live link
* Button text should be `Set up your Link in Bio`
* In other locales, there should still be the old translation
