### PR TITLE
Pricing page rework: Hide "Start with Jetpack Free" section when a site is already connected

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-show-jetpack-free.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-show-jetpack-free.ts
@@ -1,0 +1,20 @@
+import { useSelector } from 'react-redux';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import { isConnectionFlow } from '../../product-grid/utils';
+
+export const useShowJetpackFree = () => {
+	return useSelector( ( state ) => {
+		if ( isConnectionFlow() ) {
+			return true;
+		}
+
+		// If a site is passed by URL and the site is found in the app's state, we will assume the site
+		// is connected, and thus, we don't need to show "Start with the free"
+		if ( getSelectedSiteId( state ) ) {
+			return false;
+		}
+
+		return isJetpackCloud();
+	} );
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StoreItemInfoContext from './context/store-item-info-context';
+import { useShowJetpackFree } from './hooks/use-show-jetpack-free';
 import { useStoreItemInfo } from './hooks/use-store-item-info';
 import { ItemsList } from './items-list';
 import { JetpackFree } from './jetpack-free';
@@ -39,6 +40,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 		siteId,
 	} );
 
+	const showJetpackFree = useShowJetpackFree();
+
 	return (
 		<div className="jetpack-product-store">
 			{ header }
@@ -51,7 +54,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			<StoreItemInfoContext.Provider value={ storeItemInfo }>
 				<ItemsList currentView={ currentView } duration={ duration } siteId={ siteId } />
 			</StoreItemInfoContext.Provider>
-			<JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } />
+
+			{ showJetpackFree && <JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } /> }
 
 			<Recommendations />
 


### PR DESCRIPTION
#### Proposed Changes

* Hide "Start with Jetpack Free" section on WPCOM plans page and when a site is already connected, same as the previous pricing page (right now in production)

#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout fix/jp-pricing-rework/cond-show-jp-free`
        - Run `yarn start` in one terminal tab/window and `yarn start-jetpack-cloud-p` in another one
        - Goto [http://jetpack.cloud.localhost:3001/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Confirm that you see "Still not sure?" section with "Start with Jetpack Free"
- Create a JN site and click on "Set up Jetpack"
- On "Explore our Jetpack plans" page (`wordpress.com/jetpack/connect/plans`), replace `https://wordpress.com` with `http://calypso.localhost:3000` or the Calypso Live link below (after the redirect).
- Confirm that you see "Start with Jetpack Free"
- Choose a plan e.g. Backup and complete the setup
- On Jetpack Cloud Live link, goto `/pricing:site` or goto `http://jetpack.cloud.localhost:3001/pricing/:site`
- Confirm that you don't see "Start with Jetpack Free"
- On Calypso Live link, goto `/plans/:site` or goto `http://calypso.localhost:3000/plans/:site`
- Confirm that you don't see "Start with Jetpack Free"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Completes: 0-as-1203005354786552/f


<img width="1427" alt="Screenshot 2022-09-21 at 11 50 27 AM" src="https://user-images.githubusercontent.com/18226415/191432815-bf137ac0-870c-461d-89ad-ed129e331ea4.png">
<img width="1393" alt="Screenshot 2022-09-21 at 11 50 50 AM" src="https://user-images.githubusercontent.com/18226415/191432821-e50674c1-c1d3-4f34-ba5e-69ae9bce83ce.png">
<img width="1420" alt="Screenshot 2022-09-21 at 12 13 06 PM" src="https://user-images.githubusercontent.com/18226415/191433086-d35dcec9-66c1-461e-9c76-a7d26c99e3d8.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203005354786552