### PR TITLE
Style selection: Updated full-screen preview's mobile layout breakpoint to 1024px

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -1,11 +1,18 @@
 @import "@wordpress/components/build-style/style";
 @import "@automattic/onboarding/styles/mixins";
-@import "@wordpress/base-styles/_breakpoints.scss";
-@import "@wordpress/base-styles/_mixins.scss";
+@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/mixins.scss";
 
 $gray-100: #101517;
 $gray-60: #50575e;
 $design-button-primary-color: rgb(17, 122, 201);
+$break-design-preview: 1024px;
+
+@mixin break-design-preview() {
+	@media (min-width: #{ ($break-design-preview) }) {
+		@content;
+	}
+}
 
 .design-setup {
 	.step-container {
@@ -135,6 +142,8 @@ $design-button-primary-color: rgb(17, 122, 201);
 		// Grid
 		.design-picker__grid {
 			.design-picker__design-option {
+				background: transparent;
+				border: none;
 				padding: 0;
 			}
 
@@ -168,11 +177,6 @@ $design-button-primary-color: rgb(17, 122, 201);
 						}
 					}
 				}
-			}
-
-			.design-picker__design-option {
-				background: transparent;
-				border: none;
 			}
 
 			.design-button-cover__button:not(.is-primary) {
@@ -538,7 +542,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 	.generated-design-picker__view-more {
 		border-radius: 4px;
 		font-weight: 500;
-		line-height: 1.25rem;
+		line-height: 20px;
 		margin: 8px 0 -6px;
 		width: 100%;
 		flex-shrink: 0;
@@ -577,6 +581,29 @@ $design-button-primary-color: rgb(17, 122, 201);
 		padding-inline-start: 0;
 		padding-inline-end: 0;
 
+		.step-container__navigation {
+			&.action-buttons {
+				bottom: 0;
+				inset-inline-start: 0;
+				inset-inline-end: 0;
+				padding: 0 20px;
+				position: fixed;
+				top: auto;
+
+				@include break-design-preview {
+					inset-inline-start: 72px;
+					inset-inline-end: 24px;
+					padding: 1px 0 0;
+					position: absolute;
+					top: 8px;
+
+					.is-primary {
+						display: none;
+					}
+				}
+			}
+		}
+
 		.step-container__header {
 			display: none;
 		}
@@ -585,9 +612,11 @@ $design-button-primary-color: rgb(17, 122, 201);
 			// 156px = .design-preview__sidebar + step-container__navigation.action-buttons
 			height: calc(100vh - 156px);
 			margin-top: 36px;
+			position: relative;
+			z-index: 1;
 		}
 
-		@include break-small {
+		@include break-design-preview {
 			max-width: none;
 			padding-inline-start: 32px;
 			padding-inline-end: 32px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -581,6 +581,16 @@ $break-design-preview: 1024px;
 		padding-inline-start: 0;
 		padding-inline-end: 0;
 
+		.action-buttons__title {
+			font-size: 0.875rem;
+			font-weight: 500;
+			line-height: 20px;
+
+			@include break-design-preview {
+				display: none;
+			}
+		}
+
 		.step-container__navigation {
 			&.action-buttons {
 				bottom: 0;
@@ -590,6 +600,10 @@ $break-design-preview: 1024px;
 				position: fixed;
 				top: auto;
 
+				.navigation-link {
+					margin-top: -2px;
+				}
+
 				@include break-design-preview {
 					inset-inline-start: 72px;
 					inset-inline-end: 24px;
@@ -597,7 +611,11 @@ $break-design-preview: 1024px;
 					position: absolute;
 					top: 8px;
 
-					.is-primary {
+					.navigation-link {
+						margin-top: 0;
+					}
+
+					button.is-primary {
 						display: none;
 					}
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -339,17 +339,22 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
 
 		const actionButtons = (
-			<div>
-				{ shouldUpgrade ? (
-					<Button primary borderless={ false } onClick={ upgradePlan }>
-						{ translate( 'Unlock theme' ) }
-					</Button>
-				) : (
-					<Button primary borderless={ false } onClick={ () => pickDesign() }>
-						{ pickDesignText }
-					</Button>
+			<>
+				{ isEnabledStyleSelection && (
+					<div className="action-buttons__title">{ headerDesignTitle }</div>
 				) }
-			</div>
+				<div>
+					{ shouldUpgrade ? (
+						<Button primary borderless={ false } onClick={ upgradePlan }>
+							{ translate( 'Unlock theme' ) }
+						</Button>
+					) : (
+						<Button primary borderless={ false } onClick={ () => pickDesign() }>
+							{ pickDesignText }
+						</Button>
+					) }
+				</div>
+			</>
 		);
 
 		const stepContent = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -47,7 +47,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 
-	// CSS breakpoints are set at 600px for mobile
 	const isMobile = ! useViewportMatch( 'small' );
 
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -403,7 +403,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				hideSkip
 				className="design-setup__preview design-setup__preview__has-more-info"
 				goBack={ handleBackClick }
-				customizedActionButtons={ isMobile ? actionButtons : undefined }
+				customizedActionButtons={ actionButtons }
 				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		) : (

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -2,12 +2,20 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
+$break-design-preview: 1024px;
+
+@mixin break-design-preview() {
+	@media (min-width: #{ ($break-design-preview) }) {
+		@content;
+	}
+}
+
 .design-preview {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
 
-	@include break-small {
+	@include break-design-preview {
 		flex-direction: row;
 		margin: 0;
 		gap: 32px;
@@ -17,8 +25,8 @@
 .design-preview__sidebar {
 	align-items: center;
 	background: #fff;
-	border-bottom: 1px solid rgb( 0 0 0 / 5% );
-	box-shadow: -4px 0 8px rgb( 0 0 0 / 7% );
+	border-bottom: 1px solid rgb(0 0 0 / 5%);
+	box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 	box-sizing: border-box;
 	display: flex;
 	height: 96px;
@@ -91,6 +99,11 @@
 	}
 
 	@include break-small {
+		align-items: center;
+		justify-content: center;
+	}
+
+	@include break-design-preview {
 		border: 0;
 		box-shadow: none;
 		display: block;
@@ -143,7 +156,7 @@
 
 	.edit-site-global-styles-preview__iframe {
 		border-radius: 3px; /* stylelint-disable-line scales/radii */
-		box-shadow: 0 0 1px rgba( 0 0 0 / 25% );
+		box-shadow: 0 0 1px rgba(0 0 0 / 25%);
 		border: 0;
 		display: block;
 		max-width: 100%;
@@ -154,4 +167,29 @@
 .design-preview__site-preview {
 	flex-grow: 1;
 	position: relative;
+
+	.theme-preview__frame-wrapper {
+		.theme-preview__frame {
+			border: 0;
+			border-radius: 0;
+			box-shadow: none;
+
+			@include break-design-preview {
+				border-radius: 20px; /* stylelint-disable-line scales/radii */
+				box-shadow:
+					0 15px 20px rgb(0 0 0 / 4%),
+					0 13px 10px rgb(0 0 0 / 3%),
+					0 6px 6px rgb(0 0 0 / 2%);
+				margin-top: 0;
+			}
+		}
+	}
+
+	.theme-preview__toolbar {
+		display: none;
+
+		@include break-design-preview {
+			display: block;
+		}
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

As per discussion in 7l53h5fxAUNjVRBQ82YFwn-fi-943%3A58280, we want to show the mobile layout for the full-screen theme preview up to `1024px`, instead of `600px`. To accomplish that, we need to override the default mobile breakpoint for the `<ThemePreview />` component and the Stepper framework.

See screenshot for reference:
![Screen Shot 2022-09-14 at 12 17 35 PM](https://user-images.githubusercontent.com/797888/190058451-8e20fad8-783c-43ea-9c39-9c3acd9c8168.png)

Note that for the sake of consistency of UX in the Stepper framework, we are showing the navigation at the bottom, and the style variation switcher button at the top.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the unified design picker `setup/designSetup?siteSlug=${site_slug}`
* Click on any theme with style variations.
* Ensure that the full-screen theme preview shows the mobile layout up to `1024px`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67388