### PR TITLE
Disable and remove jest/no-disabled-tests rule for the test/e2e folder

### DIFF
--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -37,5 +37,9 @@ module.exports = {
 
 		// We compose the test titles dynamically
 		'jest/valid-title': 'off',
+
+		// The rule hasn't had the intended results (encouraging owners to re-enable and fix their tests).
+		// See GitHub issue #64870 for context (https://github.com/Automattic/wp-calypso/issues/64870).
+		'jest/no-disabled-tests': 'off',
 	},
 };

--- a/test/e2e/specs/appearance/theme__details-preview-activate.ts
+++ b/test/e2e/specs/appearance/theme__details-preview-activate.ts
@@ -74,18 +74,15 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 		await previewComponent.closePreview();
 	} );
 
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'Activate theme', async function () {
 		await themesDetailPage.activate();
 	} );
 
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'Open theme customizer', async function () {
 		popupTab = await themesDetailPage.customizeSite();
 		await popupTab.waitForLoadState( 'load' );
 	} );
 
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'Close theme customizer', async function () {
 		await popupTab.close();
 	} );

--- a/test/e2e/specs/domains/domains__add.ts
+++ b/test/e2e/specs/domains/domains__add.ts
@@ -18,7 +18,6 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-// eslint-disable-next-line jest/no-disabled-tests
 describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
 	let page: Page;
 	let sidebarComponent: SidebarComponent;

--- a/test/e2e/specs/onboarding/signup__domain.ts
+++ b/test/e2e/specs/onboarding/signup__domain.ts
@@ -75,7 +75,6 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 
 		// Skipping this test because of inconsistency in cookie working in this flow
 		// See GH Issue #56961 (https://github.com/Automattic/wp-calypso/issues/56961)
-		// eslint-disable-next-line jest/no-disabled-tests
 		it.skip( 'Prices are shown in Japanese Yen', async function () {
 			const cartAmount = ( await cartCheckoutPage.getCheckoutTotalAmount( {
 				rawString: true,

--- a/test/e2e/specs/support/support__home.ts
+++ b/test/e2e/specs/support/support__home.ts
@@ -54,13 +54,11 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 
 		// Invalid keyword search often takes more than 30s to resolve.
 		// See: https://github.com/Automattic/wp-calypso/issues/55478
-		// eslint-disable-next-line jest/no-disabled-tests
 		it.skip( 'Enter invalid search keyword', async function () {
 			const keyword = ';;;ppp;;;';
 			await supportComponent.search( keyword );
 		} );
 
-		// eslint-disable-next-line jest/no-disabled-tests
 		it.skip( 'No search results are shown', async function () {
 			await supportComponent.noResultsShown();
 		} );

--- a/test/e2e/specs/support/support__popover-invalid.ts
+++ b/test/e2e/specs/support/support__popover-invalid.ts
@@ -56,7 +56,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover/Invalid Keywords' ), fu
 
 		// Invalid keyword search often takes more than 30s to resolve.
 		// See: https://github.com/Automattic/wp-calypso/issues/55478
-		// eslint-disable-next-line jest/no-disabled-tests
 		it.skip( 'Enter invalid search keyword and expect no results to be shown', async function () {
 			const keyword = ';;;ppp;;;';
 			await supportComponent.search( keyword );


### PR DESCRIPTION
### Context
Work based on issue [#64870](https://github.com/Automattic/wp-calypso/issues/64870) (Lint: consider disable or removal of the jest/no-disabled-tests rule.)
### Changes
- Removed comments suppressing the `jest/no-disabled-tests` rule from tests in `tests/e2e`.
- Disabled the `jest/no-disabled-tests` rule for the `test/e2e` folder.