### PR TITLE
CI: upgrade docker image from `buster` to `bullseye-slim`.

### DIFF
--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -23,11 +23,11 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 	result.scriptContent = """
 		#!/bin/bash
 		# Update node
-		. "${'$'}NVM_DIR/nvm.sh" --no-use
-		nvm install
-		set -o errexit
-		set -o nounset
-		set -o pipefail
+		#. "${'$'}NVM_DIR/nvm.sh" --no-use
+		#nvm install
+		#set -o errexit
+		#set -o nounset
+		#set -o pipefail
 
 		# Existing script content set by caller:
 		${result.scriptContent}

--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -22,12 +22,10 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 	val result = ScriptBuildStep(init)
 	result.scriptContent = """
 		#!/bin/bash
-		# Update node
-		#. "${'$'}NVM_DIR/nvm.sh" --no-use
-		#nvm install
-		#set -o errexit
-		#set -o nounset
-		#set -o pipefail
+		# Set bash options.
+		set -o errexit
+		set -o nounset
+		set -o pipefail
 
 		# Existing script content set by caller:
 		${result.scriptContent}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG node_version=16.17.0
 ARG base_image=registry.a8c.com/calypso/base:latest
 
 ###################
-FROM node:${node_version}-buster as builder-cache-false
+FROM node:${node_version}-bullseye-slim as builder-cache-false
 
 
 ###################

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,7 @@
 #### This image is not pushed to any repository and it shouldn't be used as base image for any other docker build.
 #### Its main goal is to create a `/calypso/.cache` that can be copied over other images that can benefit from a warm cache.
 #### Note that yarn v3 cache lives in `/calypso/.yarn`
-FROM node:16.17.0-buster as cache
+FROM node:16.17.0-bullseye-slim as cache
 
 ARG node_memory=8192
 WORKDIR /calypso
@@ -11,25 +11,22 @@ ENV PERSISTENT_CACHE=true
 ENV READONLY_CACHE=false
 ENV PROFILE=true
 ENV SKIP_TSC=true
-ENV NVM_DIR=/calypso/.nvm
+# ENV NVM_DIR=/calypso/.nvm
 ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 
-RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
-	&& echo ". ${NVM_DIR}/nvm.sh" >> "${HOME}/.bashrc"
+# RUN apt update && apt install git
+
+# RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
+# 	&& echo ". ${NVM_DIR}/nvm.sh" >> "${HOME}/.bashrc"
 
 COPY . .
 
 # Run nvm.sh in a different dir so it doesn't try to use the version specified in /calypso/.nvmrc.
 # If not, it will fail the image generation.
-RUN cd / \
-	&& . "$NVM_DIR/nvm.sh" \
-	&& cd $HOME \
-	&& nvm install \
-	# Prime yarn cache
-	&& yarn \
+RUN yarn \
 	# Prime webpack caches, including sourcemaps.
 	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
 
@@ -37,7 +34,7 @@ ENTRYPOINT [ "/bin/bash" ]
 
 #### base image
 #### This image can be used as a base image for other builds, or to uni test and build calypso.
-FROM node:16.17.0-buster as base
+FROM node:16.17.0-bullseye-slim as base
 
 ARG node_memory=8192
 ARG user=calypso
@@ -45,7 +42,7 @@ ARG UID=1003
 
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
-ENV NVM_DIR=/calypso/.nvm
+# ENV NVM_DIR=/calypso/.nvm
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 ENV SKIP_TSC=true
@@ -54,7 +51,7 @@ ENV PLAYWRIGHT_SKIP_DOWNLOAD=true
 
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
-	&& apt-get install -y sudo zip jq \
+	&& apt-get install -y sudo zip jq curl \
 	&& adduser --uid $UID --disabled-password $user \
 	&& echo "$user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user \
 	&& chmod 0440 /etc/sudoers.d/$user \
@@ -64,10 +61,10 @@ RUN apt-get update \
 # Set bash as the default shell
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 # Copy nvm cache so we don't need to download it again
-COPY --from=cache --chown=$UID /calypso/.nvm /calypso/.nvm
+# COPY --from=cache --chown=$UID /calypso/.nvm /calypso/.nvm
 # Copy all other caches (webpack, babel, yarn...)
 COPY --from=cache --chown=$UID /calypso/.cache /calypso/.cache
-COPY --from=cache --chown=$UID /calypso/.bashrc /calypso/.bashrc
+# COPY --from=cache --chown=$UID /calypso/.bashrc /calypso/.bashrc
 COPY --from=cache --chown=$UID /calypso/.yarn /calypso/.yarn
 
 ENTRYPOINT [ "/bin/bash" ]
@@ -82,6 +79,7 @@ ENV DISPLAY=:99
 
 RUN apt update \
 	&& apt-get install -y \
+		openssl \
 		fonts-liberation \
 		fonts-noto \
 		git-restore-mtime \
