### PR TITLE
Add className on body to target VideoPress stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -3,7 +3,7 @@
 $videopress-theme-base-text-color: #fff;
 $videopress-theme-yellow: #ffe61c;
 
-body {
+body.is-videopress-stepper {
 	background-color: #010101;
 	color: $videopress-theme-base-text-color;
 

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -28,6 +28,11 @@ export const videopress: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
+		// Make sure we only target videopress stepper for body css
+		if ( document.body && ! document.body.classList.contains( 'is-videopress-stepper' ) ) {
+			document.body.classList.add( 'is-videopress-stepper' );
+		}
+
 		const name = this.name;
 		const { setStepProgress, setSiteTitle, setSiteDescription } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );


### PR DESCRIPTION
#### Proposed Changes

This PR adds a class name to the body so we could theme the VideoPress stepper properly without affecting other steppers.

#### Testing Instructions

* Apply patch
* Go to http://calypso.localhost:3000/setup/intro?flow=videopress
* ✅ The background should be black
* ✅ An "is-videopress-stepper" class should be on the body element
* Go to http://calypso.localhost:3000/setup/intro?flow=newsletter
* ✅ The background shouldn't be black
* ✅ No "is-videopress-stepper" class should be on the body element

