### PR TITLE
Promoted posts: Adds error msg when cancellation fails.

### DIFF
--- a/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
+++ b/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
@@ -1,16 +1,22 @@
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
+import { useDispatch } from 'react-redux';
 import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import { requestDSP } from 'calypso/lib/promote-post';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 export const useCancelCampaignMutation = () => {
 	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
 	const mutation = useMutation(
 		async ( { siteId, campaignId }: { siteId: number; campaignId: number } ) =>
 			await requestDSP< { results: Campaign[] } >( siteId, `/campaigns/${ campaignId }/stop` ),
 		{
 			onSuccess( data, { siteId } ) {
 				queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
+			},
+			onError() {
+				dispatch( errorNotice( 'Something wrong happened, please try again later.' ) );
 			},
 		}
 	);

--- a/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
+++ b/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
@@ -1,13 +1,10 @@
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-import { useDispatch } from 'react-redux';
 import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import { requestDSP } from 'calypso/lib/promote-post';
-import { errorNotice } from 'calypso/state/notices/actions';
 
-export const useCancelCampaignMutation = () => {
+export const useCancelCampaignMutation = ( onError: () => void ) => {
 	const queryClient = useQueryClient();
-	const dispatch = useDispatch();
 	const mutation = useMutation(
 		async ( { siteId, campaignId }: { siteId: number; campaignId: number } ) =>
 			await requestDSP< { results: Campaign[] } >( siteId, `/campaigns/${ campaignId }/stop` ),
@@ -15,9 +12,7 @@ export const useCancelCampaignMutation = () => {
 			onSuccess( data, { siteId } ) {
 				queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
 			},
-			onError() {
-				dispatch( errorNotice( 'Something wrong happened, please try again later.' ) );
-			},
+			onError,
 		}
 	);
 

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -31,9 +31,10 @@ type Props = {
 
 export default function CampaignItem( { campaign }: Props ) {
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
+	const [ showErrorDialog, setShowErrorDialog ] = useState( false );
 	const siteId = useSelector( getSelectedSiteId );
 
-	const { cancelCampaign } = useCancelCampaignMutation();
+	const { cancelCampaign } = useCancelCampaignMutation( () => setShowErrorDialog( true ) );
 
 	const {
 		impressions_total,
@@ -119,16 +120,32 @@ export default function CampaignItem( { campaign }: Props ) {
 	const buttons = [
 		{
 			action: 'cancel',
+			isPrimary: true,
 			label: __( 'No' ),
 		},
 		{
 			action: 'remove',
-			isPrimary: true,
 			label: cancelCampaignConfirmButtonText,
 			onClick: async () => {
 				setShowDeleteDialog( false );
 				cancelCampaign( siteId, campaign.campaign_id );
 			},
+		},
+	];
+
+	const errorDialogButtons = [
+		{
+			action: 'remove',
+			label: __( 'Contact support' ),
+			onClick: async () => {
+				setShowErrorDialog( false );
+				window.open( 'https://wordpress.com/support/', '_blank' );
+			},
+		},
+		{
+			action: 'cancel',
+			isPrimary: true,
+			label: __( 'Ok' ),
 		},
 	];
 
@@ -141,6 +158,15 @@ export default function CampaignItem( { campaign }: Props ) {
 			>
 				<h1>{ cancelCampaignTitle }</h1>
 				<p>{ cancelCampaignMessage }</p>
+			</Dialog>
+
+			<Dialog
+				isVisible={ showErrorDialog }
+				buttons={ errorDialogButtons }
+				onClose={ () => setShowErrorDialog( false ) }
+			>
+				<h1>{ __( "Something's gone wrong" ) }</h1>
+				<p>{ __( 'Please try again later or contact support if the problem persists.' ) }</p>
 			</Dialog>
 
 			<FoldableCard header={ header } hideSummary={ true } className="campaign-item__foldable-card">


### PR DESCRIPTION
#### Proposed Changes
![image](https://user-images.githubusercontent.com/6070516/191141478-4648e7d1-9f3d-494b-b7fd-bbd84f1c9be7.png)


https://user-images.githubusercontent.com/6070516/190932236-3db09b11-d729-4dcc-9b81-7317a83a9eda.mov



#### Testing Instructions
Try cancel a campaign and return error deliberately, then it should show an error msg as above.
If the cancellation is successful, then it would refresh the campaign list.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
