### PR TITLE
Update new Stripe key for DSP widget

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -39,7 +39,7 @@
 	"facebook_app_id": "611241942420191",
 	"livechat_support_locales": [ "en", "en-gb" ],
 	"olark_chat_identity": false,
-	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
+	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSdEWhhLQtVOYNQFhZovJa6WkS7Mw0XcgPsfk7RcIMWsK2nHqjqxbUmTHgorTkctjjWX9948Fp00PKtwCxYq",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"upwork_support_locales": [
 		"de",

--- a/config/development.json
+++ b/config/development.json
@@ -25,7 +25,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"olark_chat_identity": "7089-503-10-5123",
-	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
+	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSdEWhhLQtVOYNQFhZovJa6WkS7Mw0XcgPsfk7RcIMWsK2nHqjqxbUmTHgorTkctjjWX9948Fp00PKtwCxYq",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,

--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,7 @@
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"olark_chat_identity": "7089-503-10-5123",
-	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
+	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSdEWhhLQtVOYNQFhZovJa6WkS7Mw0XcgPsfk7RcIMWsK2nHqjqxbUmTHgorTkctjjWX9948Fp00PKtwCxYq",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,7 +12,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
-	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
+	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSdEWhhLQtVOYNQFhZovJa6WkS7Mw0XcgPsfk7RcIMWsK2nHqjqxbUmTHgorTkctjjWX9948Fp00PKtwCxYq",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,7 +13,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
-	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSgKblr83WK7rNUtB2d3ZWo2Xii87EUfdmGV6Ap0OeWH15PzUgEE3Q6s4fWCXzYNsgu4n9G28K00ODec4RxO",
+	"dsp_stripe_pub_key": "pk_test_51L5t7gJQesStQBzSdEWhhLQtVOYNQFhZovJa6WkS7Mw0XcgPsfk7RcIMWsK2nHqjqxbUmTHgorTkctjjWX9948Fp00PKtwCxYq",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,


### PR DESCRIPTION
#### Proposed Changes

- Update Stripe key in prod

#### Testing Instructions

- Create a new campaign in the DSP and perform a payment. It should let you create a subscription

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
