### PR TITLE
SMP: Fix sites thumbnail flickering

### DIFF
--- a/packages/components/src/site-thumbnail/style.scss
+++ b/packages/components/src/site-thumbnail/style.scss
@@ -21,21 +21,17 @@
 	background-position: center;
 	background-size: cover;
 	background-repeat: no-repeat;
-
 	width: 150%;
 	height: 150%;
+	will-change: opacity;
 }
 
 .site-thumbnail__image-blur-small {
 	filter: blur(50px);
-	// this transformation improves the Safari performance
-	transform: translate3d(0, 0, 0);
 }
 
 .site-thumbnail__image-blur-medium {
 	filter: blur(150px);
-	// this transformation improves the Safari performance
-	transform: translate3d(0, 0, 0);
 }
 
 .site-thumbnail-visible {


### PR DESCRIPTION
#### Proposed Changes
CSS property` transform: translate3d(0,0,0) ` was introduced [here](https://github.com/Automattic/wp-calypso/pull/67205) to for GPU rendering for safari optimisation, this however caused thumbnail image to flicker on chrome.

https://user-images.githubusercontent.com/47489215/190507891-a8d802ca-ede1-458d-9999-ff2c033cfcf8.mov


* This PR uses the `will-change` property instead to force browser optimisation so there will be no flicker and safari will render properly also.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to` /sites` 
* Verify there is no longer any flicker when the page loads
* Verify on Safari that` /sites `is still performant and regression from [here](https://github.com/Automattic/wp-calypso/pull/67205) is not introduced.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67750
