### PR TITLE
Small refactor to reuse marketplace footer in the new plans page

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -28,6 +28,35 @@ const EducationFooterContainer = styled.div`
 	margin-top: 48px;
 `;
 
+export const MarketplaceFooter = () => {
+	const { __ } = useI18n();
+
+	return (
+		<Section
+			header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
+			dark
+		>
+			<ThreeColumnContainer>
+				<FeatureItem header={ __( 'Fully Managed' ) }>
+					{ __(
+						'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
+					) }
+				</FeatureItem>
+				<FeatureItem header={ __( 'Thousands of plugins' ) }>
+					{ __(
+						'From WordPress.com premium plugins to thousands more community-authored plugins, we’ve got you covered.'
+					) }
+				</FeatureItem>
+				<FeatureItem header={ __( 'Flexible pricing' ) }>
+					{ __(
+						'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
+					) }
+				</FeatureItem>
+			</ThreeColumnContainer>
+		</Section>
+	);
+};
+
 const EducationFooter = () => {
 	const { __ } = useI18n();
 	const localizeUrl = useLocalizeUrl();
@@ -84,28 +113,7 @@ const EducationFooter = () => {
 					/>
 				</ThreeColumnContainer>
 			</Section>
-			<Section
-				header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
-				dark
-			>
-				<ThreeColumnContainer>
-					<FeatureItem header={ __( 'Fully Managed' ) }>
-						{ __(
-							'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
-						) }
-					</FeatureItem>
-					<FeatureItem header={ __( 'Thousands of plugins' ) }>
-						{ __(
-							'From WordPress.com premium plugins to thousands more community-authored plugins, we’ve got you covered.'
-						) }
-					</FeatureItem>
-					<FeatureItem header={ __( 'Flexible pricing' ) }>
-						{ __(
-							'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
-						) }
-					</FeatureItem>
-				</ThreeColumnContainer>
-			</Section>
+			<MarketplaceFooter />
 		</EducationFooterContainer>
 	);
 };

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -2,6 +2,8 @@ import { FEATURE_INSTALL_PLUGINS, PLAN_BUSINESS } from '@automattic/calypso-prod
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import ActionCard from 'calypso/components/action-card';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -66,6 +68,24 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					isReskinned
 				/>
 			</div>
+			<ActionCard
+				classNames="plugin-plans"
+				headerText=""
+				mainText={ translate(
+					'Need some help? Let us help you find the perfect plan for your site. {{a}}Chat now{{/a}} or {{a}}contact our support{{/a}}.',
+					{
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					}
+				) }
+				buttonText={ translate( 'Upgrade to Business' ) }
+				buttonPrimary={ true }
+				buttonOnClick={ () => {
+					alert( 'Connect code after merging PR 68087' );
+				} }
+				buttonDisabled={ false }
+			/>
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -15,11 +15,11 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
+import { MARKETPLACE_FLOW } from 'calypso/my-sites/plugins/flows';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { MarketplaceFooter } from '../education-footer';
-import { MARKETPLACE_FLOW } from '../flows';
 
 import './style.scss';
 

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -13,8 +13,8 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-
 import './style.scss';
+import { MarketplaceFooter } from '../education-footer';
 
 const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
@@ -86,6 +86,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 				} }
 				buttonDisabled={ false }
 			/>
+			<MarketplaceFooter />
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -6,3 +6,38 @@
 		font-size: $font-body;
 	}
 }
+
+.plugin-plans {
+	&.action-card.is-compact {
+		background: #f0f7fc;
+		box-shadow: none;
+		padding: 0;
+		min-height: 100px;
+
+		@media ( max-width: 660px ) {
+			padding: 0 25px;
+		}
+	}
+
+	&.action-card::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #f0f7fc;
+		position: absolute;
+		width: 215vw;
+		left: -100vw;
+		top: 0;
+		z-index: -1;
+		bottom: 0;
+	}
+
+	.action-card__main {
+		display: flex;
+		align-items: center;
+	}
+
+	.action-card__main p {
+		font-size: $font-body-small;
+		margin: 20px 0;
+	}
+}


### PR DESCRIPTION
Fixes #67975

#### Proposed Changes

Small refactor to reuse marketplace footer in the new plans page:


![image](https://user-images.githubusercontent.com/1044309/191562814-b15db6f3-f1cc-4d33-ab53-e551eba963a6.png)



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure /plugins footer still works as expected
* Go to the new plans page: http://calypso.localhost:3000/plugins/plans/yearly/{yourSite}?flags=plugins-plans-page
* The implementation follows the design at Figma: HOg65lHD0QOfaq0QtzKQbC-fi-507%3A10329
* Works well on desktop and mobile

Note: I'm merging it against https://github.com/Automattic/wp-calypso/pull/68106 to avoid conflicts and simplify the deployment.
