### PR TITLE
Jetpack De-fusion: Tiled Galleries

### DIFF
--- a/client/components/gallery-shortcode/index.tsx
+++ b/client/components/gallery-shortcode/index.tsx
@@ -46,12 +46,12 @@ export default class GalleryShortcode extends Component< Props > {
 			...rendered,
 			scripts: {
 				'tiled-gallery': {
-					src: 'https://s0.wp.com/wp-content/mu-plugins/tiled-gallery/tiled-gallery.js',
+					src: 'https://s0.wp.com/wp-content/mu-plugins/jetpack-plugin/production/modules/tiled-gallery/tiled-gallery/tiled-gallery.js',
 				},
 			},
 			styles: {
 				'tiled-gallery': {
-					src: 'https://s0.wp.com/wp-content/mu-plugins/tiled-gallery/tiled-gallery.css',
+					src: 'https://s0.wp.com/wp-content/mu-plugins/jetpack-plugin/production/modules/tiled-gallery/tiled-gallery/tiled-gallery.css',
 				},
 				'gallery-styles': {
 					src: 'https://widgets.wp.com/gallery-preview/style.css',


### PR DESCRIPTION

#### Proposed Changes

* As part of https://github.com/Automattic/jetpack/issues/25240 this PR updates a couple of paths in `client/components/gallery-shortcode/index.tsx`.
* [Similar PR here ](https://github.com/Automattic/wp-calypso/pull/67231)for comparison.


#### Testing Instructions

* Double check that the updated URLs load:
  * `https://s0.wp.com/wp-content/mu-plugins/jetpack-plugin/production/modules/tiled-gallery/tiled-gallery/tiled-gallery.js`
  * `https://s0.wp.com/wp-content/mu-plugins/jetpack-plugin/production/modules/tiled-gallery/tiled-gallery/tiled-gallery.css` (content differs slightly due to omission of 'opacity:0').

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Related to https://github.com/Automattic/jetpack/issues/25240
