### PR TITLE
Add Jetpack Cloud site info into HotJar analytics tracking code.

### DIFF
--- a/client/lib/analytics/hotjar.js
+++ b/client/lib/analytics/hotjar.js
@@ -2,6 +2,7 @@ import { getDoNotTrack } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import debug from 'debug';
 import { isE2ETest } from 'calypso/lib/e2e';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { mayWeTrackCurrentUserGdpr, isPiiUrl } from './utils';
 
 const hotjarDebug = debug( 'calypso:analytics:hotjar' );
@@ -21,6 +22,10 @@ export function addHotJarScript() {
 		return;
 	}
 
+	const hotjarSiteSettings = isJetpackCloud()
+		? { hjid: 3165344, hjsv: 6 } // Calypso green (cloud.jetpack.com)
+		: { hjid: 227769, hjsv: 5 }; // Calypso blue (wordpress.com)
+
 	( function ( h, o, t, j, a, r ) {
 		hotjarDebug( 'Loading HotJar script' );
 		h.hj =
@@ -28,7 +33,7 @@ export function addHotJarScript() {
 			function () {
 				( h.hj.q = h.hj.q || [] ).push( arguments );
 			};
-		h._hjSettings = { hjid: 227769, hjsv: 5 };
+		h._hjSettings = hotjarSiteSettings;
 		a = o.getElementsByTagName( 'head' )[ 0 ];
 		r = o.createElement( 'script' );
 		r.async = 1;


### PR DESCRIPTION
#### Proposed Changes

This PR allows the Calypso HotJar integration to also work with Jetpack Cloud, (not solely wordpress.com).

- Updated the code to use a different site id for jetpack cloud when using the script on a jetpack cloud page.

#### Testing Instructions

- This code can't really be tested until after deploying. After it's deployed, we'll log into the HotJar account interface to make sure it's now working with the cloud.jetpack.com property within HotJar.
- Just inspect the code and verify it looks good and makes sense.  It's a small simple change. 😉

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203005354786544