### PR TITLE
Add document page title for tailored flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,9 +1,11 @@
 import { ProgressBar } from '@automattic/components';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect } from 'react';
 import Modal from 'react-modal';
 import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from 'react-router-dom';
+import DocumentHead from 'calypso/components/data/document-head';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -84,27 +86,36 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		return <StepComponent navigation={ stepNavigation } flow={ flow.name } data={ stepData } />;
 	};
 
+	const getDocumentHeadTitle = () => {
+		if ( isNewsletterOrLinkInBioFlow( flow.name ) ) {
+			return flow.title;
+		}
+	};
+
 	return (
-		<Switch>
-			{ stepPaths.map( ( path ) => {
-				return (
-					<Route key={ path } path={ `/${ path }` }>
-						<div className={ classnames( flow.name, flow.classnames, kebabCase( path ) ) }>
-							<ProgressBar
-								// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-								className="flow-progress"
-								value={ progressValue * 100 }
-								total={ 100 }
-							/>
-							<SignupHeader pageTitle={ flow.title } />
-							{ renderStep( path ) }
-						</div>
-					</Route>
-				);
-			} ) }
-			<Route>
-				<Redirect to={ stepPaths[ 0 ] + search } />
-			</Route>
-		</Switch>
+		<>
+			<DocumentHead title={ getDocumentHeadTitle() } />
+			<Switch>
+				{ stepPaths.map( ( path ) => {
+					return (
+						<Route key={ path } path={ `/${ path }` }>
+							<div className={ classnames( flow.name, flow.classnames, kebabCase( path ) ) }>
+								<ProgressBar
+									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+									className="flow-progress"
+									value={ progressValue * 100 }
+									total={ 100 }
+								/>
+								<SignupHeader pageTitle={ flow.title } />
+								{ renderStep( path ) }
+							</div>
+						</Route>
+					);
+				} ) }
+				<Route>
+					<Redirect to={ stepPaths[ 0 ] + search } />
+				</Route>
+			</Switch>
+		</>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

Add Document page title for LiB and NL

Before:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/2653810/189953423-1d9e1e5a-505a-405b-8287-7d5766c37dd8.png">



After:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/2653810/189953309-e788a760-246f-4b3b-997b-428a599b5ddc.png">


## Testing Instructions

- Pull this branch and run yarn start
- Navigate to /setup/intro?flow=link-in-bio or ?flow=newsletter
- Check the document title, should match the flow name.


 Related to #67732
