### PR TITLE
Add gdpr banner on stepper

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -137,6 +137,9 @@ window.AppBoot = async () => {
 					<WindowLocaleEffectManager />
 					<BrowserRouter basename="setup">
 						<FlowSwitch user={ user as UserStore.CurrentUser } />
+						{ config.isEnabled( 'gdpr-banner' ) && (
+							<AsyncLoad require="calypso/blocks/gdpr-banner" placeholder={ null } />
+						) }
 					</BrowserRouter>
 					{ config.isEnabled( 'signup/inline-help' ) && (
 						<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />


### PR DESCRIPTION
## Proposed Changes

When landing on stepper, it shows the GDPR ( classic cookies message ) if the user has not accepted it yet.

## Testing Instructions
- Pull this branch and run yarn start
- Clean the browse cookie or open an incognito tab 
- Navigate to `/setup/intro?flow=link-in-bio` or `/setup/intro?flow=newsletter`
- You should see the cookie message.
- After accepting and refreshing, you should not see it again.

Related to #67664
Fixes #67664
