### PR TITLE
Add web-previews api to disable interactions [DO NOT MERGE]

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -274,9 +274,11 @@ export default class WebPreviewContent extends Component {
 		if ( this.props.previewMarkup ) {
 			debug( 'preview loaded with markup' );
 			this.props.onLoad( this.iframe.contentDocument );
-		} else {
-			debug( 'preview loaded for url:', this.state.iframeUrl );
+			this.setState( { loaded: true, isLoadingSubpage: false } );
+			return;
 		}
+		debug( 'preview loaded for url:', this.state.iframeUrl );
+
 		if ( this.checkForIframeLoadFailure( caller ) ) {
 			debug( `preview not loaded yet, waiting ${ loadingTimeout }ms` );
 			clearTimeout( this.loadingTimeoutTimer );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,27 +1,37 @@
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
+import wp from 'calypso/lib/wp';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
-	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const defaultDevice = 'phone';
 	const devicesToShow: Device[] = [ 'computer', 'phone' ];
 
-	function formatPreviewUrl() {
-		if ( ! previewUrl ) {
-			return null;
-		}
+	const [ previewContent, setPreviewContent ] = useState( '' );
+	const [ webPreviewLoadingStatus, setWebPreviewLoadingStatus ] = useState(
+		translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+			components: { strong: <strong /> },
+		} )
+	);
 
-		return addQueryArgs( previewUrl, {
-			iframe: true,
-			theme_preview: true,
-			// hide the "Create your website with WordPress.com" banner
-			hide_banners: true,
-		} );
-	}
+	useEffect( () => {
+		if ( siteSlug ) {
+			const previewUrl = siteSlug ? `/sites/${ siteSlug }/web-previews?hide_banners=true` : null;
+			const errorWebPreviewMessage = translate(
+				'{{strong}}Error{{/strong}} There was an issue loading the site preview.',
+				{
+					components: { strong: <strong /> },
+				}
+			);
+			wp.req
+				.get( { path: previewUrl, apiNamespace: 'wpcom/v2' } )
+				.then( ( response: string ) => setPreviewContent( response ) )
+				.catch( () => setWebPreviewLoadingStatus( errorWebPreviewMessage ) );
+		}
+	}, [ siteSlug, translate ] );
 
 	return (
 		<div className={ 'launchpad__site-preview-wrapper' }>
@@ -32,14 +42,12 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 				showSEO={ true }
 				isContentOnly
 				externalUrl={ siteSlug }
-				previewUrl={ formatPreviewUrl() }
+				previewMarkup={ previewContent }
 				toolbarComponent={ PreviewToolbar }
 				showClose={ false }
 				showEdit={ false }
 				showExternal={ false }
-				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
-					components: { strong: <strong /> },
-				} ) }
+				loadingMessage={ webPreviewLoadingStatus }
 				translate={ translate }
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }


### PR DESCRIPTION
#### Proposed Changes

* Changes to use new web-previews API that fetches site preview page with interactions disabled.
* Modified `<WebPreview/>` component to load site preview using existing previewMarkup prop. 

Changes from https://github.com/Automattic/wp-calypso/pull/67472 have been moved here.

**Will merge this PR after backend changes are merged: D87462-code**

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and run `yarn start`
* Sandbox and setup backend changes following the instructions from: D87462-code
* Create a new link-in-bio and newsletter site: https://wordpress.com/hp-2022-tailored-flows/
* Go through the site creation flow until you reach the Launchpad screen.
* Ensure the site preview is loading correctly and that links within the site preview no longer redirect the user. You should be able to scroll the site preview. but nothing will be clickable.
* The endpoint should not be accessible if youre not logged in ( You can test this out by accessing the endpoint directly in the browser or opening a incognito window and then directly navigating to the launchpad screen: [http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug={SITE_SLUG_HERE}](http://calypso.localhost:3000/setup/launchpad?flow=newsletter&siteSlug=%7BSITE_SLUG_HERE%7D) )

![image](https://user-images.githubusercontent.com/10482592/188753416-706a0f41-4d2c-4f25-8c3b-08f163266a4d.png)




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66574