### PR TITLE
Changing copy for Cancel CTAs within refund window

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -493,15 +493,15 @@ class ManagePurchase extends Component {
 
 		if ( hasAmountAvailableToRefund( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
-				text = translate( 'Cancel Domain and Refund' );
+				text = translate( 'Cancel Domain' );
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = translate( 'Cancel Subscription and Refund' );
+				text = translate( 'Cancel Subscription' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
-				text = translate( 'Cancel and Refund' );
+				text = translate( 'Cancel' );
 			}
 		} else {
 			if ( isDomainTransfer( purchase ) ) {


### PR DESCRIPTION
#### Proposed Changes

* We're proposing to change the copy for cancel options within the refund window to measure impact. 

* This PR is just copy changes, no logic changes.

#### Testing Instructions

* Purchase a plan, go to Manage my plan within the refund window, and check the Cancel option doesn't mention refund.
