### PR TITLE
Jetpack New Pricing Page - Fix issues related to Foldable cards in lightbox

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/description-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/description-list.tsx
@@ -1,0 +1,17 @@
+import { TranslateResult } from 'i18n-calypso';
+
+type DescriptionListProps = { items?: TranslateResult[] };
+const DescriptionList: React.FC< DescriptionListProps > = ( { items } ) => {
+	if ( ! items || ! items.length ) {
+		return null;
+	}
+
+	return (
+		<ul>
+			{ items.map( ( item, index ) => (
+				<li key={ index }>{ item }</li>
+			) ) }
+		</ul>
+	);
+};
+export default DescriptionList;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -119,7 +119,7 @@ const ProductLightbox: React.FC< Props > = ( {
 							href={ isMultiSiteIncompatible ? '#' : getCheckoutURL( product ) }
 							disabled={ isMultiSiteIncompatible }
 						>
-							{ translate( 'Checkout' ) }
+							{ translate( 'Proceed to checkout' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -1,10 +1,8 @@
 import { JetpackTag, JETPACK_RELATED_PRODUCTS_MAP } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import Modal from 'react-modal';
-import FoldableCard from 'calypso/components/foldable-card';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
 import { useStoreItemInfoContext } from '../product-store/context/store-item-info-context';
 import { ProductStoreBaseProps } from '../product-store/types';
@@ -15,6 +13,8 @@ import { PRODUCT_OPTIONS, PRODUCT_OPTIONS_HEADER } from './constants';
 import { Icons } from './icons/icons';
 import { Tags } from './icons/tags';
 import PaymentPlan from './payment-plan';
+import ProductDetails from './product-details';
+
 import './style.scss';
 
 type Props = ProductStoreBaseProps & {
@@ -24,20 +24,6 @@ type Props = ProductStoreBaseProps & {
 	onClose: () => void;
 	onChangeProduct: ( product: SelectorProduct | null ) => void;
 	siteId: number | null;
-};
-
-const DescriptionList: React.FC< { items?: TranslateResult[] } > = ( { items } ) => {
-	if ( ! items || ! items.length ) {
-		return null;
-	}
-
-	return (
-		<ul>
-			{ items.map( ( item, index ) => (
-				<li key={ index }>{ item }</li>
-			) ) }
-		</ul>
-	);
 };
 
 const TagItems: React.FC< { tags: JetpackTag[] } > = ( { tags } ) => (
@@ -67,7 +53,6 @@ const ProductLightbox: React.FC< Props > = ( {
 	);
 
 	const { getCheckoutURL, getIsMultisiteCompatible, isMultisite } = useStoreItemInfoContext();
-	const isMobile = useMobileBreakpoint();
 
 	const variantOptions = useMemo( () => {
 		const variants = JETPACK_RELATED_PRODUCTS_MAP[ product.productSlug ] || [];
@@ -108,31 +93,7 @@ const ProductLightbox: React.FC< Props > = ( {
 						{ product.recommendedFor && <TagItems tags={ product.recommendedFor } /> }
 					</div>
 
-					<div className="product-lightbox__detail-list">
-						{ isMobile ? (
-							<FoldableCard hideSummary header={ translate( 'Includes' ) } expanded={ false }>
-								<DescriptionList items={ product.whatIsIncluded } />
-							</FoldableCard>
-						) : (
-							<>
-								<p>{ translate( 'Includes' ) }</p>
-								<DescriptionList items={ product.whatIsIncluded } />
-							</>
-						) }
-					</div>
-					<hr />
-					<div className="product-lightbox__detail-list">
-						{ isMobile ? (
-							<FoldableCard hideSummary header={ translate( 'Benefits' ) } expanded={ false }>
-								<DescriptionList items={ product.benefits } />
-							</FoldableCard>
-						) : (
-							<>
-								<p>{ translate( 'Benefits' ) }</p>
-								<DescriptionList items={ product.benefits } />
-							</>
-						) }
-					</div>
+					<ProductDetails product={ product } />
 				</div>
 				<div className="product-lightbox__variants">
 					<div className="product-lightbox__variants-content">

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
@@ -1,0 +1,46 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useState } from 'react';
+import FoldableCard from 'calypso/components/foldable-card';
+import { SelectorProduct } from '../types';
+import DescriptionList from './description-list';
+
+type ProductDetailsProps = {
+	product: SelectorProduct;
+};
+
+const ProductDetails: React.FC< ProductDetailsProps > = ( { product } ) => {
+	const isMobile = useMobileBreakpoint();
+	const [ expandedDetailType, setExpandedDetailType ] = useState( '' );
+	const productDetails = [
+		{ type: 'includes', title: 'Includes', items: product.whatIsIncluded },
+		{ type: 'benefits', title: 'Benefits', items: product.benefits },
+	];
+
+	return (
+		<>
+			{ productDetails.map( ( { type, title, items }, index, infoList ) => (
+				<div className="product-lightbox__detail-list" key={ type }>
+					{ isMobile ? (
+						<FoldableCard
+							hideSummary
+							header={ title }
+							clickableHeader={ true }
+							expanded={ expandedDetailType === type }
+							onOpen={ () => setExpandedDetailType( type ) }
+						>
+							<DescriptionList items={ items } />
+						</FoldableCard>
+					) : (
+						<>
+							<p>{ title }</p>
+							<DescriptionList items={ items } />
+						</>
+					) }
+					{ index !== infoList.length - 1 && <hr /> }
+				</div>
+			) ) }
+		</>
+	);
+};
+
+export default ProductDetails;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
@@ -1,6 +1,5 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import FoldableCard from 'calypso/components/foldable-card';
 import { SelectorProduct } from '../types';
 import DescriptionList from './description-list';

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
@@ -1,4 +1,5 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FoldableCard from 'calypso/components/foldable-card';
 import { SelectorProduct } from '../types';
@@ -10,10 +11,12 @@ type ProductDetailsProps = {
 
 const ProductDetails: React.FC< ProductDetailsProps > = ( { product } ) => {
 	const isMobile = useMobileBreakpoint();
+	const translate = useTranslate();
 	const [ expandedDetailType, setExpandedDetailType ] = useState( '' );
+
 	const productDetails = [
-		{ type: 'includes', title: 'Includes', items: product.whatIsIncluded },
-		{ type: 'benefits', title: 'Benefits', items: product.benefits },
+		{ type: 'includes', title: translate( 'Includes' ), items: product.whatIsIncluded },
+		{ type: 'benefits', title: translate( 'Benefits' ), items: product.benefits },
 	];
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
@@ -12,7 +12,6 @@ type ProductDetailsProps = {
 const ProductDetails: React.FC< ProductDetailsProps > = ( { product } ) => {
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
-	const [ expandedDetailType, setExpandedDetailType ] = useState( '' );
 
 	const productDetails = [
 		{ type: 'includes', title: translate( 'Includes' ), items: product.whatIsIncluded },
@@ -24,13 +23,7 @@ const ProductDetails: React.FC< ProductDetailsProps > = ( { product } ) => {
 			{ productDetails.map( ( { type, title, items }, index, infoList ) => (
 				<div className="product-lightbox__detail-list" key={ type }>
 					{ isMobile ? (
-						<FoldableCard
-							hideSummary
-							header={ title }
-							clickableHeader={ true }
-							expanded={ expandedDetailType === type }
-							onOpen={ () => setExpandedDetailType( type ) }
-						>
+						<FoldableCard hideSummary header={ title } clickableHeader={ true }>
 							<DescriptionList items={ items } />
 						</FoldableCard>
 					) : (

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
@@ -44,7 +44,11 @@ export const FeaturesList: React.FC< FeaturesListProps > = ( { item } ) => {
 
 	if ( isMobile ) {
 		return (
-			<FoldableCard header={ translate( 'View all features' ) } hideSummary expanded={ ! isMobile }>
+			<FoldableCard
+				header={ translate( 'View all features' ) }
+				clickableHeader={ true }
+				hideSummary
+			>
 				{ output }
 			</FoldableCard>
 		);

--- a/client/my-sites/plans/jetpack-plans/product-store/jetpack-free/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/jetpack-free/index.tsx
@@ -16,7 +16,7 @@ export const JetpackFree: React.FC< JetpackFreeProps > = ( { urlQueryArgs, siteI
 				{ translate( 'Still not sure?' ) }
 			</h3>
 			<p className="jetpack-product-store__jetpack-free--info">
-				{ translate( 'Start with the free version and try out the premium plugins later.' ) }
+				{ translate( 'Start with the free version and try out our premium products later.' ) }
 			</p>
 			<Button onClick={ onClick } href={ href }>
 				{ translate( 'Start with %(productName)s', {


### PR DESCRIPTION
#### Proposed Changes
* Refactor Lightbox to move the Includes and Benefits section to a separate component
* Fix issue with the FoldableCard not expanding on header click on mobile
* Fix Jetpack Free text

#### Testing Instructions


* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout add/lightbox-info-to-calypso-package`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Open any lighbox by clicking on More link in any of the cards
* Make sure everything is working expected as before
* Resize to mobile view and make sure Foldable Cards expands when clicked on any part of the row (not just on the arrow)
* Make sure expanding **Benefits** section closes the **Includes** section (if already in open) and vice-versa
* And also confirm that **Still not sure** in main products page displays the following message 
    * *Start with the free version and try out our premium products later.*  
 
#### Screenrecord 

##### Lightbox

##### Before
[Lightbox-before.webm](https://user-images.githubusercontent.com/2027003/190323194-3313ad8c-3f56-4432-b0d8-f235b992bf85.webm)



##### After
[LightBox-after.webm](https://user-images.githubusercontent.com/2027003/190323228-605b5bee-f7a2-4315-8546-a711fbddc762.webm)


##### Still not sure section 

##### Before

![still-not-sire-before](https://user-images.githubusercontent.com/2027003/190323302-b93fea29-c6a5-4efb-822d-d3e7365cddeb.png)


##### After
![still-not-sure-after](https://user-images.githubusercontent.com/2027003/190323315-08e32ae2-8c43-4c4b-847c-ce07d87fde8a.png)


#### Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202979841166413
  - https://app.asana.com/0/0/1202979995370874
  - https://app.asana.com/0/0/1202980219801564