### PR TITLE
Design Picker cleanup: Remove always-true signup/theme-preview-screen  flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -484,8 +484,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		/>
 	);
 
-	const newDesignEnabled = isEnabled( 'signup/theme-preview-screen' );
-
 	const stepContent = (
 		<UnifiedDesignPicker
 			generatedDesigns={ generatedDesigns }
@@ -494,13 +492,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			locale={ locale }
 			onSelect={ pickDesign }
 			onPreview={ previewDesign }
-			onUpgrade={ upgradePlan }
 			onCheckout={ goToCheckout }
 			heading={ heading }
 			categorization={ categorization }
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
-			previewOnly={ newDesignEnabled }
-			hasDesignOptionHeader={ ! newDesignEnabled }
 			purchasedThemes={ purchasedThemes }
 		/>
 	);

--- a/config/development.json
+++ b/config/development.json
@@ -167,7 +167,6 @@
 		"signup/standard-theme-v13n": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
-		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -112,7 +112,6 @@
 		"signup/standard-theme-v13n": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
-		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -130,7 +130,6 @@
 		"signup/standard-theme-v13n": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
-		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -129,7 +129,6 @@
 		"signup/standard-theme-v13n": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
-		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,7 +138,6 @@
 		"signup/standard-theme-v13n": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
-		"signup/theme-preview-screen": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -84,7 +83,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	locale,
 	onSelect,
 	design,
-	premiumBadge = null,
 	highRes,
 	disabled,
 	hideDesignTitle,
@@ -106,19 +104,13 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 	const badgeType = design.is_premium ? 'premium' : 'none';
 
