### PR TITLE
Pattern Assembler: Remove blank canvas injection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -85,9 +85,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			allDesigns.static.designs = removeLegacyDesignVariations( allDesigns?.static?.designs || [] );
 		}
 
-		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( ( design ) =>
-			isBlankCanvasDesign( design )
-		);
+		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );
 		if ( blankCanvasDesignOffset !== -1 ) {
 			// Extract the blank canvas design first and then insert it into 4th position for the build and write intent
 			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -26,10 +26,7 @@ export type { SetSiteLogoResponse } from './queries/use-site-logo-mutation';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
-export { useStarterDesignBySlug } from './starter-designs-queries/use-starter-design-by-slug';
-export { useStarterDesignsGeneratedQuery } from './starter-designs-queries/use-starter-designs-generated-query';
-export { useStarterDesignsQuery } from './starter-designs-queries/use-starter-designs-query';
-export { isThemeVerticalizable } from './starter-designs-queries/utils';
+export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';
 export * from './site/types';
 

--- a/packages/data-stores/src/starter-designs-queries/index.ts
+++ b/packages/data-stores/src/starter-designs-queries/index.ts
@@ -1,0 +1,5 @@
+export { useStarterDesignBySlug } from './use-starter-design-by-slug';
+export { useStarterDesignsGeneratedQuery } from './use-starter-designs-generated-query';
+export { useStarterDesignsQuery } from './use-starter-designs-query';
+export { isThemeVerticalizable } from './utils';
+export type { StarterDesigns } from './types';

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -19,6 +19,7 @@ interface StarterDesignsQueryParams {
 
 interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
 	enabled?: boolean;
+	select?: ( response: StarterDesigns ) => StarterDesigns;
 }
 
 interface StarterDesignsResponse {
@@ -44,18 +45,20 @@ interface GeneratedDesign {
 
 export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
-	queryOptions: Options = {}
+	{ select, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
 	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
-			return {
+			const allDesigns = {
 				generated: {
 					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
 				},
 				static: {
 					designs: response.static?.designs?.map( apiStarterDesignsStaticToDesign ),
 				},
-			} as StarterDesigns;
+			};
+
+			return select ? select( allDesigns ) : allDesigns;
 		},
 		refetchOnMount: 'always',
 		staleTime: Infinity,

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -11,7 +11,7 @@
 	background-color: #f6f7f7;
 	color: #50575e;
 
-	@include break-mobile {
+	@include break-medium {
 		display: flex;
 	}
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -285,9 +285,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	const isBlankCanvas = isBlankCanvasDesign( props.design );
 
 	if ( isBlankCanvas ) {
-		return isEnabled( 'signup/design-picker-pattern-assembler' ) ? (
-			<PatternAssemblerCta onButtonClick={ () => props.onSelect( props.design ) } />
-		) : null;
+		return <PatternAssemblerCta onButtonClick={ () => props.onSelect( props.design ) } />;
 	}
 
 	if ( ! onPreview || props.hideFullScreenPreview ) {

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -15,14 +15,12 @@ import {
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
-	SHOW_ALL_SLUG,
 } from '../constants';
 import {
 	getDesignPreviewUrl,
 	getMShotOptions,
 	isBlankCanvasDesign,
 	filterDesignsByCategory,
-	sortDesigns,
 } from '../utils';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
 import PatternAssemblerCta from './pattern-assembler-cta';
@@ -286,6 +284,12 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	const isDesktop = useViewportMatch( 'large' );
 	const isBlankCanvas = isBlankCanvasDesign( props.design );
 
+	if ( isBlankCanvas ) {
+		return isEnabled( 'signup/design-picker-pattern-assembler' ) ? (
+			<PatternAssemblerCta onButtonClick={ () => props.onSelect( props.design ) } />
+		) : null;
+	}
+
 	if ( ! onPreview || props.hideFullScreenPreview ) {
 		return (
 			<div className="design-button-container design-button-container--without-preview">
@@ -307,8 +311,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 		);
 	}
 
-	// We don't need preview for blank canvas
-	return ! isBlankCanvas ? (
+	return (
 		<div className="design-button-container">
 			{ ! previewOnly && (
 				<DesignButtonCover
@@ -326,11 +329,6 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 				disabled={ ! previewOnly }
 			/>
 		</div>
-	) : (
-		<PatternAssemblerCta
-			key={ props.design.slug }
-			onButtonClick={ () => props.onSelect( props.design ) }
-		/>
 	);
 };
 
@@ -395,27 +393,11 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 	const hasCategories = !! categorization?.categories.length;
 
 	const filteredDesigns = useMemo( () => {
-		const result = categorization?.selection
-			? filterDesignsByCategory( designs, categorization.selection )
-			: designs.slice(); // cloning because otherwise .sort() would mutate the original prop
-
-		result.sort( sortDesigns );
-
-		if (
-			isEnabled( 'signup/design-picker-pattern-assembler' ) &&
-			categorization?.selection === SHOW_ALL_SLUG
-		) {
-			const blankCanvasDesign = {
-				recipe: {
-					stylesheet: 'pub/blank-canvas-blocks',
-				},
-				slug: 'blank-canvas-blocks',
-				title: 'Blank Canvas',
-			} as Design;
-			result.splice( Math.min( result.length, 3 ), 0, blankCanvasDesign );
+		if ( categorization?.selection ) {
+			return filterDesignsByCategory( designs, categorization.selection );
 		}
 
-		return result;
+		return designs;
 	}, [ designs, categorization?.selection ] );
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Remove the blank canvas injection as it will be returned via D87702-code
* Only render blank canvas CTA when the feature flag is on. Otherwise, we won't show it
* Fix the issue that we show the mShot of the blank canvas when the viewport is between mobile and medium.

| Build and Write Flow | Other Flows |
| - | - |
| <img width="1012" alt="image" src="https://user-images.githubusercontent.com/13596067/189879106-36aa3f04-5c09-47f0-9cf3-083fffa59e01.png"> | <img width="1012" alt="image" src="https://user-images.githubusercontent.com/13596067/189878964-f3a68457-94c2-443a-bac8-37c619bee999.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Build and Write Flow**

* Apply D87702-code to your sandbox
* Go to `/setup?siteSlug=<your_site>`
* Select **one** of the following goals
  * Write & Publish
  * Promote myself or business
  * Other
* When you land on the Design Picker, you will see the blank canvas CTA

**Other Flows**

* Apply D87702-code to your sandbox
* Go to `/setup?siteSlug=<your_site>`
* Select **none** of the following goals
  * Write & Publish
  * Promote myself or business
  * Other
* When you land on the Design Picker, you won't see the blank canvas CTA

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67713