### PR TITLE
Fix reporting of JP pricing page to correct GA env

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -219,7 +219,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					path={ viewTrackerPath }
 					properties={ viewTrackerProps }
 					title="Plans"
-					options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
+					options={ { useJetpackGoogleAnalytics: isJetpackCloud() } }
 				/>
 
 				{ isEnabled( 'jetpack/pricing-page-rework-v1' ) ? (


### PR DESCRIPTION
#### Proposed Changes
Currently, the pageview is sent to Jetpack GA when triggered on wordpress.com/plans/:site, and to WPcom GA on cloud.jetpack.com/pricing/site_domain. The expected behavior should be the opposite. This PR fixes the mentioned.

#### Testing Instructions

**General tracking debug instructions**
* Activate `ad-tracking` in development.json and jetpack-cloud-development.json
* Set `localStorage.setItem( 'debug', 'calypso:analytics:ga' );` in the console for `calypso.localhost:3000` and `jetpack.cloud.localhost:3001`
* The `:site` used should be a Jetpack-connected site.

**Testing plan**

* Checkout `trunk`
* Run `yarn start` and `yarn start-jetpack-cloud-p`
* Open page `calypso.localhost:3000/plans/:site?flags=gdpr-banner,google-analytics,ad-tracking`
* Verify wrong behavior that `calypso:analytics:ga Recording Page View ~ [URL: /plans/:site] [Title: Plans] [useJetpackGoogleAnalytics: true]`
* Open page `jetpack.cloud.localhost:3001/pricing/:site?flags=gdpr-banner,google-analytics,ad-tracking`
* Verify wrong behavior that `calypso:analytics:ga Recording Page View ~ [URL: /pricing/:site] [Title: Plans] [useJetpackGoogleAnalytics: false]`

* Checkout `fix/jp-cloud-pricing-pageviews-env`
* Open both mentioned pages and verify that `useJetpackGoogleAnalytics` now mentions the opposite.

#### Pre-merge Checklist

N/A
