### PR TITLE
bump tree-select version 2.0.0

### DIFF
--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/tree-select",
-	"version": "1.0.3",
+	"version": "2.0.0",
 	"description": "A selector library for Redux.",
 	"keywords": [
 		"redux",


### PR DESCRIPTION
#### Proposed Changes

* Bumping `tree-select` version, so we can publish it on NPM.
We currently use this package on Happy Tools and since the recent move to TypeScript we could benefit from having a properly typed `tree-select` package.
Decided on a new major version since there were some changes, and the introduction of TypeScript since the last [release](https://www.npmjs.com/package/@automattic/tree-select/v/1.0.3). Please let me know if this is not the best option.

#### Testing Instructions
I tested it only on our Happy Tools repo, following the steps mentioned [here](https://github.com/Automattic/wp-calypso/blob/trunk/docs/monorepo.md#developing-packages)
This change shouldn't have any side effect on wp-calypso.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
