### PR TITLE
Jetpack New Pricing Page - Increase lightbox font from 0.875rem to 1rem  

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -164,7 +164,7 @@
 
 	.foldable-card__header {
 		min-height: 0;
-		font-size: 1rem;
+		font-size: $font-body;
 		font-weight: 600;
 		font-family: Inter, $sans;
 		padding: 0.5rem 0;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -132,7 +132,7 @@
 
 .product-lightbox__detail-list {
 	p {
-		font-size: 0.875rem;
+		font-size: 1rem;
 		font-weight: 700;
 		width: 100%;
 		padding: 0.5rem 0;
@@ -150,7 +150,7 @@
 		background: url(./icons/check.svg) no-repeat 0 2px;
 		padding-left: 20px;
 		font-weight: 400;
-		font-size: 0.875rem;
+		font-size: 1rem;
 		color: #3c434a;
 	}
 
@@ -164,7 +164,7 @@
 
 	.foldable-card__header {
 		min-height: 0;
-		font-size: 0.875rem;
+		font-size: 1rem;
 		font-weight: 600;
 		font-family: Inter, $sans;
 		padding: 0.5rem 0;
@@ -194,7 +194,7 @@
 .product-lightbox__variants-options {
 	.form-legend {
 		font-weight: 600;
-		font-size: 0.875rem;
+		font-size: 1rem;
 		margin-bottom: 0.5rem;
 	}
 
@@ -257,7 +257,7 @@
 
 	p {
 		font-weight: 600;
-		font-size: 0.875rem;
+		font-size: 1rem;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -101,7 +101,7 @@
 
 	&-label {
 		font-weight: 600;
-		font-size: 0.75rem;
+		font-size: $font-body-small;
 		margin-right: 6px;
 		color: #000;
 	}
@@ -122,7 +122,7 @@
 
 		p {
 			color: #3c434a;
-			font-size: 0.75rem;
+			font-size: $font-body-small;
 			margin: 0;
 			position: relative;
 			top: 2px;
@@ -132,7 +132,7 @@
 
 .product-lightbox__detail-list {
 	p {
-		font-size: 1rem;
+		font-size: $font-body;
 		font-weight: 700;
 		width: 100%;
 		padding: 0.5rem 0;
@@ -150,7 +150,7 @@
 		background: url(./icons/check.svg) no-repeat 0 2px;
 		padding-left: 20px;
 		font-weight: 400;
-		font-size: 1rem;
+		font-size: $font-body;
 		color: #3c434a;
 	}
 
@@ -194,7 +194,7 @@
 .product-lightbox__variants-options {
 	.form-legend {
 		font-weight: 600;
-		font-size: 1rem;
+		font-size: $font-body;
 		margin-bottom: 0.5rem;
 	}
 
@@ -257,7 +257,7 @@
 
 	p {
 		font-weight: 600;
-		font-size: 1rem;
+		font-size: $font-body;
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes
* Update lightbox font to 1rem 

#### Testing Instructions


* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout add/lightbox-info-to-calypso-package`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Open any lighbox by clicking on More link in any of the cards
* Make sure the font size for content inside **Great For**, **Benefits** and **Includes** looks larger than before (refer screenshot)
 
#### Screenshot

##### Before
![font-before](https://user-images.githubusercontent.com/2027003/190644419-179a6d06-f2ee-4b93-8ca1-9e669b36c473.png)


##### After
![Screenshot 2022-09-16 at 6 38 01 PM](https://user-images.githubusercontent.com/2027003/190646040-8f4d7392-553d-40a7-8220-e8e19e70fa57.png)



#### Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?



---
- Completes 0-as-1202994523021994/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202994523021994