### PR TITLE
Remove unneeded JSX return type annotations

### DIFF
--- a/client/components/eligibility-warnings/card/index.tsx
+++ b/client/components/eligibility-warnings/card/index.tsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
-import { ReactElement, ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 
 const CardTitle = styled.span`
 	display: flex;
@@ -41,13 +41,12 @@ const Icon = styled( Gridicon )`
 	}
 `;
 
-interface Card {
+type CardProps = PropsWithChildren< {
 	title: string;
 	icon?: string;
-	children: ReactNode;
-}
+} >;
 
-export default function Card( { title, icon = 'domains', children }: Card ): ReactElement | null {
+export default function Card( { title, icon = 'domains', children }: CardProps ) {
 	return (
 		<>
 			<CardTitle>

--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -1,5 +1,4 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { ReactElement } from 'react';
 import Card from '../card';
 import InfoLabel from '../info-label';
 
@@ -11,7 +10,7 @@ type DomainEligibilityWarningProps = {
 const DomainEligibilityWarning = ( {
 	wpcomDomain,
 	stagingDomain,
-}: DomainEligibilityWarningProps ): ReactElement => (
+}: DomainEligibilityWarningProps ) => (
 	<Card title={ __( 'Domain change required' ) }>
 		<InfoLabel label={ __( 'New' ) }>{ stagingDomain }</InfoLabel>
 		<p>

--- a/client/components/eligibility-warnings/info-label/index.tsx
+++ b/client/components/eligibility-warnings/info-label/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ReactElement, ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 
 const Banner = styled.div`
 	color: var( --studio-gray-90 );
@@ -30,17 +30,12 @@ const Label = styled.div< { type: string } >`
 	margin-left: 10px;
 `;
 
-interface InfoLabelProps {
-	children: ReactNode;
+type InfoLabelProps = PropsWithChildren< {
 	label?: string;
 	type?: string;
-}
+} >;
 