-	const badgeContainer = ! isEnabled( 'signup/theme-preview-screen' ) ? (
-		design.is_premium && premiumBadge
-	) : (
+	const badgeContainer = (
 		<BadgeContainer badgeType={ badgeType } isPremiumThemeAvailable={ isPremiumThemeAvailable } />
 	);
 
 	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 
 	function getPricingDescription() {
-		if ( ! isEnabled( 'signup/theme-preview-screen' ) ) {
-			return null;
-		}
-
 		if ( hideDescription ) {
 			return null;
 		}

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -9,7 +9,6 @@ import { sprintf, hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { noop } from 'lodash';
 import { useMemo } from 'react';
 import {
 	DEFAULT_VIEWPORT_WIDTH,
@@ -36,14 +35,12 @@ const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name
 interface DesignPreviewImageProps {
 	design: Design;
 	locale: string;
-	highRes: boolean;
 	verticalId?: string;
 }
 
 const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	design,
 	locale,
-	highRes,
 	verticalId,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
@@ -57,7 +54,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""
-			options={ getMShotOptions( { scrollable: true, highRes, isMobile } ) }
+			options={ getMShotOptions( { scrollable: true, highRes: false, isMobile } ) }
 			scrollable={ true }
 		/>
 	);
@@ -66,12 +63,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 interface DesignButtonProps {
 	design: Design;
 	locale: string;
-	onSelect: ( design: Design, variation?: StyleVariation ) => void;
-	highRes: boolean;
-	disabled?: boolean;
-	hideFullScreenPreview?: boolean;
-	hideDesignTitle?: boolean;
-	hasDesignOptionHeader?: boolean;
+	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	isPremiumThemeAvailable?: boolean;
 	hasPurchasedTheme?: boolean;
 	onCheckout?: any;
@@ -80,12 +72,8 @@ interface DesignButtonProps {
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
 	locale,
-	onSelect,
+	onPreview,
 	design,
-	highRes,
-	disabled,
-	hideDesignTitle,
-	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable = false,
 	hasPurchasedTheme = false,
 	onCheckout,
@@ -93,16 +81,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 } ) => {
 	const { __ } = useI18n();
 	const { style_variations = [], is_premium: isPremium = false } = design;
-	const isEnableThemePreviewScreen = isEnabled( 'signup/theme-preview-screen' );
-	const isEnableThemeStyleVariations =
-		isEnabled( 'signup/design-picker-style-selection' ) && isEnableThemePreviewScreen;
+	const isEnableThemeStyleVariations = isEnabled( 'signup/design-picker-style-selection' );
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 
 	function getPricingDescription() {
-		if ( ! isEnableThemePreviewScreen ) {
-			return null;
-		}
-
 		let text: React.ReactNode = null;
 		if ( isPremium && shouldUpgrade ) {
 			if ( isEnabled( 'signup/seller-upgrade-modal' ) ) {
@@ -160,53 +142,29 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	return (
 		<div className="design-picker__design-option">
 			<button
-				disabled={ disabled }
 				data-e2e-button={ isPremium ? 'paidOption' : 'freeOption' }
-				onClick={ () => onSelect( design ) }
+				onClick={ () => onPreview( design ) }
 			>
-				{ hasDesignOptionHeader && (
-					<span className="design-picker__design-option-header">
-						<svg width="28" height="6">
-							<g>
-								<rect width="6" height="6" rx="3" />
-								<rect x="11" width="6" height="6" rx="3" />
-								<rect x="22" width="6" height="6" rx="3" />
-							</g>
-						</svg>
-					</span>
-				) }
 				<span
 					className={ classnames(
 						'design-picker__image-frame',
 						'design-picker__image-frame-landscape',
 						'design-picker__scrollable',
-						{
-							'design-picker__image-frame-no-header': ! hasDesignOptionHeader,
-						}
+						'design-picker__image-frame-no-header'
 					) }
 				>
 					<div className="design-picker__image-frame-inside">
-						<DesignPreviewImage
-							design={ design }
-							locale={ locale }
-							highRes={ highRes }
-							verticalId={ verticalId }
-						/>
+						<DesignPreviewImage design={ design } locale={ locale } verticalId={ verticalId } />
 					</div>
 				</span>
 				<span className="design-picker__option-overlay">
 					<span id={ makeOptionId( design ) } className="design-picker__option-meta">
-						{ ! hideDesignTitle && (
-							<span className="design-picker__option-name">{ design.title }</span>
-						) }
-						{ ! isEnableThemePreviewScreen && isPremium && (
-							<PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
-						) }
+						<span className="design-picker__option-name">{ design.title }</span>
 						{ isEnableThemeStyleVariations && style_variations.length > 0 && (
 							<div className="design-picker__options-style-variations">
 								<StyleVariationBadges
 									variations={ style_variations }
-									onClick={ ( variation ) => onSelect( design, variation ) }
+									onClick={ ( variation ) => onPreview( design, variation ) }
 								/>
 							</div>
 						) }
@@ -218,114 +176,23 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	);
 };
 
-interface DesignButtonCoverProps {
-	design: Design;
-	isPremiumThemeAvailable?: boolean;
-	onSelect: ( design: Design ) => void;
-	onPreview: ( design: Design ) => void;
-	onUpgrade?: ( design: Design ) => void;
-}
-
-const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
-	design,
-	isPremiumThemeAvailable = false,
-	onSelect,
-	onPreview,
-	onUpgrade,
-} ) => {
-	const { __ } = useI18n();
-	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable;
-
-	return (
-		<div className="design-button-cover">
-			{ /* Make all of design button clickable and default behavior is preview  */ }
-			<button
-				className="design-button-cover__button-overlay"
-				tabIndex={ -1 }
-				onClick={ () => onPreview( design ) }
-			/>
-			<div className="design-button-cover__button-groups">
-				<Button
-					className="design-button-cover__button"
-					isPrimary
-					onClick={ () => ( shouldUpgrade ? onUpgrade?.( design ) : onSelect( design ) ) }
-				>
-					{ shouldUpgrade
-						? __( 'Upgrade Plan', __i18n_text_domain__ )
-						: // translators: %s is the title of design with currency. Eg: Alves
-						  sprintf( __( 'Start with %s', __i18n_text_domain__ ), design.title ) }
-				</Button>
-				<Button className="design-button-cover__button" onClick={ () => onPreview( design ) }>
-					{
-						// translators: %s is the title of design with currency. Eg: Alves
-						sprintf( __( 'Preview %s', __i18n_text_domain__ ), design.title )
-					}
-				</Button>
-			</div>
-		</div>
-	);
-};
-
 interface DesignButtonContainerProps extends DesignButtonProps {
-	isPremiumThemeAvailable?: boolean;
-	hasPurchasedTheme?: boolean;
-	onPreview?: ( design: Design, variation?: StyleVariation ) => void;
-	onUpgrade?: () => void;
-	previewOnly?: boolean;
+	onSelect: ( design: Design ) => void;
 }
 
 const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
-	isPremiumThemeAvailable,
-	onPreview,
-	onUpgrade,
-	previewOnly = false,
+	onSelect,
 	...props
 } ) => {
-	const isDesktop = useViewportMatch( 'large' );
 	const isBlankCanvas = isBlankCanvasDesign( props.design );
 
 	if ( isBlankCanvas ) {
-		return <PatternAssemblerCta onButtonClick={ () => props.onSelect( props.design ) } />;
-	}
-
-	if ( ! onPreview || props.hideFullScreenPreview ) {
-		return (
-			<div className="design-button-container design-button-container--without-preview">
-				<DesignButton { ...props } />
-			</div>
-		);
-	}
-
-	// Show the preview directly when selecting the design if the device is not desktop
-	if ( ! isDesktop ) {
-		return (
-			<div className="design-button-container">
-				<DesignButton
-					{ ...props }
-					isPremiumThemeAvailable={ isPremiumThemeAvailable }
-					onSelect={ onPreview }
-				/>
-			</div>
-		);
+		return <PatternAssemblerCta onButtonClick={ () => onSelect( props.design ) } />;
 	}
 
 	return (
 		<div className="design-button-container">
-			{ ! previewOnly && (
-				<DesignButtonCover
-					design={ props.design }
-					isPremiumThemeAvailable={ isPremiumThemeAvailable }
-					onSelect={ props.onSelect }
-					onPreview={ onPreview }
-					onUpgrade={ onUpgrade }
-				/>
-			) }
-			<DesignButton
-				{ ...props }
-				isPremiumThemeAvailable={ isPremiumThemeAvailable }
-				onSelect={ previewOnly ? onPreview : noop }
-				disabled={ ! previewOnly }
-			/>
+			<DesignButton { ...props } />
 		</div>
 	);
 };
@@ -340,14 +207,11 @@ export interface UnifiedDesignPickerProps {
 	verticalId?: string;
 	onSelect: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	onUpgrade?: () => void;
 	generatedDesigns: Design[];
 	staticDesigns: Design[];
 	categorization?: Categorization;
 	heading?: React.ReactNode;
 	isPremiumThemeAvailable?: boolean;
-	previewOnly?: boolean;
-	hasDesignOptionHeader?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
 }
@@ -357,12 +221,9 @@ interface StaticDesignPickerProps {
 	verticalId?: string;
 	onSelect: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	onUpgrade?: () => void;
 	designs: Design[];
 	categorization?: Categorization;
 	isPremiumThemeAvailable?: boolean;
-	previewOnly?: boolean;
-	hasDesignOptionHeader?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
 }
@@ -378,11 +239,8 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 	locale,
 	onSelect,
 	onPreview,
-	onUpgrade,
 	designs,
 	categorization,
-	previewOnly = false,
-	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable,
 	onCheckout,
 	verticalId,
@@ -415,13 +273,7 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 						locale={ locale }
 						onSelect={ onSelect }
 						onPreview={ onPreview }
-						onUpgrade={ onUpgrade }
-						highRes={ false }
-						hideFullScreenPreview={ false }
-						hideDesignTitle={ false }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
-						previewOnly={ previewOnly }
-						hasDesignOptionHeader={ hasDesignOptionHeader }
 						onCheckout={ onCheckout }
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
@@ -474,14 +326,11 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
 	onSelect,
 	onPreview,
-	onUpgrade,
 	verticalId,
 	staticDesigns,
 	generatedDesigns,
 	heading,
 	categorization,
-	previewOnly = false,
-	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable,
 	onCheckout,
 	purchasedThemes,
@@ -531,12 +380,9 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					locale={ locale }
 					onSelect={ onSelect }
 					onPreview={ onPreview }
-					onUpgrade={ onUpgrade }
 					designs={ staticDesigns }
 					categorization={ categorization }
 					verticalId={ verticalId }
-					previewOnly={ previewOnly }
-					hasDesignOptionHeader={ hasDesignOptionHeader }
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
 					onCheckout={ onCheckout }
 					purchasedThemes={ purchasedThemes }


### PR DESCRIPTION
#### Proposed Changes

This flag was used to enable/disable selecting a theme without previewing it:

false | true
-----| -----
<img width="474" alt="image" src="https://user-images.githubusercontent.com/1525580/191479610-da554a08-617d-4b06-bf2c-bdfb807a44fc.png"> | <img width="479" alt="image" src="https://user-images.githubusercontent.com/1525580/191479807-ead05563-1d5f-4a4d-a933-381fe118f557.png">

This PR cleans this up by assuming the value is always true. With this, we can clean up so much code.

#### Testing Instructions

* Go to `/setup`
* Test happy cases of the Design Picker flows
* Verify that nothing breaks :) in particular:
   - We can still preview and select a generated design
   - We can still preview and select a static theme
   - We can still use the Pattern Assembler
   - We can still unlock premium themes

As this PR somehow touches DIFM flow a little, it's a good idea to test it as well:

* Go to `/start/do-it-for-me/`
* Select new site
* Verify that the Design Picker is still working.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68244