@@ -116,13 +114,16 @@ FROM base as ci-wpcom
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 
-RUN apt update &&\
-	apt-get install -y apt-transport-https &&\
-	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg &&\
-	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list &&\
-	apt update &&\
- 	apt-get upgrade -y &&\
-	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose &&\
+RUN apt update && \
+	apt install -y apt-transport-https wget
+
+RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && \
+	dpkg -i libffi6_3.2.1-8_amd64.deb && \
+	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg && \
+	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list && \
+	apt update && \
+ 	apt upgrade -y && \
+	apt install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \
 	composer install
 
 # Install sentry-cli.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -42,7 +42,7 @@ ENV PLAYWRIGHT_SKIP_DOWNLOAD=true
 
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
-	&& apt-get install -y sudo zip jq curl \
+	&& apt-get install -y sudo zip jq curl git \
 	&& adduser --uid $UID --disabled-password $user \
 	&& echo "$user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user \
 	&& chmod 0440 /etc/sudoers.d/$user \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -93,7 +93,7 @@ RUN apt update \
 		xfonts-base \
 		xfonts-cyrillic \
 		xfonts-scalable \
-		xvfb && \
+		xvfb \
 	&& apt autoremove --purge \
 	&& apt autoclean \
 	&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -68,7 +68,7 @@ ENV PLAYWRIGHT_SKIP_DOWNLOAD=false
 ENV DISPLAY=:99
 
 RUN apt update \
-	&& apt install -y \
+	&& apt install -y --no-install-recommends \
 		fonts-liberation \
 		fonts-noto \
 		git-restore-mtime \
@@ -87,6 +87,7 @@ RUN apt update \
 		libxss1 \
 		libxtst6 \
 		openssl \
+		xauth \
 		xdg-utils \
 		xfonts-100dpi \
 		xfonts-75dpi \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,7 +47,9 @@ RUN apt-get update \
 	&& echo "$user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user \
 	&& chmod 0440 /etc/sudoers.d/$user \
 	&& chown $UID /calypso \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt autoremove --purge \
+	&& apt autoclean
 
 # Set bash as the default shell
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -66,7 +68,7 @@ ENV PLAYWRIGHT_SKIP_DOWNLOAD=false
 ENV DISPLAY=:99
 
 RUN apt update \
-	&& apt-get install -y \
+	&& apt install -y \
 		fonts-liberation \
 		fonts-noto \
 		git-restore-mtime \
@@ -91,7 +93,10 @@ RUN apt update \
 		xfonts-base \
 		xfonts-cyrillic \
 		xfonts-scalable \
-		xvfb
+		xvfb && \
+	&& apt autoremove --purge \
+	&& apt autoclean \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,21 +11,13 @@ ENV PERSISTENT_CACHE=true
 ENV READONLY_CACHE=false
 ENV PROFILE=true
 ENV SKIP_TSC=true
-# ENV NVM_DIR=/calypso/.nvm
 ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 
-# RUN apt update && apt install git
-
-# RUN git clone --branch v0.37.0 --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
-# 	&& echo ". ${NVM_DIR}/nvm.sh" >> "${HOME}/.bashrc"
-
 COPY . .
 
-# Run nvm.sh in a different dir so it doesn't try to use the version specified in /calypso/.nvmrc.
-# If not, it will fail the image generation.
 RUN yarn \
 	# Prime webpack caches, including sourcemaps.
 	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
@@ -42,7 +34,6 @@ ARG UID=1003
 
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
-# ENV NVM_DIR=/calypso/.nvm
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
 ENV SKIP_TSC=true
@@ -60,11 +51,8 @@ RUN apt-get update \
 
 # Set bash as the default shell
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-# Copy nvm cache so we don't need to download it again
-# COPY --from=cache --chown=$UID /calypso/.nvm /calypso/.nvm
 # Copy all other caches (webpack, babel, yarn...)
 COPY --from=cache --chown=$UID /calypso/.cache /calypso/.cache
-# COPY --from=cache --chown=$UID /calypso/.bashrc /calypso/.bashrc
 COPY --from=cache --chown=$UID /calypso/.yarn /calypso/.yarn
 
 ENTRYPOINT [ "/bin/bash" ]
@@ -79,7 +67,6 @@ ENV DISPLAY=:99
 
 RUN apt update \
 	&& apt-get install -y \
-		openssl \
 		fonts-liberation \
 		fonts-noto \
 		git-restore-mtime \
@@ -97,6 +84,7 @@ RUN apt update \
 		libx11-xcb1 \
 		libxss1 \
 		libxtst6 \
+		openssl \
 		xdg-utils \
 		xfonts-100dpi \
 		xfonts-75dpi \
@@ -117,6 +105,7 @@ COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 RUN apt update && \
 	apt install -y apt-transport-https wget
 
+# libffi6 is no longer available from apt as of bullseye.
 RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && \
 	dpkg -i libffi6_3.2.1-8_amd64.deb && \
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg && \


### PR DESCRIPTION
#### Proposed Changes

This PR upgrades our docker base image from `buster` to `bullseye-slim`.

**Key changes:**
- use `bullseye-slim` instead of `buster`.
- removal of nvm from the image.
- other optimizations throughout the docker build process to reduce the image size.

**Context:**
In pdqkMK-x6-p2 I wrote about the need for the Docker base images to eventually move onto `bullseye`-based images. This was precipitated by Playwright, whose 1.25 release stated that `buster` support is slated to end in December 2022.  

Additionally, seeing as `buster` was initially released mid-2019 it is starting to get a little long in the tooth. While the base images affected here are not the same images pushed to production servers, staying reasonably up to date is still important.

**Removal of nvm**
I've opted to remove `nvm` from our dependencies because the current version of node is already baked into the image we use. It felt unnecessary to install `nvm` on top of this for every docker image created.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] Code Style
  - [x] Unit Tests
  - [x] Build base image

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #