### PR TITLE
Launchpad: Try to fix infinite redirect without query params

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -96,7 +96,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace( `/home/${ siteSlug }?forceLoadLaunchpadData=true` );
+									window.location.replace( `/home/${ siteSlug }` );
 								} );
 
 								submit?.();

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -31,11 +31,16 @@ export async function maybeRedirect( context, next ) {
 	const siteId = getSelectedSiteId( state );
 	const maybeStalelaunchpadScreenOption = getSiteOptions( state, siteId )?.launchpad_screen;
 
+	// We need the latest site info to determine if a user should be redirected to Launchpad.
+	// As a result, we can't use locally cached data, which might think that Launchpad is
+	// still enabled when, in reality, the final tasks have been completed and everything is
+	// disabled. Because of this, we refetch site information and limit traffic by scoping down
+	// requests to launchpad enabled sites.
+	// See https://cylonp2.wordpress.com/2022/09/19/question-about-infinite-redirect/#comment-1731
 	if ( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) {
 		await context.store.dispatch( requestSite( siteId ) );
 	}
 
-	// TODO: Write explanation for refetching launchpad site options
 	const refetchedOptions = getSiteOptions( context.store.getState(), siteId );
 	const shouldRedirectToLaunchpad = refetchedOptions?.launchpad_screen === 'full';
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -49,8 +49,9 @@ export async function maybeRedirect( context, next ) {
 	}
 
 	const siteId = getSelectedSiteId( state );
+	const maybeStalelaunchpadScreenOption = getSiteOptions( state, siteId )?.launchpad_screen;
 
-	if ( getSiteOptions( state, siteId )?.launchpad_screen !== 'off' ) {
+	if ( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption !== 'off' ) {
 		await refetchLaunchpadScreenOption( siteId, context );
 	}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -31,7 +31,7 @@ export async function maybeRedirect( context, next ) {
 	const siteId = getSelectedSiteId( state );
 	const maybeStalelaunchpadScreenOption = getSiteOptions( state, siteId )?.launchpad_screen;
 
-	if ( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption !== 'off' ) {
+	if ( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) {
 		await context.store.dispatch( requestSite( siteId ) );
 	}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,10 +1,6 @@
 import page from 'page';
 import { requestSite } from 'calypso/state/sites/actions';
-import {
-	canCurrentUserUseCustomerHome,
-	isRequestingSite,
-	getSiteOptions,
-} from 'calypso/state/sites/selectors';
+import { canCurrentUserUseCustomerHome, getSiteOptions } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { redirectToLaunchpad } from 'calypso/utils';
 import CustomerHome from './main';
@@ -23,22 +19,6 @@ export default async function ( context, next ) {
 	next();
 }
 
-const refetchLaunchpadScreenOption = async ( siteId, context ) => {
-	return new Promise( ( resolve ) => {
-		const unsubscribe = context.store.subscribe( () => {
-			if ( isRequestingSite( context.store.getState(), siteId ) ) {
-				return;
-			}
-
-			unsubscribe();
-			resolve();
-		} );
-
-		// Trigger a `store.subscribe()` callback
-		context.store.dispatch( requestSite( siteId ) );
-	} );
-};
-
 export async function maybeRedirect( context, next ) {
 	const state = context.store.getState();
 	const slug = getSelectedSiteSlug( state );
@@ -52,7 +32,7 @@ export async function maybeRedirect( context, next ) {
 	const maybeStalelaunchpadScreenOption = getSiteOptions( state, siteId )?.launchpad_screen;
 
 	if ( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption !== 'off' ) {
-		await refetchLaunchpadScreenOption( siteId, context );
+		await context.store.dispatch( requestSite( siteId ) );
 	}
 
 	// TODO: Write explanation for refetching launchpad site options


### PR DESCRIPTION
#### Proposed Changes

* Handles infinite redirect by refetching site data before redirecting to launchpad
* Added a condition that only fetches data for sites with launchpad enabled
* Notes: 
  * Big downside is that we now have to wait for a network request before redirecting sites to launchpad ( for sites with launchpad enabled )
  * @Sharpirate was working on an alternative fix which we might find more appealing than this approach

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create link-in-bio site https://wordpress.com/hp-2022-tailored-flows/
* Stop at the launchpad view
* Ensure that you're loading the local dev environment ( calypso.localhost:3000 )
* Complete edit links task
* Click on launch link in bio task
* Verify that infinite redirect is no longer happening
* Verify that not query params are added to homepage url
* I could only intermittently reproduce the infinite redirect issue in local dev, so we may want to repeat this test several times to ensure that the infinite redirect is no longer a problem

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
