### PR TITLE
Emails: fix appearance of mailbox upsell component for GW subscriptions

### DIFF
--- a/client/lib/emails/can-add-mailboxes-to-domain.ts
+++ b/client/lib/emails/can-add-mailboxes-to-domain.ts
@@ -1,0 +1,19 @@
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { getGSuiteProductSlug, getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
+import { getTitanProductSlug } from 'calypso/lib/titan';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+/**
+ * Determines whether a domain has email provider and is everything set up to add new mailboxes
+ */
+export function canAddMailboxesToDomain( domain?: ResponseDomain ): boolean {
+	const domainIsNotProvisioning = getGSuiteProductSlug( domain ) || getTitanProductSlug( domain );
+	const isAwaitingGoogleTosAcceptance = getGSuiteSubscriptionStatus( domain ) === 'suspended';
+
+	return (
+		( domainIsNotProvisioning || hasEmailForwards( domain ) ) &&
+		! isAwaitingGoogleTosAcceptance &&
+		canCurrentUserAddEmail( domain )
+	);
+}

--- a/client/lib/emails/can-add-mailboxes-to-email-subscription.ts
+++ b/client/lib/emails/can-add-mailboxes-to-email-subscription.ts
@@ -7,7 +7,7 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
 /**
  * Determines whether a domain has email provider and is everything set up to add new mailboxes
  */
-export function canAddMailboxesToDomain( domain?: ResponseDomain ): boolean {
+export function canAddMailboxesToEmailSubscription( domain?: ResponseDomain ): boolean {
 	const domainIsNotProvisioning = getGSuiteProductSlug( domain ) || getTitanProductSlug( domain );
 	const isAwaitingGoogleTosAcceptance = getGSuiteSubscriptionStatus( domain ) === 'suspended';
 

--- a/client/lib/emails/can-add-mailboxes-to-email-subscription.ts
+++ b/client/lib/emails/can-add-mailboxes-to-email-subscription.ts
@@ -5,14 +5,16 @@ import { getTitanProductSlug } from 'calypso/lib/titan';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 /**
- * Determines whether a domain has email provider and is everything set up to add new mailboxes
+ * Determines if a domain has a provisioned email subscription and if the current user can add new mailboxes.
  */
 export function canAddMailboxesToEmailSubscription( domain?: ResponseDomain ): boolean {
-	const domainIsNotProvisioning = getGSuiteProductSlug( domain ) || getTitanProductSlug( domain );
+	const emailSubscriptionIsProvisioned = Boolean(
+		getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) || hasEmailForwards( domain )
+	);
 	const isAwaitingGoogleTosAcceptance = getGSuiteSubscriptionStatus( domain ) === 'suspended';
 
 	return (
-		( domainIsNotProvisioning || hasEmailForwards( domain ) ) &&
+		emailSubscriptionIsProvisioned &&
 		! isAwaitingGoogleTosAcceptance &&
 		canCurrentUserAddEmail( domain )
 	);

--- a/client/lib/emails/index.js
+++ b/client/lib/emails/index.js
@@ -12,4 +12,4 @@ export { isEmailForwardVerified } from './is-email-forward-verified';
 export { isEmailUserAdmin } from './is-email-user-admin';
 export { isGoogleEmailAccount } from './is-google-email-account';
 export { isTitanMailAccount } from './is-titan-mail-account';
-export { canAddMailboxesToDomain } from './can-add-mailboxes-to-domain';
+export { canAddMailboxesToEmailSubscription } from './can-add-mailboxes-to-email-subscription';

--- a/client/lib/emails/index.js
+++ b/client/lib/emails/index.js
@@ -12,3 +12,4 @@ export { isEmailForwardVerified } from './is-email-forward-verified';
 export { isEmailUserAdmin } from './is-email-user-admin';
 export { isGoogleEmailAccount } from './is-google-email-account';
 export { isTitanMailAccount } from './is-titan-mail-account';
+export { canAddMailboxesToDomain } from './can-add-mailboxes-to-domain';

--- a/client/lib/titan/get-titan-product-slug.ts
+++ b/client/lib/titan/get-titan-product-slug.ts
@@ -1,5 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function getTitanProductSlug( domain: ResponseDomain ): string | null {
+export function getTitanProductSlug( domain?: ResponseDomain ): string | null {
 	return domain?.titanMailSubscription?.productSlug ?? null;
 }

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -11,23 +11,16 @@ import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
-import { canCurrentUserAddEmail } from 'calypso/lib/domains';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { canAddMailboxesToDomain } from 'calypso/lib/emails';
 import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
 	getGSuiteProductSlug,
-	getGSuiteSubscriptionStatus,
 	getProductType,
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
-import {
-	getTitanProductName,
-	getTitanProductSlug,
-	getTitanSubscriptionId,
-	hasTitanMailWithUs,
-} from 'calypso/lib/titan';
+import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
@@ -94,13 +87,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
 	const currentRoute = useSelector( getCurrentRoute );
-
-	const domainIsNotProvisioning = getGSuiteProductSlug( domain ) || getTitanProductSlug( domain );
-	const isAwaitingGoogleTosAcceptance = getGSuiteSubscriptionStatus( domain ) === 'suspended';
-	const canAddMailboxes =
-		( domainIsNotProvisioning || hasEmailForwards( domain ) ) &&
-		! isAwaitingGoogleTosAcceptance &&
-		canCurrentUserAddEmail( domain );
+	const canAddMailboxes = canAddMailboxesToDomain( domain );
 	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -11,7 +11,7 @@ import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
-import { canAddMailboxesToDomain } from 'calypso/lib/emails';
+import { canAddMailboxesToEmailSubscription } from 'calypso/lib/emails';
 import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
@@ -87,7 +87,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
 	const currentRoute = useSelector( getCurrentRoute );
-	const canAddMailboxes = canAddMailboxesToDomain( domain );
+	const canAddMailboxes = canAddMailboxesToEmailSubscription( domain );
 	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {

--- a/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
+++ b/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
@@ -2,7 +2,7 @@ import { Button, Ribbon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { canAddMailboxesToDomain } from 'calypso/lib/emails';
+import { canAddMailboxesToEmailSubscription } from 'calypso/lib/emails';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs, isUserOnTitanFreeTrial } from 'calypso/lib/titan';
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
@@ -20,7 +20,7 @@ const NewMailboxUpsell = ( { domains }: { domains: ResponseDomain[] } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteSlug = selectedSite?.slug;
 
-	const canAddMailboxes = domains.some( canAddMailboxesToDomain );
+	const canAddMailboxes = domains.some( canAddMailboxesToEmailSubscription );
 	if ( ! canAddMailboxes ) {
 		return null;
 	}

--- a/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
+++ b/client/my-sites/email/inbox/new-mailbox-upsell/index.tsx
@@ -2,6 +2,7 @@ import { Button, Ribbon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { canAddMailboxesToDomain } from 'calypso/lib/emails';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs, isUserOnTitanFreeTrial } from 'calypso/lib/titan';
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
@@ -18,6 +19,11 @@ const NewMailboxUpsell = ( { domains }: { domains: ResponseDomain[] } ) => {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteSlug = selectedSite?.slug;
+
+	const canAddMailboxes = domains.some( canAddMailboxesToDomain );
+	if ( ! canAddMailboxes ) {
+		return null;
+	}
 
 	// By default, upsell CTA links to the email management landing page.
 	let upsellURL = emailManagement( selectedSiteSlug, null, null, { source: INBOX_SOURCE } );


### PR DESCRIPTION
#### Proposed Changes
When the Google Workspace account is still being setup, the "Add new mailbox" item is disabled on the Email Management page, however, the "Create a new mailbox" upsell CTA remains visible on the Inbox page.
This PR hides the upsell element until Google Workspace account is fully set up.

#### Testing Instructions
Let's check a few scenarios.

**1) Test that nothing changed for Professional Email (FREE TRIAL)**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* If you have existed account with Professional Email (FREE TRIAL):
	* Choose it
* Otherwise, if you don't have existed account with the Professional Email (FREE TRIAL):
	* Click on "Add new site" at the end of the appeared list
	* Enter any domain name for test purposes
	* In the appeared list below - choose a domain with the help of the "Select" button
	* Choose any plan from the proposed with the help of the "Select" button
	* Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
	* Fill data in the "Professional Email" form to create your 3-month free email account and click on the "Add professional Email" button
	* Scroll down and click on "Complete Checkout"
	* On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
* In the left sidebar, click on the "Inbox" item
**Expected result:** nothing changed, we still see upsell component <img width="1336" alt="Screenshot 2022-09-16 at 16 20 08" src="https://user-images.githubusercontent.com/5598437/190673785-7b093a83-54ff-407d-aebb-dd10fabfee93.png">
* In the left sidebar, click on the the "Upgrades -> Emails" 
**Expected result:** Button "Add new mailboxes" is not disabled <img width="1497" alt="Screenshot 2022-09-16 at 16 19 00" src="https://user-images.githubusercontent.com/5598437/190673566-3cc57a9c-6b4e-4d85-b3ea-27466003cfb5.png">

**2) Test that nothing changed for Professional Email (PAID)**

* Using the site from previous test instruction - in the left sidebar, click on the "Upgrades -> Emails" 
* Click on the "Renew now" button, which is located at the top part of the page body (on the right side of the text "Expires: {Date}") and pay for it
* In the left sidebar, click on the "Inbox" item
**Expected result:** nothing changed, we still see upsell component <img width="1360" alt="Screenshot 2022-09-16 at 16 30 48" src="https://user-images.githubusercontent.com/5598437/190675817-dd4da774-329d-4f0d-8b2d-579d57688f34.png">
* In the left sidebar, click on the "Upgrades -> Emails" 
**Expected result:** Button "Add new mailboxes" is not disabled <img width="1564" alt="Screenshot 2022-09-16 at 16 31 12" src="https://user-images.githubusercontent.com/5598437/190675887-60aad9ae-1635-44a4-9b3e-05933bb8c759.png">

**3) Test that now we have correct behaviour for Google Workspace (PAID, BUT IS NOT FULLY COMPLETED)**

* Go to your dashboard
* Click on the "Switch Site" button in the top left corner
* Recommended if you have existed account with "Google Workspace" subscription, BUT it's not fully completed - you see "Action required" warning on "Upgrades -> Emails" page:
	* Choose it
* Otherwise, if you don't have existed account with the "Google Workspace" subscription:
	* Click on "Add new site" at the end of the appeared list
	* Enter any domain name for test purposes
	* In the appeared list below - choose a domain with the help of the "Select" button
	* Choose any plan from the proposed with the help of the "Select" button
	* Scroll down and pay for the subscription with the help of the "Pay {amount} with credits" button
	* Note, on the page "Add Professional Email" - click on the "Skip for now" button
	* On the page "What are your goals?" - click on "Skip to dashboard" in the top right corner
	* In the left sidebar menu, click on the "Inbox" item
	* At the bottom of the page is located the "Google Workspace" section, click on the "Select" button, on the right side of the section
	* Fill "Google Workspace" form and click on the "Purchase" button, below the form
	* Click on "Pay {amount} with credits"
	* Click on the "Manage email" button in the middle of the page body
	* In the left sidebar menu, click on the "Inbox" item
	* If you see the warning "Configuring mailboxes" at the top part of the page body - it means that it's necessary to wait a bit
	* Reload the page to check for any news regarding the configuration of your mailboxes. 
	* If it's finished, you will see the notification "Action required". **NB: DON'T** click on the "Finish setup" button, it will be used in the next test instruction.
* In the left sidebar, click on the "Inbox" item
**Expected result:** we **DON'T** see upsell component <img width="1200" alt="Screenshot 2022-09-16 at 16 40 42" src="https://user-images.githubusercontent.com/5598437/190677604-dc5cfede-b9e4-4e1d-a278-737576037488.png">
* In the left sidebar, click on the "Upgrades -> Emails" 
**Expected result:** Button "Add new mailboxes" is **DISABLED** <img width="1603" alt="Screenshot 2022-09-16 at 16 41 10" src="https://user-images.githubusercontent.com/5598437/190677674-3941727b-9a34-4271-abcd-cce45b1769fa.png">

**4) Test that nothing changed for Google Workspace (PAID AND FULLY COMPLETED)**

* Using site from previous test instruction - open "Upgrades -> Emails" page
* Click on the "Finish setup" button and follow the instructions.
* In the left sidebar, click on the "Inbox" item
**Expected result:** upsell component now is shown <img width="1206" alt="Screenshot 2022-09-16 at 16 45 07" src="https://user-images.githubusercontent.com/5598437/190678392-8109c836-283b-4d21-8399-c70df32df43e.png">
* In the left sidebar, click on the "Upgrades -> Emails" 
**Expected result:** Button "Add new mailboxes" now is **ENABLED** <img width="1508" alt="Screenshot 2022-09-16 at 16 45 32" src="https://user-images.githubusercontent.com/5598437/190678461-42677bc8-8b57-45ef-a73a-2cca4a7b2acc.png">

**5) Test case when we have a few domains on the site (Some w/o subscriptions, some w/ any subscription)**

* Create a site with a few domains and with different types of subscriptions (Free trial Titan, Paid Titan, GW completed, GW not completed)
**Expected result:** if at least one domain can add mailboxes, then upsell component is shown  <img width="1427" alt="Screenshot 2022-09-16 at 16 51 23" src="https://user-images.githubusercontent.com/5598437/190679524-687822b5-4f8e-4345-9bb4-fc669ed5ab37.png">
* In the left sidebar, click on the "Upgrades -> Emails" and open every existed email subscription
**Expected result:** Button "Add new mailboxes" should be disabled/enabled according to test the previous instructions.

#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202920313782212/f