### PR TITLE
Fix Stylelint error for rule: `no-eol-whitespace` 

### DIFF
--- a/client/my-sites/customize/style.scss
+++ b/client/my-sites/customize/style.scss
@@ -32,7 +32,7 @@
 
 /**
  * We need to block focus access to the main site behind the customizer so that focus remains on the customizer.
- * We can't use a focus lock (as on a Modal) as that would block access from exiting the browser window. 
+ * We can't use a focus lock (as on a Modal) as that would block access from exiting the browser window.
  * The customizer should behave like a normal page. This excludes the header and sidebar from being in the
  * focus order, while still allowing access to the chat and notices.
  */


### PR DESCRIPTION
Related to: #67467 

#### Proposed Changes

* Fix error for `no-eol-whitespace` after running `yarn lint:css`

#### Testing Instructions

1. TeamCity
2. Smoke test calypso.live and verify styles are generally correct 