### PR TITLE
Tailored Flows: Remove hasTranslation for Set up

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import { getLocaleSlug } from 'i18n-calypso';
 import type { WPElement } from '@wordpress/element';
 
 interface Props {
@@ -17,7 +16,7 @@ interface IntroContent {
 }
 
 const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
-	const { __, hasTranslation } = useI18n();
+	const { __ } = useI18n();
 
 	const introContent: IntroContent = {
 		newsletter: {
@@ -25,22 +24,14 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				__( 'You’re 3 minutes away from<br />a launch-ready Newsletter. ' ),
 				{ br: <br /> }
 			),
-			buttonText:
-				hasTranslation( 'Set up your Newsletter' ) ||
-				[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-					? __( 'Set up your Newsletter' )
-					: __( 'Setup your Newsletter' ),
+			buttonText: __( 'Set up your Newsletter' ),
 		},
 		'link-in-bio': {
 			title: createInterpolateElement(
 				__( 'You’re 3 minutes away from<br />a stand-out Link in Bio site.<br />Ready? ' ),
 				{ br: <br /> }
 			),
-			buttonText:
-				hasTranslation( 'Set up your Link in Bio' ) ||
-				[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-					? __( 'Set up your Link in Bio' )
-					: __( 'Setup your Link in Bio' ),
+			buttonText: __( 'Set up your Link in Bio' ),
 		},
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,6 +1,6 @@
 import { dispatch } from '@wordpress/data';
-import { __, hasTranslation } from '@wordpress/i18n';
-import { translate, getLocaleSlug } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
+import { translate } from 'i18n-calypso';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -64,11 +64,7 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_link_in_bio':
 					taskData = {
-						title:
-							hasTranslation( 'Set up Link in Bio' ) ||
-							[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-								? translate( 'Set up Link in Bio' )
-								: translate( 'Setup your Link in Bio' ),
+						title: translate( 'Set up Link in Bio' ),
 					};
 					break;
 				case 'links_added':


### PR DESCRIPTION
#### Proposed Changes

Remove the `hasTranslation` checks from recent https://github.com/Automattic/wp-calypso/pull/67718


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch and `yarn start`.
* Check that translation of "Set up your Link in Bio" and "Set up your Newsletter", in Newsletter and Link in Bio flows, work correctly.