### PR TITLE
E2E: update FSE: Smoke Test spec to take into account non-iframed editor.

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -50,10 +50,23 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// Because this is a temporary smoke test, adding the needed FSE selectors here instead of
 		// spinning up a POM class that we will later needed to redo.
 		// This should ensure the editor hasn't done a WSoD.
-		const topFrameLocator = page.frameLocator( '.calypsoify.is-iframe iframe.is-loaded' );
-		await topFrameLocator.locator( '[aria-label="Editor top bar"]' ).waitFor();
+		await page.waitForLoadState( 'networkidle' );
 
-		const editorFrameLocator = topFrameLocator.frameLocator( 'iframe[title="Editor canvas"]' );
-		await editorFrameLocator.locator( '.edit-site-block-editor__block-list' ).waitFor();
+		// In some cases (about ~7% going by the failure rate), the editor that's loaded is
+		// the equivalent of the Atomic editor (without iframes).
+		// Thus to eliminate flakiness we must account for both iframed and non-iframed editors.
+		if ( page.url().includes( 'wp-admin' ) ) {
+			const editorLocator = page.locator( 'div[id="site-editor"]' );
+			await editorLocator.waitFor();
+
+			const editorTopBarLocator = page.locator( '[aria-label="Editor top bar"]' );
+			await editorTopBarLocator.waitFor();
+		} else {
+			const topFrameLocator = page.frameLocator( '.calypsoify.is-iframe iframe.is-loaded' );
+			await topFrameLocator.locator( '[aria-label="Editor top bar"]' ).waitFor();
+
+			const editorFrameLocator = topFrameLocator.frameLocator( 'iframe[title="Editor canvas"]' );
+			await editorFrameLocator.locator( '.edit-site-block-editor__block-list' ).waitFor();
+		}
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR updates the FSE: Smoke Test spec to account for the scenario where the non-iframed editor is loaded (aka the Atomic editor).

**Key changes:**
- if/else statement in the last step `Editor canvas loads` that branches depending on the URL loaded.

**Context:**
We have two types of block editors: iframed and non-iframed.
The iframed editor is typically loaded on Simple sites.
The non-iframed editor is usually seen on Atomic sites. 

It appears that due to some issues (likely related to third-party cookies) sometimes the full site editor loads with the non-iframed editor (which is the fallback), and this causes the original testes to fail since it only accounted for the iframed editor.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/68059.
