### PR TITLE
Fix plugin breadcrumb loops

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAllJetpackSitesPlugins from 'calypso/components/data/query-all-jetpack-sites-plugins';
@@ -34,7 +34,7 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
-import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
@@ -77,7 +77,6 @@ function PluginDetails( props ) {
 	const translate = useTranslate();
 
 	const breadcrumbs = useSelector( getBreadcrumbs );
-	const [ initialBreadcrumbs ] = useState( breadcrumbs );
 
 	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
@@ -218,27 +217,28 @@ function PluginDetails( props ) {
 	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( fullPlugin.slug );
 
 	useEffect( () => {
-		const items = initialBreadcrumbs ? [ ...initialBreadcrumbs ] : [];
-		if ( ! items.length ) {
-			items.push( {
-				label: translate( 'Plugins' ),
-				href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
-				id: 'plugins',
-				helpBubble: translate(
-					'Add new functionality and integrations to your site with plugins.'
-				),
-			} );
+		if ( breadcrumbs.length === 0 ) {
+			dispatch(
+				appendBreadcrumb( {
+					label: translate( 'Plugins' ),
+					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
+					id: 'plugins',
+					helpBubble: translate(
+						'Add new functionality and integrations to your site with plugins.'
+					),
+				} )
+			);
 		}
 
 		if ( fullPlugin.name && props.pluginSlug ) {
-			items.push( {
-				label: fullPlugin.name,
-				href: localizePath( `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }` ),
-				id: `plugin-${ props.pluginSlug }`,
-			} );
+			dispatch(
+				appendBreadcrumb( {
+					label: fullPlugin.name,
+					href: localizePath( `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }` ),
+					id: `plugin-${ props.pluginSlug }`,
+				} )
+			);
 		}
-
-		dispatch( updateBreadcrumbs( items ) );
 	}, [ fullPlugin.name, props.pluginSlug, selectedSite, dispatch, translate, localizePath ] );
 
 	const getPageTitle = () => {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -217,7 +217,7 @@ function PluginDetails( props ) {
 	const { isPreinstalledPremiumPluginUpgraded } = usePreinstalledPremiumPlugin( fullPlugin.slug );
 
 	useEffect( () => {
-		if ( breadcrumbs.length === 0 ) {
+		if ( breadcrumbs?.length === 0 ) {
 			dispatch(
 				appendBreadcrumb( {
 					label: translate( 'Plugins' ),

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -12,7 +12,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+import { appendBreadcrumb, resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -115,34 +115,39 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	const { localizePath } = useLocalizedPlugins();
 
 	useEffect( () => {
-		const items = [
-			{
-				label: translate( 'Plugins' ),
-				href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
-				id: 'plugins',
-				helpBubble: translate(
-					'Add new functionality and integrations to your site with plugins.'
-				),
-			},
-		];
+		if ( breadcrumbs.length === 0 || ( ! category && ! search ) ) {
+			dispatch( resetBreadcrumbs() );
+			dispatch(
+				appendBreadcrumb( {
+					label: translate( 'Plugins' ),
+					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
+					id: 'plugins',
+					helpBubble: translate(
+						'Add new functionality and integrations to your site with plugins.'
+					),
+				} )
+			);
+		}
 
 		if ( category ) {
-			items.push( {
-				label: categoryName,
-				href: localizePath( `/plugins/browse/${ category }/${ selectedSite?.slug || '' }` ),
-				id: 'category',
-			} );
+			dispatch(
+				appendBreadcrumb( {
+					label: categoryName,
+					href: localizePath( `/plugins/browse/${ category }/${ selectedSite?.slug || '' }` ),
+					id: 'category',
+				} )
+			);
 		}
 
 		if ( search ) {
-			items.push( {
-				label: translate( 'Search Results' ),
-				href: localizePath( `/plugins/${ selectedSite?.slug || '' }?s=${ search }` ),
-				id: 'plugins-search',
-			} );
+			dispatch(
+				appendBreadcrumb( {
+					label: translate( 'Search Results' ),
+					href: localizePath( `/plugins/${ selectedSite?.slug || '' }?s=${ search }` ),
+					id: 'plugins-search',
+				} )
+			);
 		}
-
-		dispatch( updateBreadcrumbs( items ) );
 	}, [ selectedSite?.slug, search, category, categoryName, dispatch, translate, localizePath ] );
 
 	return (

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -115,7 +115,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	const { localizePath } = useLocalizedPlugins();
 
 	useEffect( () => {
-		if ( breadcrumbs.length === 0 || ( ! category && ! search ) ) {
+		if ( breadcrumbs?.length === 0 || ( ! category && ! search ) ) {
 			dispatch( resetBreadcrumbs() );
 			dispatch(
 				appendBreadcrumb( {

--- a/client/state/breadcrumb/reducer.js
+++ b/client/state/breadcrumb/reducer.js
@@ -11,15 +11,14 @@ export default ( state = [], action ) => {
 			return [];
 		case BREADCRUMB_UPDATE_LIST:
 			return [ ...action.items ];
-		case BREADCRUMB_APPEND_ITEM:
-			// If it is the same kind as the last item, replace it.
-			// eslint-disable-next-line no-case-declarations
-			const currentLastItem = state[ state.length - 1 ] || {};
-			if ( currentLastItem.id === action.item?.id ) {
-				state.pop();
+		case BREADCRUMB_APPEND_ITEM: {
+			// If the new item already exists, clear crumbs back to & including the existing item, & add the new item.
+			const existingItemIndex = state.findIndex( ( item ) => item.id === action.item?.id );
+			if ( existingItemIndex > -1 ) {
+				state = state.slice( 0, existingItemIndex );
 			}
-
 			return [ ...state, action.item ];
+		}
 	}
 
 	return state;


### PR DESCRIPTION
#### Proposed Changes

This PR aims to prevent breadcrumb loops like the following:

![Screenshot 2022-09-16 at 15-43-14 Plugins Plan Upgrade ‹ Business - Simple Site — WordPress com](https://user-images.githubusercontent.com/811776/190565062-1aebf457-e694-41a7-bb15-99ca8b431f8d.png)

This is done by updating `BREADCRUMB_APPEND_ITEM` to check if the new item already exists, clear the breadcrumbs back to & including the existing item, & finally add the new item.

This means breadcrumbs should never have duplicate items, and any time we see an existing item, we rollback the breadcrumbs to when it was first introduced.

> **Note**
> Just FYI this PR does not address the breadcrumbs site switching issue.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> To test with the "plugins-plans-page", enable the config feature flag by
> 
> - Adding `"plugins-plans-page": true,` to `config/development.json`
> - Restart your localhost with `yarn` and `yarn start`

Plugins Plans page loop:
- Try visiting the plans page through a link with the config flag enabled
- then clicking a breadcrumb back to the plugin
- then back to install.

Deep breadcrumbs test:
- On a plan lower than business
- Go to the /plugins page
- Select a category
- Then search for term
- Then select a plugin
- Then try to install and end up on the Plugins Plans page
- Try going back with or without the help of the breadcrumbs

Ensure no regression is introduced with the Activity Log breadcrumb. [see this PR](https://github.com/Automattic/wp-calypso/pull/61044):

- Install mailpoet on your site
- Go to Jetpack -> Activity Log
- Click on MailPoet on the jetpack log
- Check if the breadcrumbs show only one item for MailPoet

Improvise to break the breadcrumbs.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? -- I intend to add a new e2e test during 20% time. 😅 
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67888
