### PR TITLE
Sites Management Page: Add "automagical" sorting

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -13,6 +13,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'plan',
 	'jetpack',
 	'is_wpcom_atomic',
+	'user_interactions',
 ] as const;
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -6,9 +6,9 @@ import { ComponentPropsWithoutRef } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { MEDIA_QUERIES } from '../utils';
 import { SitesDisplayModeSwitcher } from './sites-display-mode-switcher';
-import { SitesListSortingDropdown } from './sites-list-sorting-dropdown';
 import { SitesSearch } from './sites-search';
 import { SitesSearchIcon } from './sites-search-icon';
+import { SitesSortingDropdown } from './sites-sorting-dropdown';
 
 export interface SitesDashboardQueryParams {
 	page?: number;
@@ -83,7 +83,7 @@ type SitesContentControlsProps = {
 	statuses: Statuses;
 	selectedStatus: Statuses[ number ];
 } & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher > &
-	ComponentPropsWithoutRef< typeof SitesListSortingDropdown >;
+	ComponentPropsWithoutRef< typeof SitesSortingDropdown >;
 
 /**
  * Updates one or more query param used by the sites dashboard, causing a page navigation.
@@ -112,8 +112,8 @@ export const SitesContentControls = ( {
 	selectedStatus,
 	displayMode,
 	onDisplayModeChange,
-	sitesListSorting,
-	onSitesListSortingChange,
+	sitesSorting,
+	onSitesSortingChange,
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 
@@ -146,9 +146,9 @@ export const SitesContentControls = ( {
 					) ) }
 				</ControlsSelectDropdown>
 				<VisibilityControls>
-					<SitesListSortingDropdown
-						sitesListSorting={ sitesListSorting }
-						onSitesListSortingChange={ onSitesListSortingChange }
+					<SitesSortingDropdown
+						sitesSorting={ sitesSorting }
+						onSitesSortingChange={ onSitesSortingChange }
 					/>
 					<SitesDisplayModeSwitcher
 						displayMode={ displayMode }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -23,7 +23,7 @@ import {
 } from './sites-content-controls';
 import { useSitesDisplayMode } from './sites-display-mode-switcher';
 import { SitesGrid } from './sites-grid';
-import { parseSorting, useSitesListSorting } from './sites-list-sorting-dropdown';
+import { parseSitesSorting, useSitesSortingPreference } from './sites-sorting-dropdown';
 import { SitesTable } from './sites-table';
 
 interface SitesDashboardProps {
@@ -147,11 +147,11 @@ export function SitesDashboard( {
 		status,
 	} );
 
-	const [ sitesListSorting, onSitesListSortingChange ] = useSitesListSorting();
+	const [ sitesSorting, onSitesSortingChange ] = useSitesSortingPreference();
 
 	const { sortedSites } = useSitesTableSorting(
-		sitesListSorting === 'none' ? [] : filteredSites,
-		parseSorting( sitesListSorting )
+		sitesSorting === 'none' ? [] : filteredSites,
+		parseSitesSorting( sitesSorting )
 	);
 
 	const paginatedSites = sortedSites.slice( ( page - 1 ) * perPage, page * perPage );
@@ -160,7 +160,7 @@ export function SitesDashboard( {
 
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 
-	const userPreferencesLoaded = 'none' !== sitesListSorting && 'none' !== displayMode;
+	const userPreferencesLoaded = 'none' !== sitesSorting && 'none' !== displayMode;
 
 	const elementRef = useRef( window );
 
@@ -196,8 +196,8 @@ export function SitesDashboard( {
 							selectedStatus={ selectedStatus }
 							displayMode={ displayMode }
 							onDisplayModeChange={ setDisplayMode }
-							sitesListSorting={ sitesListSorting }
-							onSitesListSortingChange={ onSitesListSortingChange }
+							sitesSorting={ sitesSorting }
+							onSitesSortingChange={ onSitesSortingChange }
 						/>
 					) }
 					{ userPreferencesLoaded && (

--- a/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-list-sorting-dropdown.tsx
@@ -64,6 +64,9 @@ export const SitesListSortingDropdown = ( {
 		}
 
 		switch ( sitesListSorting ) {
+			case `lastInteractedWith${ SEPARATOR }desc`:
+				return __( 'Sorted automagically' );
+
 			case `alphabetically${ SEPARATOR }asc`:
 				return __( 'Sorted alphabetically' );
 
@@ -101,6 +104,14 @@ export const SitesListSortingDropdown = ( {
 						} }
 					>
 						{ __( 'Alphabetically' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							onSitesListSortingChange( `lastInteractedWith${ SEPARATOR }desc` );
+							onClose();
+						} }
+					>
+						{ __( 'Automagically' ) }
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -20,16 +20,16 @@ const SortingButtonIcon = styled( Gridicon )( {
 
 const SEPARATOR = '-' as const;
 
-type SitesListSorting = `${ SitesTableSortKey }${ typeof SEPARATOR }${ SitesTableSortOrder }`;
+type SitesSorting = `${ SitesTableSortKey }${ typeof SEPARATOR }${ SitesTableSortOrder }`;
 
-const DEFAULT_LIST_SORTING = {
+const DEFAULT_SITES_SORTING = {
 	sortKey: 'updatedAt',
 	sortOrder: 'desc',
 } as const;
 
-export const parseSorting = ( sorting: SitesListSorting | 'none' ) => {
+export const parseSitesSorting = ( sorting: SitesSorting | 'none' ) => {
 	if ( sorting === 'none' ) {
-		return DEFAULT_LIST_SORTING;
+		return DEFAULT_SITES_SORTING;
 	}
 
 	const [ sortKey, sortOrder ] = sorting.split( SEPARATOR );
@@ -40,30 +40,30 @@ export const parseSorting = ( sorting: SitesListSorting | 'none' ) => {
 	};
 };
 
-export const useSitesListSorting = () =>
-	useAsyncPreference< SitesListSorting >( {
-		defaultValue: `${ DEFAULT_LIST_SORTING.sortKey }-${ DEFAULT_LIST_SORTING.sortOrder }`,
-		preferenceName: 'sites-list-sorting',
+export const useSitesSortingPreference = () =>
+	useAsyncPreference< SitesSorting >( {
+		defaultValue: `${ DEFAULT_SITES_SORTING.sortKey }-${ DEFAULT_SITES_SORTING.sortOrder }`,
+		preferenceName: 'sites-sorting',
 	} );
 
-interface SitesListSortingDropdownProps {
-	onSitesListSortingChange( newValue: SitesListSorting ): void;
-	sitesListSorting: ReturnType< typeof useSitesListSorting >[ 0 ];
+interface SitesSortingDropdownProps {
+	onSitesSortingChange( newValue: SitesSorting ): void;
+	sitesSorting: ReturnType< typeof useSitesSortingPreference >[ 0 ];
 }
 
-export const SitesListSortingDropdown = ( {
-	onSitesListSortingChange,
-	sitesListSorting,
-}: SitesListSortingDropdownProps ) => {
+export const SitesSortingDropdown = ( {
+	onSitesSortingChange,
+	sitesSorting,
+}: SitesSortingDropdownProps ) => {
 	const isSmallScreen = useMediaQuery( SMALL_MEDIA_QUERY );
 	const { __ } = useI18n();
 
 	const label = useMemo( () => {
-		if ( sitesListSorting === 'none' ) {
+		if ( sitesSorting === 'none' ) {
 			return null;
 		}
 
-		switch ( sitesListSorting ) {
+		switch ( sitesSorting ) {
 			case `lastInteractedWith${ SEPARATOR }desc`:
 				return __( 'Sorted automagically' );
 
@@ -74,11 +74,11 @@ export const SitesListSortingDropdown = ( {
 				return __( 'Sorted by last published' );
 
 			default:
-				throw new Error( `invalid sort value ${ sitesListSorting }` );
+				throw new Error( `invalid sort value ${ sitesSorting }` );
 		}
-	}, [ __, sitesListSorting ] );
+	}, [ __, sitesSorting ] );
 
-	if ( sitesListSorting === 'none' ) {
+	if ( sitesSorting === 'none' ) {
 		return null;
 	}
 
@@ -99,7 +99,7 @@ export const SitesListSortingDropdown = ( {
 				<MenuGroup>
 					<MenuItem
 						onClick={ () => {
-							onSitesListSortingChange( `alphabetically${ SEPARATOR }asc` );
+							onSitesSortingChange( `alphabetically${ SEPARATOR }asc` );
 							onClose();
 						} }
 					>
@@ -107,7 +107,7 @@ export const SitesListSortingDropdown = ( {
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {
-							onSitesListSortingChange( `lastInteractedWith${ SEPARATOR }desc` );
+							onSitesSortingChange( `lastInteractedWith${ SEPARATOR }desc` );
 							onClose();
 						} }
 					>
@@ -115,7 +115,7 @@ export const SitesListSortingDropdown = ( {
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {
-							onSitesListSortingChange( `updatedAt${ SEPARATOR }desc` );
+							onSitesSortingChange( `updatedAt${ SEPARATOR }desc` );
 							onClose();
 						} }
 					>

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -22,6 +22,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_core_site_editor_enabled',
 	'is_wpcom_atomic',
 	'description',
+	'user_interactions',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
@@ -17,6 +17,7 @@ describe( 'useSitesTableSorting', () => {
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
+			user_interactions: [ '2022-09-13' ],
 		},
 		{
 			ID: 2,
@@ -24,6 +25,7 @@ describe( 'useSitesTableSorting', () => {
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 			},
+			user_interactions: [ '2022-09-14' ],
 		},
 		{
 			ID: 3,
@@ -74,6 +76,34 @@ describe( 'useSitesTableSorting', () => {
 		expect( result.current.sortedSites[ 0 ].name ).toBe( 'C' );
 		expect( result.current.sortedSites[ 1 ].name ).toBe( 'B' );
 		expect( result.current.sortedSites[ 2 ].name ).toBe( 'A' );
+	} );
+
+	test( 'should sort sites by last interaction descending', () => {
+		const { result } = renderHook( () =>
+			useSitesTableSorting( filteredSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'desc',
+			} )
+		);
+
+		expect( result.current.sortedSites.length ).toBe( 3 );
+		expect( result.current.sortedSites[ 0 ].name ).toBe( 'A' );
+		expect( result.current.sortedSites[ 1 ].name ).toBe( 'B' );
+		expect( result.current.sortedSites[ 2 ].name ).toBe( 'C' );
+	} );
+
+	test( 'should sort sites by last interaction ascending', () => {
+		const { result } = renderHook( () =>
+			useSitesTableSorting( filteredSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+			} )
+		);
+
+		expect( result.current.sortedSites.length ).toBe( 3 );
+		expect( result.current.sortedSites[ 0 ].name ).toBe( 'B' );
+		expect( result.current.sortedSites[ 1 ].name ).toBe( 'A' );
+		expect( result.current.sortedSites[ 2 ].name ).toBe( 'C' );
 	} );
 
 	test( 'should sort sites by updatedAt descending', () => {

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -2,12 +2,13 @@ import { useMemo } from 'react';
 
 export interface SiteDetailsForSorting {
 	name: string;
+	user_interactions: string[];
 	options?: {
 		updated_at?: string;
 	};
 }
 
-export type SitesTableSortKey = 'updatedAt' | 'alphabetically';
+export type SitesTableSortKey = 'lastInteractedWith' | 'updatedAt' | 'alphabetically';
 export type SitesTableSortOrder = 'asc' | 'desc';
 
 interface SitesTableSortOptions {
@@ -25,6 +26,8 @@ export function useSitesTableSorting< T extends SiteDetailsForSorting >(
 ): UseSitesTableSortingResult< T > {
 	return useMemo( () => {
 		switch ( sortKey ) {
+			case 'lastInteractedWith':
+				return { sortedSites: sortSitesByLastInteractedWith( allSites, sortOrder ) };
 			case 'alphabetically':
 				return { sortedSites: sortSitesAlphabetically( allSites, sortOrder ) };
 			case 'updatedAt':
@@ -35,24 +38,57 @@ export function useSitesTableSorting< T extends SiteDetailsForSorting >(
 	}, [ allSites, sortKey, sortOrder ] );
 }
 
+function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
+	sites: T[],
+	sortOrder: SitesTableSortOrder
+) {
+	const interactedItems: T[] = sites.filter( ( site ) => site.user_interactions.length > 0 );
+	const remainingItems: T[] = sites.filter( ( site ) => site.user_interactions.length === 0 );
+
+	return [
+		...interactedItems.sort( ( a, b ) => {
+			// Interactions are sorted in descending order.
+			const lastInteractionA = a.user_interactions[ 0 ];
+			const lastInteractionB = b.user_interactions[ 0 ];
+
+			if ( new Date( lastInteractionA ) > new Date( lastInteractionB ) ) {
+				return sortOrder === 'asc' ? 1 : -1;
+			}
+
+			if ( new Date( lastInteractionA ) < new Date( lastInteractionB ) ) {
+				return sortOrder === 'asc' ? -1 : 1;
+			}
+
+			return 0;
+		} ),
+		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, sortOrder ) ),
+	];
+}
+
+function sortAlphabetically< T extends SiteDetailsForSorting >(
+	a: T,
+	b: T,
+	sortOrder: SitesTableSortOrder
+) {
+	const normalizedA = a.name.toLocaleLowerCase();
+	const normalizedB = b.name.toLocaleLowerCase();
+
+	if ( normalizedA > normalizedB ) {
+		return sortOrder === 'asc' ? 1 : -1;
+	}
+
+	if ( normalizedA < normalizedB ) {
+		return sortOrder === 'asc' ? -1 : 1;
+	}
+
+	return 0;
+}
+
 function sortSitesAlphabetically< T extends SiteDetailsForSorting >(
 	sites: T[],
 	sortOrder: SitesTableSortOrder
 ): T[] {
-	return [ ...sites ].sort( ( a, b ) => {
-		const normalizedA = a.name.toLocaleLowerCase();
-		const normalizedB = b.name.toLocaleLowerCase();
-
-		if ( normalizedA > normalizedB ) {
-			return sortOrder === 'asc' ? 1 : -1;
-		}
-
-		if ( normalizedA < normalizedB ) {
-			return sortOrder === 'asc' ? -1 : 1;
-		}
-
-		return 0;
-	} );
+	return [ ...sites ].sort( ( a, b ) => sortAlphabetically( a, b, sortOrder ) );
 }
 
 function sortSitesByLastPublish< T extends SiteDetailsForSorting >(

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 export interface SiteDetailsForSorting {
 	name: string;
-	user_interactions: string[];
+	user_interactions?: string[];
 	options?: {
 		updated_at?: string;
 	};
@@ -42,11 +42,17 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 	sites: T[],
 	sortOrder: SitesTableSortOrder
 ) {
-	const interactedItems: T[] = sites.filter( ( site ) => site.user_interactions.length > 0 );
-	const remainingItems: T[] = sites.filter( ( site ) => site.user_interactions.length === 0 );
+	const interactedItems = sites.filter(
+		( site ) => site.user_interactions && site.user_interactions.length > 0
+	);
+	const remainingItems = sites.filter( ( site ) => site.user_interactions?.length === 0 );
 
 	return [
 		...interactedItems.sort( ( a, b ) => {
+			if ( ! a.user_interactions || ! b.user_interactions ) {
+				return 0;
+			}
+
 			// Interactions are sorted in descending order.
 			const lastInteractionA = a.user_interactions[ 0 ];
 			const lastInteractionB = b.user_interactions[ 0 ];

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -57,11 +57,11 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 			const lastInteractionA = a.user_interactions[ 0 ];
 			const lastInteractionB = b.user_interactions[ 0 ];
 
-			if ( new Date( lastInteractionA ) > new Date( lastInteractionB ) ) {
+			if ( lastInteractionA > lastInteractionB ) {
 				return sortOrder === 'asc' ? 1 : -1;
 			}
 
-			if ( new Date( lastInteractionA ) < new Date( lastInteractionB ) ) {
+			if ( lastInteractionA < lastInteractionB ) {
 				return sortOrder === 'asc' ? -1 : 1;
 			}
 

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -67,7 +67,7 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 
 			return 0;
 		} ),
-		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, sortOrder ) ),
+		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, 'asc' ) ),
 	];
 }
 

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -45,7 +45,9 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 	const interactedItems = sites.filter(
 		( site ) => site.user_interactions && site.user_interactions.length > 0
 	);
-	const remainingItems = sites.filter( ( site ) => site.user_interactions?.length === 0 );
+	const remainingItems = sites.filter(
+		( site ) => ! site.user_interactions || site.user_interactions.length === 0
+	);
 
 	return [
 		...interactedItems.sort( ( a, b ) => {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -120,6 +120,7 @@ export interface SiteDetails {
 	slug: string;
 	visible?: boolean;
 	wpcom_url?: string;
+	user_interactions: string[];
 }
 
 export interface SiteDetailsCapabilities {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -120,7 +120,7 @@ export interface SiteDetails {
 	slug: string;
 	visible?: boolean;
 	wpcom_url?: string;
-	user_interactions: string[];
+	user_interactions?: string[];
 }
 
 export interface SiteDetailsCapabilities {


### PR DESCRIPTION
#### Proposed Changes

Part of https://github.com/Automattic/wp-calypso/issues/67043.

This PR adds a new sorting option to the Sites page called "Automagically". In a nutshell, it sorts in descending order by last interaction from the user (updating posts and/or pages):

![image](https://user-images.githubusercontent.com/26530524/190256097-ba3ec9bd-2de5-4f1b-a831-411a94e428e6.png)

#### Testing Instructions

1. Open the Sites page;
2. Open the sorting dropdown;
3. Check that "Automagically" shows up;
4. Select that option;
5. Check that the sites are now sorted in descending order by last interaction, and the ones that do not have recorded interactions are sorted alphabetically;
6. Check that sorting is persisted between page refreshes.