### PR TITLE
Purchase Page: Display note under payment method column when purchased with credit

### DIFF
--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -47,7 +47,7 @@ export default function PaymentInfoBlock( {
 	}
 
 	if ( ! purchase.isAutoRenewEnabled && isPaidWithCredits( purchase ) ) {
-		return <PaymentInfoBlockWrapper>{ translate( 'None ' ) }</PaymentInfoBlockWrapper>;
+		return <PaymentInfoBlockWrapper>{ translate( 'None' ) }</PaymentInfoBlockWrapper>;
 	}
 
 	if (

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -35,6 +35,10 @@ export default function PaymentInfoBlock( {
 		return <PaymentInfoBlockWrapper>{ translate( 'Included with plan' ) }</PaymentInfoBlockWrapper>;
 	}
 
+	if ( ! purchase.isAutoRenewEnabled && isPaidWithCredits( purchase ) ) {
+		return <PaymentInfoBlockWrapper>{ translate( 'None' ) }</PaymentInfoBlockWrapper>;
+	}
+
 	if ( hasPaymentMethod( purchase ) && isPaidWithCredits( purchase ) ) {
 		return (
 			<PaymentInfoBlockWrapper>
@@ -44,10 +48,6 @@ export default function PaymentInfoBlock( {
 				</div>
 			</PaymentInfoBlockWrapper>
 		);
-	}
-
-	if ( ! purchase.isAutoRenewEnabled && isPaidWithCredits( purchase ) ) {
-		return <PaymentInfoBlockWrapper>{ translate( 'None' ) }</PaymentInfoBlockWrapper>;
 	}
 
 	if (

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -36,7 +36,14 @@ export default function PaymentInfoBlock( {
 	}
 
 	if ( hasPaymentMethod( purchase ) && isPaidWithCredits( purchase ) ) {
-		return <PaymentInfoBlockWrapper>{ translate( 'Credits' ) }</PaymentInfoBlockWrapper>;
+		return (
+			<PaymentInfoBlockWrapper>
+				<div className={ 'manage-purchase__no-payment-method' }>
+					<Icon icon={ warning } />
+					{ translate( 'You don’t have a payment method to renew this subscription' ) }
+				</div>
+			</PaymentInfoBlockWrapper>
+		);
 	}
 
 	if (

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -38,7 +38,7 @@ export default function PaymentInfoBlock( {
 	if ( hasPaymentMethod( purchase ) && isPaidWithCredits( purchase ) ) {
 		return (
 			<PaymentInfoBlockWrapper>
-				<div className={ 'manage-purchase__no-payment-method' }>
+				<div className="manage-purchase__no-payment-method">
 					<Icon icon={ warning } />
 					{ translate( 'You don’t have a payment method to renew this subscription' ) }
 				</div>

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -46,6 +46,10 @@ export default function PaymentInfoBlock( {
 		);
 	}
 
+	if ( ! purchase.isAutoRenewEnabled && isPaidWithCredits( purchase ) ) {
+		return <PaymentInfoBlockWrapper>{ translate( 'None ' ) }</PaymentInfoBlockWrapper>;
+	}
+
 	if (
 		hasPaymentMethod( purchase ) &&
 		isPaidWithCreditCard( purchase ) &&

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -65,6 +65,17 @@ describe( 'PaymentInfoBlock', () => {
 			} );
 		} );
 
+		describe( 'when the purchase is bought with credits and has no payment method', () => {
+			const purchase = {
+				isAutoRenewEnabled: false,
+			};
+
+			it( 'renders "None"', () => {
+				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
+				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
+			} );
+		} );
+
 		describe( 'when the purchase a non-rechargable payment method', () => {
 			const purchase = {
 				expiryStatus,

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -16,7 +16,7 @@ describe( 'PaymentInfoBlock', () => {
 		describe( 'when the purchase has credits as the payment method', () => {
 			const purchase = { expiryStatus, payment: { type: 'credits' }, isRechargeable: false };
 
-			it( 'renders "Credits"', () => {
+			it( 'renders "You don’t have a payment method to renew this subscription"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
 				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
 					'You don’t have a payment method to renew this subscription'

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -18,7 +18,9 @@ describe( 'PaymentInfoBlock', () => {
 
 			it( 'renders "Credits"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
-				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'Credits' );
+				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
+					'You don’t have a payment method to renew this subscription'
+				);
 			} );
 
 			it( 'does not render "will not be billed"', () => {

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -14,14 +14,28 @@ describe( 'PaymentInfoBlock', () => {
 		[ 'disabled', 'manualRenew' ],
 	] )( 'when auto-renew is %s', ( autoRenewStatus, expiryStatus ) => {
 		describe( 'when the purchase has credits as the payment method', () => {
-			const purchase = { expiryStatus, payment: { type: 'credits' }, isRechargeable: false };
+			const purchase = {
+				expiryStatus,
+				payment: { type: 'credits' },
+				isRechargeable: false,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
+			};
 
-			it( 'renders "You don’t have a payment method to renew this subscription"', () => {
-				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
-				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
-					'You don’t have a payment method to renew this subscription'
-				);
-			} );
+			it(
+				autoRenewStatus === 'enabled'
+					? 'renders "You don’t have a payment method to renew this subscription"'
+					: 'renders "None"',
+				() => {
+					render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
+					if ( autoRenewStatus === 'enabled' ) {
+						expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
+							'You don’t have a payment method to renew this subscription'
+						);
+					} else {
+						expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
+					}
+				}
+			);
 
 			it( 'does not render "will not be billed"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
@@ -32,7 +46,10 @@ describe( 'PaymentInfoBlock', () => {
 		} );
 
 		describe( 'when the purchase has included-with-plan as the payment method', () => {
-			const purchase = { expiryStatus: 'included' };
+			const purchase = {
+				expiryStatus: 'included',
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
+			};
 
 			it( 'renders "Included with plan"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
@@ -50,12 +67,28 @@ describe( 'PaymentInfoBlock', () => {
 		} );
 
 		describe( 'when the purchase has no payment method', () => {
-			const purchase = { expiryStatus, isRechargeable: false, payment: {} };
+			const purchase = {
+				expiryStatus,
+				isRechargeable: false,
+				payment: {},
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
+			};
 
-			it( 'renders "None"', () => {
-				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
-				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
-			} );
+			it(
+				autoRenewStatus === 'enabled'
+					? 'renders "You don’t have a payment method to renew this subscription"'
+					: 'renders "None"',
+				() => {
+					render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
+					if ( autoRenewStatus === 'enabled' ) {
+						expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
+							'You don’t have a payment method to renew this subscription'
+						);
+					} else {
+						expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
+					}
+				}
+			);
 
 			it( 'does not render "will not be billed"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
@@ -65,31 +98,29 @@ describe( 'PaymentInfoBlock', () => {
 			} );
 		} );
 
-		describe( 'when the purchase is bought with credits and has no payment method', () => {
-			const purchase = {
-				isAutoRenewEnabled: false,
-			};
-
-			it( 'renders "None"', () => {
-				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
-				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
-			} );
-		} );
-
-		describe( 'when the purchase a non-rechargable payment method', () => {
+		describe( 'when the purchase has a non-rechargable payment method', () => {
 			const purchase = {
 				expiryStatus,
 				payment: { type: 'ideal' },
 				isRechargeable: false,
-				isAutoRenewEnabled: true,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
 			};
 
-			it( 'renders "You don’t have a payment method to renew this subscription"', () => {
-				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
-				expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
-					'You don’t have a payment method to renew this subscription'
-				);
-			} );
+			it(
+				autoRenewStatus === 'enabled'
+					? 'renders "You don’t have a payment method to renew this subscription"'
+					: 'renders "None"',
+				() => {
+					render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
+					if ( autoRenewStatus === 'enabled' ) {
+						expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent(
+							'You don’t have a payment method to renew this subscription'
+						);
+					} else {
+						expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( 'None' );
+					}
+				}
+			);
 
 			it( 'does not render "will not be billed"', () => {
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
@@ -109,6 +140,7 @@ describe( 'PaymentInfoBlock', () => {
 					creditCard: { number: '1234', expiryDate, type: 'mastercard' },
 				},
 				isRechargeable: true,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
 			};
 
 			it( 'renders the credit card last4', () => {
@@ -154,6 +186,7 @@ describe( 'PaymentInfoBlock', () => {
 						creditCard: { number: '1234', expiryDate, type: 'mastercard' },
 					},
 					isRechargeable: true,
+					isAutoRenewEnabled: autoRenewStatus === 'enabled',
 				};
 				render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
 				if ( expiryStatus === 'manualRenew' ) {
@@ -171,6 +204,7 @@ describe( 'PaymentInfoBlock', () => {
 					type: 'paypal',
 				},
 				isRechargeable: true,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
 			};
 
 			it( 'renders PayPal logo', () => {
@@ -207,6 +241,7 @@ describe( 'PaymentInfoBlock', () => {
 					creditCard: { number: '1234', expiryDate, type: 'mastercard' },
 				},
 				isRechargeable: true,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
 			};
 			render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
 			expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( '1234' );
@@ -222,6 +257,7 @@ describe( 'PaymentInfoBlock', () => {
 					creditCard: { number: '1234', expiryDate, type: 'mastercard' },
 				},
 				isRechargeable: true,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
 			};
 			render( <PaymentInfoBlock purchase={ purchase } cards={ [] } /> );
 			expect( screen.getByLabelText( 'Payment method' ) ).toHaveTextContent( '1234' );
@@ -237,6 +273,7 @@ describe( 'PaymentInfoBlock', () => {
 					expiryDate,
 				},
 				isRechargeable: true,
+				isAutoRenewEnabled: autoRenewStatus === 'enabled',
 			};
 
 			it( 'renders the expiration date', () => {


### PR DESCRIPTION
#### Proposed Changes

When purchasing with credit, on the purchase page under the payment method column we see that it says `Credit` This should be changed to show detailed note with icon

Before:

![4NDbwu.png](https://user-images.githubusercontent.com/552016/191133284-2f7c413e-f79b-4d31-b793-63bf13fdb24d.png)

After:

![Pna7iz.png](https://user-images.githubusercontent.com/552016/191133283-ad364546-5423-40fa-9639-5157e547b890.png)


#### Testing Instructions



1. Purchase a premium plan to your account and pay for it with Credit
2. Now, visit the purchase page from /purchases/subscriptions/:site/:subscriptionid
3. You should see the text "You don’t have a payment method to renew this subscription" under the payment method column instead of the earlier "Credit"

Fixes 1103-gh-Automattic/payments-shilling





#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #