### PR TITLE
Stepper: Design step remove white category background

### DIFF
--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -3,12 +3,13 @@
 	padding-bottom: 24px;
 
 	.responsive-toolbar-group__grouped-list {
+		background-color: transparent;
+		border-color: transparent;
 		justify-content: space-between;
 		flex-wrap: nowrap;
 		display: flex;
 		opacity: 0;
 
-		border-color: rgba(0, 0, 0, 0);
 
 		.responsive-toolbar-group__menu-item.is-selected {
 			background-color: #1e1e1e;


### PR DESCRIPTION
#### Proposed Changes

 Remove the white background in category bar on design step.
![image](https://user-images.githubusercontent.com/52076348/191050566-a56e2345-b516-4404-bc85-c81bb1695c51.png)

We made it transparent to reflect the page background color


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout and `yarn start`
* `http://calypso.localhost:3000/setup/designSetup?siteSlug=YOURSITE.wordpress.com`
* Check that the category background color is gone


Related to p1663594008614319/1663182275.243719-slack-C03E1LGV796