### PR TITLE
Pattern Assembler - Review texts and translations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -53,7 +53,7 @@ const PatternActionBar = ( {
 			<Button
 				className="pattern-action-bar__block pattern-action-bar__action"
 				role="menuitem"
-				label="Replace"
+				label={ translate( 'Replace' ) }
 				onClick={ onReplace }
 				icon={ edit }
 				iconSize={ 20 }
@@ -61,7 +61,7 @@ const PatternActionBar = ( {
 			<Button
 				className="pattern-action-bar__block pattern-action-bar__action"
 				role="menuitem"
-				label="Delete"
+				label={ translate( 'Delete' ) }
 				onClick={ onDelete }
 				icon={ closeSmall }
 				iconSize={ 23 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -65,7 +65,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 						) }
 					>
 						{ ! hasSelectedPatterns && (
-							<span>{ translate( 'Your page is blank. Start adding content on the left' ) }</span>
+							<span>{ translate( 'Your page is blank. Start adding content on the left.' ) }</span>
 						) }
 					</div>,
 					webPreviewFrameContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -38,7 +38,11 @@ const PatternLayout = ( {
 		<div className="pattern-layout">
 			<div className="pattern-layout__header">
 				<h2>{ translate( 'Design your page' ) }</h2>
-				<p>{ translate( 'Kick start the content on your page by picking patterns.' ) }</p>
+				<p>
+					{ translate(
+						'Kick start the content on your page by picking your patterns. First choose a header for your page layout, then choose at least one section pattern, and finally choose your footer.'
+					) }
+				</p>
 			</div>
 			<div className="pattern-layout__body">
 				<ul>

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -22,7 +22,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 				) }
 			</p>
 			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>
-				{ translate( 'Get Started' ) }
+				{ translate( 'Get started' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

* in the Blank Canvas CTA, use `Get started` instead of `Get Started`
* in the preview, add a period to `Your page is blank. Start adding content on the left`
* in the pattern action bar, translate the tooltips `Delete` and `Replace`

#### Testing Instructions

- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain
- Select Write & Publish in the goals screen
- Select the category `Show all` in the Design picker screen
- On the Blank Canvas CTA, check that button text is `Get started`
- Click on Blank Canvas CTA and check that the text in the preview has a period `Your page is blank. Start adding content on the left.`
- Add a pattern, hover the pattern name and check the button tooltips for `Replace` and `Delete`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67884
