### PR TITLE
Marketplace: Remove variations.product_slug dependency from plugins

### DIFF
--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -27,8 +27,8 @@ export type Plugin = {
 	icon?: string;
 	railcar: Railcar;
 	variations?: {
-		monthly: { product_slug: string };
-		yearly: { product_slug: string };
+		monthly: { product_slug?: string; product_id?: number };
+		yearly: { product_slug?: string; product_id?: number };
 	};
 };
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -399,3 +399,28 @@ export function getPreinstalledPremiumPluginsVariations( plugin ) {
 		yearly: { product_slug: yearly },
 	};
 }
+
+/**
+ * Returns the product slug of periodVariation passed filtering the productsList passed only if required
+ *
+ * @param {string} periodVariation The variation object with the shape { product_slug: string; product_id: number; }
+ * @param {Record<string, object>} productsList The list of products
+ * @returns The product slug if it exists in the periodVariation, if it does not exist in periodVariation
+ * it will find the product slug in the productsList filtering by the variation.product_id.
+ * It additionally returns:
+ *  - null|undefined if periodVariation is null|undefined
+ * - null|undefined if variation.product_id is null|undefined
+ * - undefined product is not found by productId in productsList
+ */
+export function getProductSlugByPeriodVariation( periodVariation, productsList ) {
+	if ( ! periodVariation ) return periodVariation;
+
+	const productSlug = periodVariation.product_slug;
+	if ( productSlug ) return productSlug;
+
+	const productId = periodVariation.product_id;
+	if ( productId === undefined || productId === null ) return productId;
+
+	return Object.values( productsList ).find( ( product ) => product.product_id === productId )
+		?.product_slug;
+}

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -59,7 +59,10 @@ type Props = {
 	billingPeriod: IntervalLength;
 	compact: boolean;
 	plugin?: {
-		variations?: { yearly?: { product_slug: string }; monthly?: { product_slug: string } };
+		variations?: {
+			yearly?: { product_slug?: string; product_id?: number };
+			monthly?: { product_slug?: string; product_id?: number };
+		};
 	};
 };
 

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -13,6 +13,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps';
 import theme from 'calypso/my-sites/marketplace/theme';
