### PR TITLE
VideoPress Onboarding v2: Actually create a site when the flow finishes.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/completing-purchase/index.tsx
@@ -1,4 +1,4 @@
-import { LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { LINK_IN_BIO_FLOW, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -54,6 +54,25 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 		} );
 	};
 
+	const completeVideoPressFlow = () => {
+		setPendingAction( async () => {
+			setProgress( 0 );
+			setProgressTitle( __( 'Setting up your video site' ) );
+			await siteSetup;
+
+			setProgress( 0.5 );
+			setProgressTitle( __( 'Scouting the locations' ) );
+			await wait( 1500 );
+
+			setProgress( 0.8 );
+			setProgressTitle( __( 'Kicking off the casting' ) );
+			await wait( 1500 );
+
+			setProgress( 1 );
+			await wait( 1500 );
+			return { destination: 'launchpad' };
+		} );
+	};
 	useEffect( () => {
 		if ( ! site ) {
 			return;
@@ -61,6 +80,8 @@ const CompletingPurchase: Step = function CompletingPurchase( { navigation, flow
 
 		if ( flow === LINK_IN_BIO_FLOW ) {
 			completeLinkInBioFlow();
+		} else if ( flow === VIDEOPRESS_FLOW ) {
+			completeVideoPressFlow();
 		} else {
 			completeNewsletterFlow();
 		}

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { redirect } from './internals/steps-repository/import/util';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -15,14 +16,7 @@ export const videopress: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [
-			'intro',
-			'options',
-			'chooseADomain',
-			'chooseAPlan',
-			'processing',
-			'launchpad',
-		] as StepPath[];
+		return [ 'intro', 'options', 'completingPurchase', 'processing', 'launchpad' ] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -47,7 +41,12 @@ export const videopress: Flow = {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
 					setSiteDescription( tagline as string );
-					return navigate( 'chooseADomain' );
+					// return navigate( 'chooseADomain' );
+					return window.location.replace(
+						`/start/${ name }/domains?new=${ encodeURIComponent(
+							siteTitle as string
+						) }&search=yes&hide_initial_query=yes`
+					);
 				}
 
 				case 'chooseADomain': {
@@ -55,6 +54,9 @@ export const videopress: Flow = {
 				}
 
 				case 'chooseAPlan':
+					return navigate( 'chooseAPlan' );
+
+				case 'completingPurchase':
 					return navigate( 'processing' );
 
 				case 'processing': {
@@ -62,7 +64,7 @@ export const videopress: Flow = {
 				}
 
 				case 'launchpad': {
-					return navigate( 'processing' );
+					return redirect( `/page/${ siteSlug }/home` );
 				}
 			}
 			return providedDependencies;

--- a/client/signup/config/constants.js
+++ b/client/signup/config/constants.js
@@ -1,1 +1,3 @@
-export const VIDEOPRESS_ONBOARDING_FLOW_STEPS = [ 'user', 'videopress-site', 'plans-premium' ];
+export const VIDEOPRESS_ONBOARDING_FLOW_STEPS = [ 'domains', 'plans-premium' ];
+
+// steps: [ 'domains', 'plans-link-in-bio' ],

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -276,7 +276,10 @@ export function generateFlows( {
 		{
 			name: 'videopress',
 			steps: VIDEOPRESS_ONBOARDING_FLOW_STEPS,
-			destination: ( dependencies ) => `/site-editor/${ dependencies.siteSlug }`,
+			destination: ( dependencies ) =>
+				`/setup/completingPurchase?flow=videopress&siteSlug=${ encodeURIComponent(
+					dependencies.siteSlug
+				) }`,
 			description: 'VideoPress signup flow',
 			lastModified: '2022-07-06',
 			showRecaptcha: true,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,5 +1,5 @@
 import { englishLocales } from '@automattic/i18n-utils';
-import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { VIDEOPRESS_FLOW, isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import i18n, { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
@@ -615,7 +615,7 @@ class DomainsStep extends Component {
 			return translate( 'Find the domain that defines you' );
 		}
 
-		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
+		if ( isNewsletterOrLinkInBioFlow( flowName ) || VIDEOPRESS_FLOW === flowName ) {
 			const components = {
 				span: (
 					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
@@ -626,6 +626,13 @@ class DomainsStep extends Component {
 					/>
 				),
 			};
+			if ( VIDEOPRESS_FLOW === flowName ) {
+				return translate(
+					'Set your Video site apart with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
+					{ components }
+				);
+			}
+
 			return flowName === 'newsletter'
 				? translate(
 						'Help your Newsletter stand out with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
@@ -678,7 +685,7 @@ class DomainsStep extends Component {
 	}
 
 	isTailoredFlow() {
-		return [ 'newsletter', 'link-in-bio' ].includes( this.props.flowName );
+		return [ 'newsletter', 'link-in-bio', VIDEOPRESS_FLOW ].includes( this.props.flowName );
 	}
 
 	renderContent() {


### PR DESCRIPTION
#### Proposed Changes

* Temporarily use old-style flow for onboarding v2's `domain`, `plan`, and `checkout` steps so we can test the whole thing

#### Testing Instructions

* Visit http://calypso.localhost:3000/setup/intro?flow=videopress
* Go through the whole flow. You should end up with a site at the end.

fixes 1298-gh-Automattic/greenhouse