### PR TITLE
Pattern Assembler - CSS transitions for engagement

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/keyframes.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/keyframes.scss
@@ -1,0 +1,62 @@
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes fadeOut {
+	0% {
+		opacity: 1;
+	}
+	99% {
+		opacity: 0;
+	}
+	100% {
+		height: 0;
+		overflow: hidden;
+	}
+}
+
+@keyframes fadeInShort {
+	0% {
+		opacity: 0.5;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes slideIn {
+	0.00% {
+		transform: translateX(250px);
+	}
+	16.53% {
+		transform: translateX(-8.66px);
+	}
+	37.40% {
+		transform: translateX(2.29px);
+	}
+	58.26% {
+		transform: translateX(-0.7px);
+	}
+	79.13% {
+		transform: translateX(0.02px);
+	}
+	100.00% {
+		transform: translateX(0);
+	}
+}
+
+@keyframes slideInShort {
+	from {
+		transform: translateX(15%);
+	}
+	to {
+		transform: translateX(0%);
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -52,11 +52,6 @@
 			}
 		}
 	}
-
-	&:not(.pattern-assembler-preview--has-selected-patterns) {
-		opacity: 0;
-		animation: fadeInShort 0.2s ease-in 0.8s forwards;
-	}
 }
 
 .pattern-assembler-preview__placeholder {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -5,6 +5,12 @@
 	margin-top: -60px;
 	margin-inline-start: 32px;
 	box-sizing: border-box;
+	position: relative;
+	z-index: 1;
+
+	.web-preview__loading-message {
+		filter: none;
+	}
 
 	.preview-toolbar__browser-header,
 	.spinner-line {
@@ -28,10 +34,28 @@
 		opacity: 0;
 	}
 
+	.web-preview__loading-message-wrapper + .web-preview__frame-wrapper iframe {
+		filter: blur(8px);
+	}
+
 	&--has-selected-patterns {
 		iframe {
 			opacity: 1;
 		}
+
+		.is-loaded .web-preview__frame-wrapper {
+			background-color: #f8f8f8;
+			border-radius: 20px;
+
+			iframe {
+				animation: fadeInShort 2.2s forwards;
+			}
+		}
+	}
+
+	&:not(.pattern-assembler-preview--has-selected-patterns) {
+		opacity: 0;
+		animation: fadeInShort 0.2s ease-in 0.8s forwards;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -44,9 +44,6 @@
 		}
 
 		.is-loaded .web-preview__frame-wrapper {
-			background-color: #f8f8f8;
-			border-radius: 20px;
-
 			iframe {
 				animation: fadeInShort 2.2s forwards;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,4 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
+import classnames from 'classnames';
 import { useEffect, useRef } from 'react';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
@@ -24,8 +25,10 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 
 	return (
 		<div
-			className="pattern-selector"
-			style={ show ? {} : { height: 0, overflow: 'hidden' } }
+			className={ classnames( 'pattern-selector', {
+				'pattern-selector--active': show,
+				'pattern-selector--hide': ! show,
+			} ) }
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
 			tabIndex={ show ? 0 : -1 }
 			ref={ patternSelectorRef }
@@ -46,6 +49,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 								aria-label={ item.name }
 								tabIndex={ 0 }
 								role="option"
+								title={ item.name }
 								aria-selected={ false }
 								onClick={ () => onSelect( item ) }
 								onKeyUp={ handleKeyboard( () => onSelect( item ) ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -109,7 +109,7 @@ $font-family: "SF Pro Text", $sans;
 				}
 
 				&:not(:disabled):hover svg {
-					fill: #0675c4;
+					fill: var(--studio-blue-50);
 				}
 
 				&--move-up,
@@ -153,7 +153,7 @@ $font-family: "SF Pro Text", $sans;
 					border: 0;
 					padding: 0;
 					font-family: inherit;
-					color: #0675c4;
+					color: var(--studio-blue-50);
 				}
 
 				&:hover,
@@ -233,7 +233,7 @@ $font-family: "SF Pro Text", $sans;
 		&--active {
 			height: 100%;
 			overflow: initial;
-			animation: 1.5s slideIn cubic-bezier(0.445, 0.05, 0.55, 0.95), fadeIn 0.3s ease-in;
+			animation: 1s slideIn cubic-bezier(0.445, 0.05, 0.55, 0.95), fadeIn 0.3s ease-in;
 		}
 
 		&--hide {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -50,6 +50,10 @@ $font-family: "SF Pro Text", $sans;
 		display: flex;
 		flex-direction: column;
 		height: 100%;
+		width: 100%;
+		background: #fdfdfd;
+		position: absolute;
+		top: 0;
 
 		.pattern-layout__header {
 			h2 {
@@ -220,6 +224,11 @@ $font-family: "SF Pro Text", $sans;
 	.pattern-selector {
 		display: flex;
 		flex-direction: column;
+		height: 100%;
+		width: 100%;
+		background: #fdfdfd;
+		position: absolute;
+		top: 0;
 
 		&--active {
 			height: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -1,3 +1,5 @@
+@import "./keyframes";
+
 @font-face {
 	font-family: Inter;
 	font-weight: 500;
@@ -6,69 +8,6 @@
 }
 
 $font-family: "SF Pro Text", $sans;
-
-@keyframes fadeIn {
-	0% {
-		opacity: 0;
-	}
-
-	100% {
-		opacity: 1;
-	}
-}
-
-@keyframes fadeOut {
-	0% {
-		opacity: 1;
-	}
-	99% {
-		opacity: 0;
-	}
-	100% {
-		height: 0;
-		overflow: hidden;
-	}
-}
-
-@keyframes fadeInShort {
-	0% {
-		opacity: 0.5;
-	}
-
-	100% {
-		opacity: 1;
-	}
-}
-
-@keyframes slideIn {
-	0.00% {
-		transform: translateX(250px);
-	}
-	16.53% {
-		transform: translateX(-8.66px);
-	}
-	37.40% {
-		transform: translateX(2.29px);
-	}
-	58.26% {
-		transform: translateX(-0.7px);
-	}
-	79.13% {
-		transform: translateX(0.02px);
-	}
-	100.00% {
-		transform: translateX(0);
-	}
-}
-
-@keyframes slideInShort {
-	from {
-		transform: translateX(15%);
-	}
-	to {
-		transform: translateX(0%);
-	}
-}
 
 .pattern-assembler {
 	display: flex;
@@ -160,7 +99,7 @@ $font-family: "SF Pro Text", $sans;
 
 					&:hover {
 						transform: scale(1.05);
-						transition: transform 0.1s ease-in-out;
+						transition: transform 0.1s ease-in;
 						transform-origin: center;
 					}
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -7,6 +7,69 @@
 
 $font-family: "SF Pro Text", $sans;
 
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes fadeOut {
+	0% {
+		opacity: 1;
+	}
+	99% {
+		opacity: 0;
+	}
+	100% {
+		height: 0;
+		overflow: hidden;
+	}
+}
+
+@keyframes fadeInShort {
+	0% {
+		opacity: 0.5;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes slideIn {
+	0.00% {
+		transform: translateX(250px);
+	}
+	16.53% {
+		transform: translateX(-8.66px);
+	}
+	37.40% {
+		transform: translateX(2.29px);
+	}
+	58.26% {
+		transform: translateX(-0.7px);
+	}
+	79.13% {
+		transform: translateX(0.02px);
+	}
+	100.00% {
+		transform: translateX(0);
+	}
+}
+
+@keyframes slideInShort {
+	from {
+		transform: translateX(15%);
+	}
+	to {
+		transform: translateX(0%);
+	}
+}
+
 .pattern-assembler {
 	display: flex;
 	height: calc(100vh - 60px);
@@ -40,19 +103,8 @@ $font-family: "SF Pro Text", $sans;
 		box-sizing: border-box;
 		margin-top: 50px;
 		margin-bottom: 32px;
-	}
-
-	.pattern-assembler__preview {
-		flex-basis: 100%;
-		margin-inline-start: 32px;
-		background: #f6f6f6;
-		box-shadow: 0 0 2px rgba(0, 0, 0, 10%);
-		border-radius: 4px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		margin-bottom: 32px;
-		margin-top: -25px;
+		position: relative;
+		z-index: 0;
 	}
 
 	.pattern-layout {
@@ -87,6 +139,7 @@ $font-family: "SF Pro Text", $sans;
 			opacity: 0;
 			align-items: center;
 			position: absolute;
+			z-index: 1;
 			background: #fff;
 			height: 27px;
 			right: 0;
@@ -104,6 +157,12 @@ $font-family: "SF Pro Text", $sans;
 
 				svg {
 					fill: #2c3338;
+
+					&:hover {
+						transform: scale(1.05);
+						transition: transform 0.1s ease-in-out;
+						transform-origin: center;
+					}
 				}
 
 				&:not(:disabled):hover svg {
@@ -145,15 +204,30 @@ $font-family: "SF Pro Text", $sans;
 					white-space: nowrap;
 				}
 
+				button {
+					display: flex;
+					align-items: center;
+					border: 0;
+					padding: 0;
+					font-family: inherit;
+					color: #0675c4;
+				}
+
 				&:hover,
 				&:focus,
 				&:focus-within {
+					button {
+						color: var(--color-accent-60);
+						transition: color 0.2s ease-in;
+					}
+
 					.pattern-layout__list-item-text {
 						max-width: 154px;
 					}
 
 					.pattern-action-bar {
-						opacity: 1;
+						animation: slideInShort 0.2s forwards, fadeIn 0.3s forwards;
+						animation-timing-function: cubic-bezier(0.445, 0.05, 0.55, 0.95);
 					}
 				}
 
@@ -164,15 +238,6 @@ $font-family: "SF Pro Text", $sans;
 				&:first-child {
 					margin-top: auto;
 				}
-
-				button {
-					display: flex;
-					align-items: center;
-					border: 0;
-					padding: 0;
-					font-family: inherit;
-					color: #0675c4;
-				}
 			}
 
 			.pattern-layout__list-item {
@@ -180,12 +245,12 @@ $font-family: "SF Pro Text", $sans;
 				display: flex;
 				align-items: center;
 
-				&--section {
-					background: url(./images/icon-section.svg) no-repeat 5px center;
-				}
-
 				&--header {
 					background: url(./images/icon-header.svg) no-repeat 5px center;
+				}
+
+				&--section {
+					background: url(./images/icon-section.svg) no-repeat 5px center;
 				}
 
 				&--footer {
@@ -214,9 +279,19 @@ $font-family: "SF Pro Text", $sans;
 	}
 
 	.pattern-selector {
-		height: 100%;
 		display: flex;
 		flex-direction: column;
+
+		&--active {
+			height: 100%;
+			overflow: initial;
+			animation: 1.5s slideIn cubic-bezier(0.445, 0.05, 0.55, 0.95), fadeIn 0.3s ease-in;
+		}
+
+		&--hide {
+			animation: 0.25s fadeOut forwards;
+			pointer-events: none;
+		}
 
 		.pattern-selector__header h1 {
 			font-family: $font-family;


### PR DESCRIPTION
#### Proposed Changes

* Animate action bar, icons, pattern selector, preview, and loading
  * Action bar: enters with slide in and fade in
  * Icons: on hover has a small scale up
  * Pattern selector: enters with slide in and fade in and exit with fade out
  * ~Preview placeholder: enters with fade in delayed to put the attention on the sidebar first~
  * Preview site: blur and fade in to hide a little the iframe content when loading and show it smoothly 

#### Testing Instructions
- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain
- Select the goal Promote myself or business
- Select the category `Show all`
- Click on the Blank canvas CTA
- Check how the Pattern Assembler loads
- Add/replace/remove patterns
- Check how the pattern selector loads
- Check how the site preview loads

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#67897](https://github.com/Automattic/wp-calypso/issues/67897)
