### PR TITLE
Help center: mark email tickets as overflow if chat is unavailable

### DIFF
--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -33,14 +33,14 @@ function getHCAvailabilityAndStatus( dataAuth: HappychatAuth ) {
 	} );
 }
 
-export function useHappychatAvailable() {
+export function useHappychatAvailable( enabled = true ) {
 	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth();
 
 	return useQuery(
 		'happychat-available' + key,
 		() => getHCAvailabilityAndStatus( dataAuth as HappychatAuth ),
 		{
-			enabled: ! isLoadingAuth && !! dataAuth,
+			enabled: ! isLoadingAuth && !! dataAuth && enabled,
 			staleTime: Infinity,
 		}
 	);

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -122,6 +122,7 @@ export const HelpCenterContactForm = () => {
 	const sectionName = useSelector( getSectionName );
 	const params = new URLSearchParams( search );
 	const mode = params.get( 'mode' ) as Mode;
+	const overflow = params.get( 'overflow' ) === 'true';
 	const history = useHistory();
 	const [ hideSiteInfo, setHideSiteInfo ] = useState( false );
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
@@ -235,7 +236,7 @@ export const HelpCenterContactForm = () => {
 						message: kayakoMessage,
 						locale,
 						client: 'browser:help-center',
-						is_chat_overflow: false,
+						is_chat_overflow: overflow,
 						blog_url: supportSite.URL,
 					} )
 						.then( () => {

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -86,9 +86,11 @@ export const HelpCenterContactPage: React.FC = () => {
 					) }
 					{ renderEmail && (
 						<Link
-							// set overflow flag when chat is not available and the user sends a support ticket
+							// set overflow flag when chat is not available nor closed, and the user is eligible to chat, but still sends a support ticket
 							to={ `/contact-form?mode=EMAIL&overflow=${ (
-								renderChat.render && renderChat.state !== 'AVAILABLE'
+								renderChat.eligible &&
+								renderChat.state !== 'CLOSED' &&
+								renderChat.state !== 'AVAILABLE'
 							).toString() }` }
 						>
 							<div

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -85,7 +85,12 @@ export const HelpCenterContactPage: React.FC = () => {
 						</ConditionalLink>
 					) }
 					{ renderEmail && (
-						<Link to="/contact-form?mode=EMAIL">
+						<Link
+							// set overflow flag when chat is not available and the user sends a support ticket
+							to={ `/contact-form?mode=EMAIL&overflow=${ (
+								renderChat.render && renderChat.state !== 'AVAILABLE'
+							).toString() }` }
+						>
 							<div
 								className={ classnames( 'help-center-contact-page__box', 'email' ) }
 								role="button"

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -3,34 +3,41 @@ import { useHappychatAvailable } from '@automattic/happychat-connection';
 
 type Result = {
 	render: boolean;
-	state?: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
+	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
+	eligible: boolean;
 };
 
 export function useShouldRenderChatOption(): Result {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
 	const { data, isLoading } = useHappychatAvailable();
+
 	if ( ! chatStatus?.is_user_eligible ) {
 		return {
 			render: false,
 			isLoading,
+			state: chatStatus?.is_chat_closed ? 'CLOSED' : 'UNAVAILABLE',
+			eligible: false,
 		};
 	} else if ( chatStatus?.is_chat_closed ) {
 		return {
 			render: true,
 			state: 'CLOSED',
 			isLoading,
+			eligible: true,
 		};
 	} else if ( data?.available ) {
 		return {
 			render: true,
 			state: 'AVAILABLE',
 			isLoading,
+			eligible: true,
 		};
 	}
 	return {
 		render: true,
 		state: 'UNAVAILABLE',
 		isLoading,
+		eligible: true,
 	};
 }


### PR DESCRIPTION
#### Proposed Changes

* This sets the flag `is_chat_overflow` to true in Email tickets of chat is unavailable at the moment of sending.
* This is important for statistics. See https://github.com/Automattic/wp-calypso/issues/67927 for details.

#### Testing.
1. Checkout this branch.
2. Cd into apps/editing-toolkit.
3. Run `yarn dev --sync`.
4. Go to https://hud-staging.happychat.io/ and log in and make yourself available for chat.
5. Sandbox a site and go to the editor of that site.
6. Open the help center. Chat should be available.
7. Send an email ticket, it shouldn't be marked as overflow.
8. Go to https://hud-staging.happychat.io/ and make yourself unavailable “No chats”.
9. Refresh the editor page, open the help center.
10. When you go to the contact page, chat should be unavailable.
11. Send an email ticket, it should be marked as overflow.
 