### PR TITLE
Style Selection: Enable style selection in horizon

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -131,7 +131,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const categorizationOptions = getCategorizationOptions( intent, true );
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 
-	// ********** Logic for selecting a design
+	// ********** Logic for selecting a design and style variation
 
 	const [ isPreviewingDesign, setIsPreviewingDesign ] = useState( false );
 
@@ -143,27 +143,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 
-	function getEventPropsByDesign( design: Design ) {
-		return {
-			slug: design?.slug,
-			theme: design?.recipe?.stylesheet,
-			flow,
-			intent,
-			is_premium: design?.is_premium,
-			design_type: design.design_type,
-			...( design?.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
-			...( design?.recipe?.header_pattern_ids && {
-				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
-			} ),
-			...( design?.recipe?.footer_pattern_ids && {
-				footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
-			} ),
-		};
-	}
-
-	// ********** Logic for selecting a style variation of the selected design
-
-	const isEnabledStyleSelection =
+	const hasStyleVariations =
 		selectedDesign &&
 		selectedDesign.design_type !== 'vertical' &&
 		selectedDesign.style_variations &&
@@ -171,7 +151,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		isEnabled( 'signup/design-picker-style-selection' );
 
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
-		enabled: isPreviewingDesign && isEnabledStyleSelection,
+		enabled: isPreviewingDesign && hasStyleVariations,
 	} );
 
 	const selectedStyleVariation = useSelect( ( select ) =>
@@ -179,18 +159,54 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	);
 	const { setSelectedStyleVariation } = useDispatch( ONBOARD_STORE );
 
-	function previewDesign( _selectedDesign: Design, variation?: StyleVariation ) {
+	function getEventPropsByDesign( design: Design, variation?: StyleVariation ) {
+		const variationSlugSuffix =
+			variation && variation.slug !== 'default' ? `-${ variation.slug }` : '';
+
+		return {
+			flow,
+			intent,
+			slug: design.slug + variationSlugSuffix,
+			theme: design.recipe?.stylesheet,
+			theme_style: design.recipe?.stylesheet + variationSlugSuffix,
+			design_type: design.design_type,
+			is_premium: design.is_premium,
+			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
+			...( design.recipe?.header_pattern_ids && {
+				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
+			} ),
+			...( design.recipe?.footer_pattern_ids && {
+				footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
+			} ),
+			has_style_variations: hasStyleVariations,
+		};
+	}
+
+	function previewDesign( design: Design, variation?: StyleVariation ) {
 		recordTracksEvent(
 			'calypso_signup_design_preview_select',
-			getEventPropsByDesign( _selectedDesign )
+			getEventPropsByDesign( design, variation )
 		);
+		setSelectedDesign( design );
 
-		setSelectedDesign( _selectedDesign );
 		if ( variation ) {
+			recordTracksEvent(
+				'calypso_signup_design_picker_style_variation_button_click',
+				getEventPropsByDesign( design, variation )
+			);
 			setSelectedStyleVariation( variation );
 		}
 
 		setIsPreviewingDesign( true );
+	}
+
+	function previewDesignVariation( variation: StyleVariation ) {
+		recordTracksEvent(
+			'calypso_signup_design_preview_style_variation_preview_click',
+			getEventPropsByDesign( selectedDesign as Design, variation )
+		);
+
+		setSelectedStyleVariation( variation );
 	}
 
 	// ********** Logic for unlocking a selected premium design
@@ -281,14 +297,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);
 			recordTracksEvent( 'calypso_signup_select_design', {
-				...getEventPropsByDesign( _selectedDesign ),
+				...getEventPropsByDesign( _selectedDesign, selectedStyleVariation ),
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
 			} );
 
 			if ( _selectedDesign.verticalizable ) {
 				recordTracksEvent(
 					'calypso_signup_select_verticalized_design',
-					getEventPropsByDesign( _selectedDesign )
+					getEventPropsByDesign( _selectedDesign, selectedStyleVariation )
 				);
 			}
 
@@ -306,6 +322,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			flow,
 			intent,
 			design_type: _selectedDesign?.design_type ?? 'default',
+			has_style_variations: hasStyleVariations,
 		} );
 
 		submit?.( providedDependencies );
@@ -315,7 +332,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		if ( isPreviewingDesign ) {
 			recordTracksEvent(
 				'calypso_signup_design_preview_exit',
-				getEventPropsByDesign( selectedDesign as Design )
+				getEventPropsByDesign( selectedDesign as Design, selectedStyleVariation )
 			);
 
 			setSelectedDesign( undefined );
@@ -325,6 +342,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 
 		goBack();
+	}
+
+	function recordDeviceClick( device: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_device_click', { device } );
 	}
 
 	function recordStepContainerTracksEvent( eventName: string ) {
@@ -359,7 +380,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		} );
 
 		const pickDesignText =
-			selectedDesign?.design_type === 'vertical' || isEnabledStyleSelection
+			selectedDesign?.design_type === 'vertical' || hasStyleVariations
 				? translate( 'Select and continue' )
 				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
 
