### PR TITLE
Jetpack new pricing page - Update translations in calypso-product package

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1814,8 +1814,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
 			translate( '1TB (1,000GB) of cloud storage' ),
-			translate( '30-day activity log archive' ),
-			translate( 'Unlimited one-click restores from the last 30 days' ),
+			translate( '1-year activity log archive' ),
+			translate( 'Unlimited one-click restores from the last 1-year' ),
 			translate( 'Real-time malware scanning and one-click fixes' ),
 			translate( 'Comment and form spam protection (60k API calls/mo)' ),
 			translate( 'VideoPress with 1TB of ad-free video hosting' ),
@@ -1833,9 +1833,9 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
 			translate( '10GB of cloud storage' ),
-			translate( '1-year activity log archive' ),
-			translate( 'Unlimited one-click restores from the last 1 year' ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
+			translate( '30-day activity log archive' ),
+			translate( 'Unlimited one-click restores from the last 30 days' ),
+			translate( 'Real-time malware scanning and one-click fixes ' ),
 			translate( 'Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
@@ -1864,11 +1864,23 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 2019,
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
-			translate( '1TB (1,000GB) of cloud storage' ),
-			translate( '1-year activity log archive' ),
-			translate( 'Unlimited one-click restores from the last 1 year' ),
+			translate( '{em}1TB (1,000GB){/em} of cloud storage', {
+				components: {
+					em: <em />,
+				},
+			} ),
+			translate( '{em}1-year{/em} activity log archive', {
+				components: {
+					em: <em />,
+				},
+			} ),
+			translate( 'Unlimited one-click restores from the last {em}1 year{/em}', {
+				components: {
+					em: <em />,
+				},
+			} ),
 			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (60k API calls/mo)' ),
+			translate( 'Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
 
@@ -1880,9 +1892,21 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 2020,
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
-			translate( '1TB (1,000GB) of cloud storage' ),
-			translate( '30-day activity log archive' ),
-			translate( 'Unlimited one-click restores from the last 30 days' ),
+			translate( '{em}1TB (1,000GB){/em} of cloud storage', {
+				components: {
+					em: <em />,
+				},
+			} ),
+			translate( '{em}1-year{/em} activity log archive', {
+				components: {
+					em: <em />,
+				},
+			} ),
+			translate( 'Unlimited one-click restores from the last {em}1 year{/em}', {
+				components: {
+					em: <em />,
+				},
+			} ),
 			translate( 'Real-time malware scanning and one-click fixes' ),
 			translate( 'Comment and form spam protection (10k API calls/mo)' ),
 		],

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1864,17 +1864,17 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 2019,
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
-			translate( '{em}1TB (1,000GB){/em} of cloud storage', {
+			translate( '{{em}}1TB (1,000GB){{/em}} of cloud storage', {
 				components: {
 					em: <em />,
 				},
 			} ),
-			translate( '{em}1-year{/em} activity log archive', {
+			translate( '{{em}}1-year{{/em}} activity log archive', {
 				components: {
 					em: <em />,
 				},
 			} ),
-			translate( 'Unlimited one-click restores from the last {em}1 year{/em}', {
+			translate( 'Unlimited one-click restores from the last {{em}}1 year{{/em}}', {
 				components: {
 					em: <em />,
 				},
@@ -1892,17 +1892,17 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 2020,
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
-			translate( '{em}1TB (1,000GB){/em} of cloud storage', {
+			translate( '{{em}}1TB (1,000GB){{/em}} of cloud storage', {
 				components: {
 					em: <em />,
 				},
 			} ),
-			translate( '{em}1-year{/em} activity log archive', {
+			translate( '{{em}}1-year{{/em}} activity log archive', {
 				components: {
 					em: <em />,
 				},
 			} ),
-			translate( 'Unlimited one-click restores from the last {em}1 year{/em}', {
+			translate( 'Unlimited one-click restores from the last {{em}}1 year{{/em}}', {
 				components: {
 					em: <em />,
 				},

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1835,7 +1835,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			translate( '10GB of cloud storage' ),
 			translate( '30-day activity log archive' ),
 			translate( 'Unlimited one-click restores from the last 30 days' ),
-			translate( 'Real-time malware scanning and one-click fixes ' ),
+			translate( 'Real-time malware scanning and one-click fixes' ),
 			translate( 'Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
@@ -1864,19 +1864,19 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 2019,
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
-			translate( '{{em}}1TB (1,000GB){{/em}} of cloud storage', {
+			translate( '{{strong}}1TB (1,000GB){{/strong}} of cloud storage', {
 				components: {
-					em: <em />,
+					strong: <strong />,
 				},
 			} ),
-			translate( '{{em}}1-year{{/em}} activity log archive', {
+			translate( '{{strong}}1-year{{/strong}} activity log archive', {
 				components: {
-					em: <em />,
+					strong: <strong />,
 				},
 			} ),
-			translate( 'Unlimited one-click restores from the last {{em}}1 year{{/em}}', {
+			translate( 'Unlimited one-click restores from the last {{strong}}1 year{{/strong}}', {
 				components: {
-					em: <em />,
+					strong: <strong />,
 				},
 			} ),
 			translate( 'Real-time malware scanning and one-click fixes' ),
@@ -1892,19 +1892,19 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 2020,
 		getWhatIsIncluded: () => [
 			translate( 'Real-time backups as you edit' ),
-			translate( '{{em}}1TB (1,000GB){{/em}} of cloud storage', {
+			translate( '{{strong}}1TB (1,000GB){{/strong}} of cloud storage', {
 				components: {
-					em: <em />,
+					strong: <strong />,
 				},
 			} ),
-			translate( '{{em}}1-year{{/em}} activity log archive', {
+			translate( '{{strong}}1-year{{/strong}} activity log archive', {
 				components: {
-					em: <em />,
+					strong: <strong />,
 				},
 			} ),
-			translate( 'Unlimited one-click restores from the last {{em}}1 year{{/em}}', {
+			translate( 'Unlimited one-click restores from the last {{strong}}1 year{{/strong}}', {
 				components: {
-					em: <em />,
+					strong: <strong />,
 				},
 			} ),
 			translate( 'Real-time malware scanning and one-click fixes' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -504,39 +504,42 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	const prioritySupport = translate( 'Priority support' );
 
 	const backupIncludesInfoT1Storage = translate( '10GB of cloud storage' );
-	const backupIncludesInfoT2Storage = translate( '1TB (1,000GB) of cloud storage' );
+	const backupIncludesInfoT2Storage = translate( '{em}1TB (1,000GB){/em} of cloud storage', {
+		components: {
+			em: <em />,
+		},
+	} );
 
-	const backupIncludesInfoMonthlyLog = translate( '30-day activity log archive' );
-	const backupIncludesInfoYearlyLog = translate( '1 year activity log archive' );
+	const backupIncludesInfoT1Log = translate( '30-day activity log archive' );
+	const backupIncludesInfoT2Log = translate( '{em}1 year{/em} activity log archive', {
+		components: {
+			em: <em />,
+		},
+	} );
 
-	const oneClickRestoreMonthly = translate( 'Unlimited one-click restores from the last 30 days' );
-	const oneClickRestoreYearly = translate( 'Unlimited one-click restores from the last 1 year' );
+	const oneClickRestoreT1 = translate( 'Unlimited one-click restores from the last 30 days' );
+	const oneClickRestoreT2 = translate(
+		'Unlimited one-click restores from the last {em}1 year{/em}',
+		{
+			components: {
+				em: <em />,
+			},
+		}
+	);
 
 	const otherIncludes = [ orderBackups, cloudBackups, prioritySupport ];
-	const backupIncludesInfoT1Monthly = [
+	const backupIncludesInfoT1 = [
 		realTimeBackup,
 		backupIncludesInfoT1Storage,
-		backupIncludesInfoMonthlyLog,
-		oneClickRestoreMonthly,
+		backupIncludesInfoT1Log,
+		oneClickRestoreT1,
 		...otherIncludes,
 	];
-	const backupIncludesInfoT1Yearly = [
-		realTimeBackup,
-		backupIncludesInfoT1Storage,
-		backupIncludesInfoYearlyLog,
-		oneClickRestoreYearly,
-		...otherIncludes,
-	];
-	const backupIncludesInfoT2Monthly = [
+	const backupIncludesInfoT2 = [
 		realTimeBackup,
 		backupIncludesInfoT2Storage,
-		backupIncludesInfoMonthlyLog,
-		...otherIncludes,
-	];
-	const backupIncludesInfoT2Yearly = [
-		realTimeBackup,
-		backupIncludesInfoT1Storage,
-		backupIncludesInfoMonthlyLog,
+		backupIncludesInfoT2Log,
+		oneClickRestoreT2,
 		...otherIncludes,
 	];
 
@@ -584,14 +587,14 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	];
 
 	return {
-		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupIncludesInfoT1Monthly,
-		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupIncludesInfoT1Monthly,
-		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: backupIncludesInfoT1Yearly,
-		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: backupIncludesInfoT1Monthly,
-		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupIncludesInfoT1Yearly,
-		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupIncludesInfoT1Monthly,
-		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupIncludesInfoT2Yearly,
-		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupIncludesInfoT2Monthly,
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupIncludesInfoT1,
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupIncludesInfoT1,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: backupIncludesInfoT1,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: backupIncludesInfoT1,
+		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupIncludesInfoT1,
+		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupIncludesInfoT1,
+		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupIncludesInfoT2,
+		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupIncludesInfoT2,
 		[ PRODUCT_JETPACK_VIDEOPRESS ]: videoPressIncludesInfo,
 		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: videoPressIncludesInfo,
 		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamIncludesInfo,
@@ -658,7 +661,7 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 
 	const socialBenefits = [
 		translate( 'Save time by sharing your posts automatically' ),
-		translate( 'Unlock your growth potential by building a following on social' ),
+		translate( 'Unlock your growth potential by building a following on social media' ),
 		translate( 'Easy-to-use interface' ),
 		translate( 'No developer required' ),
 	];

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -504,14 +504,14 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	const prioritySupport = translate( 'Priority support' );
 
 	const backupIncludesInfoT1Storage = translate( '10GB of cloud storage' );
-	const backupIncludesInfoT2Storage = translate( '{em}1TB (1,000GB){/em} of cloud storage', {
+	const backupIncludesInfoT2Storage = translate( '{{em}}1TB (1,000GB){{/em}} of cloud storage', {
 		components: {
 			em: <em />,
 		},
 	} );
 
 	const backupIncludesInfoT1Log = translate( '30-day activity log archive' );
-	const backupIncludesInfoT2Log = translate( '{em}1 year{/em} activity log archive', {
+	const backupIncludesInfoT2Log = translate( '{{em}}1 year{{/em}} activity log archive', {
 		components: {
 			em: <em />,
 		},
@@ -519,7 +519,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 
 	const oneClickRestoreT1 = translate( 'Unlimited one-click restores from the last 30 days' );
 	const oneClickRestoreT2 = translate(
-		'Unlimited one-click restores from the last {em}1 year{/em}',
+		'Unlimited one-click restores from the last {{em}}1 year{{/em}}',
 		{
 			components: {
 				em: <em />,

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -504,25 +504,28 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	const prioritySupport = translate( 'Priority support' );
 
 	const backupIncludesInfoT1Storage = translate( '10GB of cloud storage' );
-	const backupIncludesInfoT2Storage = translate( '{{em}}1TB (1,000GB){{/em}} of cloud storage', {
-		components: {
-			em: <em />,
-		},
-	} );
+	const backupIncludesInfoT2Storage = translate(
+		'{{strong}}1TB (1,000GB){{/strong}} of cloud storage',
+		{
+			components: {
+				strong: <strong />,
+			},
+		}
+	);
 
 	const backupIncludesInfoT1Log = translate( '30-day activity log archive' );
-	const backupIncludesInfoT2Log = translate( '{{em}}1 year{{/em}} activity log archive', {
+	const backupIncludesInfoT2Log = translate( '{{strong}}1 year{{/strong}} activity log archive', {
 		components: {
-			em: <em />,
+			strong: <strong />,
 		},
 	} );
 
 	const oneClickRestoreT1 = translate( 'Unlimited one-click restores from the last 30 days' );
 	const oneClickRestoreT2 = translate(
-		'Unlimited one-click restores from the last {{em}}1 year{{/em}}',
+		'Unlimited one-click restores from the last {{strong}}1 year{{/strong}}',
 		{
 			components: {
-				em: <em />,
+				strong: <strong />,
 			},
 		}
 	);


### PR DESCRIPTION
This PR adds data to be shown in lightbox to `calypso-product` package. 
#### Proposed Changes

* This PR is a follow-up for review comments in #67687 

#### Testing Instructions

*Note: This is an internal change to add data to `calypso-package`, no testing in UI can be done until the components are ready. However, make sure everything works as before by following the below instructions*
* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout add/lightbox-info-to-calypso-package`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Perform a sanity testing and confirm that everything works as before

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?



---
- Related To:
  -1202796695664022-as-1202796695664084/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202796695664084