### PR TITLE
Add/content detection rule for crowdsignal projects

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-crowdsignal.js
+++ b/client/lib/post-normalizer/rule-content-detect-crowdsignal.js
@@ -27,7 +27,6 @@ export default function detectCrowdsignal( post, dom ) {
 				return;
 			}
 			const noscriptText = domForHtml( noscript.innerHTML ).innerText;
-
 			const p = document.createElement( 'p' );
 			const a = document.createElement( 'a' );
 			try {

--- a/client/lib/post-normalizer/rule-content-detect-crowdsignal.js
+++ b/client/lib/post-normalizer/rule-content-detect-crowdsignal.js
@@ -1,16 +1,16 @@
 import { forEach } from 'lodash';
 import { domForHtml } from './utils';
 
-export default function detectCrowdsignal( post, dom ) {
+export default function detectCrowdsignalEmbeds( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
 
-	const crowdsignal = dom.querySelectorAll( '.embed-crowdsignal' );
-	if ( ! crowdsignal ) {
+	const crowdsignalEmbeds = dom.querySelectorAll( '.embed-crowdsignal' );
+	if ( ! crowdsignalEmbeds ) {
 		return post;
 	}
-	forEach( crowdsignal, ( crowdsignalElement ) => {
+	forEach( crowdsignalEmbeds, ( crowdsignalElement ) => {
 		const authoritativeURL = crowdsignalElement.firstElementChild.getAttribute( 'src' );
 		if ( ! authoritativeURL ) {
 			return;

--- a/client/lib/post-normalizer/rule-content-detect-crowdsignal.js
+++ b/client/lib/post-normalizer/rule-content-detect-crowdsignal.js
@@ -1,0 +1,48 @@
+import { forEach } from 'lodash';
+import { domForHtml } from './utils';
+
+export default function detectCrowdsignal( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	const crowdsignal = dom.querySelectorAll( '.embed-crowdsignal' );
+	if ( ! crowdsignal ) {
+		return post;
+	}
+	forEach( crowdsignal, ( crowdsignalElement ) => {
+		const authoritativeURL = crowdsignalElement.firstElementChild.getAttribute( 'src' );
+		if ( ! authoritativeURL ) {
+			return;
+		}
+		const noscripts = dom.querySelectorAll( 'noscript' );
+		forEach( noscripts, ( noscript ) => {
+			if ( ! noscript.firstChild ) {
+				return;
+			}
+
+			const projectURL = noscript.querySelector( 'a' ).href;
+
+			if ( projectURL.search( 'crowdsignal.net' ) < 0 ) {
+				return;
+			}
+			const noscriptText = domForHtml( noscript.innerHTML ).innerText;
+
+			const p = document.createElement( 'p' );
+			const a = document.createElement( 'a' );
+			try {
+				a.href = new URL( authoritativeURL );
+			} catch {
+				//not a valid URL, skip it
+				return;
+			}
+			a.target = '_blank';
+			a.rel = 'external noopener noreferrer';
+			a.innerText = noscriptText;
+			p.appendChild( a );
+			crowdsignalElement.removeChild( crowdsignalElement.firstElementChild );
+			crowdsignalElement.appendChild( p );
+		} );
+	} );
+	return post;
+}

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,6 +1,6 @@
 import { filter, flow } from 'lodash';
 import addDiscoverProperties from 'calypso/lib/post-normalizer/rule-add-discover-properties';
-import detectCrowdsignal from 'calypso/lib/post-normalizer/rule-content-detect-crowdsignal';
+import detectCrowdsignalEmbeds from 'calypso/lib/post-normalizer/rule-content-detect-crowdsignal';
 import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'calypso/lib/post-normalizer/rule-content-detect-polls';
 import detectSurveys from 'calypso/lib/post-normalizer/rule-content-detect-surveys';
@@ -105,7 +105,7 @@ const fastPostNormalizationRules = flow( [
 		detectMedia,
 		detectPolls,
 		detectSurveys,
-		detectCrowdsignal,
+		detectCrowdsignalEmbeds,
 		linkJetpackCarousels,
 	] ),
 	createBetterExcerpt,

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,5 +1,6 @@
 import { filter, flow } from 'lodash';
 import addDiscoverProperties from 'calypso/lib/post-normalizer/rule-add-discover-properties';
+import detectCrowdsignal from 'calypso/lib/post-normalizer/rule-content-detect-crowdsignal';
 import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'calypso/lib/post-normalizer/rule-content-detect-polls';
 import detectSurveys from 'calypso/lib/post-normalizer/rule-content-detect-surveys';
@@ -104,6 +105,7 @@ const fastPostNormalizationRules = flow( [
 		detectMedia,
 		detectPolls,
 		detectSurveys,
+		detectCrowdsignal,
 		linkJetpackCarousels,
 	] ),
 	createBetterExcerpt,


### PR DESCRIPTION
#### Proposed Changes

* Crowdsignal created a new type of content (Projects) for our Gutenberg-enabled editor.  With this came a new base URL, crowdsignal.net.  The reader already shows a link based on the <noscript> content found in our polls and surveys, but it does not recognize the same for projects.
* This PR adds a new rule to detect embeds coming from crowdsignal.net.  
* When a project is embedded, this patch will output a link with the text from the <noscript> tag and the url provided in the embed block.

#### Testing Instructions

* To view the initial issue, create a new post and embed a project from crowdsignal.net.  View the post in the reader and then notice nothing appears for the embed.  Optionally, add a Survey and/or Poll and notice the text does appear.
* Test the PR with the same post, the project should now render with a link in the reader

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 447-gh-Automattic/crowdsignal