### PR TITLE
Launchpad: Add Link in bio post-setup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -58,6 +58,7 @@ button {
 .newsletter-setup,
 .patterns,
 .link-in-bio-setup,
+.link-in-bio-post-setup,
 .completing-purchase,
 .anchor-fm,
 .subscribers,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -35,6 +35,7 @@ export { default as difmStartingPoint } from './difm-starting-point';
 export { default as letsGetStarted } from './lets-get-started';
 export { default as intro } from './intro';
 export { default as linkInBioSetup } from './link-in-bio-setup';
+export { default as linkInBioPostSetup } from './link-in-bio-post-setup';
 export { default as chooseADomain } from './choose-a-domain';
 export { default as launchpad } from './launchpad';
 export { default as subscribers } from './subscribers';
@@ -79,6 +80,7 @@ export type StepPath =
 	| 'letsGetStarted'
 	| 'chooseADomain'
 	| 'linkInBioSetup'
+	| 'linkInBioPostSetup'
 	| 'newsletterSetup'
 	| 'intro'
 	| 'launchpad'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -67,6 +67,8 @@ export function getEnhancedTasks(
 				case 'setup_link_in_bio':
 					taskData = {
 						title: translate( 'Set up Link in Bio' ),
+						keepActive: true,
+						actionUrl: `/setup/linkInBioPostSetup?flow=link-in-bio-post-setup&siteSlug=${ siteSlug }`,
 					};
 					break;
 				case 'links_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { StepContainer, base64ImageToBlob } from '@automattic/onboarding';
+import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useUploadSiteIcon } from 'calypso/data/media/use-upload-site-icon';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
@@ -18,7 +17,6 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const site = useSite();
-	const uploadSiteIcon = useUploadSiteIcon();
 
 	const [ siteTitle, setComponentSiteTitle ] = useState( '' );
 	const [ tagline, setTagline ] = useState( '' );
@@ -36,22 +34,18 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 		setInvalidSiteTitle( ! siteTitle.trim().length );
-
 		if ( site ) {
 			await saveSiteSettings( site.ID, {
 				blogname: siteTitle,
 				blogdescription: tagline,
 			} );
-		}
 
-		if ( selectedFile && base64Image ) {
-			await uploadSiteIcon(
-				base64ImageToBlob( base64Image ),
-				'site-logo.png',
-				site?.ID,
-				site?.icon?.media_id,
-				site
-			);
+			if ( base64Image ) {
+				await uploadAndSetSiteLogo(
+					site.ID,
+					new File( [ base64ImageToBlob( base64Image ) ], 'site-logo.png' )
+				);
+			}
 		}
 
 		if ( siteTitle.trim().length ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { StepContainer } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import { FormEvent, useEffect, useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../../../../hooks/use-site';
+import SetupForm from '../link-in-bio-setup/setup-form';
+import type { Step } from '../../types';
+
+import '../link-in-bio-setup/styles.scss';
+
+const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const site = useSite();
+
+	const [ siteTitle, setComponentSiteTitle ] = useState( '' );
+	const [ tagline, setTagline ] = useState( '' );
+	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
+	const [ selectedFile, setSelectedFile ] = useState< File | undefined >();
+	const [ base64Image, setBase64Image ] = useState< string | null >();
+
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
+	useEffect( () => {
+		setComponentSiteTitle( site?.name || '' );
+		setTagline( site?.description || '' );
+	}, [ site ] );
+
+	const handleSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+		setInvalidSiteTitle( ! siteTitle.trim().length );
+
+		if ( site ) {
+			await saveSiteSettings( site.ID, {
+				blogname: siteTitle,
+				blogdescription: tagline,
+			} );
+		}
+
+		// Still need to handle updating site icon here
+		if ( selectedFile && base64Image ) {
+			try {
+				// update site icon here
+			} catch ( _error ) {
+				// or communicate the error to the user
+			}
+		}
+
+		if ( siteTitle.trim().length ) {
+			submit?.();
+		}
+	};
+
+	return (
+		<StepContainer
+			stepName={ 'link-in-bio-setup' }
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName={ 'linkInBioPostSetup' }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'link-in-bio-setup-header' }
+					headerText={ createInterpolateElement( __( 'Personalize your<br />Link in Bio' ), {
+						br: <br />,
+					} ) }
+					align={ 'center' }
+				/>
+			}
+			stepContent={
+				<SetupForm
+					site={ site }
+					siteTitle={ siteTitle }
+					setComponentSiteTitle={ setComponentSiteTitle }
+					invalidSiteTitle={ invalidSiteTitle }
+					setInvalidSiteTitle={ setInvalidSiteTitle }
+					tagline={ tagline }
+					setTagline={ setTagline }
+					selectedFile={ selectedFile }
+					setSelectedFile={ setSelectedFile }
+					setBase64Image={ setBase64Image }
+					handleSubmit={ handleSubmit }
+				/>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default LinkInBioPostSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, base64ImageToBlob } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useUploadSiteIcon } from 'calypso/data/media/use-upload-site-icon';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
@@ -17,6 +18,7 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const site = useSite();
+	const uploadSiteIcon = useUploadSiteIcon();
 
 	const [ siteTitle, setComponentSiteTitle ] = useState( '' );
 	const [ tagline, setTagline ] = useState( '' );
