### PR TITLE
Issue 604: Cancel button is too small

### DIFF
--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -37,7 +37,7 @@ $headerHeight: 72px;
 			cursor: pointer;
 			font-style: normal;
 			font-weight: 500;
-			font-size: $font-body-extra-small;
+			font-size: $font-body-small;
 		}
 	}
 	.blazepress-widget__content {


### PR DESCRIPTION
#### Proposed Changes

* as mentioned in [this ticket](https://github.tumblr.net/Tumblr/wordads-picard/issues/604), the cancel button is too small

before version 

![Screenshot 2022-09-20 at 18 29 46](https://user-images.githubusercontent.com/1416426/191300569-00f3039a-79c6-4d3b-a643-a32a1db1579d.png)

after version 
![Screenshot 2022-09-20 at 18 29 33](https://user-images.githubusercontent.com/1416426/191300604-f74a1619-8b75-4cdb-9662-b2d234350a9d.png)


#### Testing Instructions

Just checkout the branch and check the font size of the cancel button on the top right part of screen

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
