### PR TITLE
Pricing page rework: Prevent scroll to top when closing the modal

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -12,7 +12,8 @@ export const useProductLightbox = () => {
 
 	const setCurrentProductAndLocationHash = useCallback( ( product: SelectorProduct | null ) => {
 		setCurrentProduct( product );
-		window.location.hash = product ? product.productSlug : '';
+		const hash = `#${ product?.productSlug || '' }`;
+		window.history.pushState( null, '', hash );
 	}, [] );
 
 	const onClickMoreInfoFactory = useCallback( ( product: SelectorProduct ): VoidFunction => {


### PR DESCRIPTION
When closing the more info modal/lightbox, it scrolls to the top of the page which may be confusing to the users.

#### Proposed Changes

* Prevent scroll to top when closing the modal by using `history.pushState()` instead of setting `location.hash`

#### Testing Instructions

- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing/:site?flags=jetpack/pricing-page-rework-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout fix/jp-pricing-rework/fix-scroll-on-close-modal`
        * Run `yarn start-jetpack-cloud`
        * Goto `http://jetpack.cloud.localhost:3000/pricing/:site?flags=jetpack/pricing-page-rework-v1`
- Scroll down a bit and click "More about ..." link for any product
- Close the modal
- Confirm that the page doesn't scroll to the top

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 0-as-1202979995370875/f

Before and after behavior

https://user-images.githubusercontent.com/18226415/190367069-cb726f52-6482-4944-98a8-e68b2746192c.mov



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202979995370875