### PR TITLE
Add plan comparison to plugins plans page

### DIFF
--- a/client/my-sites/plugins/controller-logged-in.js
+++ b/client/my-sites/plugins/controller-logged-in.js
@@ -7,6 +7,6 @@ export function upload( context, next ) {
 }
 
 export function plans( context, next ) {
-	context.primary = <Plans />;
+	context.primary = <Plans intervalType={ context.params.intervalType } />;
 	next();
 }

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -93,7 +93,7 @@ export default function ( router ) {
 	router( `/${ langParam }/plugins/plans`, notFound, makeLayout );
 
 	router(
-		`/${ langParam }/plugins/plans/:site`,
+		`/${ langParam }/plugins/plans/:intervalType(yearly|monthly)/:site`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectLoggedOut,
 		scrollTopIfNoHash,

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -13,7 +13,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const Plans = ( { intervalType = 'yearly' }: { intervalType: 'yearly' | 'monthly' } ) => {
+const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -54,6 +54,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 			/>
 			<div className="plans">
 				<PlansFeaturesMain
+					basePlansPath="/plugins/plans"
 					site={ selectedSite }
 					intervalType={ intervalType }
 					shouldShowPlansFeatureComparison

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_INSTALL_PLUGINS, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -17,7 +18,9 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );
+
 	const dispatch = useDispatch();
+
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
 			dispatch(
@@ -57,6 +60,8 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					basePlansPath="/plugins/plans"
 					site={ selectedSite }
 					intervalType={ intervalType }
+					selectedFeature={ FEATURE_INSTALL_PLUGINS }
+					selectedPlan={ PLAN_BUSINESS }
 					shouldShowPlansFeatureComparison
 					isReskinned
 				/>

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -6,13 +6,14 @@ import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const Plans = () => {
+const Plans = ( { intervalType = 'yearly' }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );
@@ -34,15 +35,15 @@ const Plans = () => {
 		dispatch(
 			appendBreadcrumb( {
 				label: translate( 'Plan Upgrade' ),
-				href: `/plugins/plans/${ selectedSite?.slug || '' }`,
+				href: `/plugins/plans/${ intervalType }/${ selectedSite?.slug || '' }`,
 				id: `plugin-plans`,
 			} )
 		);
-	}, [ dispatch, translate, selectedSite, breadcrumbs.length ] );
+	}, [ dispatch, translate, selectedSite, breadcrumbs.length, intervalType ] );
 
 	return (
 		<MainComponent wideLayout>
-			<PageViewTracker path="/plugins/plans/:site" title="Plugins > Plan Upgrade" />
+			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
 			<FixedNavigationHeader navigationItems={ breadcrumbs } />
 			<FormattedHeader
@@ -51,6 +52,14 @@ const Plans = () => {
 				subHeaderText={ `Choose the plan that's right for you and reimagine what's possible with plugins` }
 				brandFont
 			/>
+			<div className="plans">
+				<PlansFeaturesMain
+					site={ selectedSite }
+					intervalType={ intervalType }
+					shouldShowPlansFeatureComparison
+					isReskinned
+				/>
+			</div>
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -102,7 +102,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	const productsList = useSelector( getProductsList );
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
-	const pluginsPlansPage = `/plugins/plans/${ selectedSite?.slug }`;
+	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
 
 	return (
 		<>

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -54,7 +54,7 @@ const UpgradeNudge = ( {
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
 
-	const pluginsPlansPage = `/plugins/plans/${ selectedSite?.slug }`;
+	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
 
 	const translate = useTranslate();
 


### PR DESCRIPTION
Props to @candy02058912 most of this is just a refactor on https://github.com/Automattic/wp-calypso/pull/67891

#### Proposed Changes

* Adds plan comparison to plugin plans page.
* Update: Only business and ecom plans will show now. [see note](https://github.com/Automattic/wp-calypso/issues/67574#issuecomment-1251932161)

![Screenshot 2022-09-20 at 17-04-40 Plugins Plan Upgrade ‹ Personal Monthly - Simple Site — WordPress com](https://user-images.githubusercontent.com/811776/191189795-8caacfe5-e5c3-405f-9638-00eb1bb99cb6.png)

Without flag (before)

https://user-images.githubusercontent.com/811776/191165813-72a6f98b-d19c-4157-ab5b-c5056489d56c.mp4

With flag (after)

https://user-images.githubusercontent.com/811776/191165800-432eefb6-f44a-4416-a938-512bdc833c78.mp4


#### Testing Instructions

**Testing note: You require a free or monthly plan to see the price toggle. Existing annual plans will hide the toggle (going monthly is not possible once you have a yearly plan)**

* [ ] Using the `?flags=plugins-plans-page` flag e.g. http://calypso.localhost:3000/plugins/:site?flags=plugins-plans-page
* [ ] Check links from discovery page nudge
* [ ] Check links from plugin detail pages
* [ ] Check plugin plans page renders the plans comparison component
* [ ] Check plugin plans page is now at http://calypso.localhost:3000/plugins/plans/monthly/:site or http://calypso.localhost:3000/plugins/plans/yearly/:site


Related to https://github.com/Automattic/wp-calypso/issues/67574

