### PR TITLE
Plugin Management: Add unit tests covering the new me/sites/plugins REST API endpoint

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -575,6 +575,9 @@ export function fetchAllPlugins() {
 			dispatch( { type: PLUGINS_ALL_REQUEST_SUCCESS } );
 
 			Object.entries( sites ).forEach( ( [ siteId, plugins ] ) => {
+				// Cast the enumerable string-keyed property to a number.
+				siteId = Number( siteId );
+
 				dispatch( receiveSitePlugins( siteId, plugins ) );
 
 				plugins.forEach( ( plugin ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR adds some tests to cover the new `/me/sites/plugins` endpoint implemented in https://github.com/Automattic/wp-calypso/pull/66345

#### Testing Instructions

Automated Testing

- Verify the tests are passing, and the new tests make sense
```
npm run test-client client/state/plugins/installed/test
```

Manual Testing

- Run `yarn start`
- Visit http://calypso.localhost:3000/plugins/manage
- Verify the plugins list loads as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202882177960012