### PR TITLE
Pattern assembler: only show the CTA in the Build flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -87,12 +87,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );
 		if ( blankCanvasDesignOffset !== -1 ) {
-			// Extract the blank canvas design first and then insert it into 4th position for the build and write intent
+			// Extract the blank canvas design first and then insert it into 4th position for the build intent
 			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );
-			if (
-				isEnabled( 'signup/design-picker-pattern-assembler' ) &&
-				( intent === SiteIntent.Build || intent === SiteIntent.Write )
-			) {
+			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) && intent === SiteIntent.Build ) {
 				allDesigns.static.designs.splice( 3, 0, ...blankCanvasDesign );
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

The "Start with a blank canvas" CTA should only show for the build flow and not the write flow, as right now we don't have patterns suitable for blogs.

#### Testing Instructions

1. Go to `/setup?siteSlug=<site slug>&flags=design-picker-pattern-assembler`
2. Select the "Promote myself or business" goal.
3. View the designs
4. Verify that you see the CTA
5. Go back to `/setup?siteSlug=<site slug>&flags=design-picker-pattern-assembler`
2. Select the "Write & Publish" goal.
3. View the designs
4. Verify that you DO NOT see the CTA, either in the `Show all` or `Blog` categories.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67951
