### PR TITLE
Add Payments Features Modal to My Home

### DIFF
--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -9,10 +9,7 @@ export const EDUCATION_EARN = 'home-education-earn';
 
 const EducationEarn = ( { siteSlug } ) => {
 	const translate = useTranslate();
-	const { isModalOpen, openModal, closeModal } = useRouteModal(
-		'myHomeCoursePaymentsModal',
-		COURSE_SLUGS.PAYMENTS_FEATURES
-	);
+	const { openModal } = useRouteModal( 'coursePaymentsModal', COURSE_SLUGS.PAYMENTS_FEATURES );
 
 	return (
 		<EducationalContent
@@ -32,8 +29,6 @@ const EducationEarn = ( { siteSlug } ) => {
 					calypsoLink: true,
 					url: `/earn/${ siteSlug }`,
 					onClick: openModal,
-					isOpen: isModalOpen,
-					onClose: closeModal,
 					text: translate( 'Learn more' ),
 				},
 			] }

--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import earnCardPrompt from 'calypso/assets/images/customer-home/illustration--secondary-earn.svg';
-import VideoModal from 'calypso/components/videos-ui/video-modal';
 import { COURSE_SLUGS } from 'calypso/data/courses';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -11,7 +10,7 @@ export const EDUCATION_EARN = 'home-education-earn';
 const EducationEarn = ( { siteSlug } ) => {
 	const translate = useTranslate();
 	const { isModalOpen, openModal, closeModal } = useRouteModal(
-		'coursePaymentsModal',
+		'myHomeCoursePaymentsModal',
 		COURSE_SLUGS.PAYMENTS_FEATURES
 	);
 
@@ -32,16 +31,9 @@ const EducationEarn = ( { siteSlug } ) => {
 				{
 					calypsoLink: true,
 					url: `/earn/${ siteSlug }`,
-					ModalComponent: VideoModal,
-					modalComponentProps: {
-						isVisible: isModalOpen,
-						onClose: ( event ) => {
-							event.preventDefault();
-							closeModal();
-						},
-						courseSlug: COURSE_SLUGS.PAYMENTS_FEATURES,
-					},
 					onClick: openModal,
+					isOpen: isModalOpen,
+					onClose: closeModal,
 					text: translate( 'Learn more' ),
 				},
 			] }