@@ -42,13 +44,14 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 			} );
 		}
 
-		// Still need to handle updating site icon here
 		if ( selectedFile && base64Image ) {
-			try {
-				// update site icon here
-			} catch ( _error ) {
-				// or communicate the error to the user
-			}
+			await uploadSiteIcon(
+				base64ImageToBlob( base64Image ),
+				'site-logo.png',
+				site?.ID,
+				site?.icon?.media_id,
+				site
+			);
 		}
 
 		if ( siteTitle.trim().length ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -45,10 +45,9 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 			return;
 		}
 
-		setIsLoading( true );
-
 		try {
 			if ( site ) {
+				setIsLoading( true );
 				await saveSiteSettings( site.ID, {
 					blogname: siteTitle,
 					blogdescription: tagline,
@@ -59,9 +58,9 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 						new File( [ base64ImageToBlob( base64Image ) ], 'site-logo.png' )
 					);
 				}
+				setIsLoading( false );
+				submit?.();
 			}
-			setIsLoading( false );
-			submit?.();
 		} catch {
 			setIsSubmitError( true );
 			setIsLoading( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -23,6 +23,7 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
 	const [ selectedFile, setSelectedFile ] = useState< File | undefined >();
 	const [ base64Image, setBase64Image ] = useState< string | null >();
+	const [ isLoading, setIsLoading ] = useState< boolean >( false );
 
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 
@@ -31,8 +32,13 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 		setTagline( site?.description || '' );
 	}, [ site ] );
 
