### PR TITLE
`WpcomLoginForm`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -4,27 +4,28 @@ import { Component } from 'react';
 
 const debug = debugFactory( 'calypso:signup:wpcom-login' );
 
+function getFormAction( redirectTo ) {
+	const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
+	const hostname = config( 'hostname' );
+	let subdomain = '';
+
+	if (
+		subdomainRegExp.test( redirectTo ) &&
+		hostname !== 'wpcalypso.wordpress.com' &&
+		hostname !== 'horizon.wordpress.com'
+	) {
+		subdomain = redirectTo.match( subdomainRegExp )[ 1 ] + '.';
+	}
+
+	return `https://${ subdomain }wordpress.com/wp-login.php`;
+}
+
 export default class WpcomLoginForm extends Component {
 	form = null;
 
 	componentDidMount() {
 		debug( 'submit form' );
 		this.form.submit();
-	}
-
-	action() {
-		const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
-		let subdomain = '';
-
-		if (
-			subdomainRegExp.test( this.props.redirectTo ) &&
-			config( 'hostname' ) !== 'wpcalypso.wordpress.com' &&
-			config( 'hostname' ) !== 'horizon.wordpress.com'
-		) {
-			subdomain = this.props.redirectTo.match( subdomainRegExp )[ 1 ] + '.';
-		}
-
-		return `https://${ subdomain }wordpress.com/wp-login.php`;
 	}
 
 	renderExtraFields() {
@@ -34,15 +35,9 @@ export default class WpcomLoginForm extends Component {
 			return null;
 		}
 
-		return (
-			<div>
-				{ Object.keys( extraFields ).map( ( field ) => {
-					return (
-						<input key={ field } type="hidden" name={ field } value={ extraFields[ field ] } />
-					);
-				} ) }
-			</div>
-		);
+		return Object.keys( extraFields ).map( ( field ) => (
+			<input key={ field } type="hidden" name={ field } value={ extraFields[ field ] } />
+		) );
 	}
 
 	storeFormRef = ( form ) => {
@@ -50,8 +45,10 @@ export default class WpcomLoginForm extends Component {
 	};
 
 	render() {
+		const { redirectTo } = this.props;
+
 		return (
-			<form method="post" action={ this.action() } ref={ this.storeFormRef }>
+			<form method="post" action={ getFormAction( redirectTo ) } ref={ this.storeFormRef }>
 				<input type="hidden" name="log" value={ this.props.log } />
 				<input type="hidden" name="pwd" value={ this.props.pwd } />
 				<input type="hidden" name="authorization" value={ this.props.authorization } />

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -35,8 +35,8 @@ export default class WpcomLoginForm extends Component {
 			return null;
 		}
 
-		return Object.keys( extraFields ).map( ( field ) => (
-			<input key={ field } type="hidden" name={ field } value={ extraFields[ field ] } />
+		return Object.entries( extraFields ).map( ( [ field, value ] ) => (
+			<input key={ field } type="hidden" name={ field } value={ value } />
 		) );
 	}
 

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { useEffect, useRef } from 'react';
 
 function getFormAction( redirectTo ) {
-	const subdomainRegExp = /^https?:\/\/([a-z0-9]+)\.wordpress\.com(?:$|\/)/;
+	const subdomainRegExp = /^https?:\/\/([a-z0-9-]+)\.wordpress\.com(?:$|\/)/;
 	const hostname = config( 'hostname' );
 	let subdomain = '';
 

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 
 const debug = debugFactory( 'calypso:signup:wpcom-login' );
 
@@ -21,11 +21,14 @@ function getFormAction( redirectTo ) {
 }
 
 export default class WpcomLoginForm extends Component {
-	form = null;
+	constructor( props ) {
+		super( props );
+		this.form = createRef();
+	}
 
 	componentDidMount() {
 		debug( 'submit form' );
-		this.form.submit();
+		this.form.current.submit();
 	}
 
 	renderExtraFields() {
@@ -40,15 +43,11 @@ export default class WpcomLoginForm extends Component {
 		) );
 	}
 
-	storeFormRef = ( form ) => {
-		this.form = form;
-	};
-
 	render() {
 		const { redirectTo } = this.props;
 
 		return (
-			<form method="post" action={ getFormAction( redirectTo ) } ref={ this.storeFormRef }>
+			<form method="post" action={ getFormAction( redirectTo ) } ref={ this.form }>
 				<input type="hidden" name="log" value={ this.props.log } />
 				<input type="hidden" name="pwd" value={ this.props.pwd } />
 				<input type="hidden" name="authorization" value={ this.props.authorization } />

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -24,23 +24,17 @@ export default function WpcomLoginForm( { extraFields, redirectTo, authorization
 		form.current.submit();
 	}, [] );
 
-	function renderExtraFields() {
-		if ( ! extraFields ) {
-			return null;
-		}
-
-		return Object.entries( extraFields ).map( ( [ field, value ] ) => (
-			<input key={ field } type="hidden" name={ field } value={ value } />
-		) );
-	}
-
 	return (
 		<form method="post" action={ getFormAction( redirectTo ) } ref={ form }>
 			<input type="hidden" name="log" value={ log } />
 			<input type="hidden" name="pwd" value={ pwd } />
 			<input type="hidden" name="authorization" value={ authorization } />
 			<input type="hidden" name="redirect_to" value={ redirectTo } />
-			{ renderExtraFields() }
+			{ extraFields
+				? Object.entries( extraFields ).map( ( [ field, value ] ) => (
+						<input key={ field } type="hidden" name={ field } value={ value } />
+				  ) )
+				: null }
 		</form>
 	);
 }

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -5,7 +5,7 @@ import { Component } from 'react';
 const debug = debugFactory( 'calypso:signup:wpcom-login' );
 
 function getFormAction( redirectTo ) {
-	const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
+	const subdomainRegExp = /^https?:\/\/([a-z0-9]+)\.wordpress\.com(?:$|\/)/;
 	const hostname = config( 'hostname' );
 	let subdomain = '';
 

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -1,8 +1,5 @@
 import config from '@automattic/calypso-config';
-import debugFactory from 'debug';
-import { Component, createRef } from 'react';
-
-const debug = debugFactory( 'calypso:signup:wpcom-login' );
+import { useEffect, useRef } from 'react';
 
 function getFormAction( redirectTo ) {
 	const subdomainRegExp = /^https?:\/\/([a-z0-9]+)\.wordpress\.com(?:$|\/)/;
@@ -20,20 +17,14 @@ function getFormAction( redirectTo ) {
 	return `https://${ subdomain }wordpress.com/wp-login.php`;
 }
 
-export default class WpcomLoginForm extends Component {
-	constructor( props ) {
-		super( props );
-		this.form = createRef();
-	}
+export default function WpcomLoginForm( { extraFields, redirectTo, authorization, pwd, log } ) {
+	const form = useRef();
 
-	componentDidMount() {
-		debug( 'submit form' );
-		this.form.current.submit();
-	}
+	useEffect( () => {
+		form.current.submit();
+	}, [] );
 
-	renderExtraFields() {
-		const { extraFields } = this.props;
-
+	function renderExtraFields() {
 		if ( ! extraFields ) {
 			return null;
 		}
@@ -43,17 +34,13 @@ export default class WpcomLoginForm extends Component {
 		) );
 	}
 
-	render() {
-		const { redirectTo } = this.props;
-
-		return (
-			<form method="post" action={ getFormAction( redirectTo ) } ref={ this.form }>
-				<input type="hidden" name="log" value={ this.props.log } />
-				<input type="hidden" name="pwd" value={ this.props.pwd } />
-				<input type="hidden" name="authorization" value={ this.props.authorization } />
-				<input type="hidden" name="redirect_to" value={ this.props.redirectTo } />
-				{ this.renderExtraFields() }
-			</form>
-		);
-	}
+	return (
+		<form method="post" action={ getFormAction( redirectTo ) } ref={ form }>
+			<input type="hidden" name="log" value={ log } />
+			<input type="hidden" name="pwd" value={ pwd } />
+			<input type="hidden" name="authorization" value={ authorization } />
+			<input type="hidden" name="redirect_to" value={ redirectTo } />
+			{ renderExtraFields() }
+		</form>
+	);
 }

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -1,7 +1,9 @@
+/** @jest-environment jsdom */
 import config from '@automattic/calypso-config';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import WpcomLoginForm from '..';
-jest.mock( '@automattic/calypso-config', () => jest.fn().mockReturnValueOnce( 'wordpress.com' ) );
+
+jest.mock( '@automattic/calypso-config' );
 
 describe( 'WpcomLoginForm', () => {
 	const props = {
@@ -12,103 +14,99 @@ describe( 'WpcomLoginForm', () => {
 	};
 
 	test( 'should render default fields as expected.', () => {
-		const wrapper = shallow( <WpcomLoginForm { ...props } />, { disableLifecycleMethods: true } );
+		const { container, rerender } = render( <WpcomLoginForm { ...props } /> );
 
 		// should render root form element
-		const form = wrapper.find( 'form' );
-		expect( form ).toHaveLength( 1 );
-		expect( form.prop( 'method' ) ).toEqual( 'post' );
-		expect( form.prop( 'action' ) ).toEqual( 'https://test.wordpress.com/wp-login.php' );
+		const form = container.firstChild;
+		expect( form ).toBeVisible();
+		expect( form ).toHaveAttribute( 'method', 'post' );
+		expect( form ).toHaveAttribute( 'action', 'https://test.wordpress.com/wp-login.php' );
 
 		// form should include default hidden elements
-		expect( wrapper.find( 'form > input[type="hidden"]' ) ).toHaveLength( 4 );
-		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).toEqual( 'log_text' );
-		expect( wrapper.find( 'form > input[name="pwd"]' ).prop( 'value' ) ).toEqual( 'secret' );
-		expect( wrapper.find( 'form > input[name="authorization"]' ).prop( 'value' ) ).toEqual(
+		expect( container.querySelector( 'input[name="log"]' ) ).toHaveValue( 'log_text' );
+		expect( container.querySelector( 'input[name="pwd"]' ) ).toHaveValue( 'secret' );
+		expect( container.querySelector( 'input[name="authorization"]' ) ).toHaveValue(
 			'authorization_token'
 		);
-		expect( wrapper.find( 'form > input[name="redirect_to"]' ).prop( 'value' ) ).toEqual(
+		expect( container.querySelector( 'input[name="redirect_to"]' ) ).toHaveValue(
 			'https://test.wordpress.com'
 		);
 
 		// when update a prop
-		wrapper.setProps( { log: 'another_log' } );
-		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).toEqual( 'another_log' );
+		rerender( <WpcomLoginForm { ...props } log="another_log" /> );
+		const el = container.querySelector( 'input[name="log"]' );
+		expect( el.value ).toEqual( 'another_log' );
 	} );
 
 	test( 'should render extra fields if extraFields prop is passed.', () => {
-		const wrapper = shallow(
-			<WpcomLoginForm
-				{ ...props }
-				extraFields={ {
-					foo: 'bar',
-					lorem: 'ipsum',
-				} }
-			/>,
-			{ disableLifecycleMethods: true }
-		);
+		const extraFields = { foo: 'bar', lorem: 'ipsum' };
+		const { container } = render( <WpcomLoginForm { ...props } extraFields={ extraFields } /> );
 
-		expect( wrapper.find( 'input[type="hidden"]' ) ).toHaveLength( 6 );
-		expect( wrapper.find( 'input[name="foo"]' ).prop( 'value' ) ).toEqual( 'bar' );
-		expect( wrapper.find( 'input[name="lorem"]' ).prop( 'value' ) ).toEqual( 'ipsum' );
+		expect( container.querySelectorAll( 'input[type="hidden"]' ) ).toHaveLength( 6 );
+		expect( container.querySelector( 'input[name="foo"]' ) ).toHaveValue( 'bar' );
+		expect( container.querySelector( 'input[name="lorem"]' ) ).toHaveValue( 'ipsum' );
 	} );
 
 	test( 'its action should be under the wpcom subdomain that `redirectTo` prop contains.', () => {
-		const wrapper = shallow(
-			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />,
-			{ disableLifecycleMethods: true }
+		const { container, rerender } = render(
+			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />
 		);
 
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
 			'https://foo.wordpress.com/wp-login.php'
 		);
 
-		wrapper.setProps( { redirectTo: 'https://bar.wordpress.com' } );
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
+		rerender( <WpcomLoginForm { ...props } redirectTo="https://bar.wordpress.com" /> );
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
 			'https://bar.wordpress.com/wp-login.php'
 		);
 	} );
 
 	test( 'its action should has no subdomain when `hostname` is wpcalypso.wpcom or horizon.wpcom.', () => {
-		const wrapper = shallow(
-			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />,
-			{ disableLifecycleMethods: true }
+		const { container, rerender } = render(
+			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />
 		);
 
 		// should has the same hostname with redirectTo prop.
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
 			'https://foo.wordpress.com/wp-login.php'
 		);
 
 		// should be default url
 		config.mockReturnValueOnce( 'wpcalypso.wordpress.com' );
-		wrapper.setProps( { log: 'wpcalpso' } ); // to update form action
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
+		rerender( <WpcomLoginForm { ...props } /> );
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
 			'https://wordpress.com/wp-login.php'
 		);
 
 		// should has the same hostname with redirectTo prop.
 		config.mockReturnValueOnce( 'bar.wordpress.com' );
-		wrapper.setProps( { log: 'bar' } ); // to update form action
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
-			'https://foo.wordpress.com/wp-login.php'
+		rerender( <WpcomLoginForm { ...props } /> );
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
+			'https://test.wordpress.com/wp-login.php'
 		);
 
 		// should be default url
 		config.mockReturnValueOnce( 'horizon.wordpress.com' );
-		config.mockReturnValueOnce( 'horizon.wordpress.com' );
-		wrapper.setProps( { log: 'horizon' } ); // to update form action
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
+		rerender( <WpcomLoginForm { ...props } /> );
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
 			'https://wordpress.com/wp-login.php'
 		);
 	} );
 
 	test( 'its action should has no subdomain when `redirectTo` prop is not a subdomain of wpcom.', () => {
-		const wrapper = shallow( <WpcomLoginForm { ...props } redirectTo="https://wordpress.org" />, {
-			disableLifecycleMethods: true,
-		} );
+		const { container } = render(
+			<WpcomLoginForm { ...props } redirectTo="https://wordpress.org" />
+		);
 
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
 			'https://wordpress.com/wp-login.php'
 		);
 	} );

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -35,7 +35,7 @@ describe( 'WpcomLoginForm', () => {
 		// when update a prop
 		rerender( <WpcomLoginForm { ...props } log="another_log" /> );
 		const el = container.querySelector( 'input[name="log"]' );
-		expect( el.value ).toEqual( 'another_log' );
+		expect( el ).toHaveValue( 'another_log' );
 	} );
 
 	test( 'should render extra fields if extraFields prop is passed.', () => {

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -65,9 +65,8 @@ describe( 'WpcomLoginForm', () => {
 	} );
 
 	test( 'its action should has no subdomain when `hostname` is wpcalypso.wpcom or horizon.wpcom.', () => {
-		const { container, rerender } = render(
-			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />
-		);
+		const myProps = { ...props, redirectTo: 'https://foo.wordpress.com' };
+		const { container, rerender } = render( <WpcomLoginForm { ...myProps } /> );
 
 		// should has the same hostname with redirectTo prop.
 		expect( container.firstChild ).toHaveAttribute(
@@ -77,7 +76,7 @@ describe( 'WpcomLoginForm', () => {
 
 		// should be default url
 		config.mockReturnValueOnce( 'wpcalypso.wordpress.com' );
-		rerender( <WpcomLoginForm { ...props } /> );
+		rerender( <WpcomLoginForm { ...myProps } /> );
 		expect( container.firstChild ).toHaveAttribute(
 			'action',
 			'https://wordpress.com/wp-login.php'
@@ -85,15 +84,15 @@ describe( 'WpcomLoginForm', () => {
 
 		// should has the same hostname with redirectTo prop.
 		config.mockReturnValueOnce( 'bar.wordpress.com' );
-		rerender( <WpcomLoginForm { ...props } /> );
+		rerender( <WpcomLoginForm { ...myProps } /> );
 		expect( container.firstChild ).toHaveAttribute(
 			'action',
-			'https://test.wordpress.com/wp-login.php'
+			'https://foo.wordpress.com/wp-login.php'
 		);
 
 		// should be default url
 		config.mockReturnValueOnce( 'horizon.wordpress.com' );
-		rerender( <WpcomLoginForm { ...props } /> );
+		rerender( <WpcomLoginForm { ...myProps } /> );
 		expect( container.firstChild ).toHaveAttribute(
 			'action',
 			'https://wordpress.com/wp-login.php'


### PR DESCRIPTION
#### Proposed Changes

* `WpcomLoginForm`: refactor tests to `@testing-library/react`

Please note: We're not using accessible selectors here because we don't test accessible elements within these tests (the form is rendered invisible to the user so we got to use `container` and `container.querySelector*` to retrieve elements).

#### Testing Instructions

* Verify unit tests still pass

To test the component:

* Invite a non-registered user via email to one of your sites (I chose the _Editor_ role)
* Click on the link you receive via email and after Calypso loaded change the hostname to match this branch
* Enter details and hit "Signup & Join"; this should work as on prod.

Related to #63409 
