### PR TITLE
Read value of showFAQ in PlansFeaturesMain

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -440,13 +440,17 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	mayRenderFAQ() {
-		const { isInSignup, titanMonthlyRenewalCost, isFAQExperiment } = this.props;
+		const { isInSignup, titanMonthlyRenewalCost, isFAQExperiment, showFAQ } = this.props;
 
 		if ( isInSignup ) {
 			if ( isFAQExperiment ) {
 				return <PlanFAQ titanMonthlyRenewalCost={ titanMonthlyRenewalCost } />;
 			}
 			return null;
+		}
+
+		if ( ! showFAQ ) {
+			return;
 		}
 
 		return <WpcomFAQ />;


### PR DESCRIPTION
#### Proposed Changes

* read the showFAQ value so that it can control whether FAQ should be showing or not

#### Testing Instructions

https://user-images.githubusercontent.com/6586048/191233668-272a2035-041e-43c5-96ec-a3b957527ae1.mp4


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Probably hard to test with the live site since code is not for development:

Locally:
- [ ] Go to `/plans`
- [ ] Open react dev tools
- [ ] Find <PlansFeaturesMain>
- [ ] Toggle `showFAQ` value

Also:
- [ ] Make sure `/start/plans` doesn't show the FAQ

Fixes #68003
