### PR TITLE
Themes: Changed default theme to twentytwentytwo

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -4,7 +4,7 @@ import { find, get } from 'lodash';
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: 'pub/zoologist',
+			theme: 'pub/twentytwentytwo',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the default theme from `zoologist` to `twentytwentytwo`.
* It would change the default for all new blogs since the `siteType` doesn't appear to be populated (so always get the default)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new blog using /start
* Check that the blog is using `twentytwentytwo`.

Related to https://github.com/Automattic/wp-calypso/issues/67562