### PR TITLE
Launchpad: Allow going back to Choose a Plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -37,6 +37,8 @@ export function getEnhancedTasks(
 				case 'plan_selected':
 					taskData = {
 						title: translate( 'Choose a Plan' ),
+						keepActive: true,
+						actionUrl: `/plans/${ siteSlug }`,
 						badgeText: translatedPlanName,
 					};
 					break;


### PR DESCRIPTION
#### Summary
Currently, once the user lands on the Launchpad checklist screen, they are unable to go back to the **Choose a Plan** task since it's disabled:

![OTQHbz.png](https://user-images.githubusercontent.com/20927667/189990630-b1a65834-5c66-411f-bece-be0934228ae5.png)

#### Proposed changes
This PR allows going back to the Plans page. For the moment we will be going back to Calypso's Plan page:

![CB6KQY.png](https://user-images.githubusercontent.com/20927667/189990710-989d26b2-64fa-4e2c-97d5-ffed6caef2b9.png)

![mPzGvH.png](https://user-images.githubusercontent.com/20927667/189991229-5b267b50-16a3-426e-92dc-a931ab130982.png)

#### Testing Instructions
1. Go to `http://calypso.localhost:3000/setup/launchpad?flow=newsletter&complete-setup=true&siteSlug=YOUR_SITE_SLUG`
2. You should see that the **Choose a Plan**  task is completed but still active
3. Click on the **Choose a Plan**  task
4. You should see the Calypso Plans screen

https://user-images.githubusercontent.com/20927667/189991020-9ca41268-6bff-40c0-a8ff-e1fa2dae52cf.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67667