### PR TITLE
Add tracking for "Add new site" button clicks

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Button,
 	Gridicon,
@@ -191,12 +192,18 @@ export function SitesDashboard( {
 						primary
 						whiteSeparator
 						label={ __( 'Add new site' ) }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+						} }
 						href={ addQueryArgs( '/start', {
 							source: TRACK_SOURCE_NAME,
 							ref: TRACK_SOURCE_NAME,
 						} ) }
 					>
 						<PopoverMenuItem
+							onClick={ () => {
+								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
+							} }
 							href={ addQueryArgs( '/jetpack/connect', {
 								cta_from: TRACK_SOURCE_NAME,
 								cta_id: 'add-site',
@@ -206,6 +213,9 @@ export function SitesDashboard( {
 							<span>{ __( 'Add Jetpack to a self-hosted site' ) }</span>
 						</PopoverMenuItem>
 						<PopoverMenuItem
+							onClick={ () => {
+								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
+							} }
 							href={ addQueryArgs( '/start', {
 								source: TRACK_SOURCE_NAME,
 								ref: 'smp-import',


### PR DESCRIPTION
#### Proposed Changes

I propose to add click tracking for three actions that can be triggered by clicking the "Add new site" button on the Site Management Page. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the `/sites` page
2. Enable tracks debug logging (PCYsg-cae-p2) and keep the dev console open
3. Use each of the actions:
- "Add new site"
- "Add Jetpack to a self-hosted site"
- "Import an existing site"
4. Use the dev console to confirm that Calypso recorded the track

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67534 and https://github.com/Automattic/wp-calypso/pull/67847