### PR TITLE
Site Selector: Log `sort_key` and `sort_order` to click event

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -23,6 +23,7 @@ import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-
 import getSites from 'calypso/state/selectors/get-sites';
 import getVisibleSites from 'calypso/state/selectors/get-visible-sites';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
+import { withSitesSortingPreference } from 'calypso/state/sites/hooks/with-sites-sorting';
 import { getSite, hasAllSitesList } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SiteSelectorAddSite from './add-site';
@@ -201,6 +202,8 @@ export class SiteSelector extends Component {
 				position: visibleSites.indexOf( siteId ) + 1,
 				list_item_count: visibleSites.length,
 				is_searching: this.state.searchTerm.length > 0,
+				sort_key: this.props.sitesSorting.sortKey,
+				sort_order: this.props.sitesSorting.sortOrder,
 			} );
 		}
 
@@ -579,5 +582,6 @@ const mapState = ( state ) => {
 export default flow(
 	localize,
 	searchSites,
+	withSitesSortingPreference,
 	connect( mapState, { navigateToSite, recordTracksEvent } )
 )( SiteSelector );


### PR DESCRIPTION
Fixes 922-gh-Automattic/dotcom-forge

Tracks event 1077-gh-Automattic/tracks-events-registration

## Proposed Changes

Adds the `sort_key` and `sort_order` to the `calypso_switch_site_click_item` event:

<img width="1607" alt="image" src="https://user-images.githubusercontent.com/36432/191251517-f59f1712-267a-4f4f-82a2-d0db0c922f7d.png">

## Testing Instructions

1. Enable Tracks debugging in your console: `localStorage.setItem( 'debug', 'calypso:analytics*' );`.
2. Open the site switcher.
3. Click on a site and verify `sort_key` and `sort_order` are present.