### PR TITLE
Remove conditional now that 'Back to Sites' is translated

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,6 +1,5 @@
-import { englishLocales } from '@automattic/i18n-utils';
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -775,10 +774,7 @@ class DomainsStep extends Component {
 		let isExternalBackUrl = false;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
-		const sitesBackLabelText =
-			englishLocales.includes( this.props.locale ) || i18n.hasTranslation( 'Back to Sites' )
-				? translate( 'Back to Sites' )
-				: translate( 'Back to My Sites' );
+		const sitesBackLabelText = translate( 'Back to Sites' );
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -6,7 +6,6 @@ import {
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { englishLocales } from '@automattic/i18n-utils';
 import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
@@ -387,10 +386,7 @@ export class PlansStep extends Component {
 
 		if ( 0 === positionInFlow && hasInitializedSitesBackUrl ) {
 			backUrl = hasInitializedSitesBackUrl;
-			backLabelText =
-				englishLocales.includes( this.props.locale ) || i18n.hasTranslation( 'Back to Sites' )
-					? translate( 'Back to Sites' )
-					: translate( 'Back to My Sites' );
+			backLabelText = translate( 'Back to Sites' );
 		}
 
 		let queryParams;

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,5 +1,4 @@
-import { englishLocales } from '@automattic/i18n-utils';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -73,11 +72,6 @@ class SiteType extends Component {
 			'This is just a starting point. You can add or change features later.'
 		);
 
-		const backLabelText =
-			englishLocales.includes( this.props.locale ) || i18n.hasTranslation( 'Back to Sites' )
-				? translate( 'Back to Sites' )
-				: translate( 'Back to My Sites' );
-
 		return (
 			<StepWrapper
 				flowName={ flowName }
@@ -90,7 +84,7 @@ class SiteType extends Component {
 				stepContent={ this.renderStepContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
-				backLabelText={ hasInitializedSitesBackUrl ? backLabelText : null }
+				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to Sites' ) : null }
 			/>
 		);
 	}


### PR DESCRIPTION
Fixes #67183

## Proposed Changes

Removes the conditional now that 'Back to Sites' [is translated](https://translate.wordpress.com/projects/wpcom/-all-translated/249622/).

## Testing Instructions

1. Navigate to `/sites`.
2. Click on 'Add new site' in the top right.
3. Observe 'Back to Sites' in the top left.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/36432/189917083-fed71251-ecf8-47a9-9fa9-6d984c6bf988.png">
