### PR TITLE
Add Subscriber Form: Add missing padding style

### DIFF
--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -1,3 +1,7 @@
+.step-container.subscribers {
+	padding: 0 1.5rem;
+}
+
 .add-subscriber {
 	.components-notice {
 		margin: 0 0 1rem;
@@ -80,7 +84,7 @@
 		display: inline-block;
 		width: 100%;
 		font-size: 0.875rem;
-		line-height: 1.25rem;
+		line-height: 1.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin: 0.75rem 0 1.5rem;
 
 		&.add-subscriber__form-label-links {
@@ -166,7 +170,7 @@
 
 	.add-subscriber__form--disclaimer {
 		font-size: 0.875rem;
-		line-height: 1.25rem;
+		line-height: 1.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		color: var(--studio-gray-50);
 		margin-bottom: 1.5rem;
 


### PR DESCRIPTION
#### Proposed Changes

* Add missing padding

#### Testing Instructions

* Go to `/setup/subscribers?flow=newsletter&siteSlug={SLUG}`
* Check if there is container padding on mobile resolutions

#### Screenshots
<table>
<tr>
<td>
**Before:**
<img width="312" alt="Screenshot 2022-09-20 at 13 06 18" src="https://user-images.githubusercontent.com/1241413/191242366-2859a879-ffc1-4c59-8d27-9ca1d23f1bba.png">
</td>
<td>
**After:**
<img width="313" alt="Screenshot 2022-09-20 at 13 03 15" src="https://user-images.githubusercontent.com/1241413/191242419-410a4a6b-319b-407a-a50a-4bc49b06b43f.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #67895
