### PR TITLE
Marketplace: Add header to plans page

### DIFF
--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -3,11 +3,14 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import FormattedHeader from 'calypso/components/formatted-header';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+import './style.scss';
 
 const Plans = () => {
 	const translate = useTranslate();
@@ -42,6 +45,12 @@ const Plans = () => {
 			<PageViewTracker path="/plugins/plans/:site" title="Plugins > Plan Upgrade" />
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
 			<FixedNavigationHeader navigationItems={ breadcrumbs } />
+			<FormattedHeader
+				className="plugin-plans-header"
+				headerText={ `Your current plan doesn't support plugins` }
+				subHeaderText={ `Choose the plan that's right for you and reimagine what's possible with plugins` }
+				brandFont
+			/>
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -1,0 +1,8 @@
+.plugin-plans-header {
+	.formatted-header__title {
+		font-size: $font-title-large;
+	}
+	.formatted-header__subtitle {
+		font-size: $font-body;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* Add header to plans page in marketplace

![header](https://user-images.githubusercontent.com/6586048/190130818-d22c248b-0940-4845-9dc6-bf9fc534c486.png)



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /plugins/plans/<siteurl>
* View the header

Related to #67574
