### PR TITLE
Sites Management Page: Use scoring algo to promote interaction recency

### DIFF
--- a/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
@@ -190,9 +190,13 @@ describe( 'useSitesTableSorting', () => {
 		// Object equality is important for memoizing the site table row
 
 		const { result, rerender } = renderHook(
-			( { sortOrder } ) =>
-				useSitesTableSorting( filteredSites, { sortKey: 'updatedAt', sortOrder } ),
-			{ initialProps: { sortOrder: 'asc' as SitesTableSortOrder } }
+			( { sortKey, sortOrder } ) => useSitesTableSorting( filteredSites, { sortKey, sortOrder } ),
+			{
+				initialProps: {
+					sortKey: 'updatedAt' as SitesTableSortKey,
+					sortOrder: 'asc' as SitesTableSortOrder,
+				},
+			}
 		);
 
 		expect( result.current.sortedSites ).toHaveLength( 3 );
@@ -200,11 +204,26 @@ describe( 'useSitesTableSorting', () => {
 		expect( result.current.sortedSites[ 1 ] ).toBe( filteredSites[ 2 ] );
 		expect( result.current.sortedSites[ 2 ] ).toBe( filteredSites[ 1 ] );
 
-		rerender( { sortOrder: 'desc' } );
+		rerender( { sortKey: 'updatedAt', sortOrder: 'desc' } );
 
+		// A (1) -> C (2) -> B (0)
 		expect( result.current.sortedSites ).toHaveLength( 3 );
 		expect( result.current.sortedSites[ 0 ] ).toBe( filteredSites[ 1 ] );
 		expect( result.current.sortedSites[ 1 ] ).toBe( filteredSites[ 2 ] );
 		expect( result.current.sortedSites[ 2 ] ).toBe( filteredSites[ 0 ] );
+
+		// A (1) -> B (0) -> C (2)
+		rerender( { sortKey: 'alphabetically', sortOrder: 'asc' } );
+		expect( result.current.sortedSites ).toHaveLength( 3 );
+		expect( result.current.sortedSites[ 0 ] ).toBe( filteredSites[ 1 ] );
+		expect( result.current.sortedSites[ 1 ] ).toBe( filteredSites[ 0 ] );
+		expect( result.current.sortedSites[ 2 ] ).toBe( filteredSites[ 2 ] );
+
+		// A (1) -> B (0) -> C (2)
+		rerender( { sortKey: 'lastInteractedWith', sortOrder: 'desc' } );
+		expect( result.current.sortedSites ).toHaveLength( 3 );
+		expect( result.current.sortedSites[ 0 ] ).toBe( filteredSites[ 1 ] );
+		expect( result.current.sortedSites[ 1 ] ).toBe( filteredSites[ 0 ] );
+		expect( result.current.sortedSites[ 2 ] ).toBe( filteredSites[ 2 ] );
 	} );
 } );

--- a/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/test/use-sites-table-sorting.tsx
@@ -35,6 +35,32 @@ describe( 'useSitesTableSorting', () => {
 			},
 		},
 	];
