### PR TITLE
Remove legacy newdash_pageviews stats

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -10,7 +10,6 @@ import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
 import { ProviderWrappedLayout } from 'calypso/controller';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
-import { bumpStat } from 'calypso/lib/analytics/mc';
 import getSuperProps from 'calypso/lib/analytics/super-props';
 import { tracksEvents } from 'calypso/lib/analytics/tracks';
 import Logger from 'calypso/lib/catch-js-errors';
@@ -338,21 +337,6 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 		}
 
 		return normalize( context, next );
-	} );
-
-	page( '*', function ( context, next ) {
-		const path = context.pathname;
-
-		// Bypass this global handler for legacy routes and site management pages
-		// to avoid bumping stats and changing focus to the content
-		if ( isLegacyRoute( path ) || context.section?.group === 'sites-dashboard' ) {
-			return next();
-		}
-
-		// Bump general stat tracking overall Newdash usage
-		bumpStat( { newdash_pageviews: 'route' } );
-
-		next();
 	} );
 
 	page( '*', function ( context, next ) {

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -28,10 +28,7 @@ export function trackScrollPage( path, title, category, readerView, pageNum ) {
 		section: readerView,
 	} );
 	recordPageView( path, title );
-	bumpStat( {
-		newdash_pageviews: 'scroll',
-		reader_views: readerView + '_scroll',
-	} );
+	bumpStat( 'reader_views', readerView + '_scroll' );
 }
 
 export function trackUpdatesLoaded( key ) {


### PR DESCRIPTION
Looking at the recently merged #67215, seems the `newdash_pageviews` stat bumps can be removed completely. They were relevant 8 years ago, when Atlas/Newdash pages were migrated to Calypso, but today they are hopelessly outdated. We have other means to track pageviews and Reader scroll events.