### PR TITLE
Emails: add post checkout professional email tracking event

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -98,7 +98,6 @@ export interface UpsellNudgeAutomaticProps extends WithShoppingCartProps {
 	trackUpsellButtonClick: ( key: string ) => void;
 	translate: ReturnType< typeof useTranslate >;
 	cards: PaymentMethod[];
-	isFetchingStoredCards?: boolean;
 	currentPlanTerm: string;
 }
 
@@ -596,12 +595,11 @@ export default connect(
 				: undefined;
 
 		return {
-			isFetchingStoredCards: areStoredCardsLoading,
 			cards,
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			currentPlanTerm,
 			isLoading:
-				isFetchingCards ||
+				areStoredCardsLoading ||
 				isProductsListFetching( state ) ||
 				isRequestingSitePlans( state, selectedSiteId ),
 			hasProductsList: Object.keys( productsList ).length > 0,

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -192,7 +192,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 	};
 
 	render() {
-		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans, upsellType } = this.props;
+		const { selectedSiteId, hasProductsList, hasSitePlans, upsellType } = this.props;
 
 		return (
 			<Main className={ upsellType }>
@@ -200,7 +200,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }
 				{ ! hasSitePlans && <QuerySitePlans siteId={ parseInt( String( selectedSiteId ), 10 ) } /> }
-				{ isLoading ? this.renderPlaceholders() : this.renderContent() }
+				{ this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }
 			</Main>
@@ -253,50 +253,6 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		);
 	}
 
