### PR TITLE
Plugin Management: replace old tables in plugin details with the new design in Calypso Blue

### DIFF
--- a/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
@@ -35,6 +35,7 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 			shouldCloseOnEsc
 		>
 			<SitesWithInstalledPluginsList
+				isWpCom
 				sites={ sitesWithPlugin }
 				isLoading={ isLoading }
 				plugin={ plugin }

--- a/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
@@ -1,22 +1,19 @@
-import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { Dialog, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import PluginSiteList from 'calypso/my-sites/plugins/plugin-site-list';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
-import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import {
 	getSiteObjectsWithPlugin,
 	getSiteObjectsWithoutPlugin,
 } from 'calypso/state/plugins/installed/selectors';
+import { isFetching as isWporgPluginFetchingSelector } from 'calypso/state/plugins/wporg/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import './style.scss';
+import PluginAvailableOnSitesList from '../plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
+import SitesWithInstalledPluginsList from '../plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list';
 
 export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 	const translate = useTranslate();
-
-	const billingPeriod = useSelector( getBillingInterval );
 
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
@@ -28,16 +25,7 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 		getSiteObjectsWithoutPlugin( state, siteIds, plugin.slug )
 	);
 
-	const availableOnSites = useSelector( ( state ) =>
-		sitesWithoutPlugin.filter( ( site ) =>
-			siteHasFeature( state, site.ID, FEATURE_INSTALL_PLUGINS )
-		)
-	);
-	const upgradeNeededSites = useSelector( ( state ) =>
-		sitesWithoutPlugin.filter(
-			( site ) => ! siteHasFeature( state, site.ID, FEATURE_INSTALL_PLUGINS )
-		)
-	);
+	const isLoading = useSelector( ( state ) => isWporgPluginFetchingSelector( state, plugin.slug ) );
 
 	return (
 		<Dialog
@@ -46,32 +34,16 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 			onClose={ onClose }
 			shouldCloseOnEsc
 		>
-			<PluginSiteList
-				className="manage-site-plugins-dialog__plugin-list"
-				title={ translate( 'Installed on %d site', 'Installed on %d sites', {
-					comment: 'header for list of sites a plugin is installed on',
-					args: [ sitesWithPlugin.length ],
-					count: sitesWithPlugin.length,
-				} ) }
+			<SitesWithInstalledPluginsList
 				sites={ sitesWithPlugin }
+				isLoading={ isLoading }
 				plugin={ plugin }
-				showAdditionalHeaders
 			/>
 
-			<PluginSiteList
-				className="manage-site-plugins-dialog__plugin-list"
-				title={ translate( 'Available sites' ) }
-				sites={ availableOnSites }
+			<PluginAvailableOnSitesList
+				sites={ sitesWithoutPlugin }
+				isLoading={ isLoading }
 				plugin={ plugin }
-				billingPeriod={ billingPeriod }
-			/>
-
-			<PluginSiteList
-				className="manage-site-plugins-dialog__plugin-list"
-				title={ translate( 'Upgrade needed' ) }
-				sites={ upgradeNeededSites }
-				plugin={ plugin }
-				billingPeriod={ billingPeriod }
 			/>
 
 			<Button className="manage-site-plugins-dialog__finish-button" onClick={ onClose } primary>

--- a/client/my-sites/plugins/manage-site-plugins-dialog/style.scss
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/style.scss
@@ -10,12 +10,6 @@
 		}
 	}
 
-	.plugin-site-list__title {
-		color: var(--studio-gray-100);
-		font-size: $font-title-small;
-		padding: 16px 0;
-	}
-
 	.plugin-site-list__content {
 		border-bottom: 1px solid var(--studio-gray-0);
 
@@ -50,14 +44,6 @@
 		margin-bottom: 0;
 	}
 
-	.manage-site-plugins-dialog__plugin-list {
-		margin-bottom: 16px;
-
-		@media screen and ( max-width: 1040px ) {
-			margin-bottom: 50px;
-		}
-	}
-
 	.manage-site-plugins-dialog__finish-button {
 		float: right;
 
@@ -65,8 +51,15 @@
 			margin-top: 16px;
 		}
 	}
+
+	.plugin-details-v2__title {
+		color: var(--studio-gray-100);
+		font-size: $font-title-small;
+		padding: 16px 0;
+	}
 }
 
