### PR TITLE
Pricing page rework: Fix product display name on the simple cards.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -92,7 +92,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 							key={ item.productSlug }
 							onClickCta={ getOnClickPurchase( item ) }
 							price={ price }
-							title={ item.shortName }
+							title={ item.displayName }
 						/>
 					);
 				} ) }


### PR DESCRIPTION
#### Proposed Changes

* Update product simple card to use display name instead of short name.

#### Testing Instructions

1. * Run `git fetch && git checkout fix/simple-item-card-display-name`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
3. Confirm the product simple card for Jetpack search shows **Site Search**.

**Before**
<img width="578" alt="Screen Shot 2022-09-21 at 4 16 46 PM" src="https://user-images.githubusercontent.com/56598660/191452402-2f7313f6-49c6-4ab0-a9c8-501a53fceb4b.png">

**After**
<img width="589" alt="Screen Shot 2022-09-21 at 4 13 05 PM" src="https://user-images.githubusercontent.com/56598660/191452256-9d312b52-1ab4-4e42-b89e-5e111f72afec.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203013485095840

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203013485095840