### PR TITLE
Help Center: use defined breakpoint to detect if mobile and fix `sectionName` typo

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -79,9 +79,8 @@ function SidebarScrollSynchronizer() {
 
 function HelpCenterLoader( { sectionName, loadHelpCenter } ) {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
-	const isDesktop = useBreakpoint( '>760px' );
+	const isDesktop = useBreakpoint( '>782px' );
 
-	// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
 	if ( ! loadHelpCenter ) {
 		return null;
 	}
@@ -93,6 +92,7 @@ function HelpCenterLoader( { sectionName, loadHelpCenter } ) {
 			handleClose={ () => {
 				setShowHelpCenter( false );
 			} }
+			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
 			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
 		/>
 	);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -253,7 +253,10 @@ class Layout extends Component {
 
 		return (
 			<div className={ sectionClass }>
-				<HelpCenterLoader sectionName={ this.props.sectioName } loadHelpCenter={ loadHelpCenter } />
+				<HelpCenterLoader
+					sectionName={ this.props.sectionName }
+					loadHelpCenter={ loadHelpCenter }
+				/>
 				<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />
 				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<BodySectionCssClass


### PR DESCRIPTION
#### Proposed Changes

* This fixes a typo on passing `sectionName`.
* Addresses this [comment](https://github.com/Automattic/wp-calypso/pull/66407#discussion_r972610592). 

#### Testing Instructions

1. Go to any page in Calypso except My Home. Posts would work well.
2. Open the Help Center.
3. Click "Add new" to go to the editor.
4. The help center should disappear. 
5. Don't worry, if you have a chat session, the help center will pop back up in the editor.