### PR TITLE
Issue 691: update cancel dialog copy text

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -66,12 +66,12 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const cancelDialogButtons = [
 		{
 			action: 'cancel',
-			label: __( 'No' ),
+			isPrimary: true,
+			label: __( 'No, let me finish' ),
 		},
 		{
 			action: 'close',
-			isPrimary: true,
-			label: __( 'Yes, cancel' ),
+			label: __( 'Yes, quit' ),
 			onClick: async () => {
 				setShowCancelDialog( false );
 				onClose();
@@ -111,12 +111,8 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 							buttons={ cancelDialogButtons }
 							onClose={ () => setShowCancelDialog( false ) }
 						>
-							<h1>{ __( 'Cancel the campaign' ) }</h1>
-							<p>
-								{ __(
-									'If you cancel now, you will lose any progress you have made. Are you sure you want to cancel?'
-								) }
-							</p>
+							<h1>{ __( 'Are you sure you want to quit?' ) }</h1>
+							<p>{ __( 'All progress in this session will be lost.' ) }</p>
 						</Dialog>
 						{ isLoading && <LoadingEllipsis /> }
 						<div className={ 'blazepress-widget__widget-container' } ref={ widgetContainer }></div>


### PR DESCRIPTION
#### Proposed Changes

Minor changes on copy texts according to [this ticket](https://github.tumblr.net/Tumblr/wordads-picard/issues/691)

before version 
![Screenshot 2022-09-16 at 12 21 25](https://user-images.githubusercontent.com/1416426/190604182-c5152136-14d7-477c-a500-fa74d2447739.png)

updated version 
![Screenshot 2022-09-16 at 12 21 00](https://user-images.githubusercontent.com/1416426/190604220-73aa271f-5159-47f8-8d5f-3aa3f67cea78.png)

#### Testing Instructions
Just checkout this branch and check the texts (and functionality of the buttons, even though functionality wasnt changed)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
