### PR TITLE
E2E (Atomic): Fix unpublished post check

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -588,6 +588,10 @@ export class EditorPage {
 			this.getPublishedURLFromToast(),
 		] );
 
+		if ( ! publishedURL ) {
+			throw new Error( 'Could not retrieve published post URL' );
+		}
+
 		if ( visit ) {
 			await this.visitPublishedPost( publishedURL.href );
 		}

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -129,7 +129,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		it( 'Post is no longer visible', async function () {
 			const testPage = await browser.newPage();
 			await testPage.goto( postURL.href );
-			await testPage.waitForSelector( 'div.error-404.not-found' );
+			await testPage.waitForSelector( 'body.error404' );
 			await testPage.close();
 		} );
 	} );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -63,7 +63,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 		it( 'Publish post', async function () {
 			postURL = await editorPage.publish();
-			expect( postURL.href ).toBeDefined();
 		} );
 
 		it( 'Validate post', async function () {


### PR DESCRIPTION
Tracking issue: #65906
Related: pMz3w-fZ0-p2

### Proposed Changes

Make the following test compatible with Atomic environment:

> **Published post contains additional post content**
> specs/editor/editor__post-advanced-flow.ts: Editor: Advanced Post Flow: Edit published post

### Why was it failing?

Two reasons:
1. When previewing the post after reverting to draft, it still appeared as published. This is because Atomic cache works different from Simple one: There aren't currently cache invalidations when content changes - the cache will self-invalidate every 300s (pMz3w-fZ0-p2#comment-102119). The workaround is to use another context **only** to ensure that the page was reverted to draft (should 404). If we use the author session (same context) to preview the published post, it will never get cached, and the 404 will be shown as expected.
2. We were checking for a specific "404" classname which is theme-specific. Because we're using different themes for Atomic sites, the test was failing. The classname was updated to match both environments regardless of the theme used.

### Testing instruction

The fixed test should pass for both Simple and Atomic sites (production).