+	useEffect( () => {
+		setIsLoading( false );
+	}, [ siteTitle, tagline, invalidSiteTitle, selectedFile, base64Image ] );
+
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
+		setIsLoading( true );
 		setInvalidSiteTitle( ! siteTitle.trim().length );
 		if ( site ) {
 			await saveSiteSettings( site.ID, {
@@ -81,6 +87,7 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 					setSelectedFile={ setSelectedFile }
 					setBase64Image={ setBase64Image }
 					handleSubmit={ handleSubmit }
+					isLoading={ isLoading }
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -38,14 +38,18 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		setIsLoading( true );
+
 		setInvalidSiteTitle( ! siteTitle.trim().length );
+		if ( ! siteTitle.trim().length ) {
+			return;
+		}
+
+		setIsLoading( true );
 		if ( site ) {
 			await saveSiteSettings( site.ID, {
 				blogname: siteTitle,
 				blogdescription: tagline,
 			} );
-
 			if ( base64Image ) {
 				await uploadAndSetSiteLogo(
 					site.ID,
@@ -54,9 +58,7 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 			}
 		}
 
-		if ( siteTitle.trim().length ) {
-			submit?.();
-		}
+		submit?.();
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -1,21 +1,13 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-
-import { Button, FormInputValidation } from '@automattic/components';
 import { StepContainer, base64ImageToBlob } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
-import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormattedHeader from 'calypso/components/formatted-header';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormInput from 'calypso/components/forms/form-text-input';
-import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
-import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
+import SetupForm from './setup-form';
 import type { Step } from '../../types';
 
 import './styles.scss';
@@ -25,7 +17,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 	const { __ } = useI18n();
 	const site = useSite();
 
-	const usesSite = !! useSiteSlugParam();
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
 	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
 	const [ base64Image, setBase64Image ] = React.useState< string | null >();
@@ -54,28 +45,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 		setTagline( site.description );
 	}, [ site ] );
 
-	useEffect( () => {
-		if ( siteTitle.trim().length && invalidSiteTitle ) {
-			setInvalidSiteTitle( false );
-		}
-	}, [ siteTitle, invalidSiteTitle ] );
-
-	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
-		switch ( event.currentTarget.name ) {
-			case 'link-in-bio-input-name':
-				return setComponentSiteTitle( event.currentTarget.value );
-			case 'link-in-bio-input-description':
-				return setTagline( event.currentTarget.value );
-		}
-	};
-
-	const imageFileToBase64 = ( file: Blob ) => {
-		const reader = new FileReader();
-		reader.readAsDataURL( file );
-		reader.onload = () => setBase64Image( reader.result as string );
-		reader.onerror = () => setBase64Image( null );
-	};
-
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 		setInvalidSiteTitle( ! siteTitle.trim().length );
@@ -96,54 +65,6 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 		}
 	};
 
-	const stepContent = (
-		<form className="link-in-bio-setup__form" onSubmit={ handleSubmit }>
-			<SiteIconWithPicker
-				site={ site }
-				placeholderText={ __( 'Upload a profile image' ) }
-				onSelect={ ( file ) => {
-					setSelectedFile( file );
-					imageFileToBase64( file );
-				} }
-				disabled={ usesSite ? ! site : false }
-				selectedFile={ selectedFile }
-			/>
-			<FormFieldset>
-				<FormLabel htmlFor="link-in-bio-input-name">{ __( 'Site name' ) }</FormLabel>
-				<FormInput
-					name="link-in-bio-input-name"
-					id="link-in-bio-input-name"
-					value={ siteTitle }
-					onChange={ onChange }
-					placeholder={ __( 'My Link in Bio' ) }
-					isError={ invalidSiteTitle }
-				/>
-				{ invalidSiteTitle && (
-					<FormInputValidation
-						isError
-						text={ __( `Oops. Looks like your Link in Bio doesn't have a name yet.` ) }
-					/>
-				) }
-			</FormFieldset>
-
-			<FormFieldset>
-				<FormLabel htmlFor="link-in-bio-input-description">{ __( 'Brief description' ) }</FormLabel>
-				<ForwardedAutoresizingFormTextarea
-					name="link-in-bio-input-description"
-					id="link-in-bio-input-description"
-					value={ tagline }
-					placeholder={ __( 'Add a short biography here' ) }
-					enableAutoFocus={ false }
-					onChange={ onChange }
-				/>
-			</FormFieldset>
-
-			<Button className="link-in-bio-setup-form__submit" primary type="submit">
-				{ __( 'Continue' ) }
-			</Button>
-		</form>
-	);
-
 	return (
 		<StepContainer
 			stepName={ 'link-in-bio-setup' }
@@ -159,7 +80,21 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 					align={ 'center' }
 				/>
 			}
