### PR TITLE
Pricing page rework: Add HotJar analytics script

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -16,10 +16,12 @@ import LicensingActivationBanner from 'calypso/components/jetpack/licensing-acti
 import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-dialog';
 import Main from 'calypso/components/main';
 import { MAIN_CONTENT_ID } from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
+import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { showMasterbar } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -64,6 +66,22 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		'calypso_jetpack_upsell_page_2022_06'
 	);
 	const showUpsellPage = experimentAssignment?.variationName === 'treatment';
+
+	useEffect( () => {
+		if (
+			isEnabled( 'jetpack/pricing-page-rework-v1' ) &&
+			/**
+			 * Load the HotJar script on routes 'cloud.jetpack.com/pricing/..' and
+			 * 'wordpress.com/jetpack/connect/plans/:site/..' (Jetpack plugin post-conneciton route)
+			 */
+			( isJetpackCloud() || window.location.pathname.startsWith( JPC_PATH_PLANS ) )
+		) {
+			// HotJar analytics tracking
+			// https://github.com/Automattic/wp-calypso/blob/trunk/client/state/analytics/README_HotJar.md
+			dispatch( loadTrackingTool( 'HotJar' ) );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	useEffect( () => {
 		dispatch(

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -83,5 +83,5 @@
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
 	"google_analytics_key": "UA-52447-43",
-	"hotjar_enabled": false
+	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -82,5 +82,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"google_analytics_key": "UA-52447-43"
+	"google_analytics_key": "UA-52447-43",
+	"hotjar_enabled": false
 }

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -72,5 +72,6 @@
 		"site-purchases": true
 	},
 	"site_filter": [ "jetpack" ],
-	"theme": "jetpack-cloud"
+	"theme": "jetpack-cloud",
+	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -78,5 +78,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"google_analytics_key": "UA-52447-43"
+	"google_analytics_key": "UA-52447-43",
+	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -79,5 +79,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"google_analytics_key": "UA-52447-43"
+	"google_analytics_key": "UA-52447-43",
+	"hotjar_enabled": true
 }


### PR DESCRIPTION
#### Proposed Changes

This PR adds the [HotJar analytics script](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/analytics/README_HotJar.md) into the new pricing page, so we can closely measure the impact of the new page.

See: P2 "Measuring the impact of the new pricing page/structure" -->  p1HpG7-hEn-p2

Asana Task: 1202796695664022-as-1202898236955395/f

**Implementation notes:**

- It loads the HotJar script on routes `cloud.jetpack.com/pricing/..` and `wordpress.com/jetpack/connect/plans/:site/..` (the Jetpack plugin post-connection route)
- This PR _also_ enables the `config( 'hotjar_enabled')` in the Jetpack Cloud environment for staging & production.  HotJar was already enabled for wordpress.com, so no need to enable it there.

#### Testing Instructions

* Run `git fetch && git checkout add/hotjar-jetpack-cloud-pricing`
  * Open file `config/jetpack-cloud-development.json`, and set the `"hotjar_enabled"` property to `true`.
  * Run `yarn start` in one command line tab/window, and also run `yarn start-jetpack-cloud-p' in another command line tab/window. (This runs Calypso blue and Calypso green concurrently)
  * Go to `cloud.jetpack.com:3001/pricing?flags=jetpack/pricing-page-rework-v1`.
  * Open dev tools console and enter `localStorage.debug = 'calypso:analytics:hotjar'; and press enter.
  * Reload the page and verify in the console you see the debug statement: `calypso:analytics:hotjar Loading HotJar script`. (You will also see an error that "HotJar only works over HTTPS", but that's ok for our purposes here. We are just testing that the script is trying to load.)
  * Next, visit `calypso.localhost:3000/jetpack/connect/plans/:site?flags=jetpack/pricing-page-rework-v1` (where `:site` is a connected Jetpack site you own (or if you don't already have a connected Jetpack site, create a JN site and connect it)). Users are redirected to this page right after Jetpack plugin connection.
  * Again open dev tools console and enter `localStorage.debug = 'calypso:analytics:hotjar'; and press enter.
  * Reload the page and verify in the console you see the debug statement: `calypso:analytics:hotjar Loading HotJar script`.
  * Now go to `http://calypso.localhost:3000/plans/site?flags=jetpack/pricing-page-rework-v1` and verify that the HotJar script is **not** loading for this page (`wordpress.com/plans/` page). (There should **not** be a HotJar debug statement in the console.)
  * Now also go to `http://calypso.localhost:3000/jetpack/connect/store?flags=jetpack/pricing-page-rework-v1`and verify that the HotJar script is **not** loading for this page either.
  

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202898236955395