### PR TITLE
i18n: Add context for `Social` when referring to Jetpack Social

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -100,6 +100,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 				<SidebarItem
 					customIcon={ showIcons && <JetpackIcons icon="social" /> }
 					label={ translate( 'Social', {
+						context: 'Jetpack product name',
 						comment: 'Jetpack sidebar menu item',
 					} ) }
 					link={ `/jetpack-social/${ siteSlug }` }

--- a/client/jetpack-cloud/sections/jetpack-social/connections.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/connections.jsx
@@ -16,7 +16,7 @@ import 'calypso/my-sites/marketing/style.scss';
 import './style.scss';
 
 export const Connections = ( { siteId, translate } ) => {
-	const titleHeader = translate( 'Social' );
+	const titleHeader = translate( 'Social', { context: 'Jetpack product name' } );
 
 	const learnMoreLink = (
 		<a

--- a/client/jetpack-cloud/sections/jetpack-social/promo.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/promo.jsx
@@ -13,7 +13,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './promo.scss';
 
 export const Promo = ( { isSocialActive, adminUrl, translate } ) => {
-	const titleHeader = translate( 'Social' );
+	const titleHeader = translate( 'Social', { context: 'Jetpack product name' } );
 	const features = [
 		translate( 'Connect with Twitter, Facebook, LinkedIn and Tumblr' ),
 		translate( 'Select the social media to share posts while publishing' ),

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -95,7 +95,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 						href: `${ JETPACK_COM_BASE_URL }/features/growth/`,
 						items: [
 							{
-								label: translate( 'Social' ),
+								label: translate( 'Social', { context: 'Jetpack product name' } ),
 								tagline: translate( 'Write once, post everywhere' ),
 								href: `${ JETPACK_COM_BASE_URL }/social/`,
 							},

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
@@ -17,7 +17,7 @@ const useSocialFreeItem = (): SelectorProduct => {
 		() => ( {
 			productSlug: 'jetpack-social-free',
 			isFree: true,
-			displayName: translate( 'Social' ),
+			displayName: translate( 'Social', { context: 'Jetpack product name' } ),
 			features: {
 				items: [
 					{ slug: 'not used', text: translate( 'Auto-publish on popular social media platforms' ) },

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -110,8 +110,10 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		} ),
 		[ PRODUCT_JETPACK_VIDEOPRESS ]: translate( 'VideoPress' ),
 		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: translate( 'VideoPress' ),
-		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: translate( 'Social' ),
-		[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: translate( 'Social' ),
+		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: translate( 'Social', { context: 'Jetpack product name' } ),
+		[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: translate( 'Social', {
+			context: 'Jetpack product name',
+		} ),
 	};
 };
 
@@ -150,7 +152,7 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		},
 	} );
 	const boost = translate( 'Boost' );
-	const social = translate( 'Social' );
+	const social = translate( 'Social', { context: 'Jetpack product name' } );
 
 	const text10gb = translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
 		comment:


### PR DESCRIPTION
#### Proposed Changes

This adds a translation context to several `Social` strings, as per 515-gh-Automattic/i18n-issues, to clarify that they refer to the Jetpack Social product name. This signals translators that the string can remain untranslated.

These usages have been obtained from [the `Social` original at translate.wordpress.com](https://translate.wordpress.com/projects/wpcom/-all-translations/80081/).

Before & after of one of the usages: 
![image](https://user-images.githubusercontent.com/75777864/191534620-a565b38a-3605-4bc5-b8f0-30b84e5dc07c.png) ![image](https://user-images.githubusercontent.com/75777864/191534563-c8ce3af1-39b8-46b6-9745-8ad97450208d.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Run `yarn start-jetpack-cloud` and check for example the usage shown above at http://jetpack.cloud.localhost:3000/nl/pricing

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **N/A** 
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? **N/A** 
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) **N/A** 
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **The goal of this PR is to leave the string untranslated for most locales, so deploying without the label could be an improvement by itself.**

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
