### PR TITLE
Update the auto-renew toggle to use a link on Purchase Details

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -250,7 +250,9 @@ class AutoRenewDisablingDialog extends Component {
 				onClose={ this.closeAndCleanup }
 				buttons={ buttons }
 			>
-				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
+				<h2 className="auto-renew-disabling-dialog__header">
+					{ translate( 'Turn off auto-renew' ) }
+				</h2>
 				<p>{ description }</p>
 			</Dialog>
 		);

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -219,7 +219,7 @@ class AutoRenewToggle extends Component {
 				'…'
 			) : (
 				<Button
-					plain
+					link
 					className="is-link"
 					onClick={ this.onToggleAutoRenew }
 					disabled={ shouldDisable }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -32,6 +33,7 @@ class AutoRenewToggle extends Component {
 		siteSlug: PropTypes.string,
 		getChangePaymentMethodUrlFor: PropTypes.func,
 		paymentMethodUrl: PropTypes.string,
+		showLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -204,20 +206,41 @@ class AutoRenewToggle extends Component {
 	}
 
 	render() {
-		const { planName, siteDomain, purchase, withTextStatus, shouldDisable } = this.props;
+		const { planName, siteDomain, purchase, withTextStatus, shouldDisable, showLink, children } =
+			this.props;
 
 		if ( ! this.shouldRender( purchase ) ) {
 			return null;
 		}
 
-		return (
-			<>
+		let toggle;
+		if ( showLink ) {
+			toggle = this.isUpdatingAutoRenew() ? (
+				'…'
+			) : (
+				<Button
+					plain
+					className="is-link"
+					onClick={ this.onToggleAutoRenew }
+					disabled={ shouldDisable }
+				>
+					{ children }
+				</Button>
+			);
+		} else {
+			toggle = (
 				<ToggleControl
 					checked={ this.getToggleUiStatus() }
 					disabled={ this.isUpdatingAutoRenew() || shouldDisable }
 					onChange={ this.onToggleAutoRenew }
 					label={ withTextStatus && this.renderTextStatus() }
 				/>
+			);
+		}
+
+		return (
+			<>
+				{ toggle }
 				<AutoRenewDisablingDialog
 					isVisible={ this.state.showAutoRenewDisablingDialog }
 					planName={ planName }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -504,9 +504,32 @@ function PurchaseMetaExpiration( {
 
 	if ( isRenewable( purchase ) && ! isExpired( purchase ) ) {
 		const dateSpan = <span className="manage-purchase__detail-date-span" />;
+		const shouldRenderToggle = site && isProductOwner;
+		const autoRenewToggle = shouldRenderToggle ? (
+			<AutoRenewToggle
+				planName={ site.plan.product_name_short }
+				siteDomain={ site.domain }
+				siteSlug={ site.slug }
+				purchase={ purchase }
+				toggleSource="manage-purchase"
+				showLink={ true }
+				getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
+			/>
+		) : (
+			<span />
+		);
 		const subsRenewText = isAutorenewalEnabled
-			? translate( 'Auto-renew is ON' )
-			: translate( 'Auto-renew is OFF' );
+			? translate( 'Auto-renew is {{autoRenewToggle}}ON{{/autoRenewToggle}}', {
+					components: {
+						autoRenewToggle,
+					},
+			  } )
+			: translate( 'Auto-renew is {{autoRenewToggle}}OFF{{/autoRenewToggle}}', {
+					components: {
+						autoRenewToggle,
+					},
+			  } );
+
 		let subsBillingText;
 		if (
 			isAutorenewalEnabled &&
@@ -533,25 +556,11 @@ function PurchaseMetaExpiration( {
 			} );
 		}
 
-		const shouldRenderToggle = site && isProductOwner;
-
 		return (
 			<li className="manage-purchase__meta-expiration">
 				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
 				{ ! hideAutoRenew && (
 					<div className="manage-purchase__auto-renew">
-						{ shouldRenderToggle && (
-							<span className="manage-purchase__detail manage-purchase__auto-renew-toggle">
-								<AutoRenewToggle
-									planName={ site.plan.product_name_short }
-									siteDomain={ site.domain }
-									siteSlug={ site.slug }
-									purchase={ purchase }
-									toggleSource="manage-purchase"
-									getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
-								/>
-							</span>
-						) }
 						<span className="manage-purchase__detail manage-purchase__auto-renew-text">
 							{ subsRenewText }
 						</span>

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -445,7 +445,8 @@
 	}
 }
 
-.manage-purchase__auto-renew-text button {
+.manage-purchase__auto-renew-text button.is-link {
 	color: var(--color-link);
 	text-decoration: underline;
+	line-height: inherit;
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -444,3 +444,8 @@
 		margin-top: 0;
 	}
 }
+
+.manage-purchase__auto-renew-text button {
+	color: var(--color-link);
+	text-decoration: underline;
+}


### PR DESCRIPTION
This component is used in several places. All other places should remain intact.

The change will replace the Toggle component with an On/Off button in the middle of the Auto-renew ON copy.

#### Proposed Changes

- The Auto-renew toggle should be visible as a link on the purchase details page.
- There should be no link if the user doesn't own the upgrade
- Domain Management and Email Management that also use this toggle should be unaffected

This is how it works with the purchase owner:
https://user-images.githubusercontent.com/82778/191526566-15ec4e91-48d5-4919-9acc-6a58fbd31202.mov

And this is how it looks with another admin account:
<img width="1066" alt="Screenshot 2022-09-21 at 17 13 47" src="https://user-images.githubusercontent.com/82778/191528163-54d65369-ebc2-40c6-bcad-ded37e80acd2.png">

#### Testing Instructions

* Buy a plan, domain, and email with the store sandbox
* Go to /me/purchases, then to a purchase detail of one of these upgrades (or any other)
* Try clicking on the new link and make sure the auto-renew goes on and off
* Go to Domain Management. Make sure the toggle is unchanged there
* Go to Email Management. Make sure the toggle is also unchanged
* Add another user to your test site. Make sure they see no clickable toggles anywhere

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
