### PR TITLE
Pricing page rework: Add lightbox entrance transition.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -8,7 +8,10 @@
 	font-family: Inter, $sans;
 	max-width: 1080px;
 	max-height: 100%;
-	transform: translateY(20px);
+
+	@media ( prefers-reduced-motion: no-preference ) {
+		transform: translateY(20px);
+	}
 
 	&.ReactModal__Content--after-open {
 		transform: translateY(0);

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -4,7 +4,7 @@
 	width: 85%;
 	height: auto;
 	background-color: #fff;
-	transition: all 0.35s ease-out;
+	transition: all 0.25s ease;
 	font-family: Inter, $sans;
 	max-width: 1080px;
 	max-height: 100%;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -8,6 +8,11 @@
 	font-family: Inter, $sans;
 	max-width: 1080px;
 	max-height: 100%;
+	transform: translateY(20px);
+
+	&.ReactModal__Content--after-open {
+		transform: translateY(0);
+	}
 
 	p {
 		margin-bottom: 0.5rem;
@@ -303,7 +308,6 @@
 	}
 }
 
-
 .product-lightbox__variants-grey-label {
 	font-size: 0.75rem;
 	color: #646970;
@@ -323,7 +327,6 @@
 		color: #646970;
 	}
 }
-
 
 @media screen and ( max-width: 768px ) and ( orientation: portrait ) {
 	.product-lightbox__modal {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -4,7 +4,7 @@
 	width: 85%;
 	height: auto;
 	background-color: #fff;
-	transition: all 0.2s ease-out;
+	transition: all 0.35s ease-out;
 	font-family: Inter, $sans;
 	max-width: 1080px;
 	max-height: 100%;
@@ -27,7 +27,7 @@
 }
 
 .product-lightbox__modal-overlay {
-	background-color: rgb(0 0 0 / 70%);
+	background-color: transparent;
 	align-items: center;
 	display: flex;
 	justify-content: center;
@@ -36,9 +36,13 @@
 	bottom: 0;
 	right: 0;
 	left: 0;
-	transition: background-color 0.2s ease-in;
+	transition: background-color 0.35s ease-out;
 	z-index: 100200;
 	box-sizing: border-box;
+
+	&.ReactModal__Overlay--after-open {
+		background-color: rgb(0 0 0 / 70%);
+	}
 }
 
 .product-lightbox__content-wrapper {


### PR DESCRIPTION
#### Proposed Changes

This PR add an entrance transition to the product lighbox/dialog. (See screen capture)

https://user-images.githubusercontent.com/11078128/190451027-2a335e69-49ff-4503-87ff-2a34df046f0c.mp4

Completes task: 1202796695664022-as-1202979860928332

#### Testing Instructions

- Do any one of these:
    * Click on **Jetpack Cloud Live** link below and add this to the end of URL `?flags=jetpack/pricing-page-rework-v1`
    * or spin up this PR 
        * Run `git fetch && git checkout update/lightbox-entrance-transition`
        * Run `yarn start-jetpack-cloud`
        * Goto `http://jetpack.cloud.localhost:3000/pricing/?flags=jetpack/pricing-page-rework-v1`
- Click on the "More about [product_name]" links for all the products/bundles (except not CRM Entrepreneur)
- Verify the lightbox/dialog opens with a small transition, easing the lightbox upwards when it opens.
- Enable your "**Reduce Motion**" OS accessibility preference:
    * On your Mac, choose Apple menu > System Preferences > Accessibility , then click Display. Select **Reduce motion**.
    * On Windows, go to Settings > Ease of Access > Display > Show animations in Windows > Toggle the _animated visual effects_ **off**.
- Reload the pricing page. then open any lightbox and verify that the lightbox entrance animation os no longer occurring.
- Bonus points for testing in the Calypso green environment also, (Although the lightbox code & styles are the same for both environments).

#### Pre-merge Checklist

Only CSS/SCSS changes were made. The checklist is N/A.
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202979860928332