### PR TITLE
Sites Sorting: Use default sorting value if Magic sorting is disabled

### DIFF
--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -2,6 +2,7 @@ import {
 	SitesTableSortOptions,
 	SitesTableSortKey,
 	SitesTableSortOrder,
+	isValidSorting,
 } from '@automattic/components';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 
@@ -15,14 +16,17 @@ const DEFAULT_SITES_SORTING = {
 } as const;
 
 export const parseSitesSorting = ( sorting: SitesSorting | 'none' ) => {
-	if ( 'none' === sorting ) {
+	const separated = sorting.split( SEPARATOR );
+
+	if ( ! isValidSorting( separated ) ) {
 		return DEFAULT_SITES_SORTING;
 	}
 
-	const [ sortKey, sortOrder ] = sorting.split( SEPARATOR );
+	const [ sortKey, sortOrder ] = separated;
+
 	return {
-		sortKey: sortKey as SitesTableSortKey,
-		sortOrder: sortOrder as SitesTableSortOrder,
+		sortKey,
+		sortOrder,
 	};
 };
 

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -16,23 +16,23 @@ const DEFAULT_SITES_SORTING = {
 	sortOrder: 'desc',
 } as const;
 
-export const parseSitesSorting = ( sorting: SitesSorting | 'none' ) => {
-	const sortingElements = sorting.split( SEPARATOR );
+export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) => {
+	const [ sortKey, sortOrder ] = serializedSorting.split( SEPARATOR );
 
-	if ( ! isValidSorting( sortingElements ) ) {
+	const sorting = { sortKey, sortOrder };
+
+	if ( ! isValidSorting( sorting ) ) {
 		return DEFAULT_SITES_SORTING;
 	}
 
-	const [ sortKey, sortOrder ] = sortingElements;
-
-	if ( sortKey === 'lastInteractedWith' && ! config.isEnabled( 'sites/automagical-sorting' ) ) {
+	if (
+		sorting.sortKey === 'lastInteractedWith' &&
+		! config.isEnabled( 'sites/automagical-sorting' )
+	) {
 		return DEFAULT_SITES_SORTING;
 	}
 
-	return {
-		sortKey,
-		sortOrder,
-	};
+	return sorting;
 };
 
 export const stringifySitesSorting = (

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	SitesTableSortOptions,
 	SitesTableSortKey,
@@ -23,6 +24,10 @@ export const parseSitesSorting = ( sorting: SitesSorting | 'none' ) => {
 	}
 
 	const [ sortKey, sortOrder ] = separated;
+
+	if ( sortKey === 'lastInteractedWith' && ! config.isEnabled( 'sites/automagical-sorting' ) ) {
+		return DEFAULT_SITES_SORTING;
+	}
 
 	return {
 		sortKey,

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -17,13 +17,13 @@ const DEFAULT_SITES_SORTING = {
 } as const;
 
 export const parseSitesSorting = ( sorting: SitesSorting | 'none' ) => {
-	const separated = sorting.split( SEPARATOR );
+	const sortingElements = sorting.split( SEPARATOR );
 
-	if ( ! isValidSorting( separated ) ) {
+	if ( ! isValidSorting( sortingElements ) ) {
 		return DEFAULT_SITES_SORTING;
 	}
 
-	const [ sortKey, sortOrder ] = separated;
+	const [ sortKey, sortOrder ] = sortingElements;
 
 	if ( sortKey === 'lastInteractedWith' && ! config.isEnabled( 'sites/automagical-sorting' ) ) {
 		return DEFAULT_SITES_SORTING;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -29,7 +29,7 @@ export {
 	SITES_TABLE_SEARCH_INDEX_KEYS,
 } from './sites-table/use-sites-table-filtering';
 export type { FilterableSiteLaunchStatuses } from './sites-table/use-sites-table-filtering';
-export { useSitesTableSorting } from './sites-table/use-sites-table-sorting';
+export { useSitesTableSorting, isValidSorting } from './sites-table/use-sites-table-sorting';
 export type {
 	SitesTableSortOptions,
 	SitesTableSortKey,

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -14,18 +14,15 @@ const validSortOrders = [ 'asc', 'desc' ] as const;
 export type SitesTableSortKey = typeof validSortKeys[ number ];
 export type SitesTableSortOrder = typeof validSortOrders[ number ];
 
-export const isValidSorting = (
-	input: string[]
-): input is [ SitesTableSortKey, SitesTableSortOrder ] => {
-	if ( input.length !== 2 ) {
-		return false;
-	}
-
-	const [ key, order ] = input;
+export const isValidSorting = ( input: {
+	sortKey: string;
+	sortOrder: string;
+} ): input is Required< SitesTableSortOptions > => {
+	const { sortKey, sortOrder } = input;
 
 	return (
-		validSortKeys.includes( key as SitesTableSortKey ) &&
-		validSortOrders.includes( order as SitesTableSortOrder )
+		validSortKeys.includes( sortKey as SitesTableSortKey ) &&
+		validSortOrders.includes( sortOrder as SitesTableSortOrder )
 	);
 };
 

--- a/packages/components/src/sites-table/use-sites-table-sorting.tsx
+++ b/packages/components/src/sites-table/use-sites-table-sorting.tsx
@@ -8,8 +8,26 @@ export interface SiteDetailsForSorting {
 	};
 }
 
-export type SitesTableSortKey = 'lastInteractedWith' | 'updatedAt' | 'alphabetically';
-export type SitesTableSortOrder = 'asc' | 'desc';
+const validSortKeys = [ 'lastInteractedWith', 'updatedAt', 'alphabetically' ] as const;
+const validSortOrders = [ 'asc', 'desc' ] as const;
+
+export type SitesTableSortKey = typeof validSortKeys[ number ];
+export type SitesTableSortOrder = typeof validSortOrders[ number ];
+
+export const isValidSorting = (
+	input: string[]
+): input is [ SitesTableSortKey, SitesTableSortOrder ] => {
+	if ( input.length !== 2 ) {
+		return false;
+	}
+
+	const [ key, order ] = input;
+
+	return (
+		validSortKeys.includes( key as SitesTableSortKey ) &&
+		validSortOrders.includes( order as SitesTableSortOrder )
+	);
+};
 
 export interface SitesTableSortOptions {
 	sortKey?: SitesTableSortKey;


### PR DESCRIPTION
#### Proposed Changes

Despite removing it from the dropdown, all the Magic sorting logic is still stored in Calypso, including the saved preference value, which is restored on page load.

This PR changes that and falls back to the default sorting value if the feature flag is disabled.

#### Testing Instructions

1. Enable the feature flag in development (it is enabled by default);
2. Open SMD and choose `Automagically` as the sorting algorithm;
3. Check that the sites are sorted automagically;
4. Stop the development server and toggle the `sites/automagical-sorting` flag in `config/development.json`;
5. Restart the server;
6. Check that the items are now sorted by last published.
