### PR TITLE
Jetpack New Pricing Page - Align the section header icons with included/not included icons. 

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
@@ -22,7 +22,7 @@
 
 .features-list__group--title {
 	font-size: 1.25rem;
-	padding: 1.25rem 1rem;
+	padding: 1.25rem 1.2rem;
 	border-bottom: 1px solid var(--studio-gray-5);
 	line-height: 24px;
 }


### PR DESCRIPTION
*Aligns the bundle section header icon correctly with the feature's icon


#### Testing Instructions

* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout fix/section-header-padding`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
*Switch to Bundles Tab and make sure the lock icon in the Security and Complete heading aligns to the included/not-included icon 

#### Screenshot

##### Before
![Screenshot 2022-09-21 at 2 54 12 PM](https://user-images.githubusercontent.com/2027003/191467947-b89f9e6b-0ea4-4629-8b09-6b391c899fb5.png)



##### After
![Screenshot 2022-09-21 at 2 45 16 PM](https://user-images.githubusercontent.com/2027003/191468017-5be7b362-fac3-4cc2-bf1c-630c2093cfcc.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
0-as-1203013485095848/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203013485095848