### PR TITLE
Marketplace: Add current plan to plan table

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -25,6 +25,7 @@ import {
 	GROUP_WPCOM,
 	PLAN_PERSONAL,
 	TITAN_MAIL_MONTHLY_SLUG,
+	PLAN_FREE,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
@@ -401,6 +402,11 @@ export class PlansFeaturesMain extends Component {
 		const withIntervalSelector = this.getKindOfPlanTypeSelector( this.props ) === 'interval';
 
 		if ( isMarketplaceFlow( flowName ) ) {
+			// workaround to show free plan on both monthly/yearly toggle
+			if ( sitePlanSlug === PLAN_FREE && ! plans.includes( PLAN_FREE ) ) {
+				// elements are rendered in order, needs to be the first one
+				plans.unshift( PLAN_FREE );
+			}
 			return plans.filter(
 				( plan ) =>
 					plan === sitePlanSlug || isPlanOneOfType( plan, [ TYPE_BUSINESS, TYPE_ECOMMERCE ] )

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -61,6 +61,7 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
+import { isMarketplaceFlow } from '../plugins/flows';
 import PlanTypeSelector from './plan-type-selector';
 import PlanFAQ from './plansStepFaq';
 import WpcomFAQ from './wpcom-faq';
@@ -359,7 +360,14 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getVisiblePlansForPlanFeatures( availablePlans ) {
-		const { customerType, selectedPlan, plansWithScroll, isAllPaidPlansShown } = this.props;
+		const {
+			customerType,
+			selectedPlan,
+			plansWithScroll,
+			isAllPaidPlansShown,
+			flowName,
+			sitePlanSlug,
+		} = this.props;
 
 		const isPlanOneOfType = ( plan, types ) =>
 			types.filter( ( type ) => planMatches( plan, { type } ) ).length > 0;
@@ -391,6 +399,13 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		const withIntervalSelector = this.getKindOfPlanTypeSelector( this.props ) === 'interval';
+
+		if ( isMarketplaceFlow( flowName ) ) {
+			return plans.filter(
+				( plan ) =>
+					plan === sitePlanSlug || isPlanOneOfType( plan, [ TYPE_BUSINESS, TYPE_ECOMMERCE ] )
+			);
+		}
 
 		if ( isAllPaidPlansShown || withIntervalSelector ) {
 			return plans.filter( ( plan ) =>

--- a/client/my-sites/plugins/flows.ts
+++ b/client/my-sites/plugins/flows.ts
@@ -1,0 +1,4 @@
+export const MARKETPLACE_FLOW = 'marketplace';
+export const isMarketplaceFlow = ( flowName: string | null ) => {
+	return MARKETPLACE_FLOW === flowName;
+};

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -1,4 +1,9 @@
-import { FEATURE_INSTALL_PLUGINS, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	getPlan,
+	PLAN_BUSINESS,
+	TYPE_BUSINESS,
+	TYPE_ECOMMERCE,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -11,7 +16,6 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
@@ -20,6 +24,12 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 
 	const dispatch = useDispatch();
+
+	const currentPlanSlug = selectedSite?.plan?.product_slug;
+	let currentPlanType = null;
+	if ( currentPlanSlug ) {
+		currentPlanType = getPlan( currentPlanSlug )?.type;
+	}
 
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
@@ -60,10 +70,9 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					basePlansPath="/plugins/plans"
 					site={ selectedSite }
 					intervalType={ intervalType }
-					selectedFeature={ FEATURE_INSTALL_PLUGINS }
 					selectedPlan={ PLAN_BUSINESS }
-					shouldShowPlansFeatureComparison
-					isReskinned
+					showFAQ={ null }
+					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
 				/>
 			</div>
 		</MainComponent>

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -71,7 +71,6 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					site={ selectedSite }
 					intervalType={ intervalType }
 					selectedPlan={ PLAN_BUSINESS }
-					showFAQ={ null }
 					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
 				/>
 			</div>

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -75,6 +75,8 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					selectedPlan={ PLAN_BUSINESS }
 					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
 					flowName={ MARKETPLACE_FLOW }
+					shouldShowPlansFeatureComparison
+					isReskinned
 				/>
 			</div>
 		</MainComponent>

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -16,6 +16,8 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { MARKETPLACE_FLOW } from '../flows';
+
 import './style.scss';
 
 const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
@@ -72,6 +74,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					intervalType={ intervalType }
 					selectedPlan={ PLAN_BUSINESS }
 					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
+					flowName={ MARKETPLACE_FLOW }
 				/>
 			</div>
 		</MainComponent>


### PR DESCRIPTION
#### Proposed Changes

We can get the current plan and remove `shouldShowPlansFeatureComparison` to get a plan table like this:


https://user-images.githubusercontent.com/6586048/191447561-bc61d328-6a6d-421f-a3c9-c4076b4b27d5.mp4




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- [x] go to `/plugins/:site?flags=plugins-plans-page`

Then go to the plans page from either:
- [x] discovery page nudge
- [x] plugin detail pages

---

- [x] Check whether premium/free plan shows up in yearly
- [x] Check whether premium/free plan shows up in monthly

---

NOTE: Whether the monthly/yearly toggle shows up depends on whether your plan is on monthly or yearly. Only the **free plan** should show up on both the monthly/yearly toggle.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#67574](https://github.com/Automattic/wp-calypso/issues/67574)
