### PR TITLE
Use ES results to display popular plugins section

### DIFF
--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -32,6 +32,7 @@ function generateApiQueryString( {
 	query,
 	author,
 	groupId,
+	category,
 	pageHandle,
 	pageSize,
 	locale,
@@ -46,6 +47,7 @@ function generateApiQueryString( {
 		sort: string;
 		size: number;
 		group_id: string;
+		category?: string;
 		from?: number;
 		lang: string;
 	} = {
@@ -56,6 +58,7 @@ function generateApiQueryString( {
 		size: pageSize,
 		lang: locale,
 		group_id: groupId,
+		category: category,
 	};
 
 	if ( author ) {

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -83,6 +83,7 @@ export type ESDateRangeFilter = { range: Record< string, { gte: string; lt: stri
 export type SearchParams = {
 	query: string | undefined;
 	author: string | undefined;
+	category: string | undefined;
 	groupId: string;
 	pageHandle: string | undefined;
 	pageSize: number;

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -52,7 +52,6 @@ export type ESIndexResult = {
 	'plugin.tested'?: string;
 	'plugin.support_threads'?: number;
 	'plugin.support_threads_resolved'?: number;
-	'plugin.active_installs'?: number;
 	plugin: {
 		author: string;
 		title: string;
@@ -60,6 +59,7 @@ export type ESIndexResult = {
 		icons: string;
 		rating: number;
 		num_ratings: number;
+		active_installs: number;
 	};
 };
 

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -77,7 +77,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			num_ratings: hit.plugin.num_ratings,
 			support_threads: hit[ 'plugin.support_threads' ],
 			support_threads_resolved: hit[ 'plugin.support_threads_resolved' ],
-			active_installs: hit[ 'plugin.active_installs' ],
+			active_installs: hit.plugin.active_installs,
 			last_updated: hit.modified,
 			short_description: hit.plugin.excerpt, // TODO: add localization
 			icon: createIconUrl( hit.slug, hit.plugin.icons ),

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -116,6 +116,7 @@ export const useESPluginsInfinite = (
 				query: searchTerm,
 				author,
 				groupId: 'wporg',
+				category: options.category,
 				pageHandle: pageParam,
 				pageSize,
 				locale: getWpLocaleBySlug( options.locale || locale ),

--- a/client/my-sites/plugins/plugins-category-results-page/header.tsx
+++ b/client/my-sites/plugins/plugins-category-results-page/header.tsx
@@ -7,13 +7,13 @@ const Header = ( {
 }: {
 	title: string;
 	subtitle: string;
-	count: string;
+	count?: string;
 } ) => {
 	return (
 		<div className="plugin-category-results-header">
 			<h1 className="plugin-category-results-header__title">{ title }</h1>
 			{ subtitle && <h2 className="plugin-category-results-header__subtitle">{ subtitle }</h2> }
-			<div className="plugin-category-results-header__count">{ count }</div>
+			{ count && <div className="plugin-category-results-header__count">{ count }</div> }
 		</div>
 	);
 };

--- a/client/my-sites/plugins/plugins-category-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-category-results-page/index.jsx
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import UpgradeNudge from 'calypso/my-sites/plugins/plugins-discovery-page/upgrade-nudge';
@@ -7,31 +6,19 @@ import usePlugins from '../use-plugins';
 import Header from './header';
 
 const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
-	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
+	const { plugins, isFetching, fetchNextPage } = usePlugins( {
 		category,
 		infinite: true,
 	} );
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || category;
-	const categoryDescription = categories[ category ]?.description;
-	const translate = useTranslate();
-
-	let title = '';
-	if ( categoryName && pagination ) {
-		title = translate( '%(total)s plugin', '%(total)s plugins', {
-			count: pagination.results,
-			textOnly: true,
-			args: {
-				total: pagination.results.toLocaleString(),
-			},
-		} );
-	}
+	const categoryDescription = categories[ category ]?.categoryDescription;
 
 	return (
 		<>
 			<UpgradeNudge siteSlug={ siteSlug } paidPlugins={ true } />
-			<Header title={ categoryName } count={ title } subtitle={ categoryDescription } />
+			<Header title={ categoryName } subtitle={ categoryDescription } />
 
 			<FullListView
 				plugins={ plugins }

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -74,10 +74,9 @@ const usePlugins = ( {
 	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
-	const searchHook =
-		isEnabled( 'marketplace-jetpack-plugin-search' ) && search
-			? useESPluginsInfinite
-			: useWPORGInfinitePlugins;
+	const searchHook = isEnabled( 'marketplace-jetpack-plugin-search' )
+		? useESPluginsInfinite
+		: useWPORGInfinitePlugins;
 
 	const { localeSlug = '' } = useTranslate();
 	const wporgPluginsOptions = {


### PR DESCRIPTION
#### Proposed Changes

> **Note**: Depends on D87985-code

- update the ES queries to pass an additional `category` parameter
- update the search hook to use the ES API for categories as well

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* patch D87985-code and sandbox `public-api`
* in calypso, visit `/plugins`
* verify that the network request is made to the search API, and the `category` parameter is passed
* click on 'Browse All ->' on the top-right of the Top Essentials section, or visit `/plugins/browse/popular`
* verify the same

| Before | After |
| ------ | ----- |
| <img width="914" alt="CleanShot 2022-09-21 at 11 06 55@2x" src="https://user-images.githubusercontent.com/11555574/191463919-3eb674eb-0874-4453-b3ef-a403872123b1.png"> | <img width="916" alt="CleanShot 2022-09-21 at 11 07 12@2x" src="https://user-images.githubusercontent.com/11555574/191463941-a279457d-b07a-47da-a768-a84baeb8f2ad.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #63167