### PR TITLE
Update `pluginRequiresCustomPrimaryDomain` to use `seo` tag instead of the `required_primary_domain` field

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -76,8 +76,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	);
 
 	const pluginRequiresCustomPrimaryDomain =
-		( primaryDomain?.isWPCOMDomain || primaryDomain?.isWpcomStagingDomain ) &&
-		plugin?.requirements?.required_primary_domain;
+		( primaryDomain?.isWPCOMDomain || primaryDomain?.isWpcomStagingDomain ) && !! plugin?.tags?.seo;
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 
 	const updatedKeepMeUpdatedPreference = useCallback(


### PR DESCRIPTION
#### Proposed Changes

* update the `pluginRequiresCustomPrimaryDomain` variable in Calypso to use the `seo` tag instead of the `required_primary_domain` variable 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the SEO category (`/plugins/browse/seo`), and click on any plugin (eg. `/plugins/cloudflare`)
* Click the CTA button
* Verify that the primary custom domain dialog is shown before the upgrade modal

Before | After
--- | ---
Just the upgrade modal is shown: <img width="807" alt="CleanShot 2022-09-13 at 15 01 02@2x" src="https://user-images.githubusercontent.com/11555574/189907885-b338c8f3-89a1-4e9d-af7c-e04f2642c752.png"> | The custom domain dialog is shown before the upgrade modal: <img width="469" alt="CleanShot 2022-09-13 at 15 00 17@2x" src="https://user-images.githubusercontent.com/11555574/189907654-1afcd3dd-8d5f-412c-a856-c38c13c681a5.png">

* Go to a plugin that doesn't have the SEO tag (eg. `/plugins/woocommerce-subscriptions`)
* Click the CTA button
* Verify that there are no regressions

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67502
