### PR TITLE
Statsd: record multiple events at once 

### DIFF
--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -28,7 +28,11 @@ function createBeacon( calypsoSection: string, { name, value, type }: BeaconData
 	}`;
 }
 
-export function createStatsdURL( calypsoSection: string, events: BeaconData[] ) {
+export function createStatsdURL( calypsoSection: string, events: BeaconData[] | BeaconData ) {
+	if ( ! Array.isArray( events ) ) {
+		events = [ events ]; // Only a single event was passed to process.
+	}
+
 	const section = calypsoSection.replace( /[.:-]/g, '_' );
 	const json = JSON.stringify( {
 		beacons: events.map( ( event ) => createBeacon( section, event ) ),
@@ -50,7 +54,7 @@ export function createStatsdURL( calypsoSection: string, events: BeaconData[] ) 
  * @param calypsoSection The Calypso section the event occurred under.
  * @param events List of events to send to the server.
  */
-export function logServerEvent( calypsoSection: string, events: BeaconData[] ) {
+export function logServerEvent( calypsoSection: string, events: BeaconData[] | BeaconData ) {
 	if ( config( 'server_side_boom_analytics_enabled' ) ) {
 		superagent.get( createStatsdURL( calypsoSection, events ) ).end();
 	}

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -19,8 +19,8 @@ function createBeacon( calypsoSection: string, { name, value, type }: BeaconData
 	const event = name.replace( '-', '_' );
 
 	// A counting event defaults to incrementing by one.
-	if ( type === 'counting' && value == null ) {
-		value = 1;
+	if ( type === 'counting' ) {
+		value ??= 1;
 	}
 
 	return `calypso.${ config( 'boom_analytics_key' ) }.${ calypsoSection }.${ event }:${ value }|${

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -1,20 +1,34 @@
 import config from '@automattic/calypso-config';
 
-function generateUrl( featureSlug: string, eventType: string, eventValue: string ) {
-	const slug = featureSlug.replace( /[.:-]/g, '_' );
-	const type = eventType.replace( '-', '_' );
+interface BeaconData {
+	eventName: string;
+	value: number;
+	type: 'counting' | 'timing';
+}
+
+function createBeacon( calypsoSection: string, { eventName, value, type }: BeaconData ) {
+	const section = calypsoSection.replace( /[.:-]/g, '_' );
+	const event = eventName.replace( '-', '_' );
+
+	// A counting event defaults to incrementing by one.
+	if ( type === 'counting' && value == null ) {
+		value = 1;
+	}
+
+	return `calypso.${ config( 'boom_analytics_key' ) }.${ section }.${ event }:${ value }|${
+		type === 'timing' ? 'ms' : 'c'
+	}`;
+}
+
+export function createStatsdURL( calypsoSection: string, events: BeaconData[] ) {
 	const json = JSON.stringify( {
-		beacons: [ `calypso.${ config( 'boom_analytics_key' ) }.${ slug }.${ type }:${ eventValue }` ],
+		beacons: events.map( ( event ) => createBeacon( calypsoSection, event ) ),
 	} );
 
-	const [ encodedSlug, jsonData ] = [ slug, json ].map( encodeURIComponent );
-	return `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedSlug }&json=${ jsonData }`;
-}
+	const [ encodedSection, encodedJson ] = [ calypsoSection, json ].map( encodeURIComponent );
 
-export function statsdTimingUrl( featureSlug: string, eventType: string, duration: number ) {
-	return generateUrl( featureSlug, eventType, `${ duration }|ms` );
-}
-
-export function statsdCountingUrl( featureSlug: string, eventType: string, increment: number ) {
-	return generateUrl( featureSlug, eventType, `${ increment }|c` );
+	// While the `u` parameter is typically the URL, the original statsd code in Calypso
+	// used just the section name everywhere. To keep things consistent, we continue
+	// to use just the section name today.
+	return `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedSection }&json=${ encodedJson }`;
 }

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -1,10 +1,18 @@
 import config from '@automattic/calypso-config';
 
-interface BeaconData {
+interface CountingBeacon {
+	name: string;
+	value?: number;
+	type: 'counting';
+}
+
+interface TimingBeacon {
 	name: string;
 	value: number;
-	type: 'counting' | 'timing';
+	type: 'timing';
 }
+
+export type BeaconData = CountingBeacon | TimingBeacon;
 
 function createBeacon( calypsoSection: string, { name, value, type }: BeaconData ) {
 	const event = name.replace( '-', '_' );

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import superagent from 'superagent';
 
 interface CountingBeacon {
 	name: string;
@@ -39,4 +40,18 @@ export function createStatsdURL( calypsoSection: string, events: BeaconData[] ) 
 	// used just the section name everywhere. To keep things consistent, we continue
 	// to use just the section name today.
 	return `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedSection }&json=${ encodedJson }`;
+}
+
+/**
+ * Logs server events to statsd. Uses superagent for server-side network requests
+ * and can disable statsd events with the server_side_boom_analytics_enabled
+ * config flag.
+ *
+ * @param calypsoSection The Calypso section the event occurred under.
+ * @param events List of events to send to the server.
+ */
+export function logServerEvent( calypsoSection: string, events: BeaconData[] ) {
+	if ( config( 'server_side_boom_analytics_enabled' ) ) {
+		superagent.get( createStatsdURL( calypsoSection, events ) ).end();
+	}
 }

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -7,7 +7,6 @@ interface BeaconData {
 }
 
 function createBeacon( calypsoSection: string, { name, value, type }: BeaconData ) {
-	const section = calypsoSection.replace( /[.:-]/g, '_' );
 	const event = name.replace( '-', '_' );
 
 	// A counting event defaults to incrementing by one.
@@ -15,17 +14,18 @@ function createBeacon( calypsoSection: string, { name, value, type }: BeaconData
 		value = 1;
 	}
 
-	return `calypso.${ config( 'boom_analytics_key' ) }.${ section }.${ event }:${ value }|${
+	return `calypso.${ config( 'boom_analytics_key' ) }.${ calypsoSection }.${ event }:${ value }|${
 		type === 'timing' ? 'ms' : 'c'
 	}`;
 }
 
 export function createStatsdURL( calypsoSection: string, events: BeaconData[] ) {
+	const section = calypsoSection.replace( /[.:-]/g, '_' );
 	const json = JSON.stringify( {
-		beacons: events.map( ( event ) => createBeacon( calypsoSection, event ) ),
+		beacons: events.map( ( event ) => createBeacon( section, event ) ),
 	} );
 
-	const [ encodedSection, encodedJson ] = [ calypsoSection, json ].map( encodeURIComponent );
+	const [ encodedSection, encodedJson ] = [ section, json ].map( encodeURIComponent );
 
 	// While the `u` parameter is typically the URL, the original statsd code in Calypso
 	// used just the section name everywhere. To keep things consistent, we continue

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -1,14 +1,14 @@
 import config from '@automattic/calypso-config';
 
 interface BeaconData {
-	eventName: string;
+	name: string;
 	value: number;
 	type: 'counting' | 'timing';
 }
 
-function createBeacon( calypsoSection: string, { eventName, value, type }: BeaconData ) {
+function createBeacon( calypsoSection: string, { name, value, type }: BeaconData ) {
 	const section = calypsoSection.replace( /[.:-]/g, '_' );
-	const event = eventName.replace( '-', '_' );
+	const event = name.replace( '-', '_' );
 
 	// A counting event defaults to incrementing by one.
 	if ( type === 'counting' && value == null ) {

--- a/client/lib/analytics/test/statsd-utils.js
+++ b/client/lib/analytics/test/statsd-utils.js
@@ -27,5 +27,22 @@ describe( 'StatsD Analytics Utils', () => {
 				} )
 			);
 		} );
+
+		test( 'processes a single event without an array container', () => {
+			const event = {
+				name: 'response_time',
+				value: 100,
+				type: 'timing',
+			};
+			const sdUrl = new URL( createStatsdURL( 'my-section-name', event ) );
+
+			expect( sdUrl.searchParams.get( 'v' ) ).toEqual( 'calypso' );
+			expect( sdUrl.searchParams.get( 'u' ) ).toEqual( 'my_section_name' );
+			expect( sdUrl.searchParams.get( 'json' ) ).toEqual(
+				JSON.stringify( {
+					beacons: [ 'calypso.development.my_section_name.response_time:100|ms' ],
+				} )
+			);
+		} );
 	} );
 } );

--- a/client/lib/analytics/test/statsd-utils.js
+++ b/client/lib/analytics/test/statsd-utils.js
@@ -1,32 +1,29 @@
-import url from 'url';
-import { statsdTimingUrl, statsdCountingUrl } from '../statsd-utils';
+import { createStatsdURL } from '../statsd-utils';
 
 describe( 'StatsD Analytics Utils', () => {
-	describe( 'statsdTimingUrl', () => {
-		test( 'returns a URL for recording timing data to statsd', () => {
-			const sdUrl = url.parse( statsdTimingUrl( 'post-mysite.com', 'page-load', 150 ), true, true );
-			expect( sdUrl.query.v ).toEqual( 'calypso' );
-			expect( sdUrl.query.u ).toEqual( 'post_mysite_com' );
-			expect( sdUrl.query.json ).toEqual(
-				JSON.stringify( {
-					beacons: [ 'calypso.development.post_mysite_com.page_load:150|ms' ],
-				} )
-			);
-		} );
-	} );
+	describe( 'createStatsdURL', () => {
+		test( 'returns a URL for sending events to statsd', () => {
+			const events = [
+				{
+					name: 'response_time',
+					value: 100,
+					type: 'timing',
+				},
+				{
+					name: 'page-load',
+					type: 'counting',
+				},
+			];
+			const sdUrl = new URL( createStatsdURL( 'my-section-name', events ) );
 
-	describe( 'statsdCountingUrl', () => {
-		test( 'returns a URL for recording counting data to statsd', () => {
-			const sdUrl = url.parse(
-				statsdCountingUrl( 'post-mysite.com', 'page-count', 1 ),
-				true,
-				true
-			);
-			expect( sdUrl.query.v ).toEqual( 'calypso' );
-			expect( sdUrl.query.u ).toEqual( 'post_mysite_com' );
-			expect( sdUrl.query.json ).toEqual(
+			expect( sdUrl.searchParams.get( 'v' ) ).toEqual( 'calypso' );
+			expect( sdUrl.searchParams.get( 'u' ) ).toEqual( 'my_section_name' );
+			expect( sdUrl.searchParams.get( 'json' ) ).toEqual(
 				JSON.stringify( {
-					beacons: [ 'calypso.development.post_mysite_com.page_count:1|c' ],
+					beacons: [
+						'calypso.development.my_section_name.response_time:100|ms',
+						'calypso.development.my_section_name.page_load:1|c',
+					],
 				} )
 			);
 		} );

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -13,6 +13,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			( req, res, next ) => {
+				req.context.usedSSRHandler = true;
 				debug( `Using SSR pipeline for path: ${ req.path } with handler ${ route }` );
 				next();
 			},

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -13,7 +13,6 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			( req, res, next ) => {
-				req.context.usedSSRHandler = true;
 				debug( `Using SSR pipeline for path: ${ req.path } with handler ${ route }` );
 				next();
 			},

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -1,7 +1,5 @@
-import config from '@automattic/calypso-config';
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
-import { createStatsdURL } from 'calypso/lib/analytics/statsd-utils';
 const URL = require( 'url' );
 
 function getUserFromRequest( request ) {
@@ -42,21 +40,6 @@ function getUserFromRequest( request ) {
 }
 
 const analytics = {
-	statsd: {
-		/**
-		 * Sends statsd events for a Calypso section.
-		 *
-		 * @param {string} calypsoSection The section in which the events occured.
-		 * @param {{name: string, value: number, type: 'counting'|'timing'}[]} events Array of events to process.
-		 */
-		recordEvents: ( calypsoSection, events ) => {
-			if ( config( 'server_side_boom_analytics_enabled' ) ) {
-				const url = createStatsdURL( calypsoSection, events );
-				superagent.get( url ).end();
-			}
-		},
-	},
-
 	tracks: {
 		createPixel: function ( data ) {
 			data._rt = new Date().getTime();

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -47,7 +47,7 @@ const analytics = {
 		 * Sends statsd events for a Calypso section.
 		 *
 		 * @param {string} calypsoSection The section in which the events occured.
-		 * @param {{eventName: string, value: number, type: 'counting'|'timing'}[]} events Array of events to process.
+		 * @param {{name: string, value: number, type: 'counting'|'timing'}[]} events Array of events to process.
 		 */
 		recordEvents: ( calypsoSection, events ) => {
 			if ( config( 'server_side_boom_analytics_enabled' ) ) {

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
-import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
+import { createStatsdURL } from 'calypso/lib/analytics/statsd-utils';
 const URL = require( 'url' );
 
 function getUserFromRequest( request ) {
@@ -43,16 +43,15 @@ function getUserFromRequest( request ) {
 
 const analytics = {
 	statsd: {
-		recordTiming: function ( featureSlug, eventType, duration ) {
+		/**
+		 * Sends statsd events for a Calypso section.
+		 *
+		 * @param {string} calypsoSection The section in which the events occured.
+		 * @param {{eventName: string, value: number, type: 'counting'|'timing'}[]} events Array of events to process.
+		 */
+		recordEvents: ( calypsoSection, events ) => {
 			if ( config( 'server_side_boom_analytics_enabled' ) ) {
-				const url = statsdTimingUrl( featureSlug, eventType, duration );
-				superagent.get( url ).end();
-			}
-		},
-
-		recordCounting: function ( featureSlug, eventType, increment = 1 ) {
-			if ( config( 'server_side_boom_analytics_enabled' ) ) {
-				const url = statsdCountingUrl( featureSlug, eventType, increment );
+				const url = createStatsdURL( calypsoSection, events );
 				superagent.get( url ).end();
 			}
 		},

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -1,7 +1,5 @@
-import config from '@automattic/calypso-config';
 import UserAgent from 'express-useragent';
 import superagent from 'superagent';
-import { createStatsdURL } from 'calypso/lib/analytics/statsd-utils';
 import analytics from '../index';
 jest.mock( '@automattic/calypso-config', () => jest.fn() );
 jest.mock( 'calypso/lib/analytics/statsd-utils', () => ( {
@@ -52,38 +50,6 @@ describe( 'Server-Side Analytics', () => {
 			expect( superagent.get ).toHaveBeenCalled();
 			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
 			expect( url.searchParams.get( 'a' ) ).toBeNull();
-		} );
-	} );
-
-	describe( 'statsd.recordEvents', () => {
-		beforeEach( () => {
-			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
-		} );
-
-		afterEach( () => {
-			createStatsdURL.mockClear();
-			superagent.get.mockClear();
-		} );
-
-		test( 'sends an HTTP request to the statsd URL', () => {
-			config.mockReturnValue( true ); // server_side_boom_analytics_enabled
-			createStatsdURL.mockReturnValue( 'http://example.com/boom.gif' );
-
-			const testArr = [ 'foo' ];
-			analytics.statsd.recordEvents( 'reader', testArr );
-
-			expect( createStatsdURL ).toHaveBeenCalledWith( 'reader', testArr );
-			expect( superagent.get ).toHaveBeenCalledWith( 'http://example.com/boom.gif' );
-		} );
-
-		test( 'does nothing if statsd analytics is not allowed', () => {
-			config.mockReturnValue( false ); // server_side_boom_analytics_enabled
-
-			const testArr = [ 'foo' ];
-			analytics.statsd.recordEvents( 'reader', testArr );
-
-			expect( createStatsdURL ).not.toHaveBeenCalled();
-			expect( superagent.get ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -1,10 +1,6 @@
 import UserAgent from 'express-useragent';
 import superagent from 'superagent';
 import analytics from '../index';
-jest.mock( '@automattic/calypso-config', () => jest.fn() );
-jest.mock( 'calypso/lib/analytics/statsd-utils', () => ( {
-	createStatsdURL: jest.fn(),
-} ) );
 
 describe( 'Server-Side Analytics', () => {
 	describe( 'tracks.recordEvent', () => {

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -15,7 +15,7 @@ const logAnalyticsThrottled = throttle( ( { sectionName, duration, loggedIn, use
 		},
 		// More granular response-time metric including SSR and auth status.
 		{
-			name: `loggedin_${ loggedIn }.ssr_${ usedSSRHandler }.response_time.`,
+			name: `loggedin_${ loggedIn }.ssr_${ usedSSRHandler }.response_time`,
 			value: duration,
 			type: 'timing',
 		},
@@ -28,7 +28,7 @@ const logAnalyticsThrottled = throttle( ( { sectionName, duration, loggedIn, use
  * Only logs if the request context contains a `sectionName` attribute.
  */
 export function logSectionResponse( req, res, next ) {
-	const startRenderTime = Date().now();
+	const startRenderTime = Date.now();
 
 	res.on( 'close', function () {
 		if ( ! req.context?.sectionName ) {
@@ -39,7 +39,7 @@ export function logSectionResponse( req, res, next ) {
 		logAnalyticsThrottled( {
 			loggedIn: !! user,
 			usedSSRHandler: !! usedSSRHandler, // Convert undefined to false
-			duration: Date().now() - startRenderTime,
+			duration: Date.now() - startRenderTime,
 			sectionName,
 		} );
 	} );

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { throttle } from 'lodash';
-import analytics from '../lib/analytics';
+import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 
 // Compute the number of milliseconds between each call to recordTiming
 const THROTTLE_MILLIS = 1000 / config( 'statsd_analytics_response_time_max_logs_per_second' );
@@ -20,7 +20,7 @@ const logAnalyticsThrottled = throttle( ( { sectionName, duration, loggedIn, use
 			type: 'timing',
 		},
 	];
-	analytics.statsd.recordEvents( sectionName, events );
+	logServerEvent( sectionName, events );
 }, THROTTLE_MILLIS );
 
 /*

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -5,36 +5,26 @@ import analytics from '../lib/analytics';
 // Compute the number of milliseconds between each call to recordTiming
 const THROTTLE_MILLIS = 1000 / config( 'statsd_analytics_response_time_max_logs_per_second' );
 
-const logAnalyticsThrottled = throttle(
-	( { sectionName, target, duration, loggedIn, usedSSRHandler } ) => {
-		const events = [
-			// Basic per-section response time metric for backwards compatibility.
-			{
-				name: 'response_time',
-				value: duration,
-				type: 'timing',
-			},
-			// More granular response-time metric including SSR and auth status.
-			{
-				name: `response_time.loggedin_${ loggedIn }.ssr_${ usedSSRHandler }`,
-				value: duration,
-				type: 'timing',
-			},
-		];
-		if ( target ) {
-			events.push( {
-				name: `target.${ target }`,
-				type: 'counting',
-			} );
-		}
-		analytics.statsd.recordEvents( sectionName, events );
-	},
-	THROTTLE_MILLIS
-);
+const logAnalyticsThrottled = throttle( ( { sectionName, duration, loggedIn, usedSSRHandler } ) => {
+	const events = [
+		// Basic per-section response time metric for backwards compatibility.
+		{
+			name: 'response_time',
+			value: duration,
+			type: 'timing',
+		},
+		// More granular response-time metric including SSR and auth status.
+		{
+			name: `response_time.loggedin_${ loggedIn }.ssr_${ usedSSRHandler }`,
+			value: duration,
+			type: 'timing',
+		},
+	];
+	analytics.statsd.recordEvents( sectionName, events );
+}, THROTTLE_MILLIS );
 
 /*
- * Middleware to log the response time of the node request for a
- * section, as well as which build target was served.
+ * Middleware to log the response time of the node request for a section.
  * Only logs if the request context contains a `sectionName` attribute.
  */
 export function logSectionResponse( req, res, next ) {
@@ -44,14 +34,13 @@ export function logSectionResponse( req, res, next ) {
 		if ( ! req.context?.sectionName ) {
 			return;
 		}
-		const { user, sectionName, target, usedSSRHandler } = req.context;
+		const { user, sectionName, usedSSRHandler } = req.context;
 
 		logAnalyticsThrottled( {
 			loggedIn: !! user,
 			usedSSRHandler: !! usedSSRHandler, // Convert undefined to false
 			duration: Date().now() - startRenderTime,
 			sectionName,
-			target,
 		} );
 	} );
 

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -10,20 +10,20 @@ const logAnalyticsThrottled = throttle(
 		const events = [
 			// Basic per-section response time metric for backwards compatibility.
 			{
-				eventName: 'response_time',
+				name: 'response_time',
 				value: duration,
 				type: 'timing',
 			},
 			// More granular response-time metric including SSR and auth status.
 			{
-				eventName: `.loggedin_${ loggedIn }.ssr_${ usedSSRHandler }.response_time`,
+				name: `response_time.loggedin_${ loggedIn }.ssr_${ usedSSRHandler }`,
 				value: duration,
 				type: 'timing',
 			},
 		];
 		if ( target ) {
 			events.push( {
-				eventName: `target.${ target }`,
+				name: `target.${ target }`,
 				type: 'counting',
 			} );
 		}
@@ -49,7 +49,7 @@ export function logSectionResponse( req, res, next ) {
 		logAnalyticsThrottled( {
 			loggedIn: !! user,
 			usedSSRHandler: !! usedSSRHandler, // Convert undefined to false
-			duration: new Date() - startRenderTime,
+			duration: Date().now() - startRenderTime,
 			sectionName,
 			target,
 		} );

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -15,7 +15,7 @@ const logAnalyticsThrottled = throttle( ( { sectionName, duration, loggedIn, use
 		},
 		// More granular response-time metric including SSR and auth status.
 		{
-			name: `response_time.loggedin_${ loggedIn }.ssr_${ usedSSRHandler }`,
+			name: `loggedin_${ loggedIn }.ssr_${ usedSSRHandler }.response_time.`,
 			value: duration,
 			type: 'timing',
 		},

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -6,13 +6,11 @@ import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 const THROTTLE_MILLIS = 1000 / config( 'statsd_analytics_response_time_max_logs_per_second' );
 
 const logAnalyticsThrottled = throttle( function ( sectionName, duration ) {
-	logServerEvent( sectionName, [
-		{
-			name: 'response-time',
-			type: 'timing',
-			value: duration,
-		},
-	] );
+	logServerEvent( sectionName, {
+		name: 'response-time',
+		type: 'timing',
+		value: duration,
+	} );
 }, THROTTLE_MILLIS );
 
 /*

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -8,10 +8,10 @@ const TWO_SECONDS = 2000;
 
 const noop = () => {};
 
-jest.mock( '@automattic/calypso-config', () => jest.fn() );
+jest.mock( '@automattic/calypso-config' );
 
 describe( 'index', () => {
-	beforeAll( function () {
+	beforeAll( () => {
 		// Enable analytics tracking on the server.
 		config.mockReturnValue( true );
 	} );

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -101,7 +101,7 @@ describe( 'index', () => {
 				logSectionResponse( request, response, next );
 
 				// Mock the "finish" event
-				response.emit( 'close' );
+				response.emit( 'finish' );
 
 				expect( statsdUtils.logServerEvent ).not.toBeCalled();
 			} );

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
 		"@signal-noise/stylelint-scales": "^2.0.3",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@types/gtag.js": "^0.0.10",
+		"@types/superagent": "^4.1.15",
 		"@typescript-eslint/eslint-plugin": "^5.7.0",
 		"@typescript-eslint/parser": "^5.7.0",
 		"@wordpress/eslint-plugin": "^12.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6761,6 +6761,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookiejar@npm:*":
+  version: 2.1.2
+  resolution: "@types/cookiejar@npm:2.1.2"
+  checksum: f663f2476ad0aed8ccab03056bbc18b62ed059642077eaec7ab497f56c78149558bfbc0f34345a85872e019352dc28f3c12872af971dc455da3c598ff3966cda
+  languageName: node
+  linkType: hard
+
 "@types/cssnano@npm:^4.0.1":
   version: 4.0.1
   resolution: "@types/cssnano@npm:4.0.1"
@@ -7410,6 +7417,16 @@ __metadata:
   version: 2.0.2
   resolution: "@types/store@npm:2.0.2"
   checksum: d40224bd8bf728b86b9bd3a2413d29484712b6ec22b690c08350f9a2c1b57295861e96169307f7096c1cbba5316afc2165a41f9122493d3e312382f28722182d
+  languageName: node
+  linkType: hard
+
+"@types/superagent@npm:^4.1.15":
+  version: 4.1.15
+  resolution: "@types/superagent@npm:4.1.15"
+  dependencies:
+    "@types/cookiejar": "*"
+    "@types/node": "*"
+  checksum: 73d624d82c2d8e094706af6b9b23b8d938d4013270e0276cc372c730a4d7495fedc62e0dbc1d0e35d3c224e73c71ca312339c8b09ad44825c71037e5c9d72843
   languageName: node
   linkType: hard
 
@@ -35968,6 +35985,7 @@ swiper@4.5.1:
     "@types/react-router-dom": ^5.3.3
     "@types/react-transition-group": ^4.4.4
     "@types/store": ^2.0.2
+    "@types/superagent": ^4.1.15
     "@types/uuid": ^8.3.4
     "@types/validator": ^13.7.1
     "@types/webpack-env": ^1.16.3


### PR DESCRIPTION
### Proposed Changes
This PR accomplishes a few things:

1. Refactor the statsd helpers to accept multiple events at once.
2. Update the place we use those helpers to use the new format.
3. Remove the server-side statsd wrapper because it wasn't adding value.

### Statsd helper refactor

If you search across the repo for `statsdCountingUrl` or `statsdTimingUrl`, they are only used by the server-side analytics. Then, the server-side analytics `recordTiming` or `recordCounting` are only used by the post-request logging function.

As a result, this refactor is very low impact. But my hope is that it makes it easier to use statsd in the future because it's more consistent. An event now has this very basic structure:

```ts
interface BeaconData {
	name: string;
	value: number;
	type: 'counting' | 'timing';
}
```

Previously, a function signature was `function recordCounting( featureSlug, eventType, duration )`. It's unclear what data should be in the "featureSlug" or what an "eventType" is. How do I add data which can be filtered in grafana? Is that part of the "feature?" Do I have to specify a known "eventType"? The Calypso section is the same as the "featureSlug" -- should I add that? 

The new approach exposes things a little more clearly -- you always log the section name, and can log multiple events, each of which has a name, value, and type. The name includes everything you'd use to filter the event. You also always import from `calypso/lib/analytics/statsd-utils` instead of a custom server analytics lib.

IMO, this is easier to use without looking up documentation. Plus, this approach makes it very straightforward to log multiple events without extra network requests, and I figured it made more sense to have it all in one function rather than have multiple functions for single events and multiple events and different types of events.

### Extra event data
_I will add this to a follow-up PR to simplify this one._

~I'd like to get extra data into our Calypso server response time dashboard. (Search for "calypso node response times" in Grafana to find it.) In particular, I'd like to visualize response time of SSR sections vs non-SSR sections and logged-in vs logged-out requests.~

~Periods in an event name are used to filter things. So we just need an event like this: `calypso.production.${section}.loggedin_${true|false}.ssr_${true|false}.response_time:${value}`~

~Since this isn't backwards compatible with the existing dashboard queries (`calypso.production.*.response_time`), we add it as an extra event. (Which is now very easy to do thanks to the above refactor!)~

#### Testing Instructions
1. Test calypso.live and verify various responses still work.
2. Verify that your requests to calypso.live show up in Calypso server analytics. (TBD)