### PR TITLE
Launchpad: Truncate long domain names

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -109,6 +109,11 @@
 	line-height: 48px;
 	margin: 32px 0;
 	padding: 0 20px;
+
+	// trunkate long domain names
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .launchpad__url-box-top-level-domain {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -110,7 +110,7 @@
 	margin: 32px 0;
 	padding: 0 20px;
 
-	// trunkate long domain names
+	// truncate long domain names
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
#### Proposed changes
This PR allows the long domain names that would typically overflow the container to be truncated (...)

#### Before

https://user-images.githubusercontent.com/20927667/191383956-823133a6-09f9-47d5-82bb-71777c08ba39.mov

#### After

https://user-images.githubusercontent.com/20927667/191384123-c9e6f6be-c023-4e7d-bce3-c7083812b6e2.mov

#### Testing Instructions
1. Create a new site with a very long domain name
1. Go to `http://calypso.localhost:3000/setup/launchpad?flow=newsletter&complete-setup=true&siteSlug=YOUR_SITE_SLUG`
2. Ensure the domain name is being truncated and does not overflow the domain preview container

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68038