### PR TITLE
Pricing page rework: Fix product lightbox tags spacing.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -109,7 +109,7 @@
 }
 
 .product-lightbox__detail-tags {
-	margin-bottom: 0.25rem;
+	margin-bottom: 16px;
 
 	&-label {
 		font-weight: 600;
@@ -122,8 +122,7 @@
 		align-items: center;
 		display: inline-flex;
 		justify-content: center;
-		margin-bottom: 0.5rem;
-		margin-right: 1rem;
+		margin-right: 16px;
 
 		span {
 			margin-right: 4px;


### PR DESCRIPTION
#### Proposed Changes

* Remove margin bottom on Product lightbox tags to make it more closer and not disconnected.

#### Testing Instructions

1. * Run `git fetch && git checkout fix/lightbox-tag-spacing`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
3. Click on the '**more about Anti-spam**' link.
4. Confirm the spacing is closer compared before.

**Before**
<img width="538" alt="Screen Shot 2022-09-21 at 3 33 04 PM" src="https://user-images.githubusercontent.com/56598660/191443135-ec7af7d2-63b6-4f47-838a-18d7177286e6.png">
**After**
<img width="578" alt="Screen Shot 2022-09-21 at 3 34 19 PM" src="https://user-images.githubusercontent.com/56598660/191443315-5a158b77-e0aa-448c-adf2-17438cb08d32.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203013485095837

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203013485095837