### PR TITLE
Update PlanPill component for Marketplace styles

### DIFF
--- a/client/components/plans/plan-pill/index.jsx
+++ b/client/components/plans/plan-pill/index.jsx
@@ -1,7 +1,15 @@
+import classNames from 'classnames';
+
 import './style.scss';
 
-export default ( props ) => (
-	<div className={ `plan-pill${ props.isInSignup ? ' is-in-signup' : '' }` }>
-		{ props.children }
-	</div>
-);
+export default ( { isInSignup, isInMarketplace, backgroundColor, color, children } ) => {
+	const classes = classNames( 'plan-pill', {
+		'is-in-signup': isInSignup,
+		'is-in-marketplace': isInMarketplace,
+	} );
+	return (
+		<div className={ classes } style={ { backgroundColor, color } }>
+			{ children }
+		</div>
+	);
+};

--- a/client/components/plans/plan-pill/style.scss
+++ b/client/components/plans/plan-pill/style.scss
@@ -27,3 +27,13 @@
 	border-radius: 10px; /* stylelint-disable-line scales/radii */
 	background-color: var(--color-neutral-100);
 }
+
+.plan-pill.is-in-marketplace {
+	top: unset;
+	bottom: unset;
+	right: unset;
+	left: 50%;
+	transform: translateX(-50%);
+	text-transform: none;
+	padding: 4px 10px;
+}


### PR DESCRIPTION
#### Proposed Changes

* Make the PlanPill component more flexible with colors
* Add styles to position the PlanPill correctly when in Marketplace

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* PlanPills in `/start/plans` remain the same
* PlanPills in `/plans/yearly`, `/plans/monthly` remain the same

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67574
