### PR TITLE
Link upgrade nudge to plugins plans page if flag is set

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
 	findFirstSimilarPlanKey,
@@ -51,6 +52,10 @@ const UpgradeNudge = ( {
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
 
+	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
+
+	const pluginsPlansPage = `/plugins/plans/${ selectedSite?.slug }`;
+
 	const translate = useTranslate();
 
 	if (
@@ -89,7 +94,11 @@ const UpgradeNudge = ( {
 				callToAction={ translate( 'Upgrade now' ) }
 				icon={ 'notice-outline' }
 				showIcon={ true }
-				href={ `/checkout/${ siteSlug }/${ requiredPlan.getPathSlug() }` }
+				href={
+					pluginsPlansPageFlag
+						? pluginsPlansPage
+						: `/checkout/${ siteSlug }/${ requiredPlan.getPathSlug() }`
+				}
 				feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
 				plan={ requiredPlan.getStoreSlug() }
 				title={ title }
@@ -112,7 +121,7 @@ const UpgradeNudge = ( {
 				callToAction={ translate( 'Upgrade now' ) }
 				icon={ 'notice-outline' }
 				showIcon={ true }
-				href={ `/checkout/${ siteSlug }/pro` }
+				href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/pro` }
 				feature={ FEATURE_INSTALL_PLUGINS }
 				plan={ plan }
 				title={ translate( 'Upgrade to the Pro plan to install plugins.' ) }
@@ -128,7 +137,7 @@ const UpgradeNudge = ( {
 			callToAction={ translate( 'Upgrade now' ) }
 			icon={ 'notice-outline' }
 			showIcon={ true }
-			href={ `/checkout/${ siteSlug }/business` }
+			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ translate( 'Upgrade to the Business plan to install plugins.' ) }


### PR DESCRIPTION
#### Proposed Changes

* The upgrade nudges on the /plugins page now links to the new plugins plans page we've created, when the `plugins-plans-page` feature flag is enabled.

<img src="https://user-images.githubusercontent.com/140841/190252304-ee110c05-2868-4e41-b8eb-40340612904c.png" width="600" />


#### Testing Instructions

* Checkout this PR
* Go to http://calypso.localhost:3000/plugins/{your_test_site}?flags=plugins-plans-page on a sub business plan site.
  * note the `plugins-plans-page` flag
* With the flag enabled, clicking on "Upgrade now" should direct you to `/plugins/plans/{your_test_site}`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67693
