### PR TITLE
Add feature flag and direct to plugin plans page on eligibility blocker

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -106,6 +106,9 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 			<PluginCustomDomainDialog
 				onProceed={ () => {
 					if ( hasEligibilityMessages ) {
+						if ( isEnabled( 'plugins-plans-page' ) && shouldUpgrade ) {
+							return page( `/plugins/plans/${ selectedSite?.slug }` );
+						}
 						return setShowEligibility( true );
 					}
 					onClickInstallPlugin( {

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -157,7 +157,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 						return setShowAddCustomDomain( true );
 					}
 					if ( hasEligibilityMessages ) {
-						if ( isEnabled( 'marketplace-plans-page' ) && shouldUpgrade ) {
+						if ( isEnabled( 'plugins-plans-page' ) && shouldUpgrade ) {
 							return page( `/plugins/plans/${ selectedSite?.slug }` );
 						}
 						return setShowEligibility( true );

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -101,13 +101,16 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 
 	const productsList = useSelector( getProductsList );
 
+	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
+	const pluginsPlansPage = `/plugins/plans/${ selectedSite?.slug }`;
+
 	return (
 		<>
 			<PluginCustomDomainDialog
 				onProceed={ () => {
 					if ( hasEligibilityMessages ) {
-						if ( isEnabled( 'plugins-plans-page' ) && shouldUpgrade ) {
-							return page( `/plugins/plans/${ selectedSite?.slug }` );
+						if ( pluginsPlansPageFlag && shouldUpgrade ) {
+							return page( pluginsPlansPage );
 						}
 						return setShowEligibility( true );
 					}
@@ -160,8 +163,8 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 						return setShowAddCustomDomain( true );
 					}
 					if ( hasEligibilityMessages ) {
-						if ( isEnabled( 'plugins-plans-page' ) && shouldUpgrade ) {
-							return page( `/plugins/plans/${ selectedSite?.slug }` );
+						if ( pluginsPlansPageFlag && shouldUpgrade ) {
+							return page( pluginsPlansPage );
 						}
 						return setShowEligibility( true );
 					}

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
@@ -156,6 +157,9 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 						return setShowAddCustomDomain( true );
 					}
 					if ( hasEligibilityMessages ) {
+						if ( isEnabled( 'marketplace-plans-page' ) ) {
+							return page( `/plugins/plans/${ selectedSite?.slug }` );
+						}
 						return setShowEligibility( true );
 					}
 					onClickInstallPlugin( {

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -157,7 +157,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 						return setShowAddCustomDomain( true );
 					}
 					if ( hasEligibilityMessages ) {
-						if ( isEnabled( 'marketplace-plans-page' ) ) {
+						if ( isEnabled( 'marketplace-plans-page' ) && shouldUpgrade ) {
 							return page( `/plugins/plans/${ selectedSite?.slug }` );
 						}
 						return setShowEligibility( true );


### PR DESCRIPTION
#### Proposed Changes

* If a site is on a plan that doesn't allow plugin installation, we should show the new plan upgrade page from https://github.com/Automattic/wp-calypso/issues/67574 when "Upgrade/Purchase and activate" is clicked.
* Adds a 'plugins-plans-page' feature flag.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR

Test Paid Plugins
* Go to calypso.localhost:3000/plugins/woocommerce-subscriptions/{your-test-site}?flags=plugins-plans-page
  * Note the need for the feature flag in the URL `?flags=plugins-plans-page`
* Click "Purchase and activate"
<img src="https://user-images.githubusercontent.com/140841/190247578-9651a545-643b-4955-96d7-c9a129e6a867.png" width="300" />

* All sub-business plan sites should be directed to the `/plugins/plans/{site}` page.
* Non-Atomic business or higher plans should get a "domain change warning" modal.
* Atomic business or higher plans should be directed to checkout
* Jetpack sites can't see paid plugins

Test "Free" Plugins
* Go to calypso.localhost:3000/plugins/elementor/{your-test-site}?flags=plugins-plans-page
  * Note the need for the feature flag in the URL `?flags=plugins-plans-page`
* Click "Upgrade and activate"
<img src="https://user-images.githubusercontent.com/140841/190247768-dcd4391b-caa5-43f5-92e5-dcd7bda93f0d.png" width="300" />

* All sub-business plan sites should be directed to the `/plugins/plans/{site}` page.
* Non-Atomic business or higher plans should get a "domain change warning" modal.
* Atomic business or higher plans should install the plugin
* Jetpack sites should install the plugin

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67575
