### PR TITLE
Pricing page rework: Fix View filter component styling issue in Calypso blue.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/view-filter/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/view-filter/style.scss
@@ -24,7 +24,7 @@
 	}
 }
 
-.jetpack-product-store .jetpack-product-store__view-filter .jetpack-product-store__view-filter--toggle.segmented-control .segmented-control__item .segmented-control__link {
+.jetpack-product-store .jetpack-product-store__view-filter :is(.jetpack-product-store__view-filter--toggle.segmented-control, .jetpack-product-store__view-filter--toggle.segmented-control.is-primary) .segmented-control__item .segmented-control__link {
 	color: var(--color-text);
 	padding: 6px 11px;
 	border: 1px solid #f2f2f2;
@@ -42,7 +42,7 @@
 	}
 }
 
-.jetpack-product-store__view-filter .jetpack-product-store__view-filter--toggle.segmented-control .segmented-control__item.is-selected .segmented-control__link {
+.jetpack-product-store .jetpack-product-store__view-filter .jetpack-product-store__view-filter--toggle.segmented-control .segmented-control__item.is-selected .segmented-control__link {
 	background-color: var(--studio-white);
 	border-color: var(--studio-white);
 	color: var(--color-text);


### PR DESCRIPTION
### Description
When trying to view the pricing page while coming from post page. The view filter styling appears to be broken.
<img width="397" alt="Screen Shot 2022-09-20 at 4 35 56 PM" src="https://user-images.githubusercontent.com/56598660/191210844-25a8c7e5-420f-440d-80dd-b8ae671a896d.png">
<img width="377" alt="Screen Shot 2022-09-20 at 4 36 04 PM" src="https://user-images.githubusercontent.com/56598660/191210431-b6c1648e-c956-4369-8d7f-77ac3f4a10fd.png">


#### Proposed Changes

* Modify view filter style selectors to be more specific to ensure style doesn't get override by global styling.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. * Run `git fetch && git checkout fix/view-filter-styling-issue`
    * Run `yarn start`
3. Go to http://calypso.localhost:3000/plans/:site?flags=jetpack/pricing-page-rework-v1 or use the calypso live link and goto `/plans/:site?flags=jetpack/pricing-page-rework-v1`.
4. Go to the Post page by clicking the Post menu.
<img width="311" alt="Screen Shot 2022-09-20 at 4 43 48 PM" src="https://user-images.githubusercontent.com/56598660/191211736-40ad542e-e42a-4cbe-82b0-6e2d419e9868.png">
5. Go back to the pricing page by clicking the Plans menu.
<img width="305" alt="Screen Shot 2022-09-20 at 4 44 46 PM" src="https://user-images.githubusercontent.com/56598660/191212285-1fa1e6a6-05a3-4049-92d6-bac8d3698ff6.png">

6. Confirm that the styling of the view filter component is not broken. Try to switch from `product` to `bundle` page.

<img width="1035" alt="Screen Shot 2022-09-20 at 4 48 57 PM" src="https://user-images.githubusercontent.com/56598660/191213356-1888d3e3-9287-4db5-b859-2628e709ac4b.png">
<img width="1262" alt="Screen Shot 2022-09-20 at 4 49 12 PM" src="https://user-images.githubusercontent.com/56598660/191213380-0dd53189-33ee-4cd1-b066-021aed7c95d1.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203011579754801


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203011579754801