### PR TITLE
Launchpad: Allow user to go back to Add Links

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -75,6 +75,7 @@ export function getEnhancedTasks(
 					taskData = {
 						title: translate( 'Add links' ),
 						actionUrl: `/site-editor/${ siteSlug }`,
+						keepActive: true,
 						isCompleted: linkInBioLinksEditCompleted,
 					};
 					break;


### PR DESCRIPTION
#### Summary
Currently, once the user lands on the Launchpad checklist screen via the LinkInBio flow, they are unable to go back to the **Add Links** task since it's disabled:

https://user-images.githubusercontent.com/20927667/189232830-28d74eee-bda0-4f50-aae1-daa6a21adac8.mov

#### Proposed changes
This PR allows users to revisit the **Add Links** task:

https://user-images.githubusercontent.com/20927667/189232848-836262a5-9dec-44c1-863f-275d2653818c.mov

#### Testing Instructions
1. Go to `http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug=YOUR_SITE_SLUG&notice=purchase-success`
2. You should see that the **Add Links** task is completed but still active
3. Click on the **Add Links** task
4. You should see the Site Editor screen

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67430