### PR TITLE
Iterate on domain eligibility warning

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -9,14 +9,13 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
 import page from 'page';
 import { connect, useSelector } from 'react-redux';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
-import ExternalLink from 'calypso/components/external-link';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -154,14 +153,11 @@ export const EligibilityWarnings = ( {
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
 					<div className="support-block">
-						<span>{ translate( 'Need help?' ) }</span>
-						<ExternalLink
-							href={ localizeUrl( 'https://wordpress.com/support' ) }
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Contact support' ) }
-						</ExternalLink>
+						{ translate( 'Need help? {{a}}Contact support{{/a}}', {
+							components: {
+								a: <ActionPanelLink href="/help/contact" />,
+							},
+						} ) }
 					</div>
 					<Button
 						primary={ true }
@@ -198,7 +194,7 @@ function getSiteIsEligibleMessage(
 
 function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
 	if ( siteRequiresUpgrade( holds ) ) {
-		return translate( 'Upgrade and continue' );
+		return translate( 'Upgrade and activate' );
 	}
 	if ( siteRequiresLaunch( holds ) ) {
 		return translate( 'Launch your site and continue' );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -9,12 +9,14 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
 import page from 'page';
 import { connect, useSelector } from 'react-redux';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import ExternalLink from 'calypso/components/external-link';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -151,6 +153,16 @@ export const EligibilityWarnings = ( {
 			) }
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
+					<div className="support-block">
+						<span>{ translate( 'Need help?' ) }</span>
+						<ExternalLink
+							href={ localizeUrl( 'https://wordpress.com/support' ) }
+							icon={ false }
+							target="_blank"
+						>
+							{ translate( 'Contact support' ) }
+						</ExternalLink>
+					</div>
 					<Button
 						primary={ true }
 						disabled={

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,6 +1,17 @@
 .eligibility-warnings {
 	margin-top: 16px;
 	font-size: $font-body-small;
+
+	.eligibility-warnings__confirm-buttons {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.support-block {
+		align-items: center;
+		display: flex;
+		gap: 5px;
+	}
 }
 
 .eligibility-warnings--with-indent {
@@ -45,13 +56,8 @@
 
 .eligibility-warnings__hold,
 .eligibility-warnings__warning {
-	align-items: center;
 	display: flex;
 	flex-direction: row;
-}
-
-.eligibility-warnings__hold,
-.eligibility-warnings__warning {
 	align-items: flex-start;
 	margin-bottom: 16px;
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,4 +1,5 @@
 .eligibility-warnings {
+	max-width: 650px;
 	margin-top: 16px;
 	font-size: $font-body-small;
 
@@ -12,13 +13,23 @@
 		display: flex;
 		gap: 5px;
 	}
+
+	.eligibility-warnings__warning {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		padding-bottom: 15px;
+		border-bottom: 1px solid #dcdcde;
+		margin-bottom: 15px;
+	}
+
+	.eligibility-warnings__message-description {
+		color: var(--color-text-subtle);
+		font-size: $font-body;
+	}
 }
 
 .eligibility-warnings--with-indent {
-	.eligibility-warnings__message {
-		padding: 0 16px;
-		margin-left: 24px;
-	}
 	.gridicon + .eligibility-warnings__message {
 		margin-left: 0;
 	}
@@ -60,10 +71,15 @@
 	flex-direction: row;
 	align-items: flex-start;
 	margin-bottom: 16px;
+}
 
-	&:first-of-type {
-		padding-top: 6px;
-	}
+.eligibility-warnings__warning:first-child {
+	border-bottom: none;
+}
+
+.eligibility-warnings__warning:last-child {
+	margin-bottom: 0;
+	border-bottom: none;
 }
 
 .eligibility-warnings__hold .gridicon,
@@ -83,13 +99,30 @@
 	flex-grow: 1;
 	line-height: 24px;
 	padding: 0;
+	max-width: 100%;
 
 	.eligibility-warnings__message-title {
 		font-weight: 600;
 	}
+}
 
-	.eligibility-warnings__message-description {
-		color: var(--color-text-subtle);
+.eligibility-warnings__warnings-card {
+	background: #f6f7f7;
+	margin: 0 24px;
+}
+
+.eligibility-warnings__domain-names {
+	margin-top: 10px;
+
+	.card {
+		padding: 10px 24px;
+		margin-bottom: 5px;
+	}
+
+	.badge {
+		position: absolute;
+		right: 20px;
+		border-radius: 4px;
 	}
 }
 
@@ -101,6 +134,12 @@
 	&:hover .gridicons-help-outline {
 		color: var(--color-primary);
 	}
+}
+
+.eligibility-warnings__hold {
+	padding-top: 18px;
+	margin: 20px 0;
+	border-top: 1px solid #dcdcde;
 }
 
 .eligibility-warnings__hold-action {
@@ -120,6 +159,23 @@
 		flex-grow: 1;
 		padding-left: 16px;
 	}
+}
+
+.eligibility-warnings .card-heading {
+	font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+	font-size: $font-title-large;
+	line-height: 40px;
+	color: var(--studio-gray-100);
+}
+
+.eligibility-warnings__box {
+	border: 1px solid #dcdcde;
+	padding: 16px 24px;
+	margin-top: 15px;
+}
+
+.eligibility-warnings__box h2 {
+	font-size: $font-body;
 }
 
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold-heading,

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,10 +1,10 @@
-import { Gridicon } from '@automattic/components';
-import { localize, LocalizeProps } from 'i18n-calypso';
+import { Card } from '@automattic/components';
+import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { map } from 'lodash';
 import { Fragment } from 'react';
-import ActionPanelLink from 'calypso/components/action-panel/link';
+import Badge from 'calypso/components/badge';
 import ExternalLink from 'calypso/components/external-link';
-import type { EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
+import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {
 	context: string | null;
@@ -15,16 +15,17 @@ type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { context, translate, warnings }: Props ) => (
 	<div>
-		<div className="eligibility-warnings__warning">
-			<Gridicon icon="notice-outline" size={ 24 } />
-			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-description">
-					{ getWarningDescription( context, warnings.length, translate ) }
-				</span>
+		{ getWarningDescription( context, warnings.length, translate ) && (
+			<div className="eligibility-warnings__warning">
+				<div className="eligibility-warnings__message">
+					<span className="eligibility-warnings__message-description">
+						{ getWarningDescription( context, warnings.length, translate ) }
+					</span>
+				</div>
 			</div>
-		</div>
+		) }
 
-		{ map( warnings, ( { name, description, supportUrl }, index ) => (
+		{ map( warnings, ( { name, description, supportUrl, domainNames }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
 				<div className="eligibility-warnings__message">
 					{ context !== 'plugin-details' && (
@@ -33,7 +34,8 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 						</Fragment>
 					) }
 					<span className="eligibility-warnings__message-description">
-						{ description }{ ' ' }
+						<span>{ description } </span>
+						{ domainNames && displayDomainNames( domainNames ) }
 						{ supportUrl && (
 							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
 								{ translate( 'Learn more.' ) }
@@ -43,20 +45,23 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 				</div>
 			</div>
 		) ) }
-
-		<div className="eligibility-warnings__warning">
-			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-description">
-					{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					} ) }
-				</span>
-			</div>
-		</div>
 	</div>
 );
+
+function displayDomainNames( domainNames: DomainNames ) {
+	return (
+		<div className="eligibility-warnings__domain-names">
+			<Card compact>
+				<span>{ domainNames.current }</span>
+				<Badge type="info">{ translate( 'current' ) }</Badge>
+			</Card>
+			<Card compact>
+				<span>{ domainNames.new }</span>
+				<Badge type="success">{ translate( 'new' ) }</Badge>
+			</Card>
+		</div>
+	);
+}
 
 function getWarningDescription(
 	context: string | null,

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -129,6 +129,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 				isVisible={ showEligibility }
 				title={ translate( 'Eligibility' ) }
 				onClose={ () => setShowEligibility( false ) }
+				showCloseIcon={ true }
 			>
 				<EligibilityWarnings
 					currentContext={ 'plugin-details' }

--- a/client/state/automated-transfer/selectors/index.ts
+++ b/client/state/automated-transfer/selectors/index.ts
@@ -13,11 +13,17 @@ export { isAutomatedTransferActive } from 'calypso/state/automated-transfer/sele
 export { isAutomatedTransferFailed } from 'calypso/state/automated-transfer/selectors/is-automated-transfer-failed';
 export { default as isFetchingAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors/is-fetching-automated-transfer-status';
 
+export interface DomainNames {
+	current: string;
+	new: string;
+}
+
 export interface EligibilityWarning {
 	description: string;
 	name: string;
 	id: string;
 	supportUrl?: string;
+	domainNames?: DomainNames;
 }
 
 export interface EligibilityData {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -60,11 +60,12 @@ export const eligibilityHoldsFromApi = ( { errors = [] }, options = {} ) =>
 const eligibilityWarningsFromApi = ( { warnings = {} } ) =>
 	Object.keys( warnings )
 		.reduce( ( list, type ) => list.concat( warnings[ type ] ), [] ) // combine plugin and theme warnings into one list
-		.map( ( { description, name, support_url, id } ) => ( {
+		.map( ( { description, name, support_url, id, domain_names } ) => ( {
 			id,
 			name,
 			description,
 			supportUrl: support_url,
+			domainNames: domain_names,
 		} ) );
 
 /**

--- a/packages/components/src/dialog/README.md
+++ b/packages/components/src/dialog/README.md
@@ -12,6 +12,8 @@ By controlling the dialog's visibility through the `isVisible` property, the dia
 providing any CSS transitions to animate the opening/closing of the dialog. This also keeps the parent's code clean and
 readable, with a minimal amount of boilerplate code required to show a dialog.
 
+The `showCloseIcon` property is used to show a `x` icon at the top right, closing the dialog once it's clicked.
+
 ## Basic Usage
 
 ```js

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import { useCallback } from 'react';
 import Modal from 'react-modal';
+import Gridicon from '../gridicon';
 import ButtonBar from './button-bar';
 import type { Button, BaseButton } from './button-bar';
 import type { PropsWithChildren } from 'react';
@@ -20,6 +21,7 @@ type Props = {
 	leaveTimeout?: number;
 	onClose: ( action?: string ) => void;
 	shouldCloseOnEsc?: boolean;
+	showCloseIcon?: boolean;
 };
 
 const Dialog = ( {
@@ -36,6 +38,7 @@ const Dialog = ( {
 	leaveTimeout = 200,
 	onClose,
 	shouldCloseOnEsc,
+	showCloseIcon = false,
 }: PropsWithChildren< Props > ) => {
 	const close = useCallback( () => onClose?.(), [ onClose ] );
 	const onButtonClick = useCallback(
@@ -71,6 +74,11 @@ const Dialog = ( {
 			role="dialog"
 			shouldCloseOnEsc={ shouldCloseOnEsc }
 		>
+			{ showCloseIcon && (
+				<button className="dialog__action-buttons-close" onClick={ () => onClose( this ) }>
+					<Gridicon icon={ 'cross' } size={ 24 } />
+				</button>
+			) }
 			<div className={ contentClassName } tabIndex={ -1 }>
 				{ children }
 			</div>

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -51,8 +51,7 @@
 
 	h1 {
 		color: var(--color-neutral-70);
-		/* stylelint-disable-next-line scales/font-size */
-		font-size: 1.375em;
+		font-size: $font-title-small;
 		font-weight: 600;
 		margin-bottom: 0.5em;
 	}
@@ -110,6 +109,19 @@
 
 .dialog__action-buttons .is-left-aligned {
 	float: left;
+}
+
+.dialog__action-buttons-close {
+	padding: 15px 15px 5px 5px;
+	position: absolute;
+	z-index: 1;
+	right: 0;
+	opacity: 0.5;
+	cursor: pointer;
+}
+
+.dialog__action-buttons-close:hover {
+	opacity: 1;
 }
 
 .ReactModal__Body--open {


### PR DESCRIPTION
## Old designs

- Simple domain migration:
	![image](https://user-images.githubusercontent.com/1044309/191311195-9e84d268-71d7-46eb-910b-c58a25fd6042.png)


- Domain migration with a list of warnings (widget warnings):

	![image](https://user-images.githubusercontent.com/1044309/191311874-cff9124b-33ed-45ca-85c0-9c1f220fa2b1.png)

- Errors during migration:

	![image](https://user-images.githubusercontent.com/1044309/191312348-ba1ffb2f-d529-428b-a57f-7cf661b3b202.png)



## New designs implemented

- Simple domain migration:

	![image](https://user-images.githubusercontent.com/1044309/191311394-1d836682-3b8c-4641-8123-3730907ba6f8.png)

- Domain migration with a list of warnings (widget warnings):

	![image](https://user-images.githubusercontent.com/1044309/191311652-f76fe160-5a01-4078-9f06-73c0bd31b82e.png)

- Errors during migration:

	![image](https://user-images.githubusercontent.com/1044309/191312618-2e4e4e4e-e350-44e3-b53f-123d377542ff.png)




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
