### PR TITLE
Launchpad: Create translations unit tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getLaunchpadTranslations } from '../translations';
+
+describe( 'Translations', () => {
+	describe( 'getLaunchpadTranslations', () => {
+		describe( 'when using a tailored onboarding flow', () => {
+			it( 'provides flow specific text', () => {
+				const newsletterTranslations = getLaunchpadTranslations( 'newsletter' );
+				expect( newsletterTranslations.flowName ).toEqual( 'Newsletter' );
+				expect( newsletterTranslations.sidebarTitle ).toEqual(
+					'Your Newsletter is ready to launch!'
+				);
+
+				const linkInBioTranslations = getLaunchpadTranslations( 'link-in-bio' );
+				expect( linkInBioTranslations.flowName ).toEqual( 'Link in Bio' );
+				expect( linkInBioTranslations.sidebarTitle ).toEqual(
+					'Your Link in Bio is ready to launch!'
+				);
+			} );
+		} );
+
+		describe( 'when no flow is specified', () => {
+			it( 'provides generic text', () => {
+				const translations = getLaunchpadTranslations( null );
+				expect( translations.flowName ).toEqual( 'WordPress' );
+				expect( translations.sidebarTitle ).toEqual( 'Your website is ready to launch!' );
+				expect( translations.sidebarSubtitle ).toEqual(
+					'Keep up the momentum with these final steps.'
+				);
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Add unit testing for launchpad translation helpers

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn test-client launchpad/test/translations`
* Verify that unit tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67824
