### PR TITLE
Newsletter Flow: Launch as Indexed

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -151,7 +151,7 @@ function getNewSiteParams( {
 
 	const newSiteParams = {
 		blog_title: siteTitle,
-		public: Visibility.PublicNotIndexed,
+		public: launchAsComingSoon ? Visibility.PublicNotIndexed : Visibility.PublicIndexed,
 		options: {
 			designType: designType || undefined,
 			theme,


### PR DESCRIPTION
#### Proposed Changes

Currently the visibility setting is set to PublicIndexed only when the user launches the site.
Newsletter site is not launched as 'coming soon', but it's already public. So the user will not launch it and the visibility setting will not be set to PublicIndexed.
With this PR we set Newsletter sites directly as PublicIndexed


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Checkout branch and `yarn start`
* Launch a newsletter site
* Verify that `Discourage search engines from indexing this site` in General settings is not checked

Related to #67814
Fixes #67814
