### PR TITLE
Add optional plugin slug to plugins plan path

### DIFF
--- a/client/my-sites/plugins/controller-logged-in.js
+++ b/client/my-sites/plugins/controller-logged-in.js
@@ -7,6 +7,11 @@ export function upload( context, next ) {
 }
 
 export function plans( context, next ) {
-	context.primary = <Plans intervalType={ context.params.intervalType } />;
+	context.primary = (
+		<Plans
+			intervalType={ context.params.intervalType }
+			pluginSlug={ context.params.pluginSlug || false }
+		/>
+	);
 	next();
 }

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -93,7 +93,7 @@ export default function ( router ) {
 	router( `/${ langParam }/plugins/plans`, notFound, makeLayout );
 
 	router(
-		`/${ langParam }/plugins/plans/:intervalType(yearly|monthly)/:site`,
+		`/${ langParam }/plugins/plans/:pluginSlug?/:intervalType(yearly|monthly)/:site`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectLoggedOut,
 		scrollTopIfNoHash,

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -102,7 +102,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	const productsList = useSelector( getProductsList );
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
-	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
+	const pluginsPlansPage = `/plugins/plans/${ plugin.slug }/yearly/${ selectedSite?.slug }`;
 
 	return (
 		<>


### PR DESCRIPTION
#### Proposed Changes

This PR adds an optional plugin slug to the Plugins Plans page route. Note `woocommerce-subscriptions` in this example:

http://wordpress/plugins/woocommerce-subscriptions/example.wordpress.com

This PR also adds this slug to the "Purchase/Upgrade and activate" button in the plugin details page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* On a sub-business plan
* Go to a plugin details page with `?flags=plugins-plans-page` enabled
* Click on "Purchase/Upgrade and activate" and note that the plugin slug is in the plugins plans page URL.
* Remove the plugin slug from the URL and note that the page still loads.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67574