@@ -385,7 +406,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					closeModal={ closeUpgradeModal }
 					checkout={ goToCheckout }
 				/>
-				{ isEnabledStyleSelection ? (
+				{ hasStyleVariations ? (
 					<AsyncLoad
 						require="@automattic/design-preview"
 						placeholder={ null }
@@ -394,8 +415,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 						description={ selectedDesign.description }
 						variations={ selectedDesignDetails?.style_variations }
 						selectedVariation={ selectedStyleVariation }
-						onSelectVariation={ setSelectedStyleVariation }
+						onSelectVariation={ previewDesignVariation }
 						actionButtons={ actionButtons }
+						recordDeviceClick={ recordDeviceClick }
 					/>
 				) : (
 					<WebPreview
@@ -421,7 +443,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			</>
 		);
 
-		return isEnabledStyleSelection ? (
+		return hasStyleVariations ? (
 			<StepContainer
 				stepName={ STEP_NAME }
 				stepContent={ stepContent }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -97,7 +97,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/design-picker-premium-themes-checkout": true,
-		"signup/design-picker-style-selection": false,
+		"signup/design-picker-style-selection": true,
 		"signup/design-picker-unified": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/ftm-flow-non-en": true,

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -22,6 +22,7 @@ interface ThemePreviewProps {
 	isFitHeight?: boolean;
 	isShowFrameBorder?: boolean;
 	isShowDeviceSwitcher?: boolean;
+	recordDeviceClick?: ( device: string ) => void;
 }
 
 const ThemePreview: React.FC< ThemePreviewProps > = ( {
@@ -32,15 +33,21 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	isFitHeight,
 	isShowFrameBorder,
 	isShowDeviceSwitcher,
+	recordDeviceClick,
 } ) => {
 	const { __ } = useI18n();
 	const iframeRef = useRef< HTMLIFrameElement >( null );
 	const [ isLoaded, setIsLoaded ] = useState( false );
-	const [ device, setDevice ] = useState< Device >( DEVICE_TYPE.COMPUTER );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
 	const calypso_token = useMemo( () => uuid(), [] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : 1;
+
+	const [ device, setDevice ] = useState< Device >( DEVICE_TYPE.COMPUTER );
+	function handleDeviceClick( device: string ) {
+		recordDeviceClick?.( device );
+		setDevice( device );
+	}
 
 	useEffect( () => {
 		const handleMessage = ( event: MessageEvent ) => {
@@ -100,7 +107,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			} ) }
 		>
 			{ containerResizeListener }
-			{ isShowDeviceSwitcher && <Toolbar device={ device } onDeviceClick={ setDevice } /> }
+			{ isShowDeviceSwitcher && <Toolbar device={ device } onDeviceClick={ handleDeviceClick } /> }
 			<div className="theme-preview__frame-wrapper">
 				{ ! isLoaded && loadingMessage && (
 					<div className="theme-preview__frame-message">{ loadingMessage }</div>

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -12,6 +12,7 @@ interface PreviewProps {
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	actionButtons: React.ReactNode;
+	recordDeviceClick: ( device: string ) => void;
 }
 
 const getVariationBySlug = ( variations: StyleVariation[], slug: string ) =>
@@ -25,6 +26,7 @@ const Preview: React.FC< PreviewProps > = ( {
 	selectedVariation,
 	onSelectVariation,
 	actionButtons,
+	recordDeviceClick,
 } ) => {
 	const sitePreviewInlineCss = useMemo( () => {
 		if ( selectedVariation ) {
@@ -47,7 +49,11 @@ const Preview: React.FC< PreviewProps > = ( {
 				onSelectVariation={ onSelectVariation }
 				actionButtons={ actionButtons }
 			/>
-			<SitePreview url={ previewUrl } inlineCss={ sitePreviewInlineCss } />
+			<SitePreview
+				url={ previewUrl }
+				inlineCss={ sitePreviewInlineCss }
+				recordDeviceClick={ recordDeviceClick }
+			/>
 		</div>
 	);
 };

--- a/packages/design-preview/src/components/site-preview.tsx
+++ b/packages/design-preview/src/components/site-preview.tsx
@@ -4,9 +4,14 @@ import { translate } from 'i18n-calypso';
 interface SitePreviewProps {
 	url: string;
 	inlineCss?: string;
+	recordDeviceClick: ( device: string ) => void;
 }
 
-const SitePreview: React.FC< SitePreviewProps > = ( { url, inlineCss = '' } ) => {
+const SitePreview: React.FC< SitePreviewProps > = ( {
+	url,
+	inlineCss = '',
+	recordDeviceClick,
+} ) => {
 	return (
 		<div className="design-preview__site-preview">
 			<ThemePreview
@@ -17,6 +22,7 @@ const SitePreview: React.FC< SitePreviewProps > = ( { url, inlineCss = '' } ) =>
 				inlineCss={ inlineCss }
 				isShowFrameBorder
 				isShowDeviceSwitcher
+				recordDeviceClick={ recordDeviceClick }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

This PR enables the feature style selection in the design picker in the Horizon environment.   

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

