### PR TITLE
Pricing page rework: Fix the incorrect discount value displayed in the lightbox.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -70,14 +70,13 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 								<span className="product-lightbox__variants-plan-card-old-price">
 									{ originalPriceValue }
 								</span>
-								{ translate( '%(percentOff)d% off the first year', {
+								{ translate( '%(percentOff)d%% off the first year', {
 									args: {
 										percentOff: Math.floor(
 											( ( originalPrice - discountedPrice ) / originalPrice ) * 100
 										),
 									},
-									comment:
-										'Second "%" symbol is the literal percent. "%(percentOff)d" will be a number and the final string will be somethig like "20% off the first year"',
+									comment: '"%%" is the literal percent symbol escaped using the other one.',
 								} ) }
 							</div>
 						) }

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -71,7 +71,11 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 									{ originalPriceValue }
 								</span>
 								{ translate( '%(percentOff)d% off the first year', {
-									args: { percentOff: Math.ceil( ( discountedPrice * 100 ) / originalPrice ) },
+									args: {
+										percentOff: Math.floor(
+											( ( originalPrice - discountedPrice ) / originalPrice ) * 100
+										),
+									},
 									comment:
 										'Second "%" symbol is the literal percent. "%(percentOff)d" will be a number and the final string will be somethig like "20% off the first year"',
 								} ) }


### PR DESCRIPTION
#### Proposed Changes

* Fix incorrect discount value calculation in lightbox payment plan component.

#### Testing Instructions

1. * Run `git fetch && git checkout fix/incorrect-display-discount`
    * Run `yarn start-jetpack-cloud`
3. Go to http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1 or use the jetpack cloud live link and goto `/pricing?flags=jetpack/pricing-page-rework-v1`.
4. Click on the **bundle** filter and then click '**more about Security**' link.
5. Confirm that the discount shows **56% off**.

Before:
<img width="458" alt="Screen Shot 2022-09-20 at 6 13 58 PM" src="https://user-images.githubusercontent.com/56598660/191233961-daeac162-b884-42b4-8ac9-4464fdc189ad.png">

After:
<img width="393" alt="Screen Shot 2022-09-20 at 6 14 51 PM" src="https://user-images.githubusercontent.com/56598660/191234012-e8dd64e0-d7cc-4478-9154-b7df01ed92ea.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203013329495319

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203013329495319