### PR TITLE
Plugin Management: Fix the check for already updated plugins

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -246,7 +246,7 @@ export function updatePlugin( siteId, plugin ) {
 			pluginId,
 		};
 
-		if ( ! plugin.update || plugin.update?.recentlyUpdated ) {
+		if ( ! plugin?.update || plugin?.update?.recentlyUpdated ) {
 			return dispatch( { ...defaultAction, type: PLUGIN_UPDATE_REQUEST_SUCCESS, data: plugin } );
 		}
 

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -246,7 +246,7 @@ export function updatePlugin( siteId, plugin ) {
 			pluginId,
 		};
 
-		if ( ! plugin.update ) {
+		if ( ! plugin.update || plugin.update?.recentlyUpdated ) {
 			return dispatch( { ...defaultAction, type: PLUGIN_UPDATE_REQUEST_SUCCESS, data: plugin } );
 		}
 


### PR DESCRIPTION
#### Proposed Changes

When the user performs an update for a specific plugin, we don't wipe out the `update` property from the plugin object itself. Instead, we set the `recentlyUpdated` property, so this PR will improve the existing check for whether or not the plugin has an update available **or was updated recently.**

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a self-hosted site and install a few plugins, one of which should be outdated (you can use the advanced view, as described [here](https://wordpress.org/support/topic/old-version-of-plugin-2/)).
- Checkout this branch locally
- Run yarn start-jetpack-cloud
- Open single-site plugins view: http://jetpack.cloud.localhost:3000/plugins/manage/:site
- Click "Edit all" and update all plugins
- Verify that the plugins without updates available will immediately show the "success" indicator
- Verify that the plugin requiring update will be updated
- Click "Edit all" again and update all plugins
- Verify that no API requests will be made to the Jetpack sites (as all plugins are updated, and we also have recently updated one)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202971373822980