### PR TITLE
Sites Management Page: Display selected sorting option in dropdown

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -1,6 +1,6 @@
 import { Gridicon, SitesTableSortKey, SitesTableSortOrder } from '@automattic/components';
 import styled from '@emotion/styled';
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button, Dropdown, MenuItemsChoice } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
@@ -96,32 +96,27 @@ export const SitesSortingDropdown = ( {
 				</SortingButton>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<MenuGroup>
-					<MenuItem
-						onClick={ () => {
-							onSitesSortingChange( `alphabetically${ SEPARATOR }asc` );
-							onClose();
-						} }
-					>
-						{ __( 'Alphabetically' ) }
-					</MenuItem>
-					<MenuItem
-						onClick={ () => {
-							onSitesSortingChange( `lastInteractedWith${ SEPARATOR }desc` );
-							onClose();
-						} }
-					>
-						{ __( 'Automagically' ) }
-					</MenuItem>
-					<MenuItem
-						onClick={ () => {
-							onSitesSortingChange( `updatedAt${ SEPARATOR }desc` );
-							onClose();
-						} }
-					>
-						{ __( 'Last published' ) }
-					</MenuItem>
-				</MenuGroup>
+				<MenuItemsChoice
+					value={ sitesSorting }
+					onSelect={ ( value: SitesSorting ) => {
+						onSitesSortingChange( value );
+						onClose();
+					} }
+					choices={ [
+						{
+							value: `alphabetically${ SEPARATOR }asc`,
+							label: __( 'Alphabetically' ),
+						},
+						{
+							value: `lastInteractedWith${ SEPARATOR }desc`,
+							label: __( 'Automagically' ),
+						},
+						{
+							value: `updatedAt${ SEPARATOR }desc`,
+							label: __( 'Last published' ),
+						},
+					] }
+				/>
 			) }
 		/>
 	);


### PR DESCRIPTION
#### Proposed Changes

Improve UX of the sorting dropdown in the Sites page by check-marking the selected option.

![image](https://user-images.githubusercontent.com/26530524/190716536-8a040a3b-2a60-47cb-a1e6-f1bf61d14dc8.png)

#### Testing Instructions

1. Open the sorting dropdown;
2. Check that there is a checkmark alongside the selected option;
3. Change another sorting algorithm;
4. Check that the check is now on the selected option.