### PR TITLE
[E2E][GB 14.1.x] Test fixes for Gutenberg

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -1,7 +1,7 @@
 import { Page, Locator } from 'playwright';
 import envVariables from '../../env-variables';
 
-const sidebarParentSelector = '.block-editor-inserter__content';
+const sidebarParentSelector = '.block-editor-inserter__main-area';
 const selectors = {
 	closeBlockInserterButton: 'button[aria-label="Close block inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Misc test fixes, preparing for the upcoming 14.1.x release on WPCOM.

#### Testing instructions

* Tests should pass.

To be merged **after** 14.1.x is released to production WPCOM.

Tracking issue: https://github.com/Automattic/wp-calypso/issues/67821.