### PR TITLE
Launchpad: Fix flashing my home before launchpad redirect

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -44,6 +44,7 @@ export function maybeRedirect( context, next ) {
 		// client-side router, so page.redirect won't work. We need to use the
 		// traditional window.location Web API.
 		redirectToLaunchpad( slug, options?.site_intent );
+		return;
 	}
 	next();
 }


### PR DESCRIPTION
### Context
The page client side router was rendering the home page instead of a loading screen when we were redirecting to launchpad.

This is because, previously, we inadvertently allowed client side routing to continue processing the /home/:siteId route, even after calling our redirect function. We now include an early return, which prevents homepage rendering and, instead, displays a loading screen.

#### Proposed Changes

* Add early return to client side routing after redirecting to launchpad

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a newsletter site in https://wordpress.com/hp-2022-tailored-flows/
* Continue until at the launchpad screen
* Click on the Go to Admin button in the bottom left hand corner of the screen
* Verify that clicking on "My Home" in the Calypso UI Admin Sidebar flashes a WordPress loading screen instead of My Home
* Repeat the steps for link in bio

![2022-09-13 16 10 04](https://user-images.githubusercontent.com/5414230/190024952-f72340b8-9a17-41ed-a2f1-7094b4dac47c.gif)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67658
