### PR TITLE
Fix text for receipt quantity

### DIFF
--- a/client/me/purchases/billing-history/utils.jsx
+++ b/client/me/purchases/billing-history/utils.jsx
@@ -1,4 +1,9 @@
-import { getPlanTermLabel, isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
+import {
+	getPlanTermLabel,
+	isDIFMProduct,
+	isGoogleWorkspace,
+	isTitanMail,
+} from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { find, map, partition, reduce, some } from 'lodash';
 import { Fragment } from 'react';
@@ -109,6 +114,18 @@ function renderTransactionQuantitySummaryForMailboxes(
 	} );
 }
 
+function renderDIFMTransactionQuantitySummary( licensed_quantity, translate ) {
+	return translate(
+		'One-time fee includes %(quantity)d page',
+		'One-time fee includes %(quantity)d pages',
+		{
+			args: { quantity: licensed_quantity },
+			count: licensed_quantity,
+			comment: '%(quantity)d is number of pages included in the purchase of the DIFM service',
+		}
+	);
+}
+
 export function renderTransactionQuantitySummary(
 	{ licensed_quantity, new_quantity, type, wpcom_product_slug },
 	translate
@@ -131,6 +148,10 @@ export function renderTransactionQuantitySummary(
 			isUpgrade,
 			translate
 		);
+	}
+
+	if ( isDIFMProduct( product ) ) {
+		return renderDIFMTransactionQuantitySummary( licensed_quantity, translate );
 	}
 
 	if ( isRenewal ) {


### PR DESCRIPTION
#### Proposed Changes

Changes text in the reciept for DIFM to below
<img width="758" alt="image" src="https://user-images.githubusercontent.com/3422709/190619138-63ce3443-91b5-4925-8b93-e86516cfa3fb.png">


#### Testing Instructions

- Go to /start/do-it-for-me
- Complete a purchase with more than 5 pages.
- Go to the link`/purchases/billing-history/<site-slug>` And select the difm purchase and check the reciept
- The text for additional pages should show as above.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
