### PR TITLE
Show the category selector when the selected category is not on the list

### DIFF
--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -37,10 +37,6 @@ const Categories = ( { selected }: { selected?: string } ) => {
 		page( getCategoryUrl( category.slug ) );
 	};
 
-	if ( selected && ! displayCategories.includes( selected ) ) {
-		return <div></div>;
-	}
-
 	const current = selected ? categories.findIndex( ( { slug } ) => slug === selected ) : 0;
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

Show the category selector when the selected category is not on the list.
This is needed to keep the visual consistency for generic categories and the `discover` ones: Top premium plugins, Editor’s pick, and Top free plugins.

#### Testing Instructions
##### Generic category
* Go to Yoast Premium page (`/plugins/wordpress-seo-premium`)
* Click on the `seo` tag on the header
* You should be redirected to the Plugins Browser page with the `Search Engine Optimization` category selected
* Go to another plugin page. Ex: `/plugins/all-in-one-seo-pack`
* Click on an unmapped plugin tag (if on the suggested plugin it can be any tag)
* You should be redirected to the same page, but with no category selected.

| Generic category (before)  | Generic category (after) | 
| ------------- | ------------- |
|<img width="1069" alt="Screen Shot 2022-09-14 at 14 52 16" src="https://user-images.githubusercontent.com/5039531/190249280-de557e49-344a-4106-b908-841ab4bae9fe.png">|<img width="1005" alt="Screen Shot 2022-09-14 at 14 41 57" src="https://user-images.githubusercontent.com/5039531/190249142-f71b30a3-a999-4759-b812-ca0353a4ba10.png"> | 

#####  Discover categories 
* To to the main plugins page (`/plugins`)
* Click on a `Browse All` link
* You should see all the plugins from the selected category and the category selected should be still presented

 | Discover categories (before) | Discover categories (after) | 
| ------------- | ------------- |
 | <img width="1069" alt="Screen Shot 2022-09-14 at 14 48 41" src="https://user-images.githubusercontent.com/5039531/190249499-c26b99e8-c86d-4a34-9492-58361afb7961.png">|<img width="1069" alt="Screen Shot 2022-09-14 at 14 48 50" src="https://user-images.githubusercontent.com/5039531/190249564-4aaa450d-4146-4bc8-90ca-b6fc386de110.png">|
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---

Fixes #66899

cc: @SaxonF @vinimotaa 
