### PR TITLE
Pricing page rework: Open new tab when clicking 'More about CRM' link.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -10,6 +10,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 	description,
 	hero,
 	isCtaDisabled,
+	isCtaExternal,
 	onClickCta,
 	price,
 	title,
@@ -30,6 +31,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 						primary={ ctaAsPrimary }
 						onClick={ onClickCta }
 						disabled={ isCtaDisabled }
+						target={ isCtaExternal ? '_blank' : undefined }
 						href={ isCtaDisabled ? '#' : ctaHref }
 					>
 						{ ctaLabel }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -27,6 +27,9 @@ import { UseStoreItemInfoProps } from '../types';
 
 const getIsDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
+const getIsExternal = ( item: SelectorProduct ) =>
+	EXTERNAL_PRODUCTS_LIST.includes( item.productSlug );
+
 const getIsMultisiteCompatible = ( item: SelectorProduct ) => {
 	if ( isJetpackPlanSlug( item.productSlug ) ) {
 		// plans containing Jetpack Backup and/or Jetpack Scan are incompatible with multisite installs
@@ -105,11 +108,6 @@ export const useStoreItemInfo = ( {
 			);
 		},
 		[ getIsIncludedInPlan, getIsOwned, sitePlan ]
-	);
-
-	const getIsExternal = useCallback(
-		( item: SelectorProduct ) => EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ),
-		[]
 	);
 
 	const getIsIncludedInPlanOrSuperseded = useCallback(
@@ -214,7 +212,6 @@ export const useStoreItemInfo = ( {
 		[
 			getCheckoutURL,
 			getCtaLabel,
-			getIsExternal,
 			getIsIncludedInPlan,
 			getIsIncludedInPlanOrSuperseded,
 			getIsOwned,

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -20,6 +20,7 @@ import {
 	getSiteProducts,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
+import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import productButtonLabel from '../../product-card/product-button-label';
 import { SelectorProduct } from '../../types';
 import { UseStoreItemInfoProps } from '../types';
@@ -104,6 +105,11 @@ export const useStoreItemInfo = ( {
 			);
 		},
 		[ getIsIncludedInPlan, getIsOwned, sitePlan ]
+	);
+
+	const getIsExternal = useCallback(
+		( item: SelectorProduct ) => EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ),
+		[]
 	);
 
 	const getIsIncludedInPlanOrSuperseded = useCallback(
@@ -192,6 +198,7 @@ export const useStoreItemInfo = ( {
 			getCheckoutURL,
 			getCtaLabel,
 			getIsDeprecated,
+			getIsExternal,
 			getIsIncludedInPlan,
 			getIsIncludedInPlanOrSuperseded,
 			getIsMultisiteCompatible,
@@ -207,6 +214,7 @@ export const useStoreItemInfo = ( {
 		[
 			getCheckoutURL,
 			getCtaLabel,
+			getIsExternal,
 			getIsIncludedInPlan,
 			getIsIncludedInPlanOrSuperseded,
 			getIsOwned,

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -19,6 +19,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		getCheckoutURL,
 		getCtaLabel,
 		getIsDeprecated,
+		getIsExternal,
 		getIsIncludedInPlan,
 		getIsIncludedInPlanOrSuperseded,
 		getIsMultisiteCompatible,
@@ -41,6 +42,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					const isOwned = getIsOwned( item );
 					const isSuperseded = getIsSuperseded( item );
 					const isDeprecated = getIsDeprecated( item );
+					const isExternal = getIsExternal( item );
 					const isIncludedInPlanOrSuperseded = getIsIncludedInPlanOrSuperseded( item );
 					const isIncludedInPlan = getIsIncludedInPlan( item );
 					const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( item );
@@ -67,7 +69,11 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						<>
 							{ item?.shortDescription || item.description } <br />
 							{ ! hideMoreInfoLink && (
-								<MoreInfoLink onClick={ onClickMoreInfoFactory( item ) } item={ item } />
+								<MoreInfoLink
+									onClick={ onClickMoreInfoFactory( item ) }
+									item={ item }
+									isExternal={ isExternal }
+								/>
 							) }
 						</>
 					);
@@ -82,6 +88,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 							description={ description }
 							icon={ <img alt="" src={ getProductIcon( { productSlug: item.productSlug } ) } /> }
 							isCtaDisabled={ isCtaDisabled }
+							isCtaExternal={ isExternal }
 							key={ item.productSlug }
 							onClickCta={ getOnClickPurchase( item ) }
 							price={ price }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -22,6 +22,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 		getCheckoutURL,
 		getCtaLabel,
 		getIsDeprecated,
+		getIsExternal,
 		getIsIncludedInPlan,
 		getIsIncludedInPlanOrSuperseded,
 		getIsMultisiteCompatible,
@@ -41,6 +42,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 					const isOwned = getIsOwned( item );
 					const isSuperseded = getIsSuperseded( item );
 					const isDeprecated = getIsDeprecated( item );
+					const isExternal = getIsExternal( item );
 					const isIncludedInPlanOrSuperseded = getIsIncludedInPlanOrSuperseded( item );
 					const isIncludedInPlan = getIsIncludedInPlan( item );
 					const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( item );
@@ -69,7 +71,11 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 							<br />
 
 							{ ! hideMoreInfoLink && (
-								<MoreInfoLink item={ item } onClick={ onClickMoreInfoFactory( item ) } />
+								<MoreInfoLink
+									item={ item }
+									isExternal={ isExternal }
+									onClick={ onClickMoreInfoFactory( item ) }
+								/>
 							) }
 						</p>
 					);
@@ -85,6 +91,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 								description={ description }
 								hero={ <HeroImage item={ item } /> }
 								isCtaDisabled={ isCtaDisabled }
+								isCtaExternal={ isExternal }
 								onClickCta={ getOnClickPurchase( item ) }
 								price={ price }
 								title={ item.displayName }

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -1,19 +1,17 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import { MoreInfoLinkProps } from '../types';
 
 import './style.scss';
 
-export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } ) => {
+export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick, isExternal } ) => {
 	const translate = useTranslate();
 
-	const isExternalProductLink =
-		EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) && item.externalUrl;
+	const isExternalLink = isExternal && item.externalUrl;
 
-	const href = isExternalProductLink ? item.externalUrl : `#${ item.productSlug }`;
+	const href = isExternalLink ? item.externalUrl : `#${ item.productSlug }`;
 
-	const target = isExternalProductLink ? '_blank' : undefined;
+	const target = isExternalLink ? '_blank' : undefined;
 
 	return (
 		<Button className="more-info-link" onClick={ onClick } href={ href } target={ target } plain>
@@ -21,7 +19,7 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } )
 				components: { productName: <>{ item.shortName }</> },
 			} ) }
 
