### PR TITLE
Jetpack cloud: show error notice if primary site is not Jetpack

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -50,7 +50,7 @@ import DIFMLiteInProgress from 'calypso/my-sites/marketing/do-it-for-me/difm-lit
 import NavigationComponent from 'calypso/my-sites/navigation';
 import SitesComponent from 'calypso/my-sites/sites';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { successNotice, warningNotice } from 'calypso/state/notices/actions';
+import { successNotice, warningNotice, errorNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
 import getP2HubBlogId from 'calypso/state/selectors/get-p2-hub-blog-id';
@@ -394,6 +394,18 @@ export function showMissingPrimaryError( currentUser, dispatch ) {
 		);
 		recordTracksEvent( 'calypso_mysites_single_site_jetpack_connection_error', tracksPayload );
 	} else {
+		dispatch(
+			errorNotice(
+				isJetpackCloud()
+					? i18n.translate( 'Your Primary site is not a Jetpack site.' )
+					: i18n.translate( 'Please set a Primary site.' ),
+				{
+					button: i18n.translate( 'Account Settings' ),
+					href: `https://wordpress.com/me/account`,
+				}
+			)
+		);
+
 		recordTracksEvent( 'calypso_mysites_single_site_error', tracksPayload );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the Jetpack cloud interface showing a blank canvas (reported [in this issue](7654-gh-Automattic/jpop-issues)), by adding an error message.

It seems that the aforementioned issue occurred when a user had a hidden simple site set as their Primary site, and a visible Jetpack site. However, it doesn't seem possible to actively hide the Primary site, so this is much likely an edge case. Regardless, this addition should catch it.

### Testing instructions

As mentioned above, I'm not aware of any way to reproduce the issue, so you can just review the code changes.

However, if you'd like to view the changes in the app:
- Make sure your account has Jetpack sites attached
- Your Primary WordPress site should be a simple site
- Run cloud locally with that branch
- Set `hasOneSite` to `true` here (this simulates the case mentioned above): https://github.com/Automattic/wp-calypso/blob/95fa44ce6e977a14499adad35b1d065cb3f3afa1/client/jetpack-cloud/controller.ts#L64 
- Visit `/landing`
- Notice the error warning

### Screenshots
<img width="965" alt="Screen Shot 2022-09-14 at 11 25 18 AM" src="https://user-images.githubusercontent.com/1620183/190196564-2720b111-531a-4bbc-9208-63c3d2e0f95f.png">
