### PR TITLE
Marketplace: Add plan upgrade handler

### DIFF
--- a/client/my-sites/plugins/controller-logged-in.js
+++ b/client/my-sites/plugins/controller-logged-in.js
@@ -7,6 +7,11 @@ export function upload( context, next ) {
 }
 
 export function plans( context, next ) {
-	context.primary = <Plans intervalType={ context.params.intervalType } />;
+	context.primary = (
+		<Plans
+			intervalType={ context.params.intervalType }
+			pluginSlug={ context.params.pluginSlug || false }
+		/>
+	);
 	next();
 }

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -93,7 +93,7 @@ export default function ( router ) {
 	router( `/${ langParam }/plugins/plans`, notFound, makeLayout );
 
 	router(
-		`/${ langParam }/plugins/plans/:intervalType(yearly|monthly)/:site`,
+		`/${ langParam }/plugins/plans/:pluginSlug?/:intervalType(yearly|monthly)/:site`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectLoggedOut,
 		scrollTopIfNoHash,

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -1,25 +1,95 @@
-import { FEATURE_INSTALL_PLUGINS, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	FEATURE_INSTALL_PLUGINS,
+	PLAN_BUSINESS,
+	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
+} from '@automattic/calypso-products';
+import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import page from 'page';
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
+import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import {
+	isMarketplaceProduct as isMarketplaceProductSelector,
+	getProductsList,
+} from 'calypso/state/products-list/selectors';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
+import { getPeriodVariationValue } from '../plugin-price';
 
 import './style.scss';
 
-const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
+const Plans = ( {
+	pluginSlug,
+	intervalType,
+}: {
+	pluginSlug: string | false;
+	intervalType: 'yearly' | 'monthly';
+} ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );
 
-	const dispatch = useDispatch();
+	const [ showEligibility, setShowEligibility ] = useState( false );
+	const [ showAddCustomDomain, setShowAddCustomDomain ] = useState( false );
+
+	// const {
+	// 	data: wpComPluginData,
+	// 	isFetched: isWpComPluginFetched,
+	// 	isFetching: isWpComPluginFetching,
+	// } = useWPCOMPlugin( props.pluginSlug, { enabled: isProductListFetched && isMarketplaceProduct } );
+
+	// // Unify plugin details
+	// const fullPlugin = useMemo( () => {
+	// 	const wpcomPlugin = {
+	// 		...wpComPluginData,
+	// 		fetched: isWpComPluginFetched,
+	// 	};
+
+	// 	return {
+	// 		...wpcomPlugin,
+	// 		...wporgPlugin,
+	// 		...plugin,
+	// 		fetched: wpcomPlugin?.fetched || wporgPlugin?.fetched,
+	// 		isMarketplaceProduct,
+	// 	};
+	// }, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched, isMarketplaceProduct ] );
+
+	const billingPeriod = useSelector( getBillingInterval );
+
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, pluginSlug )
+	);
+
+	const pluginFeature = isMarketplaceProduct
+		? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
+		: FEATURE_INSTALL_PLUGINS;
+
+	const primaryDomain = useSelector( ( state ) =>
+		getPrimaryDomainBySiteId( state, selectedSite?.ID || null )
+	);
+
+	const pluginRequiresCustomPrimaryDomain =
+		( primaryDomain?.isWPCOMDomain || primaryDomain?.isWpcomStagingDomain ) && !! plugin?.tags?.seo;
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+
+	const productsList = useSelector( getProductsList );
 
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
@@ -44,9 +114,14 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 		);
 	}, [ dispatch, translate, selectedSite, breadcrumbs.length, intervalType ] );
 
+	let path = '/plugins/plans/:interval/:site';
+	if ( pluginSlug ) {
+		path = '/plugins/plans/:plugin/:interval/:site';
+	}
+
 	return (
 		<MainComponent wideLayout>
-			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
+			<PageViewTracker path={ path } title="Plugins > Plan Upgrade" />
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
 			<FixedNavigationHeader navigationItems={ breadcrumbs } />
 			<FormattedHeader
@@ -60,14 +135,155 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					basePlansPath="/plugins/plans"
 					site={ selectedSite }
 					intervalType={ intervalType }
-					selectedFeature={ FEATURE_INSTALL_PLUGINS }
+					selectedFeature={ pluginFeature }
 					selectedPlan={ PLAN_BUSINESS }
 					shouldShowPlansFeatureComparison
 					isReskinned
+					onUpgradeClick={ () => {
+						if ( pluginRequiresCustomPrimaryDomain ) {
+							return setShowAddCustomDomain( true );
+						}
+						if ( hasEligibilityMessages ) {
+							return setShowEligibility( true );
+						}
+						onClickInstallPlugin( {
+							dispatch,
+							selectedSite,
+							plugin,
+							upgradeAndInstall: true,
+							isMarketplaceProduct,
+							billingPeriod,
+							productsList,
+						} );
+					} }
 				/>
 			</div>
+			<PluginCustomDomainDialog
+				onProceed={ () => {
+					if ( hasEligibilityMessages ) {
+						return setShowEligibility( true );
+					}
+					onClickInstallPlugin( {
+						dispatch,
+						selectedSite,
+						plugin,
+						upgradeAndInstall: true,
+						isMarketplaceProduct,
+						billingPeriod,
+						productsList,
+					} );
+				} }
+				isDialogVisible={ showAddCustomDomain }
+				plugin={ plugin }
+				domains={ domains }
+				closeDialog={ () => setShowAddCustomDomain( false ) }
+			/>
+			<Dialog
+				additionalClassNames={ 'plugin-details-cta__dialog-content' }
+				additionalOverlayClassNames={ 'plugin-details-cta__modal-overlay' }
+				isVisible={ showEligibility }
+				title={ translate( 'Eligibility' ) }
+				onClose={ () => setShowEligibility( false ) }
+			>
+				<EligibilityWarnings
+					currentContext={ 'plugin-details' }
+					isMarketplace={ isMarketplaceProduct }
+					standaloneProceed
+					onProceed={ () =>
+						onClickInstallPlugin( {
+							dispatch,
+							selectedSite,
+							plugin,
+							upgradeAndInstall: true,
+							isMarketplaceProduct,
+							billingPeriod,
+							productsList,
+						} )
+					}
+				/>
+			</Dialog>
 		</MainComponent>
 	);
 };
 
 export default Plans;
