### PR TITLE
SSR: Use normal renderer for non-SSR requests to SSR sections

### DIFF
--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -1,13 +1,24 @@
+import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
 import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
 import { setSectionMiddleware } from 'calypso/controller';
 import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
 import { setRoute } from 'calypso/state/route/actions';
 
+const calypsoEnv = config( 'env_id' );
+const debug = debugFactory( 'calypso:pages' );
+
 export function serverRouter( expressApp, setUpRoute, section ) {
 	return function ( route, ...middlewares ) {
 		expressApp.get(
 			route,
+			calypsoEnv === 'development'
+				? ( req, res, next ) => {
+						debug( `Using SSR pipeline for path: ${ req.path } with matcher ${ route }` );
+						next();
+				  }
+				: undefined,
 			setUpRoute,
 			combineMiddlewares(
 				setSectionMiddleware( section ),

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
@@ -6,19 +5,16 @@ import { setSectionMiddleware } from 'calypso/controller';
 import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
 import { setRoute } from 'calypso/state/route/actions';
 
-const calypsoEnv = config( 'env_id' );
 const debug = debugFactory( 'calypso:pages' );
 
 export function serverRouter( expressApp, setUpRoute, section ) {
 	return function ( route, ...middlewares ) {
 		expressApp.get(
 			route,
-			calypsoEnv === 'development'
-				? ( req, res, next ) => {
-						debug( `Using SSR pipeline for path: ${ req.path } with matcher ${ route }` );
-						next();
-				  }
-				: undefined,
+			( req, res, next ) => {
+				debug( `Using SSR pipeline for path: ${ req.path } with matcher ${ route }` );
+				next();
+			},
 			setUpRoute,
 			combineMiddlewares(
 				setSectionMiddleware( section ),

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -12,7 +12,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			( req, res, next ) => {
-				debug( `Using SSR pipeline for path: ${ req.path } with matcher ${ route }` );
+				debug( `Using SSR pipeline for path: ${ req.path } with handler ${ route }` );
 				next();
 			},
 			setUpRoute,

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -789,7 +789,6 @@ export default function pages() {
 			setupDefaultContext( entrypoint ),
 			( req, res, next ) => {
 				req.context.sectionName = section.name;
-				req.context.section = section;
 
 				if ( ! entrypoint ) {
 					req.context.chunkFiles = req.getFilesForChunk( section.name );


### PR DESCRIPTION
#### Proposed Changes
The goal of this PR is to improve the performance of the Calypso server for logged-in requests to SSR sections. (In some rough local testing, I'm seeing this branch perform 40-50% faster than trunk.) 

Here's how the pipeline currently works:

1. For every section, we run `handleSectionPath`, which adds a basic route handler to every single section. For all sections, this adds some default context, and for non-isiomorphic sections, it adds the renderer used to handle the entire route.
2. Every isomorphic section's router is loaded, which adds several custom route handlers to the server. Whenever these route handlers are triggered -- e.g. a direct request to /themes/:site while logged in or logged out -- a lot of custom middleware is run to do work specific to SSR rendering. (like fetching the themes data)
3. The SSR middleware pipeline ends with the server renderer, which checks if the request is SSR compatible. If it is, it does a full SSR render. If not, it defers most work to the client.

This PR moves "check if the request is SSR compatible" from step 3 to step 1. Now, if we know for certain that the request will _not_ be server side rendered (e.g. the request is logged in), we skip the SSR pipeline altogether and just resolve using the "normal" renderer.

This check is relatively cautious, so if there's any chance SSR _would_ be used (e.g. the section is isomorphic and the request is logged out), we skip the middleware chain and allow the SSR pipeline to run its full course. This might include additional checks which ultimately disable SSR, but those cases would be hard to handle earlier in the lifecycle, and I think they are more rare. (Plus, this is just the behavior we had before.)

The big improvement here is that logged in requests will _never_ go through the SSR pipeline -- because the SSR renderer never worked for logged in requests anyways. But this allows us to skip all the extra middleware associated with the SSR route matchers (some of which are async), which should improve performance.

#### Testing Instructions

**Logged in:**
1. Enable server user bootstrapping (see PCYsg-5YE-p2)
2. Run `DEBUG=calypso:pages yarn start`
3. Directly visit `/themes/:site`, where :site is one of your wpcom sites. We need to directly visit the URL, not click it in the app. 
4. Observe a "Using non-SSR pipeline for path" in the log output.

**Logged out:**
1. Disable user boostrapping by changing `wpcom-user-bootstrap` in `development.json` false.
2. Run `DEBUG=calypso:pages yarn start`
3. Directly visit `/themes/:site`, where :site is one of your wpcom sites. We need to directly visit the URL, not click it in the app. 
5. Observe a "Using SSR pipeline for path" in the log output.