### PR TITLE
Plugin Management: update style for plugin action confirmation modal popups

### DIFF
--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -59,6 +59,7 @@ class AcceptDialog extends Component {
 				onClose={ this.onClose }
 				className="accept__dialog"
 				isVisible
+				additionalClassNames={ this.props?.options?.additionalClassNames }
 			>
 				{ this.props.message }
 			</Dialog>

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -19,6 +19,7 @@ import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { removePlugin } from 'calypso/state/plugins/installed/actions';
 import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import { getPluginActionDailogMessage } from '../utils';
 
 import './style.scss';
 
@@ -26,25 +27,22 @@ class PluginRemoveButton extends Component {
 	static displayName = 'PluginRemoveButton';
 
 	removeAction = () => {
+		const { translate, plugin, site } = this.props;
+		const dialogOptions = {
+			additionalClassNames: 'plugins__confirmation-modal',
+			isScary: true,
+		};
+		const heading = translate( 'Remove %(pluginName)s', {
+			args: {
+				pluginName: plugin.name,
+			},
+		} );
 		accept(
-			this.props.translate(
-				'Are you sure you want to remove {{strong}}%(pluginName)s{{/strong}} from' +
-					' %(siteName)s? {{br /}} {{em}}This will deactivate the plugin and delete all' +
-					' associated files and data.{{/em}}',
-				{
-					components: {
-						em: <em />,
-						br: <br />,
-						strong: <strong />,
-					},
-					args: {
-						pluginName: this.props.plugin.name,
-						siteName: this.props.site.title,
-					},
-				}
-			),
+			getPluginActionDailogMessage( [ site ], [ plugin ], heading, 'deactivate and delete' ),
 			this.processRemovalConfirmation,
-			this.props.translate( 'Remove' )
+			heading,
+			null,
+			dialogOptions
 		);
 	};
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -33,6 +33,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PluginManagementV2 from '../plugin-management-v2';
+import { getPluginActionDailogMessage } from '../utils';
 
 import './style.scss';
 
@@ -347,102 +348,8 @@ export class PluginsList extends Component {
 		}
 	};
 
-	getConfirmationText( selectedPlugins, actionText, actionPreposition ) {
-		const pluginsList = {};
-		const sitesList = {};
-		let pluginName;
-		let siteName;
-		const { translate } = this.props;
-
-		selectedPlugins.forEach( ( plugin ) => {
-			pluginsList[ plugin.slug ] = true;
-			pluginName = plugin.name || plugin.slug;
-
-			Object.keys( plugin.sites ).forEach( ( siteId ) => {
-				const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );
-				if ( site.canUpdateFiles ) {
-					sitesList[ site.ID ] = true;
-					siteName = site.title;
-				}
-			} );
-		} );
-
-		const pluginsListSize = Object.keys( pluginsList ).length;
-		const siteListSize = Object.keys( sitesList ).length;
-		const combination =
-			( siteListSize > 1 ? 'n sites' : '1 site' ) +
-			' ' +
-			( pluginsListSize > 1 ? 'n plugins' : '1 plugin' );
-
-		switch ( combination ) {
-			case '1 site 1 plugin':
-				return translate(
-					'You are about to %(actionText)s {{em}}%(plugin)s %(actionPreposition)s %(site)s{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-						args: {
-							actionText: actionText,
-							actionPreposition: actionPreposition,
-							plugin: pluginName,
-							site: siteName,
-						},
-					}
-				);
-
-			case '1 site n plugins':
-				return translate(
-					'You are about to %(actionText)s {{em}}%(numberOfPlugins)d plugins %(actionPreposition)s %(site)s{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-						args: {
-							actionText: actionText,
-							actionPreposition: actionPreposition,
-							numberOfPlugins: pluginsListSize,
-							site: siteName,
-						},
-					}
-				);
-
-			case 'n sites 1 plugin':
-				return translate(
-					'You are about to %(actionText)s {{em}}%(plugin)s %(actionPreposition)s %(numberOfSites)d sites{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-						args: {
-							actionText: actionText,
-							actionPreposition: actionPreposition,
-							plugin: pluginName,
-							numberOfSites: siteListSize,
-						},
-					}
-				);
-
-			case 'n sites n plugins':
-				return translate(
-					'You are about to %(actionText)s {{em}}%(numberOfPlugins)d plugins %(actionPreposition)s %(numberOfSites)d sites{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-						args: {
-							actionText: actionText,
-							actionPreposition: actionPreposition,
-							numberOfPlugins: pluginsListSize,
-							numberOfSites: siteListSize,
-						},
-					}
-				);
-		}
-	}
-
 	bulkActionDialog = ( actionName, selectedPlugin ) => {
-		const { plugins, translate } = this.props;
+		const { plugins, translate, allSites } = this.props;
 		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
 		const pluginsCount = selectedPlugins.length;
 
@@ -453,109 +360,132 @@ export class PluginsList extends Component {
 			count: pluginsCount,
 		};
 
+		const dialogOptions = {
+			additionalClassNames: 'plugins__confirmation-modal',
+		};
+
 		switch ( actionName ) {
-			case 'activate':
+			case 'activate': {
+				const heading = translate(
+					'Activate %(pluginsCount)d plugin',
+					'Activate %(pluginsCount)d plugins',
+					translationArgs
+				);
 				acceptDialog(
-					<div>
-						<span>{ this.getConfirmationText( selectedPlugins, 'activate', 'on' ) }</span>
-					</div>,
+					getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'activate' ),
 					( accepted ) => this.activateSelected( accepted ),
-					translate(
-						'Activate %(pluginsCount)d plugin',
-						'Activate %(pluginsCount)d plugins',
-						translationArgs
-					)
+					heading,
+					null,
+					dialogOptions
 				);
 				break;
-			case 'deactivate':
+			}
+			case 'deactivate': {
+				const heading = translate(
+					'Deactivate %(pluginsCount)d plugin',
+					'Deactivate %(pluginsCount)d plugins',
+					translationArgs
+				);
 				acceptDialog(
-					<div>
-						<span>{ this.getConfirmationText( selectedPlugins, 'deactivate', 'on' ) }</span>
-					</div>,
+					getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'deactivate' ),
 					isJetpackIncluded
 						? ( accepted ) => this.deactiveAndDisconnectSelected( accepted )
 						: ( accepted ) => this.deactivateSelected( accepted ),
-					translate(
-						'Deactivate %(pluginsCount)d plugin',
-						'Deactivate %(pluginsCount)d plugins',
-						translationArgs
-					)
+					heading,
+					null,
+					dialogOptions
 				);
 				break;
-			case 'enableAutoupdates':
+			}
+			case 'enableAutoupdates': {
+				const heading = translate(
+					'Enable autoupdates for %(pluginsCount)d plugin',
+					'Enable autoupdates for %(pluginsCount)d plugins',
+					translationArgs
+				);
 				acceptDialog(
-					<div>
-						<span>
-							{ this.getConfirmationText( selectedPlugins, 'enable autoupdates for', 'on' ) }
-						</span>
-					</div>,
+					getPluginActionDailogMessage(
+						allSites,
+						selectedPlugins,
+						heading,
+						'enable autoupdates for'
+					),
 					( accepted ) => this.setAutoupdateSelected( accepted ),
-					translate(
-						'Enable autoupdates for %(pluginsCount)d plugin',
-						'Enable autoupdates for %(pluginsCount)d plugins',
-						translationArgs
-					)
+					heading,
+					null,
+					dialogOptions
 				);
 				break;
-			case 'disableAutoupdates':
+			}
+			case 'disableAutoupdates': {
+				const heading = translate(
+					'Disable autoupdates for %(pluginsCount)d plugin',
+					'Disable autoupdates for %(pluginsCount)d plugins',
+					translationArgs
+				);
 				acceptDialog(
-					<div>
-						<span>
-							{ this.getConfirmationText( selectedPlugins, 'disable autoupdates for', 'on' ) }
-						</span>
-					</div>,
+					getPluginActionDailogMessage(
+						allSites,
+						selectedPlugins,
+						heading,
+						'disable autoupdates for'
+					),
 					( accepted ) => this.unsetAutoupdateSelected( accepted ),
-					translate(
-						'Disable autoupdates for %(pluginsCount)d plugin',
-						'Disable autoupdates for %(pluginsCount)d plugins',
-						translationArgs
-					)
+					heading,
+					null,
+					dialogOptions
 				);
 				break;
-			case 'update':
-				acceptDialog(
-					<div>
-						<span>{ this.getConfirmationText( selectedPlugins, 'update', 'on' ) }</span>
-					</div>,
-					( accepted ) => this.updateSelected( accepted ),
-					translate(
-						'Update %(pluginsCount)d plugin',
-						'Update %(pluginsCount)d plugins',
-						translationArgs
-					)
+			}
+			case 'update': {
+				const heading = translate(
+					'Update %(pluginsCount)d plugin',
+					'Update %(pluginsCount)d plugins',
+					translationArgs
 				);
+				acceptDialog(
+					getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'update' ),
+					( accepted ) => this.updateSelected( accepted ),
+					heading,
+					null,
+					dialogOptions
+				);
+			}
 		}
 	};
 
 	removePluginDialog = ( selectedPlugin ) => {
-		const { plugins, translate } = this.props;
+		const { plugins, translate, allSites } = this.props;
 
 		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
 		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
 
-		const message = (
-			<div>
-				<span>{ this.getConfirmationText( selectedPlugins, 'remove', 'from' ) }</span>
-				<span>
-					{ translate(
-						'{{p}}This will deactivate the plugins and delete all associated files and data.{{/p}}',
-						{
-							components: {
-								p: <p />,
-							},
-						}
-					) }
-				</span>
-				<span>{ translate( 'Do you want to continue?' ) }</span>
-			</div>
+		const dialogOptions = {
+			additionalClassNames: 'plugins__confirmation-modal',
+			isScary: true,
+		};
+
+		const pluginsCount = selectedPlugins.length;
+
+		const translationArgs = {
+			args: { pluginsCount },
+			count: pluginsCount,
+		};
+
+		const heading = translate(
+			'Remove %(pluginsCount)d plugin',
+			'Remove %(pluginsCount)d plugins',
+			translationArgs
 		);
 
 		acceptDialog(
-			message,
+			getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'deactivate and delete' ),
 			isJetpackIncluded
 				? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
 				: ( accepted ) => this.removeSelected( accepted, selectedPlugins ),
-			translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } )
+			heading,
+			null,
+			dialogOptions
 		);
 	};
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -355,22 +355,24 @@ export class PluginsList extends Component {
 
 		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
 
-		const translationArgs = {
-			args: { pluginsCount },
-			count: pluginsCount,
-		};
-
 		const dialogOptions = {
 			additionalClassNames: 'plugins__confirmation-modal',
+			...( actionName === 'remove' && { isScary: true } ),
 		};
+
+		let pluginName;
+		const hasOnePlugin = pluginsCount === 1;
+
+		if ( hasOnePlugin ) {
+			const [ { name, slug } ] = selectedPlugins;
+			pluginName = name || slug;
+		}
 
 		switch ( actionName ) {
 			case 'activate': {
-				const heading = translate(
-					'Activate %(pluginsCount)d plugin',
-					'Activate %(pluginsCount)d plugins',
-					translationArgs
-				);
+				const heading = hasOnePlugin
+					? translate( 'Activate %(pluginName)s', { args: { pluginName } } )
+					: translate( 'Activate %(pluginsCount)d plugins', { args: { pluginsCount } } );
 				acceptDialog(
 					getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'activate' ),
 					( accepted ) => this.activateSelected( accepted ),
@@ -381,11 +383,9 @@ export class PluginsList extends Component {
 				break;
 			}
 			case 'deactivate': {
-				const heading = translate(
-					'Deactivate %(pluginsCount)d plugin',
-					'Deactivate %(pluginsCount)d plugins',
-					translationArgs
-				);
+				const heading = hasOnePlugin
+					? translate( 'Deactivate %(pluginName)s', { args: { pluginName } } )
+					: translate( 'Deactivate %(pluginsCount)d plugins', { args: { pluginsCount } } );
 				acceptDialog(
 					getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'deactivate' ),
 					isJetpackIncluded
@@ -398,11 +398,11 @@ export class PluginsList extends Component {
 				break;
 			}
 			case 'enableAutoupdates': {
-				const heading = translate(
-					'Enable autoupdates for %(pluginsCount)d plugin',
-					'Enable autoupdates for %(pluginsCount)d plugins',
-					translationArgs
-				);
+				const heading = hasOnePlugin
+					? translate( 'Enable autoupdate for %(pluginName)s', { args: { pluginName } } )
+					: translate( 'Enable autoupdates for %(pluginsCount)d plugins', {
+							args: { pluginsCount },
+					  } );
 				acceptDialog(
 					getPluginActionDailogMessage(
 						allSites,
@@ -418,11 +418,11 @@ export class PluginsList extends Component {
 				break;
 			}
 			case 'disableAutoupdates': {
-				const heading = translate(
-					'Disable autoupdates for %(pluginsCount)d plugin',
-					'Disable autoupdates for %(pluginsCount)d plugins',
-					translationArgs
-				);
+				const heading = hasOnePlugin
+					? translate( 'Disable autoupdate for %(pluginName)s', { args: { pluginName } } )
+					: translate( 'Disable autoupdates for %(pluginsCount)d plugins', {
+							args: { pluginsCount },
+					  } );
 				acceptDialog(
 					getPluginActionDailogMessage(
 						allSites,
@@ -438,11 +438,11 @@ export class PluginsList extends Component {
 				break;
 			}
 			case 'update': {
-				const heading = translate(
-					'Update %(pluginsCount)d plugin',
-					'Update %(pluginsCount)d plugins',
-					translationArgs
-				);
+				const heading = hasOnePlugin
+					? translate( 'Update %(pluginName)s', { args: { pluginName } } )
+					: translate( 'Update %(pluginsCount)d plugins', {
+							args: { pluginsCount },
+					  } );
 				acceptDialog(
 					getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'update' ),
 					( accepted ) => this.updateSelected( accepted ),
@@ -450,43 +450,35 @@ export class PluginsList extends Component {
 					null,
 					dialogOptions
 				);
+				break;
+			}
+			case 'remove': {
+				const heading = hasOnePlugin
+					? translate( 'Remove %(pluginName)s', { args: { pluginName } } )
+					: translate( 'Remove %(pluginsCount)d plugins', {
+							args: { pluginsCount },
+					  } );
+				acceptDialog(
+					getPluginActionDailogMessage(
+						allSites,
+						selectedPlugins,
+						heading,
+						'deactivate and delete'
+					),
+					isJetpackIncluded
+						? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
+						: ( accepted ) => this.removeSelected( accepted, selectedPlugins ),
+					heading,
+					null,
+					dialogOptions
+				);
+				break;
 			}
 		}
 	};
 
 	removePluginDialog = ( selectedPlugin ) => {
-		const { plugins, translate, allSites } = this.props;
-
-		const selectedPlugins = selectedPlugin ? [ selectedPlugin ] : plugins.filter( this.isSelected );
-		const isJetpackIncluded = selectedPlugins.some( ( { slug } ) => slug === 'jetpack' );
-
-		const dialogOptions = {
-			additionalClassNames: 'plugins__confirmation-modal',
-			isScary: true,
-		};
-
-		const pluginsCount = selectedPlugins.length;
-
-		const translationArgs = {
-			args: { pluginsCount },
-			count: pluginsCount,
-		};
-
-		const heading = translate(
-			'Remove %(pluginsCount)d plugin',
-			'Remove %(pluginsCount)d plugins',
-			translationArgs
-		);
-
-		acceptDialog(
-			getPluginActionDailogMessage( allSites, selectedPlugins, heading, 'deactivate and delete' ),
-			isJetpackIncluded
-				? ( accepted ) => this.removeSelectedWithJetpack( accepted, selectedPlugins )
-				: ( accepted ) => this.removeSelected( accepted, selectedPlugins ),
-			heading,
-			null,
-			dialogOptions
-		);
+		this.bulkActionDialog( 'remove', selectedPlugin );
 	};
 
 	removeSelected = ( accepted, selectedPlugins ) => {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,5 +1,5 @@
-@import "@wordpress/base-styles/_breakpoints.scss";
-@import "@wordpress/base-styles/_mixins.scss";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "./grid-mixins.scss";
 @import "./woocommerce-box.scss";
 
@@ -454,6 +454,31 @@ body.is-section-plugins header .select-dropdown__item {
 					color: var(--color-neutral-70);
 				}
 			}
+		}
+	}
+}
+
+.plugins__confirmation-modal {
+	.plugins__confirmation-modal-heading {
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.plugins__confirmation-modal-desc {
+		display: block;
+		padding-top: 12px;
+		font-size: 1rem;
+		font-weight: 400;
+	}
+
+	.dialog__action-buttons {
+		padding: 24px;
+
+		button {
+			margin-inline-start: 16px;
+			padding: 7px;
+			font-size: 0.75rem;
+			line-height: 1;
 		}
 	}
 }

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,5 +1,5 @@
 import { isMagnificentLocale } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -28,3 +28,90 @@ export function useLocalizedPlugins() {
 
 	return { localizePath };
 }
+
+// Returns translated text based on different combination of plugins and sites
+const getConfirmationText = ( sites, selectedPlugins, actionText ) => {
+	const pluginsList = {};
+	const sitesList = {};
+	let pluginName;
+	let siteName;
+
+	selectedPlugins.forEach( ( plugin ) => {
+		pluginsList[ plugin.slug ] = true;
+		pluginName = plugin.name || plugin.slug;
+
+		Object.keys( plugin.sites ).forEach( ( siteId ) => {
+			const site = sites.find( ( s ) => s.ID === parseInt( siteId ) );
+			if ( site.canUpdateFiles ) {
+				sitesList[ site.ID ] = true;
+				siteName = site.title;
+			}
+		} );
+	} );
+
+	const pluginsListSize = Object.keys( pluginsList ).length;
+	const siteListSize = Object.keys( sitesList ).length;
+	const combination =
+		( siteListSize > 1 ? 'n sites' : '1 site' ) +
+		' ' +
+		( pluginsListSize > 1 ? 'n plugins' : '1 plugin' );
+
+	switch ( combination ) {
+		case '1 site 1 plugin':
+			return translate( 'You are about to %(actionText)s %(plugin)s installed on %(site)s.', {
+				args: {
+					actionText: actionText,
+					plugin: pluginName,
+					site: siteName,
+				},
+			} );
+
+		case '1 site n plugins':
+			return translate(
+				'You are about to %(actionText)s %(numberOfPlugins)d plugins installed on %(site)s.',
+				{
+					args: {
+						actionText: actionText,
+						numberOfPlugins: pluginsListSize,
+						site: siteName,
+					},
+				}
+			);
+
+		case 'n sites 1 plugin':
+			return translate(
+				'You are about to %(actionText)s %(plugin)s installed across %(numberOfSites)d sites.',
+				{
+					args: {
+						actionText: actionText,
+						plugin: pluginName,
+						numberOfSites: siteListSize,
+					},
+				}
+			);
+
+		case 'n sites n plugins':
+			return translate(
+				'You are about to %(actionText)s %(numberOfPlugins)d plugins installed across %(numberOfSites)d sites.',
+				{
+					args: {
+						actionText: actionText,
+						numberOfPlugins: pluginsListSize,
+						numberOfSites: siteListSize,
+					},
+				}
+			);
+	}
+};
+
+// Returns plugin action dailog message for different action types
+export const getPluginActionDailogMessage = ( sites, selectedPlugins, heading, actionText ) => {
+	return (
+		<div>
+			<div className="plugins__confirmation-modal-heading">{ heading }</div>
+			<span className="plugins__confirmation-modal-desc">
+				{ getConfirmationText( sites, selectedPlugins, actionText ) }
+			</span>
+		</div>
+	);
+};


### PR DESCRIPTION
#### Proposed Changes

This PR makes UI enhancements to the plugin actions confirmation modal popups.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/plugin-action-popup-style-enhancement` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Plugins** in the sidebar -> Click on **Edit all** and test all the possible scenarios as mentioned below

<table>
<tr>

<th>
1 plugin, 1 site
</th>
<th>
n plugins, 1 site
</th>
<th>
1 plugin, n sites
</th>
<th>
n plugins, n sites
</th>
</tr>

<tr>
<td colspan="4">
Activate Plugin
</td>
</tr>

<tr>
<td>
<img width="487" alt="Screenshot 2022-09-15 at 10 25 44 AM" src="https://user-images.githubusercontent.com/10586875/190323723-5f0b1328-68a0-4671-aede-9d4920aa00c5.png">
</td>

<td>
<img width="516" alt="Screenshot 2022-09-14 at 2 10 06 PM" src="https://user-images.githubusercontent.com/10586875/190120276-932167f2-90cb-4007-b476-1ec1a16986dd.png">
</td>

<td>
<img width="542" alt="Screenshot 2022-09-15 at 10 28 30 AM" src="https://user-images.githubusercontent.com/10586875/190323784-3cfecd57-3995-4d70-8fe5-0a55f9e149a6.png">
</td>

<td>
<img width="524" alt="Screenshot 2022-09-14 at 2 10 24 PM" src="https://user-images.githubusercontent.com/10586875/190120301-d36a6455-cb01-4755-92e1-06f106e4ac9a.png">
</td>
</tr>

<tr>
<td colspan="4">
Deactivate Plugin
</td>
</tr>

<tr>
<td>
<img width="505" alt="Screenshot 2022-09-15 at 10 25 57 AM" src="https://user-images.githubusercontent.com/10586875/190323815-cd28292e-dc83-4045-9a60-0946fd92c051.png">
</td>

<td>
<img width="530" alt="Screenshot 2022-09-14 at 3 19 37 PM" src="https://user-images.githubusercontent.com/10586875/190122258-ae9ef2d0-4440-40ef-b1eb-2e61f66fc175.png">
</td>

<td>
<img width="546" alt="Screenshot 2022-09-15 at 10 28 37 AM" src="https://user-images.githubusercontent.com/10586875/190323847-51ae7bd8-50db-40d5-be03-c1451b3721ff.png">
</td>

<td>
<img width="502" alt="Screenshot 2022-09-14 at 3 19 55 PM" src="https://user-images.githubusercontent.com/10586875/190122269-cee1f504-93af-47d6-8333-f87c62360ae8.png">
</td>
</tr>

<tr>
<td colspan="4">
Enable Autoupdate
</td>
</tr>

<tr>
<td>
<img width="546" alt="Screenshot 2022-09-15 at 10 26 35 AM" src="https://user-images.githubusercontent.com/10586875/190323883-86024efd-7ed8-4acd-8a62-a7435bbca803.png">
</td>

<td>
<img width="584" alt="Screenshot 2022-09-14 at 2 11 40 PM" src="https://user-images.githubusercontent.com/10586875/190123251-f7f6e72c-d0c3-43d7-bc2e-1c87e3af8b98.png">
</td>

<td>
<img width="544" alt="Screenshot 2022-09-15 at 10 28 45 AM" src="https://user-images.githubusercontent.com/10586875/190323921-d5095fc2-8647-4a70-bf2c-580d0e831244.png">
</td>

<td>
<img width="578" alt="Screenshot 2022-09-14 at 2 12 04 PM" src="https://user-images.githubusercontent.com/10586875/190123262-b8846578-7f8d-499f-b9c2-5fbead9e4c92.png">
</td>
</tr>

<tr>
<td colspan="4">
Disable Autoupdate
</td>
</tr>

<tr>
<td>
<img width="546" alt="Screenshot 2022-09-15 at 10 26 50 AM" src="https://user-images.githubusercontent.com/10586875/190324141-45494f81-f85f-49f8-a1d2-26ea30a567e9.png">
</td>

<td>
<img width="582" alt="Screenshot 2022-09-14 at 2 12 29 PM" src="https://user-images.githubusercontent.com/10586875/190123530-63d5b47f-53d2-41d7-8d5a-e4b9844ba014.png">
</td>

<td>
<img width="548" alt="Screenshot 2022-09-15 at 10 28 54 AM" src="https://user-images.githubusercontent.com/10586875/190324031-9767352d-fee4-4773-a4de-7fff4ec9e680.png">
</td>

<td>
<img width="586" alt="Screenshot 2022-09-14 at 2 12 56 PM" src="https://user-images.githubusercontent.com/10586875/190123550-7672275d-373e-4cda-8ac4-8259f3586f6e.png">
</td>
</tr>


<tr>
<td colspan="4">
Update Plugins
</td>
</tr>

<tr>
<td>
<img width="476" alt="Screenshot 2022-09-15 at 10 27 50 AM" src="https://user-images.githubusercontent.com/10586875/190324199-13990777-ea0d-4302-9643-dc3933d029da.png">
</td>

<td>
<img width="508" alt="Screenshot 2022-09-14 at 2 13 22 PM" src="https://user-images.githubusercontent.com/10586875/190124014-e38fd4f7-461a-45c3-9773-cb5385fa668b.png">
</td>

<td>
<img width="545" alt="Screenshot 2022-09-15 at 10 29 03 AM" src="https://user-images.githubusercontent.com/10586875/190324241-88fb1ff9-0315-4305-8418-49fb31d0699f.png">
</td>

<td>
<img width="509" alt="Screenshot 2022-09-14 at 2 13 37 PM" src="https://user-images.githubusercontent.com/10586875/190124033-4480b9cf-920c-4ba8-b0a2-699d21dfd09c.png">
</td>
</tr>


<tr>
<td colspan="4">
Remove Plugin
</td>
</tr>

<tr>
<td>
<img width="546" alt="Screenshot 2022-09-15 at 10 28 05 AM" src="https://user-images.githubusercontent.com/10586875/190324267-b2400caa-510d-4163-bd5e-54a07f2f1fd6.png">
</td>

<td>
<img width="584" alt="Screenshot 2022-09-14 at 2 42 40 PM" src="https://user-images.githubusercontent.com/10586875/190124448-0c148e59-f64b-425e-9622-0f812e3ae689.png">
</td>

<td>
<img width="545" alt="Screenshot 2022-09-15 at 10 29 13 AM" src="https://user-images.githubusercontent.com/10586875/190324287-cf385ea4-4bcd-4b6d-ab02-40b6df1daa53.png">
</td>

<td>
<img width="584" alt="Screenshot 2022-09-14 at 2 43 06 PM" src="https://user-images.githubusercontent.com/10586875/190124466-92c10f2a-dcef-4d45-bc16-db92f110c6c5.png">
</td>
</tr>

</table>

4. Go to plugin details and click on `Remove` on any site and verify the confirmation popup is as below.

<img width="618" alt="Screenshot 2022-09-14 at 2 42 20 PM" src="https://user-images.githubusercontent.com/10586875/190125283-8a27c049-83d2-48d6-8c90-d450a3aebecc.png">

5. Test the same in Calypso blue and verify that everything looks good.

<img width="534" alt="Screenshot 2022-09-14 at 3 04 07 PM" src="https://user-images.githubusercontent.com/10586875/190124787-8eed8d39-9475-41f9-bfcb-5d964a82376b.png">

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202967461339771