### PR TITLE
Plugin Management: add update all plugins warning modal popup

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -335,6 +335,7 @@ export class PluginsMain extends Component {
 				header={ this.props.translate( 'Installed Plugins' ) }
 				plugins={ currentPlugins }
 				pluginUpdateCount={ this.props.pluginUpdateCount }
+				pluginsWithUpdates={ this.props.pluginsWithUpdates }
 				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
 				isLoading={ this.props.requestingPluginsForSites }
 				isJetpackCloud={ this.props.isJetpackCloud }
@@ -563,6 +564,7 @@ export default flow(
 				currentPlugins: getPlugins( state, siteIds, filter ),
 				currentPluginsOnVisibleSites: getPlugins( state, visibleSiteIds, filter ),
 				pluginUpdateCount: pluginsWithUpdates && pluginsWithUpdates.length,
+				pluginsWithUpdates,
 				allPluginsCount: allPlugins && allPlugins.length,
 				requestingPluginsForSites:
 					isRequestingForSites( state, siteIds ) || isRequestingForAllSites( state ),

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -125,7 +125,7 @@ export class PluginsListHeader extends PureComponent {
 			if ( 0 < this.props.pluginUpdateCount ) {
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-update-all">
-						<Button compact primary onClick={ this.props.updateAllPlugins }>
+						<Button compact primary onClick={ this.props.updateAllPluginsNotice }>
 							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
 								context: 'button label',
 								count: this.props.pluginUpdateCount,

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -38,7 +38,7 @@ export class PluginsListHeader extends PureComponent {
 		isBulkManagementActive: PropTypes.bool,
 		isWpComAtomic: PropTypes.bool,
 		toggleBulkManagement: PropTypes.func.isRequired,
-		updateAllPlugins: PropTypes.func.isRequired,
+		updateAllPluginsNotice: PropTypes.func.isRequired,
 		updateSelected: PropTypes.func.isRequired,
 		pluginUpdateCount: PropTypes.number.isRequired,
 		activateSelected: PropTypes.func.isRequired,

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -20,9 +20,8 @@ interface Props {
 	isBulkManagementActive: boolean;
 	pluginUpdateCount: number;
 	toggleBulkManagement: () => void;
-	updateAllPlugins: () => void;
-	removePluginNotice: ( plugin: Plugin ) => void;
 	updateAllPluginsNotice: () => void;
+	removePluginNotice: ( plugin: Plugin ) => void;
 	updatePlugin: ( plugin: Plugin ) => void;
 }
 export default function PluginManagementV2( {
@@ -33,8 +32,8 @@ export default function PluginManagementV2( {
 	isBulkManagementActive,
 	pluginUpdateCount,
 	toggleBulkManagement,
-	removePluginNotice,
 	updateAllPluginsNotice,
+	removePluginNotice,
 	updatePlugin,
 }: Props ): ReactElement {
 	const translate = useTranslate();

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -22,6 +22,7 @@ interface Props {
 	toggleBulkManagement: () => void;
 	updateAllPlugins: () => void;
 	removePluginNotice: ( plugin: Plugin ) => void;
+	updateAllPluginsNotice: () => void;
 	updatePlugin: ( plugin: Plugin ) => void;
 }
 export default function PluginManagementV2( {
@@ -32,8 +33,8 @@ export default function PluginManagementV2( {
 	isBulkManagementActive,
 	pluginUpdateCount,
 	toggleBulkManagement,
-	updateAllPlugins,
 	removePluginNotice,
+	updateAllPluginsNotice,
 	updatePlugin,
 }: Props ): ReactElement {
 	const translate = useTranslate();
@@ -54,7 +55,7 @@ export default function PluginManagementV2( {
 			<div className="plugin-common-table__bulk-actions">
 				{ !! pluginUpdateCount && (
 					<ButtonGroup className="plugin-management-v2__table-button-group">
-						<Button compact primary onClick={ updateAllPlugins }>
+						<Button compact primary onClick={ updateAllPluginsNotice }>
 							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
 								context: 'button label',
 								count: pluginUpdateCount,

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -311,10 +311,12 @@ export class PluginsList extends Component {
 		} );
 	};
 
-	updateAllPlugins = () => {
-		this.handleUpdatePlugins( this.props.plugins );
-		this.recordEvent( 'Clicked Update all Plugins', true );
-		recordTracksEvent( 'calypso_plugins_update_all_click' );
+	updateAllPlugins = ( accepted ) => {
+		if ( accepted ) {
+			this.handleUpdatePlugins( this.props.plugins );
+			this.recordEvent( 'Clicked Update all Plugins', true );
+			recordTracksEvent( 'calypso_plugins_update_all_click' );
+		}
 	};
 
 	updateSelected = ( accepted ) => {
@@ -503,6 +505,26 @@ export class PluginsList extends Component {
 		}
 	};
 
+	updateAllPluginsDialog = () => {
+		const { translate } = this.props;
+
+		const siteDetails = this.props.selectedSiteSlug ? this.props.selectedSiteSlug : 'all sites';
+
+		acceptDialog(
+			<div>
+				<span>
+					{ translate( 'You are about to update all plugins on %(siteDetails)s', {
+						args: {
+							siteDetails: siteDetails,
+						},
+					} ) }
+				</span>
+			</div>,
+			( accepted ) => this.updateAllPlugins( accepted ),
+			translate( 'Update all plugins' )
+		);
+	};
+
 	removePluginDialog = ( selectedPlugin ) => {
 		this.bulkActionDialog( 'remove', selectedPlugin );
 	};
@@ -609,6 +631,7 @@ export class PluginsList extends Component {
 					autoupdateEnablePluginNotice={ () => this.bulkActionDialog( 'enableAutoupdates' ) }
 					autoupdateDisablePluginNotice={ () => this.bulkActionDialog( 'disableAutoupdates' ) }
 					updatePluginNotice={ () => this.bulkActionDialog( 'update' ) }
+					updateAllPluginsNotice={ () => this.updateAllPluginsDialog() }
 				/>
 				<PluginManagementV2
 					plugins={ this.getPlugins() }
@@ -619,6 +642,7 @@ export class PluginsList extends Component {
 					pluginUpdateCount={ this.props.pluginUpdateCount }
 					toggleBulkManagement={ this.toggleBulkManagement }
 					updateAllPlugins={ this.updateAllPlugins }
+					updateAllPluginsNotice={ this.updateAllPluginsDialog }
 					removePluginNotice={ this.removePluginDialog }
 					updatePlugin={ this.updatePlugin }
 				/>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -506,22 +506,36 @@ export class PluginsList extends Component {
 	};
 
 	updateAllPluginsDialog = () => {
-		const { translate } = this.props;
+		const { pluginUpdateCount, translate } = this.props;
 
 		const siteDetails = this.props.selectedSiteSlug ? this.props.selectedSiteSlug : 'all sites';
+
+		const translationArgs = {
+			args: { pluginUpdateCount },
+			count: pluginUpdateCount,
+		};
 
 		acceptDialog(
 			<div>
 				<span>
-					{ translate( 'You are about to update all plugins on %(siteDetails)s', {
-						args: {
-							siteDetails: siteDetails,
-						},
-					} ) }
+					{ translate(
+						'You are about to update %(pluginUpdateCount)d plugin on %(siteDetails)s',
+						'You are about to update %(pluginUpdateCount)d plugins on %(siteDetails)s',
+						{
+							args: {
+								pluginUpdateCount: pluginUpdateCount,
+								siteDetails: siteDetails,
+							},
+						}
+					) }
 				</span>
 			</div>,
 			( accepted ) => this.updateAllPlugins( accepted ),
-			translate( 'Update all plugins' )
+			translate(
+				'Update %(pluginUpdateCount)d plugin',
+				'Update %(pluginUpdateCount)d plugins',
+				translationArgs
+			)
 		);
 	};
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -510,32 +510,57 @@ export class PluginsList extends Component {
 
 		const siteDetails = this.props.selectedSiteSlug ? this.props.selectedSiteSlug : 'all sites';
 
-		const translationArgs = {
-			args: { pluginUpdateCount },
-			count: pluginUpdateCount,
+		const dialogOptions = {
+			additionalClassNames: 'plugins__confirmation-modal',
 		};
 
+		const heading =
+			pluginUpdateCount === 1
+				? translate( 'Update 1 plugin' )
+				: translate( 'Update %(pluginUpdateCount)d plugins', { args: { pluginUpdateCount } } );
+
+		const combination =
+			( ! siteDetails ? 'n sites' : '1 site' ) +
+			' ' +
+			( pluginUpdateCount > 1 ? 'n plugins' : '1 plugin' );
+
+		let message = 'You are about to update all plugins on all sites';
+		switch ( combination ) {
+			case '1 site 1 plugin':
+				message = translate( ' You are about to update 1 plugin on %(siteDetails)s', {
+					args: { siteDetails },
+				} );
+				break;
+			case '1 site n plugins':
+				message = translate(
+					' You are about to update %(pluginUpdateCount)d plugins on %(siteDetails)s',
+					{
+						args: {
+							pluginUpdateCount: pluginUpdateCount,
+							siteDetails: siteDetails,
+						},
+					}
+				);
+				break;
+			case 'n sites 1 plugin':
+				message = translate( ' You are about to update 1 plugin on all sites', {
+					args: { siteDetails },
+				} );
+				break;
+			case 'n sites n plugins':
+				message = translate(
+					' You are about to update %(pluginUpdateCount)d plugins on all sites',
+					{ args: { pluginUpdateCount } }
+				);
+				break;
+		}
+
 		acceptDialog(
-			<div>
-				<span>
-					{ translate(
-						'You are about to update %(pluginUpdateCount)d plugin on %(siteDetails)s',
-						'You are about to update %(pluginUpdateCount)d plugins on %(siteDetails)s',
-						{
-							args: {
-								pluginUpdateCount: pluginUpdateCount,
-								siteDetails: siteDetails,
-							},
-						}
-					) }
-				</span>
-			</div>,
+			message,
 			( accepted ) => this.updateAllPlugins( accepted ),
-			translate(
-				'Update %(pluginUpdateCount)d plugin',
-				'Update %(pluginUpdateCount)d plugins',
-				translationArgs
-			)
+			heading,
+			null,
+			dialogOptions
 		);
 	};
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -506,57 +506,28 @@ export class PluginsList extends Component {
 	};
 
 	updateAllPluginsDialog = () => {
-		const { pluginUpdateCount, translate } = this.props;
+		const { pluginUpdateCount, translate, pluginsWithUpdates, allSites } = this.props;
 
-		const siteDetails = this.props.selectedSiteSlug ? this.props.selectedSiteSlug : 'all sites';
+		let pluginName;
+		const hasOnePlugin = pluginUpdateCount === 1;
+
+		if ( hasOnePlugin ) {
+			const [ { name, slug } ] = pluginsWithUpdates;
+			pluginName = name || slug;
+		}
 
 		const dialogOptions = {
 			additionalClassNames: 'plugins__confirmation-modal',
 		};
 
-		const heading =
-			pluginUpdateCount === 1
-				? translate( 'Update 1 plugin' )
-				: translate( 'Update %(pluginUpdateCount)d plugins', { args: { pluginUpdateCount } } );
-
-		const combination =
-			( ! siteDetails ? 'n sites' : '1 site' ) +
-			' ' +
-			( pluginUpdateCount > 1 ? 'n plugins' : '1 plugin' );
-
-		let message = 'You are about to update all plugins on all sites';
-		switch ( combination ) {
-			case '1 site 1 plugin':
-				message = translate( ' You are about to update 1 plugin on %(siteDetails)s', {
-					args: { siteDetails },
-				} );
-				break;
-			case '1 site n plugins':
-				message = translate(
-					' You are about to update %(pluginUpdateCount)d plugins on %(siteDetails)s',
-					{
-						args: {
-							pluginUpdateCount: pluginUpdateCount,
-							siteDetails: siteDetails,
-						},
-					}
-				);
-				break;
-			case 'n sites 1 plugin':
-				message = translate( ' You are about to update 1 plugin on all sites', {
-					args: { siteDetails },
-				} );
-				break;
-			case 'n sites n plugins':
-				message = translate(
-					' You are about to update %(pluginUpdateCount)d plugins on all sites',
-					{ args: { pluginUpdateCount } }
-				);
-				break;
-		}
+		const heading = hasOnePlugin
+			? translate( 'Update %(pluginName)s', { args: { pluginName } } )
+			: translate( 'Update %(pluginUpdateCount)d plugins', {
+					args: { pluginUpdateCount },
+			  } );
 
 		acceptDialog(
-			message,
+			getPluginActionDailogMessage( allSites, pluginsWithUpdates, heading, 'update' ),
 			( accepted ) => this.updateAllPlugins( accepted ),
 			heading,
 			null,


### PR DESCRIPTION
#### Proposed Changes

This PR makes UI enhancements to the plugin actions confirmation modal popups.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/add-update-all-plugins-warning-modal` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Plugins** in the sidebar -> Click on **Edit all** and test all the possible scenarios as mentioned below
4.  For testing purposes and to get an outdated version of the Jetpack plugin, install the beta version on a testing site and use the options on the manage page to install an older version.
5. Click on **Plugins** on the sidebar, verify that the `Update X Plugin` button being clicked results in a warning modal.
6. Switch to a specific site or visit `http://calypso.localhost:3000/plugins/manage/{site-slug}` for a particular site, verify that the `Update X Plugin` button being clicked results in a warning modal.
7. In all the above cases, verify that the plugin updates are executed once the action is confirmed.
8. Verify the same in Calypso Blue.

<table>
<tr>

<th>
1 plugin, 1 site
</th>
<th>
n plugins, 1 site
</th>
<th>
1 plugin, n sites
</th>
<th>
n plugins, n sites
</th>
</tr>

<tr>

<td>
<img width="584" alt="Screenshot 2022-09-21 at 2 38 23 PM" src="https://user-images.githubusercontent.com/10586875/191467478-2b467dac-204d-48da-a979-25646dfc83db.png">
</td>

<td>
<img width="518" alt="Screenshot 2022-09-21 at 2 40 22 PM" src="https://user-images.githubusercontent.com/10586875/191467508-73c4bea1-e6f4-4875-b677-e3c810ff049b.png">
</td>

<td>
<img width="549" alt="Screenshot 2022-09-21 at 2 42 23 PM" src="https://user-images.githubusercontent.com/10586875/191467522-583117a8-8ab1-44b4-ae31-a9ddbd2eb902.png">
</td>

<td>
<img width="480" alt="Screenshot 2022-09-21 at 2 41 47 PM" src="https://user-images.githubusercontent.com/10586875/191467513-560e1f13-527e-46de-be0f-5aca3c97d0a2.png">
</td>

</tr>

</table>

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202939629357161