### PR TITLE
Pricing page rework: Make /jetpack/connect/plans/:site page background white.

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -314,6 +314,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	background-color: var(--color-neutral-20);
 	width: 8px;
 	height: 8px;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 }
 
@@ -362,10 +363,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	background-color: var(--color-neutral-0);
 }
 
-.example-components__connect-jetpack {
-	background-color: var(--color-neutral-0);
-}
-
 .example-components__content-wp-admin-masterbar {
 	width: 100%;
 	padding-bottom: 6%;
@@ -388,6 +385,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .example-components__connect-jetpack {
+	background-color: var(--color-neutral-0);
+
 	.example-components__content-wp-admin-plugin-name {
 		font-size: $font-body-small;
 		margin-bottom: 8px;
@@ -1086,14 +1085,6 @@ body.is-section-jetpack-connect {
 // ProductCard overrides
 
 .is-section-jetpack-connect .product-card {
-	.product-card__header {
-		padding: 12px 0;
-
-		@include breakpoint-deprecated( "<660px" ) {
-			padding: 16px 0;
-		}
-	}
-
 	.product-card__header-primary {
 		@include breakpoint-deprecated( "<660px" ) {
 			justify-content: center;
@@ -1129,6 +1120,12 @@ body.is-section-jetpack-connect {
 	}
 
 	.product-card__header {
+		padding: 12px 0;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			padding: 16px 0;
+		}
+
 		.plan-price,
 		.plan-price * {
 			font-size: $font-body;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1071,11 +1071,14 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 }
 
-body.is-section-jetpack-connect .layout {
-	&.is-jetpack-woocommerce-flow,
-	&.is-jetpack-woo-dna-flow {
-		.wpcom-site__logo {
-			display: none;
+body.is-section-jetpack-connect {
+	background-color: var(--color-surface);
+	.layout {
+		&.is-jetpack-woocommerce-flow,
+		&.is-jetpack-woo-dna-flow {
+			.wpcom-site__logo {
+				display: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR makes the post-connection Plans/Pricing page background white(ish) (--color-surface) (on page: `/jetpack/connect/plans:site`)

**Additional implementation notes:**

 - I also fixed/cleaned up some (3) SCSS stylelint errors.  So now committing to the file no longer requires `--no-verify` to commit.

Completes task: 1202796695664022-as-1203005354786551

#### Screenshots:

Before | AFTER
--- | ---
![Markup 2022-09-20 at 15 17 11](https://user-images.githubusercontent.com/11078128/191345595-0f35cbdb-c868-478c-af9c-a036962f5c69.png) | ![Markup 2022-09-20 at 15 17 44](https://user-images.githubusercontent.com/11078128/191345621-af60a9ec-cec8-431a-89f7-d5b168540094.png)


.
#### Testing Instructions

- Do either of these:
    * Click on **Calypso Live** link below and go to `/jetpack/connect/plans/:site`, where `:site` is a connected Jetpack site that doesn't own any jetpack products yet.
    * or spin up this PR 
        * Run `git fetch && git checkout fix/jetpack-connect-plans-background`
        * Run `yarn start`
        * Goto `http://calypso.localhost:3000/jetpack/connect/plans/:site`, where `:site` is a connected Jetpack site that doesn't own any jetpack products yet.
- Verify that the `body` background-color is `var(--color-surface)`.
- You can compare with wordpress.com to see that the background-color prior to this PR was: `var(--color-surface-backdrop)`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203005354786551