### PR TITLE
Setup Flow: Send exception to sentry

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -237,15 +237,20 @@ const configureReduxStore = ( currentUser, reduxStore ) => {
 	}
 };
 
-function setupErrorLogger( reduxStore ) {
+export function setupErrorLogger( reduxStore ) {
 	// Add a bit of metadata from the redux store to the sentry event.
 	const beforeSend = ( event ) => {
 		const state = reduxStore.getState();
-		if ( ! event.tags ) {
-			event.tags = {};
-		}
-		event.tags.blog_id = getSelectedSiteId( state );
-		event.tags.calypso_section = getSectionName( state );
+		const tags = {
+			blog_id: getSelectedSiteId( state ),
+			calypso_section: getSectionName( state ),
+		};
+
+		event.tags = {
+			...tags,
+			...event.tags,
+		};
+
 		return event;
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -6,6 +6,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useInterval } from 'calypso/lib/interval';
+import useCaptureFlowException from '../../../../hooks/use-capture-flow-exception';
 import { useProcessingLoadingMessages } from './hooks/use-processing-loading-messages';
 import type { Step } from '../../types';
 import './style.scss';
@@ -39,6 +40,8 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 		return progressTitle || loadingMessages[ currentMessageIndex ]?.title;
 	};
 
+	const captureFlowException = useCaptureFlowException( 'ProcessingStep' );
+
 	useEffect( () => {
 		( async () => {
 			if ( typeof action === 'function' ) {
@@ -54,6 +57,7 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 				} catch ( e ) {
 					// eslint-disable-next-line no-console
 					console.error( 'ProcessingStep failed:', e );
+					captureFlowException( e );
 					submit?.( {}, ProcessingResult.FAILURE );
 				}
 			} else {

--- a/client/landing/stepper/hooks/use-capture-flow-exception.ts
+++ b/client/landing/stepper/hooks/use-capture-flow-exception.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { captureException } from 'calypso/lib/sentry';
+import { useFlowParam } from './use-flow-param';
+import { useIntent } from './use-intent';
+import { useSite } from './use-site';
+
+const useCaptureFlowException = ( stepName: string ) => {
+	const flow = useFlowParam() || 'default';
+	const intent = useIntent() || null;
+	const site = useSite();
+
+	return useCallback(
+		( error: any ) => {
+			captureException( error, {
+				tags: {
+					blog_id: site?.ID || null,
+					calypso_section: 'setup',
+					flow,
+					intent,
+					stepName,
+				},
+			} );
+		},
+		[ flow, intent, site ]
+	);
+};
+
+export default useCaptureFlowException;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
+import { setupErrorLogger } from 'calypso/boot/common';
 import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
@@ -127,6 +128,8 @@ window.AppBoot = async () => {
 	setupLocale( user, reduxStore );
 
 	user && initializeCalypsoUserStore( reduxStore, user as CurrentUser );
+
+	setupErrorLogger( reduxStore );
 
 	ReactDom.render(
 		<CalypsoI18nProvider i18n={ defaultCalypsoI18n }>


### PR DESCRIPTION
#### Proposed Changes

* I thought it's a critical issue if customers encounter any error and they cannot complete the setup flow. As a result, I made a change to send exceptions to sentry once customers cannot finish their onboarding flow. Any thoughts?

See p4TIVU-9Ww-p2 and p4TIVU-a8b-p2 for more details about sentry.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Block the network request to `/wpcom/v2/sites/<your_site>/theme-setup` to simulate error
* Go to `/setup/designSetup?siteSlug=<your_site>&flags=catch-js-errors`
* Select any design and continue
* When you see the following screenshot, check whether your browser sends a request to the sentry (Note that not every error would be sent to sentry, so we might need to try it multiple times)
  ![image](https://user-images.githubusercontent.com/13596067/190560283-c4f4479c-bce2-4345-ae4d-b3333c999fd5.png)
* Go to sentry and you have to see the issue like below
  ![image](https://user-images.githubusercontent.com/13596067/190560683-56f3d953-102f-4774-a720-c73e44532509.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #