### PR TITLE
Sites Management Page: Apply sort order before searching

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -146,16 +146,16 @@ export function SitesDashboard( {
 
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
 
-	const { filteredSites, statuses } = useSitesTableFiltering( allSites, {
+	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
+	const { sortedSites } = useSitesTableSorting( allSites, sitesSorting );
+
+	const { filteredSites, statuses } = useSitesTableFiltering( sortedSites, {
 		search,
 		showHidden: search ? true : showHidden,
 		status,
 	} );
 
-	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
-	const { sortedSites } = useSitesTableSorting( filteredSites, sitesSorting );
-
-	const paginatedSites = sortedSites.slice( ( page - 1 ) * perPage, page * perPage );
+	const paginatedSites = filteredSites.slice( ( page - 1 ) * perPage, page * perPage );
 
 	const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 


### PR DESCRIPTION
Discovered in #68041

## Proposed Changes

Applies sort order before searching to ensure the search relevancy algorithm gets applied to the results.

### After

'Milwaukie Family Dentistry' appears first in the result list:

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/36432/191308010-7532d9cf-0502-45e2-b19c-ddca26269c92.png">

### Before

'Milwaukie Family Dentistry' doesn't appear in the top results, even though it's an exact match:

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/36432/191308310-1ab88196-53e6-46b7-9919-90e470cf746c.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Test searching before and after.