### PR TITLE
HelpCenter: fix some styling bugs

### DIFF
--- a/packages/help-center/src/components/help-center-inline-chat.scss
+++ b/packages/help-center/src/components/help-center-inline-chat.scss
@@ -2,3 +2,7 @@
 	width: 100%;
 	height: calc(100% - 4px);
 }
+
+.help-center .components-card.help-center__container .help-center__container-content:has(> iframe) {
+	overflow: hidden;
+}

--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -19,6 +19,7 @@ const InlineChat: React.FC = () => {
 			className="help-center-inline-chat__iframe"
 			title="Happychat"
 			src={ `https://widgets.wp.com/calypso-happychat/?env=${ env }` }
+			scrolling="no"
 		/>
 	);
 };

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -138,11 +138,12 @@ $head-foot-height: 50px;
 		.help-center-header__unread-count {
 			display: inline-block;
 			margin-left: 8px;
-			padding: 2px 6px;
+			padding: 2px 8px;
 			background: var(--studio-pink-50);
-			border-radius: 20px; /* stylelint-disable-line scales/radii */
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			border-radius: 50%;
 			font-size: $font-body-extra-small;
-			color: #000;
+			color: #fff;
 		}
 
 		.help-center-header__a8c-only-badge {


### PR DESCRIPTION
## Proposed Changes

This fixes some general issue.

* There was two scroll bars in chat.
* Toggling minimize was clunky due to these scroll bars
* Unread message count was skewed and hard to read

## Testing Instructions

1. Pull branch and `cd apps/editing-toolkit/ && yarn dev --sync`
2. Go to the editor and open Help Center
3. Toggle minimize and ensure its smoother especially relating to the scroll bar.
4. Navigate around and see if there is any regression
5. Test from chat as well.