-.popover.ellipsis-menu__menu {
-	z-index: z-index("root", ".popover.ellipsis-menu__menu");
+.popover,
+.global-notices {
+	z-index: z-index("root", ".popover.ellipsis-menu__menu") !important;
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -1,7 +1,9 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getSitesWithSecondarySites } from 'calypso/my-sites/plugins/plugin-management-v2/utils/get-sites-with-secondary-sites';
 import PluginManageConnection from '../plugin-manage-connection';
+import PluginManageSubcription from '../plugin-manage-subscription';
 import RemovePlugin from '../remove-plugin';
 import SitesList from '../sites-list';
 import type { Plugin } from '../types';
@@ -15,12 +17,14 @@ interface Props {
 	selectedSite: SiteDetails;
 	isLoading: boolean;
 	plugin: Plugin;
+	isWpCom?: boolean;
 }
 
 export default function SitesWithInstalledPluginsList( {
 	sites,
 	plugin,
 	selectedSite,
+	isWpCom,
 	...rest
 }: Props ): ReactElement | null {
 	const translate = useTranslate();
@@ -56,10 +60,25 @@ export default function SitesWithInstalledPluginsList( {
 	const siteCount = sitesWithSecondarySites.length;
 
 	const renderActions = ( site: SiteDetails ) => {
+		const settingsLink = plugin?.action_links?.Settings ?? null;
 		return (
 			<>
 				<RemovePlugin site={ site } plugin={ plugin } />
 				<PluginManageConnection site={ site } plugin={ plugin } />
+				{ isWpCom && (
+					<>
+						<PluginManageSubcription site={ site } plugin={ plugin } />
+						{ settingsLink && (
+							<PopoverMenuItem
+								className="plugin-management-v2__actions"
+								icon="cog"
+								href={ settingsLink }
+							>
+								{ translate( 'Settings' ) }
+							</PopoverMenuItem>
+						) }
+					</>
+				) }
 			</>
 		);
 	};

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getSitesWithSecondarySites } from 'calypso/my-sites/plugins/plugin-management-v2/utils/get-sites-with-secondary-sites';
 import PluginManageConnection from '../plugin-manage-connection';
@@ -95,6 +96,7 @@ export default function SitesWithInstalledPluginsList( {
 					}
 				) }
 			</div>
+			{ isWpCom && plugin.isMarketplaceProduct && <QueryUserPurchases /> }
 			<SitesList
 				{ ...rest }
 				plugin={ plugin }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
@@ -1,0 +1,44 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import type { Plugin } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { ReactElement } from 'react';
+
+import '../style.scss';
+
+interface Props {
+	site: SiteDetails;
+	plugin: Plugin;
+}
+
+export default function PluginManageSubcription( { site, plugin }: Props ): ReactElement | null {
+	const translate = useTranslate();
+
+	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
+
+	const currentPurchase =
+		plugin.isMarketplaceProduct &&
+		purchases.find( ( purchase ) =>
+			Object.values( plugin?.variations ).some(
+				( variation: any ) =>
+					variation.product_slug === purchase.productSlug ||
+					variation.product_id === purchase.productId
+			)
+		);
+
+	return currentPurchase?.id ? (
+		<>
+			{ plugin.isMarketplaceProduct && <QuerySitePurchases siteId={ site.ID } /> }
+			<PopoverMenuItem
+				className="plugin-management-v2__actions"
+				icon="credit-card"
+				href={ `/me/purchases/${ site.domain }/${ currentPurchase.id }` }
+			>
+				{ translate( 'Manage Subscription' ) }
+			</PopoverMenuItem>
+		</>
+	) : null;
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import type { Plugin } from '../types';
@@ -31,7 +30,6 @@ export default function PluginManageSubcription( { site, plugin }: Props ): Reac
 
 	return currentPurchase?.id ? (
 		<>
-			{ plugin.isMarketplaceProduct && <QuerySitePurchases siteId={ site.ID } /> }
 			<PopoverMenuItem
 				className="plugin-management-v2__actions"
 				icon="credit-card"

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -101,6 +101,7 @@ a.button.plugin-row-formatter__plugin-name-card {
 	@include break-xlarge {
 		display: flex;
 		justify-content: end;
+		white-space: pre;
 
 		.plugin-install-button__install.embed {
 			margin: 0;


### PR DESCRIPTION
#### Proposed Changes

This PR replaces the old table design used in plugin details with the new design in Calypso Blue and also fixes an issue where the notification is shown below the modal, which was not visible clearly.

#### Testing Instructions

**Instructions**

1. Run `git checkout update/plugin-details-table-on-calypso-blue` and `yarn start`.
2. Visit `http://calypso.localhost:3000/plugins/manage` and click on any plugin to visit the details page.
3. Click on `Manage Sites` on the right column

<img width="1186" alt="Screenshot 2022-09-21 at 5 05 52 PM" src="https://user-images.githubusercontent.com/10586875/191494206-d7fe4d2a-5a0d-4dff-8f71-c376efdeedef.png">

4. Verify that the old plugin table is replaced with the new table design, and you can view the tooltip, open the actions menu, and notifications on the top of the modal.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1458" alt="Screenshot 2022-09-21 at 5 35 22 PM" src="https://user-images.githubusercontent.com/10586875/191499694-7d57b38d-047a-40ad-80e8-a53b2f033c0c.png">
</td>
<td>
<img width="1505" alt="Screenshot 2022-09-21 at 4 12 40 PM" src="https://user-images.githubusercontent.com/10586875/191499829-76e7eb98-0f1f-464d-9201-ea1780edc163.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? It will be added later - 1202518759611394-as-1202979359232065
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202993209552908