### PR TITLE
Sites Management Page: Use consistent language for the sort labels

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -42,13 +42,13 @@ export const SitesSortingDropdown = ( {
 
 		switch ( `${ sortKey }${ SEPARATOR }${ sortOrder }` ) {
 			case `lastInteractedWith${ SEPARATOR }desc`:
-				return __( 'Sorting by: Magic' );
+				return __( 'Sort: Magic' );
 
 			case `alphabetically${ SEPARATOR }asc`:
-				return __( 'Sorting by: Name' );
+				return __( 'Sort: Name' );
 
 			case `updatedAt${ SEPARATOR }desc`:
-				return __( 'Sorting by: Last published' );
+				return __( 'Sort: Last published' );
 
 			default:
 				throw new Error( `invalid sort value ${ sitesSorting }` );
@@ -62,14 +62,14 @@ export const SitesSortingDropdown = ( {
 					sortKey: 'alphabetically',
 					sortOrder: 'asc',
 				} ),
-				label: __( 'Alphabetically' ),
+				label: __( 'Name' ),
 			},
 			{
 				value: stringifySitesSorting( {
 					sortKey: 'lastInteractedWith',
 					sortOrder: 'desc',
 				} ),
-				label: __( 'Automagically' ),
+				label: __( 'Magic' ),
 			},
 			{
 				value: stringifySitesSorting( {


### PR DESCRIPTION
## Proposed Changes

Uses more consistent language for the sort labels.

### Before

<img width="498" alt="image" src="https://user-images.githubusercontent.com/36432/191556466-2639d2c7-eb9f-46d8-b0be-91ce0de9d218.png">

### After

<img width="483" alt="image" src="https://user-images.githubusercontent.com/36432/191556410-f084f4b9-f68d-44ac-9e4a-ccefb9989ed6.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Verify the labels appear as expected.