### PR TITLE
Search Component: fix nonexistent focus handler call

### DIFF
--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -423,7 +423,7 @@ const InnerSearch = (
 			<Button
 				className="search-component__icon-navigation"
 				ref={ openIcon }
-				onClick={ enableOpenIcon ? openSearch : focus }
+				onClick={ enableOpenIcon ? openSearch : () => searchInput.current?.focus() }
 				tabIndex={ enableOpenIcon ? 0 : undefined }
 				onKeyDown={ enableOpenIcon ? openListener : undefined }
 				aria-controls={ 'search-component-' + instanceId }


### PR DESCRIPTION
Fixes a nonexistent `focus` identifier used as an event handler. There is a valid `window.focus` value, so TypeScript things we're referencing that and doesn't complain, so the bug went undetected. Last year, during a refactoring review, [we discussed](https://github.com/Automattic/wp-calypso/pull/51059/files#r594343730) with @tyxla another instance of the issue in the same component, but missed the second one.

The `focus` thing used to be a `this.focus` method on a class component, later moved to a local function in a functional component, and then moved inside a `useImperativeHandle` hook, leaving some dangling references behind.

Discovered in #67747 which starts using the `Search` component in SSR, where the `window.focus` reference was crashing.