### PR TITLE
Plans Step FAQ experiment: Update experiment slug

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -223,7 +223,7 @@ export class PlansStep extends Component {
 			<div>
 				{ errorDisplay }
 				<ProvideExperimentData
-					name="calypso_signup_plans_step_faq_202209_v1"
+					name="calypso_signup_plans_step_faq_202209_v2"
 					options={ {
 						isEligible:
 							[ 'en-gb', 'en' ].includes( locale ) &&


### PR DESCRIPTION
#### Proposed Changes

* We're relaunching the experiment (https://github.com/Automattic/wp-calypso/pull/67414) since we found a bug in the plans step caused by another PR (and reverted the problematic PR in https://github.com/Automattic/wp-calypso/pull/68074). 
* This PR simply updates the Abacus slug so that we can relaunch

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing instructions of https://github.com/Automattic/wp-calypso/pull/67414 should pass. 
