### PR TITLE
Jetpack New Pricing Page - Fix extra border on mobile for foldable cards

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -59,6 +59,7 @@
 
 .jetpack-product-store__most-popular--item .foldable-card.is-expanded {
 	margin: 0;
+	border-bottom: 0;
 }
 
 .jetpack-product-store__most-popular--item .foldable-card.is-expanded .foldable-card__content {


### PR DESCRIPTION
*Fix extra bottom border show in bundles foldable cards on mobile 


#### Testing Instructions

* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout fix/card-border-mobile`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Switch to mobile view and navigate to the the **Bundles** section 
* Under **Security** click on *View all features* and make sure only one border is shown at the end of the features list. 
  
#### Screenshot

##### Before
![Screenshot 2022-09-21 at 3 24 45 PM](https://user-images.githubusercontent.com/2027003/191475280-76ddebe7-abb3-4c43-b9b9-488109951e49.png)



##### After
![Screenshot 2022-09-21 at 3 24 05 PM](https://user-images.githubusercontent.com/2027003/191475316-0b59c3ba-058e-4e1f-a5c2-f50677b48eb0.png)

#### Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
0-as-1203013485095848/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203013485095849
  - [0-as-1203013485095848](0-as-1203013485095849/f)