### PR TITLE
HelpCenter: add box-sizing to fix overflow of submit

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -93,6 +93,7 @@ section.contact-form-submit {
 	bottom: 0;
 	left: 0;
 	width: 100%;
+	box-sizing: border-box;
 	background: #fff;
 	padding: 16px;
 	border-top: 1px solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Proposed Changes

Add `box-sizing` to prevent Contact Us button from overflowing out of help center.

## Testing Instructions

1. Pull branch & `cd apps/editing-toolkit/ && yarn dev --sync`
2. Go to /posts and open Help Center
3. Open up either Email or Chat support and make sure the button doesn't overflow

Closes #67931 