### PR TITLE
Inline Support: Change publicize support link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -164,8 +164,8 @@ const contextLinks = {
 		post_id: 1507,
 	},
 	publicize: {
-		link: 'https://wordpress.com/support/publicize/',
-		post_id: 4789,
+		link: 'https://wordpress.com/support/post-automatically-to-social-media/',
+		post_id: 216472,
 	},
 	purchases: {
 		link: 'https://wordpress.com/support/manage-purchases/',


### PR DESCRIPTION
#### Proposed Changes

* Fixes the support link for the auto-sharing (formerly Publicize) feature.
* More context: 1675-gh-Automattic/en.support-docs-content#issuecomment-1246266068

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/marketing/connections/<site slug>`.
* Click on the question mark next to "Publicize posts".
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/5436027/190068785-8370f46e-5050-45b4-81a8-dca418e334b4.png">

* Confirm that you can see the correct support article.
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/5436027/190069051-f93472f8-a0dc-4cdb-984f-e59a3f7076ae.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **-NA**
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? **-NA**
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) **-NA**
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **-NA**

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/en.support-docs-content#1675