### PR TITLE
Launchpad: Change hover & focus styles on all active links

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -18,9 +18,9 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 	return (
 		<li
 			className={ classnames( 'launchpad__task', {
-				'keep-active': keepActive,
-				'is-completed': isCompleted && ! keepActive,
-				pending: ! isCompleted,
+				'keep-active': keepActive && isCompleted, // a task that is completed and can be revisited
+				'is-completed': isCompleted && ! keepActive, // a task that is completed and can't be revisited
+				pending: ! isCompleted && ! keepActive, // a task that hasn't been completed yet
 			} ) }
 		>
 			<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -18,9 +18,9 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 	return (
 		<li
 			className={ classnames( 'launchpad__task', {
-				'keep-active': keepActive && isCompleted, // a task that is completed and can be revisited
-				'is-completed': isCompleted && ! keepActive, // a task that is completed and can't be revisited
-				pending: ! isCompleted && ! keepActive, // a task that hasn't been completed yet
+				'completed-and-active': isCompleted && keepActive, // a task that is completed and can be revisited
+				'completed-and-inactive': isCompleted && ! keepActive, // a task that is completed and can't be revisited
+				'not-completed': ! isCompleted && ! keepActive, // a task that hasn't been completed yet
 			} ) }
 		>
 			<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -19,7 +19,8 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 		<li
 			className={ classnames( 'launchpad__task', {
 				'keep-active': keepActive,
-				'is-completed': isCompleted,
+				'is-completed': isCompleted && ! keepActive,
+				pending: ! isCompleted,
 			} ) }
 		>
 			<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -231,9 +231,9 @@
 	font-weight: 600;
 }
 
-// completed && keep active tasks
-.launchpad__task.is-completed,
-.launchpad__task.keep-active {
+// completed tasks
+.launchpad__task.completed-and-inactive,
+.launchpad__task.completed-and-active {
 	.launchpad__checklist-item-text {
 		color: var(--studio-gray-50);
 		font-weight: 400;
@@ -245,11 +245,11 @@
 	}
 }
 
-// pending && keep active tasks
-.launchpad__task.keep-active:hover,
-.launchpad__task.pending:hover,
-.launchpad__task.keep-active > a:focus,
-.launchpad__task.pending > a:focus {
+// not-completed && completed-and-active tasks
+.launchpad__task.completed-and-active:hover,
+.launchpad__task.not-completed:hover,
+.launchpad__task.completed-and-active > a:focus,
+.launchpad__task.not-completed > a:focus {
 	.launchpad__checklist-item-text {
 		color: var(--studio-blue-50);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -125,8 +125,12 @@
 	padding: 80px 20px 10px;
 	display: none;
 
-	button {
+	.button.navigation-link {
 		text-decoration: underline;
+
+		&:hover {
+			color: var(--studio-blue-50);
+		}
 	}
 
 	@include break-large {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -231,8 +231,9 @@
 	font-weight: 600;
 }
 
-// completed tasks
-.launchpad__task.is-completed {
+// completed && keep active tasks
+.launchpad__task.is-completed,
+.launchpad__task.keep-active {
 	.launchpad__checklist-item-text {
 		color: var(--studio-gray-50);
 		font-weight: 400;
@@ -244,9 +245,11 @@
 	}
 }
 
-// completed tasks that are kept active
+// pending && keep active tasks
 .launchpad__task.keep-active:hover,
-.launchpad__task.keep-active > a:focus {
+.launchpad__task.pending:hover,
+.launchpad__task.keep-active > a:focus,
+.launchpad__task.pending > a:focus {
 	.launchpad__checklist-item-text {
 		color: var(--studio-blue-50);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -128,7 +128,8 @@
 	.button.navigation-link {
 		text-decoration: underline;
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--studio-blue-50);
 		}
 	}
@@ -230,13 +231,6 @@
 	font-weight: 600;
 }
 
-// change badge color on hover (Choose a Plan step)
-.launchpad__task:hover {
-	.launchpad__checklist-item .badge {
-		background: var(--studio-blue-10);
-	}
-}
-
 // completed tasks
 .launchpad__task.is-completed {
 	.launchpad__checklist-item-text {
@@ -251,7 +245,8 @@
 }
 
 // completed tasks that are kept active
-.launchpad__task.keep-active:hover {
+.launchpad__task.keep-active:hover,
+.launchpad__task.keep-active > a:focus {
 	.launchpad__checklist-item-text {
 		color: var(--studio-blue-50);
 	}
@@ -259,6 +254,11 @@
 	.launchpad__checklist-item-chevron,
 	.launchpad__checklist-item-checkmark {
 		fill: var(--studio-blue-50);
+	}
+
+	// change badge color on hover (Choose a Plan step)
+	.badge {
+		background: var(--studio-blue-10);
 	}
 }
 


### PR DESCRIPTION
#### Proposed changes
This PR makes all active Launchpad links (including "Go to Admin") blue (`--studio-blue-50`) both when hovering and when navigating with the keyboard. Disabled links stay gray.

#### Before

https://user-images.githubusercontent.com/20927667/191381904-f10b7a94-92aa-4570-b542-f721c4a6caaa.mov

#### After

https://user-images.githubusercontent.com/20927667/191381899-9d78c33f-3039-41d6-8c89-37ee581f9127.mov

#### Testing Instructions
1. Go to `http://calypso.localhost:3000/setup/launchpad?flow=newsletter&complete-setup=true&siteSlug=YOUR_SITE_SLUG`
2. Ensure hovering with the mouse and focusing with the keyboard on all active links should turn them blue (`--studio-blue-50`)
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68035