-			stepContent={ stepContent }
+			stepContent={
+				<SetupForm
+					site={ site }
+					siteTitle={ siteTitle }
+					setComponentSiteTitle={ setComponentSiteTitle }
+					invalidSiteTitle={ invalidSiteTitle }
+					setInvalidSiteTitle={ setInvalidSiteTitle }
+					tagline={ tagline }
+					setTagline={ setTagline }
+					selectedFile={ selectedFile }
+					setSelectedFile={ setSelectedFile }
+					setBase64Image={ setBase64Image }
+					handleSubmit={ handleSubmit }
+				/>
+			}
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/setup-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/setup-form.tsx
@@ -1,0 +1,114 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button, FormInputValidation } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { Dispatch, FormEvent, SetStateAction, useEffect } from 'react';
+import { SiteDetails } from 'calypso/../packages/data-stores/src';
+import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormInput from 'calypso/components/forms/form-text-input';
+import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+
+interface SetupFormProps {
+	site: SiteDetails | null;
+	siteTitle: string;
+	setComponentSiteTitle: Dispatch< SetStateAction< string > >;
+	invalidSiteTitle: boolean;
+	setInvalidSiteTitle: Dispatch< SetStateAction< boolean > >;
+	tagline: string;
+	setTagline: Dispatch< SetStateAction< string > >;
+	selectedFile: File | undefined;
+	setSelectedFile: Dispatch< SetStateAction< File | undefined > >;
+	setBase64Image: Dispatch< SetStateAction< string | null | undefined > >;
+	handleSubmit: ( event: FormEvent< Element > ) => void;
+}
+
+const SetupForm = ( {
+	site,
+	siteTitle,
+	setComponentSiteTitle,
+	invalidSiteTitle,
+	setInvalidSiteTitle,
+	tagline,
+	setTagline,
+	selectedFile,
+	setSelectedFile,
+	setBase64Image,
+	handleSubmit,
+}: SetupFormProps ) => {
+	const { __ } = useI18n();
+	const usesSite = !! useSiteSlugParam();
+
+	const imageFileToBase64 = ( file: Blob ) => {
+		const reader = new FileReader();
+		reader.readAsDataURL( file );
+		reader.onload = () => setBase64Image( reader.result as string );
+		reader.onerror = () => setBase64Image( null );
+	};
+
+	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
+		switch ( event.currentTarget.name ) {
+			case 'link-in-bio-input-name':
+				return setComponentSiteTitle( event.currentTarget.value );
+			case 'link-in-bio-input-description':
+				return setTagline( event.currentTarget.value );
+		}
+	};
+
+	useEffect( () => {
+		if ( siteTitle.trim().length && invalidSiteTitle ) {
+			setInvalidSiteTitle( false );
+		}
+	}, [ siteTitle, invalidSiteTitle, setInvalidSiteTitle ] );
+
+	return (
+		<form className="link-in-bio-setup__form" onSubmit={ handleSubmit }>
+			<SiteIconWithPicker
+				site={ site }
+				placeholderText={ __( 'Upload a profile image' ) }
+				onSelect={ ( file ) => {
+					setSelectedFile( file );
+					imageFileToBase64( file );
+				} }
+				disabled={ usesSite ? ! site : false }
+				selectedFile={ selectedFile }
+			/>
+			<FormFieldset>
+				<FormLabel htmlFor="link-in-bio-input-name">{ __( 'Site name' ) }</FormLabel>
+				<FormInput
+					name="link-in-bio-input-name"
+					id="link-in-bio-input-name"
+					value={ siteTitle }
+					onChange={ onChange }
+					placeholder={ __( 'My Link in Bio' ) }
+					isError={ invalidSiteTitle }
+				/>
+				{ invalidSiteTitle && (
+					<FormInputValidation
+						isError
+						text={ __( `Oops. Looks like your Link in Bio doesn't have a name yet.` ) }
+					/>
+				) }
+			</FormFieldset>
+
+			<FormFieldset>
+				<FormLabel htmlFor="link-in-bio-input-description">{ __( 'Brief description' ) }</FormLabel>
+				<ForwardedAutoresizingFormTextarea
+					name="link-in-bio-input-description"
+					id="link-in-bio-input-description"
+					value={ tagline }
+					placeholder={ __( 'Add a short biography here' ) }
+					enableAutoFocus={ false }
+					onChange={ onChange }
+				/>
+			</FormFieldset>
+
+			<Button className="link-in-bio-setup-form__submit" primary type="submit">
+				{ __( 'Continue' ) }
+			</Button>
+		</form>
+	);
+};
+
+export default SetupForm;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/setup-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/setup-form.tsx
@@ -22,6 +22,7 @@ interface SetupFormProps {
 	setSelectedFile: Dispatch< SetStateAction< File | undefined > >;
 	setBase64Image: Dispatch< SetStateAction< string | null | undefined > >;
 	handleSubmit: ( event: FormEvent< Element > ) => void;
+	isLoading?: boolean;
 }
 
 const SetupForm = ( {
@@ -36,6 +37,7 @@ const SetupForm = ( {
 	setSelectedFile,
 	setBase64Image,
 	handleSubmit,
+	isLoading = false,
 }: SetupFormProps ) => {
 	const { __ } = useI18n();
 	const usesSite = !! useSiteSlugParam();
@@ -103,9 +105,13 @@ const SetupForm = ( {
 					onChange={ onChange }
 				/>
 			</FormFieldset>
-
-			<Button className="link-in-bio-setup-form__submit" primary type="submit">
-				{ __( 'Continue' ) }
+			<Button
+				className="link-in-bio-setup-form__submit"
+				disabled={ isLoading }
+				primary
+				type="submit"
+			>
+				{ isLoading ? __( 'Loading' ) : __( 'Continue' ) }
 			</Button>
 		</form>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/setup-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/setup-form.tsx
@@ -23,6 +23,7 @@ interface SetupFormProps {
 	setBase64Image: Dispatch< SetStateAction< string | null | undefined > >;
 	handleSubmit: ( event: FormEvent< Element > ) => void;
 	isLoading?: boolean;
+	isSubmitError?: boolean;
 }
 
 const SetupForm = ( {
@@ -38,6 +39,7 @@ const SetupForm = ( {
 	setBase64Image,
 	handleSubmit,
 	isLoading = false,
+	isSubmitError = false,
 }: SetupFormProps ) => {
 	const { __ } = useI18n();
 	const usesSite = !! useSiteSlugParam();
@@ -93,7 +95,6 @@ const SetupForm = ( {
 					/>
 				) }
 			</FormFieldset>
-
 			<FormFieldset>
 				<FormLabel htmlFor="link-in-bio-input-description">{ __( 'Brief description' ) }</FormLabel>
 				<ForwardedAutoresizingFormTextarea
@@ -113,6 +114,12 @@ const SetupForm = ( {
 			>
 				{ isLoading ? __( 'Loading' ) : __( 'Continue' ) }
 			</Button>
+			{ isSubmitError && (
+				<FormInputValidation
+					isError={ isSubmitError }
+					text={ __( 'Oops, there was an issue! Please try again.' ) }
+				/>
+			) }
 		</form>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -50,10 +50,6 @@ $font-family: "SF Pro Text", $sans;
 			font-family: $font-family;
 			font-weight: 400;
 		}
-<<<<<<< HEAD
-=======
-
->>>>>>> f94b2c5b74 (Add loading status to Setup button)
 		input,
 		textarea,
 		pre {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -50,6 +50,10 @@ $font-family: "SF Pro Text", $sans;
 			font-family: $font-family;
 			font-weight: 400;
 		}
+<<<<<<< HEAD
+=======
+
+>>>>>>> f94b2c5b74 (Add loading status to Setup button)
 		input,
 		textarea,
 		pre {
@@ -72,7 +76,7 @@ $font-family: "SF Pro Text", $sans;
 		width: 100%;
 		height: 40px;
 
-		&:hover {
+		&:hover:not([disabled]) {
 			background-color: var(--wp-admin-theme-color-darker-10);
 		}
 	}

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -1,0 +1,43 @@
+import { LINK_IN_BIO_POST_SETUP_FLOW } from '@automattic/onboarding';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { ProvidedDependencies } from './internals/types';
+import type { StepPath } from './internals/steps-repository';
+import type { Flow } from './internals/types';
+
+export const linkInBioPostSetup: Flow = {
+	name: LINK_IN_BIO_POST_SETUP_FLOW,
+	title: 'Link in Bio',
+	useSteps() {
+		return [ 'linkInBioPostSetup' ] as StepPath[];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const siteSlug = useSiteSlug();
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'link-in-bio-post-setup', currentStep );
+
+			switch ( currentStep ) {
+				case 'linkInBioPostSetup':
+					return window.location.assign(
+						`/setup/launchpad?flow=link-in-bio&siteSlug=${ siteSlug }`
+					);
+			}
+		}
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			return;
+		};
+
+		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -30,6 +30,7 @@ import { setupWpDataDebug } from '../gutenboarding/devtools';
 import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
+import { linkInBioPostSetup } from './declarative-flow/link-in-bio-post-setup';
 import { newsletter } from './declarative-flow/newsletter';
 import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
@@ -64,6 +65,7 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'newsletter', pathToFlow: newsletter },
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
+	{ flowName: 'link-in-bio-post-setup', pathToFlow: linkInBioPostSetup },
 	config.isEnabled( 'themes/plugin-bundling' )
 		? { flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow }
 		: null,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -1,9 +1,13 @@
 export const NEWSLETTER_FLOW = 'newsletter';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
+export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
-	return Boolean( flowName && [ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW ].includes( flowName ) );
+	return Boolean(
+		flowName &&
+			[ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_POST_SETUP_FLOW ].includes( flowName )
+	);
 };
 
 export const isTailoredSignupFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
### Proposed Changes

**Related to:** https://github.com/Automattic/wp-calypso/issues/67429

Before arriving at Launchpad, users go through the linkInBioSetup stepper screen. We want to allow them to edit the same values from that screen after arriving at Launchpad. Following [discussion from a prior PR,](https://github.com/Automattic/wp-calypso/pull/67523#pullrequestreview-1107102774) rather than send users back to the original Setup screen, we are creating a new stepper flow and screen. Users can navigate between Launchpad and the new Setup screen, and changes made on new screen should be reflected on their site, including the Launchpad website preview. 

Specific changes include: 
* Separate setup form in original linkInBioSetup screen to its own component for re-use.
* Add link-in-bio-post-setup flow, with linkInBioPostSetup screen (uses same form as the original).
* Ensure linkInBioPostSetup screen pre-populates site title/tagline/icon from the redux SITE_STORE.
* Ensure changes to site title/tagline/icon are updated on the site.
* Add link to new flow/screen from Launchpad. 

### Testing Instructions

1. Checkout this branch, and run yarn and yarn start if needed.
2. Start a new link-in-bio site from https://wordpress.com/hp-2022-tailored-flows/
3. As soon as you've started the process (and before you arrive at the Link in Bio setup screen), switch to your local Calypso instance. Replace `https://worpdress.com` with `http://calypso.localhost:3000/` in your browser. 
4. TEST: When you arrive on the first link-in-bio set up screen where you set title/tagline/icon, confirm that everything works as expected. I moved a large part of this screen to a new component, so we want to be sure no regressive breakages.
5. TEST: Continue as normal until Launchpad, and confirm that the site title/tagline/icon in the Launchpad web preview is correct. Again, we want to ensure no regressive breakages. 
6. TEST: From Launchpad, confirm the 'Set up Link in Bio' task is clickable. 
7. TEST: Click the 'Set up Link in Bio' task. You should arrive at a screen that looks exactly like the original setup screen, but the url of this screen should be different: http://calypso.localhost:3000/setup/linkInBioPostSetup?flow=link-in-bio-post-setup&siteSlug=[YOUR_SITE_SLUG]
8. TEST: Confirm you can edit the site title, tagline, and icon. 
9. TEST: Click the 'Continue' button and confirm you are returned to Launchpad. 
10. TEST: Confirm in the Launchpad web preview that your new site title, tagline, and icon are there.

### Screenshots

For potential translations and for reference during testing, the new linkInBioPostSetup screen should look like this.

<img width="1506" alt="link-in-bio-post-setup" src="https://user-images.githubusercontent.com/21228350/190272990-97fbf3c3-a75a-4173-bea7-325b9c12fb30.png">