### PR TITLE
Trigger tailored flows emails during flows

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -4,12 +4,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
-import wpcomRequest from 'wpcom-proxy-request';
 
 export const linkInBio: Flow = {
 	name: LINK_IN_BIO_FLOW,
@@ -33,10 +33,8 @@ export const linkInBio: Flow = {
 		const locale = useLocale();
 
 		// trigger guides on step movement, we don't care about failures or response
-		wpcomRequest( {
-			path: `guides/trigger?flow=${ name }&step=${ _currentStep }`,
+		wpcom.req.post( `guides/trigger?flow=${ name }&step=${ _currentStep }`, {
 			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
 		} );
 
 		const getStartUrl = () => {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -9,6 +9,7 @@ import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
+import wpcomRequest from 'wpcom-proxy-request';
 
 export const linkInBio: Flow = {
 	name: LINK_IN_BIO_FLOW,
@@ -30,6 +31,13 @@ export const linkInBio: Flow = {
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const locale = useLocale();
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcomRequest( {
+			path: `guides/trigger?flow=${ name }&step=${ _currentStep }`,
+			apiNamespace: 'wpcom/v2/',
+			apiVersion: '2',
+		} );
 
 		const getStartUrl = () => {
 			return locale && locale !== 'en'

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -33,9 +33,16 @@ export const linkInBio: Flow = {
 		const locale = useLocale();
 
 		// trigger guides on step movement, we don't care about failures or response
-		wpcom.req.post( `guides/trigger?flow=${ name }&step=${ _currentStep }`, {
-			apiNamespace: 'wpcom/v2/',
-		} );
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: name,
+				step: _currentStep,
+			}
+		);
 
 		const getStartUrl = () => {
 			return locale && locale !== 'en'

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -39,7 +39,7 @@ export const linkInBio: Flow = {
 				apiNamespace: 'wpcom/v2/',
 			},
 			{
-				flow: name,
+				flow: flowName,
 				step: _currentStep,
 			}
 		);

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -10,6 +10,7 @@ import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow } from './internals/types';
+import wpcomRequest from 'wpcom-proxy-request';
 
 export const newsletter: Flow = {
 	name: NEWSLETTER_FLOW,
@@ -40,6 +41,13 @@ export const newsletter: Flow = {
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Newsletter&redirect_to=/setup/newsletterSetup?flow=${ flowName }`
 				: `/start/account/user?variationName=${ flowName }&pageTitle=Newsletter&redirect_to=/setup/newsletterSetup?flow=${ flowName }`;
 		};
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcomRequest( {
+			path: `guides/trigger?flow=${ name }&step=${ _currentStep }`,
+			apiNamespace: 'wpcom/v2/',
+			apiVersion: '2',
+		} );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -4,13 +4,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow } from './internals/types';
-import wpcomRequest from 'wpcom-proxy-request';
 
 export const newsletter: Flow = {
 	name: NEWSLETTER_FLOW,
@@ -43,10 +43,8 @@ export const newsletter: Flow = {
 		};
 
 		// trigger guides on step movement, we don't care about failures or response
-		wpcomRequest( {
-			path: `guides/trigger?flow=${ name }&step=${ _currentStep }`,
+		wpcom.req.post( `guides/trigger?flow=${ name }&step=${ _currentStep }`, {
 			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
 		} );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -49,7 +49,7 @@ export const newsletter: Flow = {
 				apiNamespace: 'wpcom/v2/',
 			},
 			{
-				flow: name,
+				flow: flowName,
 				step: _currentStep,
 			}
 		);

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -43,9 +43,16 @@ export const newsletter: Flow = {
 		};
 
 		// trigger guides on step movement, we don't care about failures or response
-		wpcom.req.post( `guides/trigger?flow=${ name }&step=${ _currentStep }`, {
-			apiNamespace: 'wpcom/v2/',
-		} );
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: name,
+				step: _currentStep,
+			}
+		);
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,7 +4,7 @@ import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
-import { Component } from 'react';
+import { Component, useEffect } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
@@ -59,6 +59,7 @@ import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getExternalBackUrl } from './utils';
 import './style.scss';
+import wpcomRequest from 'wpcom-proxy-request';
 
 class DomainsStep extends Component {
 	static propTypes = {
@@ -123,6 +124,15 @@ class DomainsStep extends Component {
 		this.state = {
 			currentStep: null,
 		};
+	}
+
+	componentDidMount() {
+		// trigger guides on this step, we don't care about failures or response
+		wpcomRequest( {
+			path: `guides/trigger?flow=${ this.props.flowName }&step=domains`,
+			apiNamespace: 'wpcom/v2/',
+			apiVersion: '2',
+		} );
 	}
 
 	getLocale() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -128,9 +128,16 @@ class DomainsStep extends Component {
 
 	componentDidMount() {
 		// trigger guides on this step, we don't care about failures or response
-		wpcom.req.post( `guides/trigger?flow=${ this.props.flowName }&step=domains `, {
-			apiNamespace: 'wpcom/v2/',
-		} );
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: this.props.flowName,
+				step: 'domains',
+			}
+		);
 	}
 
 	getLocale() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,7 +4,7 @@ import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
-import { Component, useEffect } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
@@ -27,6 +27,7 @@ import {
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
+import wpcom from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -59,7 +60,6 @@ import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getExternalBackUrl } from './utils';
 import './style.scss';
-import wpcomRequest from 'wpcom-proxy-request';
 
 class DomainsStep extends Component {
 	static propTypes = {
@@ -128,10 +128,8 @@ class DomainsStep extends Component {
 
 	componentDidMount() {
 		// trigger guides on this step, we don't care about failures or response
-		wpcomRequest( {
-			path: `guides/trigger?flow=${ this.props.flowName }&step=domains`,
+		wpcom.req.post( `guides/trigger?flow=${ this.props.flowName }&step=domains `, {
 			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
 		} );
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,5 @@
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
@@ -127,17 +128,19 @@ class DomainsStep extends Component {
 	}
 
 	componentDidMount() {
-		// trigger guides on this step, we don't care about failures or response
-		wpcom.req.post(
-			'guides/trigger',
-			{
-				apiNamespace: 'wpcom/v2/',
-			},
-			{
-				flow: this.props.flowName,
-				step: 'domains',
-			}
-		);
+		if ( isTailoredSignupFlow( this.props.flowName ) ) {
+			// trigger guides on this step, we don't care about failures or response
+			wpcom.req.post(
+				'guides/trigger',
+				{
+					apiNamespace: 'wpcom/v2/',
+				},
+				{
+					flow: this.props.flowName,
+					step: 'domains',
+				}
+			);
+		}
 	}
 
 	getLocale() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -43,7 +43,6 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
-import wpcomRequest from 'wpcom-proxy-request';
 
 export class PlansStep extends Component {
 	state = {
@@ -57,10 +56,8 @@ export class PlansStep extends Component {
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 
 		// trigger guides on this step, we don't care about failures or response
-		wpcomRequest( {
-			path: `guides/trigger?flow=${ this.props.flowName }&step=plan`,
+		wp.req.post( `guides/trigger?flow=${ this.props.flowName }&step=plans`, {
 			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
 		} );
 	}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -12,6 +12,7 @@ import {
 	NEWSLETTER_FLOW,
 	isNewsletterOrLinkInBioFlow,
 } from '@automattic/onboarding';
+import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -55,17 +56,19 @@ export class PlansStep extends Component {
 		);
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 
-		// trigger guides on this step, we don't care about failures or response
-		wp.req.post(
-			'guides/trigger',
-			{
-				apiNamespace: 'wpcom/v2/',
-			},
-			{
-				flow: this.props.flowName,
-				step: 'plans',
-			}
-		);
+		if ( isTailoredSignupFlow( this.props.flowName ) ) {
+			// trigger guides on this step, we don't care about failures or response
+			wp.req.post(
+				'guides/trigger',
+				{
+					apiNamespace: 'wpcom/v2/',
+				},
+				{
+					flow: this.props.flowName,
+					step: 'plans',
+				}
+			);
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -43,6 +43,7 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
+import wpcomRequest from 'wpcom-proxy-request';
 
 export class PlansStep extends Component {
 	state = {
@@ -54,6 +55,13 @@ export class PlansStep extends Component {
 			this.setState( { isDesktop: matchesDesktop } )
 		);
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
+
+		// trigger guides on this step, we don't care about failures or response
+		wpcomRequest( {
+			path: `guides/trigger?flow=${ this.props.flowName }&step=plan`,
+			apiNamespace: 'wpcom/v2/',
+			apiVersion: '2',
+		} );
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -56,9 +56,16 @@ export class PlansStep extends Component {
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 
 		// trigger guides on this step, we don't care about failures or response
-		wp.req.post( `guides/trigger?flow=${ this.props.flowName }&step=plans`, {
-			apiNamespace: 'wpcom/v2/',
-		} );
+		wp.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: this.props.flowName,
+				step: 'plans',
+			}
+		);
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -3,6 +3,7 @@ jest.mock( 'calypso/signup/step-wrapper', () => () => <div data-testid="step-wra
 jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
 jest.mock( 'calypso/components/data/query-plans', () => 'query-plans' );
 jest.mock( 'calypso/components/marketing-message', () => 'marketing-message' );
+jest.mock( 'calypso/lib/wp', () => ( { req: { post: () => {} } } ) );
 
 import {
 	PLAN_FREE,


### PR DESCRIPTION
#### Proposed Changes

This calls a new endpoint in D87638-code that allows for reminding users about an uncompleted flow after a few days.

#### Testing Instructions

See D87638-code

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
