### PR TITLE
Add langParam and notFound if missing :site

### DIFF
--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -1,6 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import {
 	makeLayout,
+	notFound,
 	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
 	render as clientRender,
@@ -90,7 +91,15 @@ export default function ( router ) {
 	);
 
 	router(
-		'/plugins/plans/:site',
+		`/${ langParam }/plugins/plans`,
+		redirectWithoutLocaleParamIfLoggedIn,
+		notFound,
+		makeLayout
+	);
+
+	router(
+		`/${ langParam }/plugins/plans/:site`,
+		redirectWithoutLocaleParamIfLoggedIn,
 		redirectLoggedOut,
 		scrollTopIfNoHash,
 		siteSelection,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -90,12 +90,7 @@ export default function ( router ) {
 		clientRender
 	);
 
-	router(
-		`/${ langParam }/plugins/plans`,
-		redirectWithoutLocaleParamIfLoggedIn,
-		notFound,
-		makeLayout
-	);
+	router( `/${ langParam }/plugins/plans`, notFound, makeLayout );
 
 	router(
 		`/${ langParam }/plugins/plans/:site`,


### PR DESCRIPTION
#### Proposed Changes

* Add localization to `/plugins/plans/:site` for logged out routes (these routes will be asked to log in).
* If logged in dynamically remove localization with `redirectWithoutLocaleParamIfLoggedIn`
* Add `notFound` to `/plugins/plans` routes missing the site parameter. This prevents the `/plugins/plans` route from being mistaken as a plugin details page for a plugin named "plans"

#### Testing Instructions

Logged Out
* Go to http://calypso.localhost:3000/plugins/plans/example.wordpress.com -> You should be asked to login
* Go to http://calypso.localhost:3000/ja/plugins/plans/example.wordpress.com -> You should be asked to login
* Go to http://calypso.localhost:3000/ja/plugins/plans -> You should see "Uh oh. Page not found."
* Go to http://calypso.localhost:3000/plugins/plans -> You should see "Uh oh. Page not found."

Logged In
* Go to http://calypso.localhost:3000/plugins/plans/example.wordpress.com -> Plugins plans page should render
* Go to http://calypso.localhost:3000/ja/plugins/plans/example.wordpress.com -> You should be redirect so `ja` is removed from your URL path, and the plugins plans page should render.
* Go to http://calypso.localhost:3000/ja/plugins/plans -> You should see "Uh oh. Page not found."
* Go to http://calypso.localhost:3000/plugins/plans -> You should see "Uh oh. Page not found."


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67841
