### PR TITLE
Pattern Assembler: Show blank canvas CTA only for build and write flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
@@ -1,1 +1,9 @@
 export const STEP_NAME = 'design-setup';
+
+export const BLANK_CANVAS_DESIGN = {
+	recipe: {
+		stylesheet: 'pub/blank-canvas-blocks',
+	},
+	slug: 'blank-canvas-blocks',
+	title: 'Blank Canvas',
+};

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -11,7 +11,7 @@
 	background-color: #f6f7f7;
 	color: #50575e;
 
-	@include break-mobile {
+	@include break-medium {
 		display: flex;
 	}
 

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -22,6 +22,7 @@ export {
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
 	STICKY_OFFSET_TOP,
+	SHOW_ALL_SLUG,
 } from './constants';
 export type {
 	FontPair,


### PR DESCRIPTION
#### Proposed Changes

* We want to show blank canvas CTA only for the build and write flow, so I made a change to inject the blank canvas only when the site intent is `build` or `write`
* I move the logic of blank canvas injection outside the `UnifiedDesignPicker` in the package as I thought this component doesn't need to know the **intent**. Therefore, I add a new prop `onFilterDesigns` to allow people to do something when we're filtering designs in `UnifiedDesignPicker`
* Besides, I fix the issue that we show the mShot of the blank canvas when the viewport is between mobile and medium.

| Build and Write Flow | Other Flows |
| - | - |
| <img width="1012" alt="image" src="https://user-images.githubusercontent.com/13596067/189879106-36aa3f04-5c09-47f0-9cf3-083fffa59e01.png"> | <img width="1012" alt="image" src="https://user-images.githubusercontent.com/13596067/189878964-f3a68457-94c2-443a-bac8-37c619bee999.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Build and Write Flow**

* Go to `/setup?siteSlug=<your_site>`
* Select **one** of the following goals
  * Write & Publish
  * Promote myself or business
  * Other
* When you land on the Design Picker, you will see the blank canvas CTA

**Other Flows**

* Go to `/setup?siteSlug=<your_site>`
* Select **none** of the following goals
  * Write & Publish
  * Promote myself or business
  * Other
* When you land on the Design Picker, you won't see the blank canvas CTA

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67713
