### PR TITLE
Bypass ContinueAsUser component when email_address is supplied

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -71,6 +71,7 @@ class Login extends Component {
 		signupUrl: PropTypes.string,
 		redirectTo: PropTypes.string,
 		isPartnerSignup: PropTypes.bool,
+		loginEmailAddress: PropTypes.string,
 	};
 
 	state = {
@@ -118,6 +119,7 @@ class Login extends Component {
 			fromSite,
 			currentUser,
 			twoFactorEnabled,
+			loginEmailAddress,
 		} = this.props;
 
 		return (
@@ -129,6 +131,7 @@ class Login extends Component {
 			! isJetpack &&
 			! fromSite &&
 			! twoFactorEnabled &&
+			! loginEmailAddress &&
 			currentUser &&
 			! this.state.continueAsAnotherUser
 		);
@@ -540,6 +543,7 @@ export default connect(
 			get( getCurrentQueryArguments( state ), 'redirect_to' )
 		),
 		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
+		loginEmailAddress: getCurrentQueryArguments( state )?.email_address,
 	} ),
 	{
 		rebootAfterLogin,


### PR DESCRIPTION
#### Proposed Changes

Currently, if the user is logged in, when navigating to the login page with a query string parameter `email_address` (e.g. `/login?email_address=angela@example.com`), the user will be shown the `ContinueAsUser` component, showing their current logged in account. The user would only be able to login with the account specified by `email_address` by clicking on link "Log in as another user" located at the bottom of the page.

This change ensures that when `email_address` is supplied as a query string parameter, we do not show the `ContinueAsUser` component and users will land on the login page with the email field pre-populated with the email specified by `email_address`.

Additional context: p1663255252251739/1663255204.756889-slack-C03DY3RJ5

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login to your WordPress.com account
* Navigate to `/log-in?email_address=someone@example.com`
* **Expected outcome:** Land on the login page with the Email Address field pre-populated with `someone@example.com`

| Before | After |
| ------------- | ------------- |
| <img width="1569" alt="Screen Shot 2022-09-19 at 9 36 35 PM" src="https://user-images.githubusercontent.com/104910361/191148379-160e65e3-c1e2-4586-b725-d6276567d72d.png"> | <img width="1153" alt="Screen Shot 2022-09-19 at 9 37 53 PM" src="https://user-images.githubusercontent.com/104910361/191148297-40aa6453-2e38-420a-937a-b6a38b162c40.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #