### PR TITLE
Emails: fix styles of monthly/annually switcher

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -19,7 +19,7 @@
 	.billing-interval-toggle {
 		display: flex;
 
-		.segmented-control {
+		.segmented-control.is-primary {
 			background-color: var(--studio-gray-0);
 			border: 1px solid var(--studio-gray-5);
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
@@ -35,8 +35,8 @@
 				border: 1px solid var(--studio-gray-0);
 				padding: 2px;
 
-				&.is-selected {
-					padding: 1px 0 0 1px;
+				.segmented-control__link .segmented-control__text span {
+					padding: 6px 9px;
 				}
 
 				&:hover:not(.is-selected) {
@@ -50,9 +50,6 @@
 				& .segmented-control__link {
 					color: var(--color-text);
 					border: 0;
-					line-height: 18px;
-					margin: 1px;
-					padding-bottom: 6px;
 					&:hover {
 						background-color: unset;
 					}
@@ -67,9 +64,9 @@
 						0 3px 8px rgba(0, 0, 0, 0.12),
 						inset 0 0 0 rgba(0, 0, 0, 0.2);
 					color: var(--color-text);
-					padding-top: 6px;
 
-					&:hover {
+					&:hover,
+					&:focus {
 						background-color: var(--studio-white);
 					}
 				}


### PR DESCRIPTION
#### Proposed Changes
Previously in [this PR](https://github.com/Automattic/wp-calypso/pull/67036) I made changes to switcher styles on the "Email Comparison" page, but haven't noticed that the same switcher is used for the "Email Upsell" page, but with overridden styles, so I broke it :(

This PR fixes the instance of the switcher on the "Email Upsell" page.


#### Testing Instructions
* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* Click on "Add new site" at the end of the appeared list
* Enter any domain name for test purposes
* In the appeared list below - choose a domain with the help of the "Select" button
* Choose any plan from the proposed with the help of the "Select" button
* Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
* On the "Email Upsell" page click on "Pay Monthly"


<table>
<tr>
	<td> BEFORE
	<td> AFTER
<tr>
	<td> <img width="511" alt="Screenshot 2022-09-15 at 11 28 58" src="https://user-images.githubusercontent.com/5598437/190381457-33f02ee6-e502-45fe-8b11-e4f5a1210844.png">
	<td> <img width="446" alt="Screenshot 2022-09-15 at 11 29 22" src="https://user-images.githubusercontent.com/5598437/190381526-9cb2cd7c-43bc-4256-b23f-e1cb1e5e73b5.png">
</table>


#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202916437620574/f