### PR TITLE
Sites Management Page: Restrict Automagical sorting to A12s

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Button, Dropdown, MenuItemsChoice } from '@wordpress/components';
@@ -23,6 +24,8 @@ const SortingButtonIcon = styled( Gridicon )( {
 } );
 
 type SitesSortingDropdownProps = ReturnType< typeof useSitesSorting >;
+
+const isTruthy = < T, >( x: T | false ): x is T => !! x;
 
 export const SitesSortingDropdown = ( {
 	onSitesSortingChange,
@@ -55,6 +58,32 @@ export const SitesSortingDropdown = ( {
 		}
 	}, [ __, sitesSorting, hasSitesSortingPreferenceLoaded ] );
 
+	const choices = useMemo( () => {
+		return [
+			{
+				value: stringifySitesSorting( {
+					sortKey: 'alphabetically',
+					sortOrder: 'asc',
+				} ),
+				label: __( 'Alphabetically' ),
+			},
+			config.isEnabled( 'sites/automagical-sorting' ) && {
+				value: stringifySitesSorting( {
+					sortKey: 'lastInteractedWith',
+					sortOrder: 'desc',
+				} ),
+				label: __( 'Automagically' ),
+			},
+			{
+				value: stringifySitesSorting( {
+					sortKey: 'updatedAt',
+					sortOrder: 'desc',
+				} ),
+				label: __( 'Last published' ),
+			},
+		].filter( isTruthy );
+	}, [ __ ] );
+
 	if ( ! hasSitesSortingPreferenceLoaded ) {
 		return null;
 	}
@@ -79,29 +108,7 @@ export const SitesSortingDropdown = ( {
 						onSitesSortingChange( parseSitesSorting( value ) );
 						onClose();
 					} }
-					choices={ [
-						{
-							value: stringifySitesSorting( {
-								sortKey: 'alphabetically',
-								sortOrder: 'asc',
-							} ),
-							label: __( 'Alphabetically' ),
-						},
-						{
-							value: stringifySitesSorting( {
-								sortKey: 'lastInteractedWith',
-								sortOrder: 'desc',
-							} ),
-							label: __( 'Automagically' ),
-						},
-						{
-							value: stringifySitesSorting( {
-								sortKey: 'updatedAt',
-								sortOrder: 'desc',
-							} ),
-							label: __( 'Last published' ),
-						},
-					] }
+					choices={ choices }
 				/>
 			) }
 		/>

--- a/config/development.json
+++ b/config/development.json
@@ -171,6 +171,7 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -116,6 +116,7 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"themes/atomic-homepage-replace": true,

--- a/config/production.json
+++ b/config/production.json
@@ -134,6 +134,7 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/automagical-sorting": false,
 		"ssr/sample-log-cache-misses": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,6 +133,7 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,6 +142,7 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
#### Proposed Changes

Let's disable automagical sorting to everyone except Automatticians until it's more mature.

#### Testing Instructions

1. Start Calypso locally and check that Automagical sorting is available;
2. Build Calypso production locally with the instructions defined in PCYsg-5YE-p2 and check that the sorting option is gone.