### PR TITLE
Created action card for plan upgrade screen

### DIFF
--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -2,6 +2,8 @@ import { FEATURE_INSTALL_PLUGINS, PLAN_BUSINESS } from '@automattic/calypso-prod
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import ActionCard from 'calypso/components/action-card';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -66,6 +68,24 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					isReskinned
 				/>
 			</div>
+			<ActionCard
+				classNames="plugin-plans"
+				headerText=""
+				mainText={ translate(
+					'Need some help? Let us help you find the perfect plan for your site. {{a}}Chat now{{/a}} or {{a}}contact our support{{/a}}.',
+					{
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					}
+				) }
+				buttonText={ translate( 'Upgrade to Business' ) }
+				buttonPrimary={ true }
+				buttonOnClick={ () => {
+					alert( 'Connect code after merging PR 68087' );
+				} }
+				buttonDisabled={ false }
+			/>
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -6,3 +6,38 @@
 		font-size: $font-body;
 	}
 }
+
+.plugin-plans {
+	&.action-card.is-compact {
+		background: #f0f7fc;
+		box-shadow: none;
+		padding: 0;
+		min-height: 100px;
+
+		@media ( max-width: 660px ) {
+			padding: 0 25px;
+		}
+	}
+
+	&.action-card::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #f0f7fc;
+		position: absolute;
+		width: 215vw;
+		left: -100vw;
+		top: 0;
+		z-index: -1;
+		bottom: 0;
+	}
+
+	.action-card__main {
+		display: flex;
+		align-items: center;
+	}
+
+	.action-card__main p {
+		font-size: $font-body-small;
+		margin: 20px 0;
+	}
+}


### PR DESCRIPTION
fix #67976
Figma: HOg65lHD0QOfaq0QtzKQbC-fi-507%3A10329

## Proposed Changes

Added the action card.

#### Desktop 

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/1044309/191530234-3ffaa8fe-18a1-41d0-bb51-399056c363bb.png">

#### Mobile

<img width="359" alt="image" src="https://user-images.githubusercontent.com/1044309/191530768-41f2c8b2-266d-407d-b87c-84e43423b142.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* After checkout this branch, open the new plugins plan page: [http://calypso.localhost:3000/plugins/plans/{site}?flags=plugins-plans-page](http://calypso.localhost:3000/plugins/plans/%7Bsite%7D?flags=plugins-plans-page)
* Make sure the current implementation match the design and works as expected on mobile as well
* The button click is not connected to the next screen, I'll do it after emerging #68087