--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -26,8 +26,6 @@ const EducationEarn = ( { siteSlug } ) => {
 			] }
 			modalLinks={ [
 				{
-					calypsoLink: true,
-					url: `/earn/${ siteSlug }`,
 					onClick: openModal,
 					text: translate( 'Learn more' ),
 				},

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -76,7 +76,7 @@ function EducationalContent( {
 					{ modalLinks &&
 						modalLinks.map( ( { ModalComponent, modalComponentProps, onClick, text } ) => (
 							<div className="educational-content__link" key={ text }>
-								<ModalComponent { ...modalComponentProps } />
+								{ ModalComponent && <ModalComponent { ...modalComponentProps } /> }
 								<button onClick={ () => onClick() }>{ text }</button>
 							</div>
 						) ) }

--- a/client/my-sites/customer-home/locations/modal/index.js
+++ b/client/my-sites/customer-home/locations/modal/index.js
@@ -4,8 +4,8 @@ import { useRouteModal } from 'calypso/lib/route-modal';
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 
 const Modals = () => {
-	const { isModalOpen, openModal, closeModal } = useRouteModal(
-		'myHomeCoursePaymentsModal',
+	const { closeModal, isModalOpen } = useRouteModal(
+		'coursePaymentsModal',
 		COURSE_SLUGS.PAYMENTS_FEATURES
 	);
 
@@ -15,7 +15,6 @@ const Modals = () => {
 			<VideoModal
 				isVisible={ isModalOpen }
 				onClose={ closeModal }
-				onOpen={ openModal }
 				courseSlug={ COURSE_SLUGS.PAYMENTS_FEATURES }
 			/>
 		</>

--- a/client/my-sites/customer-home/locations/modal/index.js
+++ b/client/my-sites/customer-home/locations/modal/index.js
@@ -12,14 +12,12 @@ const Modals = () => {
 	return (
 		<>
 			<PluginsAnnouncementModal />
-			<div className="payments-features-video__modal">
-				<VideoModal
-					isVisible={ isModalOpen }
-					onClose={ closeModal }
-					onOpen={ openModal }
-					courseSlug={ COURSE_SLUGS.PAYMENTS_FEATURES }
-				/>
-			</div>
+			<VideoModal
+				isVisible={ isModalOpen }
+				onClose={ closeModal }
+				onOpen={ openModal }
+				courseSlug={ COURSE_SLUGS.PAYMENTS_FEATURES }
+			/>
 		</>
 	);
 };

--- a/client/my-sites/customer-home/locations/modal/index.js
+++ b/client/my-sites/customer-home/locations/modal/index.js
@@ -1,0 +1,27 @@
+import VideoModal from 'calypso/components/videos-ui/video-modal';
+import { COURSE_SLUGS } from 'calypso/data/courses';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
+
+const Modals = () => {
+	const { isModalOpen, openModal, closeModal } = useRouteModal(
+		'myHomeCoursePaymentsModal',
+		COURSE_SLUGS.PAYMENTS_FEATURES
+	);
+
+	return (
+		<>
+			<PluginsAnnouncementModal />
+			<div className="payments-features-video__modal">
+				<VideoModal
+					isVisible={ isModalOpen }
+					onClose={ closeModal }
+					onOpen={ openModal }
+					courseSlug={ COURSE_SLUGS.PAYMENTS_FEATURES }
+				/>
+			</div>
+		</>
+	);
+};
+
+export default Modals;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -10,11 +10,14 @@ import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import VideoModal from 'calypso/components/videos-ui/video-modal';
+import { COURSE_SLUGS } from 'calypso/data/courses';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useRouteModal } from 'calypso/lib/route-modal';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
@@ -29,7 +32,6 @@ import {
 	getSiteOption,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 const Home = ( {
@@ -43,6 +45,11 @@ const Home = ( {
 	const translate = useTranslate();
 
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
+
+	const { isModalOpen, openModal, closeModal } = useRouteModal(
+		'myHomeCoursePaymentsModal',
+		COURSE_SLUGS.PAYMENTS_FEATURES
+	);
 
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	useEffect( () => {
@@ -126,6 +133,14 @@ const Home = ( {
 						<div className="customer-home__layout-col customer-home__layout-col-right">
 							<Tertiary cards={ layout.tertiary } />
 						</div>
+					</div>
+					<div className="payments-features-video__modal">
+						<VideoModal
+							isVisible={ isModalOpen }
+							onClose={ closeModal }
+							onOpen={ openModal }
+							courseSlug={ COURSE_SLUGS.PAYMENTS_FEATURES }
+						/>
 					</div>
 				</>
 			) }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -10,18 +10,15 @@ import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
-import VideoModal from 'calypso/components/videos-ui/video-modal';
-import { COURSE_SLUGS } from 'calypso/data/courses';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { preventWidows } from 'calypso/lib/formatting';
-import { useRouteModal } from 'calypso/lib/route-modal';
+import Modals from 'calypso/my-sites/customer-home/locations/modal';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
-import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
@@ -45,11 +42,6 @@ const Home = ( {
 	const translate = useTranslate();
 
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
-
-	const { isModalOpen, openModal, closeModal } = useRouteModal(
-		'myHomeCoursePaymentsModal',
-		COURSE_SLUGS.PAYMENTS_FEATURES
-	);
 
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	useEffect( () => {
@@ -125,7 +117,7 @@ const Home = ( {
 			) : (
 				<>
 					<Primary cards={ layout.primary } />
-					<PluginsAnnouncementModal />
+					<Modals />
 					<div className="customer-home__layout">
 						<div className="customer-home__layout-col customer-home__layout-col-left">
 							<Secondary cards={ layout.secondary } />
@@ -133,14 +125,6 @@ const Home = ( {
 						<div className="customer-home__layout-col customer-home__layout-col-right">
 							<Tertiary cards={ layout.tertiary } />
 						</div>
-					</div>
-					<div className="payments-features-video__modal">
-						<VideoModal
-							isVisible={ isModalOpen }
-							onClose={ closeModal }
-							onOpen={ openModal }
-							courseSlug={ COURSE_SLUGS.PAYMENTS_FEATURES }
-						/>
 					</div>
 				</>
 			) }

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'react-redux';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NewReleases from '../icons/new-releases';
+export const SITE_STORE = 'automattic/site';
 
 const circle = (
 	<SVG viewBox="0 0 24 24">
@@ -29,6 +30,7 @@ export const HelpCenterMoreResources = () => {
 		const purchases = getUserPurchases( state );
 		const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );
 		const siteId = getSelectedSiteId( state );
+
 		return {
 			isBusinessOrEcomPlanUser: !! (
 				purchaseSlugs &&
@@ -91,6 +93,21 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ video } size={ 24 } />
 							<span>{ __( 'Video tutorials', __i18n_text_domain__ ) }</span>
+							<Icon icon={ external } size={ 20 } />
+						</a>
+					</div>
+				</li>
+				<li className="inline-help__resource-item">
+					<div className="inline-help__resource-cell">
+						<a
+							href={ `https://wordpress.com/home/${ window.location.host }?myHomeCoursePaymentsModal=payments-features` }
+							rel="noreferrer"
+							target="_blank"
+							className="inline-help__video"
+							onClick={ () => trackMoreResourcesButtonClick( 'payments-features-video' ) }
+						>
+							<Icon icon={ video } size={ 24 } />
+							<span>{ __( 'Payments Features Videos', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -11,9 +11,9 @@ import { Icon, captureVideo, desktop, formatListNumbered, video, external } from
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NewReleases from '../icons/new-releases';
-export const SITE_STORE = 'automattic/site';
 
 const circle = (
 	<SVG viewBox="0 0 24 24">
@@ -26,10 +26,11 @@ export const HelpCenterMoreResources = () => {
 	const [ showWhatsNewDot, setShowWhatsNewDot ] = useState( false );
 	const sectionName = useSelector( getSectionName );
 
-	const { isBusinessOrEcomPlanUser, siteId } = useSelector( ( state ) => {
+	const { isBusinessOrEcomPlanUser, siteId, siteSlug } = useSelector( ( state ) => {
 		const purchases = getUserPurchases( state );
 		const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );
 		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSiteSlug( state, siteId );
 
 		return {
 			isBusinessOrEcomPlanUser: !! (
@@ -37,6 +38,7 @@ export const HelpCenterMoreResources = () => {
 				( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
 			),
 			siteId: siteId,
+			siteSlug: siteSlug,
 		};
 	} );
 
@@ -100,7 +102,7 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ `https://wordpress.com/home/${ window.location.host }?myHomeCoursePaymentsModal=payments-features` }
+							href={ `https://wordpress.com/home/${ siteSlug }?myHomeCoursePaymentsModal=payments-features` }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__video"

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -102,7 +102,7 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ `https://wordpress.com/home/${ siteSlug }?myHomeCoursePaymentsModal=payments-features` }
+							href={ `https://wordpress.com/home/${ siteSlug }?coursePaymentsModal=payments-features` }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__video"

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -74,6 +74,7 @@ declare module 'calypso/state/ui/selectors' {
 declare module 'calypso/state/sites/selectors' {
 	export const getSite: ( state: unknown, siteId: number ) => { is_wpcom_atomic: boolean };
 	export const getIsSimpleSite: ( state: unknown ) => boolean;
+	export const getSiteSlug: ( state: unknown, siteId: number ) => string;
 }
 
 declare module 'calypso/state/sites/selectors/is-simple-site' {


### PR DESCRIPTION
#### Proposed Changes

* Add Payments Features Modal to My Home.
* Add link to above course in Help Center

#### Testing Instructions

* use [Calypso Live link](https://calypso.live/?image=registry.a8c.com/calypso/app:build-43345)
* select any site
* Open My Home page with additional param:
[calypso]/home/[your-site]?myHomeCoursePaymentsModal=payments-features
* You should see Payments Features Course inside black modal

To test changes in packages (Help Center) you need to setup your sandbox. See PCYsg-KyT-p2

* Go to Posts, create new
* Open Help Center (top right corner question mark icon)
* Look into "More Resources" section
* You should see link "Payments Features Videos" link
* Click on above link 
* You should see in new tab opened page: https://wordpress.com/home/[site_slug]?myHomeCoursePaymentsModal=payments-features

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/65447