### PR TITLE
Pattern Assembler - Replace/Edit pattern icon

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { reusableBlock, chevronUp, chevronDown, closeSmall } from '@wordpress/icons';
+import { chevronUp, chevronDown, closeSmall, edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 
 type PatternActionBarProps = {
@@ -55,8 +55,8 @@ const PatternActionBar = ( {
 				role="menuitem"
 				label="Replace"
 				onClick={ onReplace }
-				icon={ reusableBlock }
-				iconSize={ 23 }
+				icon={ edit }
+				iconSize={ 20 }
 			/>
 			<Button
 				className="pattern-action-bar__block pattern-action-bar__action"


### PR DESCRIPTION
#### Proposed Changes

* Replace the icon 

#### Testing Instructions

- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain
- Select Write & Publish in the goals screen
- Select the category `Show all` in the Design picker screen
- Check that the icon is a pencil

|Before|After|
|-------|------|
|![Image](https://user-images.githubusercontent.com/1881481/190325024-dc9d37f2-7a02-4b15-a891-f73484d5bcb3.png)|![Image](https://user-images.githubusercontent.com/1881481/190324595-9e809f72-55ca-4d97-974d-263afeb94ce7.png)|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
