### PR TITLE
Show Blank Canvas CTA on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -44,7 +44,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 						>
 							<div
 								aria-label={ item.name }
-								tabIndex={ 0 }
+								tabIndex={ show ? 0 : -1 }
 								role="option"
 								aria-selected={ false }
 								onClick={ () => onSelect( item ) }

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -98,7 +98,7 @@ export const siteSetupFlow: Flow = {
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 		const urlQueryParams = useQuery();
 		const isPluginBundleEligible = useIsPluginBundleEligible();
-		const isMobile = useViewportMatch( 'medium', '<' );
+		const isDesktop = useViewportMatch( 'large' );
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -187,7 +187,7 @@ export const siteSetupFlow: Flow = {
 
 				case 'designSetup':
 					if (
-						! isMobile &&
+						isDesktop &&
 						isBlankCanvasDesign( providedDependencies?.selectedDesign as Design )
 					) {
 						return navigate( 'patternAssembler' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, useDesignsBySite, isBlankCanvasDesign } from '@automattic/design-picker';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -97,6 +98,7 @@ export const siteSetupFlow: Flow = {
 		const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 		const urlQueryParams = useQuery();
 		const isPluginBundleEligible = useIsPluginBundleEligible();
+		const isMobile = useViewportMatch( 'medium', '<' );
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -184,7 +186,10 @@ export const siteSetupFlow: Flow = {
 				}
 
 				case 'designSetup':
-					if ( isBlankCanvasDesign( providedDependencies?.selectedDesign as Design ) ) {
+					if (
+						! isMobile &&
+						isBlankCanvasDesign( providedDependencies?.selectedDesign as Design )
+					) {
 						return navigate( 'patternAssembler' );
 					}
 

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -10,7 +10,7 @@ type PatternAssemblerCtaProps = {
 
 const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 	const translate = useTranslate();
-	const isMobile = useViewportMatch( 'medium', '<' );
+	const isDesktop = useViewportMatch( 'large' );
 
 	return (
 		<div className="pattern-assembler-cta-wrapper">
@@ -19,7 +19,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 			</div>
 			<h3 className="pattern-assembler-cta__title">{ translate( 'Start with a blank canvas' ) }</h3>
 			<p className="pattern-assembler-cta__subtitle">
-				{ isMobile
+				{ ! isDesktop
 					? translate(
 							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
 					  )
@@ -28,7 +28,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 					  ) }
 			</p>
 			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>
-				{ isMobile ? translate( 'Open the editor' ) : translate( 'Get started' ) }
+				{ ! isDesktop ? translate( 'Open the editor' ) : translate( 'Get started' ) }
 			</Button>
 		</div>
 	);

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import blankCanvasImage from '../assets/images/blank-canvas-cta.svg';
 import './style.scss';
@@ -9,6 +10,7 @@ type PatternAssemblerCtaProps = {
 
 const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 	const translate = useTranslate();
+	const isMobile = useViewportMatch( 'medium', '<' );
 
 	return (
 		<div className="pattern-assembler-cta-wrapper">
@@ -17,12 +19,16 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 			</div>
 			<h3 className="pattern-assembler-cta__title">{ translate( 'Start with a blank canvas' ) }</h3>
 			<p className="pattern-assembler-cta__subtitle">
-				{ translate(
-					"Can't find something you like? Create something of your own by mixing and matching patterns."
-				) }
+				{ isMobile
+					? translate(
+							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
+					  )
+					: translate(
+							"Can't find something you like? Create something of your own by mixing and matching patterns."
+					  ) }
 			</p>
 			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>
-				{ translate( 'Get started' ) }
+				{ isMobile ? translate( 'Open the editor' ) : translate( 'Get started' ) }
 			</Button>
 		</div>
 	);

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -2,17 +2,17 @@
 @import "@wordpress/base-styles/mixins";
 
 .pattern-assembler-cta-wrapper {
-	display: none;
+	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	text-align: center;
 	align-items: center;
 	padding: 64px;
-	grid-column: 1 / span 3;
 	background-color: #f6f7f7;
 	color: #50575e;
 
 	@include break-medium {
-		display: flex;
+		grid-column: 1 / span 3;
 	}
 
 	.pattern-assembler-cta__title {


### PR DESCRIPTION
## Proposed Changes

* Show Blank Canvas CTA button on mobile and redirect use to editor upon clicked

## Testing Instructions

* Land on /designSetup step
* Confim the blank canvas CTA is shown on mobile
* Upon clicking it navigates to the editor
Screenshot: 
![image](https://user-images.githubusercontent.com/10071857/191657928-c0c79a7e-ffa2-4c78-ae4c-9c2949b1c358.png)


## Reference
Related to [Pattern Assembler: Show "Start with a blank canvas" CTA on mobile#67631](https://github.com/Automattic/wp-calypso/issues/67631)
