### PR TITLE
SiteIconPicker: open cropping UI on image click

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -82,7 +82,7 @@ export class ImageEditorCanvas extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.src !== prevProps.src ) {
+		if ( this.props.src !== prevProps.src || ! this.image ) {
 			this.getImage( this.props.src );
 		}
 

--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -65,11 +65,14 @@ export function SiteIconWithPicker( {
 					onDone={ ( _error: Error | null, image: Blob ) => {
 						onSelect( new File( [ image ], editingFileName || 'site-logo.png' ) );
 						setSelectedFileUrl( URL.createObjectURL( image ) );
+						setEditingFile( URL.createObjectURL( image ) );
 						setImageEditorOpen( false );
 					} }
 					onCancel={ () => {
-						setEditingFile( undefined );
-						setEditingFileName( undefined );
+						if ( ! selectedFileUrl ) {
+							setEditingFile( undefined );
+							setEditingFileName( undefined );
+						}
 						setImageEditorOpen( false );
 					} }
 					widthLimit={ 512 }
@@ -100,15 +103,24 @@ export function SiteIconWithPicker( {
 					} }
 				>
 					{ selectedFileUrl || siteIconUrl ? (
-						<img src={ selectedFileUrl || siteIconUrl } alt={ site?.name } />
+						// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+						<span
+							title={ 'Edit' }
+							onClick={ ( event ) => {
+								event.stopPropagation();
+								setImageEditorOpen( true );
+							} }
+						>
+							<img src={ selectedFileUrl || siteIconUrl } alt={ site?.name } />
+						</span>
 					) : (
 						<Icon icon={ upload } />
 					) }
-					<span>
-						{ selectedFileUrl || siteIconUrl
-							? __( 'Replace' )
-							: placeholderText || __( 'Add a site icon' ) }
-					</span>
+					{ selectedFileUrl || siteIconUrl ? (
+						<span className="replace">{ __( 'Replace' ) }</span>
+					) : (
+						<span className="add"> { placeholderText || __( 'Add a site icon' ) } </span>
+					) }
 				</FormFileUpload>
 			</FormFieldset>
 		</>

--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -103,9 +103,11 @@ export function SiteIconWithPicker( {
 					} }
 				>
 					{ selectedFileUrl || siteIconUrl ? (
-						// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+						// eslint-disable-next-line jsx-a11y/click-events-have-key-events
 						<span
-							title={ 'Edit' }
+							role="button"
+							tabIndex={ 0 }
+							title={ __( 'Edit' ) }
 							onClick={ ( event ) => {
 								event.stopPropagation();
 								setImageEditorOpen( true );

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -10,7 +10,7 @@ $icon-border-radius: 50%; /* stylelint-disable-line declaration-property-unit-al
 	min-width: 50vw;
 
 	use {
-		fill: white;
+		fill: #fff;
 	}
 }
 
@@ -57,7 +57,9 @@ button.components-button.site-icon-with-picker__upload-button {
 		left: 50%;
 		transform: translate(-50%, -50%);
 	}
-	span {
+
+	span.replace,
+	span.add {
 		position: absolute;
 		width: 200px;
 		display: block;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -179,7 +179,18 @@ button {
 
 					span {
 						font-size: $font-body-extra-small;
-						color: var(--studio-blue-50);
+
+						&.add {
+							color: var(--studio-blue-50);
+						}
+
+						&.replace {
+							color: var(--studio-gray-60);
+
+							&:hover {
+								color: var(--studio-blue-50);
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**Before**

https://user-images.githubusercontent.com/7000684/190665700-f51472dd-6084-468b-b879-e1ceeaa3a132.mov

**After**

https://user-images.githubusercontent.com/7000684/190665810-b63e7f55-83d2-4ca4-8c3c-ac814d1c0096.mov

#### Proposed Changes

* This PR makes the avatar image clickable and opens the image editing tool on click

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Open the newsletter or link in bio flow
- Upload an image for the site
- Click on the image 
- The image editing tool should show

**Verify that**
- Changes done in the editing tool should reflect after clicking 'Done'
- Clicking 'Cancel' should revert the temporary changes and close the tool.
- Clicking 'Cancel' should remove the image if it's the [first time the tool is shown](p1663236502431819-slack-C02T4NVL4JJ). 
- Dropping of files should work as it did

Related to #67668