### PR TITLE
Pricing page rework: Temporarily remove Jetpack social from intro banner calculation

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-slugs.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-slugs.ts
@@ -1,3 +1,4 @@
+import { JETPACK_SOCIAL_PRODUCTS } from '@automattic/calypso-products';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getSitePlan } from 'calypso/state/sites/selectors';
@@ -21,7 +22,13 @@ const useProductSlugs = ( { siteId, duration }: ProductSlugsProps ): string[] =>
 					includedInPlanProducts,
 				} ),
 				...getPlansToDisplay( { duration, currentPlanSlug } ),
-			].map( ( { productSlug } ) => productSlug ),
+			]
+				.map( ( { productSlug } ) => productSlug )
+				// TO-DO: Once Jetpack Social pricing tiers and the introductory discount have been worked on, filtering should be removed.
+				.filter(
+					( productSlug ) =>
+						! ( JETPACK_SOCIAL_PRODUCTS as ReadonlyArray< string > ).includes( productSlug )
+				),
 		[ duration, availableProducts, purchasedProducts, includedInPlanProducts, currentPlanSlug ]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/index.tsx
@@ -1,5 +1,3 @@
-import { JETPACK_SOCIAL_PRODUCTS } from '@automattic/calypso-products';
-import { useMemo } from 'react';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import useProductSlugs from '../hooks/use-product-slugs';
 import { ProductSlugsProps } from '../types';
@@ -9,19 +7,9 @@ import './style.scss';
 export const PricingBanner: React.FC< ProductSlugsProps > = ( { siteId, duration } ) => {
 	const productSlugs = useProductSlugs( { siteId, duration } );
 
-	// TO-DO: Once Jetpack Social pricing tiers and the introductory discount have been worked on, filtering should be removed.
-	const filteredProductSlugs = useMemo(
-		() =>
-			productSlugs.filter(
-				( productSlug ) =>
-					! ( JETPACK_SOCIAL_PRODUCTS as ReadonlyArray< string > ).includes( productSlug )
-			),
-		[ productSlugs ]
-	);
-
 	return (
 		<div className="jetpack-product-store__pricing-banner">
-			<IntroPricingBanner productSlugs={ filteredProductSlugs } siteId={ siteId ?? 'none' } />
+			<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/index.tsx
@@ -1,3 +1,5 @@
+import { JETPACK_SOCIAL_PRODUCTS } from '@automattic/calypso-products';
+import { useMemo } from 'react';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import useProductSlugs from '../hooks/use-product-slugs';
 import { ProductSlugsProps } from '../types';
@@ -7,9 +9,19 @@ import './style.scss';
 export const PricingBanner: React.FC< ProductSlugsProps > = ( { siteId, duration } ) => {
 	const productSlugs = useProductSlugs( { siteId, duration } );
 
+	// TO-DO: Once Jetpack Social pricing tiers and the introductory discount have been worked on, filtering should be removed.
+	const filteredProductSlugs = useMemo(
+		() =>
+			productSlugs.filter(
+				( productSlug ) =>
+					! ( JETPACK_SOCIAL_PRODUCTS as ReadonlyArray< string > ).includes( productSlug )
+			),
+		[ productSlugs ]
+	);
+
 	return (
 		<div className="jetpack-product-store__pricing-banner">
-			<IntroPricingBanner productSlugs={ productSlugs } siteId={ siteId ?? 'none' } />
+			<IntroPricingBanner productSlugs={ filteredProductSlugs } siteId={ siteId ?? 'none' } />
 		</div>
 	);
 };


### PR DESCRIPTION
#### Description
In the new pricing page, the intro banner shows `Get up to 100% off for the first year`. This is due to including Jetpack Social Basic plan in the calculation.

<img width="982" alt="Screen Shot 2022-09-20 at 12 50 29 PM" src="https://user-images.githubusercontent.com/56598660/191170227-579ffb5b-c3f8-4ab4-9c41-e5fab24c670c.png">


#### Proposed Changes

* While Jetpack Social official plans are yet to be release and the introductory discount is to be work on. I filtered the Jetpack Social plan from getting calculated in the new pricing page's intro banner so it doesn't show '_up to 100% discount_'.

#### Testing Instructions

1. * Run `git fetch && git checkout remove/jetpack-social-from-intro-banner-calculation`
    * Run `yarn start-jetpack-cloud`
3. Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
4. Confirm the Pricing intro banner does not show 'up to 100%'.

<img width="980" alt="Screen Shot 2022-09-20 at 12 51 31 PM" src="https://user-images.githubusercontent.com/56598660/191170293-cada0589-d5d9-4c7a-870e-1afa9428d86d.png">




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1202979995370872

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202979995370872