### PR TITLE
Fix Font Weight for fraction part of the price in the new pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -91,11 +91,11 @@
 
 /*
 Hack to fix line-through not showing in the middle of the text in firefox browser.
-1.4rem seems to be rigth value to have the line in the middle of the text. But stylelint rule set in the project won't allow this value
 */
 @-moz-document url-prefix() {
 	.plan-price {
-		font-size: 1.5rem;
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 1.4rem;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -68,6 +68,10 @@
 		font-weight: 700;
 	}
 
+	.plan-price.is-discounted .plan-price__fraction {
+		font-weight: inherit;
+	}
+
 	.display-price__billing-time-frame {
 		margin-top: 3px;
 	}
@@ -82,6 +86,16 @@
 
 	.display-price__billing-time-frame {
 		line-height: 20px;
+	}
+}
+
+/*
+Hack to fix line-through not showing in the middle of the text in firefox browser.
+1.4rem seems to be rigth value to have the line in the middle of the text. But stylelint rule set in the project won't allow this value
+*/
+@-moz-document url-prefix() {
+	.plan-price {
+		font-size: 1.5rem;
 	}
 }
 


### PR DESCRIPTION
This PR fixes a couple of styles

#### Proposed Changes

* Fix incorrect `font-weight` property for fraction part in the price.
* An Hacky Fix for `line-through` not showing up exactly in the centre of the text

#### Testing Instructions


* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout add/lightbox-info-to-calypso-package`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* In the product cards make sure the `font-weight` for integer and decimal part are same
* Now, open the some page in Firefox and make sure the `line-through` is in the middle of the number. (Refer screenshot)
#### Screenshot 
##### Fraction part of the price
##### Before
![fraction-before](https://user-images.githubusercontent.com/2027003/190110164-1de3deb1-2d2d-47d9-9bbd-cb32de6c2a9c.png)

##### After
![fraction-after](https://user-images.githubusercontent.com/2027003/190110324-662cd15b-99cf-4930-aa5b-0e459157ac9f.png)

##### Firefox line-through the price
##### Before
<img width="875" alt="Screenshot 2022-09-14 at 7 26 25 PM" src="https://user-images.githubusercontent.com/2027003/190173996-c67208a8-e67a-418a-a091-00bd90546108.png">



##### After
<img width="890" alt="Screenshot 2022-09-14 at 7 23 28 PM" src="https://user-images.githubusercontent.com/2027003/190173704-edadec90-980d-49dd-85e0-fea7ce780e0c.png">





#### Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