+	const frequentSites = [
+		{
+			ID: 1,
+			title: 'B',
+			options: {
+				updated_at: '2022-05-27T07:19:20+00:00',
+			},
+			user_interactions: [ '2022-09-20' ],
+		},
+		{
+			ID: 2,
+			title: 'A',
+			options: {
+				updated_at: '2022-07-13T17:17:12+00:00',
+			},
+			user_interactions: [ '2022-09-19' ],
+		},
+		{
+			ID: 3,
+			title: 'C',
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+			},
+			user_interactions: [ '2022-09-19', '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+	];
 
 	test( 'should not sort sites if unsupported sortKey is provided', () => {
 		const { result } = renderHook( () =>
@@ -101,9 +127,35 @@ describe( 'useSitesTableSorting', () => {
 		);
 
 		expect( result.current.sortedSites.length ).toBe( 3 );
-		expect( result.current.sortedSites[ 0 ].title ).toBe( 'B' );
-		expect( result.current.sortedSites[ 1 ].title ).toBe( 'A' );
+		expect( result.current.sortedSites[ 0 ].title ).toBe( 'C' );
+		expect( result.current.sortedSites[ 1 ].title ).toBe( 'B' );
+		expect( result.current.sortedSites[ 2 ].title ).toBe( 'A' );
+	} );
+
+	test( 'should pick the site more frequently interacted with ascending', () => {
+		const { result } = renderHook( () =>
+			useSitesTableSorting( frequentSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+			} )
+		);
+		expect( result.current.sortedSites.length ).toBe( 3 );
+		expect( result.current.sortedSites[ 0 ].title ).toBe( 'A' );
+		expect( result.current.sortedSites[ 1 ].title ).toBe( 'B' );
 		expect( result.current.sortedSites[ 2 ].title ).toBe( 'C' );
+	} );
+
+	test( 'should pick the site more frequently interacted with descending', () => {
+		const { result } = renderHook( () =>
+			useSitesTableSorting( frequentSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'desc',
+			} )
+		);
+		expect( result.current.sortedSites.length ).toBe( 3 );
+		expect( result.current.sortedSites[ 0 ].title ).toBe( 'C' );
+		expect( result.current.sortedSites[ 1 ].title ).toBe( 'B' );
+		expect( result.current.sortedSites[ 2 ].title ).toBe( 'A' );
 	} );
 
 	test( 'should sort sites by updatedAt descending', () => {

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -1,12 +1,24 @@
 import { useMemo } from 'react';
 
-export interface SiteDetailsForSorting {
+interface SiteDetailsForSortingWithOptionalUserInteractions {
 	title: string;
 	user_interactions?: string[];
 	options?: {
 		updated_at?: string;
 	};
 }
+
+interface SiteDetailsForSortingWithUserInteractions {
+	title: string;
+	user_interactions: string[];
+	options?: {
+		updated_at?: string;
+	};
+}
+
+export type SiteDetailsForSorting =
+	| SiteDetailsForSortingWithOptionalUserInteractions
+	| SiteDetailsForSortingWithUserInteractions;
 
 const validSortKeys = [ 'lastInteractedWith', 'updatedAt', 'alphabetically' ] as const;
 const validSortOrders = [ 'asc', 'desc' ] as const;
@@ -53,52 +65,35 @@ export function useSitesTableSorting< T extends SiteDetailsForSorting >(
 	}, [ allSites, sortKey, sortOrder ] );
 }
 
-function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
-	sites: T[],
-	sortOrder: SitesTableSortOrder
-) {
-	const mostRecentInteraction = [
-		...( sites
-			.map( ( site ) => site.user_interactions )
-			.flat( 1 )
-			.sort()
-			.reverse() || [] ),
-	].pop();
-	let threeDaysAgo = '';
-	let sevenDaysAgo = '';
-	let twoWeeksAgo = '';
-	if ( mostRecentInteraction ) {
-		const date = new Date( mostRecentInteraction );
-		date.setDate( date.getDate() - 3 );
-		threeDaysAgo = [
-			date.getFullYear(),
-			( '0' + ( date.getMonth() + 1 ) ).slice( -2 ),
-			( '0' + date.getDate() ).slice( -2 ),
-		].join( '-' );
-		date.setDate( date.getDate() - 4 );
-		sevenDaysAgo = [
-			date.getFullYear(),
-			( '0' + ( date.getMonth() + 1 ) ).slice( -2 ),
-			( '0' + date.getDate() ).slice( -2 ),
-		].join( '-' );
-		date.setDate( date.getDate() - 7 );
-		twoWeeksAgo = [
-			date.getFullYear(),
-			( '0' + ( date.getMonth() + 1 ) ).slice( -2 ),
-			( '0' + date.getDate() ).slice( -2 ),
-		].join( '-' );
-	}
+const subtractDays = ( date: string, days: number ) => {
+	const MILLISECONDS_IN_DAY = 86400 * 1000;
+	const timestamp = new Date( date ).valueOf();
 
-	const interactedItems = sites.filter(
-		( site ) => site.user_interactions && site.user_interactions.length > 0
-	);
-	const remainingItems = sites.filter(
-		( site ) => ! site.user_interactions || site.user_interactions.length === 0
-	);
+	const subtractedDate = new Date( timestamp - MILLISECONDS_IN_DAY * days );
+
+	const year = subtractedDate.getFullYear();
+	const month = subtractedDate.getMonth().toString().padStart( 2, '0' );
+	const day = subtractedDate.getDate().toString().padStart( 2, '0' );
+
+	return `${ year }-${ month }-${ day }`;
+};
+
+const sortInteractedItems = (
+	interactedItems: SiteDetailsForSortingWithUserInteractions[],
+	sortOrder: SitesTableSortOrder
+) => {
+	const [ mostRecentInteraction ] = interactedItems
+		.map( ( site ) => site.user_interactions )
+		.flat()
+		.sort()
+		.reverse();
+
+	const threeDaysAgo = subtractDays( mostRecentInteraction, 3 );
+	const sevenDaysAgo = subtractDays( mostRecentInteraction, 7 );
+	const twoWeeksAgo = subtractDays( mostRecentInteraction, 14 );
 
 	const scoreInteractions = ( interactions: string[] ) => {
-		let score = 0;
-		interactions.forEach( ( interaction: string ) => {
+		return interactions.reduce( ( score, interaction ) => {
 			if ( interaction >= threeDaysAgo ) {
 				score += 3;
 			} else if ( interaction >= sevenDaysAgo ) {
@@ -106,47 +101,67 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 			} else if ( interaction >= twoWeeksAgo ) {
 				score += 1;
 			}
-		} );
-		return score;
+
+			return score;
+		}, 0 );
 	};
 
-	const sortedItems = [
-		...interactedItems.sort( ( a, b ) => {
-			if ( ! a.user_interactions || ! b.user_interactions ) {
-				return 0;
-			}
+	const sortedInteractions = interactedItems.sort( ( a, b ) => {
+		const mostRecentInteractionA = a.user_interactions[ 0 ];
+		const mostRecentInteractionB = b.user_interactions[ 0 ];
 
-			const lastInteractionA = a.user_interactions.sort().reverse()[ 0 ] || 0;
-			const lastInteractionB = b.user_interactions.sort().reverse()[ 0 ] || 0;
+		// If one of these interactions is within fourteen days of the most recent
+		// interaction, sort by the frequency of interactions in that time period.
+		if ( mostRecentInteractionA > twoWeeksAgo || mostRecentInteractionB > twoWeeksAgo ) {
+			const scoreA = scoreInteractions( a.user_interactions );
+			const scoreB = scoreInteractions( b.user_interactions );
 
-			// If one of these interactions is within fourteen days of the most recent
-			// interaction, sort by the frequency of interactions in that time period.
-			if ( twoWeeksAgo && ( lastInteractionA > twoWeeksAgo || lastInteractionB > twoWeeksAgo ) ) {
-				const scoreA = scoreInteractions( a.user_interactions );
-				const scoreB = scoreInteractions( b.user_interactions );
-				if ( scoreA > scoreB ) {
-					return -1;
-				}
-				if ( scoreA < scoreB ) {
-					return 1;
-				}
-				// Fall through to comparing the most recent.
-			}
-
-			if ( lastInteractionA > lastInteractionB ) {
+			if ( scoreA > scoreB ) {
 				return -1;
 			}
 
-			if ( lastInteractionA < lastInteractionB ) {
+			if ( scoreA < scoreB ) {
 				return 1;
 			}
 
-			// If the interaction date is equal, sort alphabetically.
-			return sortAlphabetically( a, b, 'asc' );
-		} ),
+			// Otherwise, compare the most recent.
+		}
+
+		if ( mostRecentInteractionA > mostRecentInteractionB ) {
+			return -1;
+		}
+
+		if ( mostRecentInteractionA < mostRecentInteractionB ) {
+			return 1;
+		}
+
+		// If the interaction date is equal, sort alphabetically.
+		return sortAlphabetically( a, b, 'asc' );
+	} );
+
+	return 'desc' === sortOrder ? sortedInteractions : sortedInteractions.reverse();
+};
+
+const hasInteractions = (
+	site: SiteDetailsForSorting
+): site is SiteDetailsForSortingWithUserInteractions => {
+	return !! site.user_interactions && site.user_interactions.length > 0;
+};
+
+function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
+	sites: T[],
+	sortOrder: SitesTableSortOrder
+) {
+	const interactedItems = ( sites as SiteDetailsForSorting[] ).filter( hasInteractions );
+
+	const remainingItems = sites.filter(
+		( site ) => ! site.user_interactions || site.user_interactions.length === 0
+	);
+
+	return [
+		...( sortInteractedItems( interactedItems, sortOrder ) as T[] ),
 		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, 'asc' ) ),
 	];
-	return 'desc' === sortOrder ? sortedItems : sortedItems.reverse();
 }
 
 function sortAlphabetically< T extends SiteDetailsForSorting >(

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -78,10 +78,7 @@ const subtractDays = ( date: string, days: number ) => {
 	return `${ year }-${ month }-${ day }`;
 };
 
-const sortInteractedItems = (
-	interactedItems: SiteDetailsForSortingWithUserInteractions[],
-	sortOrder: SitesTableSortOrder
-) => {
+const sortInteractedItems = ( interactedItems: SiteDetailsForSortingWithUserInteractions[] ) => {
 	const [ mostRecentInteraction ] = interactedItems
 		.map( ( site ) => site.user_interactions )
 		.flat()
@@ -139,7 +136,7 @@ const sortInteractedItems = (
 		return sortAlphabetically( a, b, 'asc' );
 	} );
 
-	return 'desc' === sortOrder ? sortedInteractions : sortedInteractions.reverse();
+	return sortedInteractions;
 };
 
 const hasInteractions = (
@@ -158,10 +155,12 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 		( site ) => ! site.user_interactions || site.user_interactions.length === 0
 	);
 
-	return [
-		...( sortInteractedItems( interactedItems, sortOrder ) as T[] ),
+	const sortedItems = [
+		...( sortInteractedItems( interactedItems ) as T[] ),
 		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, 'asc' ) ),
 	];
+
+	return sortOrder === 'desc' ? sortedItems : sortedItems.reverse();
 }
 
 function sortAlphabetically< T extends SiteDetailsForSorting >(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68030

## Proposed Changes

Uses a scoring algorithm to promote interaction recency for 'Magic' sort order.

### Before

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/36432/191302376-2a3fb7b1-8f9c-45a9-99db-d5c41d3fb41d.png">

### After

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/36432/191301776-6cbbcb95-dcd0-4c00-b914-6b3133cb3eb1.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Switch to 'Magic' sorting.
3. Verify the new 'Magic' sort order is better than the prior 'Magic' sort order.