### PR TITLE
Don't disable Add new mailboxes button for email forwards

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -12,6 +12,7 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
@@ -94,9 +95,11 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	);
 	const currentRoute = useSelector( getCurrentRoute );
 
+	const domainIsNotProvisioning = getGSuiteProductSlug( domain ) || getTitanProductSlug( domain );
+	const isAwaitingGoogleTosAcceptance = getGSuiteSubscriptionStatus( domain ) === 'suspended';
 	const canAddMailboxes =
-		( getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) ) &&
-		getGSuiteSubscriptionStatus( domain ) !== 'suspended' &&
+		( domainIsNotProvisioning || hasEmailForwards( domain ) ) &&
+		! isAwaitingGoogleTosAcceptance &&
 		canCurrentUserAddEmail( domain );
 	const hasSubscription = hasEmailSubscription( domain );
 


### PR DESCRIPTION
#### Proposed Changes

Fixes a regression where the `Add new mailboxes` button would be disabled for domains with email forwarding.

The logic behind `canAddMailboxes` is surprisingly complex, so I tried to clarify it with this PR. In #62556, we introduced this variable as a means to disable the `Add new mailboxes` button if the email subscription is currently provisioning. In #63864, we amended logic that disables the button if a Google subscription is awaiting ToS acceptance. In #64322, we added logic that also looks at the `domain.currentUserCanAddEmail` property. And then in the recent #67717, we disabled all instances of the `Add new mailboxes` button if `canAddMailboxes` is falsy, failing to realize that this would impact domains with email forwarding.

#### Testing Instructions

**Email forwarding** is the critical thing to test, but we should test with all types of email subscriptions.

1. Have a domain with email forwarding
2. Go to `/email/:domain/manage/:site_slug`
3. Ensure that the `Add new mailboxes` button is clickable

**Professional Email**

1. Have a domain with Professional email
2. Go to `/email/:domain/manage/:site_slug`
3. Ensure that the `Add new mailboxes` button is clickable

**Google**

1. Have a domain with Google Workspace
2. Go to `/email/:domain/manage/:site_slug`
3. Ensure that the `Add new mailboxes` button is clickable

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
