### PR TITLE
Launchpad: Update titles and make title conditional

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,12 +1,13 @@
 import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import Checklist from './checklist';
-import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
+import { getArrayOfFilteredTasks, getEnhancedTasks, isTaskDisabled } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
@@ -44,15 +45,23 @@ function getChecklistCompletionProgress( tasks: Task[] | null ) {
 const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
+	const [ showLaunchTitle, setShowLaunchTitle ] = useState< boolean >( false );
 	const flow = useFlowParam();
 	const translate = useTranslate();
 	const site = useSite();
-	const translatedStrings = getLaunchpadTranslations( flow );
+	const { flowName, title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
 	const enhancedTasks =
 		site && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site, submit, goToStep );
 
 	const taskCompletionProgress = site && getChecklistCompletionProgress( enhancedTasks );
+
+	useEffect( () => {
+		const launchTask = enhancedTasks?.filter( ( task ) => task.id.includes( 'launched' ) );
+		if ( launchTask && launchTask?.length > 0 && ! isTaskDisabled( launchTask[ 0 ] ) ) {
+			setShowLaunchTitle( true );
+		}
+	}, [ enhancedTasks ] );
 
 	if ( siteSlug ) {
 		[ siteName, topLevelDomain ] = getUrlInfo( siteSlug );
@@ -62,7 +71,7 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 		<div className="launchpad__sidebar">
 			<div className="launchpad__sidebar-header">
 				<WordPressLogo className="launchpad__sidebar-header-logo" size={ 24 } />
-				<span className="launchpad__sidebar-header-flow-name">{ translatedStrings.flowName }</span>
+				<span className="launchpad__sidebar-header-flow-name">{ flowName }</span>
 			</div>
 			<div className="launchpad__sidebar-content-container">
 				{ taskCompletionProgress && (
@@ -77,8 +86,10 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 					</div>
 				) }
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }
-				<h1 className="launchpad__sidebar-h1">{ translatedStrings.sidebarTitle }</h1>
-				<p className="launchpad__sidebar-description">{ translatedStrings.sidebarSubtitle }</p>
+				<h1 className="launchpad__sidebar-h1">
+					{ showLaunchTitle && launchTitle ? launchTitle : title }
+				</h1>
+				<p className="launchpad__sidebar-description">{ subtitle }</p>
 				<div className="launchpad__url-box">
 					<span>{ siteName }</span>
 					<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -57,7 +57,7 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 	const taskCompletionProgress = site && getChecklistCompletionProgress( enhancedTasks );
 
 	useEffect( () => {
-		const launchTask = enhancedTasks?.filter( ( task ) => task.id.includes( 'launched' ) );
+		const launchTask = enhancedTasks?.filter( ( task ) => task.isLaunchTask === true );
 		if ( launchTask && launchTask?.length > 0 && ! isTaskDisabled( launchTask[ 0 ] ) ) {
 			setShowLaunchTitle( true );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -57,8 +57,8 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 	const taskCompletionProgress = site && getChecklistCompletionProgress( enhancedTasks );
 
 	useEffect( () => {
-		const launchTask = enhancedTasks?.filter( ( task ) => task.isLaunchTask === true );
-		if ( launchTask && launchTask?.length > 0 && ! isTaskDisabled( launchTask[ 0 ] ) ) {
+		const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
+		if ( launchTask && ! isTaskDisabled( launchTask ) ) {
 			setShowLaunchTitle( true );
 		}
 	}, [ enhancedTasks ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,6 +1,5 @@
 import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -45,7 +44,6 @@ function getChecklistCompletionProgress( tasks: Task[] | null ) {
 const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
-	const [ showLaunchTitle, setShowLaunchTitle ] = useState< boolean >( false );
 	const flow = useFlowParam();
 	const translate = useTranslate();
 	const site = useSite();
@@ -55,13 +53,8 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 		site && getEnhancedTasks( arrayOfFilteredTasks, siteSlug, site, submit, goToStep );
 
 	const taskCompletionProgress = site && getChecklistCompletionProgress( enhancedTasks );
-
-	useEffect( () => {
-		const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
-		if ( launchTask && ! isTaskDisabled( launchTask ) ) {
-			setShowLaunchTitle( true );
-		}
-	}, [ enhancedTasks ] );
+	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
+	const showLaunchTitle = launchTask && ! isTaskDisabled( launchTask );
 
 	if ( siteSlug ) {
 		[ siteName, topLevelDomain ] = getUrlInfo( siteSlug );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -82,6 +82,7 @@ export function getEnhancedTasks(
 						title: translate( 'Launch Link in bio' ),
 						isCompleted: linkInBioSiteLaunchCompleted,
 						dependencies: [ linkInBioLinksEditCompleted ],
+						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -32,6 +32,14 @@ describe( 'Task Helpers', () => {
 				);
 			} );
 		} );
+		describe( 'when it is link_in_bio_launched task', () => {
+			it( 'then it receives launchtask property = true', () => {
+				const fakeTasks = [ getTask( { id: 'link_in_bio_launched' } ) ];
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				const enhancedTasks = getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {} );
+				expect( enhancedTasks[ 0 ].isLaunchTask ).toEqual( true );
+			} );
+		} );
 	} );
 
 	describe( 'getArrayOfFilteredTasks', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -9,13 +9,13 @@ describe( 'Translations', () => {
 			it( 'provides flow specific text', () => {
 				const newsletterTranslations = getLaunchpadTranslations( 'newsletter' );
 				expect( newsletterTranslations.flowName ).toEqual( 'Newsletter' );
-				expect( newsletterTranslations.sidebarTitle ).toEqual(
-					'Your Newsletter is ready to launch!'
-				);
+				expect( newsletterTranslations.title ).toEqual( 'Your Newsletter is ready!' );
+				expect( newsletterTranslations.launchTitle ).toBe( undefined );
 
 				const linkInBioTranslations = getLaunchpadTranslations( 'link-in-bio' );
 				expect( linkInBioTranslations.flowName ).toEqual( 'Link in Bio' );
-				expect( linkInBioTranslations.sidebarTitle ).toEqual(
+				expect( linkInBioTranslations.title ).toEqual( 'Your Link in Bio is almost ready!' );
+				expect( linkInBioTranslations.launchTitle ).toEqual(
 					'Your Link in Bio is ready to launch!'
 				);
 			} );
@@ -25,10 +25,8 @@ describe( 'Translations', () => {
 			it( 'provides generic text', () => {
 				const translations = getLaunchpadTranslations( null );
 				expect( translations.flowName ).toEqual( 'WordPress' );
-				expect( translations.sidebarTitle ).toEqual( 'Your website is ready to launch!' );
-				expect( translations.sidebarSubtitle ).toEqual(
-					'Keep up the momentum with these final steps.'
-				);
+				expect( translations.title ).toEqual( 'Your website is ready!' );
+				expect( translations.subtitle ).toEqual( 'Keep up the momentum with these final steps.' );
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -3,24 +3,21 @@ import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
 
 export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunchpadStrings {
-	const translatedStrings = {
+	const translatedStrings: TranslatedLaunchpadStrings = {
 		flowName: translate( 'WordPress' ),
-		sidebarTitle: translate( 'Your website is ready to launch!' ),
-		sidebarSubtitle: translate( 'Keep up the momentum with these final steps.' ),
+		title: translate( 'Your website is ready!' ),
+		subtitle: translate( 'Keep up the momentum with these final steps.' ),
 	};
 
 	switch ( flow ) {
 		case NEWSLETTER_FLOW:
 			translatedStrings.flowName = translate( 'Newsletter' );
-			translatedStrings.sidebarTitle = translate( 'Your Newsletter is ready to launch!' );
+			translatedStrings.title = translate( 'Your Newsletter is ready!' );
 			break;
 		case LINK_IN_BIO_FLOW:
 			translatedStrings.flowName = translate( 'Link in Bio' );
-			translatedStrings.sidebarTitle = translate( 'Your Link in Bio is ready to launch!' );
-			break;
-		case 'podcast':
-			translatedStrings.flowName = translate( 'Podcast' );
-			translatedStrings.sidebarTitle = translate( 'Your Podcast is ready to launch!' );
+			translatedStrings.title = translate( 'Your Link in Bio is almost ready!' );
+			translatedStrings.launchTitle = translate( 'Your Link in Bio is ready to launch!' );
 			break;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -17,6 +17,7 @@ export interface LaunchpadFlowTaskList {
 
 export interface TranslatedLaunchpadStrings {
 	flowName: string;
-	sidebarTitle: string;
-	sidebarSubtitle: string;
+	title: string;
+	launchTitle?: string;
+	subtitle: string;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -9,6 +9,7 @@ export interface Task {
 	badgeText?: string;
 	dependencies?: boolean[];
 	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
 }
 
 export interface LaunchpadFlowTaskList {


### PR DESCRIPTION
### Proposed Changes

Related to: https://github.com/Automattic/wp-calypso/issues/68033

We want to alter Launchpad titles depending on the situation.
1) Newletter (and possibly similar flows later) are already launched. These will always show the same title. We've updated for Newsletters to be 'Your Newsletter is ready!'.
2) Link-in-Bio (and possibly similar flows later) are not yet launched when a user arrives at Launchpad. In this case, there is a a Launch task, which may be disabled if there are other task that need to be completed first. We want to show two different titles depending on whether the sites is ready to launch or not. If not ready, the title is "Your Link in Bio is almost ready!" If ready, the title is "Your Link in Bio is ready to launch!"  

Note, we do not dynamically construct titles, like `'Your ${ flowName } is ready to launch!'` due to i18n constraints. This was discussed in an [earlier PR](https://github.com/Automattic/wp-calypso/pull/66882) when we first added translatable titles and text to launchpad.

### Testing Instructions

1) Checkout this branch and run yarn and yarn start if needed. 

2) Go to https://wordpress.com/hp-2022-tailored-flows/ and start a Newsletter site. In one of the early steps, remember to replace https://wordpress.com/ with http://calypso.localhost:3000/ so you are seeing the code in your local branch.

3) TEST: When you get to Launchpad, confirm the title says "Your Newsletter is ready!" Screenshot: 
<img width="1507" alt="newsletter title" src="https://user-images.githubusercontent.com/21228350/191353076-c564d4a6-4567-4b91-a456-797dda2ed28b.png">

4) Go to https://wordpress.com/hp-2022-tailored-flows/ and start a Link in Bio site. In one of the early steps, remember to replace https://wordpress.com/ with http://calypso.localhost:3000/ so you are seeing the code in your local branch.

5) TEST: When you get to Launchpad, confirm the title says "Your Link in Bio is almost ready!" Note that the Launch task is still disabled because Add Links is required first. Screenshot: 
<img width="1503" alt="link in bio title 1" src="https://user-images.githubusercontent.com/21228350/191353112-e51e65d2-346f-4aac-b60c-117d4220a7b8.png">

6) Click Add Links and then navigate back back to launchpad by trying to go to the Dashboard.
 
7) TEST: Now, confirm the title says "Your Link in Bio is ready to launch!" Screenshot: 
<img width="1509" alt="link in bio title 2" src="https://user-images.githubusercontent.com/21228350/191353189-785c8168-af6d-4c2e-a06b-5bb0ac4959e6.png">


### Translations

This PR adds or updates translatable strings. The screenshots above show how those translated strings appear. 


