### PR TITLE
Backup Dashboard: Fixed non-realtime-enabled-backup sites to show stats

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,4 +1,3 @@
-import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import ActivityCard from 'calypso/components/activity-card';
@@ -11,24 +10,19 @@ import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ActionButtons from '../action-buttons';
-import BackupChanges from '../backup-changes';
 import useGetDisplayDate from '../use-get-display-date';
 import cloudSuccessIcon from './icons/cloud-success.svg';
 import cloudWarningIcon from './icons/cloud-warning.svg';
 
 import './style.scss';
 
-const BackupSuccessful = ( { backup, deltas, selectedDate, lastBackupAttemptOnDate } ) => {
+const BackupSuccessful = ( { backup, selectedDate, lastBackupAttemptOnDate } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
-	const hasRealtimeBackups = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_REAL_TIME_BACKUPS )
-	);
 	const warnings = getBackupWarnings( lastBackupAttemptOnDate );
 	const hasWarnings = Object.keys( warnings ).length !== 0;
 
@@ -52,9 +46,8 @@ const BackupSuccessful = ( { backup, deltas, selectedDate, lastBackupAttemptOnDa
 
 	// We should only showing the summarized ActivityCard for Real-time sites when the latest backup is not a full backup
 	const showBackupDetails =
-		hasRealtimeBackups &&
-		( 'rewind__backup_complete_full' !== backup.activityName ||
-			'rewind__backup_only_complete_full' !== backup.activityName );
+		'rewind__backup_complete_full' !== backup.activityName ||
+		'rewind__backup_only_complete_full' !== backup.activityName;
 
 	const actionableRewindId = useActionableRewindId( backup );
 
@@ -115,7 +108,6 @@ const BackupSuccessful = ( { backup, deltas, selectedDate, lastBackupAttemptOnDa
 				</div>
 			) }
 			{ hasWarnings && <BackupWarningRetry siteId={ siteId } /> }
-			{ ! hasRealtimeBackups && <BackupChanges deltas={ deltas } /* metaDiff={ metaDiff */ /> }
 		</>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* This change will fix the message `Looks like there have been no new site changes since your last backup` on the backup dashboard ([WordPress.com dashboard » Jetpack » Backup](https://wordpress.com/backup/www.fjords.com)) for sites _not having_ `backup-realtime` capability even when there are changes in the last backup.

Current Dashboard [For a non `backup-realtime` capable site] 

![image](https://user-images.githubusercontent.com/13975226/190127835-d7cf03d2-3844-418f-b9a3-055a84ffc789.png)

Proposed Fix [Existing for real-time backup sites, new for non-ones]

<img width="762" alt="affected-site-fjords-shows-stat-now" src="https://user-images.githubusercontent.com/13975226/190127960-60f78eb8-eb3b-434e-bea1-801b69abd7db.png">


#### Testing Instructions

* To replicate the issue, just open WordPress.com dashboard » Jetpack » Backup for a non-real-time backup capable site (must have some successful backups done before). It will show the message `Looks like there have been no new site changes since your last backup` while the ActivityLog (WordPress.com dashboard » Jetpack » Activity Log) will show the backup stats as follows. 

![image](https://user-images.githubusercontent.com/13975226/190137113-61dcc5e9-1601-4fe8-b591-15aa6b860486.png)

Test the changes

* Checkout this branch.
* Start [your local instance of Calypso](https://github.com/Automattic/wp-calypso#getting-started).
* Test a site not having `backup-realtime` for whether it shows the stats for last successful backup and compare it with the activity log. 
* If there are more than one backups in the day, check whether it shows the latest one for that date.
* Check the stats for yesterday or any previous backups.
* Test a site having `backup-realtime` capability for stats just to ensure exist things work properly.
* Check for any console errors if any.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Tested the changes for sites with/without `backup-realtime` capability.
- [x] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to Asana Task: [Jetpack Backup shows no changes recorded in "Backup Dashboard" but its visible in Activity log ](https://app.asana.com/0/1202586245449203/1202960372482693)