-export default function InfoLabel( {
-	children,
-	label,
-	type = 'info',
-}: InfoLabelProps ): ReactElement {
+export default function InfoLabel( { children, label, type = 'info' }: InfoLabelProps ) {
 	return (
 		<Banner>
 			<Content>{ children }</Content>

--- a/client/components/eligibility-warnings/plan-warning/index.tsx
+++ b/client/components/eligibility-warnings/plan-warning/index.tsx
@@ -1,12 +1,11 @@
-import { ReactElement, ReactNode } from 'react';
 import Card from '../card';
+import type { PropsWithChildren } from 'react';
 
-type Props = {
+type Props = PropsWithChildren< {
 	title: string;
-	children: ReactNode;
-};
+} >;
 
-const SitePlanWarning = ( { title, children }: Props ): ReactElement => (
+const SitePlanWarning = ( { title, children }: Props ) => (
 	<Card title={ title } icon="notice-outline">
 		<p>{ children }</p>
 	</Card>

--- a/client/components/eligibility-warnings/warnings-list/index.tsx
+++ b/client/components/eligibility-warnings/warnings-list/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { __ } from '@wordpress/i18n';
-import { ReactElement } from 'react';
 import Card from '../card';
 
 const WarningsList = styled.ul`
@@ -28,7 +27,7 @@ type WarningListProps = {
 	} >;
 };
 
-const WarningList = ( { warnings }: WarningListProps ): ReactElement => (
+const WarningList = ( { warnings }: WarningListProps ) => (
 	<Card icon="notice-outline" title={ __( 'Things you should be aware of' ) }>
 		<WarningsList>
 			{ warnings?.map( ( { name, description }, index ) => (

--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -1,6 +1,6 @@
 import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
-import { ReactElement, ComponentType } from 'react';
+import { ComponentType } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -35,7 +35,7 @@ const Placeholder = () => (
  * If the plan is an Atomic plan, we show a component to activate the
  * automated transfer process. If it's not, we show the upsell component.
  */
-const BusinessATSwitch = ( { UpsellComponent }: Props ): ReactElement => {
+const BusinessATSwitch = ( { UpsellComponent }: Props ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	const featuresNotLoaded: boolean = useSelector(

--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import SectionNav from 'calypso/components/section-nav';
@@ -25,7 +24,7 @@ interface Props {
 	className: string;
 }
 
-export default function PortalNav( { className = '' }: Props ): ReactElement | null {
+export default function PortalNav( { className = '' }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -1,6 +1,13 @@
 import { getPlan } from '@automattic/calypso-products';
 import classNames from 'classnames';
-import { ReactElement, useState, ReactNode, useEffect, ComponentType, useMemo } from 'react';
+import {
+	ReactElement,
+	useState,
+	PropsWithChildren,
+	useEffect,
+	ComponentType,
+	useMemo,
+} from 'react';
 import * as React from 'react';
 import { connect, DefaultRootState } from 'react-redux';
 import Main from 'calypso/components/main';
@@ -27,8 +34,7 @@ type SiteState = {
 	reason?: string;
 };
 
-type Props = {
-	children: ReactNode;
+type Props = PropsWithChildren< {
 	UpsellComponent: ComponentType< UpsellComponentProps >;
 	display: ReactElement;
 	QueryComponent: ComponentType< QueryComponentProps >;
@@ -41,14 +47,14 @@ type Props = {
 	atomicSite: boolean;
 	siteProducts: SiteProduct[] | null;
 	sitePlan: SitePlan | null | undefined;
-};
+} >;
 
 const UI_STATE_LOADING = Symbol();
 const UI_STATE_LOADED = Symbol();
 
 type UiState = typeof UI_STATE_LOADED | typeof UI_STATE_LOADING | null;
 
-function UpsellSwitch( props: Props ): React.ReactElement {
+function UpsellSwitch( props: Props ) {
 	const {
 		UpsellComponent,
 		QueryComponent,

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { ReactElement, useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import {
@@ -68,7 +68,7 @@ const content = {
 	},
 };
 
-function BlockingHoldNotice( { siteId }: BlockingHoldNoticeProps ): ReactElement | null {
+function BlockingHoldNotice( { siteId }: BlockingHoldNoticeProps ) {
 	const { eligibilityHolds: holds } = useSelector( ( state ) => getEligibility( state, siteId ) );
 	if ( ! holds ) {
 		return null;
@@ -92,9 +92,7 @@ function BlockingHoldNotice( { siteId }: BlockingHoldNoticeProps ): ReactElement
 	);
 }
 
-function TransferFailureNotice( {
-	transferStatus,
-}: TransferFailureNoticeProps ): ReactElement | null {
+function TransferFailureNotice( { transferStatus }: TransferFailureNoticeProps ) {
 	if ( transferStatus !== transferStates.FAILURE && transferStatus !== transferStates.ERROR ) {
 		return null;
 	}
@@ -116,7 +114,7 @@ function TransferFailureNotice( {
 	);
 }
 
-export default function WPCOMBusinessAT(): ReactElement {
+export default function WPCOMBusinessAT() {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 

--- a/client/components/loading-ellipsis/index.tsx
+++ b/client/components/loading-ellipsis/index.tsx
@@ -1,7 +1,10 @@
 import classnames from 'classnames';
-import type { ReactElement } from 'react';
 
-export function LoadingEllipsis( { className }: { className?: string } ): ReactElement {
+type LoadingEllipsisProps = {
+	className?: string;
+};
+
+export function LoadingEllipsis( { className }: LoadingEllipsisProps ) {
 	return (
 		// Styles are defined globally in _loading.scss so that this component
 		// can be rendered on the server and will appear immediately.

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -1,8 +1,7 @@
 import { Card } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { useState, useCallback, ReactElement } from 'react';
-import * as React from 'react';
+import { useRef, useState, useCallback, ChangeEvent } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
@@ -20,10 +19,10 @@ interface JetpackCancellationSurveyProps {
 export default function JetpackCancellationSurvey( {
 	selectedAnswerId,
 	onAnswerChange,
-}: JetpackCancellationSurveyProps ): ReactElement {
+}: JetpackCancellationSurveyProps ) {
 	const translate = useTranslate();
-	const [ customAnswerText, setCustomAnswerText ] = useState< string >( '' );
-	const customAnswerInputRef = React.useRef< HTMLInputElement | null >();
+	const [ customAnswerText, setCustomAnswerText ] = useState( '' );
+	const customAnswerInputRef = useRef< HTMLInputElement | null >();
 
 	const choices: Choice[] = [
 		{
@@ -61,7 +60,7 @@ export default function JetpackCancellationSurvey( {
 	);
 
 	const onChangeCustomAnswerText = useCallback(
-		( event: React.ChangeEvent< HTMLInputElement > ) => {
+		( event: ChangeEvent< HTMLInputElement > ) => {
 			const { value } = event.target;
 
 			onAnswerChange( selectedAnswerId, value );
@@ -70,7 +69,7 @@ export default function JetpackCancellationSurvey( {
 		[ selectedAnswerId, onAnswerChange, setCustomAnswerText ]
 	);
 
-	const renderChoiceCard = ( choice: Choice ): ReactElement => {
+	const renderChoiceCard = ( choice: Choice ) => {
 		return (
 			<Card
 				className={ classnames( 'jetpack-cancellation-survey__card', {
@@ -88,7 +87,7 @@ export default function JetpackCancellationSurvey( {
 	};
 
 	return (
-		<React.Fragment>
+		<>
 			<FormattedHeader
 				headerText={ translate( 'Before you go, help us improve Jetpack' ) }
 				subHeaderText={ translate( 'Please let us know why you are cancelling.' ) }
@@ -120,6 +119,6 @@ export default function JetpackCancellationSurvey( {
 					/>
 				</div>
 			</Card>
-		</React.Fragment>
+		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -1,4 +1,3 @@
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
@@ -17,7 +16,7 @@ export default function DashboardOverview( {
 	search,
 	currentPage,
 	filter,
-}: SitesOverviewContextInterface ): ReactElement {
+}: SitesOverviewContextInterface ) {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -3,7 +3,7 @@ import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { ReactElement, useContext, useEffect, useState, useMemo } from 'react';
+import { useContext, useEffect, useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Count from 'calypso/components/count';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -26,7 +26,7 @@ import SiteWelcomeBanner from './site-welcome-banner';
 
 import './style.scss';
 
-export default function SitesOverview(): ReactElement {
+export default function SitesOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const isMobile = useMobileBreakpoint();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -8,7 +8,6 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getActionEventName } from '../utils';
 import type { SiteNode, AllowedActionTypes } from '../types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -18,11 +17,7 @@ interface Props {
 	siteError: boolean | undefined;
 }
 
-export default function SiteActions( {
-	isLargeScreen = false,
-	site,
-	siteError,
-}: Props ): ReactElement {
+export default function SiteActions( { isLargeScreen = false, site, siteError }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -11,7 +11,7 @@ export default function SiteAddLicenseNotification( {
 	purchasedLicense,
 }: {
 	purchasedLicense: PurchasedProduct;
-} ): ReactElement | null {
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -1,6 +1,6 @@
 import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { useState, useCallback, ReactElement, MouseEvent, KeyboardEvent } from 'react';
+import { useState, useCallback, MouseEvent, KeyboardEvent } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SiteActions from '../site-actions';
@@ -15,7 +15,7 @@ interface Props {
 	columns: SiteColumns;
 }
 
-export default function SiteCard( { rows, columns }: Props ): ReactElement {
+export default function SiteCard( { rows, columns }: Props ) {
 	const dispatch = useDispatch();
 
 	const [ isExpanded, setIsExpanded ] = useState( false );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -7,7 +7,6 @@ import { addQueryArgs } from 'calypso/lib/route';
 import SiteCard from '../site-card';
 import SiteTable from '../site-table';
 import { formatSites, siteColumns } from '../utils';
-import type { ReactElement } from 'react';
 import './style.scss';
 
 const addPageArgs = ( pageNumber: number ) => {
@@ -22,7 +21,7 @@ interface Props {
 	currentPage: number;
 }
 
-export default function SiteContent( { data, isLoading, currentPage }: Props ): ReactElement {
+export default function SiteContent( { data, isLoading, currentPage }: Props ) {
 	const isMobile = useMobileBreakpoint();
 
 	const sites = formatSites( data?.sites );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
@@ -2,9 +2,8 @@ import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import type { ReactElement } from 'react';
 
-export default function SiteErrorContent( { siteUrl }: { siteUrl: string } ): ReactElement {
+export default function SiteErrorContent( { siteUrl }: { siteUrl: string } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-filters/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-filters/index.tsx
@@ -2,7 +2,6 @@ import { useDispatch } from 'react-redux';
 import { FilterbarWithoutDispatch as Filterbar } from 'calypso/my-sites/activity/filterbar';
 import { updateFilter } from 'calypso/state/jetpack-agency-dashboard/actions';
 import type { AgencyDashboardFilter, AgencyDashboardFilterOption } from '../types';
-import type { ReactElement } from 'react';
 
 export default function SiteFilters( {
 	filter,
@@ -10,7 +9,7 @@ export default function SiteFilters( {
 }: {
 	filter: AgencyDashboardFilter;
 	isLoading: boolean;
-} ): ReactElement {
+} ) {
 	const dispatch = useDispatch();
 	const selectIssueTypes = ( types: AgencyDashboardFilterOption[] ) => {
 		dispatch( updateFilter( types ) );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/SiteSearchFilterContainer.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/SiteSearchFilterContainer.tsx
@@ -1,7 +1,6 @@
 import SiteFilters from '../site-filters';
 import SiteSearch from '../site-search';
 import type { AgencyDashboardFilter } from '../types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -17,7 +16,7 @@ export default function SiteSearchFilterContainer( {
 	currentPage,
 	filter,
 	isLoading,
-}: Props ): ReactElement {
+}: Props ) {
 	return (
 		<div className="site-search-filter-container">
 			<div className="site-search-filter-container__search">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
@@ -3,14 +3,13 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import Search from 'calypso/components/search';
 import { addQueryArgs } from 'calypso/lib/route';
-import type { ReactElement } from 'react';
 
 export default function SiteSearch( {
 	searchQuery,
 }: {
 	searchQuery: string | null;
 	currentPage: number;
-} ): ReactElement {
+} ) {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -3,7 +3,7 @@ import { Icon, starFilled, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { ReactElement, useContext } from 'react';
+import { useContext } from 'react';
 import { useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
 import useToggleFavoriteSiteMutation from 'calypso/data/agency-dashboard/use-toggle-favourite-site-mutation';
@@ -20,7 +20,7 @@ interface Props {
 	siteUrl: string;
 }
 
-export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ): ReactElement {
+export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { ReactElement, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
@@ -22,7 +22,7 @@ export default function SiteStatusContent( {
 	type,
 	isLargeScreen = false,
 	isFavorite = false,
-}: Props ): ReactElement {
+}: Props ) {
 	const dispatch = useDispatch();
 
 	const {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,6 +1,6 @@
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
-import { ReactElement, Fragment } from 'react';
+import { Fragment } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
@@ -15,7 +15,7 @@ interface Props {
 	items: Array< SiteData >;
 }
 
-export default function SiteTable( { isLoading, columns, items }: Props ): ReactElement {
+export default function SiteTable( { isLoading, columns, items }: Props ) {
 	return (
 		<table className="site-table__table">
 			<thead>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import tipIcon from 'calypso/assets/images/jetpack/tip-icon.svg';
 import Banner from 'calypso/components/banner';
@@ -19,7 +19,7 @@ export default function SiteWelcomeBanner( {
 }: {
 	isDashboardView?: boolean;
 	bannerKey?: string;
-} ): ReactElement | null {
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -18,10 +18,9 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import { translateInvalidPartnerParameterError } from 'calypso/state/partner-portal/partner/utils';
 import type { APIError } from 'calypso/state/partner-portal/types';
-import type { ReactElement } from 'react';
 import './style.scss';
 
-export default function AgencySignupForm(): ReactElement {
+export default function AgencySignupForm() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );

--- a/client/jetpack-cloud/sections/agency-signup/primary/agency-signup/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/primary/agency-signup/index.tsx
@@ -3,9 +3,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import AgencySignupForm from 'calypso/jetpack-cloud/sections/agency-signup/agency-signup-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
-import type { ReactElement } from 'react';
 
-export default function AgencySignup(): ReactElement {
+export default function AgencySignup() {
 	const translate = useTranslate();
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
@@ -1,12 +1,11 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
-export default function AddStoredCreditCard(): ReactElement {
+export default function AddStoredCreditCard() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -2,7 +2,7 @@ import { Button, Card } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { ReactElement, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import FormRadio from 'calypso/components/forms/form-radio';
 import Pagination from 'calypso/components/pagination';
@@ -44,7 +44,7 @@ export default function AssignLicenseForm( {
 	sites: Array< any >;
 	currentPage: number;
 	search: string;
-} ): ReactElement {
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ selectedSite, setSelectedSite ] = useState( false );

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
-import type { ReactChild, ReactElement } from 'react';
+import type { ReactChild } from 'react';
 import './style.scss';
 
 function getStepClassName( currentStep: number, step: number ): any {
@@ -16,13 +16,7 @@ function getStepClassName( currentStep: number, step: number ): any {
 	} );
 }
 
-function CheckMarkOrNumber( {
-	currentStep,
-	step,
-}: {
-	currentStep: number;
-	step: number;
-} ): ReactElement {
+function CheckMarkOrNumber( { currentStep, step }: { currentStep: number; step: number } ) {
 	if ( currentStep > step ) {
 		return (
 			<span className="assign-license-step-progress__step-circle">
@@ -49,7 +43,7 @@ interface Props {
 	currentStep: StepKey;
 }
 
-export default function AssignLicenseStepProgress( { currentStep }: Props ): ReactElement | null {
+export default function AssignLicenseStepProgress( { currentStep }: Props ) {
 	const translate = useTranslate();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const sites = useSelector( getSites ).length;

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -1,13 +1,12 @@
 import { Card, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
 import './style.scss';
 
-export default function BillingDetails(): ReactElement {
+export default function BillingDetails() {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const billing = useBillingDashboardQuery();

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { numberFormat, useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Tooltip from 'calypso/components/tooltip';
@@ -10,7 +10,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
 import './style.scss';
 
-function CostTooltip(): ReactElement {
+function CostTooltip() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const tooltip = useRef< SVGSVGElement >( null );
@@ -60,7 +60,7 @@ function CostTooltip(): ReactElement {
 	);
 }
 
-export default function BillingSummary(): ReactElement {
+export default function BillingSummary() {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const billing = useBillingDashboardQuery();

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, ReactElement, useCallback, useState } from 'react';
+import { ReactChild, useCallback, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -48,7 +48,7 @@ export default function CompanyDetailsForm( {
 	initialValues = {},
 	onSubmit,
 	submitLabel,
-}: Props ): ReactElement {
+}: Props ) {
 	const translate = useTranslate();
 	const { countryOptions, stateOptionsMap } = useCountriesAndStates();
 	const showCountryFields = countryOptions.length > 0;

--- a/client/jetpack-cloud/sections/partner-portal/invoices-list-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list-card/index.tsx
@@ -8,19 +8,10 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import InvoicesListRow from 'calypso/jetpack-cloud/sections/partner-portal/invoices-list-row';
 import usePayInvoiceMutation from 'calypso/state/partner-portal/invoices/hooks/pay-invoice-mutation';
 import type { Invoice } from 'calypso/state/partner-portal/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
-function InvoicesListCard( {
-	id,
-	number,
-	dueDate,
-	status,
-	total,
-	currency,
-	pdfUrl,
-}: Invoice ): ReactElement {
+function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUrl }: Invoice ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const dueDateMoment = moment( dueDate );

--- a/client/jetpack-cloud/sections/partner-portal/invoices-list-row/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list-row/index.tsx
@@ -1,21 +1,19 @@
 import { Card } from '@automattic/components';
 import classnames from 'classnames';
 import { memo } from 'react';
-import type { ReactNode, ReactElement } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import './style.scss';
 
-interface Props {
+type Props = PropsWithChildren< {
 	header?: boolean;
-	children: ReactNode;
-}
+} >;
 
-function InvoicesListRow( { header, children }: Props ): ReactElement {
+function InvoicesListRow( { header, children }: Props ) {
 	return (
 		<Card
 			compact
-			className={ classnames( {
-				'invoices-list-row': true,
+			className={ classnames( 'invoices-list-row', {
 				'invoices-list-row--header': header,
 			} ) }
 		>

--- a/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { memo, ReactElement, useCallback, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import Pagination from 'calypso/components/pagination';
 import { useCursorPagination } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import InvoicesListCard from 'calypso/jetpack-cloud/sections/partner-portal/invoices-list-card';
@@ -10,7 +10,7 @@ import useInvoicesQuery from 'calypso/state/partner-portal/invoices/hooks/use-in
 
 import './style.scss';
 
-const InvoicePlaceholderCard = memo( (): ReactElement => {
+const InvoicePlaceholderCard = memo( () => {
 	return (
 		<InvoicesListRow>
 			<div>
@@ -36,7 +36,7 @@ const InvoicePlaceholderCard = memo( (): ReactElement => {
 	);
 } );
 
-export default function InvoicesList(): ReactElement {
+export default function InvoicesList() {
 	const translate = useTranslate();
 	const [ pagination, setPagination ] = useState( { starting_after: '', ending_before: '' } );
 	const invoices = useInvoicesQuery( pagination );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import sortBy from 'lodash/sortBy';
-import { ReactElement, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLicenseIssuing } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
@@ -22,10 +22,7 @@ function alphabeticallySortedProductOptions(
 	return sortBy( selectProductOptions( families ), ( product ) => product.name );
 }
 
-export default function IssueLicenseForm( {
-	selectedSite,
-	suggestedProduct,
-}: AssignLicenceProps ): ReactElement {
+export default function IssueLicenseForm( { selectedSite, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const products = useProductsQuery( {

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
@@ -23,7 +23,7 @@ export default function LicenseDetailsActions( {
 	siteUrl,
 	attachedAt,
 	revokedAt,
-}: Props ): ReactElement {
+}: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -1,6 +1,5 @@
 import { Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import LicenseDetailsActions from 'calypso/jetpack-cloud/sections/partner-portal/license-details/actions';
@@ -32,7 +31,7 @@ export default function LicenseDetails( {
 	attachedAt,
 	revokedAt,
 	onCopyLicense = noop,
-}: Props ): ReactElement {
+}: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -11,7 +10,7 @@ interface Props {
 	filter: LicenseFilter;
 }
 
-export default function LicenseListEmpty( { filter }: Props ): ReactElement {
+export default function LicenseListEmpty( { filter }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const counts = useSelector( getLicenseCounts );

--- a/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
+import { PropsWithChildren, useCallback, useContext } from 'react';
 import { useDispatch } from 'react-redux';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
@@ -76,7 +76,7 @@ function SortButton( {
 	);
 }
 
-export default function LicenseListHeader(): ReactElement {
+export default function LicenseListHeader() {
 	const translate = useTranslate();
 	const { filter, sortField, sortDirection } = useContext( LicenseListContext );
 

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -1,5 +1,5 @@
 import page from 'page';
-import { PropsWithChildren, ReactElement, useContext, useCallback } from 'react';
+import { PropsWithChildren, useContext, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
@@ -38,7 +38,7 @@ const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > )
 	<CSSTransition { ...props } classNames="license-list__license-transition" timeout={ 150 } />
 );
 
-export default function LicenseList(): ReactElement {
+export default function LicenseList() {
 	const dispatch = useDispatch();
 	const { filter, search, sortField, sortDirection, currentPage } =
 		useContext( LicenseListContext );

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
-import { ReactElement, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FormattedDate from 'calypso/components/formatted-date';
 import LicenseDetails from 'calypso/jetpack-cloud/sections/partner-portal/license-details';
@@ -40,7 +40,7 @@ export default function LicensePreview( {
 	attachedAt,
 	revokedAt,
 	filter,
-}: Props ): ReactElement {
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
@@ -219,7 +219,7 @@ export default function LicensePreview( {
 	);
 }
 
-export function LicensePreviewPlaceholder(): ReactElement {
+export function LicensePreviewPlaceholder() {
 	const translate = useTranslate();
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { getProductTitle } from '../utils';
 import './style.scss';
@@ -15,7 +15,7 @@ interface Props {
 	suggestedProduct?: string | null;
 }
 
-export default function LicenseProductCard( props: Props ): ReactElement {
+export default function LicenseProductCard( props: Props ) {
 	const { tabIndex, product, isSelected, onSelectProduct, suggestedProduct } = props;
 	const productTitle = getProductTitle( product.name );
 	const translate = useTranslate();

--- a/client/jetpack-cloud/sections/partner-portal/license-select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-select-partner-key/index.tsx
@@ -1,6 +1,5 @@
 import { Spinner } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
@@ -15,7 +14,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import { PartnerKey } from 'calypso/state/partner-portal/types';
 
-export default function LicenseSelectPartnerKey(): ReactElement | null {
+export default function LicenseSelectPartnerKey() {
 	const translate = useTranslate();
 	const hasKey = useSelector( hasActivePartnerKey );
 	const hasFetched = useSelector( hasFetchedPartner );

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useContext } from 'react';
+import { useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Count from 'calypso/components/count';
 import Search from 'calypso/components/search';
@@ -19,7 +19,7 @@ interface Props {
 	getSearchOpen: () => boolean;
 }
 
-function LicenseStateFilter( { doSearch }: Props ): ReactElement {
+function LicenseStateFilter( { doSearch }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { filter, search } = useContext( LicenseListContext );

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -15,7 +15,7 @@ export default function AssignLicense( {
 	sites: Array< any >;
 	currentPage: number;
 	search: string;
-} ): ReactElement {
+} ) {
 	const translate = useTranslate();
 
 	const scrollToTop = () => {

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -9,7 +8,7 @@ import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-por
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import './style.scss';
 
-export default function BillingDashboard(): ReactElement {
+export default function BillingDashboard() {
 	const translate = useTranslate();
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/primary/company-details-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/company-details-dashboard/index.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -8,7 +7,7 @@ import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sid
 import UpdateCompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/update-company-details-form';
 import './style.scss';
 
-export default function CompanyDetailsDashboard(): ReactElement {
+export default function CompanyDetailsDashboard() {
 	const translate = useTranslate();
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -8,7 +7,7 @@ import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-por
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import './style.scss';
 
-export default function InvoicesDashboard(): ReactElement {
+export default function InvoicesDashboard() {
 	const translate = useTranslate();
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -8,10 +8,7 @@ import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issu
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import { AssignLicenceProps } from '../../types';
 
-export default function IssueLicense( {
-	selectedSite,
-	suggestedProduct,
-}: AssignLicenceProps ): ReactElement {
+export default function IssueLicense( { selectedSite, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
@@ -1,10 +1,9 @@
 import page from 'page';
 import { useEffect } from 'react';
-import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { getActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
 
-export default function LandingPage(): React.ReactElement | null {
+export default function LandingPage() {
 	const activePartnerKey = useSelector( getActivePartnerKey );
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -34,7 +33,7 @@ export default function Licenses( {
 	currentPage,
 	sortDirection,
 	sortField,
-}: Props ): ReactElement {
+}: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isAgencyUser = useSelector( showAgencyDashboard );

--- a/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
@@ -1,6 +1,5 @@
 import { Button, Spinner } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
@@ -12,15 +11,14 @@ import {
 	getCurrentPartner,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
-import { PartnerKey } from 'calypso/state/partner-portal/types';
 
-export default function PartnerAccess(): ReactElement | null {
+export default function PartnerAccess() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const partner = useSelector( getCurrentPartner );
-	const keys = ( partner?.keys || [] ) as PartnerKey[];
+	const keys = partner?.keys || [];
 	const hasPartner = hasFetched && ! isFetching && keys.length > 0;
 	const showError = hasFetched && ! isFetching && keys.length === 0;
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -13,7 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useCallback, useMemo, ReactElement, useEffect } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -39,7 +39,7 @@ import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/acti
 
 import './style.scss';
 
-function PaymentMethodAdd(): ReactElement {
+function PaymentMethodAdd() {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
@@ -235,7 +235,7 @@ function PaymentMethodAdd(): ReactElement {
 	);
 }
 
-export default function PaymentMethodAddWrapper(): ReactElement {
+export default function PaymentMethodAddWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -19,7 +19,6 @@ import {
 	isFetchingStoredCards,
 	hasMoreStoredCards,
 } from 'calypso/state/partner-portal/stored-cards/selectors';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -41,7 +40,7 @@ const preparePagingCursor = (
 	};
 };
 
-export default function PaymentMethodList(): ReactElement {
+export default function PaymentMethodList() {
 	const translate = useTranslate();
 	const storedCards = useSelector( getAllStoredCards );
 	const isFetching = useSelector( isFetchingStoredCards );

--- a/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
@@ -1,6 +1,5 @@
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
@@ -8,7 +7,7 @@ import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selector
 import { PartnerKey } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
-export default function SelectPartnerKey(): ReactElement | null {
+export default function SelectPartnerKey() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );

--- a/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Gridicon, Spinner } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
@@ -20,7 +20,7 @@ import {
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
-export default function TermsOfServiceConsent(): ReactElement | null {
+export default function TermsOfServiceConsent() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const consent = useTOSConsentMutation( {

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
@@ -23,7 +23,7 @@ export default function RevokeLicenseDialog( {
 	siteUrl,
 	onClose,
 	...rest
-}: Props ): ReactElement {
+}: Props ) {
 	let close = noop;
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -10,7 +10,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import './style.scss';
 
-export default function SelectPartnerKeyDropdown(): ReactElement | null {
+export default function SelectPartnerKeyDropdown() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );

--- a/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
@@ -1,10 +1,9 @@
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
 import './style.scss';
 
-export default function PartnerPortalSidebarNavigation(): ReactElement {
+export default function PartnerPortalSidebarNavigation() {
 	const headerTitle = useSelector( getDocumentHeadTitle );
 
 	return <SidebarNavigation sectionTitle={ headerTitle } />;

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
@@ -5,11 +5,10 @@ import { useSelector } from 'react-redux';
 import PaymentMethodActions from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-actions';
 import { isDeletingStoredCard } from 'calypso/state/partner-portal/stored-cards/selectors';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
-export default function StoredCreditCard( props: { card: PaymentMethod } ): ReactElement {
+export default function StoredCreditCard( props: { card: PaymentMethod } ) {
 	const translate = useTranslate();
 	const creditCard = props.card;
 

--- a/client/jetpack-cloud/sections/partner-portal/text-placeholder/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/text-placeholder/index.tsx
@@ -1,7 +1,5 @@
-import { ReactElement } from 'react';
 import './style.scss';
 
-export default function TextPlaceholder(): ReactElement {
-	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+export default function TextPlaceholder() {
 	return <span className="partner-portal-text-placeholder" />;
 }

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
@@ -23,7 +23,7 @@ export default function UnassignLicenseDialog( {
 	siteUrl,
 	onClose,
 	...rest
-}: Props ): ReactElement {
+}: Props ) {
 	let close = noop;
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
 import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
@@ -12,7 +12,7 @@ import { translateInvalidPartnerParameterError } from 'calypso/state/partner-por
 import { PartnerDetailsPayload } from 'calypso/state/partner-portal/types';
 import type { APIError } from 'calypso/state/partner-portal/types';
 
-export default function UpdateCompanyDetailsForm(): ReactElement {
+export default function UpdateCompanyDetailsForm() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
@@ -23,13 +23,7 @@ interface Props {
 	path?: string;
 }
 
-export default function PluginsOverview( {
-	filter,
-	search,
-	site,
-	pluginSlug,
-	path,
-}: Props ): ReactElement {
+export default function PluginsOverview( { filter, search, site, pluginSlug, path }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -63,7 +57,5 @@ export default function PluginsOverview( {
 		);
 	}
 
-	return (
-		<>{ isFetching ? <JetpackLogo className="plugins-overview__logo" size={ 72 } /> : null }</>
-	);
+	return isFetching ? <JetpackLogo className="plugins-overview__logo" size={ 72 } /> : null;
 }

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -10,7 +9,7 @@ import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-fr
 
 import './style.scss';
 
-export default function StoreHeader(): React.ReactElement {
+export default function StoreHeader() {
 	const translate = useTranslate();
 	const partnerSlug = useSelector( getPartnerSlugFromQuery );
 	const currentRoute = useSelector( getCurrentRoute );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
@@ -4,7 +4,7 @@ import { CheckboxControl, SelectControl, TextControl } from '@wordpress/componen
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { without } from 'lodash';
-import { FormEvent, ReactElement, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -32,7 +32,7 @@ const StyledNextButton = styled( NextButton )`
 	}
 `;
 
-const BusinessInfo: Step = function ( props ): ReactElement | null {
+const BusinessInfo: Step = function ( props ) {
 	const { goNext, goBack, submit } = props.navigation;
 
 	const { __ } = useI18n();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/index.tsx
@@ -3,7 +3,7 @@ import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import emailValidator from 'email-validator';
-import React, { FormEvent, ReactElement, useState } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -73,7 +73,7 @@ const EditEmail: Step = function EditEmail( { navigation } ) {
 							value={ email }
 							name="email"
 							id="email"
-							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) => {
+							onChange={ ( e: ChangeEvent< HTMLInputElement > ) => {
 								setErrors( {} as Record< FormFields, string > );
 								setEmail( e.target.value );
 							} }
@@ -125,7 +125,7 @@ const EditEmail: Step = function EditEmail( { navigation } ) {
 	);
 };
 
-function ControlError( { error }: { error: string } ): ReactElement | null {
+function ControlError( { error }: { error: string } ) {
 	if ( error ) {
 		return <FormInputValidation isError={ true } isValid={ false } text={ error } />;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -1,7 +1,7 @@
 import { StepContainer, isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -16,7 +16,7 @@ export enum ProcessingResult {
 	FAILURE = 'failure',
 }
 
-const ProcessingStep: Step = function ( props ): ReactElement | null {
+const ProcessingStep: Step = function ( props ) {
 	const { submit } = props.navigation;
 
 	const { __ } = useI18n();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -5,7 +5,7 @@ import { ComboboxControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import emailValidator from 'email-validator';
-import { FormEvent, ReactElement, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -322,7 +322,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 	);
 };
 
-function ControlError( { error }: { error: string } ): ReactElement | null {
+function ControlError( { error }: { error: string } ) {
 	if ( error ) {
 		return <FormInputValidation isError={ true } isValid={ false } text={ error } />;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/support-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/support-card.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { ReactElement } from 'react';
 
 const SupportLinkContainer = styled.p`
 	@media ( max-width: 320px ) {
@@ -19,13 +18,7 @@ const SupportLinkStyle = styled.a`
 	font-weight: bold;
 `;
 
-export default function SupportCard( {
-	domain,
-	backUrl,
-}: {
-	domain: string;
-	backUrl?: string;
-} ): ReactElement {
+export default function SupportCard( { domain, backUrl }: { domain: string; backUrl?: string } ) {
 	domain = domain?.replace( /http[s]*:\/\//, '' );
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -2,12 +2,11 @@ import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
-const Subscribers: Step = function ( { navigation } ): ReactElement | null {
+const Subscribers: Step = function ( { navigation } ) {
 	const __ = useTranslate();
 	const { submit } = navigation;
 	const site = useSite();

--- a/client/layout/masterbar/write-icon.tsx
+++ b/client/layout/masterbar/write-icon.tsx
@@ -1,6 +1,4 @@
-import * as React from 'react';
-
-export const WriteIcon = (): React.ReactNode => (
+export const WriteIcon = () => (
 	<svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M11.5 8.5C10.1501 9.76923 7.64987 12.4487 6 14C5.85001 13.0128 6 10.7663 7.24982 8.80769C7.57814 8.29318 8.14971 7.53846 9.4996 6.69231C10.8495 5.84615 13.9992 5 13.9992 5C13.9993 5.84615 12.8499 7.23077 11.5 8.5Z"

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -59,7 +59,7 @@ const ContainerMain = styled.div`
 	}
 `;
 
-const ContentWithHeader = ( props: { children: ReactElement } ): ReactElement => {
+const ContentWithHeader = ( props: { children: ReactElement } ) => {
 	const translate = useTranslate();
 	const isWide = useDesktopBreakpoint();
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -2,7 +2,6 @@ import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
@@ -28,7 +27,7 @@ import './style.scss';
 
 const JetpackBackupErrorSVG = '/calypso/images/illustrations/jetpack-cloud-backup-error.svg';
 
-const BackupMultisiteBody: FunctionComponent = () => {
+const BackupMultisiteBody = () => {
 	const translate = useTranslate();
 	return (
 		<PromoCard
@@ -47,7 +46,7 @@ const BackupMultisiteBody: FunctionComponent = () => {
 	);
 };
 
-const BackupVPActiveBody: FunctionComponent = () => {
+const BackupVPActiveBody = () => {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_backup_vaultpress_click' );
 	const translate = useTranslate();
 	return (
@@ -71,7 +70,7 @@ const BackupVPActiveBody: FunctionComponent = () => {
 	);
 };
 
-const BackupUpsellBody: FunctionComponent = () => {
+const BackupUpsellBody = () => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
 	const isAdmin = useSelector(
@@ -166,7 +165,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 	);
 };
 
-export default function WPCOMUpsellPage( { reason }: { reason: string } ): ReactElement {
+export default function WPCOMUpsellPage( { reason }: { reason: string } ) {
 	const translate = useTranslate();
 	let body;
 	switch ( reason ) {

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -1,7 +1,6 @@
 import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -23,7 +22,7 @@ import './style.scss';
 
 const trackEventName = 'calypso_jetpack_backup_business_upsell';
 
-export default function WPCOMUpsellPage(): ReactElement {
+export default function WPCOMUpsellPage() {
 	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );

--- a/client/my-sites/customer-home/cards/tasks/verify-email/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/verify-email/index.tsx
@@ -1,12 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { TASK_VERIFY_EMAIL } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 
-const VerifyEmail = (): React.ReactElement => {
+const VerifyEmail = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const userEmail = useSelector( getCurrentUserEmail );

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -26,11 +26,11 @@ import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
-const ContentWithHeader = ( props: { children: ReactNode } ): ReactElement => {
+const ContentWithHeader = ( props: { children: ReactNode } ) => {
 	const translate = useTranslate();
 	return (
 		<Main wideLayout>
@@ -43,7 +43,7 @@ const ContentWithHeader = ( props: { children: ReactNode } ): ReactElement => {
 	);
 };
 
-const NoAccess = (): ReactElement => {
+const NoAccess = () => {
 	const translate = useTranslate();
 	return (
 		<ContentWithHeader>
@@ -55,7 +55,7 @@ const NoAccess = (): ReactElement => {
 	);
 };
 
-const LoadingPlaceholder = (): ReactElement => {
+const LoadingPlaceholder = () => {
 	return (
 		<ContentWithHeader>
 			<SectionHeader className="email-home__section-placeholder is-placeholder" />

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
@@ -3,7 +3,6 @@ import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -15,7 +14,7 @@ interface BillingIntervalToggleProps {
 export const BillingIntervalToggle = ( {
 	intervalLength,
 	onIntervalChange,
-}: BillingIntervalToggleProps ): ReactElement => {
+}: BillingIntervalToggleProps ) => {
 	const translate = useTranslate();
 	const [ payAnnuallyButtonRef, setPayAnnuallyButtonRef ] = useState< HTMLSpanElement | null >(
 		null

--- a/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/email-forwarding-link/index.tsx
@@ -6,7 +6,6 @@ import { emailManagementAddEmailForwards } from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -14,9 +13,7 @@ type EmailForwardingLinkProps = {
 	selectedDomainName: string;
 };
 
-const EmailForwardingLink = ( {
-	selectedDomainName,
-}: EmailForwardingLinkProps ): ReactElement | null => {
+const EmailForwardingLink = ( { selectedDomainName }: EmailForwardingLinkProps ) => {
 	const translate = useTranslate();
 
 	const currentRoute = useSelector( getCurrentRoute );

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -1,12 +1,9 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-
 import { Card } from '@automattic/components';
 import EmailProviderFeatures from 'calypso/my-sites/email/email-provider-features';
 import EmailProviderPrice from 'calypso/my-sites/email/email-providers-comparison/in-depth/email-provider-price';
 import LearnMoreLink from 'calypso/my-sites/email/email-providers-comparison/in-depth/learn-more-link';
 import SelectButton from 'calypso/my-sites/email/email-providers-comparison/in-depth/select-button';
 import { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -15,60 +12,58 @@ const ComparisonList = ( {
 	intervalLength,
 	onSelectEmailProvider,
 	selectedDomainName,
-}: ComparisonListOrTableProps ): ReactElement => {
-	return (
-		<div className="email-providers-in-depth-comparison-list">
-			{ emailProviders.map( ( emailProviderFeatures ) => {
-				const { collaboration, importing, tools, storage, support } = emailProviderFeatures.list;
+}: ComparisonListOrTableProps ) => (
+	<div className="email-providers-in-depth-comparison-list">
+		{ emailProviders.map( ( emailProviderFeatures ) => {
+			const { collaboration, importing, tools, storage, support } = emailProviderFeatures.list;
 
-				return (
-					<Card key={ emailProviderFeatures.slug }>
-						<div className="email-providers-in-depth-comparison-list__provider">
-							{ emailProviderFeatures.logo }
+			return (
+				<Card key={ emailProviderFeatures.slug }>
+					<div className="email-providers-in-depth-comparison-list__provider">
+						{ emailProviderFeatures.logo }
 
-							<div className="email-providers-in-depth-comparison-list__provider-info">
-								<h2>{ emailProviderFeatures.name }</h2>
+						<div className="email-providers-in-depth-comparison-list__provider-info">
+							<h2>{ emailProviderFeatures.name }</h2>
 
-								<p>{ emailProviderFeatures.description }</p>
-							</div>
+							<p>{ emailProviderFeatures.description }</p>
 						</div>
+					</div>
 
-						<div className="email-providers-in-depth-comparison-list__price">
-							<EmailProviderPrice
-								emailProviderSlug={ emailProviderFeatures.slug }
-								intervalLength={ intervalLength }
-								selectedDomainName={ selectedDomainName }
-							/>
-						</div>
-
-						<div className="email-providers-in-depth-comparison-list__features">
-							<EmailProviderFeatures
-								features={ [ tools, storage, collaboration, importing, support ] }
-							/>
-						</div>
-
-						<div className="email-providers-in-depth-comparison-list__support-link">
-							<LearnMoreLink url={ emailProviderFeatures.supportUrl } />
-						</div>
-
-						{ emailProviderFeatures.badge && (
-							<div className="email-providers-in-depth-comparison-list__badge">
-								{ emailProviderFeatures.badge }
-							</div>
-						) }
-
-						<SelectButton
-							className="email-providers-in-depth-comparison-list__button"
+					<div className="email-providers-in-depth-comparison-list__price">
+						<EmailProviderPrice
 							emailProviderSlug={ emailProviderFeatures.slug }
 							intervalLength={ intervalLength }
-							onSelectEmailProvider={ onSelectEmailProvider }
 							selectedDomainName={ selectedDomainName }
 						/>
-					</Card>
-				);
-			} ) }
-		</div>
-	);
-};
+					</div>
+
+					<div className="email-providers-in-depth-comparison-list__features">
+						<EmailProviderFeatures
+							features={ [ tools, storage, collaboration, importing, support ] }
+						/>
+					</div>
+
+					<div className="email-providers-in-depth-comparison-list__support-link">
+						<LearnMoreLink url={ emailProviderFeatures.supportUrl } />
+					</div>
+
+					{ emailProviderFeatures.badge && (
+						<div className="email-providers-in-depth-comparison-list__badge">
+							{ emailProviderFeatures.badge }
+						</div>
+					) }
+
+					<SelectButton
+						className="email-providers-in-depth-comparison-list__button"
+						emailProviderSlug={ emailProviderFeatures.slug }
+						intervalLength={ intervalLength }
+						onSelectEmailProvider={ onSelectEmailProvider }
+						selectedDomainName={ selectedDomainName }
+					/>
+				</Card>
+			);
+		} ) }
+	</div>
+);
 
 export default ComparisonList;

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -5,7 +5,6 @@ import EmailProviderPrice from 'calypso/my-sites/email/email-providers-compariso
 import LearnMoreLink from 'calypso/my-sites/email/email-providers-comparison/in-depth/learn-more-link';
 import SelectButton from 'calypso/my-sites/email/email-providers-comparison/in-depth/select-button';
 import type { ComparisonListOrTableProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -14,7 +13,7 @@ const ComparisonTable = ( {
 	intervalLength,
 	onSelectEmailProvider,
 	selectedDomainName,
-}: ComparisonListOrTableProps ): ReactElement => {
+}: ComparisonListOrTableProps ) => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
@@ -9,13 +9,12 @@ import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-compa
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProviderPriceProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-import type { ReactElement } from 'react';
 
 const EmailProviderPrice = ( {
 	emailProviderSlug,
 	intervalLength,
 	selectedDomainName,
-}: EmailProviderPriceProps ): ReactElement => {
+}: EmailProviderPriceProps ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );

--- a/client/my-sites/email/email-providers-comparison/in-depth/learn-more-link.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/learn-more-link.tsx
@@ -1,9 +1,8 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import type { LearnMoreLinkProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-import type { ReactElement } from 'react';
 
-const LearnMoreLink = ( { url }: LearnMoreLinkProps ): ReactElement => {
+const LearnMoreLink = ( { url }: LearnMoreLinkProps ) => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -12,7 +12,6 @@ import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsu
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { SelectButtonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-import type { ReactElement } from 'react';
 
 const usePlanAvailable = (
 	emailProviderSlug: string,
@@ -50,7 +49,7 @@ const SelectButton = ( {
 	intervalLength,
 	onSelectEmailProvider,
 	selectedDomainName,
-}: SelectButtonProps ): ReactElement => {
+}: SelectButtonProps ) => {
 	const translate = useTranslate();
 
 	const cartKey = useCartKey();

--- a/client/my-sites/email/email-providers-comparison/price-badge/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-badge/index.tsx
@@ -8,7 +8,7 @@ type PriceBadgeProps = {
 	priceInformation?: ReactElement;
 };
 
-const PriceBadge = ( { price, priceInformation }: PriceBadgeProps ): ReactElement => (
+const PriceBadge = ( { price, priceInformation }: PriceBadgeProps ) => (
 	<div className="price-badge">
 		<PromoCardPrice formattedPrice={ price } additionalPriceInformation={ priceInformation } />
 	</div>

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -3,7 +3,6 @@ import { translate } from 'i18n-calypso';
 import { hasIntroductoryOfferFreeTrial } from 'calypso/lib/emails';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -31,7 +30,7 @@ const SalePriceWithInterval = ( {
 	intervalLength: IntervalLength;
 	salePrice: string | null;
 	standardPrice: string | null;
-} ): ReactElement => {
+} ) => {
 	const translateArguments = {
 		args: {
 			salePrice,
@@ -72,7 +71,7 @@ const StandardPriceWithInterval = ( {
 }: {
 	intervalLength: IntervalLength;
 	standardPrice: string | null;
-} ): ReactElement => {
+} ) => {
 	const translateArguments = {
 		args: { standardPrice },
 		comment:
@@ -103,7 +102,7 @@ const PriceWithInterval = ( {
 	isDiscounted?: boolean;
 	isEligibleForIntroductoryOffer: boolean;
 	product: ProductListItem | null;
-} ): ReactElement => {
+} ) => {
 	const standardPrice = formatCurrency( product?.cost ?? 0, currencyCode ?? '', {
 		stripZeros: true,
 	} );

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -12,7 +12,6 @@ import useGetDomainIntroductoryOfferEligibilities from 'calypso/my-sites/email/e
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -36,7 +35,7 @@ const DiscountPriceInformation = ( {
 }: {
 	isEligibleForIntroductoryOffer: boolean;
 	product: ProductListItem;
-} ): ReactElement => {
+} ) => {
 	const translate = useTranslate();
 
 	return (
@@ -66,7 +65,7 @@ export const FreeTrialPriceInformation = ( {
 }: {
 	className?: string;
 	product: ProductListItem;
-} ): ReactElement | null => {
+} ) => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const translate = useTranslate();
 
@@ -112,7 +111,7 @@ const PriceInformation = ( {
 	domain?: ResponseDomain;
 	isDomainInCart?: boolean;
 	product: ProductListItem | null;
-} ): ReactElement | null => {
+} ) => {
 	const { isEligibleForIntroductoryOffer, isEligibleForIntroductoryOfferFreeTrial } =
 		useGetDomainIntroductoryOfferEligibilities( {
 			domain,

--- a/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/email-provider-stacked-features.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/email-provider-stacked-features.tsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { preventWidows } from 'calypso/lib/formatting';
 import type { TranslateResult } from 'i18n-calypso';
-import type { MouseEventHandler, ReactElement } from 'react';
+import type { MouseEventHandler } from 'react';
 
 import './style.scss';
 
@@ -10,9 +10,7 @@ export interface EmailProviderStackedFeatureProps {
 	title: TranslateResult;
 }
 
-const EmailProviderStackedFeature = ( {
-	title,
-}: EmailProviderStackedFeatureProps ): ReactElement => {
+const EmailProviderStackedFeature = ( { title }: EmailProviderStackedFeatureProps ) => {
 	const size = 18;
 	return (
 		<div className="email-provider-stacked-features__feature">
@@ -37,7 +35,7 @@ export interface EmailProviderStackedFeaturesProps {
 export const EmailProviderStackedFeatures = ( {
 	features,
 	appLogos,
-}: EmailProviderStackedFeaturesProps ): ReactElement | null => {
+}: EmailProviderStackedFeaturesProps ) => {
 	const translate = useTranslate();
 
 	if ( ! features ) {
@@ -73,7 +71,7 @@ interface EmailProviderStackedFeaturesToggleButtonProps {
 export const EmailProviderStackedFeaturesToggleButton = ( {
 	handleClick,
 	isRelatedContentExpanded,
-}: EmailProviderStackedFeaturesToggleButtonProps ): ReactElement => {
+}: EmailProviderStackedFeaturesToggleButtonProps ) => {
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/index.tsx
@@ -8,7 +8,7 @@ import {
 	EmailProviderStackedFeaturesToggleButton,
 } from 'calypso/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/email-provider-stacked-features';
 import type { ProviderCardProps } from 'calypso/my-sites/email/email-providers-comparison/stacked/provider-cards/provider-card-props';
-import type { MouseEvent, ReactElement } from 'react';
+import type { MouseEvent } from 'react';
 
 import './style.scss';
 
@@ -30,7 +30,7 @@ const EmailProvidersStackedCard = ( {
 	productName,
 	providerKey,
 	showExpandButton = true,
-}: ProviderCardProps ): ReactElement => {
+}: ProviderCardProps ) => {
 	const [ areFeaturesExpanded, setFeaturesExpanded ] = useState( false );
 
 	const isViewportSizeLowerThan660px = useBreakpoint( '<660px' );

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/google-workspace-card.tsx
@@ -28,7 +28,6 @@ import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsu
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactElement } from 'react';
 
 import './google-workspace-card.scss';
 
@@ -59,7 +58,7 @@ const googleWorkspaceCardInformation: ProviderCardProps = {
 	features: getGoogleFeatures(),
 };
 
-const GoogleWorkspaceCard = ( props: EmailProvidersStackedCardProps ): ReactElement => {
+const GoogleWorkspaceCard = ( props: EmailProvidersStackedCardProps ) => {
 	const {
 		detailsExpanded,
 		intervalLength,

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.tsx
@@ -26,7 +26,6 @@ import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedCardProps, ProviderCardProps } from './provider-card-props';
-import type { ReactElement } from 'react';
 
 import './professional-email-card.scss';
 
@@ -66,7 +65,7 @@ const professionalEmailCardInformation: ProviderCardProps = {
 	},
 };
 
-const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactElement => {
+const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ) => {
 	const {
 		detailsExpanded,
 		intervalLength,

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -15,7 +15,6 @@ import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -23,7 +22,7 @@ type GoogleSaleBannerProps = {
 	domains: Array< ResponseDomain >;
 };
 
-const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ): ReactElement | null => {
+const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ) => {
 	const googleWorkspaceProduct = useSelector( ( state ) =>
 		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY )
 	);

--- a/client/my-sites/jetpack-search/disconnected.tsx
+++ b/client/my-sites/jetpack-search/disconnected.tsx
@@ -1,4 +1,3 @@
-import { ReactElement } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackDisconnected from 'calypso/components/jetpack/jetpack-disconnected';
 import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
@@ -7,7 +6,7 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
-export default function JetpackSearchDisconnected(): ReactElement {
+export default function JetpackSearchDisconnected() {
 	const isCloud = isJetpackCloud();
 	return (
 		<Main className="jetpack-search">

--- a/client/my-sites/jetpack-search/footer.tsx
+++ b/client/my-sites/jetpack-search/footer.tsx
@@ -1,11 +1,10 @@
-import { ReactElement, Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
-export default function JetpackSearchFooter(): ReactElement | null {
+export default function JetpackSearchFooter() {
 	const siteId = useSelector( getSelectedSiteId );
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const isCloud = isJetpackCloud();
@@ -15,9 +14,5 @@ export default function JetpackSearchFooter(): ReactElement | null {
 		return null;
 	}
 
-	return (
-		<Fragment>
-			<WhatIsJetpack />
-		</Fragment>
-	);
+	return <WhatIsJetpack />;
 }

--- a/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
@@ -1,7 +1,7 @@
 import { PRODUCT_JETPACK_SEARCH } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search-new.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -29,7 +29,7 @@ import JetpackSearchFooter from '../footer';
 
 import './style.scss';
 
-export default function JetpackSearchUpsell(): ReactElement {
+export default function JetpackSearchUpsell() {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_search_upsell' );
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';

--- a/client/my-sites/jetpack-search/logo.tsx
+++ b/client/my-sites/jetpack-search/logo.tsx
@@ -1,7 +1,6 @@
-import { ReactElement } from 'react';
 import JetpackSearchSVG from 'calypso/assets/images/illustrations/jetpack-search.svg';
 
-export default function JetpackSearchLogo(): ReactElement {
+export default function JetpackSearchLogo() {
 	return (
 		<div className="jetpack-search__logo">
 			<img src={ JetpackSearchSVG } alt="Search logo" />

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -1,6 +1,5 @@
 import { ProductIcon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
@@ -22,7 +21,7 @@ import JetpackSearchFooter from './footer';
 
 import './style.scss';
 
-export default function SearchMain(): ReactElement {
+export default function SearchMain() {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const site = useSelector( getSelectedSite );
 	const siteSlug = useSelector( getSelectedSiteSlug );

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -21,7 +21,7 @@ type DIFMLiteInProgressProps = {
 	siteId: number;
 };
 
-function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactElement {
+function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	const slug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
 	const isLoadingSite = useSelector(
 		( state: AppState ) => isRequestingSite( state, siteId ) || isRequestingSites( state )

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/anti-spam-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/anti-spam-thank-you.tsx
@@ -1,6 +1,5 @@
 import { Button, ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import getJetpackProductInstallProgress from 'calypso/state/selectors/get-jetpack-product-install-progress';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -17,11 +16,7 @@ const ThankYouCta: ThankYouCtaType = ( { siteAdminUrl, recordThankYouClick } ) =
 	);
 };
 
-const AntiSpamProductThankYou = ( {
-	installProgress,
-}: {
-	installProgress: number | null;
-} ): ReactElement => {
+const AntiSpamProductThankYou = ( { installProgress }: { installProgress: number | null } ) => {
 	const translate = useTranslate();
 	const isInstalled = installProgress === 100;
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-videopress-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-videopress-thank-you.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYou, { ThankYouCtaType } from './thank-you';
@@ -22,7 +21,7 @@ const ThankYouCta: ThankYouCtaType = ( { dismissUrl, recordThankYouClick } ) => 
 	);
 };
 
-const VideoPressProductThankYou = (): ReactElement => {
+const VideoPressProductThankYou = () => {
 	const translate = useTranslate();
 	return (
 		<ThankYou

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, ReactElement } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
@@ -33,7 +33,7 @@ const ThankYouCta: ThankYouCtaType = ( {
 	);
 };
 
-const ScanProductThankYou = (): ReactElement => {
+const ScanProductThankYou = () => {
 	const translate = useTranslate();
 	return (
 		<ThankYou

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import ThankYou, { ThankYouCtaType } from './thank-you';
 
 const ThankYouCta: ThankYouCtaType = ( {
@@ -23,7 +22,7 @@ const ThankYouCta: ThankYouCtaType = ( {
 	);
 };
 
-const SearchProductThankYou = (): ReactElement => {
+const SearchProductThankYou = () => {
 	const translate = useTranslate();
 	return (
 		<ThankYou

--- a/client/my-sites/plugins/plugin-details-body/index.tsx
+++ b/client/my-sites/plugins/plugin-details-body/index.tsx
@@ -1,7 +1,6 @@
 import PluginDetailsSidebar from 'calypso/my-sites/plugins/plugin-details-sidebar';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
-import type { ReactElement } from 'react';
 
 interface Props {
 	fullPlugin: any;
@@ -9,11 +8,7 @@ interface Props {
 	isWpcom: boolean;
 }
 
-export default function PluginDetailsBody( {
-	fullPlugin,
-	isMarketplaceProduct,
-	isWpcom,
-}: Props ): ReactElement {
+export default function PluginDetailsBody( { fullPlugin, isMarketplaceProduct, isWpcom }: Props ) {
 	return (
 		<div className="plugin-details__layout plugin-details__body">
 			<div className="plugin-details__layout-col-left">

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import ButtonGroup from 'calypso/components/button-group';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -35,7 +35,7 @@ export default function PluginManagementV2( {
 	updateAllPluginsNotice,
 	removePluginNotice,
 	updatePlugin,
-}: Props ): ReactElement {
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/index.tsx
@@ -21,7 +21,7 @@ export default function PluginActionStatus( {
 	selectedSite,
 	showMultipleStatuses = true,
 	retryButton,
-}: Props ): ReactElement | null {
+}: Props ) {
 	// Group statuses by status type(completed, error, inProgress)
 	const groupedStatues = currentSiteStatuses.reduce( ( group, plugin ) => {
 		const { status } = plugin;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/render-status-message.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/render-status-message.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { ReactElement } from 'react';
 import { CurrentSiteStatus, PluginActionStatus } from '../types';
 import { getPluginActionStatusMessages } from '../utils/get-plugin-action-status-messages';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -18,7 +17,7 @@ export default function RenderStatusMessage( {
 	currentStatus,
 	groupedStatues,
 	hasOneStatus,
-}: Props ): ReactElement | null {
+}: Props ) {
 	const currentGroupStatuses = groupedStatues[ currentStatus ];
 	const currentStatusAction = currentGroupStatuses[ 0 ].action;
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
@@ -1,7 +1,7 @@
 import PluginCommonCard from '../plugin-common/plugin-common-card';
 import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 interface Props {
 	item: Plugin;
@@ -11,6 +11,6 @@ interface Props {
 	hasMoreActions: boolean;
 }
 
-export default function PluginCard( props: Props ): ReactElement {
+export default function PluginCard( props: Props ) {
 	return <PluginCommonCard { ...props } />;
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-actions/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-actions/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 	item: any;
 }
 
-export default function PluginCommonActions( { renderActions, item }: Props ): ReactElement {
+export default function PluginCommonActions( { renderActions, item }: Props ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -23,7 +23,7 @@ export default function PluginCommonCard( {
 	rowFormatter,
 	columns,
 	renderActions,
-}: Props ): ReactElement {
+}: Props ) {
 	const columnKeys: { [ key: string ]: boolean } = columns.reduce(
 		( obj, cur ) => ( { ...obj, [ cur.key ]: true } ),
 		{}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/index.tsx
@@ -25,7 +25,7 @@ export default function PluginCommonList( {
 	primaryKey,
 	selectedSite,
 	...rest
-}: Props ): ReactElement {
+}: Props ) {
 	return (
 		<>
 			<div className={ classNames( { 'plugin-common-multi-site-table': ! selectedSite } ) }>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/index.tsx
@@ -25,7 +25,7 @@ export default function PluginCommonTable( {
 	primaryKey,
 	renderActions,
 	className,
-}: Props ): ReactElement {
+}: Props ) {
 	return (
 		<table className={ classNames( 'plugin-common-table__table', className ) }>
 			<thead>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -42,7 +42,7 @@ export default function PluginDetailsV2( {
 	showPlaceholder,
 	isMarketplaceProduct,
 	isWpcom,
-}: Props ): ReactElement {
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list.tsx
@@ -4,7 +4,6 @@ import { getSitesWithSecondarySites } from 'calypso/my-sites/plugins/plugin-mana
 import SitesList from '../sites-list';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -15,7 +14,7 @@ interface Props {
 	plugin: Plugin;
 }
 
-export default function PluginAvailableOnSitesList( props: Props ): ReactElement | null {
+export default function PluginAvailableOnSitesList( props: Props ) {
 	const translate = useTranslate();
 
 	const columns = [

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -6,7 +6,6 @@ import RemovePlugin from '../remove-plugin';
 import SitesList from '../sites-list';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -22,7 +21,7 @@ export default function SitesWithInstalledPluginsList( {
 	plugin,
 	selectedSite,
 	...rest
-}: Props ): ReactElement | null {
+}: Props ) {
 	const translate = useTranslate();
 	const columns = [
 		{

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
@@ -4,7 +4,6 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getManageConnectionHref } from 'calypso/lib/plugins/utils';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import '../style.scss';
 
@@ -13,7 +12,7 @@ interface Props {
 	plugin: Plugin;
 }
 
-export default function PluginManageConnection( { site, plugin }: Props ): ReactElement | null {
+export default function PluginManageConnection( { site, plugin }: Props ) {
 	const translate = useTranslate();
 
 	const isJetpackPlugin = plugin && 'jetpack' === plugin.slug;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, ReactChild } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -22,6 +21,7 @@ import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { MomentInput } from 'moment';
+import type { MouseEventHandler, PropsWithChildren } from 'react';
 
 import './style.scss';
 
@@ -41,15 +41,13 @@ export default function PluginRowFormatter( {
 	isSmallScreen,
 	className,
 	updatePlugin,
-}: Props ): ReactElement | any {
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const PluginDetailsButton = ( props: {
-		className: string;
-		children: ReactChild;
-		onClick?: React.MouseEventHandler;
-	} ) => {
+	const PluginDetailsButton = (
+		props: PropsWithChildren< { className: string; onClick?: MouseEventHandler } >
+	) => {
 		return (
 			<Button
 				borderless
@@ -175,14 +173,16 @@ export default function PluginRowFormatter( {
 			);
 		case 'sites':
 			return isSmallScreen ? (
-				translate(
-					'Installed on %(count)d site',
-					'Installed on %(count)d sites', // plural version of the string
-					{
-						count: siteCount,
-						args: { count: siteCount },
-					}
-				)
+				<>
+					{ translate(
+						'Installed on %(count)d site',
+						'Installed on %(count)d sites', // plural version of the string
+						{
+							count: siteCount,
+							args: { count: siteCount },
+						}
+					) }
+				</>
 			) : (
 				<PluginDetailsButton
 					className="plugin-row-formatter__sites-count-button"
@@ -192,49 +192,42 @@ export default function PluginRowFormatter( {
 				</PluginDetailsButton>
 			);
 		case 'activate':
-			return (
-				canActivate && (
-					<div className="plugin-row-formatter__toggle">
-						<PluginActivateToggle
-							isJetpackCloud
-							hideLabel={ ! isSmallScreen }
-							plugin={ pluginOnSite }
-							site={ selectedSite }
-							disabled={ !! item?.isSelectable }
-						/>
-					</div>
-				)
-			);
+			return canActivate ? (
+				<div className="plugin-row-formatter__toggle">
+					<PluginActivateToggle
+						isJetpackCloud
+						hideLabel={ ! isSmallScreen }
+						plugin={ pluginOnSite }
+						site={ selectedSite }
+						disabled={ !! item?.isSelectable }
+					/>
+				</div>
+			) : null;
 		case 'autoupdate':
-			return (
-				canUpdate && (
-					<div className="plugin-row-formatter__toggle">
-						<PluginAutoupdateToggle
-							plugin={ pluginOnSite }
-							site={ selectedSite }
-							wporg={ !! item.wporg }
-							isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
-							disabled={ !! item?.isSelectable }
-						/>
-					</div>
-				)
-			);
+			return canUpdate ? (
+				<div className="plugin-row-formatter__toggle">
+					<PluginAutoupdateToggle
+						plugin={ pluginOnSite }
+						site={ selectedSite }
+						wporg={ !! item.wporg }
+						isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
+						disabled={ !! item?.isSelectable }
+					/>
+				</div>
+			) : null;
 		case 'last-updated':
-			if ( item?.update && item?.last_updated ) {
-				return (
-					<span className="plugin-row-formatter__last-updated">
-						{ translate( '{{span}}Updated{{/span}} %(ago)s', {
-							components: {
-								span: <span />,
-							},
-							args: {
-								ago: ago( item.last_updated ),
-							},
-						} ) }
-					</span>
-				);
-			}
-			return null;
+			return item?.update && item?.last_updated ? (
+				<span className="plugin-row-formatter__last-updated">
+					{ translate( '{{span}}Updated{{/span}} %(ago)s', {
+						components: {
+							span: <span />,
+						},
+						args: {
+							ago: ago( item.last_updated ),
+						},
+					} ) }
+				</span>
+			) : null;
 		case 'update':
 			return (
 				<UpdatePlugin
@@ -257,6 +250,8 @@ export default function PluginRowFormatter( {
 				</div>
 			);
 		case 'bulk-actions':
+			return null;
+		default:
 			return null;
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -7,7 +7,6 @@ import PluginRowFormatter from '../plugin-row-formatter';
 import RemovePlugin from '../remove-plugin';
 import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import '../style.scss';
 
@@ -26,7 +25,7 @@ export default function PluginsList( {
 	removePluginNotice,
 	updatePlugin,
 	...rest
-}: Props ): ReactElement {
+}: Props ) {
 	const translate = useTranslate();
 
 	const rowFormatter = ( props: PluginRowFormatterArgs ) => {

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
@@ -1,6 +1,6 @@
 import PluginCommonTable from '../plugin-common/plugin-common-table';
 import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 interface Props {
 	isLoading: boolean;
@@ -11,6 +11,6 @@ interface Props {
 	primaryKey: string;
 }
 
-export default function PluginsTable( props: Props ): ReactElement {
+export default function PluginsTable( props: Props ) {
 	return <PluginCommonTable { ...props } />;
 }

--- a/client/my-sites/plugins/plugin-management-v2/remove-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/remove-plugin/index.tsx
@@ -3,7 +3,6 @@ import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import PluginRemoveButton from '../../plugin-remove-button';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import '../style.scss';
 
@@ -12,7 +11,7 @@ interface Props {
 	plugin: Plugin;
 }
 
-export default function RemovePlugin( { site, plugin }: Props ): ReactElement {
+export default function RemovePlugin( { site, plugin }: Props ) {
 	const pluginOnSite = useSelector( ( state ) => getPluginOnSite( state, site.ID, plugin.slug ) );
 
 	return (

--- a/client/my-sites/plugins/plugin-management-v2/sites-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/sites-list/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 	renderActions?: ( args: any ) => ReactElement;
 }
 
-export default function SitesList( { selectedSite, plugin, ...rest }: Props ): ReactElement {
+export default function SitesList( { selectedSite, plugin, ...rest }: Props ) {
 	const dispatch = useDispatch();
 
 	const rowFormatter = ( { item, ...rest }: SiteRowFormatterArgs ) => {

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -13,7 +13,6 @@ import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
 import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -24,12 +23,7 @@ interface Props {
 	updatePlugin?: ( plugin: Plugin ) => void;
 }
 
-export default function UpdatePlugin( {
-	plugin,
-	selectedSite,
-	className,
-	updatePlugin,
-}: Props ): ReactElement | null {
+export default function UpdatePlugin( { plugin, selectedSite, className, updatePlugin }: Props ) {
 	const translate = useTranslate();
 	const allSites = useSelector( getSites );
 	const state = useSelector( ( state ) => state );

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
@@ -20,7 +19,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
-const ScanMultisiteBody: FunctionComponent = () => {
+const ScanMultisiteBody = () => {
 	const translate = useTranslate();
 	return (
 		<PromoCard
@@ -39,7 +38,7 @@ const ScanMultisiteBody: FunctionComponent = () => {
 	);
 };
 
-const ScanVPActiveBody: FunctionComponent = () => {
+const ScanVPActiveBody = () => {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_vaultpress_click' );
 	const translate = useTranslate();
 	return (
@@ -69,7 +68,7 @@ const ScanVPActiveBody: FunctionComponent = () => {
 	);
 };
 
-const ScanUpsellBody: FunctionComponent = () => {
+const ScanUpsellBody = () => {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
@@ -119,7 +118,7 @@ const ScanUpsellBody: FunctionComponent = () => {
 	);
 };
 
-export default function WPCOMScanUpsellPage( { reason }: { reason?: string } ): ReactElement {
+export default function WPCOMScanUpsellPage( { reason }: { reason?: string } ) {
 	const translate = useTranslate();
 	let body;
 	switch ( reason ) {

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -4,7 +4,6 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -21,7 +20,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 
 import './style.scss';
 
-export default function WPCOMScanUpsellPage(): ReactElement {
+export default function WPCOMScanUpsellPage() {
 	const translate = useTranslate();
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_business_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );

--- a/client/my-sites/site-settings/jetpack-credentials-banner/index.tsx
+++ b/client/my-sites/site-settings/jetpack-credentials-banner/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -13,12 +13,12 @@ interface Props {
 	siteSlug: string;
 }
 
-const JetpackCredentialsBanner: React.FC< Props > = ( { siteSlug } ): React.ReactElement => {
+const JetpackCredentialsBanner = ( { siteSlug }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const preference: Preference[] = useSelector( ( state ) => getPreference( state ) );
 
-	const savePreferenceType = React.useCallback(
+	const savePreferenceType = useCallback(
 		( type: PreferenceType ) => {
 			dispatch(
 				savePreference( JETPACK_CREDENTIALS_BANNER_PREFERENCE, [
@@ -33,11 +33,11 @@ const JetpackCredentialsBanner: React.FC< Props > = ( { siteSlug } ): React.Reac
 		[ dispatch, preference ]
 	);
 
-	React.useEffect( () => {
+	useEffect( () => {
 		savePreferenceType( 'view' );
 	}, [] );
 
-	const dismissBanner = React.useCallback( () => {
+	const dismissBanner = useCallback( () => {
 		savePreferenceType( 'dismiss' );
 	}, [ savePreferenceType ] );
 

--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
@@ -59,14 +59,13 @@ function renderFeedError( err: FeedError ) {
 	);
 }
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 export default function FeedItem( props: {
 	hideIfInList?: boolean;
 	isFollowed?: boolean;
 	item: Item;
 	list: List;
 	owner: string;
-} ): React.ReactElement | null {
+} ) {
 	const { list, owner, item } = props;
 	const feed = useSelector( ( state ) => {
 		let feed = props.item.meta?.data?.feed;
@@ -83,7 +82,7 @@ export default function FeedItem( props: {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = React.useState( false );
+	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
 	const addItem = () => dispatch( addReaderListFeed( list.ID, owner, list.slug, item.feed_ID ) );
 	const deleteItem = ( shouldDelete: boolean ) => {
 		setShowDeleteConfirmation( false );

--- a/client/reader/list-manage/list-item.tsx
+++ b/client/reader/list-manage/list-item.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import FeedItem from './feed-item';
 import SiteItem from './site-item';
 import TagItem from './tag-item';
@@ -10,7 +9,7 @@ export default function ListItem( props: {
 	item: Item;
 	list: List;
 	owner: string;
-} ): React.ReactElement | null {
+} ) {
 	if ( props.item.feed_ID ) {
 		return <FeedItem { ...props } />;
 	} else if ( props.item.site_ID ) {

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
@@ -67,7 +67,7 @@ export default function SiteItem( props: {
 	item: Item;
 	list: List;
 	owner: string;
-} ): React.ReactElement | null {
+} ) {
 	const { item, list, owner } = props;
 	const site = props.item.meta?.data?.site as Site | SiteError | undefined;
 	const dispatch = useDispatch();
@@ -77,7 +77,7 @@ export default function SiteItem( props: {
 		getMatchingItem( state, { siteId: props.item.site_ID, listId: props.list.ID } )
 	);
 
-	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = React.useState( false );
+	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
 	const addItem = () => dispatch( addReaderListSite( list.ID, owner, list.slug, item.site_ID ) );
 	const deleteItem = ( shouldDelete: boolean ) => {
 		setShowDeleteConfirmation( false );

--- a/client/reader/list-manage/tag-item.tsx
+++ b/client/reader/list-manage/tag-item.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
@@ -20,7 +20,7 @@ export default function TagItem( props: {
 	item: Item;
 	list: List;
 	owner: string;
-} ): React.ReactElement | null {
+} ) {
 	const { item, list, owner } = props;
 	const tag: Tag = props.item.meta?.data?.tag?.tag as Tag;
 	const dispatch = useDispatch();
@@ -30,7 +30,7 @@ export default function TagItem( props: {
 		getMatchingItem( state, { tagId: props.item.tag_ID, listId: list.ID } )
 	);
 
-	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = React.useState( false );
+	const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState( false );
 	const addItem = () =>
 		dispatch( addReaderListTag( list.ID, owner, list.slug, item.meta?.data?.tag?.tag.slug ) );
 	const deleteItem = ( shouldDelete: boolean ) => {

--- a/client/signup/icons/index.tsx
+++ b/client/signup/icons/index.tsx
@@ -1,7 +1,6 @@
 import { Path, SVG, Rect } from '@wordpress/components';
-import type { ReactElement } from 'react';
 
-export const build: ReactElement = (
+export const build = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<mask id="path-1-inside-1" fill="white">
 			<Rect x="1" y="3.5" width="22" height="18" rx="1" />
@@ -34,7 +33,7 @@ export const build: ReactElement = (
 	</SVG>
 );
 
-export const write: ReactElement = (
+export const write = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path
 			d="M20.24 12.24C21.3658 11.1142 21.9983 9.58722 21.9983 7.99504C21.9983 6.40285 21.3658 4.87588 20.24 3.75004C19.1142 2.62419 17.5872 1.9917 15.995 1.9917C14.4028 1.9917 12.8758 2.62419 11.75 3.75004L5 10.5V19H13.5L20.24 12.24Z"
@@ -54,13 +53,13 @@ export const write: ReactElement = (
 	</SVG>
 );
 
-export const play: ReactElement = (
+export const play = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M5 3L19 12L5 21V3Z" stroke="#8C8F94" strokeWidth="1.6" strokeLinecap="round" />
 	</SVG>
 );
 
-export const design: ReactElement = (
+export const design = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path
 			d="M3 9H21"
@@ -80,28 +79,28 @@ export const design: ReactElement = (
 	</SVG>
 );
 
-export const computer: ReactElement = (
+export const computer = (
 	<SVG width="36" height="36" viewBox="0 0 36 36">
 		<Rect x="6" y="9" width="24" height="18" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
 		<Rect x="3" y="26.5" width="30" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
-export const tablet: ReactElement = (
+export const tablet = (
 	<SVG width="24" height="24" viewBox="0 0 24 24">
 		<Rect x="3" y="2" width="18" height="20" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
 		<Rect x="10" y="17" width="4" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
-export const phone: ReactElement = (
+export const phone = (
 	<SVG width="24" height="24" viewBox="0 0 24 24">
 		<Rect x="6" y="3" width="12" height="18" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
 		<Rect x="11" y="17" width="2" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
-export const tip: ReactElement = (
+export const tip = (
 	<SVG
 		width="20"
 		height="20"
@@ -117,7 +116,7 @@ export const tip: ReactElement = (
 	</SVG>
 );
 
-export const bulb: ReactElement = (
+export const bulb = (
 	<svg width="12" height="16" viewBox="0 0 12 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M3.2 14.4H8V16H3.2V14.4ZM9.5248 9.3696C10.3488 8.4048 11.2 7.4072 11.2 5.6C11.2 2.5128 8.6872 0 5.6 0C2.5128 0 0 2.5128 0 5.6C0 7.428 0.8536 8.4224 1.6808 9.384C1.9672 9.7184 2.264 10.0648 2.548 10.4632C2.6632 10.628 2.852 11.26 3.0208 12H2.4V13.6H8.8V12H8.1808C8.3512 11.2584 8.5408 10.6248 8.6552 10.46C8.9368 10.0576 9.236 9.708 9.5248 9.3696ZM7.3456 9.54C6.9984 10.0336 6.7088 11.2 6.5408 12H4.66C4.4928 11.1984 4.2024 10.0296 3.8512 9.536C3.551 9.12347 3.23172 8.72517 2.8944 8.3424C2.1152 7.4352 1.6 6.8352 1.6 5.6C1.6 3.3944 3.3944 1.6 5.6 1.6C7.8056 1.6 9.6 3.3944 9.6 5.6C9.6 6.8168 9.0856 7.4192 8.308 8.3304C8.0096 8.6808 7.6712 9.0768 7.3456 9.54V9.54Z"
@@ -126,7 +125,7 @@ export const bulb: ReactElement = (
 	</svg>
 );
 
-export const check: ReactElement = (
+export const check = (
 	<svg width="84" height="84" viewBox="0 0 84 84" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M82.4087 41.9905C82.4087 52.4607 78.2507 62.5023 70.8489 69.9077C63.4471 77.313 53.4074 81.4758 42.9372 81.4809C35.0449 70.4373 30.6458 57.2807 30.3081 43.7111C29.9705 30.1415 33.7099 16.7825 41.0432 5.3601L42.9372 2.50011C53.4074 2.50513 63.4471 6.66792 70.8489 14.0733C78.2507 21.4786 82.4087 31.5202 82.4087 41.9905Z"
@@ -149,7 +148,7 @@ export const check: ReactElement = (
 	</svg>
 );
 
-export const jetpack: ReactElement = (
+export const jetpack = (
 	<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M10 20C15.5228 20 20 15.5228 20 10C20 4.47715 15.5228 0 10 0C4.47715 0 0 4.47715 0 10C0 15.5228 4.47715 20 10 20Z"
@@ -160,7 +159,7 @@ export const jetpack: ReactElement = (
 	</svg>
 );
 
-export const upload: ReactElement = (
+export const upload = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M12 13V21" stroke="#8C8F94" strokeWidth="1.5" strokeLinecap="square" />
 		<Path
@@ -173,7 +172,7 @@ export const upload: ReactElement = (
 	</SVG>
 );
 
-export const truck: ReactElement = (
+export const truck = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M16 3H1V16H16V3Z"
@@ -206,7 +205,7 @@ export const truck: ReactElement = (
 	</svg>
 );
 
-export const shoppingBag: ReactElement = (
+export const shoppingBag = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M6 2L3 6V20C3 20.5304 3.21071 21.0391 3.58579 21.4142C3.96086 21.7893 4.46957 22 5 22H19C19.5304 22 20.0391 21.7893 20.4142 21.4142C20.7893 21.0391 21 20.5304 21 20V6L18 2H6Z"
@@ -232,7 +231,7 @@ export const shoppingBag: ReactElement = (
 	</svg>
 );
 
-export const shoppingCart: ReactElement = (
+export const shoppingCart = (
 	<svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="m9 22c.55228 0 1-.4477 1-1s-.44772-1-1-1-1 .4477-1 1 .44772 1 1 1z"
@@ -258,7 +257,7 @@ export const shoppingCart: ReactElement = (
 	</svg>
 );
 
-export const award: ReactElement = (
+export const award = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M12 15C15.866 15 19 11.866 19 8C19 4.13401 15.866 1 12 1C8.13401 1 5 4.13401 5 8C5 11.866 8.13401 15 12 15Z"
@@ -277,7 +276,7 @@ export const award: ReactElement = (
 	</svg>
 );
 
-export const frame: ReactElement = (
+export const frame = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<mask id="mask0_2727_2533" maskUnits="userSpaceOnUse" x="3" y="4" width="18" height="16">
 			<path
@@ -293,7 +292,7 @@ export const frame: ReactElement = (
 	</svg>
 );
 
-export const headset: ReactElement = (
+export const headset = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M7 17C8.105 17 9 16.105 9 15V11C9 9.895 8.105 9 7 9C5.895 9 5 9.895 5 11V15C5 16.105 5.895 17 7 17Z"
@@ -330,7 +329,7 @@ export const headset: ReactElement = (
 	</svg>
 );
 
-export const mouse: ReactElement = (
+export const mouse = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M5 9H19"

--- a/client/signup/steps/add-ons/index.tsx
+++ b/client/signup/steps/add-ons/index.tsx
@@ -82,7 +82,7 @@ const AddOns = ( {
 	);
 };
 
-export default function AddOnsStep( props: Props ): React.ReactElement {
+export default function AddOnsStep( props: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const addOns = useAddOns();

--- a/client/signup/steps/courses/header.tsx
+++ b/client/signup/steps/courses/header.tsx
@@ -1,7 +1,6 @@
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import type { ReactElement } from 'react';
 
-const CoursesHeader = (): ReactElement => (
+const CoursesHeader = () => (
 	<div className="courses__header">
 		<WordPressLogo size={ 24 } className="courses__header-logo" />
 	</div>

--- a/client/signup/steps/courses/index.tsx
+++ b/client/signup/steps/courses/index.tsx
@@ -1,6 +1,6 @@
 import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import VideosUi from 'calypso/components/videos-ui';
 import { COURSE_SLUGS, useCourseData } from 'calypso/data/courses';
@@ -15,7 +15,7 @@ interface Props {
 	goToNextStep: () => void;
 }
 
-export default function CoursesStep( props: Props ): React.ReactNode {
+export default function CoursesStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { stepName, goToNextStep } = props;
@@ -29,7 +29,7 @@ export default function CoursesStep( props: Props ): React.ReactNode {
 		goToNextStep();
 	};
 
-	React.useEffect( () => {
+	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -33,7 +33,7 @@ const DIFMSitePicker = ( {
 	);
 };
 
-export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
+export default function DIFMSitePickerStep( props: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { goToNextStep } = props;

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -1,7 +1,7 @@
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -48,7 +48,7 @@ const EXTERNAL_FLOW: { [ key: string ]: string } = {
 const getExcludedSteps = ( providedDependencies?: Dependencies ) =>
 	EXCLUDED_STEPS[ providedDependencies?.intent ];
 
-export default function IntentStep( props: Props ): React.ReactNode {
+export default function IntentStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { goToNextStep, stepName, queryObject } = props;
@@ -82,7 +82,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	};
 
 	// Only do following things when mounted
-	React.useEffect( () => {
+	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -37,7 +37,7 @@ type NewOrExistingSiteIntent = SelectItem< ChoiceType >;
 
 const Placeholder = () => <span className="new-or-existing-site__placeholder">&nbsp;</span>;
 
-export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
+export default function NewOrExistingSiteStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const displayCost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_DIFM_LITE ) );

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import siteOptionsImage from 'calypso/assets/images/onboarding/site-options.svg';
 import storeImageUrl from 'calypso/assets/images/onboarding/store-onboarding.svg';
@@ -18,7 +18,7 @@ interface Props {
 	initialContext: any;
 }
 
-export default function SiteOptionsStep( props: Props ): React.ReactNode {
+export default function SiteOptionsStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { stepName, signupDependencies, goToNextStep } = props;
@@ -75,7 +75,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 	};
 
 	// Only do following things when mounted
-	React.useEffect( () => {
+	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 

--- a/client/signup/steps/social-profiles/index.tsx
+++ b/client/signup/steps/social-profiles/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 	signupDependencies: SocialProfilesState;
 }
 
-export default function SocialProfilesStep( props: Props ): React.ReactNode {
+export default function SocialProfilesStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { stepName, signupDependencies, goToNextStep } = props;

--- a/client/signup/steps/starting-point/index.tsx
+++ b/client/signup/steps/starting-point/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import startingPointImageUrl from 'calypso/assets/images/onboarding/starting-point.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -28,7 +28,7 @@ const EXCLUDED_STEPS: { [ key: string ]: string[] } = {
 const getExcludedSteps = ( providedDependencies?: Dependencies ) =>
 	EXCLUDED_STEPS[ providedDependencies?.startingPoint ];
 
-export default function StartingPointStep( props: Props ): React.ReactNode {
+export default function StartingPointStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { goToNextStep, stepName } = props;
@@ -47,7 +47,7 @@ export default function StartingPointStep( props: Props ): React.ReactNode {
 	};
 
 	// Only do following things when mounted
-	React.useEffect( () => {
+	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -1,7 +1,7 @@
 import { FEATURE_SIMPLE_PAYMENTS, FEATURE_WOOP } from '@automattic/calypso-products';
 import { SelectItems } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -25,7 +25,7 @@ interface Props {
 	siteId: number;
 }
 
-export default function StoreFeaturesStep( props: Props ): React.ReactNode {
+export default function StoreFeaturesStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const headerText = translate( 'Set up your store' );
@@ -69,7 +69,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 	};
 
 	// Only do following things when mounted
-	React.useEffect( () => {
+	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 

--- a/client/signup/steps/woocommerce-install/components/support-card/index.tsx
+++ b/client/signup/steps/woocommerce-install/components/support-card/index.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -20,7 +19,7 @@ const SupportLinkStyle = styled.a`
 	font-weight: bold;
 `;
 
-export default function SupportCard( { backUrl }: { backUrl?: string } ): ReactElement {
+export default function SupportCard( { backUrl }: { backUrl?: string } ) {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
-import { ReactElement, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
 import PlanWarning from 'calypso/components/eligibility-warnings/plan-warning';
@@ -28,7 +28,7 @@ const WarningsOrHoldsSection = styled.div`
 	margin-bottom: 40px;
 `;
 
-export default function Confirm( props: WooCommerceInstallProps ): ReactElement | null {
+export default function Confirm( props: WooCommerceInstallProps ) {
 	const { goToNextStep, isReskinned } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -1,7 +1,6 @@
 import { CheckboxControl, SelectControl, TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { without } from 'lodash';
-import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -18,7 +17,7 @@ import { getRevenueOptions } from './revenue-options';
 import type { WooCommerceInstallProps } from '..';
 import './style.scss';
 
-export default function StepBusinessInfo( props: WooCommerceInstallProps ): ReactElement | null {
+export default function StepBusinessInfo( props: WooCommerceInstallProps ) {
 	const { goToNextStep, isReskinned } = props;
 	const { __ } = useI18n();
 

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { TextControl, ComboboxControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import emailValidator from 'email-validator';
-import { ReactElement, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -37,9 +37,7 @@ const CityZipRow = styled.div`
 	justify-items: stretch;
 `;
 
-export default function StepStoreAddress(
-	props: WooCommerceStoreAddressProps
-): ReactElement | null {
+export default function StepStoreAddress( props: WooCommerceStoreAddressProps ) {
 	const { goToNextStep, isReskinned, signupDependencies } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
@@ -231,7 +229,7 @@ export default function StepStoreAddress(
 	);
 }
 
-function ControlError( props: { error: string } ): ReactElement | null {
+function ControlError( props: { error: string } ) {
 	const { error } = props;
 	if ( error ) {
 		return <FormInputValidation isError={ true } isValid={ false } text={ error } />;

--- a/client/signup/steps/woocommerce-install/transfer/error.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/error.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -11,7 +10,7 @@ const WarningsOrHoldsSection = styled.div`
 	margin-top: 40px;
 `;
 
-export default function Error(): ReactElement {
+export default function Error() {
 	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { ReactElement, useState } from 'react';
+import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { logToLogstash } from 'calypso/lib/logstash';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -18,7 +18,7 @@ export interface FailureInfo {
 	error: string;
 }
 
-export default function Transfer( props: WooCommerceInstallProps ): ReactElement | null {
+export default function Transfer( props: WooCommerceInstallProps ) {
 	const dispatch = useDispatch();
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -1,5 +1,5 @@
 import page from 'page';
-import { ReactElement, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import {
@@ -23,7 +23,7 @@ export default function InstallPlugins( {
 }: {
 	onFailure: ( type: FailureInfo ) => void;
 	trackRedirect: () => void;
-} ): ReactElement | null {
+} ) {
 	const dispatch = useDispatch();
 	// selectedSiteId is set by the controller whenever site is provided as a query param.
 	const siteId = useSelector( getSelectedSiteId ) as number;

--- a/client/signup/steps/woocommerce-install/transfer/progress.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/progress.tsx
@@ -1,8 +1,8 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement, useState, useEffect } from 'react';
+import { CSSProperties, useState, useEffect } from 'react';
 import StepContent from './step-content';
 
-export default function Progress( { progress }: { progress: number } ): ReactElement {
+export default function Progress( { progress }: { progress: number } ) {
 	const { __ } = useI18n();
 	const [ step, setStep ] = useState( __( 'Building your store' ) );
 
@@ -39,9 +39,7 @@ export default function Progress( { progress }: { progress: number } ): ReactEle
 		<StepContent title={ step }>
 			<div
 				className="transfer__progress-bar"
-				style={
-					{ '--progress': simulatedProgress > 1 ? 1 : simulatedProgress } as React.CSSProperties
-				}
+				style={ { '--progress': simulatedProgress > 1 ? 1 : simulatedProgress } as CSSProperties }
 			/>
 		</StepContent>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/step-content.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/step-content.tsx
@@ -1,15 +1,12 @@
 import { Title, SubTitle } from '@automattic/onboarding';
-import { ReactElement } from 'react';
+import type { PropsWithChildren } from 'react';
 
-export default function StepContent( {
-	title,
-	subtitle,
-	children,
-}: {
+type Props = PropsWithChildren< {
 	title?: string;
 	subtitle?: string;
-	children: ReactElement | null;
-} ): ReactElement {
+} >;
+
+export default function StepContent( { title, subtitle, children }: Props ) {
 	return (
 		<>
 			<div className="transfer__heading-wrapper woocommerce-install__heading-wrapper">

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -1,5 +1,5 @@
 import page from 'page';
-import { ReactElement, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import { requestAtomicSoftwareStatus } from 'calypso/state/atomic/software/actions';
@@ -23,7 +23,7 @@ export default function TransferSite( {
 }: {
 	onFailure: ( type: FailureInfo ) => void;
 	trackRedirect: () => void;
-} ): ReactElement | null {
+} ) {
 	const dispatch = useDispatch();
 
 	const [ progress, setProgress ] = useState( 0.1 );

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -2,7 +2,7 @@ import { NavigableMenu, MenuItem, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import type { Category } from '../../types';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import './style.scss';
 
 interface Props {
@@ -21,7 +21,7 @@ export function DesignPickerCategoryFilter( {
 	heading,
 	footer,
 	recommendedCategorySlug,
-}: Props ): ReactElement | null {
+}: Props ) {
 	const instanceId = useInstanceId( DesignPickerCategoryFilter );
 	const { __ } = useI18n();
 

--- a/packages/design-picker/src/components/design-picker-category-filter/unified-design-picker-category-filter.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/unified-design-picker-category-filter.tsx
@@ -1,7 +1,6 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks'; // eslint-disable-line no-restricted-imports
 import type { Category } from '../../types';
-import type { ReactElement } from 'react';
 import './style.scss';
 
 interface Props {
@@ -10,11 +9,7 @@ interface Props {
 	onSelect: ( selectedSlug: string | null ) => void;
 }
 
-export function UnifiedDesignPickerCategoryFilter( {
-	categories,
-	onSelect,
-	selectedSlug,
-}: Props ): ReactElement | null {
+export function UnifiedDesignPickerCategoryFilter( { categories, onSelect, selectedSlug }: Props ) {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
 

--- a/packages/design-picker/src/components/theme-preview/icons.tsx
+++ b/packages/design-picker/src/components/theme-preview/icons.tsx
@@ -1,21 +1,20 @@
 import { SVG, Rect } from '@wordpress/components';
-import type { ReactElement } from 'react';
 
-export const computer: ReactElement = (
+export const computer = (
 	<SVG width="36" height="36" viewBox="0 0 36 36">
 		<Rect x="6" y="9" width="24" height="18" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
 		<Rect x="3" y="26.5" width="30" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
-export const tablet: ReactElement = (
+export const tablet = (
 	<SVG width="24" height="24" viewBox="0 0 24 24">
 		<Rect x="3" y="2" width="18" height="20" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
 		<Rect x="10" y="17" width="4" height="1.5" fill="currentColor" />
 	</SVG>
 );
 
-export const phone: ReactElement = (
+export const phone = (
 	<SVG width="24" height="24" viewBox="0 0 24 24">
 		<Rect x="6" y="3" width="12" height="18" rx="1.25" stroke="currentColor" strokeWidth="1.5" />
 		<Rect x="11" y="17" width="2" height="1.5" fill="currentColor" />

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import type { Header } from '../types';
-import type { ReactElement } from 'react';
 
 export function ArticleTitle() {
 	const location = useLocation();
@@ -19,7 +18,7 @@ export function ArticleTitle() {
 	);
 }
 
-const SupportModeTitle = (): ReactElement => {
+const SupportModeTitle = () => {
 	const { __ } = useI18n();
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
@@ -44,12 +43,7 @@ const SupportModeTitle = (): ReactElement => {
 		}
 	}
 };
-const HelpCenterHeader: React.FC< Header > = ( {
-	isMinimized = false,
-	onMinimize,
-	onMaximize,
-	onDismiss,
-} ) => {
+const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDismiss }: Header ) => {
 	const { unreadCount, closeChat } = useHCWindowCommunicator( isMinimized );
 	const classNames = classnames( 'help-center__container-header' );
 	const { __ } = useI18n();

--- a/packages/onboarding/src/select-items-alt/index.tsx
+++ b/packages/onboarding/src/select-items-alt/index.tsx
@@ -3,7 +3,6 @@ import { Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { TranslateResult } from 'i18n-calypso';
-import React from 'react';
 import './style.scss';
 
 export interface SelectItemAlt< T > {
@@ -22,7 +21,7 @@ interface Props< T > {
 	onSelect: ( value: T ) => void;
 }
 
-function SelectItemsAlt< T >( { className, items, onSelect }: Props< T > ): React.ReactElement {
+function SelectItemsAlt< T >( { className, items, onSelect }: Props< T > ) {
 	return (
 		<div className={ classnames( 'select-items-alt', className ) }>
 			{ items.map(

--- a/packages/onboarding/src/select-items/index.tsx
+++ b/packages/onboarding/src/select-items/index.tsx
@@ -22,12 +22,7 @@ interface Props< T > {
 	preventWidows: ( text: TranslateResult, wordsToKeep?: number ) => string;
 }
 
-function SelectItems< T >( {
-	className,
-	items,
-	onSelect,
-	preventWidows,
-}: Props< T > ): React.ReactElement {
+function SelectItems< T >( { className, items, onSelect, preventWidows }: Props< T > ) {
 	return (
 		<div className={ classnames( 'select-items', className ) }>
 			{ items.map( ( { key, title, description, icon, actionText, value, isPrimary } ) => (

--- a/packages/plans-grid/src/badge/index.tsx
+++ b/packages/plans-grid/src/badge/index.tsx
@@ -1,16 +1,15 @@
 import classNames from 'classnames';
-import * as React from 'react';
+import type { PropsWithChildren } from 'react';
 
 import './style.scss';
 
 // @TODO: move to '@automattic/components' and reuse in Gutenboarding
 
-interface Props {
-	children: React.ReactElement[];
+type Props = PropsWithChildren< {
 	className?: string;
-}
+} >;
 
-const Badge: React.FunctionComponent< Props > = ( { children, className, ...props } ) => (
+const Badge = ( { children, className, ...props }: Props ) => (
 	<span { ...props } className={ classNames( 'badge', className ) }>
 		{ children }
 	</span>


### PR DESCRIPTION
Followup to #63817 which I did a few months ago, further removing unneeded return type annotations on React components, declaring a `ReactNode` return type. That's easy to infer and it's always obvious what a React component or a `render` method returns.

One place where I needed to change actual code (as opposed to just types) was the `PluginRowFormatter` component which was also returning a `string | number | boolean | undefined` type which, although the values work in practice, is not compatible with types for React components. Leads to a type error:
```
'PluginRowFormatter' cannot be used as a JSX component.
  Its return type 'string | number | false | Element | null | undefined' is not a valid JSX element.ts(2786)
```
I fixed that by wrapping a `translate` result inside a fragment (removes the string and number types) and by carefully returning `null` when rendering something conditionally (removes the `undefined` type).
