### PR TITLE
Tailored flows: fix backgrounds in tailored flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -9,6 +9,7 @@
 			url(calypso/assets/images/onboarding/newsletter-intro-right.png);
 		background-repeat: no-repeat, no-repeat;
 		background-attachment: fixed;
+		/*!rtl:ignore*/
 		background-position-x: 0%, 100%;
 		background-position-y: 100%, 100px;
 		background-size: auto 30%, auto 50%;
@@ -25,6 +26,7 @@
 			url(calypso/assets/images/onboarding/link-in-bio-intro-left.png),
 			url(calypso/assets/images/onboarding/link-in-bio-intro-right.png);
 		background-position-y: 85%, 15%;
+		/*!rtl:ignore*/
 		background-position-x: 0, 100%;
 		background-repeat: no-repeat, no-repeat;
 		background-attachment: fixed;

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -68,6 +68,7 @@
 			background-position: left bottom, right top;
 			background-repeat: no-repeat, no-repeat;
 			background-attachment: fixed;
+			/*!rtl:ignore*/
 			background-position-x: 0%, 100%;
 			background-position-y: 30%, 100%;
 			background-size: auto 55%, auto 25%;
@@ -89,7 +90,8 @@
 			background-image:
 				url(calypso/assets/images/onboarding/link-in-bio-processing-left.png),
 				url(calypso/assets/images/onboarding/link-in-bio-processing-right.png);
-			background-position-y: 92%, 8%;
+			background-position-y: 92%, 15%;
+			/*!rtl:ignore*/
 			background-position-x: 0, 100%;
 			background-repeat: no-repeat, no-repeat;
 			background-attachment: fixed;


### PR DESCRIPTION
#### Proposed Changes

* Similar to https://github.com/Automattic/wp-calypso/pull/67764. This prevents RTL post-processing from flipping backgrounds in intro and loading steps.

#### Testing Instructions

1. Go through LiB and NL using an RTL user.
2. Intro and loading steps background should look perfect.
