### PR TITLE
Site Switcher: Use 'Switch site' instead of 'Switch Site'

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -70,7 +70,7 @@ class CurrentSite extends Component {
 									className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
 								></span>
 								<span className="current-site__switch-sites-label">
-									{ translate( 'Switch Site' ) }
+									{ translate( 'Switch site' ) }
 								</span>
 							</Button>
 						</span>


### PR DESCRIPTION
## Proposed Changes

Uses `Switch site` instead of `Switch site` because the button is an action, not a place.

From p1663014301903419-slack-C041RHH38NQ

### Before

<img width="686" alt="image" src="https://user-images.githubusercontent.com/36432/189932323-98d19321-a9e8-48f5-897f-22bd5c6248bc.png">

### After

<img width="589" alt="image" src="https://user-images.githubusercontent.com/36432/189932213-fe5473dc-6569-4f04-b4d6-8657ef439e54.png">

## Testing Instructions

1. Navigate to a site.
2. Open the sidebar and observe the new language.