@@ -296,7 +297,8 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 		}
 		if ( noDirectAccessError && ! directInstallationAllowed ) {
 			const variationPeriod = 'monthly';
-			const marketplaceProductSlug = wpComPluginData?.variations?.[ variationPeriod ]?.product_slug;
+			const variation = wpComPluginData?.variations?.[ variationPeriod ];
+			const marketplaceProductSlug = getProductSlugByPeriodVariation( variation, productsList );
 
 			return (
 				<>

--- a/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
@@ -19,7 +19,9 @@ export const ManagePluginMenu = ( { plugin } ) => {
 		plugin.isMarketplaceProduct &&
 		purchases.find( ( purchase ) =>
 			Object.values( plugin?.variations ).some(
-				( variation ) => variation.product_slug === purchase.productSlug
+				( variation ) =>
+					variation.product_slug === purchase.productSlug ||
+					variation.product_id === purchase.productId
 			)
 		);
 	const settingsLink = pluginOnSite?.action_links?.Settings ?? null;

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -12,12 +12,13 @@ import { connect } from 'react-redux';
 import QuerySiteConnectionStatus from 'calypso/components/data/query-site-connection-status';
 import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
-import { marketplacePlanToAdd } from 'calypso/lib/plugins/utils';
+import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { installPlugin } from 'calypso/state/plugins/installed/actions';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { getProductsList } from 'calypso/state/products-list/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -173,9 +174,11 @@ export class PluginInstallButton extends Component {
 			billingPeriod,
 			canInstallPurchasedPlugins,
 			eligibleForProPlan,
+			productsList,
 		} = this.props;
 		const variationPeriod = getPeriodVariationValue( billingPeriod );
-		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
+		const variation = plugin?.variations?.[ variationPeriod ];
+		const product_slug = getProductSlugByPeriodVariation( variation, productsList );
 
 		const buttonLink = canInstallPurchasedPlugins
 			? `/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }`
@@ -326,6 +329,7 @@ export default connect(
 				WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 			),
 			eligibleForProPlan: isEligibleForProPlan( state, siteId ),
+			productsList: getProductsList( state ),
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugin-price/index.jsx
+++ b/client/my-sites/plugins/plugin-price/index.jsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import {
 	getProductDisplayCost,
@@ -12,15 +12,8 @@ export const PluginPrice = ( { plugin, billingPeriod, children } ) => {
 	const translate = useTranslate();
 	const variationPeriod = getPeriodVariationValue( billingPeriod );
 	const productList = useSelector( getProductsList );
-
-	const priceSlug = useMemo( () => {
-		let productSlug = plugin?.variations?.[ variationPeriod ]?.product_slug;
-		if ( productSlug ) return productSlug;
-
-		const variationProductId = plugin?.variations?.[ variationPeriod ]?.product_id;
-		productSlug = getProductSlugfromProductId( variationProductId, productList );
-		return productSlug;
-	}, [ plugin?.variations, productList, variationPeriod ] );
+	const variation = plugin?.variations?.[ variationPeriod ];
+	const priceSlug = getProductSlugByPeriodVariation( variation, productList );
 
 	const price = useSelector( ( state ) => getProductDisplayCost( state, priceSlug ) );
 	const isFetching = useSelector( isProductsListFetching );
@@ -53,13 +46,4 @@ export function getPeriodVariationValue( billingPeriod ) {
 		default:
 			return '';
 	}
-}
-
-function getProductSlugfromProductId( productId, productList ) {
-	if ( productId === undefined ) return undefined;
-
-	const productSlug = Object.values( productList ).find(
-		( product ) => product.product_id === productId
-	)?.product_slug;
-	return productSlug;
 }

--- a/client/my-sites/plugins/plugin-saving/index.jsx
+++ b/client/my-sites/plugins/plugin-saving/index.jsx
@@ -1,11 +1,21 @@
 import formatCurrency from '@automattic/format-currency';
 import { useSelector } from 'react-redux';
-import { getProductBySlug, isProductsListFetching } from 'calypso/state/products-list/selectors';
+import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
+import {
+	getProductBySlug,
+	isProductsListFetching,
+	getProductsList,
+} from 'calypso/state/products-list/selectors';
 
 export const PluginAnnualSaving = ( { plugin, children } ) => {
-	const priceSlugYearly = plugin?.variations?.yearly?.product_slug;
+	const productList = useSelector( getProductsList );
+
+	const variationYearly = plugin?.variations?.yearly;
+	const priceSlugYearly = getProductSlugByPeriodVariation( variationYearly, productList );
 	const productYearly = useSelector( ( state ) => getProductBySlug( state, priceSlugYearly ) );
-	const priceSlugMonthly = plugin?.variations?.monthly?.product_slug;
+
+	const variationMonthly = plugin?.variations?.monthly;
+	const priceSlugMonthly = getProductSlugByPeriodVariation( variationMonthly, productList );
 	const productMonthly = useSelector( ( state ) => getProductBySlug( state, priceSlugMonthly ) );
 	const isFetching = useSelector( isProductsListFetching );
 

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -39,7 +39,9 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 		plugin.isMarketplaceProduct &&
 		purchases.find( ( purchase ) =>
 			Object.values( plugin?.variations ).some(
-				( variation ) => variation.product_slug === purchase.productSlug
+				( variation ) =>
+					variation.product_slug === purchase.productSlug ||
+					variation.product_id === purchase.productId
 			)
 		);
 


### PR DESCRIPTION
> **Note**: Depends on D87698-code

#### Proposed Changes

The `plugin` object contains a `variations` object that has the form 
```
// plugin.variations
{
    monthly: { product_slug: <monthly_product_slug>, product_id: <monthly_product_id> },
    yearly: { product_slug: <yearly_product_slug>, product_id: <yearly_product_id> },
}
```
This field is populated from the backend for `wpcom` plugins so it needs to be stored and indexed by the backend. Those fields are used to obtain the prices for each period.

To avoid returning both fields, `product_id` and `product_slug`, this change will calculate `product_slug` from the list of products using the `product_id` so `product_slug` can be removed from the backend.

The backend changes have been applied as part of D87698-code

#### Testing Instructions

The changes should be tested with and _without_ the related diff D87698-code applied, as this front-end change must be applied **before** the backend change

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Using the production API, i.e. **not** being sandboxed, apply this branch
2. Navigate to a _paid_ plugin details page, e.g. `/plugins/woocommerce-subscriptions/<site_id>` being `<site_id>` any of your sites url
3. Make sure you can see the correct prices for `Monthly` and `Annually` periods
4. Make sure you can see the discount 
![CleanShot 2022-09-15 at 11 10 45@2x](https://user-images.githubusercontent.com/3519124/190364659-7c1b685d-a61f-4a61-b5e2-dfbae78a1e2c.png)
8. Make sure you can add the product to the cart and you can see the correct product added
5. Navigate to a free plugin, e.g. `/plugins/zero-bs-crm/<site_id>` or select one from the list of plugins
6. Make sure you do not see any unexpected errors
8. Sandbox the API and apply the following diff D87698-code
9. Repeat the steps 2 to 7 to make sure there are no unexpected errors 
10. Additionally, use `jetpack-search` in some testing to check there are no unexpected errors as that plugin is a special case of preinstalled premium plugin 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67507