### PR TITLE
Pricing page rework: Fix layout shift on CTA click/focus

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -23,6 +23,9 @@
 		color: var(--color-neutral-100);
 		border: 1px solid var(--color-neutral-100);
 	}
+	.button:focus {
+		border-width: 1px;
+	}
 
 	.info-popover.owner-info__pop-over {
 		line-height: inherit;

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -17,6 +17,10 @@ $wpcom-menu-collapse: 783px;
 		background-color: var(--studio-gray-5);
 	}
 
+	:is(.button:active,	.button.is-active, .button:focus) {
+		border-width: 0;
+	}
+
 	h2 {
 		font-size: $font-title-small;
 		font-weight: 600;


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes the minor layout shift when CTA buttons are clicked or focussed especially on WPCOM plans page and on Jetpack connection screen

Problem

https://user-images.githubusercontent.com/18226415/191438501-424f97e4-983a-42bb-996e-b692a9885501.mov


#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout fix/jp-pricing-rework/layout-shift-on-cta-click`
        - Run `yarn start` in one terminal tab/window and `yarn start-jetpack-cloud-p` in another one
        - Goto [http://jetpack.cloud.localhost:3001/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Click or Focus on any CTA in featured or simple cards
- Confirm that there is no layout shift
- Create a JN site and click on "Set up Jetpack"
- On "Explore our Jetpack plans" page (`wordpress.com/jetpack/connect/plans`), replace `https://wordpress.com` with `http://calypso.localhost:3000` or the Calypso Live link below (after the redirect).
- Click or Focus on any CTA in featured or simple cards
- Confirm that there is no layout shift
- Complete the setup with Jetpack Free
- On Jetpack Cloud Live link, goto `/pricing:site` or goto `http://jetpack.cloud.localhost:3001/pricing/:site`
- Click or Focus on any CTA in featured or simple cards
- Confirm that there is no layout shift
- On Calypso Live link, goto `/plans/:site` or goto `http://calypso.localhost:3000/plans/:site`
- Click or Focus on any CTA in featured or simple cards
- Confirm that there is no layout shift

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: 0-as-1203002889297423/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203002889297423