+
+function onClickInstallPlugin( {
+	dispatch,
+	selectedSite,
+	plugin,
+	upgradeAndInstall,
+	isMarketplaceProduct,
+	billingPeriod,
+	isPreinstalledPremiumPlugin,
+	preinstalledPremiumPluginProduct,
+	productsList,
+} ) {
+	dispatch( removePluginStatuses( 'completed', 'error' ) );
+
+	dispatch(
+		recordGoogleEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', plugin.slug )
+	);
+	dispatch(
+		recordGoogleEvent( 'calypso_plugin_install_click_from_plugin_info', {
+			site: selectedSite?.ID,
+			plugin: plugin.slug,
+		} )
+	);
+	dispatch(
+		recordTracksEvent( 'calypso_plugin_install_activate_click', {
+			plugin: plugin.slug,
+			blog_id: selectedSite?.ID,
+			marketplace_product: isMarketplaceProduct,
+			needs_plan_upgrade: upgradeAndInstall,
+		} )
+	);
+
+	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
+
+	if ( isMarketplaceProduct ) {
+		// We need to add the product to the  cart.
+		// Plugin install is handled on the backend by activating the subscription.
+		const variationPeriod = getPeriodVariationValue( billingPeriod );
+
+		const variation = plugin?.variations?.[ variationPeriod ];
+		const product_slug = getProductSlugByPeriodVariation( variation, productsList );
+
+		if ( upgradeAndInstall ) {
+			// We also need to add a business plan to the cart.
+			return page(
+				`/checkout/${ selectedSite.slug }/${ marketplacePlanToAdd(
+					selectedSite?.plan,
+					billingPeriod
+				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
+					selectedSite.slug
+				}`
+			);
+		}
+
+		return page(
+			`/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
+		);
+	}
+
+	if ( isPreinstalledPremiumPlugin ) {
+		const checkoutUrl = `/checkout/${ selectedSite.slug }/${ preinstalledPremiumPluginProduct }`;
+		const installUrl = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
+		return page( `${ checkoutUrl }?redirect_to=${ installUrl }#step2` );
+	}
+
+	// After buying a plan we need to redirect to the plugin install page.
+	const installPluginURL = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
+	if ( upgradeAndInstall ) {
+		// We also need to add a business plan to the cart.
+		return page(
+			`/checkout/${ selectedSite.slug }/${ marketplacePlanToAdd(
+				selectedSite?.plan,
+				billingPeriod
+			) }?redirect_to=${ installPluginURL }#step2`
+		);
+	}
+
+	// No need to go through chekout, go to install page directly.
+	return page( installPluginURL );
+}

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -102,7 +102,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	const productsList = useSelector( getProductsList );
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
-	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
+	const pluginsPlansPage = `/plugins/plans/${ plugin.slug }/yearly/${ selectedSite?.slug }`;
 
 	return (
 		<>


### PR DESCRIPTION
#### Proposed Changes

* Adding click event handlers to the plan page
* Current approach: Port CTA-button.jsx dialog and install code over to the plan page

Todo:

* [ ] Plugin data gets passed in to the CTA button - need to add this in
* [ ] Eligibility data gets passed in to the CTA button - need to add this in
* [ ] CTA button assumes business upgrade - need to handle situations where user selects an ecommerce plan

Concerns:

* Wondering if the plans route/page setup even makes sense.
* Possibly we want to implement the plans page as a full page modal and let the logic remain in the CTA button?
* As long as we implement this as a wrapper / re-usable component we should be able to use the same thing on the discover page nudge which at the moment is going to struggle to re-use what I have so far since its heavily oriented around eligibility checks and plugin details.
* Alternative viewpoint, this code will eventually replace most (but not all) of the CTA code so maybe it's not so bad?


#### Testing Instructions

* TBD
* http://calypso.localhost:3000/plugins/plans/wordpress-seo-premium/yearly/:site

Related to https://github.com/Automattic/wp-calypso/issues/67574 (Didn't get to creating an issue for this yet)
Fixes https://github.com/Automattic/wp-calypso/issues/68089
