### PR TITLE
Remove green check from input text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -6,7 +6,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
-import greenCheckmarkImg from 'calypso/assets/images/onboarding/green-checkmark.svg';
 import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -117,12 +116,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 					value={ siteTitle }
 					onChange={ onChange }
 					placeholder={ __( 'My Link in Bio' ) }
-					style={ {
-						backgroundImage: siteTitle.trim() ? `url(${ greenCheckmarkImg })` : 'unset',
-						backgroundRepeat: 'no-repeat',
-						backgroundPosition: '95%',
-						paddingRight: ' 40px',
-					} }
 					isError={ invalidSiteTitle }
 				/>
 				{ invalidSiteTitle && (
@@ -143,10 +136,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 					enableAutoFocus={ false }
 					onChange={ onChange }
 					style={ {
-						backgroundImage: tagline.trim() ? `url(${ greenCheckmarkImg })` : 'unset',
-						backgroundRepeat: 'no-repeat',
-						backgroundPosition: '95%',
-						paddingRight: ' 40px',
 						paddingLeft: '14px',
 					} }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -135,9 +135,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 					placeholder={ __( 'Add a short biography here' ) }
 					enableAutoFocus={ false }
 					onChange={ onChange }
-					style={ {
-						paddingLeft: '14px',
-					} }
 				/>
 			</FormFieldset>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -50,13 +50,16 @@ $font-family: "SF Pro Text", $sans;
 			font-family: $font-family;
 			font-weight: 400;
 		}
-
 		input,
 		textarea,
 		pre {
+			min-height: 44px;
+			line-height: 20px;
+			padding: 12px 16px;
+		}
+
+		input {
 			height: 44px;
-			line-height: 2;
-			padding: 7px 14px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -51,14 +51,12 @@ $font-family: "SF Pro Text", $sans;
 			font-weight: 400;
 		}
 
-
 		input,
 		textarea,
 		pre {
-			min-height: 44px;
+			height: 44px;
 			line-height: 2;
-			padding-top: 7px;
-			padding-bottom: 7px;
+			padding: 7px 14px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -12,7 +12,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
-import greenCheckmarkImg from 'calypso/assets/images/onboarding/green-checkmark.svg';
 import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -144,10 +143,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const getBackgroundImage = ( fieldValue: string | undefined ) => {
-		return fieldValue && fieldValue.trim() ? `url( ${ greenCheckmarkImg } )` : '';
-	};
-
 	const stepContent = (
 		<form className="newsletter-setup__form" onSubmit={ onSubmit }>
 			<SiteIconWithPicker
@@ -181,9 +176,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					placeholder={ __( 'My newsletter' ) }
 					name="siteTitle"
 					id="siteTitle"
-					style={ {
-						backgroundImage: getBackgroundImage( siteTitle ),
-					} }
 					isError={ invalidSiteTitle }
 					onChange={ onChange }
 				/>
@@ -204,10 +196,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					enableAutoFocus={ false }
 					onChange={ onChange }
 					style={ {
-						backgroundImage: getBackgroundImage( tagline ),
-						backgroundRepeat: 'no-repeat',
-						backgroundPosition: '95%',
-						paddingRight: ' 40px',
 						paddingLeft: '14px',
 					} }
 				/>
@@ -218,10 +206,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					inputRef={ accentColorRef }
 					className="newsletter-setup__accent-color"
 					style={ {
-						backgroundImage: [
-							generateSwatchSVG( accentColor.hex ),
-							...( ! accentColor.default ? [ getBackgroundImage( accentColor.hex ) ] : [] ),
-						].join( ', ' ),
+						backgroundImage: [ generateSwatchSVG( accentColor.hex ) ].join( ', ' ),
 						...( accentColor.default && { color: 'var( --studio-gray-30 )' } ),
 					} }
 					name="accentColor"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -195,9 +195,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					placeholder={ __( 'Describe your Newsletter in a line or two' ) }
 					enableAutoFocus={ false }
 					onChange={ onChange }
-					style={ {
-						paddingLeft: '14px',
-					} }
 				/>
 			</FormFieldset>
 			<FormFieldset>
@@ -206,7 +203,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					inputRef={ accentColorRef }
 					className="newsletter-setup__accent-color"
 					style={ {
-						backgroundImage: [ generateSwatchSVG( accentColor.hex ) ].join( ', ' ),
+						backgroundImage: generateSwatchSVG( accentColor.hex ),
 						...( accentColor.default && { color: 'var( --studio-gray-30 )' } ),
 					} }
 					name="accentColor"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -62,6 +62,7 @@ $border-radius: 4px;
 			color: var(--studio-gray-100);
 			font-size: $font-body-small;
 			padding: 12px 16px;
+			line-height: 20px;
 			min-height: $input-height;
 			border-radius: $border-radius;
 			background-repeat: no-repeat;
@@ -77,6 +78,10 @@ $border-radius: 4px;
 				It was the cause of the https://github.com/Automattic/wp-calypso/issues/67326 */
 				transition: none;
 			}
+		}
+
+		input {
+			height: 44px;
 		}
 
 		.newsletter-setup__contrast-warning {


### PR DESCRIPTION
## Proposed Changes

Remove green check from text inputs

Before:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/2653810/190165595-922d2c28-9f6c-49fb-aba1-34f942976a36.png">

Now: 
<img width="431" alt="image" src="https://user-images.githubusercontent.com/2653810/190165645-0ca4b42f-93e7-4472-9d2c-fe53fcdf666c.png">


## Testing Instructions

- Pull this branch and run yarn start
- Navigate to `/setup/intro?flow=link-in-bio` or `/setup/intro?flow=newsletter`
- On the setup step, after filling the fields, the green check should not be visible


Related to #67677
Fixes #67677
