### PR TITLE
VideoPress Onboarding v2: Site options refined

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -21,9 +21,16 @@ import type { Step } from '../../types';
 import './style.scss';
 
 const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
+	const [ currentSiteTitle, currentTagling ] = useSelect( ( select ) => {
+		return [
+			select( ONBOARD_STORE ).getSelectedSiteTitle(),
+			select( ONBOARD_STORE ).getSelectedSiteDescription(),
+		];
+	} );
+
 	const { goBack, goNext, submit } = navigation;
-	const [ siteTitle, setSiteTitle ] = React.useState( '' );
-	const [ tagline, setTagline ] = React.useState( '' );
+	const [ siteTitle, setSiteTitle ] = React.useState( currentSiteTitle ?? '' );
+	const [ tagline, setTagline ] = React.useState( currentTagling ?? '' );
 	const [ formTouched, setFormTouched ] = React.useState( false );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -12,6 +12,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import { useSite } from '../../../../hooks/use-site';
@@ -83,6 +84,7 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 			siteTitleLabel: translate( 'Site name' ),
 			taglineLabel: translate( 'Brief description' ),
 			taglineExplanation: translate( 'Add a short description of your video site here.' ),
+			subHeaderText: translate( 'Customize some details about your new site.' ),
 		};
 	};
 
@@ -95,6 +97,7 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 					siteTitleLabel: translate( 'Store name' ),
 					taglineLabel: translate( 'Tagline' ),
 					taglineExplanation: translate( 'In a few words, explain what your store is about.' ),
+					subHeaderText: undefined,
 				};
 			case 'write':
 			default:
@@ -104,12 +107,13 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 					siteTitleLabel: translate( 'Blog name' ),
 					taglineLabel: translate( 'Tagline' ),
 					taglineExplanation: translate( 'In a few words, explain what your blog is about.' ),
+					subHeaderText: undefined,
 				};
 		}
 	};
 
 	const isSiteTitleRequired = isVideoPressFlow;
-	const isTaglineRequired = false;
+	const isTaglineRequired = isVideoPressFlow;
 	const siteTitleError = null;
 	const taglineError = null;
 
@@ -117,8 +121,14 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 		? getTextsForVideoPressFlow()
 		: getTextsFromIntent( intent );
 
-	const { headerText, headerImage, siteTitleLabel, taglineLabel, taglineExplanation } =
-		textsForFlow;
+	const {
+		headerText,
+		headerImage,
+		siteTitleLabel,
+		taglineLabel,
+		taglineExplanation,
+		subHeaderText,
+	} = textsForFlow;
 
 	const isFormDisabled = ! isVideoPressFlow && ! site;
 
@@ -134,6 +144,7 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 					value={ siteTitle }
 					isError={ siteTitleError }
 					onChange={ onChange }
+					placeholder={ isVideoPressFlow ? translate( 'My Video Site' ) : null }
 				/>
 				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
 			</FormFieldset>
@@ -141,14 +152,26 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 				<FormLabel htmlFor="tagline" optional={ ! isTaglineRequired }>
 					{ taglineLabel }
 				</FormLabel>
-				<FormInput
-					name="tagline"
-					id="tagline"
-					value={ tagline }
-					isError={ taglineError }
-					onChange={ onChange }
-					placeholder={ isVideoPressFlow ? taglineExplanation : null }
-				/>
+				{ ! isVideoPressFlow && (
+					<FormInput
+						name="tagline"
+						id="tagline"
+						value={ tagline }
+						isError={ taglineError }
+						onChange={ onChange }
+						placeholder={ null }
+					/>
+				) }
+				{ isVideoPressFlow && (
+					<FormTextarea
+						name="tagline"
+						id="tagline"
+						value={ tagline }
+						isError={ taglineError ?? undefined }
+						onChange={ onChange }
+						placeholder={ taglineExplanation }
+					/>
+				) }
 				{ taglineError && <FormInputValidation isError text={ taglineError } /> }
 				{ ! isVideoPressFlow && (
 					<FormSettingExplanation>
@@ -179,7 +202,12 @@ const SiteOptions: Step = function SiteOptions( { navigation, flow } ) {
 			goNext={ goNext }
 			isHorizontalLayout={ ! isVideoPressFlow }
 			formattedHeader={
-				<FormattedHeader id={ 'site-options-header' } headerText={ headerText } align={ 'left' } />
+				<FormattedHeader
+					id={ 'site-options-header' }
+					headerText={ headerText }
+					align={ 'left' }
+					subHeaderText={ subHeaderText }
+				/>
 			}
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -113,22 +113,27 @@
 	}
 
 	.videopress & {
-		max-width: 400px;
+		max-width: 425px;
 
-		#site-options-header {
-			text-align: center;
+		.site-options__form {
+			padding-left: 24px;
+			padding-right: 24px;
 		}
 
 		input#siteTitle,
-		input#tagline {
+		textarea#tagline {
 			border: solid 1px #c3c4c7;
+			font-family: $default-font;
 		}
 
-		input#tagline {
-			height: 64px;
+		textarea#tagline {
+			height: 84px;
+			resize: none;
+			border-radius: 4px;
 		}
 
 		.site-options__submit-button {
+			margin-top: 24px;
 			width: 100%;
 			background-color: #0675c4;
 			border: 0px none;

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -2,6 +2,7 @@
 
 $videopress-theme-base-text-color: #fff;
 $videopress-theme-yellow: #ffe61c;
+$videopress-theme-header-subtitle-text-color: #a7aaad;
 
 body {
 	background-color: #010101;
@@ -48,7 +49,13 @@ body {
 			.step-container__header {
 				header {
 					.formatted-header__title {
+						text-align: center;
 						color: $videopress-theme-base-text-color;
+					}
+
+					.formatted-header__subtitle {
+						text-align: center;
+						color: $videopress-theme-header-subtitle-text-color;
 					}
 				}
 			}

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -13,6 +13,7 @@ export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
+export const getSelectedSiteDescription = ( state: State ) => state.siteDescription;
 export const getIntent = ( state: State ) => state.intent;
 export const getStartingPoint = ( state: State ) => state.startingPoint;
 export const getStoreType = ( state: State ) => state.storeType;


### PR DESCRIPTION
#### Proposed Changes

This PR adds missing styles and features to the site options onboarding step.

#### Testing Instructions

* Apply this PR
* Go to `http://calypso.localhost:3000/setup/options?flow=videopress`
* ✅ The style should match the Figma mockup
* Add a site title and a description
* Validate
* ✅ You should be redirected to the chooseADomain step
* Go back with your browser arrow key
* ✅ The form should still be populated
* Refresh the page
* ✅ The form should still be populated
