### PR TITLE
Fix image editor in RTL contexts

### DIFF
--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -360,7 +360,7 @@ class ImageEditorCrop extends Component {
 		const { topBound, leftBound, rightBound, bottomBound } = this.props.bounds;
 
 		return (
-			<div>
+			<div className="image-editor__crop-background-container">
 				<div
 					className="image-editor__crop-background"
 					style={ {

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -106,7 +106,6 @@
 		height: 24px;
 		margin: -8px auto auto -8px;
 		width: 24px;
-		transform: translateX(-8px);
 	}
 }
 

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -61,6 +61,7 @@
 .image-editor__canvas {
 	position: absolute;
 	top: 50%;
+	/*!rtl:ignore*/
 	left: 50%;
 	&.is-placeholder {
 		@include placeholder( --color-neutral-70 );
@@ -74,6 +75,11 @@
 	box-sizing: border-box;
 }
 
+.image-editor__crop-background-container {
+	/*!rtl:ignore*/
+	direction: ltr;
+}
+
 .image-editor__crop-background {
 	position: absolute;
 	background: var(--color-neutral-90);
@@ -85,26 +91,32 @@
 	width: 8px;
 	height: 8px;
 	margin-top: -4px;
+	/*!rtl:ignore*/
 	margin-left: -4px;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	border: 2px solid var(--color-border-inverted);
 	background: var(--color-neutral-90);
 
 	&::before {
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 		content: " ";
 		display: block;
 		height: 24px;
 		margin: -8px auto auto -8px;
 		width: 24px;
+		transform: translateX(-8px);
 	}
 }
 
 .image-editor__crop-handle-nesw {
+	/*!rtl:ignore*/
 	cursor: nesw-resize;
 }
 
 .image-editor__crop-handle-nwse {
+	/*!rtl:ignore*/
 	cursor: nwse-resize;
 }
 
@@ -115,5 +127,6 @@
 }
 
 .image-editor__buttons-button.button {
+	/*!rtl:ignore*/
 	margin-left: 10px;
 }


### PR DESCRIPTION
#### Proposed Changes

*   We have a build tool that processes the CSS to make it RTL friendly. It flips all `*left` props to `*right` and does a lot of magic. This tool is breaking the image editor and this PR makes sure it doesn't interfere with dragging and cropping.

#### Testing Instructions

#### Tailored flows

1. Incognito, go to /setup/linkInBioSetup?flow=link-in-bio&locale=ar
2. Reach site setup step.
3. Upload a logo and crop it. Cropping should be perfect.

#### Avatar in Calypso
1. Go to /me using an RTL user
2. Upload an avatar, cropping should be perfect.

