### PR TITLE
Help Center: close socket connection after getting status & accept

### DIFF
--- a/packages/happychat-connection/src/connection.ts
+++ b/packages/happychat-connection/src/connection.ts
@@ -47,7 +47,7 @@ export class Connection {
 	}
 
 	/**
-	 * Init the SockeIO connection: check user authorization and bind socket events
+	 * Init the SocketIO connection: check user authorization and bind socket events
 	 *
 	 * @param dispatch Redux dispatch function
 	 * @param auth Authentication promise, will return the user info upon fulfillment
@@ -65,7 +65,7 @@ export class Connection {
 			auth
 				.then( ( { url, user: { signer_user_id, jwt, groups, skills, geoLocation } } ) => {
 					const socket = buildConnection( url );
-					socket
+					return socket
 						.once( 'connect', () => dispatch( this.receiveConnect?.() ) )
 						.on(
 							'token',

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -16,6 +16,8 @@ function getHCAvailabilityAndStatus( dataAuth: HappychatAuth ) {
 
 				if ( Object.keys( result ).length === 2 ) {
 					resolve( result );
+					// close connection after we get accept and status
+					connection.openSocket?.then( ( socket ) => socket.close() );
 				}
 			},
 			receiveStatus( status ) {
@@ -23,6 +25,8 @@ function getHCAvailabilityAndStatus( dataAuth: HappychatAuth ) {
 
 				if ( Object.keys( result ).length === 2 ) {
 					resolve( result );
+					// close connection after we get accept and status
+					connection.openSocket?.then( ( socket ) => socket.close() );
 				}
 			},
 			receiveUnauthorized: () => {


### PR DESCRIPTION
#### Proposed Changes

* This closes the initial Socket connection that checks if the there are any slots and if the user has any active sessions. 
* This doesn't come at any cost and merely preserves server resources.

#### Testing Instructions

1. Run etk by going inside apps/editing-toolkit.
2. Open DevTools and go to the editor.
3. Go to Network tab and filter by WS.
4. Look for `?EIO=3&transport=websocket`
5. Click the connection and do the following
6.  <img width="1792" alt="image" src="https://user-images.githubusercontent.com/17054134/191098047-2f781a89-52c7-45d0-9651-2afa38e5f130.png">
7. Make sure the connection doesn't show the highlighted Orange phrase.

