### PR TITLE
Remove environment url conversion from invite__revoke.ts

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -273,22 +273,6 @@ export function getTestDomainRegistrarDetails( email: string ): RegistrarDetails
 }
 
 /**
- * Adjusts the user invite link to the correct environment.
- *
- * By default, all invite links reference the production `wordpress.com` hostname.
- * However, for end-to-end tests it is desirable to test invite functionality against
- * the development environment.
- *
- * @param {string} inviteURL Full invitation link.
- * @returns {string} Adjusted invitation link with the intended hostname.
- */
-export function adjustInviteLink( inviteURL: string ): string {
-	const originalURL = new URL( inviteURL );
-	const adjustedURL = new URL( originalURL.pathname, getCalypsoURL() );
-	return adjustedURL.href;
-}
-
-/**
  * Returns the hostname for Jetpack.
  *
  * @returns {string} Hostname to be used. Returns value of JETPACKHOST environment variable if set; WPCOM otherwise.

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -25,7 +25,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 		usernamePrefix: 'invited',
 	} );
 
-	let adjustedInviteLink: string;
+	let acceptInviteLink: string;
 	let page: Page;
 
 	beforeAll( async () => {
@@ -73,15 +73,14 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 				sentTo: testUser.email,
 			} );
 			const links = await emailClient.getLinksFromMessage( message );
-			const acceptInviteLink = links.find( ( link: string ) =>
+			acceptInviteLink = links.find( ( link: string ) =>
 				link.includes( 'accept-invite' )
 			) as string;
 			expect( acceptInviteLink ).toBeDefined();
-			adjustedInviteLink = DataHelper.adjustInviteLink( acceptInviteLink );
 		} );
 
 		it( 'Sign up as invited user from the invite link', async function () {
-			await page.goto( adjustedInviteLink );
+			await page.goto( acceptInviteLink );
 
 			const userSignupPage = new UserSignupPage( page );
 			await userSignupPage.signup( testUser.email, testUser.username, testUser.password );

--- a/test/e2e/specs/users/invite__revoke.ts
+++ b/test/e2e/specs/users/invite__revoke.ts
@@ -26,7 +26,7 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 	const inviteMessage = `Test invite for role of ${ role }`;
 	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
-	let adjustedInviteLink: string;
+	let acceptInviteLink: string;
 	let peoplePage: PeoplePage;
 	let page: Page;
 	let restAPIClient: RestAPIClient;
@@ -50,13 +50,9 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 				sentTo: testEmailAddress,
 			} );
 			const links = await emailClient.getLinksFromMessage( message );
-			const acceptInviteLink = links.find( ( link: string ) =>
+			acceptInviteLink = links.find( ( link: string ) =>
 				link.includes( 'accept-invite' )
 			) as string;
-
-			expect( acceptInviteLink ).toBeDefined();
-
-			adjustedInviteLink = DataHelper.adjustInviteLink( acceptInviteLink );
 		} );
 	} );
 
@@ -83,10 +79,9 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 			revoked = true;
 		} );
 
-		// see: https://a8c.slack.com/archives/C02DQP0FP/p1663592311997839
-		it.skip( `Ensure invite link is no longer valid`, async function () {
+		it( `Ensure invite link is no longer valid`, async function () {
 			const newPage = await browser.newPage();
-			await newPage.goto( adjustedInviteLink );
+			await newPage.goto( acceptInviteLink );
 
 			// Text selector will suffice for now.
 			await newPage.waitForSelector( `:text("Oops, that invite is not valid")` );


### PR DESCRIPTION
#### Proposed Changes

* e2e/specs/users/invite__revoke.ts started failing due to a change in the expected invite URL. Starting sometime Sept 19th, the invite URL no longer has environment-specific base URLs and does not need to be adjusted. This change uses the original URL for a goto but leaves the data-helper function in case we need to adjust URLs for specific environments again in the future.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* invite__revoke.ts should pass local runs.
* Group calypso-release should pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
