### PR TITLE
Help Center: change the message when continuing session

### DIFF
--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -14,6 +14,10 @@ import {
 	sendUserInfo,
 	setChatCustomFields,
 } from 'calypso/state/happychat/connection/actions';
+import {
+	HAPPYCHAT_CONNECTION_STATUS_CONNECTING,
+	HAPPYCHAT_CONNECTION_STATUS_CONTINUING_SESSION,
+} from 'calypso/state/happychat/constants';
 import canUserSendMessages from 'calypso/state/happychat/selectors/can-user-send-messages';
 import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
 import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
@@ -140,7 +144,7 @@ export default function Happychat( { auth } ) {
 	const dispatch = useDispatch();
 	const currentUser = useSelector( getCurrentUser );
 	const chatStatus = useSelector( getHappychatChatStatus );
-	const connectionStatus = useSelector( getHappychatConnectionStatus );
+	let connectionStatus = useSelector( getHappychatConnectionStatus );
 	const timeline = useSelector( getHappychatTimeline );
 	const message = useSelector( getCurrentMessage );
 	const isServerReachable = useSelector( isHappychatServerReachable );
@@ -148,6 +152,12 @@ export default function Happychat( { auth } ) {
 	const isMessageFromCurrentUser = ( { user_id, source } ) => {
 		return user_id.toString() === currentUser.ID.toString() && source === 'customer';
 	};
+	const isContinuedSession =
+		new URLSearchParams( window.location.search ).get( 'session' ) === 'continued';
+
+	if ( isContinuedSession && connectionStatus === HAPPYCHAT_CONNECTION_STATUS_CONNECTING ) {
+		connectionStatus = HAPPYCHAT_CONNECTION_STATUS_CONTINUING_SESSION;
+	}
 	return (
 		<div className="happychat__container">
 			<HappychatConnection getAuth={ () => Promise.resolve( auth ) } isHappychatEnabled />

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -10,6 +10,7 @@ import {
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTING,
 	HAPPYCHAT_CONNECTION_STATUS_DISCONNECTED,
 	HAPPYCHAT_CONNECTION_STATUS_RECONNECTING,
+	HAPPYCHAT_CONNECTION_STATUS_CONTINUING_SESSION,
 	HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED,
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 } from 'calypso/state/happychat/constants';
@@ -41,6 +42,8 @@ class Notices extends Component {
 				return translate( 'Waiting to connect you with a Happiness Engineer…' );
 			case HAPPYCHAT_CONNECTION_STATUS_CONNECTING:
 				return translate( 'Connecting you with a Happiness Engineer…' );
+			case HAPPYCHAT_CONNECTION_STATUS_CONTINUING_SESSION:
+				return translate( 'Reconnecting you with your Happiness Engineer…' );
 			case HAPPYCHAT_CONNECTION_STATUS_RECONNECTING:
 			case HAPPYCHAT_CONNECTION_STATUS_DISCONNECTED:
 				return translate(

--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -11,6 +11,7 @@ export const HAPPYCHAT_CONNECTION_STATUS_CONNECTING = 'connecting';
 export const HAPPYCHAT_CONNECTION_STATUS_CONNECTED = 'connected';
 export const HAPPYCHAT_CONNECTION_STATUS_DISCONNECTED = 'disconnected';
 export const HAPPYCHAT_CONNECTION_STATUS_RECONNECTING = 'reconnecting';
+export const HAPPYCHAT_CONNECTION_STATUS_CONTINUING_SESSION = 'continuing_session';
 export const HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED = 'unauthorized';
 
 // Max number of messages to save between refreshes

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -69,7 +69,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 
 	return (
 		<MemoryRouter>
-			{ data?.status === 'assigned' && <Redirect to="/inline-chat" /> }
+			{ data?.status === 'assigned' && <Redirect to="/inline-chat?session=continued" /> }
 			<FeatureFlagProvider>
 				<OptionalDraggable
 					draggable={ ! isMobile }

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -75,7 +75,6 @@ const HelpCenterHeader: React.FC< Header > = ( {
 							<Route path="/inline-chat">{ __( 'Live Chat', __i18n_text_domain__ ) }</Route>
 							<Route path="/contact-form" component={ SupportModeTitle }></Route>
 							<Route path="/post" component={ ArticleTitle }></Route>
-							<Route path="/inline-chat">{ __( 'Live Chat', __i18n_text_domain__ ) }</Route>
 						</Switch>
 					) : (
 						__( 'Help Center', __i18n_text_domain__ )

--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { useDispatch } from '@wordpress/data';
+import { useLocation } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
@@ -10,13 +11,16 @@ import { HELP_CENTER_STORE } from '../stores';
 
 const InlineChat: React.FC = () => {
 	const { setIframe } = useDispatch( HELP_CENTER_STORE );
+	const { search } = useLocation();
+	const params = new URLSearchParams( search );
+	const session = params.get( 'session' ) === 'continued' ? 'continued' : 'new';
 
 	return (
 		<iframe
 			ref={ ( ref ) => setIframe( ref ) }
 			className="help-center-inline-chat__iframe"
 			title="Happychat"
-			src="https://widgets.wp.com/calypso-happychat/"
+			src={ `https://widgets.wp.com/calypso-happychat/?session=${ session }` }
 			scrolling="no"
 		/>
 	);


### PR DESCRIPTION
#### Proposed Changes

* This changes the connection message when the session is being continued in Happychat. It changes it from `Connecting you with a Happiness Engineer…` to `Reconnecting you with your Happiness Engineer…`.
* <img width="428" alt="image" src="https://user-images.githubusercontent.com/17054134/191308963-bd251864-f4c9-4166-bb51-6edf10778aac.png">

#### Testing Instructions

1. Start ETK by going in apps/editing toolkit and running `yarn dev --sync`.
2. Start Happychat by going in `apps/happychat` and running `yarn dev --sync`.
3. Go to https://hud-staging.happychat.io/ and log in to accept your own chat.
4. Go to the editor of a sandboxed site and start a chat session.
5. Refresh the page. The session should continue and the message should be "Reconnecting you with your Happiness Engineer…".

Fixes https://github.com/Automattic/wp-calypso/issues/67935