### PR TITLE
Update availability message

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -401,9 +401,9 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			break;
 
 		case 'blocked':
-			const supportURL = 'https://wordpress.com/error-report/?url=495@' + ( site?.slug || '' );
+			const supportURL = 'https://wordpress.com/error-report/?url=496@' + ( site?.slug || '' );
 			message = translate(
-				"You're blocked from purchasing domains on WordPress.com. Please {{a}}contact our support{{/a}} to find out why.",
+				'Oops! Sorry an error has occurred. Please {{a}}click here{{/a}} to contact us so that we can fix it. Please remember that you have to provide the full, complete Blog URL, otherwise we can not fix it.',
 				{
 					components: {
 						a: <a rel="noopener noreferrer" href={ supportURL } />,


### PR DESCRIPTION
## Proposed Changes

This PR updates the message that users with a suspended site receive when they try to create a new site.

This message is shown when the domain suggestion endpoint return a “blocked” error (which means that the user has a suspended site for violating the User Guidelines).

According to internal documentation the message should be:

> Oops! Sorry an error has occurred. Please [click here](https://wordpress.com/error-report/?url=496@example.wordpress.com) to contact us so that we can fix it. Please remember that you have to provide the full, complete Blog URL, otherwise we can not fix it.


![domain before](https://user-images.githubusercontent.com/2797601/190144353-7971c388-2845-4ece-89f1-3e6d31387ef0.png)

![domain after](https://user-images.githubusercontent.com/2797601/190144365-802e5399-364f-4432-b5d7-0f6d2f2d9932.png)

## Testing Instructions

Mark one of your sites as suspended, then try to create a new one: in the domain selection step, you should see the updated message.