### PR TITLE
Revert "PlanFeatures: replace margin left based on vw, instead use translateX"

### DIFF
--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -114,6 +114,8 @@ $plan-features-sidebar-width: 272px;
 
 		@include breakpoint-deprecated( "<1040px" ) {
 			border-spacing: 0;
+			margin-left: 15px;
+			margin-right: 15px;
 			width: calc(100% - 30px);
 		}
 
@@ -336,13 +338,12 @@ $plan-features-sidebar-width: 272px;
 	position: relative;
 
 	.is-section-signup & {
-		position: absolute;
-		width: 100%;
-		left: 50%;
-		transform: translateX(-50%);
+		width: 100vw;
+		margin-left: calc(50% - 50vw);
 
 		@media ( min-width: 1600px ) {
 			max-width: 1600px;
+			margin-left: -280px;
 		}
 
 		@include breakpoint-deprecated( "<1040px" ) {
@@ -470,7 +471,7 @@ body.is-section-signup.is-white-signup {
 		font-size: 0.75rem;
 		font-weight: 500;
 		letter-spacing: 0.2px;
-		line-height: 1.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 1.25rem;
 		padding: 0 8px;
 	}
 
@@ -479,7 +480,8 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.plan-features-comparison__item.plan-features-comparison__item-available {
-		.plan-features-comparison__item-annual-plan-container .plan-features-comparison__item-annual-plan {
+		.plan-features-comparison__item-annual-plan-container
+		.plan-features-comparison__item-annual-plan {
 			color: var(--studio-orange-40);
 		}
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -219,6 +219,8 @@ $plan-features-sidebar-width: 272px;
 
 	@include breakpoint-deprecated( "<1040px" ) {
 		border-spacing: 0;
+		margin-left: 15px;
+		margin-right: 15px;
 		width: calc(100% - 30px);
 	}
 }
@@ -733,29 +735,6 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	padding: 20px 0 10px;
 	transform: translateY(-20px);
 	overflow-x: auto;
-
-	.plan-features__item-annual-plan {
-		font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
-		text-transform: uppercase;
-	}
-
-	.plan-features__item-info.is-annual-plan-feature {
-		&.is-available {
-			.plan-features__item-annual-plan {
-				color: var(--color-success);
-			}
-		}
-
-		&:not(.is-available) {
-			.plan-features__item-annual-plan {
-				color: var(--color-error);
-			}
-			.plan-features__item-title {
-				text-decoration: line-through;
-				color: var(--color-neutral-30);
-			}
-		}
-	}
 }
 
 .plan-features--signup {
@@ -894,13 +873,12 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	position: relative;
 
 	.is-section-signup & {
-		position: absolute;
-		width: 100%;
-		left: 50%;
-		transform: translateX(-50%);
+		width: 100vw;
+		margin-left: calc(50% - 50vw);
 
 		@media ( min-width: 1600px ) {
 			max-width: 1600px;
+			margin-left: -280px;
 		}
 
 		@include breakpoint-deprecated( "<1040px" ) {
@@ -1243,6 +1221,31 @@ button.plan-features__scroll-button {
 @include breakpoint-deprecated( "<480px" ) {
 	.plan-features__upgrade-launch-dialog .dialog__content p {
 		padding: 0 20px;
+	}
+}
+
+.plans-wrapper {
+	.plan-features__item-annual-plan {
+		font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
+		text-transform: uppercase;
+	}
+
+	.plan-features__item-info.is-annual-plan-feature {
+		&.is-available {
+			.plan-features__item-annual-plan {
+				color: var(--color-success);
+			}
+		}
+
+		&:not(.is-available) {
+			.plan-features__item-annual-plan {
+				color: var(--color-error);
+			}
+			.plan-features__item-title {
+				text-decoration: line-through;
+				color: var(--color-neutral-30);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#67665

Reverting because the PR messed up the plans step UI for the A/B test treatment of the experiment `calypso_signup_plans_step_faq_202209_v1`. 

This is how the treatment page looks:

<img width="1494" alt="Screenshot 2022-09-21 at 11 08 38 AM" src="https://user-images.githubusercontent.com/1269602/191437740-67752304-9b01-45a1-9995-9295b53e52df.png">