-	renderProfessionalEmailUpsellPlaceholder() {
-		return (
-			<>
-				<div className="upsell-nudge__placeholders">
-					<div>
-						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__hold-tight-placeholder" />
-						<div className="upsell-nudge__placeholder-row is-placeholder" />
-						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__price-placeholder" />
-					</div>
-				</div>
-				<div className="upsell-nudge__placeholders upsell-nudge__form-container-placeholder">
-					<div className="upsell-nudge__placeholders upsell-nudge__form-placeholder">
-						<div>
-							<div className="upsell-nudge__placeholder-row is-placeholder" />
-							<div className="upsell-nudge__placeholder-row is-placeholder" />
-							<div className="upsell-nudge__placeholder-button-container">
-								<div className="upsell-nudge__placeholder-button is-placeholder" />
-								<div className="upsell-nudge__placeholder-button is-placeholder" />
-							</div>
-						</div>
-					</div>
-					<div className="upsell-nudge__placeholders upsell-nudge__benefits-placeholder">
-						<div>
-							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
-							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
-							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
-							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
-							<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
-						</div>
-					</div>
-				</div>
-			</>
-		);
-	}
-
-	renderPlaceholders() {
-		const { upsellType } = this.props;
-
-		if ( upsellType === 'professional-email-upsell' ) {
-			return this.renderProfessionalEmailUpsellPlaceholder();
-		}
-		return this.renderGenericPlaceholder();
-	}
-
 	renderContent() {
 		const {
 			receiptId,
@@ -310,12 +266,15 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			translate,
 			siteSlug,
 			hasSevenDayRefundPeriod,
+			isLoading,
 		} = this.props;
 
 		switch ( upsellType ) {
 			case CONCIERGE_QUICKSTART_SESSION:
 			case CONCIERGE_SUPPORT_SESSION:
-				return (
+				return isLoading ? (
+					this.renderGenericPlaceholder()
+				) : (
 					<QuickstartSessionsRetirement
 						handleClickDecline={ this.handleClickDecline }
 						isLoggedIn={ isLoggedIn }
@@ -326,7 +285,9 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				);
 
 			case BUSINESS_PLAN_UPGRADE_UPSELL:
-				return (
+				return isLoading ? (
+					this.renderGenericPlaceholder()
+				) : (
 					<BusinessPlanUpgradeUpsell
 						currencyCode={ currencyCode }
 						planRawPrice={ planRawPrice }
@@ -354,6 +315,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 						setCartItem={ ( newCartItem, callback = noop ) =>
 							this.setState( { cartItem: newCartItem }, callback )
 						}
+						isLoading={ isLoading }
 					/>
 				);
 		}

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
 import Badge from 'calypso/components/badge';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { titanMailMonthly, titanMailYearly } from 'calypso/lib/cart-values/cart-items';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
@@ -156,7 +157,11 @@ const ProfessionalEmailUpsell = ( {
 	);
 
 	return (
-		<div>
+		<>
+			<PageViewTracker
+				path="/checkout/offer-professional-email/:domain/:receiptId/:site"
+				title={ translate( 'Post Checkout - Professional Email Upsell' ) }
+			/>
 			<header className="professional-email-upsell__header">
 				<h3 className="professional-email-upsell__small-title">
 					{ isDomainOnlySite
@@ -224,7 +229,7 @@ const ProfessionalEmailUpsell = ( {
 					/>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 };
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -26,6 +26,7 @@ import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductCost } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import ProfessionalEmailUpsellPlaceholder from './placeholder';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -66,6 +67,7 @@ type ProfessionalEmailUpsellProps = {
 	handleClickDecline: () => void;
 	setCartItem: ( cartItem: MinimalRequestCartProduct, callback: () => void ) => void;
 	intervalLength?: IntervalLength | undefined;
+	isLoading?: boolean;
 };
 
 const ProfessionalEmailUpsell = ( {
@@ -75,6 +77,7 @@ const ProfessionalEmailUpsell = ( {
 	handleClickDecline,
 	setCartItem,
 	intervalLength = IntervalLength.ANNUALLY,
+	isLoading = false,
 }: ProfessionalEmailUpsellProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -162,73 +165,79 @@ const ProfessionalEmailUpsell = ( {
 				path="/checkout/offer-professional-email/:domain/:receiptId/:site"
 				title={ translate( 'Post Checkout - Professional Email Upsell' ) }
 			/>
-			<header className="professional-email-upsell__header">
-				<h3 className="professional-email-upsell__small-title">
-					{ isDomainOnlySite
-						? translate( "Hold tight, we're getting your domain ready." )
-						: translate( "Hold tight, we're getting your site ready." ) }
-				</h3>
-				<h1 className="professional-email-upsell__title wp-brand-font">
-					{ translate( 'Add Professional Email @%(domain)s', {
-						args: {
-							domain: domainName,
-						},
-						comment: '%(domain)s is a domain name, like example.com',
-					} ) }
-				</h1>
-				<h3 className="professional-email-upsell__small-subtitle">
-					{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
-						? translate( 'No setup required. Easy to manage.' )
-						: null }
-				</h3>
-				<BillingIntervalToggle
-					intervalLength={ selectedIntervalLength }
-					onIntervalChange={ changeIntervalLength }
-				/>
-			</header>
-			<div className="professional-email-upsell__content">
-				{ isMobileView && pricingComponent }
-				<div className="professional-email-upsell__form">
-					<NewMailBoxList
-						cancelActionText={ translate( 'Skip for now' ) }
-						fieldLabelTexts={ {
-							[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
-							[ FIELD_PASSWORD ]: translate( 'Set password' ),
-						} }
-						hiddenFieldNames={ [ FIELD_NAME, FIELD_PASSWORD_RESET_EMAIL ] }
-						isInitialMailboxPurchase
-						onCancel={ handleClickDecline }
-						onSubmit={ onSubmit }
-						provider={ EmailProvider.Titan }
-						selectedDomainName={ domainName }
-						showCancelButton
-						submitActionText={ translate( 'Add Professional Email' ) }
-					/>
-				</div>
-				<div className="professional-email-upsell__features">
-					{ ! isMobileView && pricingComponent }
-					<h2>{ translate( 'Why get Professional Email?' ) }</h2>
-					<ul className="professional-email-upsell__feature-list">
-						<ProfessionalEmailFeature>
-							{ translate( "Trusted email address that's truly yours" ) }
-						</ProfessionalEmailFeature>
-						<ProfessionalEmailFeature>
-							{ translate( 'Increase your credibility' ) }
-						</ProfessionalEmailFeature>
-						<ProfessionalEmailFeature>
-							{ translate( 'Build your brand with every email you send' ) }
-						</ProfessionalEmailFeature>
-						<ProfessionalEmailFeature>
-							{ translate( 'Reach your recipients’ primary inbox' ) }
-						</ProfessionalEmailFeature>
-					</ul>
-					<img
-						className="professional-email-upsell__titan-logo"
-						src={ poweredByTitanLogo }
-						alt={ translate( 'Powered by Titan', { textOnly: true } ) }
-					/>
-				</div>
-			</div>
+			{ isLoading ? (
+				<ProfessionalEmailUpsellPlaceholder />
+			) : (
+				<>
+					<header className="professional-email-upsell__header">
+						<h3 className="professional-email-upsell__small-title">
+							{ isDomainOnlySite
+								? translate( "Hold tight, we're getting your domain ready." )
+								: translate( "Hold tight, we're getting your site ready." ) }
+						</h3>
+						<h1 className="professional-email-upsell__title wp-brand-font">
+							{ translate( 'Add Professional Email @%(domain)s', {
+								args: {
+									domain: domainName,
+								},
+								comment: '%(domain)s is a domain name, like example.com',
+							} ) }
+						</h1>
+						<h3 className="professional-email-upsell__small-subtitle">
+							{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
+								? translate( 'No setup required. Easy to manage.' )
+								: null }
+						</h3>
+						<BillingIntervalToggle
+							intervalLength={ selectedIntervalLength }
+							onIntervalChange={ changeIntervalLength }
+						/>
+					</header>
+					<div className="professional-email-upsell__content">
+						{ isMobileView && pricingComponent }
+						<div className="professional-email-upsell__form">
+							<NewMailBoxList
+								cancelActionText={ translate( 'Skip for now' ) }
+								fieldLabelTexts={ {
+									[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
+									[ FIELD_PASSWORD ]: translate( 'Set password' ),
+								} }
+								hiddenFieldNames={ [ FIELD_NAME, FIELD_PASSWORD_RESET_EMAIL ] }
+								isInitialMailboxPurchase
+								onCancel={ handleClickDecline }
+								onSubmit={ onSubmit }
+								provider={ EmailProvider.Titan }
+								selectedDomainName={ domainName }
+								showCancelButton
+								submitActionText={ translate( 'Add Professional Email' ) }
+							/>
+						</div>
+						<div className="professional-email-upsell__features">
+							{ ! isMobileView && pricingComponent }
+							<h2>{ translate( 'Why get Professional Email?' ) }</h2>
+							<ul className="professional-email-upsell__feature-list">
+								<ProfessionalEmailFeature>
+									{ translate( "Trusted email address that's truly yours" ) }
+								</ProfessionalEmailFeature>
+								<ProfessionalEmailFeature>
+									{ translate( 'Increase your credibility' ) }
+								</ProfessionalEmailFeature>
+								<ProfessionalEmailFeature>
+									{ translate( 'Build your brand with every email you send' ) }
+								</ProfessionalEmailFeature>
+								<ProfessionalEmailFeature>
+									{ translate( 'Reach your recipients’ primary inbox' ) }
+								</ProfessionalEmailFeature>
+							</ul>
+							<img
+								className="professional-email-upsell__titan-logo"
+								src={ poweredByTitanLogo }
+								alt={ translate( 'Powered by Titan', { textOnly: true } ) }
+							/>
+						</div>
+					</div>
+				</>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -163,7 +163,7 @@ const ProfessionalEmailUpsell = ( {
 		<>
 			<PageViewTracker
 				path="/checkout/offer-professional-email/:domain/:receiptId/:site"
-				title={ translate( 'Post Checkout - Professional Email Upsell' ) }
+				title="Post Checkout - Professional Email Upsell"
 			/>
 			{ isLoading ? (
 				<ProfessionalEmailUpsellPlaceholder />

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/placeholder.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/placeholder.tsx
@@ -1,0 +1,34 @@
+export default function ProfessionalEmailUpsellPlaceholder() {
+	return (
+		<>
+			<div className="upsell-nudge__placeholders">
+				<div>
+					<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__hold-tight-placeholder" />
+					<div className="upsell-nudge__placeholder-row is-placeholder" />
+					<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__price-placeholder" />
+				</div>
+			</div>
+			<div className="upsell-nudge__placeholders upsell-nudge__form-container-placeholder">
+				<div className="upsell-nudge__placeholders upsell-nudge__form-placeholder">
+					<div>
+						<div className="upsell-nudge__placeholder-row is-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder" />
+						<div className="upsell-nudge__placeholder-button-container">
+							<div className="upsell-nudge__placeholder-button is-placeholder" />
+							<div className="upsell-nudge__placeholder-button is-placeholder" />
+						</div>
+					</div>
+				</div>
+				<div className="upsell-nudge__placeholders upsell-nudge__benefits-placeholder">
+					<div>
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+						<div className="upsell-nudge__placeholder-row is-placeholder upsell-nudge__feature-placeholder" />
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
#### Proposed Changes
Currently, we don't have the `calypso_page_view` tracking event to track opening the post-checkout Professional Email page.
With this PR, we have the event.

#### Testing Instructions
* Create a site
* Go through the flow for selecting a domain and a paid plan
* Checkout
* A Professional Email upsell screen will show up (/checkout/offer-professional-email/:Domain/:receipt_id/:site)

**Expected and actual result**: in the [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) appeared event `calypso_page_view`, and in some time, the same event will appear in our "Tracks" system. 



#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1202916437620570/f