### PR TITLE
App banners: Don't play animation if reduced motion's enabled

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -255,18 +255,20 @@ export class AppBanner extends Component {
 
 function BannerIcon( { icon } ) {
 	useEffect( () => {
+		const reducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
 		const animation = lottie.loadAnimation( {
 			container: document.querySelector( '.app-banner__icon' ),
 			renderer: 'svg',
 			loop: false,
-			autoplay: true,
+			autoplay: ! reducedMotion,
 			path: icon,
 		} );
 
-		const reducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
-
 		if ( reducedMotion ) {
-			animation.goToAndStop( 145, true );
+			animation.addEventListener( 'config_ready', () => {
+				animation.goToAndPlay( animation.totalFrames, true );
+			} );
 		}
 
 		return () => animation.destroy();

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -6,7 +6,7 @@ import { localize, withRtl } from 'i18n-calypso';
 import { get } from 'lodash';
 import lottie from 'lottie-web/build/player/lottie_light';
 import PropTypes from 'prop-types';
-import { Component, useEffect } from 'react';
+import { Component, useEffect, useRef } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -254,11 +254,13 @@ export class AppBanner extends Component {
 }
 
 function BannerIcon( { icon } ) {
+	const iconEl = useRef();
+
 	useEffect( () => {
 		const reducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
 		const animation = lottie.loadAnimation( {
-			container: document.querySelector( '.app-banner__icon' ),
+			container: iconEl.current,
 			renderer: 'svg',
 			loop: false,
 			autoplay: ! reducedMotion,
@@ -274,7 +276,7 @@ function BannerIcon( { icon } ) {
 		return () => animation.destroy();
 	}, [ icon ] );
 
-	return <div className="app-banner__icon"></div>;
+	return <div ref={ iconEl } className="app-banner__icon"></div>;
 }
 
 export function getiOSDeepLink( currentRoute, currentSection ) {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -262,6 +262,13 @@ function BannerIcon( { icon } ) {
 			autoplay: true,
 			path: icon,
 		} );
+
+		const reducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+		if ( reducedMotion ) {
+			animation.goToAndStop( 145, true );
+		}
+
 		return () => animation.destroy();
 	}, [ icon ] );
 


### PR DESCRIPTION
#### Proposed Changes

Following the feedback in https://github.com/Automattic/wp-calypso/pull/67013#discussion_r962770979, this PR takes a user's "reduced motion" preference into account before displaying an animation in the app banners. The animation will not play if the "reduced motion" is enabled.

* `window.matchMedia` is used to detect when `prefers-reduced-motion: reduce` is set.
* Lottie's built-in `goToAndPlay` function is then used to stop the animation on the last frame. Note, this is necessary as [Lottie does not take motion preferences into account by default](https://github.com/airbnb/lottie-web/issues/1986#issuecomment-586582516).

| Animated icon | Reduced motion |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/2998162/187277380-874c5103-deae-4c54-8f61-5bd1898a6973.mov" width="100%"> | <video src="https://user-images.githubusercontent.com/2998162/190220561-d9667d5c-6a01-40b9-9751-e3dd0f9bd5ce.mov" width="100%"> |

#### Testing Instructions

_Prerequisites:_ 

* Enable reduced motion on your device. To do that on a Mac, head to _System Preferences_ → _Accessibility_ → _Display_ and check the box for **Reduce motion**.
* The app banner can be viewed via the mobile web (which can also be [emulated using browser tools](https://developer.chrome.com/docs/devtools/device-mode/#viewport)) with this branch checked out.

_Testing steps:_ 

* Navigate to the Reader, Stats, Notifications, or the editor within WordPress.com's to view the app banners on the mobile web.
* Verify that the banner's icon _doesn't_ play.
* Next, turn off the "reduced motion" setting on your device, refresh the page with the banner, and confirm the icon is now animated.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->