### PR TITLE
Videopress onboarding v2 : plan selection refined

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -17,6 +17,7 @@ import type { Step } from '../../types';
 
 import 'calypso/../packages/plans-grid/src/plans-grid/style.scss';
 import 'calypso/../packages/plans-grid/src/plans-table/style.scss';
+import './style.scss';
 
 const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
@@ -64,30 +65,33 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 							<div className="plans-table">
 								{ filteredPlans
 									.filter( ( plan ) => !! plan )
-									.map( ( plan ) => (
-										<PlanItem
-											popularBadgeVariation={ 'ON_TOP' }
-											allPlansExpanded={ allPlansExpanded }
-											key={ plan.periodAgnosticSlug }
-											slug={ plan.periodAgnosticSlug }
-											domain={ domain }
-											tagline={ plan.description }
-											CTAVariation={ 'NORMAL' }
-											features={ plan.features ?? [] }
-											billingPeriod={ billingPeriod }
-											isPopular={ plan.isPopular }
-											isFree={ plan.isFree }
-											name={ plan?.title.toString() }
-											isSelected={
-												!! selectedPlanProductId &&
-												selectedPlanProductId ===
-													getPlanProduct( plan.periodAgnosticSlug, billingPeriod )?.productId
-											}
-											onSelect={ onPlanSelect }
-											onPickDomainClick={ undefined }
-											onToggleExpandAll={ () => setAllPlansExpanded( ( expand ) => ! expand ) }
-											disabledLabel={ undefined }
-										></PlanItem>
+									.map( ( plan, index ) => (
+										<>
+											<PlanItem
+												popularBadgeVariation={ 'ON_TOP' }
+												allPlansExpanded={ allPlansExpanded }
+												key={ plan.periodAgnosticSlug }
+												slug={ plan.periodAgnosticSlug }
+												domain={ domain }
+												CTAVariation={ 'NORMAL' }
+												features={ plan.features ?? [] }
+												billingPeriod={ billingPeriod }
+												isPopular={ 'business' === plan.periodAgnosticSlug }
+												isFree={ plan.isFree }
+												name={ plan?.title.toString() }
+												isSelected={
+													!! selectedPlanProductId &&
+													selectedPlanProductId ===
+														getPlanProduct( plan.periodAgnosticSlug, billingPeriod )?.productId
+												}
+												onSelect={ onPlanSelect }
+												onPickDomainClick={ undefined }
+												onToggleExpandAll={ () => setAllPlansExpanded( ( expand ) => ! expand ) }
+												CTAButtonLabel={ __( 'Get %s' ).replace( '%s', plan.title ) }
+												popularBadgeText={ __( 'Best for Video' ) }
+											/>
+											{ index < filteredPlans.length - 1 && <div className="plan-separator"></div> }
+										</>
 									) ) }
 							</div>
 						</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
@@ -1,3 +1,5 @@
+$videopress-mobile-layout-width: 700px;
+
 .videopress {
 	.segmented-control {
 		background: transparent;
@@ -19,6 +21,11 @@
 	}
 
 	.plans-table {
+		@media (max-width: $videopress-mobile-layout-width) {
+			flex-direction: column;
+			align-content: center;
+		}
+
 		justify-content: center;
 		gap: 24px;
 
@@ -28,6 +35,11 @@
 		}
 
 		.plan-item {
+			@media (max-width: $videopress-mobile-layout-width) {
+				border: solid 1px rgba(255, 255, 255, 0.2);
+				padding: 20px;
+			}
+
 			min-width: auto;
 			flex-grow: unset;
 			margin-top: 46px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
@@ -1,0 +1,123 @@
+.videopress {
+	.segmented-control {
+		background: transparent;
+		border: solid 1px rgba(255, 255, 255, 0.2);
+
+		.segmented-control__text {
+			color: #fff;
+		}
+
+		.is-selected {
+			.segmented-control__link {
+				background-color: rgba(255, 255, 255, 0.35);
+				border: none;
+				.plans-interval-toggle__label {
+					color: #fff;
+				}
+			}
+		}
+	}
+
+	.plans-table {
+		justify-content: center;
+		gap: 24px;
+
+		.plan-separator {
+			width: 1px;
+			background-color: rgba(255, 255, 255, 0.2);
+		}
+
+		.plan-item {
+			min-width: auto;
+			flex-grow: unset;
+			margin-top: 46px;
+
+			&.is-popular {
+				margin-top: 0px;
+				.plan-item__badge {
+					background-color: #b8e6bf;
+					color: #00450c;
+					width: fit-content;
+					text-transform: none;
+					font-weight: 500;
+					margin: auto;
+					border-radius: 4px;
+					padding: 0px 10px;
+					margin-bottom: 22px;
+				}
+			}
+
+			.plan-item__viewport {
+				border: none;
+				padding: 0;
+				color: #fff;
+				width: 265px;
+
+				.plans-feature-list__item-annual-nudge {
+					display: none;
+				}
+
+				.plan-item__summary {
+					text-align: center;
+
+					.plan-item__heading {
+						display: block;
+						font-size: 20px;
+					}
+				}
+
+				.plan-item__price-note {
+					text-align: center;
+					color: #a7aaad;
+				}
+
+				.plan-item__price-discount {
+					text-align: center;
+					color: #1ed15a;
+				}
+
+				.components-button.plan-item__select-button.is-primary {
+					width: 100%;
+					height: 40px;
+					border-radius: 4px;
+					border: none;
+					box-shadow: none;
+
+					&:hover,
+					&:active {
+						background-color: #ffe61c;
+						color: #000;
+					}
+				}
+
+				&:not(.is-popular) {
+					.components-button.plan-item__select-button.is-primary {
+						background: none;
+						color: #fff;
+						border: solid 1px rgba(255, 255, 255, 0.2);
+					}
+				}
+
+				.plans-feature-list__item-group {
+					list-style-type: none;
+					padding: 0;
+					margin: 0;
+
+					.plans-feature-list__item {
+						.plans-feature-list__item-bullet-icon {
+							color: #1ed15a;
+						}
+
+						&.plans-feature-list__item--requires-annual-disabled .plans-feature-list__item-bullet-icon {
+							color: #ffe61c;
+						}
+
+						.plans-feature-list__item-description {
+							color: #dcdcde;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -52,6 +52,8 @@ export interface Props {
 	disabledLabel?: string;
 	CTAVariation?: CTAVariation;
 	popularBadgeVariation?: PopularBadgeVariation;
+	popularBadgeText?: string;
+	CTAButtonLabel?: string;
 }
 
 // NOTE: there is some duplicate markup between this plan item (used in the
@@ -76,6 +78,8 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	CTAVariation = 'NORMAL',
 	popularBadgeVariation = 'ON_TOP',
 	isSelected,
+	popularBadgeText,
+	CTAButtonLabel,
 } ) => {
 	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
@@ -97,7 +101,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 
 	const isOpen = allPlansExpanded || isDesktop || isPopular || isOpenInternalState;
 
-	const normalCtaLabelFallback = __( 'Choose', __i18n_text_domain__ );
+	const normalCtaLabelFallback = CTAButtonLabel ?? __( 'Choose', __i18n_text_domain__ );
 	const fullWidthCtaLabelSelected = __( 'Current Selection', __i18n_text_domain__ );
 	// translators: %s is a WordPress.com plan name (eg: Free, Personal)
 	const fullWidthCtaLabelUnselected = __( 'Select %s', __i18n_text_domain__ );
@@ -117,6 +121,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 
 	const expandToggleLabelExpanded = __( 'Collapse all plans', __i18n_text_domain__ );
 	const expandToggleLabelCollapsed = __( 'Expand all plans', __i18n_text_domain__ );
+	const displayedPopularBadgeText = popularBadgeText ?? __( 'Popular', __i18n_text_domain__ );
 
 	return (
 		<div
@@ -127,7 +132,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 			} ) }
 		>
 			{ isPopular && popularBadgeVariation === 'ON_TOP' && (
-				<span className="plan-item__badge">{ __( 'Popular', __i18n_text_domain__ ) }</span>
+				<span className="plan-item__badge">{ displayedPopularBadgeText }</span>
 			) }
 			<div className={ classNames( 'plan-item__viewport', { 'is-popular': isPopular } ) }>
 				<div className="plan-item__details">


### PR DESCRIPTION
#### Proposed Changes

This PR adds missing styles and features to the plan selection onboarding step.

#### Testing Instructions

* Apply this PR
* Go to `http://calypso.localhost:3000/setup/chooseAPlan?flow=videopress`
* ✅ The style should match the Figma mockup
* Choose a plan
* ✅ You should be redirected to the processing step