### PR TITLE
Remove string fallback for missing translations that are now in place

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -346,10 +346,7 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			props: {
 				get headerText() {
-					return i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation( 'Empower your online presence' )
-						? i18n.translate( 'Empower your online presence' )
-						: '';
+					return i18n.translate( 'Empower your online presence' );
 				},
 				useEmailOnboardingSubheader: true,
 			},
@@ -445,10 +442,7 @@ export function generateSteps( {
 			props: {
 				forceHideFreeDomainExplainerAndStrikeoutUi: true,
 				get headerText() {
-					return i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation( 'Choose a domain for your Professional Email' )
-						? i18n.translate( 'Choose a domain for your Professional Email' )
-						: '';
+					return i18n.translate( 'Choose a domain for your Professional Email' );
 				},
 				includeWordPressDotCom: false,
 				isDomainOnly: false,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -345,9 +345,6 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug', 'emailItem' ],
 			providesDependencies: [ 'cartItem' ],
 			props: {
-				get headerText() {
-					return i18n.translate( 'Empower your online presence' );
-				},
 				useEmailOnboardingSubheader: true,
 			},
 		},

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -346,18 +346,10 @@ export class PlansStep extends Component {
 		}
 
 		if ( useEmailOnboardingSubheader ) {
-			return 'en' === locale ||
-				i18n.hasTranslation(
-					'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.'
-				)
-				? translate(
-						'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
-						{ components: { link: freePlanButton } }
-				  )
-				: translate(
-						"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
-						{ components: { link: freePlanButton } }
-				  );
+			return translate(
+				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
+				{ components: { link: freePlanButton } }
+			);
 		}
 
 		if ( ! hideFreePlan ) {


### PR DESCRIPTION
#### Proposed Changes

We deployed changes to the `onboarding-with-email` flow on September 7, 2022 (the [plan step](https://github.com/Automattic/wp-calypso/pull/67220/files) and [domain step](https://github.com/Automattic/wp-calypso/pull/66921/files)). At the time, some of the new strings introduced weren't translated, so @fredrikekelund added logic to fallback to the old strings if the locale is not `en`. Now that translation is ready, we are removing the fallback logic.

Having monitor the data for over a week, it appears that the `Empower your online presence` headline isn't performing well, we'll revert the headline back to the default of `Choose your plan`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Verify English text**
* Go to your account settings `/me/account`, be sure the "Interface Language" is set to English
* Go through the `/start/onboarding-with-email` flow, to ensure the correct headlines are shown at the domain step and plan step

At the **Choose a Domain** step, the headline should be `Choose a domain for your Professional Email`
 
<img width="1205" alt="Screen Shot 2022-09-17 at 9 57 42 AM" src="https://user-images.githubusercontent.com/104910361/190860927-77abcc48-f17e-4119-a403-092d1235a207.png">

At the **Choose a Plan** step, the headline should be `Choose a Plan`, followed by the subheader `Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.`

<img width="751" alt="Screen Shot 2022-09-17 at 9 57 57 AM" src="https://user-images.githubusercontent.com/104910361/190860947-024a0a6c-d8fc-40a3-9c2b-62fc9ba815bc.png">

**Verify non-English text**
* Under "Interface Setting", change the "Interface Language" to any language other than English
* Go through the `/start/onboarding-with-email` flow, to ensure the translated headlines are shown (we can use google translate to help verify if the correct string is rendered :))
* These are the results I'm seeing with locale set to `zh-cn`

**Choose a Domain** step
<img width="1215" alt="Screen Shot 2022-09-17 at 9 58 31 AM" src="https://user-images.githubusercontent.com/104910361/190861045-b241b329-9984-49d4-a781-f81dfc234a2f.png">

**Choose a Plan** step
<img width="592" alt="Screen Shot 2022-09-17 at 9 58 47 AM" src="https://user-images.githubusercontent.com/104910361/190861056-49f5bef1-d1a6-4b72-80d3-d81fda3491bf.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
