### PR TITLE
Update Activate/Deactivate buttons on bulk actions

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -132,7 +132,6 @@ export class PluginsListHeader extends PureComponent {
 			return buttons;
 		}
 
-		const isJetpackSelected = this.isJetpackSelected();
 		const needsRemoveButton = this.needsRemoveButton();
 		const rightSideButtons = [];
 		const leftSideButtons = [];
@@ -212,13 +211,11 @@ export class PluginsListHeader extends PureComponent {
 				</Button>
 			);
 
-			if ( ! ( isJetpackSelected && this.props.selected.length === 1 ) ) {
-				leftSideButtons.push(
-					<ButtonGroup key="plugin-list-header__buttons-activate-buttons">
-						{ activateButtons }
-					</ButtonGroup>
-				);
-			}
+			leftSideButtons.push(
+				<ButtonGroup key="plugin-list-header__buttons-activate-buttons">
+					{ activateButtons }
+				</ButtonGroup>
+			);
 
 			autoupdateButtons.push(
 				<Button


### PR DESCRIPTION
Update the bulk actions buttons to no longer disable the activate/deactivate buttons when only Jetpack is selected. A warning notice will be displayed instead if this is attempted.

#### Proposed Changes

* Apply this PR
* Run `yarn start` and `yarn start-jetpack-cloud-p` for Calypso and Jetpack cloud.
* Go to the plugins management page at `http://calypso.localhost:3000/plugins/manage`.
* Ensure that when Jetpack is the only plugin selected the activate/deactivate buttons no longer disappear.
* Ensure that a warning modal is present when attempting to deactivate only Jetpack.
* Ensure that a warning notice is present when the modal above is confirmed and the action attempted.
* Ensure that if multiple plugins are selected the previous flow works the same. Other plugins should be deactivated after which the warning notice for Jetpack is displayed.
* Repeat the above steps in the Jetpack clouds plugin management page `http://jetpack.cloud.localhost:3001/plugins/manage`.
* 
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