-			{ isExternalProductLink && <Gridicon icon="external" size={ 16 } /> }
+			{ isExternalLink && <Gridicon icon="external" size={ 16 } /> }
 		</Button>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -8,11 +8,12 @@ import './style.scss';
 export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } ) => {
 	const translate = useTranslate();
 
-	const isExternalProduct = EXTERNAL_PRODUCTS_LIST.includes( item.productSlug );
+	const isExternalProductLink =
+		EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) && item.externalUrl;
 
-	const href = isExternalProduct && item.externalUrl ? item.externalUrl : `#${ item.productSlug }`;
+	const href = isExternalProductLink ? item.externalUrl : `#${ item.productSlug }`;
 
-	const target = isExternalProduct ? '_blank' : '_self';
+	const target = isExternalProductLink ? '_blank' : '_self';
 
 	return (
 		<Button className="more-info-link" onClick={ onClick } href={ href } target={ target } plain>
@@ -20,7 +21,7 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } )
 				components: { productName: <>{ item.shortName }</> },
 			} ) }
 
-			{ isExternalProduct && <Gridicon icon="external" size={ 16 } /> }
+			{ isExternalProductLink && <Gridicon icon="external" size={ 16 } /> }
 		</Button>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import { MoreInfoLinkProps } from '../types';
