### PR TITLE
Pattern Assembler - Fix footer alignment to bottom in the preview

### DIFF
--- a/client/components/web-preview/README.md
+++ b/client/components/web-preview/README.md
@@ -47,3 +47,7 @@ const isPreviewable = isSitePreviewable( state, siteId );
 ```
 
 [function-as-children]: https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9
+
+
+### Features
+See the descriptions in the `WebPreviewContent.propTypes` of [content.jsx](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/web-preview/content.jsx).

--- a/client/components/web-preview/README.md
+++ b/client/components/web-preview/README.md
@@ -46,8 +46,7 @@ const isPreviewable = isSitePreviewable( state, siteId );
 </WithPreviewProps>;
 ```
 
-[function-as-children]: https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9
-
-
 ### Features
 See the descriptions in the `WebPreviewContent.propTypes` of [content.jsx](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/web-preview/content.jsx).
+
+[function-as-children]: https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9

--- a/client/components/web-preview/README.md
+++ b/client/components/web-preview/README.md
@@ -46,7 +46,4 @@ const isPreviewable = isSitePreviewable( state, siteId );
 </WithPreviewProps>;
 ```
 
-### Features
-See the descriptions in the `WebPreviewContent.propTypes` of [content.jsx](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/web-preview/content.jsx).
-
 [function-as-children]: https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -94,7 +94,7 @@ export default class WebPreviewContent extends Component {
 			}
 		}
 
-		if ( ! prevState.loaded && loaded ) {
+		if ( inlineCss && ! prevState.loaded && loaded ) {
 			this.iframe.contentWindow?.postMessage(
 				{
 					channel: `preview-${ this.previewId }`,

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -63,8 +63,9 @@ export default class WebPreviewContent extends Component {
 		this.unsubscribeMobileBreakpoint();
 	}
 
-	componentDidUpdate( prevProps ) {
-		const { previewUrl } = this.props;
+	componentDidUpdate( prevProps, prevState ) {
+		const { previewUrl, inlineCss } = this.props;
+		const { loaded } = this.state;
 
 		this.setIframeUrl( previewUrl );
 
@@ -91,6 +92,17 @@ export default class WebPreviewContent extends Component {
 				this.resetResize();
 				window.removeEventListener( 'resize', this.handleResize );
 			}
+		}
+
+		if ( ! prevState.loaded && loaded ) {
+			this.iframe.contentWindow?.postMessage(
+				{
+					channel: `preview-${ this.previewId }`,
+					type: 'inline-css',
+					inline_css: inlineCss,
+				},
+				'*'
+			);
 		}
 	}
 
@@ -472,6 +484,8 @@ WebPreviewContent.propTypes = {
 	isStickyToolbar: PropTypes.bool,
 	// Fixes the viewport width of the iframe if provided.
 	fixedViewportWidth: PropTypes.number,
+	// Injects CSS in the iframe after the content is loaded.
+	inlineCss: PropTypes.string,
 };
 
 WebPreviewContent.defaultProps = {
@@ -495,4 +509,5 @@ WebPreviewContent.defaultProps = {
 	overridePost: null,
 	toolbarComponent: Toolbar,
 	autoHeight: false,
+	inlineCss: null,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -16,6 +16,16 @@ import type { Pattern } from './types';
 import type { Design } from '@automattic/design-picker';
 import './pattern-assembler-preview.scss';
 
+const inlineCss = `
+	.site-footer-container {
+		margin-block-start: auto !important;
+	}
+
+	.wp-site-blocks {
+		min-height: 100vh;
+	}
+`;
+
 interface Props {
 	header: Pattern | null;
 	sections?: Pattern[];
@@ -90,6 +100,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 				url={ site?.URL }
 				translate={ translate }
 				recordTracksEvent={ recordTracksEvent }
+				inlineCss={ inlineCss }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -21,9 +21,6 @@ const inlineCss = `
 	.site-footer-container {
 		margin-block-start: auto;
 	}
-	.wp-site-blocks {
-		min-height: 100vh;
-	}
 `;
 
 interface Props {
@@ -88,6 +85,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 					hasSelectedPatterns
 						? getDesignPreviewUrl( mergedDesign, {
 								language: locale,
+								disable_viewport_height: true,
 						  } )
 						: 'about:blank'
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -16,13 +16,6 @@ import type { Pattern } from './types';
 import type { Design } from '@automattic/design-picker';
 import './pattern-assembler-preview.scss';
 
-// Footer alignment
-const inlineCss = `
-	.site-footer-container {
-		margin-block-start: auto;
-	}
-`;
-
 interface Props {
 	header: Pattern | null;
 	sections?: Pattern[];
@@ -98,7 +91,6 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 				url={ site?.URL }
 				translate={ translate }
 				recordTracksEvent={ recordTracksEvent }
-				inlineCss={ inlineCss }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -18,7 +18,7 @@ import './pattern-assembler-preview.scss';
 
 const inlineCss = `
 	.site-footer-container {
-		margin-block-start: auto !important;
+		margin-block-start: auto;
 	}
 
 	.wp-site-blocks {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -16,11 +16,11 @@ import type { Pattern } from './types';
 import type { Design } from '@automattic/design-picker';
 import './pattern-assembler-preview.scss';
 
+// Footer alignment
 const inlineCss = `
 	.site-footer-container {
 		margin-block-start: auto;
 	}
-
 	.wp-site-blocks {
 		min-height: 100vh;
 	}

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -119,6 +119,7 @@ export interface DesignPreviewOptions {
 	viewport_width?: number;
 	viewport_height?: number;
 	use_screenshot_overrides?: boolean;
+	disable_viewport_height?: boolean;
 }
 
 /** @deprecated used for Gutenboarding (/new flow) */

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -29,7 +29,9 @@ export const getDesignPreviewUrl = (
 		vertical_id: options.vertical_id,
 		language: options.language,
 		...( options.viewport_width && { viewport_width: options.viewport_width } ),
-		viewport_height: options.viewport_height || DEFAULT_VIEWPORT_HEIGHT,
+		viewport_height: ! options.disable_viewport_height
+			? options.viewport_height || DEFAULT_VIEWPORT_HEIGHT
+			: undefined,
 		source_site: 'patternboilerplates.wordpress.com',
 		use_screenshot_overrides: options.use_screenshot_overrides,
 	} );


### PR DESCRIPTION
#### Proposed Changes

* Add support for the prop `inlineCss` in `<WebPreview>`
* Add styles to fix the footer position

#### Testing Instructions

- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain
- Select Write & Publish in the goals screen
- Select the category `Show all` in the Design picker screen
- Click on the Blank Canvas CTA
- Add a footer only, and a footer with content to check that the footer is always aligned to the bottom of the preview
<img width="1015" alt="Screen Shot 2565-09-16 at 12 01 15" src="https://user-images.githubusercontent.com/1881481/190560335-8b997397-b7f0-4548-917a-97dc79a9c5a0.png">

<img width="1027" alt="Screen Shot 2565-09-16 at 12 01 56" src="https://user-images.githubusercontent.com/1881481/190560330-4ff7931f-d967-42aa-a67b-f6a029772320.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67883
