### PR TITLE
fixes for redirection and page template

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -49,10 +49,6 @@ const PatternAssembler: Step = ( { navigation } ) => {
 
 		if ( header ) {
 			pageTemplate = 'header-footer-only';
-		} else if ( footer ) {
-			pageTemplate = 'footer-only';
-		} else if ( sections.length ) {
-			pageTemplate = 'blank';
 		}
 
 		return pageTemplate;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -196,7 +196,7 @@ export const siteSetupFlow: Flow = {
 					// End of Pattern Assembler flow
 					if (
 						isEnabled( 'signup/design-picker-pattern-assembler' ) &&
-						isBlankCanvasDesign( providedDependencies?.selectedDesign as Design )
+						isBlankCanvasDesign( selectedDesign as Design )
 					) {
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}


### PR DESCRIPTION
#### Proposed Changes

* Fix for the redirection to the site editor
* Fix the issue with page template `blank` by using `footer-only` instead when users select only sections.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup/designSetup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain

- In the pattern assembler:
  - Choose only sections
  - Click on Continue
  - Check that PA redirects to the site editor and that the default footer is visible



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67783 
