### PR TITLE
Launchpad: Hide chevron for completed tasks that are kept active

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -11,6 +11,10 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 	const action = actionDispatch ? { onClick: actionDispatch } : { href: actionUrl };
 	const taskDisabled = isTaskDisabled( task );
 
+	// Display chevron if task is enabled and incomplete. Don't display chevron and badge at the same time.
+	const shouldDisplayChevron =
+		! taskDisabled && ! isCompleted && ! task.displayBadge && ! task.badgeText;
+
 	return (
 		<li
 			className={ classnames( 'launchpad__task', {
@@ -40,8 +44,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				{ task.displayBadge && task.badgeText ? (
 					<Badge type="info-blue">{ task.badgeText }</Badge>
 				) : null }
-				{ /* don't display chevron and badge at the same time */ }
-				{ ! taskDisabled && ! task.displayBadge && ! task.badgeText && (
+				{ shouldDisplayChevron && (
 					<Gridicon
 						aria-label={ translate( 'Task enabled' ) }
 						className="launchpad__checklist-item-chevron"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -11,9 +11,8 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 	const action = actionDispatch ? { onClick: actionDispatch } : { href: actionUrl };
 	const taskDisabled = isTaskDisabled( task );
 
-	// Display chevron if task is enabled and incomplete. Don't display chevron and badge at the same time.
-	const shouldDisplayChevron =
-		! taskDisabled && ! isCompleted && ! task.displayBadge && ! task.badgeText;
+	// Display chevron if task incomplete. Don't display chevron and badge at the same time.
+	const shouldDisplayChevron = ! isCompleted && ! task.displayBadge && ! task.badgeText;
 
 	return (
 		<li

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -10,11 +10,10 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 	const { id, isCompleted, keepActive, actionUrl, title, actionDispatch } = task;
 	const action = actionDispatch ? { onClick: actionDispatch } : { href: actionUrl };
 	const taskDisabled = isTaskDisabled( task );
-	const hasBadgeText = task.displayBadge && task.badgeText;
 
 	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
 	const shouldDisplayChevron =
-		! hasIncompleteDependencies( task ) && ! isCompleted && ! hasBadgeText;
+		! hasIncompleteDependencies( task ) && ! isCompleted && ! task.badgeText;
 
 	return (
 		<li
@@ -42,7 +41,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 					</div>
 				) }
 				<p className={ `launchpad__checklist-item-text` }>{ title }</p>
-				{ hasBadgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
+				{ task.badgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
 				{ shouldDisplayChevron && (
 					<Gridicon
 						aria-label={ translate( 'Task enabled' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { translate, useRtl } from 'i18n-calypso';
 import Badge from 'calypso/components/badge';
-import { isTaskDisabled } from './task-helper';
+import { isTaskDisabled, hasIncompleteDependencies } from './task-helper';
 import { Task } from './types';
 
 const ChecklistItem = ( { task }: { task: Task } ) => {
@@ -10,9 +10,11 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 	const { id, isCompleted, keepActive, actionUrl, title, actionDispatch } = task;
 	const action = actionDispatch ? { onClick: actionDispatch } : { href: actionUrl };
 	const taskDisabled = isTaskDisabled( task );
+	const hasBadgeText = task.displayBadge && task.badgeText;
 
-	// Display chevron if task incomplete. Don't display chevron and badge at the same time.
-	const shouldDisplayChevron = ! isCompleted && ! task.displayBadge && ! task.badgeText;
+	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
+	const shouldDisplayChevron =
+		! hasIncompleteDependencies( task ) && ! isCompleted && ! hasBadgeText;
 
 	return (
 		<li
@@ -40,9 +42,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 					</div>
 				) }
 				<p className={ `launchpad__checklist-item-text` }>{ title }</p>
-				{ task.displayBadge && task.badgeText ? (
-					<Badge type="info-blue">{ task.badgeText }</Badge>
-				) : null }
+				{ hasBadgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
 				{ shouldDisplayChevron && (
 					<Gridicon
 						aria-label={ translate( 'Task enabled' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -140,6 +140,12 @@ export function isTaskDisabled( task: Task ) {
 	}
 
 	if ( task.dependencies ) {
+		return hasIncompleteDependencies( task );
+	}
+}
+
+export function hasIncompleteDependencies( task: Task ) {
+	if ( 'dependencies' in task ) {
 		return task.dependencies.some( ( dependency: boolean ) => dependency === false );
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -145,7 +145,5 @@ export function isTaskDisabled( task: Task ) {
 }
 
 export function hasIncompleteDependencies( task: Task ) {
-	if ( 'dependencies' in task ) {
-		return task.dependencies.some( ( dependency: boolean ) => dependency === false );
-	}
+	return task?.dependencies?.some( ( dependency: boolean ) => dependency === false );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -44,6 +44,38 @@ describe( 'ChecklistItem', () => {
 			const taskButton = screen.queryByRole( 'link' );
 			expect( taskButton ).toHaveAttribute( 'disabled' );
 		} );
+
+		describe( 'and the task is kept active', () => {
+			it( 'enables the task', () => {
+				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
+				const taskButton = screen.queryByRole( 'link' );
+				expect( taskButton ).not.toHaveAttribute( 'disabled' );
+			} );
+
+			it( 'hides the task enabled icon', () => {
+				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
+				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
+				expect( taskEnabledIcon ).toBeFalsy();
+			} );
+		} );
+	} );
+
+	describe( 'when a task is incomplete', () => {
+		it( 'hides the task complete icon', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+			const taskCompleteIcon = screen.queryByLabelText( 'Task complete' );
+			expect( taskCompleteIcon ).toBeFalsy();
+		} );
+		it( 'shows the task enabled icon', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+			const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
+			expect( taskEnabledIcon ).toBeTruthy();
+		} );
+		it( 'enables the task', () => {
+			render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+			const taskButton = screen.queryByRole( 'link' );
+			expect( taskButton ).not.toHaveAttribute( 'disabled' );
+		} );
 	} );
 
 	describe( 'when the task depends on the completion of other tasks', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -46,16 +46,15 @@ describe( 'ChecklistItem', () => {
 		} );
 
 		describe( 'and the task is kept active', () => {
-			it( 'enables the task', () => {
-				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
-				const taskButton = screen.queryByRole( 'link' );
-				expect( taskButton ).not.toHaveAttribute( 'disabled' );
-			} );
-
 			it( 'hides the task enabled icon', () => {
 				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
 				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
 				expect( taskEnabledIcon ).toBeFalsy();
+			} );
+			it( 'enables the task', () => {
+				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
+				const taskButton = screen.queryByRole( 'link' );
+				expect( taskButton ).not.toHaveAttribute( 'disabled' );
 			} );
 		} );
 	} );
@@ -66,33 +65,38 @@ describe( 'ChecklistItem', () => {
 			const taskCompleteIcon = screen.queryByLabelText( 'Task complete' );
 			expect( taskCompleteIcon ).toBeFalsy();
 		} );
-		it( 'shows the task enabled icon', () => {
-			render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
-			const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
-			expect( taskEnabledIcon ).toBeTruthy();
-		} );
-		it( 'enables the task', () => {
-			render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
-			const taskButton = screen.queryByRole( 'link' );
-			expect( taskButton ).not.toHaveAttribute( 'disabled' );
-		} );
-	} );
 
-	describe( 'when the task depends on the completion of other tasks', () => {
-		describe( 'and some of the other tasks are not completed', () => {
+		describe( 'and the task depends on the completion of other tasks', () => {
+			it( 'hides the task enabled icon', () => {
+				const otherTaskCompleted = false;
+				render(
+					<ChecklistItem
+						task={ getTask( { isCompleted: false, dependencies: [ otherTaskCompleted ] } ) }
+					/>
+				);
+				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
+				expect( taskEnabledIcon ).toBeFalsy();
+			} );
 			it( 'disables the task', () => {
-				const otherTaskCompleted = true;
-
-				render( <ChecklistItem task={ getTask( { dependencies: [ ! otherTaskCompleted ] } ) } /> );
+				const otherTaskCompleted = false;
+				render(
+					<ChecklistItem
+						task={ getTask( { isCompleted: false, dependencies: [ otherTaskCompleted ] } ) }
+					/>
+				);
 				const taskButton = screen.queryByRole( 'link' );
 				expect( taskButton ).toHaveAttribute( 'disabled' );
 			} );
 		} );
-		describe( 'and the other tasks are completed', () => {
-			it( 'enables the task', () => {
-				const otherTaskCompleted = true;
 
-				render( <ChecklistItem task={ getTask( { dependencies: [ otherTaskCompleted ] } ) } /> );
+		describe( 'and the task does not depend on the completion of other tasks', () => {
+			it( 'shows the task enabled icon', () => {
+				render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
+				expect( taskEnabledIcon ).toBeTruthy();
+			} );
+			it( 'enables the task', () => {
+				render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
 				const taskButton = screen.queryByRole( 'link' );
 				expect( taskButton ).not.toHaveAttribute( 'disabled' );
 			} );


### PR DESCRIPTION
### Proposed Changes

* Hides task enabled chevron icon if task has been completed ( even though the user can still interact with the task )

### Screenshots

#### Before

<img width="1279" alt="Screen Shot 2022-09-20 at 12 15 28 PM" src="https://user-images.githubusercontent.com/5414230/191345463-1ea02eb3-5ee3-4adf-98bf-11fc393902ed.png">

#### After

<img width="1279" alt="Screen Shot 2022-09-20 at 12 11 01 PM" src="https://user-images.githubusercontent.com/5414230/191344186-4e8448fd-4b20-4973-93aa-ad5aef2b638b.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site through the tailored onboarding flow ( newsletter or link in bio ) https://wordpress.com/hp-2022-tailored-flows/
* Step through the onboarding process until the launchpad
* Check out this branch and `yarn start`
* Make sure that you're loading the launchpad through the local dev environment calypso.localhost:3000
* Verify that completed tasks no longer have the chevron icon displayed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68037
