### PR TITLE
Show percentage process during backup

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
@@ -50,6 +50,7 @@ const BackupInProgress: React.FC< Props > = ( { percent, inProgressDate, lastBac
 				) }
 			</p>
 
+			<p className="backup__progress-bar-percent">{ percent }%</p>
 			<ProgressBar value={ percent } total={ 100 } />
 
 			{ siteLastBackupDate && (

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -245,3 +245,12 @@
 	display: grid;
 	grid-auto-flow: column;
 }
+
+.backup__progress-bar-percent {
+	font-weight: 600;
+	line-height: 24px;
+	text-align: right;
+	color: #23282d;
+	margin-bottom: 0;
+}
+


### PR DESCRIPTION
#### Proposed Changes

* This change adds the percentage of progress when a backup is running

#### Testing Instructions

You need to check that now there is a value when a backup is running


![progress_percentage_1](https://user-images.githubusercontent.com/2747834/190436921-77113fac-bcba-4d90-8c08-5914c35a458c.png)


![progress_percentage_2](https://user-images.githubusercontent.com/2747834/190436396-2abffeef-5319-4e54-a99d-2ab6017b842f.png)


