### PR TITLE
HelpCenter: add language to HappyChat authentication

### DIFF
--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -41,7 +41,7 @@ describe( 'auth promise', () => {
 				url: config( 'happychat_url' ),
 				user: {
 					signer_user_id: state.currentUser.user.ID,
-					skills: { language: state.currentUser.user.localeSlug },
+					skills: { language: [ state.currentUser.user.localeSlug ] },
 					groups: [ 'jpop' ],
 					jwt: 'jwt',
 					geoLocation: { city: 'Lugo' },

--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -41,7 +41,7 @@ describe( 'auth promise', () => {
 				url: config( 'happychat_url' ),
 				user: {
 					signer_user_id: state.currentUser.user.ID,
-					locale: state.currentUser.user.localeSlug,
+					skills: { language: state.currentUser.user.localeSlug },
 					groups: [ 'jpop' ],
 					jwt: 'jwt',
 					geoLocation: { city: 'Lugo' },

--- a/packages/happychat-connection/src/connection.ts
+++ b/packages/happychat-connection/src/connection.ts
@@ -63,7 +63,7 @@ export class Connection {
 
 		this.openSocket = new Promise( ( resolve, reject ) => {
 			auth
-				.then( ( { url, user: { signer_user_id, jwt, locale, groups, skills, geoLocation } } ) => {
+				.then( ( { url, user: { signer_user_id, jwt, groups, skills, geoLocation } } ) => {
 					const socket = buildConnection( url );
 					socket
 						.once( 'connect', () => dispatch( this.receiveConnect?.() ) )
@@ -71,13 +71,11 @@ export class Connection {
 							'token',
 							( handler: ( happychatUser: HappychatUser & { jwt: string } ) => void ) => {
 								dispatch( this.receiveToken?.() );
-								handler( { signer_user_id, jwt, locale, groups, skills } );
+								handler( { signer_user_id, jwt, groups, skills } );
 							}
 						)
 						.on( 'init', () => {
-							dispatch(
-								this.receiveInit?.( { signer_user_id, locale, groups, skills, geoLocation } )
-							);
+							dispatch( this.receiveInit?.( { signer_user_id, groups, skills, geoLocation } ) );
 							dispatch( this.requestTranscript?.() );
 							resolve( socket );
 						} )

--- a/packages/happychat-connection/src/types.ts
+++ b/packages/happychat-connection/src/types.ts
@@ -1,5 +1,6 @@
 export interface User {
 	ID: number;
+	language: string;
 }
 
 export interface GeoLocation {
@@ -16,10 +17,10 @@ export interface HappychatSession {
 
 export interface HappychatUser {
 	signer_user_id: number;
-	locale: string | null;
 	groups?: string[];
 	skills?: {
 		product: string[];
+		language: string[];
 	};
 	geoLocation?: GeoLocation;
 }

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { getLocaleSlug } from 'i18n-calypso';
 import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { HappychatSession, HappychatUser, User, HappychatAuth } from './types';
@@ -13,14 +12,13 @@ export async function requestHappyChatAuth() {
 	} );
 
 	const url: string = config( 'happychat_url' );
-	const locale = getLocaleSlug();
 
 	const happychatUser: HappychatUser = {
 		signer_user_id: user.ID,
-		locale,
 		groups: [ 'WP.com' ],
 		skills: {
 			product: [ 'WP.com' ],
+			language: [ user.language ],
 		},
 	};
 	const session: HappychatSession = await wpcomRequest( {

--- a/packages/happychat-connection/test/index.ts
+++ b/packages/happychat-connection/test/index.ts
@@ -50,18 +50,19 @@ const getConnection = ( { autoClose = false } = {} ) => {
 const buildUserData = () => {
 	const signer_user_id = 12;
 	const jwt = 'jwt';
-	const locale = 'locale';
+	const skills = { language: [ '' ], product: [ '' ] };
 	const groups = [ 'groups' ];
 	const geoLocation = { country_short: '', country_long: '', region: '', city: '' };
 	const fullUser = {
 		ID: signer_user_id,
+		language: '',
 	};
 
 	return {
 		user: {
 			signer_user_id,
 			jwt,
-			locale,
+			skills,
 			groups,
 			geoLocation,
 		},
@@ -112,20 +113,20 @@ describe( 'connection', () => {
 
 			test( 'token event', () => {
 				const callback = jest.fn();
-				const { signer_user_id, jwt, locale, groups } = userData.user;
+				const { signer_user_id, jwt, skills, groups } = userData.user;
 				socket.emit( 'token', callback );
 				expect( dispatch ).toHaveBeenCalledTimes( 1 );
 				expect( dispatch ).toHaveBeenCalledWith( receiveToken() );
 				expect( callback ).toHaveBeenCalledTimes( 1 );
-				expect( callback ).toHaveBeenCalledWith( { signer_user_id, jwt, locale, groups } );
+				expect( callback ).toHaveBeenCalledWith( { signer_user_id, jwt, skills, groups } );
 			} );
 
 			test( 'init event', () => {
-				const { signer_user_id, locale, groups, geoLocation } = userData.user;
+				const { signer_user_id, skills, groups, geoLocation } = userData.user;
 				socket.emit( 'init' );
 				expect( dispatch ).toHaveBeenCalledTimes( 2 );
 				expect( dispatch.mock.calls[ 0 ][ 0 ] ).toEqual(
-					receiveInit( { signer_user_id, locale, groups, geoLocation } )
+					receiveInit( { signer_user_id, skills, groups, geoLocation } )
 				);
 				expect( dispatch.mock.calls[ 1 ][ 0 ] ).toEqual( requestTranscript() );
 				return expect( openSocket ).resolves.toBe( socket );


### PR DESCRIPTION
## Proposed Changes

When starting a new chat the Language option was previously not set. This uses the User data to set the language appropriately.

<img width="226" alt="Markup 2022-09-14 at 00 07 54" src="https://user-images.githubusercontent.com/33258733/190019208-031f2bbe-3319-4873-b10d-72af5888b102.png">

## Testing Instructions

1. Pull branch and `cd apps/editing-toolkit/ && yarn dev --sync`
2. Go to the editor and open Help Center
3. Start a new chat and make sure the language matches the account language.
4. Change the language on your account
5. Clear cache and reload the editor and start a new chat.
6. Observe the language matches the new language.