### PR TITLE
Add sso options to wpcc signup flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1144,6 +1144,8 @@ class SignupForm extends Component {
 						socialService={ this.props.socialService }
 						socialServiceResponse={ this.props.socialServiceResponse }
 						isReskinned={ this.props.isReskinned }
+						flowName={ this.props.flowName }
+						redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 					/>
 				) }
 

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -141,6 +141,9 @@ class SocialSignupForm extends Component {
 								// Set the original URL path for wpcc flow so that we can redirect the user back to /start/wpcc after Apple callback.
 								isWpccFlow( this.props.flowName ) ? window.location.pathname : null
 							}
+							// Attach the query string to the state so we can pass it back to the server to show the correct UI.
+							// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
+							queryString={ isWpccFlow( this.props.flowName ) ? window.location.search : null }
 						/>
 
 						{ ! this.props.disableTosText && <SocialSignupToS /> }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -137,6 +137,10 @@ class SocialSignupForm extends Component {
 							socialServiceResponse={
 								this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
 							}
+							originalUrlPath={
+								// Set the original URL path for wpcc flow so that we can redirect the user back to /start/wpcc after Apple callback.
+								isWpccFlow( this.props.flowName ) ? window.location.pathname : null
+							}
 						/>
 
 						{ ! this.props.disableTosText && <SocialSignupToS /> }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -11,6 +12,8 @@ import { isWpccFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import SocialSignupToS from './social-signup-tos';
+
+const debug = debugFactory( 'calypso:signup:social' );
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -59,8 +62,12 @@ class SocialSignupForm extends Component {
 		} );
 
 		if ( isWpccFlow( this.props.flowName ) && this.props.redirectToAfterLoginUrl ) {
-			// Persist the redirect URL for the redirect flow so that we can redirect the user back to woocommerce.com after login. See ./client/blocks/login for more details.
-			window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectToAfterLoginUrl );
+			try {
+				// Persist the redirect URL for the redirect flow so that we can redirect the user back to woocommerce.com after login. See ./client/blocks/login for more details.
+				window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectToAfterLoginUrl );
+			} catch ( e ) {
+				debug( 'Set login_redirect_to session error', e );
+			}
 		}
 	};
 

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -63,7 +63,7 @@ class SocialSignupForm extends Component {
 
 		if ( isWpccFlow( this.props.flowName ) && this.props.redirectToAfterLoginUrl ) {
 			try {
-				// Persist the redirect URL for the redirect flow so that we can redirect the user back to woocommerce.com after login. See ./client/blocks/login for more details.
+				// Persist the redirect URL for the redirect flow so that we can redirect the user back to original page after login. See ./client/blocks/login for more details.
 				window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectToAfterLoginUrl );
 			} catch ( e ) {
 				debug( 'Set login_redirect_to session error', e );

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -143,7 +143,9 @@ class SocialSignupForm extends Component {
 							}
 							// Attach the query string to the state so we can pass it back to the server to show the correct UI.
 							// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
-							queryString={ isWpccFlow( this.props.flowName ) ? window.location.search : null }
+							queryString={
+								isWpccFlow( this.props.flowName ) ? window.location.search.slice( 1 ) : null
+							}
 						/>
 
 						{ ! this.props.disableTosText && <SocialSignupToS /> }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -88,12 +88,12 @@ class SocialSignupForm extends Component {
 	}
 
 	getRedirectUri = ( socialService ) => {
-		const host = typeof window !== 'undefined' && window.location.host;
+		const origin = typeof window !== 'undefined' && window.location.origin;
 
 		// If the user is in the WPCC flow, we want to redirect user to login callback so that we can automatically log them in.
 		return isWpccFlow( this.props.flowName )
-			? `https://${ host + login( { socialService } ) }`
-			: `https://${ host }/start/user`;
+			? `${ origin + login( { socialService } ) }`
+			: `${ origin }/start/user`;
 	};
 
 	render() {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -86,7 +86,12 @@ class AppleLoginButton extends Component {
 			clientId: this.props.clientId,
 			scope: this.props.scope,
 			redirectURI: this.props.redirectUri,
-			state: oauth2State,
+			state: JSON.stringify( {
+				oauth2State,
+				// Attach the query string to the state so we can pass it back to the server to show the correct UI.
+				// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
+				queryString: window.location.search,
+			} ),
 		} );
 
 		this.appleClient = window.AppleID;

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -27,6 +27,7 @@ class AppleLoginButton extends Component {
 		uxMode: PropTypes.oneOf( [ 'redirect', 'popup' ] ),
 		socialServiceResponse: PropTypes.object,
 		originalUrlPath: PropTypes.string,
+		queryString: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -90,9 +91,7 @@ class AppleLoginButton extends Component {
 			state: JSON.stringify( {
 				oauth2State,
 				originalUrlPath: this.props.originalUrlPath,
-				// Attach the query string to the state so we can pass it back to the server to show the correct UI.
-				// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
-				queryString: window.location.search,
+				queryString: this.props.queryString,
 			} ),
 		} );
 

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -88,6 +88,7 @@ class AppleLoginButton extends Component {
 			redirectURI: this.props.redirectUri,
 			state: JSON.stringify( {
 				oauth2State,
+				originalUrlPath: window.location.pathname,
 				// Attach the query string to the state so we can pass it back to the server to show the correct UI.
 				// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
 				queryString: window.location.search,

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -26,6 +26,7 @@ class AppleLoginButton extends Component {
 		scope: PropTypes.string,
 		uxMode: PropTypes.oneOf( [ 'redirect', 'popup' ] ),
 		socialServiceResponse: PropTypes.object,
+		originalUrlPath: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -88,7 +89,7 @@ class AppleLoginButton extends Component {
 			redirectURI: this.props.redirectUri,
 			state: JSON.stringify( {
 				oauth2State,
-				originalUrlPath: window.location.pathname,
+				originalUrlPath: this.props.originalUrlPath,
 				// Attach the query string to the state so we can pass it back to the server to show the correct UI.
 				// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
 				queryString: window.location.search,

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -917,6 +917,10 @@
 			color: var( --studio-gray-60 );
 		}
 	}
+
+	.signup-form__social-buttons-tos a {
+		color: $woo-purple-60;
+	}
 }
 
 .jetpack-cloud {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -916,6 +916,10 @@
 		p {
 			color: var( --studio-gray-60 );
 		}
+
+		.social-buttons__button {
+			width: 100%;
+		}
 	}
 
 	.signup-form__social-buttons-tos a {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -845,6 +845,11 @@
 		background: none;
 		border: none;
 		text-align: center;
+		margin: 0;
+
+		&.is-blended {
+			padding-top: 16px;
+		}
 	}
 
 	.logged-out-form__links {
@@ -895,10 +900,6 @@
 		}
 	}
 
-	.logged-out-form__footer {
-		margin: 0;
-	}
-
 	.signup-form__woo-wrapper .gridicon {
 		color: var(--color-primary);
 	}
@@ -909,6 +910,12 @@
 
 	.formatted-header__subtitle {
 		display: none;
+	}
+
+	.signup-form__social {
+		p {
+			color: var( --studio-gray-60 );
+		}
 	}
 }
 

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -59,13 +59,14 @@ function redirectToCalypso( request, response, next ) {
 	}
 
 	const originalUrlPath = request.originalUrl.split( '#' )[ 0 ];
+	const state = JSON.parse( request.body.state );
 	const hashString = qs.stringify( {
 		...request.user_openid_data,
 		client_id: config( 'apple_oauth_client_id' ),
-		state: request.body.state,
+		state: state.oauth2State,
 	} );
 
-	response.redirect( originalUrlPath + '#' + hashString );
+	response.redirect( originalUrlPath + state.queryString + '#' + hashString );
 }
 
 export default function ( app ) {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -65,7 +65,7 @@ function redirectToCalypso( request, response, next ) {
 		client_id: config( 'apple_oauth_client_id' ),
 		state: state.oauth2State,
 	} );
-	response.redirect( originalUrlPath + state.queryString + '#' + hashString );
+	response.redirect( originalUrlPath + '?' + state.queryString + '#' + hashString );
 }
 
 export default function ( app ) {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -58,14 +58,13 @@ function redirectToCalypso( request, response, next ) {
 		return next();
 	}
 
-	const originalUrlPath = request.originalUrl.split( '#' )[ 0 ];
 	const state = JSON.parse( request.body.state );
+	const originalUrlPath = state.originalUrlPath ?? request.originalUrl.split( '#' )[ 0 ];
 	const hashString = qs.stringify( {
 		...request.user_openid_data,
 		client_id: config( 'apple_oauth_client_id' ),
 		state: state.oauth2State,
 	} );
-
 	response.redirect( originalUrlPath + state.queryString + '#' + hashString );
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -463,7 +463,7 @@ class Signup extends Component {
 	};
 
 	handleLogin( dependencies, destination, resetSignupFlowController = true ) {
-		const userIsLoggedIn = this.props.isLoggedIn;
+		const { userIsLoggedIn } = this.props;
 
 		debug( `Logging you in to "${ destination }"` );
 
@@ -488,7 +488,7 @@ class Signup extends Component {
 			} );
 		}
 
-		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {
+		if ( ! userIsLoggedIn && config.isEnabled( 'oauth' ) ) {
 			debug( `Handling oauth login` );
 			oauthToken.setToken( dependencies.bearer_token );
 			window.location.href = destination;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -30,7 +30,6 @@ import {
 	getPreviousStepName,
 	getStepUrl,
 	isP2Flow,
-	isWpccFlow,
 	isVideoPressFlow,
 	getVideoPressOnboardingTotalSteps,
 	getVideoPressOnboardingStepNumber,
@@ -435,12 +434,12 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, wccomFrom, isReskinned, flowName } = this.props;
+		const { oauth2Client, isReskinned } = this.props;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
 
-		if ( isWooOAuth2Client( oauth2Client ) && ( isWpccFlow( flowName ) || wccomFrom ) ) {
+		if ( isWooOAuth2Client( oauth2Client ) ) {
 			isSocialSignupEnabled = true;
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -439,18 +439,18 @@ export class UserStep extends Component {
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
-		const hashObject = this.props.initialContext && this.props.initialContext.hash;
-		if ( this.props.isSocialSignupEnabled && ! isEmpty( hashObject ) ) {
-			const clientId = hashObject.client_id;
-			socialService = getSocialServiceFromClientId( clientId );
-
-			if ( socialService ) {
-				socialServiceResponse = hashObject;
-			}
-		}
 
 		if ( isWooOAuth2Client( oauth2Client ) && ( isWpccFlow( flowName ) || wccomFrom ) ) {
 			isSocialSignupEnabled = true;
+		}
+
+		const hashObject = this.props.initialContext && this.props.initialContext.hash;
+		if ( isSocialSignupEnabled && ! isEmpty( hashObject ) ) {
+			const clientId = hashObject.client_id;
+			socialService = getSocialServiceFromClientId( clientId );
+			if ( socialService ) {
+				socialServiceResponse = hashObject;
+			}
 		}
 
 		return (

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -30,6 +30,7 @@ import {
 	getPreviousStepName,
 	getStepUrl,
 	isP2Flow,
+	isWpccFlow,
 	isVideoPressFlow,
 	getVideoPressOnboardingTotalSteps,
 	getVideoPressOnboardingStepNumber,
@@ -434,7 +435,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, wccomFrom, isReskinned } = this.props;
+		const { oauth2Client, wccomFrom, isReskinned, flowName } = this.props;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -448,7 +449,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+		if ( isWooOAuth2Client( oauth2Client ) && ( isWpccFlow( flowName ) || wccomFrom ) ) {
 			isSocialSignupEnabled = true;
 		}
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -189,6 +189,10 @@ export const isVideoPressFlow = ( flowName ) => {
 	return flowName === 'videopress';
 };
 
+export const isWpccFlow = ( flowName ) => {
+	return flowName === 'wpcc';
+};
+
 /**
  * Derive if the "plans" step actually will be visible to the customer in a given flow after the domain step
  * i.e. Check "launch-site" flow while having a purchased paid plan

--- a/client/state/oauth2-clients/ui/reducer.js
+++ b/client/state/oauth2-clients/ui/reducer.js
@@ -6,11 +6,15 @@ export const currentClientId = ( state = null, action ) => {
 	switch ( action.type ) {
 		case ROUTE_SET: {
 			const { path, query } = action;
-			if ( startsWith( path, '/log-in' ) ) {
-				return query.client_id ? Number( query.client_id ) : state;
+			if ( startsWith( path, '/log-in' ) && query.client_id ) {
+				return Number( query.client_id );
 			}
 
-			if ( startsWith( path, '/start/wpcc' ) || startsWith( path, '/start/crowdsignal' ) ) {
+			if (
+				startsWith( path, '/log-in/apple/callback' ) ||
+				startsWith( path, '/start/wpcc' ) ||
+				startsWith( path, '/start/crowdsignal' )
+			) {
 				return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
 			}
 


### PR DESCRIPTION
#### Proposed Changes

63-gh-woocommerce/team-ghidorah

This PR adds Apple and Google SSO options to wpcc signup flow for woocommerce.com.

Changes (please also check commits):

- Set `isSocialSignupEnabled` true for wpcc flow to show social signup form
- Update logic to perform regular login after SSO signup in the wpcc flow
- Set redirect_uri and save redirectToAfterLoginUrl for Apple SSO in the wpcc flow
- Persist URL query string in apple SSO "state" to show the correct UI.
- Update oauth-client form style for woo

#### Testing Instructions

See "Testing Instructions" in https://github.com/Automattic/wp-calypso/pull/64957  to set up a working `wpcalypso.wordpress.com` environment on your local machine.

### Test Google Signup

1. Make sure you're logged out WordPress.com account.
2. Go to https://woocommerce.com/
3. Click `Get Started`
4. Replace the URL host with `wpcalypso.wordpress.com`
5. Click on "Continue with Google" button.
6. Complete the Google connect flow.
7. Observe that you're logged
8. If it's a new account, you should be redirected to https://woocommerce.com/start Otherwise, you will be redirected to https://woocommerce.com/my-dashboard/. (Note that the redirection logic is implemented in the woocmmerce.com end.)

https://user-images.githubusercontent.com/4344253/189059593-28efbed6-8260-4511-ab08-2e66ef9d645d.mov

### Test Apple Signup

1. Make sure you're logged out WordPress.com account.
2. Go to https://woocommerce.com/
3. Click `Get Started`
4. Replace the the URL host with `wpcalypso.wordpress.com`
5. Click on "Continue with Apple" button.
6. Complete the Apple connect flow.
7. Observe that you're logged
8. If it's a new account, you should be redirected to https://woocommerce.com/start Otherwise, you will be redirected to https://woocommerce.com/my-dashboard/.


https://user-images.githubusercontent.com/4344253/189059899-961a1573-e4e9-477e-bcd4-9a19e3a19904.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

