### PR TITLE
Theme bundle: Add software set check before showing upgrade modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -24,9 +24,11 @@ import { urlToSlug } from 'calypso/lib/url';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
+import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
+import { useThemeDetails } from '../../../../hooks/use-theme-details';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
@@ -215,8 +217,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			? isThemePurchased( state, selectedDesignThemeId, site.ID )
 			: false
 	);
+
+	const isPluginBundleEligible = useIsPluginBundleEligible();
+	const themeDetails = useThemeDetails( selectedDesign?.slug || '' );
+	const hasThemeSoftwareSet = themeDetails?.data?.taxonomies?.theme_software_set?.length;
+
 	const shouldUpgrade =
-		selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme;
+		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
+		( isPluginBundleEligible && hasThemeSoftwareSet );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -224,7 +224,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	const shouldUpgrade =
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
-		( isEnabled( 'themes/plugin-bundling' ) && isPluginBundleEligible && hasThemeSoftwareSet );
+		( isEnabled( 'themes/plugin-bundling' ) && ! isPluginBundleEligible && hasThemeSoftwareSet );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -224,7 +224,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	const shouldUpgrade =
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
-		( isPluginBundleEligible && hasThemeSoftwareSet );
+		( isEnabled( 'themes/plugin-bundling' ) && isPluginBundleEligible && hasThemeSoftwareSet );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 


### PR DESCRIPTION
#### Proposed Changes

* Added check for `isPluginBundleEligible` and `hasThemeSoftwareSet` to cover the case when the user has access to the premium themes but not to WooCommerce. In this case, the upgrade modal should be displayed.

#### Testing Instructions


* Create a site with these flags on: `themes/plugin-bundling`,`signup/seller-upgrade-modal` 
* Choose a plan with access to premium themes, but not WooCommerce.
* On the design picker choose Thriving Artist (that has bundling)
* Check that the Upgrade Modal is shown

Related to #67120