@@ -15,10 +15,12 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } )
 	const target = isExternalProduct ? '_blank' : '_self';
 
 	return (
-		<Button className="more-info-link" onClick={ onClick } href={ href } plain target={ target }>
+		<Button className="more-info-link" onClick={ onClick } href={ href } target={ target } plain>
 			{ translate( 'More about {{productName/}}', {
 				components: { productName: <>{ item.shortName }</> },
 			} ) }
+
+			{ isExternalProduct && <Gridicon icon="external" size={ 16 } /> }
 		</Button>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -12,8 +12,10 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } )
 
 	const href = isExternalProduct && item.externalUrl ? item.externalUrl : `#${ item.productSlug }`;
 
+	const target = isExternalProduct ? '_blank' : '_self';
+
 	return (
-		<Button className="more-info-link" onClick={ onClick } href={ href } plain>
+		<Button className="more-info-link" onClick={ onClick } href={ href } plain target={ target }>
 			{ translate( 'More about {{productName/}}', {
 				components: { productName: <>{ item.shortName }</> },
 			} ) }

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -13,7 +13,7 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( { item, onClick } )
 
 	const href = isExternalProductLink ? item.externalUrl : `#${ item.productSlug }`;
 
-	const target = isExternalProductLink ? '_blank' : '_self';
+	const target = isExternalProductLink ? '_blank' : undefined;
 
 	return (
 		<Button className="more-info-link" onClick={ onClick } href={ href } target={ target } plain>

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/style.scss
@@ -11,3 +11,7 @@
 		padding-bottom: 0;
 	}
 }
+
+.more-info-link .gridicon {
+	margin: 0 1px -3px;
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
@@ -10,6 +10,7 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 	description,
 	icon,
 	isCtaDisabled,
+	isCtaExternal,
 	onClickCta,
 	price,
 	title,
@@ -28,6 +29,7 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 						onClick={ onClickCta }
 						disabled={ isCtaDisabled }
 						href={ isCtaDisabled ? '#' : ctaHref }
+						target={ isCtaExternal ? '_blank' : undefined }
 						primary={ ctaAsPrimary }
 					>
 						{ ctaLabel }

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -95,6 +95,7 @@ export type FeaturedItemCardProps = {
 	description: React.ReactNode;
 	hero: React.ReactNode;
 	isCtaDisabled?: boolean;
+	isCtaExternal?: boolean;
 	onClickCta?: VoidFunction;
 	price: React.ReactNode;
 	title: React.ReactNode;
@@ -107,4 +108,5 @@ export type SimpleItemCardProps = Omit< FeaturedItemCardProps, 'hero' > & {
 export type MoreInfoLinkProps = {
 	item: SelectorProduct;
 	onClick?: VoidFunction;
+	isExternal?: boolean;
 };


### PR DESCRIPTION
#### Proposed Changes

* Modify `MoreInfoLink` component to open a new tab when handling external products and display external icon.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. * Run `git fetch && git checkout fix/more-about-crm-link-redirect`
    * Run `yarn start-jetpack-cloud`
3. Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
4. Click 'More about CRM Entrepreneur' link.

<img width="587" alt="Screen Shot 2022-09-15 at 3 47 30 PM" src="https://user-images.githubusercontent.com/56598660/190348041-fb3c60e4-2a7a-4c45-a2d0-511817b4ffd6.png">

5. Confirm the browser opens a new tab.
6. Confirm the external icon is **visible** next to the text. 
<img width="100" alt="Screen Shot 2022-09-15 at 3 56 45 PM" src="https://user-images.githubusercontent.com/56598660/190348277-7d8f2325-d41e-4460-869c-f4d5f23eaa40.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202978853022664

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202979841166417