### PR TITLE
Disable site interaction with new query arg

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -20,6 +20,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 			theme_preview: true,
 			// hide the "Create your website with WordPress.com" banner
 			hide_banners: true,
+			do_preview_no_interactions: true,
 		} );
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Added new query argument, `do_preview_no_interactions`, to site preview URL.
* `do_preview_no_interactions=true` query argument will disable any site interactions with the backend changes: D87922-code

#### Testing Instructions

* Checkout this branch and run `yarn start`
* Sandbox and setup backend changes following the instructions from: D87922-code
* Create a new link-in-bio and newsletter site: https://wordpress.com/hp-2022-tailored-flows/
* Go through the site creation flow until you reach the Launchpad screen.
* Ensure the site preview is loading correctly and that links within the site preview no longer redirect the user. You should be able to scroll the site preview. but nothing will be clickable.
* You can also test the case when the `do_preview_no_interactions` is not set to true by visiting your sandboxed site directly in a new tab/window and adding the `do_preview_no_interactions=false` query arg to the URL. You should be able to interact with the site (click links, open menus, etc).

![image](https://user-images.githubusercontent.com/10482592/188753416-706a0f41-4d2c-4f25-8c3b-08f163266a4d.png)



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #