### PR TITLE
Purchase Management: add new cancelation modal

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -515,15 +515,16 @@ class ManagePurchase extends Component {
 
 	renderRemoveSubscriptionWarningDialog( site, purchase ) {
 		if ( this.state.showRemoveSubscriptionWarningDialog ) {
+			const { hasCustomPrimaryDomain } = this.props;
 			if ( isPlan( purchase ) ) {
-				if ( hasCustomDomain && isRefundable( purchase ) ) {
+				if ( hasCustomPrimaryDomain && isRefundable( purchase ) ) {
 					return (
 						<RemovePlanDialog
 							isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
 							closeDialog={ this.closeDialog }
 							removePlan={ this.goToCancelLink }
 							site={ site }
-							hasDomain={ hasCustomDomain }
+							hasDomain={ hasCustomPrimaryDomain }
 							wpcomSiteURL={ site.slug }
 						/>
 					);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -637,7 +637,7 @@ class ManagePurchase extends Component {
 	getCancellationFlowType = () => {
 		const { purchase } = this.props;
 		const isPlanRefundable = isRefundable( purchase );
-		const isPlanAutoRenewing = isAutoRenewing( purchase );
+		const isPlanAutoRenewing = purchase?.isAutoRenewEnabled ?? false;
 
 		if ( isPlanRefundable && hasAmountAvailableToRefund( purchase ) ) {
 			// If the subscription is refundable the subscription should be removed immediately.

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -63,6 +63,7 @@ import {
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
 	hasPaymentMethod,
+	isAutoRenewing,
 	isPaidWithCredits,
 	isCancelable,
 	isExpired,
@@ -629,9 +630,19 @@ class ManagePurchase extends Component {
 
 	getCancellationFlowType = () => {
 		const { purchase } = this.props;
-		return hasAmountAvailableToRefund( purchase )
-			? CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
-			: CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+		const isPlanRefundable = isRefundable( purchase );
+		const isPlanAutoRenewing = isAutoRenewing( purchase );
+
+		if ( isPlanRefundable && hasAmountAvailableToRefund( purchase ) ) {
+			// If the subscription is refundable the subscription should be removed immediately.
+			return CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
+		} else if ( ! isPlanRefundable && isPlanAutoRenewing ) {
+			// If the subscription is not refundable and auto-renew is on turn off auto-renew.
+			return CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+		}
+
+		// If the subscription is not refundable and auto-renew is off subscription should be removed immediately.
+		return CANCEL_FLOW_TYPE.REMOVE;
 	};
 
 	renderCancelForm() {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -512,16 +512,18 @@ class ManagePurchase extends Component {
 		return null;
 	}
 
-	renderRemoveSubscriptionWarningDialog( site ) {
+	renderRemoveSubscriptionWarningDialog( site, purchase ) {
 		if ( this.state.showRemoveSubscriptionWarningDialog ) {
-			return (
-				<RemovePlanDialog
-					isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
-					closeDialog={ this.closeDialog }
-					removePlan={ this.goToCancelLink }
-					site={ site }
-				/>
-			);
+			if ( isPlan( purchase ) ) {
+				return (
+					<RemovePlanDialog
+						isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
+						closeDialog={ this.closeDialog }
+						removePlan={ this.goToCancelLink }
+						site={ site }
+					/>
+				);
+			}
 		}
 
 		return null;
@@ -565,8 +567,10 @@ class ManagePurchase extends Component {
 			}
 
 			if ( isSubscription( purchase ) ) {
-				event.preventDefault();
-				this.showRemoveSubscriptionWarningDialog( link );
+				if ( isPlan( purchase ) && ! isJetpackProduct( purchase ) ) {
+					event.preventDefault();
+					this.showRemoveSubscriptionWarningDialog( link );
+				}
 			}
 		};
 
@@ -1000,7 +1004,7 @@ class ManagePurchase extends Component {
 				/>
 				{ this.renderPurchaseDetail( preventRenewal ) }
 				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
-				{ site && this.renderRemoveSubscriptionWarningDialog( site ) }
+				{ site && this.renderRemoveSubscriptionWarningDialog( site, purchase ) }
 			</Fragment>
 		);
 	}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -13,6 +13,7 @@ import {
 	isGoogleWorkspace,
 	isGSuiteOrGoogleWorkspace,
 	isThemePurchase,
+	isJetpackPlan,
 	isJetpackProduct,
 	isConciergeSession,
 	isTitanMail,
@@ -516,27 +517,19 @@ class ManagePurchase extends Component {
 	renderRemoveSubscriptionWarningDialog( site, purchase ) {
 		if ( this.state.showRemoveSubscriptionWarningDialog ) {
 			const { hasCustomPrimaryDomain } = this.props;
-			if ( isPlan( purchase ) ) {
-				if ( hasCustomPrimaryDomain && isRefundable( purchase ) ) {
-					return (
-						<RemovePlanDialog
-							isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
-							closeDialog={ this.closeDialog }
-							removePlan={ this.goToCancelLink }
-							site={ site }
-							hasDomain={ hasCustomPrimaryDomain }
-							wpcomSiteURL={ site.slug }
-						/>
-					);
-				}
+			let customDomain = false;
 
+			if ( isPlan( purchase ) && ! isJetpackPlan( purchase ) ) {
+				if ( hasCustomPrimaryDomain && isRefundable( purchase ) ) {
+					customDomain = true;
+				}
 				return (
 					<RemovePlanDialog
 						isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
 						closeDialog={ this.closeDialog }
 						removePlan={ this.goToCancelLink }
 						site={ site }
-						hasDomain={ false }
+						hasDomain={ customDomain }
 						wpcomSiteURL={ site.slug }
 					/>
 				);
@@ -584,7 +577,7 @@ class ManagePurchase extends Component {
 			}
 
 			if ( isSubscription( purchase ) ) {
-				if ( isPlan( purchase ) && ! isJetpackProduct( purchase ) ) {
+				if ( isPlan( purchase ) && ! isJetpackProduct( purchase ) && ! isJetpackPlan( purchase ) ) {
 					event.preventDefault();
 					this.showRemoveSubscriptionWarningDialog( link );
 				}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -627,6 +627,13 @@ class ManagePurchase extends Component {
 		this.props.successNotice( successMessage, { isPersistent: true } );
 	};
 
+	getCancellationFlowType = () => {
+		const { purchase } = this.props;
+		return hasAmountAvailableToRefund( purchase )
+			? CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
+			: CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+	};
+
 	renderCancelForm() {
 		const { purchase } = this.props;
 
@@ -638,7 +645,7 @@ class ManagePurchase extends Component {
 				isVisible={ this.state.isCancelFormVisible }
 				onClose={ this.closeDialog }
 				onClickFinalConfirm={ this.removePurchase }
-				flowType={ CANCEL_FLOW_TYPE.REMOVE }
+				flowType={ this.getCancellationFlowType() }
 			/>
 		);
 	}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -533,7 +533,7 @@ class ManagePurchase extends Component {
 						removePlan={ this.goToCancelLink }
 						site={ site }
 						hasDomain={ customDomain }
-						wpcomSlug={ site.slug }
+						wpcomURL={ site.wpcom_url }
 						primaryDomain={ primaryDomainName }
 					/>
 				);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -92,6 +92,7 @@ import {
 	getCurrentUser,
 	getCurrentUserId,
 } from 'calypso/state/current-user/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { removePurchase } from 'calypso/state/purchases/actions';
 import {
@@ -541,6 +542,9 @@ class ManagePurchase extends Component {
 			let wordpressComURL = '';
 
 			if ( isPlan( purchase ) && ! isJetpackPlan( purchase ) ) {
+				const isPlanRefundable = isRefundable( purchase );
+				const actionFunction = isPlanRefundable ? this.goToCancelLink : this.showRemovePlanDialog;
+
 				if ( hasCustomPrimaryDomain && primaryDomainName ) {
 					customDomain = true;
 				}
@@ -556,10 +560,10 @@ class ManagePurchase extends Component {
 					<RemovePlanDialog
 						isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
 						closeDialog={ this.closeDialog }
-						removePlan={ this.showRemovePlanDialog }
+						removePlan={ actionFunction }
 						site={ site }
 						hasDomain={ customDomain }
-						isRefundable={ isRefundable( purchase ) }
+						isRefundable={ isPlanRefundable }
 						primaryDomain={ primaryDomainName }
 						wpcomURL={ wordpressComURL }
 					/>
@@ -1234,5 +1238,7 @@ export default connect(
 		handleRenewNowClick,
 		handleRenewMultiplePurchasesClick,
 		removePurchase,
+		errorNotice,
+		successNotice,
 	}
 )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -32,7 +32,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card, CompactCard, ProductIcon, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -542,7 +542,12 @@ class ManagePurchase extends Component {
 			let customDomain = false;
 			let wordpressComURL = '';
 
-			if ( isPlan( purchase ) && ! isJetpackPlan( purchase ) ) {
+			if (
+				isPlan( purchase ) &&
+				! isJetpackPlan( purchase ) &&
+				! isGSuiteOrGoogleWorkspace( purchase ) &&
+				'en' === getLocaleSlug() // TODO: remove this when the translations are completed.
+			) {
 				const isPlanRefundable = isRefundable( purchase );
 				const actionFunction = isPlanRefundable ? this.goToCancelLink : this.showRemovePlanDialog;
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -570,6 +570,7 @@ class ManagePurchase extends Component {
 						site={ site }
 						hasDomain={ customDomain }
 						isRefundable={ isPlanRefundable }
+						isAutoRenewing={ isAutoRenewing }
 						primaryDomain={ primaryDomainName }
 						wpcomURL={ wordpressComURL }
 					/>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -521,10 +521,18 @@ class ManagePurchase extends Component {
 			const { hasCustomPrimaryDomain, primaryDomain } = this.props;
 			const primaryDomainName = hasCustomDomain && primaryDomain ? primaryDomain.name : '';
 			let customDomain = false;
+			let wordpressComURL = '';
 
 			if ( isPlan( purchase ) && ! isJetpackPlan( purchase ) ) {
 				if ( hasCustomPrimaryDomain && primaryDomainName ) {
 					customDomain = true;
+				}
+
+				if ( typeof site.wpcom_url !== 'undefined' ) {
+					wordpressComURL =
+						site.wpcom_url.length < 35
+							? site.wpcom_url
+							: site.wpcom_url.substr( 0, 10 ) + '…' + site.wpcom_url.slice( -20 );
 				}
 
 				return (
@@ -536,7 +544,7 @@ class ManagePurchase extends Component {
 						hasDomain={ customDomain }
 						isRefundable={ isRefundable( purchase ) }
 						primaryDomain={ primaryDomainName }
-						wpcomURL={ site.wpcom_url }
+						wpcomURL={ wordpressComURL }
 					/>
 				);
 			}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -32,7 +32,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card, CompactCard, ProductIcon, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -545,8 +545,7 @@ class ManagePurchase extends Component {
 			if (
 				isPlan( purchase ) &&
 				! isJetpackPlan( purchase ) &&
-				! isGSuiteOrGoogleWorkspace( purchase ) &&
-				'en' === getLocaleSlug() // TODO: remove this when the translations are completed.
+				! isGSuiteOrGoogleWorkspace( purchase )
 			) {
 				const isPlanRefundable = isRefundable( purchase );
 				const actionFunction = isPlanRefundable ? this.goToCancelLink : this.showRemovePlanDialog;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -77,6 +77,7 @@ import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import ProductLink from 'calypso/me/purchases/product-link';
+import { RemovePlanDialog } from 'calypso/me/purchases/remove-plan-dialog';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -155,6 +156,7 @@ class ManagePurchase extends Component {
 
 	state = {
 		showNonPrimaryDomainWarningDialog: false,
+		showRemoveSubscriptionWarningDialog: false,
 		cancelLink: null,
 	};
 
@@ -466,6 +468,15 @@ class ManagePurchase extends Component {
 	showNonPrimaryDomainWarningDialog( cancelLink ) {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: true,
+			showRemoveSubscriptionWarningDialog: false,
+			cancelLink,
+		} );
+	}
+
+	showRemoveSubscriptionWarningDialog( cancelLink ) {
+		this.setState( {
+			showNonPrimaryDomainWarningDialog: false,
+			showRemoveSubscriptionWarningDialog: true,
 			cancelLink,
 		} );
 	}
@@ -473,6 +484,7 @@ class ManagePurchase extends Component {
 	closeDialog = () => {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
+			showRemoveSubscriptionWarningDialog: false,
 			cancelLink: null,
 		} );
 	};
@@ -500,6 +512,20 @@ class ManagePurchase extends Component {
 		return null;
 	}
 
+	renderRemoveSubscriptionWarningDialog( site ) {
+		if ( this.state.showRemoveSubscriptionWarningDialog ) {
+			return (
+				<RemovePlanDialog
+					isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
+					closeDialog={ this.closeDialog }
+					removePlan={ this.goToCancelLink }
+					site={ site }
+				/>
+			);
+		}
+
+		return null;
+	}
 	renderCancelPurchaseNavItem() {
 		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
@@ -536,6 +562,11 @@ class ManagePurchase extends Component {
 			if ( this.shouldShowNonPrimaryDomainWarning() ) {
 				event.preventDefault();
 				this.showNonPrimaryDomainWarningDialog( link );
+			}
+
+			if ( isSubscription( purchase ) ) {
+				event.preventDefault();
+				this.showRemoveSubscriptionWarningDialog( link );
 			}
 		};
 
@@ -969,6 +1000,7 @@ class ManagePurchase extends Component {
 				/>
 				{ this.renderPurchaseDetail( preventRenewal ) }
 				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
+				{ site && this.renderRemoveSubscriptionWarningDialog( site ) }
 			</Fragment>
 		);
 	}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -483,6 +483,8 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: true,
 			showRemoveSubscriptionWarningDialog: false,
+			isRemoving: false,
+			isCancelFormVisible: false,
 			cancelLink,
 		} );
 	}
@@ -491,6 +493,8 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: true,
+			isRemoving: false,
+			isCancelFormVisible: false,
 			cancelLink,
 		} );
 	}
@@ -499,6 +503,7 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: false,
+			isRemoving: false,
 			isCancelFormVisible: true,
 			cancelLink,
 		} );
@@ -508,6 +513,8 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: false,
+			isRemoving: false,
+			isCancelFormVisible: false,
 			cancelLink: null,
 		} );
 	};

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -65,6 +65,7 @@ import {
 	isExpired,
 	isOneTimePurchase,
 	isPartnerPurchase,
+	isRefundable,
 	isRenewable,
 	isSubscription,
 	isCloseToExpiration,
@@ -515,12 +516,27 @@ class ManagePurchase extends Component {
 	renderRemoveSubscriptionWarningDialog( site, purchase ) {
 		if ( this.state.showRemoveSubscriptionWarningDialog ) {
 			if ( isPlan( purchase ) ) {
+				if ( hasCustomDomain && isRefundable( purchase ) ) {
+					return (
+						<RemovePlanDialog
+							isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
+							closeDialog={ this.closeDialog }
+							removePlan={ this.goToCancelLink }
+							site={ site }
+							hasDomain={ hasCustomDomain }
+							wpcomSiteURL={ site.slug }
+						/>
+					);
+				}
+
 				return (
 					<RemovePlanDialog
 						isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
 						closeDialog={ this.closeDialog }
 						removePlan={ this.goToCancelLink }
 						site={ site }
+						hasDomain={ false }
+						wpcomSiteURL={ site.slug }
 					/>
 				);
 			}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -66,6 +66,7 @@ import {
 	isExpired,
 	isOneTimePurchase,
 	isPartnerPurchase,
+	isRefundable,
 	isRenewable,
 	isSubscription,
 	isCloseToExpiration,
@@ -533,8 +534,9 @@ class ManagePurchase extends Component {
 						removePlan={ this.goToCancelLink }
 						site={ site }
 						hasDomain={ customDomain }
-						wpcomURL={ site.wpcom_url }
+						isRefundable={ isRefundable( purchase ) }
 						primaryDomain={ primaryDomainName }
+						wpcomURL={ site.wpcom_url }
 					/>
 				);
 			}

--- a/client/me/purchases/remove-plan-dialog/get-plan-features.tsx
+++ b/client/me/purchases/remove-plan-dialog/get-plan-features.tsx
@@ -1,6 +1,10 @@
 import { getPlan, isMonthly } from '@automattic/calypso-products';
 
-export default function getPlanFeatures( productSlug: string | undefined ): string[] {
+export default function getPlanFeatures(
+	productSlug: string | undefined,
+	hasDomain: boolean,
+	wpcomSiteURL: string
+): string[] {
 	if ( ! productSlug ) {
 		return [];
 	}
@@ -15,9 +19,15 @@ export default function getPlanFeatures( productSlug: string | undefined ): stri
 	const featureList = plan.getCancellationFlowFeatures();
 
 	/**
+	 * Return plan + domain cancellation flow feature list
+	 */
+	if ( hasDomain === true && wpcomSiteURL.length > 0 && featureList.withDomain ) {
+		return featureList.withDomain;
+	}
+
+	/**
 	 * Return monthly or yearly cancellation flow feature list
 	 */
-
 	// Monthly plan
 	if ( isMonthlyPlan && featureList.monthly ) {
 		return featureList.monthly;

--- a/client/me/purchases/remove-plan-dialog/get-plan-features.tsx
+++ b/client/me/purchases/remove-plan-dialog/get-plan-features.tsx
@@ -1,0 +1,32 @@
+import { getPlan, isMonthly } from '@automattic/calypso-products';
+
+export default function getPlanFeatures( productSlug: string | undefined ): string[] {
+	if ( ! productSlug ) {
+		return [];
+	}
+
+	const isMonthlyPlan = isMonthly( productSlug );
+
+	const plan = getPlan( productSlug );
+	if ( ! plan || ! plan.getCancellationFlowFeatures ) {
+		return [];
+	}
+
+	const featureList = plan.getCancellationFlowFeatures();
+
+	/**
+	 * Return monthly or yearly cancellation flow feature list
+	 */
+
+	// Monthly plan
+	if ( isMonthlyPlan && featureList.monthly ) {
+		return featureList.monthly;
+	}
+
+	// Yearly plan
+	if ( ! isMonthlyPlan && featureList.yearly ) {
+		return featureList.yearly;
+	}
+
+	return [];
+}

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -46,7 +46,7 @@ export const RemovePlanDialog = ( {
 	const launchedStatus = site.launch_status === 'launched' ? true : false;
 	const shouldUseSiteThumbnail =
 		isComingSoon === false && isPrivate === false && launchedStatus === true;
-	let subTitle = '';
+	let subTitle = translate( 'If you cancel your plan, once it expires, you will lose:' );
 
 	if ( isRefundable && isAutoRenewing ) {
 		subTitle = translate( 'If you cancel your plan, you will lose:' );

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -41,8 +41,8 @@ export const RemovePlanDialog = ( {
 	const shouldUseSiteThumbnail =
 		isComingSoon === false && isPrivate === false && launchedStatus === true;
 	const subTitle = ! isRefundable
-		? translate( 'If you cancel your plan, once it expires, you will lose:' )
-		: translate( 'If you cancel your plan, you will lose:' );
+		? translate( 'If you cancel your plan, you will lose:' )
+		: translate( 'If you cancel your plan, once it expires, you will lose:' );
 
 	/**
 	 * Click events, buttons tracking and action.

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -31,10 +31,7 @@ export const RemovePlanDialog = ( {
 	const buttons = [
 		{
 			action: 'removePlan',
-			label: translate( 'Cancel my plan', {
-				comment:
-					'This button removes the active plan and all active Marketplace subscriptions on the site',
-			} ),
+			label: translate( 'Cancel my plan' ),
 			onClick: removePlan,
 		},
 		{

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { SiteScreenshot } from '../site-screenshot/';
 import getPlanFeatures from './get-plan-features';
 
@@ -30,23 +31,6 @@ export const RemovePlanDialog = ( {
 	const siteName = site.name ?? '';
 
 	/**
-	 * Dialog buttons
-	 */
-	const buttons = [
-		{
-			action: 'remove',
-			label: translate( 'Cancel my plan' ),
-			onClick: removePlan,
-		},
-		{
-			action: 'cancel',
-			label: translate( 'Keep my plan' ),
-			onClick: closeDialog,
-			isPrimary: true,
-		},
-	];
-
-	/**
 	 * Istantiate site's plan variables.
 	 */
 	const productSlug = site.plan?.product_slug;
@@ -60,6 +44,40 @@ export const RemovePlanDialog = ( {
 		hasDomain && wpcomSiteURL
 			? translate( 'If you cancel your plan, once it expires, you will lose:' )
 			: translate( 'If you cancel your plan, you will lose:' );
+
+	/**
+	 * Click events, buttons tracking and action.
+	 */
+	const clickRemovePlan = () => {
+		recordTracksEvent( 'calypso_remove_purchase_cancellation_modal_remove_plan_click', {
+			product_slug: productSlug,
+		} );
+		removePlan();
+	};
+
+	const clickCloseDialog = () => {
+		recordTracksEvent( 'calypso_remove_purchase_cancellation_modal_cancel_click', {
+			product_slug: productSlug,
+		} );
+		closeDialog();
+	};
+
+	/**
+	 * Dialog buttons
+	 */
+	const buttons = [
+		{
+			action: 'remove',
+			label: translate( 'Cancel my plan' ),
+			onClick: clickRemovePlan,
+		},
+		{
+			action: 'cancel',
+			label: translate( 'Keep my plan' ),
+			onClick: clickCloseDialog,
+			isPrimary: true,
+		},
+	];
 
 	/**
 	 * Return the list of features that the user will lose by canceling their plan.

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -16,6 +16,7 @@ interface RemovePlanDialogProps {
 	isRemoving: boolean;
 	site: SiteExcerptData;
 	hasDomain: boolean;
+	primaryDomain: string;
 	wpcomSiteURL: string;
 }
 
@@ -25,6 +26,7 @@ export const RemovePlanDialog = ( {
 	isDialogVisible,
 	site,
 	hasDomain,
+	primaryDomain,
 	wpcomSiteURL,
 }: RemovePlanDialogProps ) => {
 	const translate = useTranslate();
@@ -89,13 +91,14 @@ export const RemovePlanDialog = ( {
 
 			if ( planFeatures.length > 0 ) {
 				const domainFeature =
-					hasDomain && wpcomSiteURL ? (
+					hasDomain && primaryDomain && wpcomSiteURL ? (
 						<p>
 							{ translate(
-								'Your custom domain as primary. Your traffic will be redirected to %(domain)s',
+								'Your custom domain as primary. Your traffic will be redirected to %(domain)s - primarydomain: %(primaryDomain)s',
 								{
 									args: {
 										domain: wpcomSiteURL,
+										primaryDomain: primaryDomain,
 									},
 								}
 							) }

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -1,0 +1,143 @@
+import { Dialog, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { SiteScreenshot } from '../site-screenshot/';
+import getPlanFeatures from './get-plan-features';
+
+import './style.scss';
+
+interface RemovePlanDialogProps {
+	closeDialog: () => void;
+	removePlan: () => void;
+	isDialogVisible: boolean;
+	isRemoving: boolean;
+	site: SiteExcerptData;
+}
+
+export const RemovePlanDialog = ( {
+	closeDialog,
+	removePlan,
+	isDialogVisible,
+	site,
+}: RemovePlanDialogProps ) => {
+	const translate = useTranslate();
+	const siteName = site.name ?? '';
+
+	/**
+	 * Dialog buttons
+	 */
+	const buttons = [
+		{
+			action: 'removePlan',
+			label: translate( 'Cancel my plan', {
+				comment:
+					'This button removes the active plan and all active Marketplace subscriptions on the site',
+			} ),
+			onClick: removePlan,
+		},
+		{
+			action: 'cancel',
+			label: translate( 'Keep my plan' ),
+			onClick: closeDialog,
+			isPrimary: true,
+		},
+	];
+
+	/**
+	 * Istantiate site's plan variables.
+	 */
+	const productSlug = site.plan?.product_slug;
+	const planLabel = site.plan?.product_name_short;
+	const isComingSoon = site.is_coming_soon;
+	const isPrivate = site.is_private;
+	const launchedStatus = site.launch_status === 'launched' ? true : false;
+	const shouldUseSiteThumbnail =
+		isComingSoon === false && isPrivate === false && launchedStatus === true;
+
+	/**
+	 * Return the list of features that the user will lose by canceling their plan.
+	 *
+	 * @returns Fragment
+	 */
+	const FeaturesList = () => {
+		if ( typeof productSlug === 'string' ) {
+			const planFeatures = getPlanFeatures( productSlug );
+
+			if ( planFeatures.length > 0 ) {
+				return (
+					<Fragment>
+						<p>{ translate( 'If you cancel your plan, you will lose:' ) }</p>
+						<ul className="remove-plan-dialog__list-plan-features">
+							{ planFeatures.map( ( feature, index ) => {
+								return (
+									<li key={ index }>
+										<Gridicon
+											className="remove-plan-dialog__item-cross-small"
+											size={ 24 }
+											icon="cross-small"
+										/>
+										{ feature }
+									</li>
+								);
+							} ) }
+						</ul>
+					</Fragment>
+				);
+			}
+		}
+
+		return null;
+	};
+
+	/**
+	 * Dialog classname
+	 */
+	const dialogClassName = shouldUseSiteThumbnail
+		? 'remove-plan-dialog --with-screenshot'
+		: 'remove-plan-dialog';
+
+	/**
+	 * Plan cancellation dialog.
+	 */
+	return (
+		<Dialog
+			buttons={ buttons }
+			className={ dialogClassName }
+			isVisible={ isDialogVisible }
+			onClose={ closeDialog }
+		>
+			<Fragment>
+				<button className="remove-plan-dialog__close-button" onClick={ closeDialog }>
+					<Gridicon
+						className="remove-plan-dialog__item-cross-small"
+						size={ 24 }
+						icon="cross-small"
+					/>
+				</button>
+				<div className="remove-plan-dialog__grid">
+					{ shouldUseSiteThumbnail && (
+						<div className="remove-plan-dialog__grid-colmn">
+							<SiteScreenshot
+								className="remove-plan-dialog__site-screenshot"
+								site={ site }
+								alt={ siteName }
+							/>
+						</div>
+					) }
+					<div className="remove-plan-dialog__grid-colmn">
+						<FormattedHeader
+							brandFont
+							headerText={ translate( 'Are you sure you want to cancel your %(label)s plan?', {
+								args: { label: planLabel },
+							} ) }
+							align="left"
+						/>
+						<FeaturesList />
+					</div>
+				</div>
+			</Fragment>
+		</Dialog>
+	);
+};

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -17,7 +17,7 @@ interface RemovePlanDialogProps {
 	site: SiteExcerptData;
 	hasDomain: boolean;
 	primaryDomain: string;
-	wpcomSlug: string;
+	wpcomURL: string;
 }
 
 export const RemovePlanDialog = ( {
@@ -27,7 +27,7 @@ export const RemovePlanDialog = ( {
 	site,
 	hasDomain,
 	primaryDomain,
-	wpcomSlug,
+	wpcomURL,
 }: RemovePlanDialogProps ) => {
 	const translate = useTranslate();
 	const siteName = site.name ?? '';
@@ -87,18 +87,18 @@ export const RemovePlanDialog = ( {
 	 */
 	const FeaturesList = () => {
 		if ( typeof productSlug === 'string' ) {
-			const planFeatures = getPlanFeatures( productSlug, hasDomain, wpcomSlug );
+			const planFeatures = getPlanFeatures( productSlug, hasDomain, wpcomURL );
 
 			if ( planFeatures.length > 0 ) {
 				const domainFeature =
-					hasDomain && primaryDomain && wpcomSlug ? (
+					hasDomain && primaryDomain && wpcomURL ? (
 						<p>
 							{ translate(
-								'Your custom domain as primary. Your traffic will be redirected to %(domain)s - primarydomain: %(primaryDomain)s',
+								'The ability to have %(customDomain)s as your primary site address. %(wpcomURL)s will be the new address that people see when they visit your site.',
 								{
 									args: {
-										domain: wpcomSlug,
-										primaryDomain: primaryDomain,
+										wpcomURL: wpcomURL,
+										customDomain: primaryDomain,
 									},
 								}
 							) }

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -89,9 +89,9 @@ export const RemovePlanDialog = ( {
 						<p>{ subTitle }</p>
 						<ul className="remove-plan-dialog__list-plan-features">
 							{ domainFeature }
-							{ planFeatures.map( ( feature, index ) => {
+							{ planFeatures.map( ( feature ) => {
 								return (
-									<li key={ index }>
+									<li key={ feature }>
 										<Gridicon
 											className="remove-plan-dialog__item-cross-small"
 											size={ 24 }

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -17,7 +17,7 @@ interface RemovePlanDialogProps {
 	site: SiteExcerptData;
 	hasDomain: boolean;
 	primaryDomain: string;
-	wpcomSiteURL: string;
+	wpcomSlug: string;
 }
 
 export const RemovePlanDialog = ( {
@@ -27,7 +27,7 @@ export const RemovePlanDialog = ( {
 	site,
 	hasDomain,
 	primaryDomain,
-	wpcomSiteURL,
+	wpcomSlug,
 }: RemovePlanDialogProps ) => {
 	const translate = useTranslate();
 	const siteName = site.name ?? '';
@@ -87,17 +87,17 @@ export const RemovePlanDialog = ( {
 	 */
 	const FeaturesList = () => {
 		if ( typeof productSlug === 'string' ) {
-			const planFeatures = getPlanFeatures( productSlug, hasDomain, wpcomSiteURL );
+			const planFeatures = getPlanFeatures( productSlug, hasDomain, wpcomSlug );
 
 			if ( planFeatures.length > 0 ) {
 				const domainFeature =
-					hasDomain && primaryDomain && wpcomSiteURL ? (
+					hasDomain && primaryDomain && wpcomSlug ? (
 						<p>
 							{ translate(
 								'Your custom domain as primary. Your traffic will be redirected to %(domain)s - primarydomain: %(primaryDomain)s',
 								{
 									args: {
-										domain: wpcomSiteURL,
+										domain: wpcomSlug,
 										primaryDomain: primaryDomain,
 									},
 								}

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -17,6 +17,7 @@ interface RemovePlanDialogProps {
 	site: SiteExcerptData;
 	hasDomain: boolean;
 	isRefundable: boolean;
+	isAutoRenewing: boolean;
 	primaryDomain: string;
 	wpcomURL: string;
 }
@@ -28,6 +29,7 @@ export const RemovePlanDialog = ( {
 	site,
 	hasDomain,
 	isRefundable,
+	isAutoRenewing,
 	primaryDomain,
 	wpcomURL,
 }: RemovePlanDialogProps ) => {
@@ -44,9 +46,15 @@ export const RemovePlanDialog = ( {
 	const launchedStatus = site.launch_status === 'launched' ? true : false;
 	const shouldUseSiteThumbnail =
 		isComingSoon === false && isPrivate === false && launchedStatus === true;
-	const subTitle = isRefundable
-		? translate( 'If you cancel your plan, once it expires, you will lose:' )
-		: translate( 'If you cancel your plan, you will lose:' );
+	let subTitle = '';
+
+	if ( isRefundable && isAutoRenewing ) {
+		subTitle = translate( 'If you cancel your plan, you will lose:' );
+	} else if ( ! isRefundable && isAutoRenewing ) {
+		subTitle = translate( 'If you cancel your plan, once it expires, you will lose:' );
+	} else if ( ! isRefundable && ! isAutoRenewing ) {
+		translate( 'If you remove your plan, you will lose:' );
+	}
 
 	/**
 	 * Click events, buttons tracking and action.

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -71,10 +71,24 @@ export const RemovePlanDialog = ( {
 			const planFeatures = getPlanFeatures( productSlug, hasDomain, wpcomSiteURL );
 
 			if ( planFeatures.length > 0 ) {
+				const domainFeature =
+					hasDomain && wpcomSiteURL ? (
+						<p>
+							{ translate(
+								'Your custom domain as primary. Your traffic will be redirected to %(domain)s',
+								{
+									args: {
+										domain: wpcomSiteURL,
+									},
+								}
+							) }
+						</p>
+					) : null;
 				return (
 					<Fragment>
 						<p>{ subTitle }</p>
 						<ul className="remove-plan-dialog__list-plan-features">
+							{ domainFeature }
 							{ planFeatures.map( ( feature, index ) => {
 								return (
 									<li key={ index }>

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -14,6 +14,8 @@ interface RemovePlanDialogProps {
 	isDialogVisible: boolean;
 	isRemoving: boolean;
 	site: SiteExcerptData;
+	hasDomain: boolean;
+	wpcomSiteURL: string;
 }
 
 export const RemovePlanDialog = ( {
@@ -21,6 +23,8 @@ export const RemovePlanDialog = ( {
 	removePlan,
 	isDialogVisible,
 	site,
+	hasDomain,
+	wpcomSiteURL,
 }: RemovePlanDialogProps ) => {
 	const translate = useTranslate();
 	const siteName = site.name ?? '';
@@ -30,7 +34,7 @@ export const RemovePlanDialog = ( {
 	 */
 	const buttons = [
 		{
-			action: 'removePlan',
+			action: 'remove',
 			label: translate( 'Cancel my plan' ),
 			onClick: removePlan,
 		},
@@ -52,6 +56,10 @@ export const RemovePlanDialog = ( {
 	const launchedStatus = site.launch_status === 'launched' ? true : false;
 	const shouldUseSiteThumbnail =
 		isComingSoon === false && isPrivate === false && launchedStatus === true;
+	const subTitle =
+		hasDomain && wpcomSiteURL
+			? translate( 'If you cancel your plan, once it expires, you will lose:' )
+			: translate( 'If you cancel your plan, you will lose:' );
 
 	/**
 	 * Return the list of features that the user will lose by canceling their plan.
@@ -60,12 +68,12 @@ export const RemovePlanDialog = ( {
 	 */
 	const FeaturesList = () => {
 		if ( typeof productSlug === 'string' ) {
-			const planFeatures = getPlanFeatures( productSlug );
+			const planFeatures = getPlanFeatures( productSlug, hasDomain, wpcomSiteURL );
 
 			if ( planFeatures.length > 0 ) {
 				return (
 					<Fragment>
-						<p>{ translate( 'If you cancel your plan, you will lose:' ) }</p>
+						<p>{ subTitle }</p>
 						<ul className="remove-plan-dialog__list-plan-features">
 							{ planFeatures.map( ( feature, index ) => {
 								return (

--- a/client/me/purchases/remove-plan-dialog/index.tsx
+++ b/client/me/purchases/remove-plan-dialog/index.tsx
@@ -3,10 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { isRefundable } from 'calypso/lib/purchases';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { SiteScreenshot } from '../site-screenshot/';
 import getPlanFeatures from './get-plan-features';
-
 import './style.scss';
 
 interface RemovePlanDialogProps {
@@ -40,10 +40,9 @@ export const RemovePlanDialog = ( {
 	const launchedStatus = site.launch_status === 'launched' ? true : false;
 	const shouldUseSiteThumbnail =
 		isComingSoon === false && isPrivate === false && launchedStatus === true;
-	const subTitle =
-		hasDomain && wpcomSiteURL
-			? translate( 'If you cancel your plan, once it expires, you will lose:' )
-			: translate( 'If you cancel your plan, you will lose:' );
+	const subTitle = ! isRefundable
+		? translate( 'If you cancel your plan, once it expires, you will lose:' )
+		: translate( 'If you cancel your plan, you will lose:' );
 
 	/**
 	 * Click events, buttons tracking and action.

--- a/client/me/purchases/remove-plan-dialog/style.scss
+++ b/client/me/purchases/remove-plan-dialog/style.scss
@@ -83,6 +83,10 @@ $modal-breakpoint-mobile: 480px;
 			@media ( max-width: $modal-breakpoint-tablet ) {
 				display: block;
 			}
+
+			strong {
+				overflow-wrap: anywhere;
+			}
 		}
 
 		.remove-plan-dialog__grid-colmn:first-child {
@@ -122,26 +126,43 @@ $modal-breakpoint-mobile: 480px;
 			}
 		}
 	}
-}
 
-.remove-plan-dialog__item-cross-small {
-	color: #e65054;
-	vertical-align: middle;
-	margin-right: 10px;
-}
-
-.remove-plan-dialog__list-plan-features {
-	list-style-type: none;
-	margin: 0;
-	text-align: left;
-
-	@media ( max-width: $modal-breakpoint-tablet ) {
-		margin-bottom: 48px;
+	.remove-plan-dialog__item-cross-small {
+		color: #e65054;
+		vertical-align: middle;
+		margin-right: 10px;
 	}
 
-	li {
-		display: grid;
-		grid-template-columns: 32px 1fr;
-		margin-bottom: 5px;
+	.remove-plan-dialog__list-plan-features {
+		list-style-type: none;
+		margin: 0;
+		text-align: left;
+
+		@media ( max-width: $modal-breakpoint-tablet ) {
+			margin-bottom: 48px;
+		}
+
+		li {
+			display: grid;
+			grid-template-columns: 32px 1fr;
+			margin-bottom: 5px;
+		}
+	}
+
+	&.--with-domain-feature {
+		.remove-plan-dialog__list-plan-features {
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				margin-bottom: 98px;
+			}
+
+			@media ( max-width: $modal-breakpoint-mobile ) {
+				margin-bottom: 58px;
+			}
+		}
+
+		& + .dialog__action-buttons {
+			margin-top: -67px;
+			margin-bottom: 27px;
+		}
 	}
 }

--- a/client/me/purchases/remove-plan-dialog/style.scss
+++ b/client/me/purchases/remove-plan-dialog/style.scss
@@ -1,0 +1,147 @@
+$modal-breakpoint-tablet: 1070px;
+$modal-breakpoint-mobile: 480px;
+
+.dialog__content.remove-plan-dialog {
+	padding: 0;
+	max-width: 500px;
+	background: #fff;
+
+	.remove-plan-dialog__close-button {
+		cursor: pointer;
+		position: absolute;
+		right: 0;
+		top: 9px;
+
+		.gridicon {
+			color: #000;
+		}
+	}
+
+	.remove-plan-dialog__site-screenshot {
+		width: 365px;
+		height: 483px;
+		padding: 48px 24px;
+
+		&.site-thumbnail-loading {
+			background-color: transparent;
+			border: none;
+
+		}
+	}
+
+	& + .dialog__action-buttons {
+		&::before {
+			background: none;
+		}
+
+		margin-left: 48px;
+		margin-top: 32px;
+		margin-bottom: 48px;
+		border: none;
+		background: transparent;
+		text-align: left;
+		padding: 0;
+
+		@media ( max-width: $modal-breakpoint-mobile ) {
+			margin-right: 48px;
+		}
+	}
+
+	.remove-plan-dialog__grid-colmn {
+		text-align: left;
+		padding: 48px 48px 0;
+
+		.formatted-header__title {
+			font-size: 1.5rem;
+			font-weight: inherit;
+			margin-bottom: 0.75em;
+		}
+
+		.formatted-header.is-left-align,
+		.formatted-header.is-right-align {
+			margin: 0;
+		}
+
+		@media ( max-width: $modal-breakpoint-mobile ) {
+			padding: 48px 24px;
+		}
+	}
+
+	&.--with-screenshot {
+		max-width: 960px;
+
+		@media ( max-width: $modal-breakpoint-tablet ) {
+			max-width: 500px;
+		}
+
+		.remove-plan-dialog__grid {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			vertical-align: middle;
+			text-align: center;
+
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				display: block;
+			}
+		}
+
+		.remove-plan-dialog__grid-colmn:first-child {
+			background: #f0f0f0;
+			padding-bottom: 0;
+
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				display: none;
+			}
+		}
+
+		& + .dialog__action-buttons {
+			margin-left: calc(50% + 48px);
+			margin-top: -92px;
+			margin-bottom: 52px;
+			border: none;
+			background: transparent;
+			text-align: left;
+			padding: 0;
+
+			&::before {
+				content: none;
+			}
+
+			button:first-child {
+				margin-left: 0;
+			}
+
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				margin-left: 48px;
+				margin-top: 0;
+				margin-bottom: 48px;
+			}
+
+			@media ( max-width: $modal-breakpoint-mobile ) {
+				margin-right: 48px;
+			}
+		}
+	}
+}
+
+.remove-plan-dialog__item-cross-small {
+	color: #e65054;
+	vertical-align: middle;
+	margin-right: 10px;
+}
+
+.remove-plan-dialog__list-plan-features {
+	list-style-type: none;
+	margin: 0;
+	text-align: left;
+
+	@media ( max-width: $modal-breakpoint-tablet ) {
+		margin-bottom: 48px;
+	}
+
+	li {
+		display: grid;
+		grid-template-columns: 32px 1fr;
+		margin-bottom: 5px;
+	}
+}

--- a/client/me/purchases/remove-plan-dialog/style.scss
+++ b/client/me/purchases/remove-plan-dialog/style.scss
@@ -63,7 +63,7 @@ $modal-breakpoint-mobile: 480px;
 		}
 
 		@media ( max-width: $modal-breakpoint-mobile ) {
-			padding: 48px 24px;
+			padding: 48px 24px 0;
 		}
 	}
 
@@ -138,10 +138,6 @@ $modal-breakpoint-mobile: 480px;
 		margin: 0;
 		text-align: left;
 
-		@media ( max-width: $modal-breakpoint-tablet ) {
-			margin-bottom: 48px;
-		}
-
 		li {
 			display: grid;
 			grid-template-columns: 32px 1fr;
@@ -150,13 +146,37 @@ $modal-breakpoint-mobile: 480px;
 	}
 
 	&.--with-domain-feature {
+
+		.remove-plan-dialog__grid-colmn {
+			@media ( max-width: $modal-breakpoint-mobile ) {
+				padding: 48px 24px;
+			}
+		}
+
 		.remove-plan-dialog__list-plan-features {
+			margin-bottom: 98px;
+
 			@media ( max-width: $modal-breakpoint-tablet ) {
 				margin-bottom: 98px;
 			}
 
 			@media ( max-width: $modal-breakpoint-mobile ) {
 				margin-bottom: 58px;
+			}
+		}
+
+		&.--with-screenshot {
+
+			.remove-plan-dialog__list-plan-features {
+				margin-bottom: 0;
+				
+				@media ( max-width: $modal-breakpoint-tablet ) {
+					margin-bottom: 98px;
+				}
+
+				@media ( max-width: $modal-breakpoint-mobile ) {
+					margin-bottom: 58px;
+				}
 			}
 		}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -241,7 +241,7 @@ class RemovePurchase extends Component {
 				removePlan={ this.showRemovePlanDialog }
 				site={ site }
 				hasDomain={ hasCustomDomain }
-				wpcomSiteURL={ site.slug }
+				wpcomSlug={ site.slug }
 				primaryDomain={ primaryDomainName }
 			/>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -225,7 +225,7 @@ class RemovePurchase extends Component {
 
 	shouldShowPlanWarning() {
 		const { purchase } = this.props;
-		return isPlan( purchase );
+		return isPlan( purchase ) && ! isJetpackProduct( purchase ) && ! isJetpackPlan( purchase );
 	}
 
 	renderPlanWarningDialog() {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -61,6 +61,7 @@ class RemovePurchase extends Component {
 		purchaseListUrl: PropTypes.string,
 		activeSubscriptions: PropTypes.array,
 		linkIcon: PropTypes.string,
+		primaryDomain: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -240,7 +241,7 @@ class RemovePurchase extends Component {
 				removePlan={ this.showRemovePlanDialog }
 				site={ site }
 				hasDomain={ hasCustomDomain }
-				wpcomSiteURL={ site.wpcom_url }
+				wpcomSiteURL={ site.slug }
 				primaryDomain={ primaryDomainName }
 			/>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -24,6 +24,7 @@ import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-surve
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { getName, isRemovable } from 'calypso/lib/purchases';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
+import { RemovePlanDialog } from 'calypso/me/purchases/remove-plan-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
@@ -68,6 +69,7 @@ class RemovePurchase extends Component {
 		isDialogVisible: false,
 		isRemoving: false,
 		isShowingNonPrimaryDomainWarning: false,
+		isShowingRemovePlanWarning: false,
 		isShowingMarketplaceSubscriptionsDialog: false,
 	};
 
@@ -75,6 +77,7 @@ class RemovePurchase extends Component {
 		this.setState( {
 			isDialogVisible: false,
 			isShowingNonPrimaryDomainWarning: false,
+			isShowingRemovePlanWarning: false,
 			isShowingMarketplaceSubscriptionsDialog: false,
 		} );
 	};
@@ -83,6 +86,7 @@ class RemovePurchase extends Component {
 		this.setState( {
 			isShowingMarketplaceSubscriptionsDialog: false,
 			isShowingNonPrimaryDomainWarning: false,
+			isShowingRemovePlanWarning: false,
 			isDialogVisible: true,
 		} );
 	};
@@ -93,7 +97,14 @@ class RemovePurchase extends Component {
 		if ( this.props.onClickTracks ) {
 			this.props.onClickTracks( event );
 		}
-		if (
+		if ( this.shouldShowPlanWarning() && ! this.state.isShowingRemovePlanWarning ) {
+			this.setState( {
+				isShowingRemovePlanWarning: true,
+				isShowingNonPrimaryDomainWarning: false,
+				isShowingMarketplaceSubscriptionsDialog: false,
+				isDialogVisible: false,
+			} );
+		} else if (
 			this.shouldShowNonPrimaryDomainWarning() &&
 			! this.state.isShowingNonPrimaryDomainWarning
 		) {
@@ -208,6 +219,23 @@ class RemovePurchase extends Component {
 				planName={ getName( purchase ) }
 				oldDomainName={ site.domain }
 				newDomainName={ site.wpcom_url }
+			/>
+		);
+	}
+
+	shouldShowPlanWarning() {
+		const { purchase } = this.props;
+		return isPlan( purchase );
+	}
+
+	renderPlanWarningDialog() {
+		const { site } = this.props;
+		return (
+			<RemovePlanDialog
+				isDialogVisible={ this.state.isShowingRemovePlanWarning }
+				closeDialog={ this.closeDialog }
+				removePlan={ this.showRemovePlanDialog }
+				site={ site }
 			/>
 		);
 	}
@@ -353,6 +381,21 @@ class RemovePurchase extends Component {
 
 		const wrapperClassName = classNames( 'remove-purchase__card', className );
 		const Wrapper = useVerticalNavItem ? VerticalNavItem : CompactCard;
+		const getWarningDialog = () => {
+			if ( this.shouldShowPlanWarning() ) {
+				return this.renderPlanWarningDialog();
+			}
+
+			if ( this.shouldShowNonPrimaryDomainWarning() ) {
+				return this.renderNonPrimaryDomainWarningDialog();
+			}
+
+			if ( this.shouldHandleMarketplaceSubscriptions() ) {
+				return this.renderMarketplaceSubscriptionsDialog();
+			}
+
+			return null;
+		};
 
 		return (
 			<>
@@ -360,9 +403,7 @@ class RemovePurchase extends Component {
 					{ this.props.children ? this.props.children : defaultContent }
 					<Gridicon className="card__link-indicator" icon={ this.props.linkIcon || 'trash' } />
 				</Wrapper>
-				{ this.shouldShowNonPrimaryDomainWarning() && this.renderNonPrimaryDomainWarningDialog() }
-				{ this.shouldHandleMarketplaceSubscriptions() &&
-					this.renderMarketplaceSubscriptionsDialog() }
+				{ getWarningDialog() }
 				{ this.renderDialog() }
 			</>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -239,7 +239,7 @@ class RemovePurchase extends Component {
 				? primaryDomainName
 				: primaryDomainName.substr( 0, 10 ) + '…' + primaryDomainName.slice( -10 );
 		const wordpressComURL =
-			site.wpcom_url.legth < 30
+			site.wpcom_url.length < 30
 				? site.wpcom_url
 				: site.wpcom_url.substr( 0, 8 ) + '…' + site.wpcom_url.slice( -20 );
 		return (

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -11,7 +11,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -229,10 +229,7 @@ class RemovePurchase extends Component {
 	shouldShowPlanWarning() {
 		const { purchase } = this.props;
 		return (
-			isPlan( purchase ) &&
-			! isJetpackPlan( purchase ) &&
-			! isGSuiteOrGoogleWorkspace( purchase ) &&
-			'en' === getLocaleSlug() // TODO: remove this when the translations are completed.
+			isPlan( purchase ) && ! isJetpackPlan( purchase ) && ! isGSuiteOrGoogleWorkspace( purchase )
 		);
 	}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -22,7 +22,7 @@ import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-pur
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getName, isRemovable } from 'calypso/lib/purchases';
+import { getName, isRefundable, isRemovable } from 'calypso/lib/purchases';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import { RemovePlanDialog } from 'calypso/me/purchases/remove-plan-dialog';
@@ -232,8 +232,16 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanWarningDialog() {
-		const { site, primaryDomain } = this.props;
+		const { site, purchase, primaryDomain } = this.props;
 		const primaryDomainName = hasCustomDomain && primaryDomain ? primaryDomain.name : '';
+		const primaryDomainURL =
+			primaryDomainName.length < 20
+				? primaryDomainName
+				: primaryDomainName.substr( 0, 10 ) + '…' + primaryDomainName.slice( -10 );
+		const wordpressComURL =
+			site.wpcom_url.legth < 30
+				? site.wpcom_url
+				: site.wpcom_url.substr( 0, 8 ) + '…' + site.wpcom_url.slice( -20 );
 		return (
 			<RemovePlanDialog
 				isDialogVisible={ this.state.isShowingRemovePlanWarning }
@@ -241,8 +249,9 @@ class RemovePurchase extends Component {
 				removePlan={ this.showRemovePlanDialog }
 				site={ site }
 				hasDomain={ hasCustomDomain }
-				wpcomURL={ site.wpcom_url }
-				primaryDomain={ primaryDomainName }
+				isRefundable={ isRefundable( purchase ) }
+				primaryDomain={ primaryDomainURL }
+				wpcomURL={ wordpressComURL }
 			/>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -241,7 +241,7 @@ class RemovePurchase extends Component {
 				removePlan={ this.showRemovePlanDialog }
 				site={ site }
 				hasDomain={ hasCustomDomain }
-				wpcomSlug={ site.slug }
+				wpcomURL={ site.wpcom_url }
 				primaryDomain={ primaryDomainName }
 			/>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -234,14 +234,15 @@ class RemovePurchase extends Component {
 	renderPlanWarningDialog() {
 		const { site, purchase, primaryDomain } = this.props;
 		const primaryDomainName = hasCustomDomain && primaryDomain ? primaryDomain.name : '';
-		const primaryDomainURL =
-			primaryDomainName.length < 20
-				? primaryDomainName
-				: primaryDomainName.substr( 0, 10 ) + '…' + primaryDomainName.slice( -10 );
-		const wordpressComURL =
-			site.wpcom_url.length < 30
-				? site.wpcom_url
-				: site.wpcom_url.substr( 0, 8 ) + '…' + site.wpcom_url.slice( -20 );
+
+		let wordpressComURL = '';
+		if ( typeof site.wpcom_url !== 'undefined' ) {
+			wordpressComURL =
+				site.wpcom_url.length < 35
+					? site.wpcom_url
+					: site.wpcom_url.substr( 0, 10 ) + '…' + site.wpcom_url.slice( -20 );
+		}
+
 		return (
 			<RemovePlanDialog
 				isDialogVisible={ this.state.isShowingRemovePlanWarning }
@@ -250,7 +251,7 @@ class RemovePurchase extends Component {
 				site={ site }
 				hasDomain={ hasCustomDomain }
 				isRefundable={ isRefundable( purchase ) }
-				primaryDomain={ primaryDomainURL }
+				primaryDomain={ primaryDomainName }
 				wpcomURL={ wordpressComURL }
 			/>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -23,6 +23,7 @@ import PrecancellationChatButton from 'calypso/components/marketing-survey/cance
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { getName, isRemovable } from 'calypso/lib/purchases';
+import { hasCustomDomain } from 'calypso/lib/site/utils';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import { RemovePlanDialog } from 'calypso/me/purchases/remove-plan-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -230,12 +231,15 @@ class RemovePurchase extends Component {
 
 	renderPlanWarningDialog() {
 		const { site } = this.props;
+
 		return (
 			<RemovePlanDialog
 				isDialogVisible={ this.state.isShowingRemovePlanWarning }
 				closeDialog={ this.closeDialog }
 				removePlan={ this.showRemovePlanDialog }
 				site={ site }
+				hasDomain={ hasCustomDomain }
+				wpcomSiteURL={ site.wpcom_url }
 			/>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -32,6 +32,7 @@ import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { removePurchase } from 'calypso/state/purchases/actions';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { receiveDeletedSite } from 'calypso/state/sites/actions';
@@ -230,8 +231,8 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanWarningDialog() {
-		const { site } = this.props;
-
+		const { site, primaryDomain } = this.props;
+		const primaryDomainName = hasCustomDomain && primaryDomain ? primaryDomain.name : '';
 		return (
 			<RemovePlanDialog
 				isDialogVisible={ this.state.isShowingRemovePlanWarning }
@@ -240,6 +241,7 @@ class RemovePurchase extends Component {
 				site={ site }
 				hasDomain={ hasCustomDomain }
 				wpcomSiteURL={ site.wpcom_url }
+				primaryDomain={ primaryDomainName }
 			/>
 		);
 	}
@@ -424,6 +426,7 @@ export default connect(
 			isJetpack,
 			purchasesError: getPurchasesError( state ),
 			userId: getCurrentUserId( state ),
+			primaryDomain: getPrimaryDomainBySiteId( state, purchase.siteId ),
 		};
 	},
 	{

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -11,7 +11,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -228,7 +228,12 @@ class RemovePurchase extends Component {
 
 	shouldShowPlanWarning() {
 		const { purchase } = this.props;
-		return isPlan( purchase ) && ! isJetpackProduct( purchase ) && ! isJetpackPlan( purchase );
+		return (
+			isPlan( purchase ) &&
+			! isJetpackPlan( purchase ) &&
+			! isGSuiteOrGoogleWorkspace( purchase ) &&
+			'en' === getLocaleSlug()
+		); // TODO: remove this when the translations are completed. ;
 	}
 
 	renderPlanWarningDialog() {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -22,7 +22,7 @@ import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-pur
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getName, isRefundable, isRemovable } from 'calypso/lib/purchases';
+import { getName, isAutoRenewing, isRefundable, isRemovable } from 'calypso/lib/purchases';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import { RemovePlanDialog } from 'calypso/me/purchases/remove-plan-dialog';
@@ -232,8 +232,8 @@ class RemovePurchase extends Component {
 			isPlan( purchase ) &&
 			! isJetpackPlan( purchase ) &&
 			! isGSuiteOrGoogleWorkspace( purchase ) &&
-			'en' === getLocaleSlug()
-		); // TODO: remove this when the translations are completed. ;
+			'en' === getLocaleSlug() // TODO: remove this when the translations are completed.
+		);
 	}
 
 	renderPlanWarningDialog() {
@@ -256,6 +256,7 @@ class RemovePurchase extends Component {
 				site={ site }
 				hasDomain={ hasCustomDomain }
 				isRefundable={ isRefundable( purchase ) }
+				isAutoRenewing={ isAutoRenewing( purchase ) }
 				primaryDomain={ primaryDomainName }
 				wpcomURL={ wordpressComURL }
 			/>

--- a/client/me/purchases/site-screenshot/index.tsx
+++ b/client/me/purchases/site-screenshot/index.tsx
@@ -50,7 +50,7 @@ export const SiteScreenshot = ( { site, alt, ...props }: SiteScreenshotProps ) =
 			bgColorImgUrl={ site.icon?.img }
 			mshotsOption={ MShotsOptions }
 			width={ 365 }
-			height={ 500 }
+			height={ 483 }
 		>
 			<Spinner className="site-screenshot__spinner" size={ 50 } />
 		</SiteThumbnail>

--- a/client/me/purchases/site-screenshot/index.tsx
+++ b/client/me/purchases/site-screenshot/index.tsx
@@ -49,6 +49,8 @@ export const SiteScreenshot = ( { site, alt, ...props }: SiteScreenshotProps ) =
 			alt={ alt }
 			bgColorImgUrl={ site.icon?.img }
 			mshotsOption={ MShotsOptions }
+			width={ 365 }
+			height={ 500 }
 		>
 			<Spinner className="site-screenshot__spinner" size={ 50 } />
 		</SiteThumbnail>

--- a/client/me/purchases/site-screenshot/index.tsx
+++ b/client/me/purchases/site-screenshot/index.tsx
@@ -1,0 +1,56 @@
+import { SiteThumbnail, getSiteLaunchStatus, Spinner } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import { ComponentProps } from 'react';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+import './style.scss';
+
+interface SiteScreenshotProps extends ComponentProps< typeof SiteThumbnail > {
+	site: SiteExcerptData;
+	alt: string;
+}
+
+/**
+ * Create a site screenshot using mShots.
+ *
+ * @returns SiteThumbnail
+ */
+export const SiteScreenshot = ( { site, alt, ...props }: SiteScreenshotProps ) => {
+	const shouldUseScreenshot = getSiteLaunchStatus( site ) === 'public';
+
+	let siteUrl = site.URL;
+	if ( site.options?.updated_at ) {
+		const updatedAt = new Date( site.options.updated_at );
+		updatedAt.setMinutes( 0 );
+		updatedAt.setSeconds( 0 );
+		siteUrl = addQueryArgs( siteUrl, {
+			v: updatedAt.getTime() / 1000,
+
+			// This combination of flags stops free site headers and cookie banners from appearing.
+			iframe: true,
+			preview: true,
+			hide_banners: true,
+		} );
+	}
+
+	// mShots screenshot options.
+	const MShotsOptions = {
+		vpw: 1602,
+		vph: 2120,
+		w: 365,
+		screen_height: 2120,
+	};
+
+	return (
+		<SiteThumbnail
+			{ ...props }
+			mShotsUrl={ shouldUseScreenshot ? siteUrl : undefined }
+			className={ `site-screenshot` }
+			alt={ alt }
+			bgColorImgUrl={ site.icon?.img }
+			mshotsOption={ MShotsOptions }
+		>
+			<Spinner className="site-screenshot__spinner" size={ 50 } />
+		</SiteThumbnail>
+	);
+};

--- a/client/me/purchases/site-screenshot/index.tsx
+++ b/client/me/purchases/site-screenshot/index.tsx
@@ -1,4 +1,4 @@
-import { SiteThumbnail, getSiteLaunchStatus, Spinner } from '@automattic/components';
+import { SiteThumbnail, Spinner } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentProps } from 'react';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -16,7 +16,8 @@ interface SiteScreenshotProps extends ComponentProps< typeof SiteThumbnail > {
  * @returns SiteThumbnail
  */
 export const SiteScreenshot = ( { site, alt, ...props }: SiteScreenshotProps ) => {
-	const shouldUseScreenshot = getSiteLaunchStatus( site ) === 'public';
+	const shouldUseScreenshot =
+		! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
 
 	let siteUrl = site.URL;
 	if ( site.options?.updated_at ) {

--- a/client/me/purchases/site-screenshot/style.scss
+++ b/client/me/purchases/site-screenshot/style.scss
@@ -1,0 +1,12 @@
+.site-screenshot.site-thumbnail {
+	width: 365px;
+	height: 483px;
+	box-shadow: 0 0 10px rgba(0, 0, 0, 15%);
+	border: 1px solid #bbe0fa;
+	margin: auto;
+}
+
+.site-screenshot.site-thumbnail-loading {
+	background-color: transparent;
+	border: none;
+}

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -233,6 +233,7 @@ import type {
 	WPComPlan,
 	IncompleteWPcomPlan,
 	IncompleteJetpackPlan,
+	CancellationFlowFeatures,
 } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -286,6 +287,32 @@ const plansDescriptionHeadingComponent = {
 	},
 };
 /* eslint-enable */
+
+const cancellationFlowTerms = {
+	ACCEPT_PAYMENTS: i18n.translate( 'Accept payments in 60+ countries' ),
+	AD_FREE_SITE: i18n.translate( 'An ad-free site' ),
+	AND_MORE: i18n.translate( 'and more…' ),
+	BACKUPS: i18n.translate( 'Automated website backups' ),
+	BACKUPS_AND_RESTORE: i18n.translate( 'Automated site backups and one-click restore' ),
+	COLLECT_PAYMENTS: i18n.translate( 'The ability to collect payments' ),
+	EARN_AD_REVENUE: i18n.translate( 'The ability to earn ad revenue' ),
+	EMAIL_SUPPORT: i18n.translate( 'Unlimited customer support via email' ),
+	GOOGLE_ANALYTICS: i18n.translate( 'Google Analytics integration' ),
+	HIGH_QUALITY_VIDEOS: i18n.translate( 'High quality videos' ),
+	HOSTING: i18n.translate( 'Best-in-class hosting' ),
+	JETPACK_ESSENTIALS: i18n.translate( 'Jetpack essentials' ),
+	LIVE_CHAT: i18n.translate( 'Access to live chat support' ),
+	MANAGED_HOSTINGS: i18n.translate( 'Access to managed hosting' ),
+	PLUGINS: i18n.translate( 'Access to more than 50,000 plugins' ),
+	PREMIUM_DESIGN: i18n.translate( 'Premium design options customized for online stores' ),
+	PREMIUM_THEMES: i18n.translate( 'Access to premium themes' ),
+	SECURITY_AND_SPAM: i18n.translate( 'Professional security and spam protection' ),
+	SEO_TOOLS: i18n.translate( 'Advanced SEO tools' ),
+	SEO_AND_SOCIAL: i18n.translate( 'SEO and social tools' ),
+	SFTP_AND_DATABASE: i18n.translate( 'SFTP and database access' ),
+	SHIPPING_CARRIERS: i18n.translate( 'Integration with top shipping carriers' ),
+	UNLIMITED_TRAFFIC: i18n.translate( 'Unlimited traffic' ),
+};
 
 const getPlanBloggerDetails = (): IncompleteWPcomPlan => ( {
 	...getDotcomPlanDetails(),
@@ -441,6 +468,20 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
 	getInferiorFeatures: () => [],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+		yearly: [
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+	} ),
 } );
 
 const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
@@ -555,6 +596,26 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_BACKUPS,
 	],
 	getInferiorFeatures: () => [],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.ACCEPT_PAYMENTS,
+			cancellationFlowTerms.SHIPPING_CARRIERS,
+			cancellationFlowTerms.PREMIUM_DESIGN,
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.SEO_TOOLS,
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AND_MORE,
+		],
+		yearly: [
+			cancellationFlowTerms.ACCEPT_PAYMENTS,
+			cancellationFlowTerms.SHIPPING_CARRIERS,
+			cancellationFlowTerms.PREMIUM_DESIGN,
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.SEO_TOOLS,
+			cancellationFlowTerms.LIVE_CHAT,
+			cancellationFlowTerms.AND_MORE,
+		],
+	} ),
 } );
 
 const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
@@ -697,6 +758,26 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_BACKUPS,
 	],
 	getInferiorFeatures: () => [],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.PREMIUM_THEMES,
+			cancellationFlowTerms.GOOGLE_ANALYTICS,
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+		yearly: [
+			cancellationFlowTerms.LIVE_CHAT,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.PREMIUM_THEMES,
+			cancellationFlowTerms.GOOGLE_ANALYTICS,
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+		],
+	} ),
 } );
 
 const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
@@ -801,6 +882,27 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_BACKUPS,
 	],
 	getInferiorFeatures: () => [],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.SEO_TOOLS,
+			cancellationFlowTerms.BACKUPS_AND_RESTORE,
+			cancellationFlowTerms.SFTP_AND_DATABASE,
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+			cancellationFlowTerms.AND_MORE,
+		],
+		yearly: [
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.SEO_TOOLS,
+			cancellationFlowTerms.BACKUPS_AND_RESTORE,
+			cancellationFlowTerms.SFTP_AND_DATABASE,
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.LIVE_CHAT,
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AND_MORE,
+		],
+	} ),
 } );
 
 const getPlanProDetails = (): IncompleteWPcomPlan => ( {
@@ -865,6 +967,26 @@ const getPlanProDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_ANTISPAM,
 		WPCOM_FEATURES_BACKUPS,
 	],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.PREMIUM_THEMES,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.HIGH_QUALITY_VIDEOS,
+			cancellationFlowTerms.SFTP_AND_DATABASE,
+			cancellationFlowTerms.BACKUPS,
+			cancellationFlowTerms.AND_MORE,
+		],
+		yearly: [
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.PREMIUM_THEMES,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.HIGH_QUALITY_VIDEOS,
+			cancellationFlowTerms.SFTP_AND_DATABASE,
+			cancellationFlowTerms.BACKUPS,
+			cancellationFlowTerms.AND_MORE,
+		],
+	} ),
 } );
 
 const getJetpackPersonalDetails = (): IncompleteJetpackPlan => ( {
@@ -1463,6 +1585,10 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getProductId: () => 1018,
 		getStoreSlug: () => PLAN_BUSINESS_MONTHLY,
 		getPathSlug: () => 'business-monthly',
+		getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+			monthly: [ 'Feature 1' ],
+			yearly: [ 'Feature 1' ],
+		} ),
 	},
 
 	[ PLAN_BUSINESS ]: {
@@ -1959,6 +2085,26 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 		FEATURE_TITAN_EMAIL,
 	],
 	getIncludedFeatures: () => [ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.MANAGED_HOSTINGS,
+			cancellationFlowTerms.SEO_AND_SOCIAL,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.SECURITY_AND_SPAM,
+			cancellationFlowTerms.JETPACK_ESSENTIALS,
+			cancellationFlowTerms.UNLIMITED_TRAFFIC,
+			cancellationFlowTerms.AND_MORE,
+		],
+		yearly: [
+			cancellationFlowTerms.MANAGED_HOSTINGS,
+			cancellationFlowTerms.SEO_AND_SOCIAL,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.SECURITY_AND_SPAM,
+			cancellationFlowTerms.JETPACK_ESSENTIALS,
+			cancellationFlowTerms.UNLIMITED_TRAFFIC,
+			cancellationFlowTerms.AND_MORE,
+		],
+	} ),
 };
 
 PLANS_LIST[ PLAN_WPCOM_FLEXIBLE ] = {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -364,6 +364,25 @@ const getPlanBloggerDetails = (): IncompleteWPcomPlan => ( {
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
 	getInferiorFeatures: () => [],
+	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
+		monthly: [
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+		yearly: [
+			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+		withDomain: [
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+	} ),
 } );
 
 const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
@@ -477,6 +496,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		],
 		yearly: [
 			cancellationFlowTerms.HOSTING,
+			cancellationFlowTerms.AD_FREE_SITE,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.EMAIL_SUPPORT,
+		],
+		withDomain: [
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 			cancellationFlowTerms.EMAIL_SUPPORT,
@@ -613,6 +637,13 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.PLUGINS,
 			cancellationFlowTerms.SEO_TOOLS,
 			cancellationFlowTerms.LIVE_CHAT,
+			cancellationFlowTerms.AND_MORE,
+		],
+		withDomain: [
+			cancellationFlowTerms.ACCEPT_PAYMENTS,
+			cancellationFlowTerms.SHIPPING_CARRIERS,
+			cancellationFlowTerms.PREMIUM_DESIGN,
+			cancellationFlowTerms.PLUGINS,
 			cancellationFlowTerms.AND_MORE,
 		],
 	} ),
@@ -777,6 +808,13 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 		],
+		withDomain: [
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.PREMIUM_THEMES,
+			cancellationFlowTerms.GOOGLE_ANALYTICS,
+			cancellationFlowTerms.COLLECT_PAYMENTS,
+			cancellationFlowTerms.AD_FREE_SITE,
+		],
 	} ),
 } );
 
@@ -902,6 +940,13 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AND_MORE,
 		],
+		withDomain: [
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.SEO_TOOLS,
+			cancellationFlowTerms.BACKUPS_AND_RESTORE,
+			cancellationFlowTerms.SFTP_AND_DATABASE,
+			cancellationFlowTerms.AND_MORE,
+		],
 	} ),
 } );
 
@@ -984,6 +1029,13 @@ const getPlanProDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.HIGH_QUALITY_VIDEOS,
 			cancellationFlowTerms.SFTP_AND_DATABASE,
 			cancellationFlowTerms.BACKUPS,
+			cancellationFlowTerms.AND_MORE,
+		],
+		withDomain: [
+			cancellationFlowTerms.PLUGINS,
+			cancellationFlowTerms.PREMIUM_THEMES,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.HIGH_QUALITY_VIDEOS,
 			cancellationFlowTerms.AND_MORE,
 		],
 	} ),
@@ -2102,6 +2154,13 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 			cancellationFlowTerms.SECURITY_AND_SPAM,
 			cancellationFlowTerms.JETPACK_ESSENTIALS,
 			cancellationFlowTerms.UNLIMITED_TRAFFIC,
+			cancellationFlowTerms.AND_MORE,
+		],
+		withDomain: [
+			cancellationFlowTerms.MANAGED_HOSTINGS,
+			cancellationFlowTerms.SEO_AND_SOCIAL,
+			cancellationFlowTerms.EARN_AD_REVENUE,
+			cancellationFlowTerms.SECURITY_AND_SPAM,
 			cancellationFlowTerms.AND_MORE,
 		],
 	} ),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -299,7 +299,6 @@ const cancellationFlowTerms = {
 	EMAIL_SUPPORT: i18n.translate( 'Unlimited customer support via email' ),
 	GOOGLE_ANALYTICS: i18n.translate( 'Google Analytics integration' ),
 	HIGH_QUALITY_VIDEOS: i18n.translate( 'High quality videos' ),
-	HOSTING: i18n.translate( 'Best-in-class hosting' ),
 	JETPACK_ESSENTIALS: i18n.translate( 'Jetpack essentials' ),
 	LIVE_CHAT: i18n.translate( 'Access to live chat support' ),
 	MANAGED_HOSTINGS: i18n.translate( 'Access to managed hosting' ),
@@ -366,13 +365,11 @@ const getPlanBloggerDetails = (): IncompleteWPcomPlan => ( {
 	getInferiorFeatures: () => [],
 	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
 		monthly: [
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 			cancellationFlowTerms.EMAIL_SUPPORT,
 		],
 		yearly: [
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 			cancellationFlowTerms.EMAIL_SUPPORT,
@@ -489,13 +486,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getInferiorFeatures: () => [],
 	getCancellationFlowFeatures: (): CancellationFlowFeatures => ( {
 		monthly: [
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 			cancellationFlowTerms.EMAIL_SUPPORT,
 		],
 		yearly: [
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 			cancellationFlowTerms.EMAIL_SUPPORT,
@@ -627,7 +622,6 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.PREMIUM_DESIGN,
 			cancellationFlowTerms.PLUGINS,
 			cancellationFlowTerms.SEO_TOOLS,
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AND_MORE,
 		],
 		yearly: [
@@ -794,7 +788,6 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.EARN_AD_REVENUE,
 			cancellationFlowTerms.PREMIUM_THEMES,
 			cancellationFlowTerms.GOOGLE_ANALYTICS,
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 			cancellationFlowTerms.EMAIL_SUPPORT,
@@ -804,7 +797,6 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.EARN_AD_REVENUE,
 			cancellationFlowTerms.PREMIUM_THEMES,
 			cancellationFlowTerms.GOOGLE_ANALYTICS,
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AD_FREE_SITE,
 			cancellationFlowTerms.COLLECT_PAYMENTS,
 		],
@@ -926,7 +918,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.SEO_TOOLS,
 			cancellationFlowTerms.BACKUPS_AND_RESTORE,
 			cancellationFlowTerms.SFTP_AND_DATABASE,
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.EMAIL_SUPPORT,
 			cancellationFlowTerms.AND_MORE,
 		],
@@ -935,9 +926,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			cancellationFlowTerms.SEO_TOOLS,
 			cancellationFlowTerms.BACKUPS_AND_RESTORE,
 			cancellationFlowTerms.SFTP_AND_DATABASE,
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.LIVE_CHAT,
-			cancellationFlowTerms.HOSTING,
 			cancellationFlowTerms.AND_MORE,
 		],
 		withDomain: [

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -118,6 +118,11 @@ export interface BillingTerm {
 	getBillingTimeFrame: () => TranslateResult;
 }
 
+export interface CancellationFlowFeatures {
+	monthly?: Feature[];
+	yearly?: Feature[];
+}
+
 export type Plan = BillingTerm & {
 	group: typeof GROUP_WPCOM | typeof GROUP_JETPACK;
 	type: string;
@@ -153,6 +158,7 @@ export type Plan = BillingTerm & {
 	 * a feature for 20GB of storage space would be inferior to it.
 	 */
 	getInferiorFeatures?: () => Feature[];
+	getCancellationFlowFeatures?: () => CancellationFlowFeatures;
 };
 
 export type WithSnakeCaseSlug = { product_slug: string };

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -121,6 +121,7 @@ export interface BillingTerm {
 export interface CancellationFlowFeatures {
 	monthly?: Feature[];
 	yearly?: Feature[];
+	withDomain?: Feature[];
 }
 
 export type Plan = BillingTerm & {


### PR DESCRIPTION
### Pemise
The PR https://github.com/Automattic/wp-calypso/pull/67090 is corrupted, I opened this new and addressed the change requests.

P2: pebzTe-6r-p2

* Add new remove-plan-dialog component to the remove purchases page

#### Issue
1039-gh-Automattic/martech

#### Acceptance  Criteria
1039-gh-Automattic/martech

#### Proposed Changes
* Add a new dialog component to show up before the user starts the cancelation flow.

#### Testing Instructions
* Checkout update/pre-cancelation-modal
* Test Calypso locally
* Visit http://calypso.localhost:3000/
* Select a site with an active subscription plan
* Click on te sidebar item Upgrade / Purchases
* Select the plan
* Click on the CTA `Remove <Plan name> plan
* Verify the screenshot image is not blurry

Edge cases:
- Site isComingSoon or private: the modal won't show the site screenshot
- Mobile screen size: the modal won't show the site screenshot
- If the user are cancelling a Jetpack, Professional emails plan: the modal won't show up
- If the user are cancelling a subscription (auto renew on) within the refund window, with a domain, the modal informs them they are going to love the domain and the traffic will be redirected to the related WPCom URL.


#### Before
![before](https://user-images.githubusercontent.com/5706607/188669017-fdcb0005-8683-40db-8255-f8c9bfa970b8.gif)

#### After
https://user-images.githubusercontent.com/5706607/188671098-defa794a-7b57-435c-839c-1d31c1eef619.mp4


#### Issue
Related to 1039-gh-Automattic/martech