### PR TITLE
Enable new Jetpack pricing page rework in Staging env.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -88,6 +88,7 @@
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -55,6 +55,7 @@
 		"jetpack/magic-link-signup": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,7 +45,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-rework-v1": false,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -39,7 +39,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-rework-v1": false,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -42,7 +42,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-rework-v1": false,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/production.json
+++ b/config/production.json
@@ -60,6 +60,7 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -58,6 +58,7 @@
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -66,6 +66,7 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Proposed Changes

This PR enables the `jetpack/pricing-page-rework-v1` config feature-flag in all environments, **except production**.

The Pricing page project ( p1HpG7-gBI-p2 ) is getting very close to being completed and we are ready to enable the project in all environments except not Production, most notably we especially want to enable it for staging (all proxied visitors, ie- all A18N's). We will be following this up with a CFT P2 post.

Completes task: 1202796695664022-as-1202979370140265/f

#### Testing Instructions

Just view the code and verify the `jetpack/pricing-page-rework-v1` flag is enabled in all environments, except not production.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202979370140265