### PR TITLE
Add select sites page for advertising.

### DIFF
--- a/client/my-sites/promote-post/index.js
+++ b/client/my-sites/promote-post/index.js
@@ -1,9 +1,11 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection } from 'calypso/my-sites/controller';
+import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
 import { promotedPosts } from './controller';
 
 export default () => {
+	page( '/advertising', siteSelection, sites, makeLayout, clientRender );
+
 	page(
 		'/advertising/:site?/:tab?',
 		siteSelection,


### PR DESCRIPTION
#### Proposed Changes

* visiting /advertising without a site now should show us the site selector
![image](https://user-images.githubusercontent.com/6070516/190948299-cb56eb23-2a66-4a39-abce-08af6d3e7fa8.png)


#### Testing Instructions
* `yarn start` then visit `http://calypso.localhost:3000/advertising`
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
