### PR TITLE
Plugin Management: UI enhancements based on CFT feedback - part 2

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -183,12 +183,17 @@ export class PluginsMain extends Component {
 	}
 
 	getPluginCount( filterId ) {
+		let count;
 		if ( 'updates' === filterId ) {
-			return this.props.pluginUpdateCount;
+			count = this.props.pluginUpdateCount;
 		}
 		if ( 'all' === filterId ) {
-			return this.props.allPluginsCount;
+			count = this.props.allPluginsCount;
 		}
+		if ( this.props.requestingPluginsForSites && ! count ) {
+			return undefined;
+		}
+		return count;
 	}
 
 	getSelectedText() {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -1,4 +1,5 @@
-import { Gridicon, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Icon, plugins } from '@wordpress/icons';
 import classNames from 'classnames';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import PluginCommonActions from '../plugin-common-actions';
@@ -54,7 +55,11 @@ export default function PluginCommonCard( {
 									alt={ item.name }
 								/>
 							) : (
-								<Gridicon className="plugin-common-card__plugin-icon has-opacity" icon="plugins" />
+								<Icon
+									size={ 32 }
+									icon={ plugins }
+									className="plugin-common-card__plugin-icon plugin-default-icon"
+								/>
 							) }
 						</div>
 					</>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -116,7 +116,7 @@ export default function PluginCommonCard( {
 						</div>
 					) }
 					{ columnKeys[ 'sites' ] && (
-						<div className="plugin-common-card__site-data">
+						<div className="plugin-common-card__site-data plugin-common-card__installed-on">
 							{ rowFormatter( {
 								columnKey: 'sites',
 								item,

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/style.scss
@@ -56,6 +56,10 @@
 	margin: 16px 0;
 }
 
+.plugin-common-card__installed-on {
+	margin: 8px 0;
+}
+
 .plugin-common-card__install-button {
 	.plugin-install-button__install.embed {
 		position: static;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Icon, plugins } from '@wordpress/icons';
 import classNames from 'classnames';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import PluginCommonAction from '../plugin-common-actions';
@@ -45,9 +45,10 @@ export default function PluginCommonTable( {
 						{ columns.map( ( column ) => (
 							<td key={ column.key }>
 								{ column.key === 'plugin' && (
-									<Gridicon
-										className="plugin-common-table__plugin-icon is-loading"
-										icon="plugins"
+									<Icon
+										size={ 32 }
+										icon={ plugins }
+										className="plugin-common-table__plugin-icon plugin-default-icon is-loading"
 									/>
 								) }
 								<TextPlaceholder />

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,4 +1,5 @@
-import { Gridicon, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
+import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement, ReactChild } from 'react';
 import { useSelector } from 'react-redux';
@@ -130,7 +131,11 @@ export default function PluginRowFormatter( {
 								alt={ item.name }
 							/>
 						) : (
-							<Gridicon className="plugin-row-formatter__plugin-icon has-opacity" icon="plugins" />
+							<Icon
+								size={ 32 }
+								icon={ plugins }
+								className="plugin-row-formatter__plugin-icon plugin-default-icon"
+							/>
 						) }
 						<div className="plugin-row-formatter__plugin-name-container">
 							<PluginDetailsButton className="plugin-row-formatter__plugin-name">

--- a/client/my-sites/plugins/plugin-management-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/style.scss
@@ -1,30 +1,38 @@
-@import "@wordpress/base-styles/_breakpoints.scss";
-@import "@wordpress/base-styles/_mixins.scss";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
-.has-opacity {
-	opacity: 0.3;
-}
 .is-loading {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	opacity: 0.3;
 }
+
 .no-padding {
 	padding: 0;
 }
+
+.plugin-default-icon {
+	background: var(--studio-gray-0);
+	fill: var(--studio-gray-40);
+}
+
 .plugin-management-v2__main-content-container {
 	margin-block-start: 0;
+
 	@include break-xlarge() {
 		margin-block-start: 8px;
 	}
+
 	&.is-bulk-management-active {
 		margin-block-start: 0;
 	}
 }
+
 .plugin-management-v2__no-sites {
 	text-align: center;
 	font-size: 1.5rem;
 	margin-top: 16px;
 }
+
 .plugin-management-v2__actions {
 	.gridicon {
 		position: absolute !important;


### PR DESCRIPTION
#### Proposed Changes

This PR makes some UI enhancements to the plugin management based on CFT feedback.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/plugin-management-cft-enhancements-2` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Plugins** in the sidebar and verify the plugin count for `All` and `Updates` is not showing until the plugins are loaded

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="432" alt="Screenshot 2022-09-13 at 3 17 57 PM" src="https://user-images.githubusercontent.com/10586875/189870281-dae077d9-23f9-4db0-8e8e-22715db85ee5.png">
</td>
<td>
<img width="406" alt="Screenshot 2022-09-13 at 3 17 50 PM" src="https://user-images.githubusercontent.com/10586875/189870342-795424da-ced7-46e3-b8d7-a7f221dd9675.png">
</td>
</tr>
</table>


4. Switch to mobile view using the dev tool and verify the spacing around `Installed on X sites` is reduced to 8px instead of 16px

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="308" alt="Screenshot 2022-09-13 at 3 20 57 PM" src="https://user-images.githubusercontent.com/10586875/189870933-836e1676-b052-4c97-9d7a-de2e8f87d0cb.png">
</td>
<td>
<img width="307" alt="Screenshot 2022-09-13 at 3 21 16 PM" src="https://user-images.githubusercontent.com/10586875/189870977-88a5a6c3-ac1c-4a45-a294-e1af3e297d00.png">
</td>
</tr>
</table>

5. Verify the default plugin icon(when there is no plugin icon) is updated as shown below.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="566" alt="Screenshot 2022-09-13 at 3 24 09 PM" src="https://user-images.githubusercontent.com/10586875/189871615-7e64f37a-f78e-4858-b20e-5f1bd217de57.png">
</td>
<td>
<img width="607" alt="Screenshot 2022-09-13 at 3 23 57 PM" src="https://user-images.githubusercontent.com/10586875/189871871-f21ea4d6-1d5b-4a57-b119-fc5e417e2393.png">
</td>
</tr>
</tr>
<tr>
<td>
<img width="463" alt="Screenshot 2022-09-13 at 3 23 30 PM" src="https://user-images.githubusercontent.com/10586875/189871904-e727e362-2943-4e31-adf2-c2906b2449d0.png">
</td>
<td>
<img width="449" alt="Screenshot 2022-09-13 at 3 23 21 PM" src="https://user-images.githubusercontent.com/10586875/189871965-32f0d9a6-d431-43c7-87ea-a397a880a7ed.png">
</td>
</tr>
<tr>
<td>
<img width="308" alt="Screenshot 2022-09-13 at 3 20 57 PM" src="https://user-images.githubusercontent.com/10586875/189872500-1a671405-8148-41b9-ba87-885eac4b3c11.png">
</td>
<td>
<img width="307" alt="Screenshot 2022-09-13 at 3 21 16 PM" src="https://user-images.githubusercontent.com/10586875/189872550-3d165547-4a13-4884-a6ff-e7f52bae201d.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202966980091207, 1202518759611394-as-1202966980091211 & 1202518759611394-as-1202956254773517