### PR TITLE
Sites Management Page: Enable 'Magic' sorting for all users

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Button, Dropdown, MenuItemsChoice } from '@wordpress/components';
@@ -24,8 +23,6 @@ const SortingButtonIcon = styled( Gridicon )( {
 } );
 
 type SitesSortingDropdownProps = ReturnType< typeof useSitesSorting >;
-
-const isTruthy = < T, >( x: T | false ): x is T => !! x;
 
 export const SitesSortingDropdown = ( {
 	onSitesSortingChange,
@@ -67,7 +64,7 @@ export const SitesSortingDropdown = ( {
 				} ),
 				label: __( 'Alphabetically' ),
 			},
-			config.isEnabled( 'sites/automagical-sorting' ) && {
+			{
 				value: stringifySitesSorting( {
 					sortKey: 'lastInteractedWith',
 					sortOrder: 'desc',
@@ -81,7 +78,7 @@ export const SitesSortingDropdown = ( {
 				} ),
 				label: __( 'Last published' ),
 			},
-		].filter( isTruthy );
+		];
 	}, [ __ ] );
 
 	if ( ! hasSitesSortingPreferenceLoaded ) {

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	SitesTableSortOptions,
 	SitesTableSortKey,
@@ -22,13 +21,6 @@ export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) =>
 	const sorting = { sortKey, sortOrder };
 
 	if ( ! isValidSorting( sorting ) ) {
-		return DEFAULT_SITES_SORTING;
-	}
-
-	if (
-		sorting.sortKey === 'lastInteractedWith' &&
-		! config.isEnabled( 'sites/automagical-sorting' )
-	) {
 		return DEFAULT_SITES_SORTING;
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -172,7 +172,6 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,7 +117,6 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"themes/atomic-homepage-replace": true,

--- a/config/production.json
+++ b/config/production.json
@@ -135,7 +135,6 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/automagical-sorting": false,
 		"ssr/sample-log-cache-misses": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,7 +134,6 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,7 +143,6 @@
 		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/automagical-sorting": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
## Proposed Changes

Now that we're logging interactions for all WordPress.com users, let's make 'Magic' sorting available for everyone.

<img width="464" alt="image" src="https://user-images.githubusercontent.com/36432/191364873-be899827-2a4d-4da8-8a2a-70659612b05d.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Verify 'Magic' sorting is available and works as expected.

Related: https://github.com/Automattic/wp-calypso/issues/68044