### PR TITLE
Limiting Global Styles: Override global styles for free sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/README.md
@@ -5,3 +5,4 @@ Functionality that limits the Global Styles feature on WordPress.com sites to pa
 ## Highlights
 
 - The site editor displays a modal after opening the Global Styles panel to alert customers that it is a paid feature.
+- When the site's plan isn't a paid plan we will override the Global Styles loaded and will return the default Global Styles for the active theme.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -130,7 +130,7 @@ function wpcom_global_styles_override_for_free_site( $blog_id = 0 ) {
 	}
 
 	// If the site does not meet the required criteria we override Global Styles with the free version of global styles.
-	if ( ! wpcom_should_limit_global_styles( $blog_id ) ) {
+	if ( wpcom_should_limit_global_styles( $blog_id ) ) {
 		global $wp_styles;
 		$wp_styles->add_data( 'global-styles', 'after', array( wpcom_get_free_global_stylesheet() ) );
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -76,4 +76,65 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles.css' )
 	);
 }
+
+/**
+ * Returns the stylesheet resulting of merging core and theme data.
+ *
+ * @return string Stylesheet.
+ */
+function wpcom_get_free_global_stylesheet() {
+	// Return cached value if it can be used and exists.
+	$can_use_cached = ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG )
+		&& ( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG )
+		&& ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST )
+		&& ! is_admin();
+
+	$transient_name = 'wpcom_free_global_styles_' . get_stylesheet();
+	if ( $can_use_cached ) {
+		$cached = get_transient( $transient_name );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+
+	$tree = new WP_Theme_JSON_Gutenberg();
+
+	// Merge theme and core data.
+	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_theme_data() );
+	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_core_data() );
+
+	// Generate the default spacing sizes presets.
+	$tree->set_spacing_sizes();
+
+	// We only get the stylesheet for variables and styles of the theme.
+	$stylesheet = $tree->get_stylesheet( array( 'variables', 'styles' ), array( 'theme' ) );
+
+	if ( $can_use_cached ) {
+		// This cache can be long since it only applies to customers that can't load global styles.
+		// Once the customer is on a paid plan this code isn't executed and will use the default
+		// Gutenberg global styles loading mechanism instead.
+		set_transient( $transient_name, $stylesheet, DAY_IN_SECONDS );
+	}
+
+	return $stylesheet;
+}
+
+/**
+ * De-queues Global Styles if the given site is on a free plan.
+ *
+ * @param  int $blog_id Blog ID.
+ */
+function wpcom_global_styles_override_for_free_site( $blog_id = 0 ) {
+	if ( ! $blog_id ) {
+		$blog_id = get_current_blog_id();
+	}
+
+	// If the site does not meet the required criteria we override Global Styles with the free version of global styles.
+	if ( ! wpcom_should_limit_global_styles( $blog_id ) ) {
+		global $wp_styles;
+		$wp_styles->add_data( 'global-styles', 'after', array( wpcom_get_free_global_stylesheet() ) );
+	}
+}
+
+add_action( 'wp_print_styles', 'wpcom_global_styles_override_for_free_site' );
 add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_and_styles' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -76,6 +76,7 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles.css' )
 	);
 }
+add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_and_styles' );
 
 /**
  * Returns the stylesheet resulting of merging core and theme data.
@@ -135,6 +136,4 @@ function wpcom_global_styles_override_for_free_site( $blog_id = 0 ) {
 		$wp_styles->add_data( 'global-styles', 'after', array( wpcom_get_free_global_stylesheet() ) );
 	}
 }
-
 add_action( 'wp_print_styles', 'wpcom_global_styles_override_for_free_site' );
-add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_and_styles' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -113,7 +113,7 @@ function wpcom_get_free_global_stylesheet() {
 		// This cache can be long since it only applies to customers that can't load global styles.
 		// Once the customer is on a paid plan this code isn't executed and will use the default
 		// Gutenberg global styles loading mechanism instead.
-		set_transient( $transient_name, $stylesheet, DAY_IN_SECONDS );
+		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
 	}
 
 	return $stylesheet;


### PR DESCRIPTION
#### Proposed Changes
Fixes 827-gh-Automattic/dotcom-forge
* We will register an action for the hook `wp_print_styles` hook. When the action gets executed we check if we should override Global Styles for the current site and display the FREE Global Styles instead of PREMIUM Global Styles.

#### Testing Instructions
##### Basic testing
1. Create a new free simple site.
2. In your sandbox run: install-plugin.sh editing-toolkit add/override-global-styles-for-free-sites
3. Open the site editor and apply some Global Styles.
4. Visit the site, global styles should be applied.
5. Add the `wpcom-limit-global-styles` blog sticker to the new site: `add_blog_sticker( 'wpcom-limit-global-styles', 'test', <YOUR_USERNAME>, <YOUR_BLOG_ID>)` and repeat steps 3 & 4.
6. You should now see the FREE Global Styles instead of the PREMIUM Global Styles.
7. Upgrade your site to a PAID plan and repeat steps 3 & 4.
8. You should now see the PREMIUM Global Styles configured.

##### Style testing
Here we want to make sure that all the possible style variations that we can configure don't show up on the user-facing site if the user is gated. I've tested some of them myself.

#### Test evidence

https://user-images.githubusercontent.com/1989914/190630672-6a364dca-39ff-4c31-8b94-fe4ed36aee32.mp4

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 827-gh-Automattic/dotcom-forge