### PR TITLE
Revert "SiteIconPicker: open cropping UI on image click"

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -82,7 +82,7 @@ export class ImageEditorCanvas extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.src !== prevProps.src || ! this.image ) {
+		if ( this.props.src !== prevProps.src ) {
 			this.getImage( this.props.src );
 		}
 

--- a/client/components/site-icon-with-picker/index.tsx
+++ b/client/components/site-icon-with-picker/index.tsx
@@ -65,14 +65,11 @@ export function SiteIconWithPicker( {
 					onDone={ ( _error: Error | null, image: Blob ) => {
 						onSelect( new File( [ image ], editingFileName || 'site-logo.png' ) );
 						setSelectedFileUrl( URL.createObjectURL( image ) );
-						setEditingFile( URL.createObjectURL( image ) );
 						setImageEditorOpen( false );
 					} }
 					onCancel={ () => {
-						if ( ! selectedFileUrl ) {
-							setEditingFile( undefined );
-							setEditingFileName( undefined );
-						}
+						setEditingFile( undefined );
+						setEditingFileName( undefined );
 						setImageEditorOpen( false );
 					} }
 					widthLimit={ 512 }
@@ -103,26 +100,15 @@ export function SiteIconWithPicker( {
 					} }
 				>
 					{ selectedFileUrl || siteIconUrl ? (
-						// eslint-disable-next-line jsx-a11y/click-events-have-key-events
-						<span
-							role="button"
-							tabIndex={ 0 }
-							title={ __( 'Edit' ) }
-							onClick={ ( event ) => {
-								event.stopPropagation();
-								setImageEditorOpen( true );
-							} }
-						>
-							<img src={ selectedFileUrl || siteIconUrl } alt={ site?.name } />
-						</span>
+						<img src={ selectedFileUrl || siteIconUrl } alt={ site?.name } />
 					) : (
 						<Icon icon={ upload } />
 					) }
-					{ selectedFileUrl || siteIconUrl ? (
-						<span className="replace">{ __( 'Replace' ) }</span>
-					) : (
-						<span className="add"> { placeholderText || __( 'Add a site icon' ) } </span>
-					) }
+					<span>
+						{ selectedFileUrl || siteIconUrl
+							? __( 'Replace' )
+							: placeholderText || __( 'Add a site icon' ) }
+					</span>
 				</FormFileUpload>
 			</FormFieldset>
 		</>

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -10,7 +10,7 @@ $icon-border-radius: 50%; /* stylelint-disable-line declaration-property-unit-al
 	min-width: 50vw;
 
 	use {
-		fill: #fff;
+		fill: white;
 	}
 }
 
@@ -57,9 +57,7 @@ button.components-button.site-icon-with-picker__upload-button {
 		left: 50%;
 		transform: translate(-50%, -50%);
 	}
-
-	span.replace,
-	span.add {
+	span {
 		position: absolute;
 		width: 200px;
 		display: block;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -183,18 +183,7 @@ button {
 
 					span {
 						font-size: $font-body-extra-small;
-
-						&.add {
-							color: var(--studio-blue-50);
-						}
-
-						&.replace {
-							color: var(--studio-gray-60);
-
-							&:hover {
-								color: var(--studio-blue-50);
-							}
-						}
+						color: var(--studio-blue-50);
 					}
 				}
 			}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#67852. It's breaking the pre-release tests even though it doesn't seem related at all. 