### PR TITLE
Hide Hosting Configuration for non-Atomic Jetpack sites

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -8,7 +8,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
-import { getHostingConfigUrl, getManagePluginsUrl, getPluginsUrl, getSettingsUrl } from '../utils';
+import {
+	getHostingConfigUrl,
+	getManagePluginsUrl,
+	getPluginsUrl,
+	getSettingsUrl,
+	isNotAtomicJetpack,
+} from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 interface SitesMenuItemProps {
@@ -146,7 +152,6 @@ export const SitesEllipsisMenu = ( {
 } ) => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
-	const isNotAtomicJetpack = site.jetpack && ! site?.is_wpcom_atomic;
 	const props: SitesMenuItemProps = {
 		site,
 		recordTracks: ( eventName, extraProps = {} ) => {
@@ -165,7 +170,7 @@ export const SitesEllipsisMenu = ( {
 					{ site.launch_status === 'unlaunched' && <LaunchItem { ...props } /> }
 					<SettingsItem { ...props } />
 					<ManagePluginsItem { ...props } />
-					{ ! isNotAtomicJetpack && <HostingConfigItem { ...props } /> }
+					{ ! isNotAtomicJetpack( site ) && <HostingConfigItem { ...props } /> }
 					<WpAdminItem { ...props } />
 				</SiteMenuGroup>
 			) }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -146,6 +146,7 @@ export const SitesEllipsisMenu = ( {
 } ) => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
+	const isNotAtomicJetpack = site.jetpack && ! site?.is_wpcom_atomic;
 	const props: SitesMenuItemProps = {
 		site,
 		recordTracks: ( eventName, extraProps = {} ) => {
@@ -164,7 +165,7 @@ export const SitesEllipsisMenu = ( {
 					{ site.launch_status === 'unlaunched' && <LaunchItem { ...props } /> }
 					<SettingsItem { ...props } />
 					<ManagePluginsItem { ...props } />
-					<HostingConfigItem { ...props } />
+					{ ! isNotAtomicJetpack && <HostingConfigItem { ...props } /> }
 					<WpAdminItem { ...props } />
 				</SiteMenuGroup>
 			) }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { memo } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
-import { displaySiteUrl, getDashboardUrl, MEDIA_QUERIES } from '../utils';
+import { displaySiteUrl, getDashboardUrl, isNotAtomicJetpack, MEDIA_QUERIES } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
@@ -80,7 +80,6 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 
 	const isP2Site = site.options?.is_wpforteams_site;
-	const isNotAtomicJetpack = site.jetpack && ! site?.is_wpcom_atomic;
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
@@ -121,7 +120,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 			</Column>
 			<Column mobileHidden>
 				<SitePlan>
-					{ isNotAtomicJetpack && (
+					{ isNotAtomicJetpack( site ) && (
 						<SitePlanIcon>
 							<JetpackLogo size={ 16 } />
 						</SitePlanIcon>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -80,7 +80,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 
 	const isP2Site = site.options?.is_wpforteams_site;
-	const isAtomicSite = site?.is_wpcom_atomic;
+	const isNotAtomicJetpack = site.jetpack && ! site?.is_wpcom_atomic;
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
@@ -121,7 +121,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 			</Column>
 			<Column mobileHidden>
 				<SitePlan>
-					{ site.jetpack && ! isAtomicSite && (
+					{ isNotAtomicJetpack && (
 						<SitePlanIcon>
 							<JetpackLogo size={ 16 } />
 						</SitePlanIcon>

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,3 +1,5 @@
+import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
+
 export const getDashboardUrl = ( slug: string ) => {
 	return `/home/${ slug }`;
 };
@@ -20,6 +22,10 @@ export const getHostingConfigUrl = ( slug: string ) => {
 
 export const displaySiteUrl = ( siteUrl: string ) => {
 	return siteUrl.replace( 'https://', '' ).replace( 'http://', '' );
+};
+
+export const isNotAtomicJetpack = ( site: SiteExcerptNetworkData ) => {
+	return site.jetpack && ! site?.is_wpcom_atomic;
 };
 
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';


### PR DESCRIPTION
#### Proposed Changes

In this PR I propose to hide the Hosting Configuration menu link on the Sites Management Page for external Jetpack sites, while leaving it for all internal ones.

As we are doing a similar check to display the plan icon, I refactor that part to use the same implementation in both places.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the `/sites` page
2. Confirm that external Jetpack sites do not have "Hosting configuration" in the ellipsis menu.
2. Confirm that Simple and Atomic sites have "Hosting configuration" in the ellipsis menu.
3. Confirm that Jetpack icon is still displayed for external Jetpack sites

![Screen Shot 2022-09-21 at 14 16 54](https://user-images.githubusercontent.com/727413/191501568-d406b4f5-71b3-4202-a6b5-670a2d8ec9e4.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67879
