### PR TITLE
Revert "Revert "Remove string fallback for missing translations that are now in place""

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -345,12 +345,6 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug', 'emailItem' ],
 			providesDependencies: [ 'cartItem' ],
 			props: {
-				get headerText() {
-					return i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation( 'Empower your online presence' )
-						? i18n.translate( 'Empower your online presence' )
-						: '';
-				},
 				useEmailOnboardingSubheader: true,
 			},
 		},
@@ -445,10 +439,7 @@ export function generateSteps( {
 			props: {
 				forceHideFreeDomainExplainerAndStrikeoutUi: true,
 				get headerText() {
-					return i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation( 'Choose a domain for your Professional Email' )
-						? i18n.translate( 'Choose a domain for your Professional Email' )
-						: '';
+					return i18n.translate( 'Choose a domain for your Professional Email' );
 				},
 				includeWordPressDotCom: false,
 				isDomainOnly: false,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -346,18 +346,10 @@ export class PlansStep extends Component {
 		}
 
 		if ( useEmailOnboardingSubheader ) {
-			return 'en' === locale ||
-				i18n.hasTranslation(
-					'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.'
-				)
-				? translate(
-						'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
-						{ components: { link: freePlanButton } }
-				  )
-				: translate(
-						"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
-						{ components: { link: freePlanButton } }
-				  );
+			return translate(
+				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
+				{ components: { link: freePlanButton } }
+			);
 		}
 
 		if ( ! hideFreePlan ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#67971

The pre-release build failure had been cleared (more details [here](p1663592311997839-slack-C02DQP0FP)). Re-deploying this change: https://github.com/Automattic/wp-calypso/pull/67924