### PR TITLE
Site Switcher: Prevent empty state from being shown when add new site button is clicked 

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -279,17 +279,18 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
-		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
+		const refParameter = query && query.ref;
+		// If the flow has siteId or siteSlug as query dependencies or is initiated from calypso site selector, we should not clear selected site id
 		if (
 			! providesDependenciesInQuery?.includes( 'siteId' ) &&
 			! providesDependenciesInQuery?.includes( 'siteSlug' ) &&
+			'calypso-selector' !== refParameter &&
 			! isManageSiteFlow
 		) {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 
 		// Set referral parameter in signup dependency store so we can retrieve it in getSignupDestination().
-		const refParameter = query && query.ref;
 		if ( refParameter ) {
 			context.store.dispatch( updateDependencies( { refParameter } ) );
 		}


### PR DESCRIPTION
#### Proposed Changes
Empty state is shown because the signup controller sets the global siteId to null.
* This PR adds a check to see if `add new site` was initiated from site switcher using the `ref=calypso-selector` and does not set the siteId to null if that's the case.

**Note:** The navigation to domain page is not always instant because the page is loaded async which results in a slightly visible wait time.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to site switcher and click `Add new site`
* Verify an empty state page is not shown and we are redirected to `start/domains` page

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67497
