### PR TITLE
HelpCenter: extend shouldShowHelpCenterToUser to include A12N

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -27,6 +27,7 @@ import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { isOffline } from 'calypso/state/application/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
@@ -36,6 +37,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
 	getSelectedSiteId,
@@ -339,6 +341,7 @@ class Layout extends Component {
 
 export default withCurrentRoute(
 	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
+		const isA12n = isAutomatticTeamMember( getReaderTeams( state ) );
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
@@ -377,9 +380,10 @@ export default withCurrentRoute(
 
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) &&
-			shouldShowHelpCenterToUser( getCurrentUserId( state ) );
+			shouldShowHelpCenterToUser( getCurrentUserId( state ), isA12n );
 
 		return {
+			isA12n,
 			masterbarIsHidden,
 			sidebarIsHidden,
 			isJetpack,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -27,7 +27,6 @@ import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { isOffline } from 'calypso/state/application/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
@@ -37,7 +36,6 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
 	getSelectedSiteId,
@@ -341,7 +339,6 @@ class Layout extends Component {
 
 export default withCurrentRoute(
 	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
-		const isA12n = isAutomatticTeamMember( getReaderTeams( state ) );
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
@@ -380,10 +377,9 @@ export default withCurrentRoute(
 
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) &&
-			shouldShowHelpCenterToUser( getCurrentUserId( state ), isA12n );
+			shouldShowHelpCenterToUser( getCurrentUserId( state ) );
 
 		return {
-			isA12n,
 			masterbarIsHidden,
 			sidebarIsHidden,
 			isJetpack,

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,10 +1,22 @@
 /* eslint-disable no-restricted-imports */
+import wpcomRequest from 'wpcom-proxy-request';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function shouldShowHelpCenterToUser( userId: number ) {
+export function shouldShowHelpCenterToUser( userId: number, readerTeams: any ) {
+	const isA12n = async () => {
+		const response: any = await wpcomRequest( {
+			method: 'GET',
+			path: '/read/teams',
+			apiVersion: '1.2',
+		} );
+		console.log( 'API - ', response.teams[ 0 ].slug === 'a8c' );
+	};
+
+	console.log( 'Reader - ', readerTeams );
+	isA12n();
 	return false;
 	/*
 	const currentSegment = 30; //percentage of users that will see the Help Center, not the FAB

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,29 +1,16 @@
-/* eslint-disable no-console */
 /* eslint-disable no-restricted-imports */
-import wpcomRequest from 'wpcom-proxy-request';
+import config from '@automattic/calypso-config';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+
+const isNonProdEnv = [ 'staging', 'development', 'horizon' ].includes( config( 'env_id' ) );
 
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function shouldShowHelpCenterToUser( userId: number, readerTeams: any ) {
-	const isA12n = async () => {
-		const response: any = await wpcomRequest( {
-			method: 'GET',
-			path: '/read/teams',
-			apiVersion: '1.2',
-		} );
-		console.log( 'API - ', response.teams[ 0 ].slug === 'a8c' );
-	};
-
-	console.log( 'Reader - ', readerTeams );
-	isA12n();
-	return false;
-	/*
+export function shouldShowHelpCenterToUser( userId: number ) {
 	const currentSegment = 30; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
-	return userSegment < currentSegment;
-	*/
+	return isNonProdEnv || userSegment < currentSegment;
 }
 
 export function shouldLoadInlineHelp( sectionName: string, currentRoute: string ) {

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -2,7 +2,7 @@
 import config from '@automattic/calypso-config';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
-const isNonProdEnv = [ 'staging', 'development', 'horizon' ].includes( config( 'env_id' ) );
+const isNonProdEnv = [ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) );
 
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable no-restricted-imports */
 import wpcomRequest from 'wpcom-proxy-request';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';


### PR DESCRIPTION
## Proposed Changes

*This is a rough draft so I can get some help*.

This extends the shouldShowHelpCenterToUser hook to include all A12N.

## Testing Instructions

1. Pull branch and `yarn start`
2. Open local calypso, add something to your cart and go to checkout.
3. HelpCenter should be loading