### PR TITLE
Marketplace: Add mobile view for Plugins plans

### DIFF
--- a/client/components/plans/plan-pill/index.jsx
+++ b/client/components/plans/plan-pill/index.jsx
@@ -1,7 +1,11 @@
 import './style.scss';
 
 export default ( props ) => (
-	<div className={ `plan-pill${ props.isInSignup ? ' is-in-signup' : '' }` }>
+	<div
+		className={ `plan-pill${ props.isInSignup ? ' is-in-signup' : '' }${
+			props.isCurrentPlan ? ' is-current-plan' : ''
+		}` }
+	>
 		{ props.children }
 	</div>
 );

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -18,13 +18,11 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
-import FoldableCard from 'calypso/components/foldable-card';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import {
 	getHighlightedFeatures,
-	getPlanDescriptionForMobile,
 	getPlanFeatureAccessor,
 } from 'calypso/my-sites/plan-features-comparison/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -70,16 +68,11 @@ export class PlanFeaturesComparison extends Component {
 			'plans-wrapper': isInSignup,
 		} );
 
-		const mobileView = (
-			<div className="plan-features-comparison__mobile">{ this.renderMobileView() }</div>
-		);
-
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
 				<div className={ planClasses }>
 					<div ref={ this.contentRef } className="plan-features-comparison__content">
-						{ mobileView }
 						<div>
 							<table className={ tableClasses }>
 								<caption className="plan-features-comparison__screen-reader-text screen-reader-text">
@@ -98,126 +91,6 @@ export class PlanFeaturesComparison extends Component {
 				</div>
 			</div>
 		);
-	}
-
-	renderMobileView() {
-		const {
-			basePlansPath,
-			planProperties,
-			translate,
-			isInVerticalScrollingPlansExperiment,
-			flowName,
-			isInSignup,
-			isLaunchPage,
-		} = this.props;
-
-		// move any free plan to last place in mobile view
-		let freePlanProperties;
-
-		// move any popular plan to the first place in the mobile view.
-		let popularPlanProperties;
-
-		const reorderedPlans = planProperties.filter( ( properties ) => {
-			if ( isFreePlan( properties.planName ) ) {
-				freePlanProperties = properties;
-				return false;
-			}
-			// remove the popular plan.
-			if ( properties.popular && ! popularPlanProperties ) {
-				popularPlanProperties = properties;
-				return false;
-			}
-
-			return true;
-		} );
-
-		if ( popularPlanProperties ) {
-			reorderedPlans.unshift( popularPlanProperties );
-		}
-
-		if ( freePlanProperties ) {
-			reorderedPlans.push( freePlanProperties );
-		}
-
-		return map( reorderedPlans, ( properties ) => {
-			const {
-				annualPricePerMonth,
-				availableForPurchase,
-				currencyCode,
-				current,
-				discountPrice,
-				planConstantObj,
-				planName,
-				popular,
-				relatedMonthlyPlan,
-				isMonthlyPlan,
-				isPlaceholder,
-				hideMonthly,
-				rawPrice,
-				rawPriceAnnual,
-				rawPriceForMonthlyPlan,
-				features,
-				primaryUpgrade,
-			} = properties;
-
-			const audience = planConstantObj.getAudience?.();
-			const billingTimeFrame = planConstantObj.getBillingTimeFrame();
-			const planDescription = getPlanDescriptionForMobile( {
-				flowName,
-				plan: planConstantObj,
-				isInVerticalScrollingPlansExperiment,
-			} );
-
-			return (
-				<div className="plan-features-comparison__mobile-plan" key={ planName }>
-					<PlanFeaturesComparisonHeader
-						audience={ audience }
-						availableForPurchase={ availableForPurchase }
-						basePlansPath={ basePlansPath }
-						billingTimeFrame={ billingTimeFrame }
-						current={ current }
-						currencyCode={ currencyCode }
-						discountPrice={ discountPrice }
-						hideMonthly={ hideMonthly }
-						isPlaceholder={ isPlaceholder }
-						planType={ planName }
-						popular={ popular }
-						rawPrice={ rawPrice }
-						rawPriceAnnual={ rawPriceAnnual }
-						rawPriceForMonthlyPlan={ rawPriceForMonthlyPlan }
-						relatedMonthlyPlan={ relatedMonthlyPlan }
-						title={ planConstantObj.getTitle() }
-						annualPricePerMonth={ annualPricePerMonth }
-						isMonthlyPlan={ isMonthlyPlan }
-					/>
-					<PlanFeaturesComparisonActions
-						availableForPurchase={ availableForPurchase }
-						className={ getPlanClass( planName ) }
-						current={ current }
-						freePlan={ isFreePlan( planName ) }
-						isPlaceholder={ isPlaceholder }
-						isPopular={ popular }
-						isInSignup={ isInSignup }
-						isLaunchPage={ isLaunchPage }
-						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
-						planName={ planConstantObj.getTitle() }
-						planType={ planName }
-						primaryUpgrade={ primaryUpgrade }
-						key={ planName }
-					/>
-					<p className="plan-features-comparison__description">{ planDescription }</p>
-					<FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
-						{ this.renderMobileFeatures( features ) }
-					</FoldableCard>
-				</div>
-			);
-		} );
-	}
-
-	renderMobileFeatures( features ) {
-		return map( features, ( currentFeature, index ) => {
-			return currentFeature ? this.renderFeatureItem( currentFeature, index ) : null;
-		} );
 	}
 
 	renderPlanHeaders() {

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -18,11 +18,13 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
+import FoldableCard from 'calypso/components/foldable-card';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import {
 	getHighlightedFeatures,
+	getPlanDescriptionForMobile,
 	getPlanFeatureAccessor,
 } from 'calypso/my-sites/plan-features-comparison/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -44,6 +46,7 @@ import {
 import PlanFeaturesComparisonActions from './actions';
 import PlanFeaturesComparisonHeader from './header';
 import { PlanFeaturesItem } from './item';
+
 import './style.scss';
 
 const noop = () => {};
@@ -67,11 +70,16 @@ export class PlanFeaturesComparison extends Component {
 			'plans-wrapper': isInSignup,
 		} );
 
+		const mobileView = (
+			<div className="plan-features-comparison__mobile">{ this.renderMobileView() }</div>
+		);
+
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
 				<div className={ planClasses }>
 					<div ref={ this.contentRef } className="plan-features-comparison__content">
+						{ mobileView }
 						<div>
 							<table className={ tableClasses }>
 								<caption className="plan-features-comparison__screen-reader-text screen-reader-text">
@@ -90,6 +98,126 @@ export class PlanFeaturesComparison extends Component {
 				</div>
 			</div>
 		);
+	}
+
+	renderMobileView() {
+		const {
+			basePlansPath,
+			planProperties,
+			translate,
+			isInVerticalScrollingPlansExperiment,
+			flowName,
+			isInSignup,
+			isLaunchPage,
+		} = this.props;
+
+		// move any free plan to last place in mobile view
+		let freePlanProperties;
+
+		// move any popular plan to the first place in the mobile view.
+		let popularPlanProperties;
+
+		const reorderedPlans = planProperties.filter( ( properties ) => {
+			if ( isFreePlan( properties.planName ) ) {
+				freePlanProperties = properties;
+				return false;
+			}
+			// remove the popular plan.
+			if ( properties.popular && ! popularPlanProperties ) {
+				popularPlanProperties = properties;
+				return false;
+			}
+
+			return true;
+		} );
+
+		if ( popularPlanProperties ) {
+			reorderedPlans.unshift( popularPlanProperties );
+		}
+
+		if ( freePlanProperties ) {
+			reorderedPlans.push( freePlanProperties );
+		}
+
+		return map( reorderedPlans, ( properties ) => {
+			const {
+				annualPricePerMonth,
+				availableForPurchase,
+				currencyCode,
+				current,
+				discountPrice,
+				planConstantObj,
+				planName,
+				popular,
+				relatedMonthlyPlan,
+				isMonthlyPlan,
+				isPlaceholder,
+				hideMonthly,
+				rawPrice,
+				rawPriceAnnual,
+				rawPriceForMonthlyPlan,
+				features,
+				primaryUpgrade,
+			} = properties;
+
+			const audience = planConstantObj.getAudience?.();
+			const billingTimeFrame = planConstantObj.getBillingTimeFrame();
+			const planDescription = getPlanDescriptionForMobile( {
+				flowName,
+				plan: planConstantObj,
+				isInVerticalScrollingPlansExperiment,
+			} );
+
+			return (
+				<div className="plan-features-comparison__mobile-plan" key={ planName }>
+					<PlanFeaturesComparisonHeader
+						audience={ audience }
+						availableForPurchase={ availableForPurchase }
+						basePlansPath={ basePlansPath }
+						billingTimeFrame={ billingTimeFrame }
+						current={ current }
+						currencyCode={ currencyCode }
+						discountPrice={ discountPrice }
+						hideMonthly={ hideMonthly }
+						isPlaceholder={ isPlaceholder }
+						planType={ planName }
+						popular={ popular }
+						rawPrice={ rawPrice }
+						rawPriceAnnual={ rawPriceAnnual }
+						rawPriceForMonthlyPlan={ rawPriceForMonthlyPlan }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
+						title={ planConstantObj.getTitle() }
+						annualPricePerMonth={ annualPricePerMonth }
+						isMonthlyPlan={ isMonthlyPlan }
+					/>
+					<PlanFeaturesComparisonActions
+						availableForPurchase={ availableForPurchase }
+						className={ getPlanClass( planName ) }
+						current={ current }
+						freePlan={ isFreePlan( planName ) }
+						isPlaceholder={ isPlaceholder }
+						isPopular={ popular }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
+						planName={ planConstantObj.getTitle() }
+						planType={ planName }
+						primaryUpgrade={ primaryUpgrade }
+						key={ planName }
+					/>
+					<p className="plan-features-comparison__description">{ planDescription }</p>
+					<FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
+						{ this.renderMobileFeatures( features ) }
+					</FoldableCard>
+				</div>
+			);
+		} );
+	}
+
+	renderMobileFeatures( features ) {
+		return map( features, ( currentFeature, index ) => {
+			return currentFeature ? this.renderFeatureItem( currentFeature, index ) : null;
+		} );
 	}
 
 	renderPlanHeaders() {

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -254,7 +254,6 @@ $plan-features-sidebar-width: 272px;
 
 		@include breakpoint-deprecated( "<660px" ) {
 			padding: 0 20px 20px;
-			border-bottom: solid 1px var(--color-neutral-0);
 		}
 	}
 
@@ -521,3 +520,50 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 }
+
+.plan-features-comparison__mobile {
+	color: var(--color-text-subtle);
+	margin: 0 16px;
+	text-align: center;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		display: none;
+	}
+
+	.foldable-card {
+		box-shadow: none;
+		border-top: solid 1px var(--color-neutral-0);
+	}
+
+	.foldable-card.card.is-expanded {
+		//original rule has this specificity
+		margin: 0;
+	}
+
+	.foldable-card.is-expanded .foldable-card__content {
+		//original rule has this specificity
+		padding: 0;
+	}
+
+	.plan-features-comparison__item {
+		border-bottom: solid 1px var(--color-neutral-5);
+		font-size: $font-body-small;
+	}
+
+	.plan-features-comparison__header-banner {
+		display: none;
+	}
+
+	.plan-features-comparison__item:last-child {
+		border-bottom: none;
+	}
+
+}
+
+.plan-features-comparison__mobile-plan {
+	font-size: $font-body-small;
+	border: solid 1px var(--color-neutral-5);
+	background-color: var(--color-surface);
+	margin-bottom: 24px;
+}
+

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -1,13 +1,15 @@
 $plan-features-header-banner-height: 20px;
 $plan-features-sidebar-width: 272px;
 
-.plan-pill.is-in-signup {
-	right: 52%;
-	transform: translate(50%);
-	border-radius: 4px;
-	background-color: var(--studio-green-5);
-	color: var(--studio-gray-80);
-	font-size: $font-body-small;
+.plan-features-comparison__content {
+	.plan-pill.is-in-signup {
+		right: 52%;
+		transform: translate(50%);
+		border-radius: 4px;
+		background-color: var(--studio-green-5);
+		color: var(--studio-gray-80);
+		font-size: $font-body-small;
+	}
 }
 
 .plan-features--loading-container {
@@ -470,7 +472,6 @@ body.is-section-signup.is-white-signup {
 		font-size: 0.75rem;
 		font-weight: 500;
 		letter-spacing: 0.2px;
-		line-height: 1.25rem;
 		padding: 0 8px;
 	}
 

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -16,16 +16,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isMarketplaceFlow } from '../plugins/flows';
 
 const noop = () => {};
-const PlanFeaturesActions = ( props ) => {
-	return (
-		<div className="plan-features__actions">
-			<div className="plan-features__actions-buttons">
-				<PlanFeaturesActionsButton { ...props } />
-			</div>
-		</div>
-	);
-};
-
 const PlanFeaturesActionsButton = ( {
 	availableForPurchase = true,
 	canPurchase,
@@ -183,6 +173,16 @@ const PlanFeaturesActionsButton = ( {
 	}
 
 	return null;
+};
+
+const PlanFeaturesActions = ( props ) => {
+	return (
+		<div className="plan-features__actions">
+			<div className="plan-features__actions-buttons">
+				<PlanFeaturesActionsButton { ...props } />
+			</div>
+		</div>
+	);
 };
 
 PlanFeaturesActions.propTypes = {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isMarketplaceFlow } from '../plugins/flows';
 
 const noop = () => {};
 const PlanFeaturesActions = ( props ) => {
@@ -46,6 +47,7 @@ const PlanFeaturesActionsButton = ( {
 	selectedPlan,
 	recordTracksEvent: trackTracksEvent,
 	translate,
+	flowName,
 	...props
 } ) => {
 	const classes = classNames(
@@ -72,10 +74,25 @@ const PlanFeaturesActionsButton = ( {
 		onUpgradeClick();
 	};
 
+	if ( isMarketplaceFlow( flowName ) ) {
+		if ( current ) {
+			return (
+				<Button className={ classes } disabled>
+					{ translate( 'Your current plan' ) }
+				</Button>
+			);
+		}
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ translate( 'Select' ) }
+			</Button>
+		);
+	}
+
 	if ( current && ! isInSignup && planType !== PLAN_P2_FREE ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
-				{ canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' ) }
+				{ canPurchase ? translate( 'Manageaa plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
 	}
@@ -184,6 +201,7 @@ PlanFeaturesActions.propTypes = {
 	planType: PropTypes.string,
 	primaryUpgrade: PropTypes.bool,
 	selectedPlan: PropTypes.string,
+	flowName: PropTypes.string,
 };
 
 export default connect(

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -31,13 +31,19 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isMarketplaceFlow } from '../plugins/flows';
 
 const PLANS_LIST = getPlans();
 
 export class PlanFeaturesHeader extends Component {
 	render() {
-		const { isInSignup, plansWithScroll, planType, isInVerticalScrollingPlansExperiment } =
-			this.props;
+		const {
+			isInSignup,
+			plansWithScroll,
+			planType,
+			isInVerticalScrollingPlansExperiment,
+			flowName,
+		} = this.props;
 
 		if ( planType === PLAN_P2_FREE ) {
 			return this.renderPlansHeaderP2Free();
@@ -51,6 +57,8 @@ export class PlanFeaturesHeader extends Component {
 				return this.renderPlansHeaderNoTabs();
 			}
 			return this.renderSignupHeader();
+		} else if ( isMarketplaceFlow( flowName ) ) {
+			return this.renderPlansHeaderMarketplace();
 		}
 		return this.renderPlansHeader();
 	}
@@ -146,6 +154,34 @@ export class PlanFeaturesHeader extends Component {
 					{ bestValue && ! selectedPlan && (
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Best Value' ) }</PlanPill>
 					) }
+				</header>
+				<div className="plan-features__pricing">
+					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
+					{ this.getIntervalDiscount() }
+				</div>
+			</span>
+		);
+	}
+
+	renderPlansHeaderMarketplace() {
+		const { availableForPurchase, planType, selectedPlan, title, translate } = this.props;
+
+		const isCurrent = this.isPlanCurrent();
+
+		return (
+			<span>
+				{ planLevelsMatch( selectedPlan, planType ) && availableForPurchase && (
+					<div>
+						<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
+					</div>
+				) }
+				{ isCurrent && (
+					<div>
+						<PlanPill isCurrentPlan>{ translate( 'Your current' ) }</PlanPill>
+					</div>
+				) }
+				<header className="plan-features__header">
+					<h4 className="plan-features__header-title">{ title }</h4>
 				</header>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
@@ -576,6 +612,7 @@ PlanFeaturesHeader.propTypes = {
 	siteSlug: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func,
+	flowName: PropTypes.string,
 
 	// Connected props
 	currentSitePlan: PropTypes.object,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -25,13 +25,13 @@ import InfoPopover from 'calypso/components/info-popover';
 import PlanPill from 'calypso/components/plans/plan-pill';
 import PlanIntervalDiscount from 'calypso/my-sites/plan-interval-discount';
 import PlanPrice from 'calypso/my-sites/plan-price';
+import { isMarketplaceFlow } from 'calypso/my-sites/plugins/flows';
 import { getPlanBySlug } from 'calypso/state/plans/selectors';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isMarketplaceFlow } from '../plugins/flows';
 
 const PLANS_LIST = getPlans();
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -82,6 +82,7 @@ import PlanFeaturesItem from './item';
 import PlanFeaturesActionsWrapper from './plan-features-action-wrapper';
 import PlanFeaturesScroller from './scroller';
 import './style.scss';
+import { isMarketplaceFlow } from '../plugins/flows';
 
 const noop = () => {};
 
@@ -99,13 +100,15 @@ export class PlanFeatures extends Component {
 	}
 
 	render() {
-		const { isInSignup, planProperties, plans, selectedPlan, withScroll, translate } = this.props;
+		const { isInSignup, planProperties, plans, selectedPlan, withScroll, translate, flowName } =
+			this.props;
 		const tableClasses = classNames(
 			'plan-features__table',
 			`has-${ planProperties.length }-cols`
 		);
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
+			'plan-features--marketplace': isMarketplaceFlow( flowName ),
 		} );
 		const planWrapperClasses = classNames( {
 			'plans-wrapper': isInSignup,
@@ -381,6 +384,7 @@ export class PlanFeatures extends Component {
 				plan: planConstantObj,
 				isInVerticalScrollingPlansExperiment,
 			} );
+
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -408,6 +412,7 @@ export class PlanFeatures extends Component {
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
+						flowName={ this.props.flowName }
 					/>
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions
@@ -936,7 +941,7 @@ const ConnectedPlanFeatures = connect(
 		const canPurchase = ! isPaid || isCurrentUserCurrentPlanOwner( state, selectedSiteId );
 		const isLoggedInMonthlyPricing =
 			! isInSignup && ! isJetpack && kindOfPlanTypeSelector === 'interval';
-		const flowName = getCurrentFlowName( state );
+		const flowName = ownProps.flowName ? ownProps.flowName : getCurrentFlowName( state );
 
 		let planProperties = compact(
 			map( plans, ( plan ) => {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -77,7 +77,6 @@ import {
 	isCurrentSitePlan,
 	isJetpackSite,
 } from 'calypso/state/sites/selectors';
-import { isMarketplaceFlow } from '../plugins/flows';
 import PlanFeaturesActions from './actions';
 import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -47,6 +47,7 @@ import {
 	getPlanDescriptionForMobile,
 	getPlanFeatureAccessor,
 } from 'calypso/my-sites/plan-features-comparison/util';
+import { isMarketplaceFlow } from 'calypso/my-sites/plugins/flows';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -82,7 +83,6 @@ import PlanFeaturesItem from './item';
 import PlanFeaturesActionsWrapper from './plan-features-action-wrapper';
 import PlanFeaturesScroller from './scroller';
 import './style.scss';
-import { isMarketplaceFlow } from '../plugins/flows';
 
 const noop = () => {};
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -77,6 +77,7 @@ import {
 	isCurrentSitePlan,
 	isJetpackSite,
 } from 'calypso/state/sites/selectors';
+import { isMarketplaceFlow } from '../plugins/flows';
 import PlanFeaturesActions from './actions';
 import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
@@ -377,6 +378,7 @@ export class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
+				rawPriceAnnual,
 			} = properties;
 			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
 			const planDescription = getPlanDescriptionForMobile( {
@@ -413,8 +415,11 @@ export class PlanFeatures extends Component {
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
 						flowName={ this.props.flowName }
+						rawPriceAnnual={ rawPriceAnnual }
 					/>
-					<p className="plan-features__description">{ planDescription }</p>
+					{ ! isMarketplaceFlow( flowName ) && (
+						<p className="plan-features__description">{ planDescription }</p>
+					) }
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
 						forceDisplayButton={ forceDisplayButton }
@@ -438,7 +443,11 @@ export class PlanFeatures extends Component {
 						planType={ planName }
 						primaryUpgrade={ primaryUpgrade }
 						selectedPlan={ selectedPlan }
+						flowName={ this.props.flowName }
 					/>
+					{ isMarketplaceFlow( flowName ) && (
+						<p className="plan-features__description">{ planDescription }</p>
+					) }
 					<FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
 						{ this.renderMobileFeatures( features ) }
 					</FoldableCard>
@@ -1028,6 +1037,10 @@ const ConnectedPlanFeatures = connect(
 						( { availableForCurrentPlan = true } ) => availableForCurrentPlan
 					);
 				}
+				const rawPriceAnnual =
+					null !== discountPrice
+						? discountPrice * 12
+						: getPlanRawPrice( state, planProductId, false );
 
 				return {
 					availableForPurchase,
@@ -1054,6 +1067,7 @@ const ConnectedPlanFeatures = connect(
 						bestValue ||
 						plans.length === 1,
 					rawPrice,
+					rawPriceAnnual,
 					relatedMonthlyPlan,
 					siteIsPrivateAndGoingAtomic,
 				};

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -737,7 +737,8 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	overflow-x: auto;
 }
 
-.plan-features--signup {
+.plan-features--signup,
+.plan-features--marketplace {
 	margin: 0 auto;
 
 	.signup__steps & {
@@ -866,6 +867,99 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__header-price-group-prices {
 		display: inline-block;
+	}
+}
+
+.plan-features--marketplace {
+	.plan-features__table {
+		@media ( max-width: 1040px ) {
+			display: none;
+		}
+	}
+
+	.plan-pill {
+		top: unset;
+		bottom: unset;
+		left: unset;
+		text-transform: none;
+		padding: 4px 10px;
+		background-color: var(--studio-green-5);
+		border-radius: 4px;
+		color: var(--studio-gray-80);
+		font-size: 0.875rem;
+		right: 50%;
+		transform: translate(50%, -40px);
+		&.is-current-plan {
+			background-color: var(--studio-gray-5);
+		}
+
+	}
+
+	//To be moved to line 66 approximately
+	.plan-features__mobile {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		@media ( min-width: 660px ) and ( max-width: 1040px ) {
+			.plan-features__summary,
+			.plan-features__description {
+				padding: 16px 33px;
+
+			}
+			.plan-features--signup .plan-features__pricing {
+				padding: 0 7px;
+			}
+		}
+
+		.plan-features__header {
+			align-items: flex-start;
+			background-color: var(--color-surface);
+			display: flex;
+			font-weight: 400;
+			justify-content: center;
+			margin-top: 30px;
+			padding: 12px 24px;
+			position: relative;
+			border: 0;
+		}
+
+		.plan-price {
+			font-weight: 600;
+			margin-right: 10px;
+			font-size: $font-headline-large;
+			text-align: center;
+			font-family: "Helvetica Neue", helvetica, arial, sans-serif;
+
+			.plan-price__currency-symbol {
+				vertical-align: super;
+				font-size: $font-title-medium;
+				font-weight: 400;
+			}
+
+			.plan-price__integer {
+				font-weight: 600;
+			}
+		}
+
+		.plan-features__header-title {
+			color: var(--studio-gray-80);
+			font-size: 1.25rem;
+			font-weight: 400;
+			line-height: 0.7;
+			margin-bottom: 5px;
+		}
+
+		.plan-features__header-billing-info {
+			margin-bottom: 1.4em;
+			color: var(--color-text-subtle);
+			line-height: normal;
+			text-align: center;
+		}
+
+		.plan-features__mobile-plan {
+			max-width: 408px;
+		}
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -927,18 +927,23 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		.plan-price {
 			font-weight: 600;
 			margin-right: 10px;
-			font-size: $font-headline-large;
+			font-size: 2rem;
 			text-align: center;
 			font-family: "Helvetica Neue", helvetica, arial, sans-serif;
 
 			.plan-price__currency-symbol {
-				vertical-align: super;
-				font-size: $font-title-medium;
-				font-weight: 400;
+				color: var(--color-text);
+				font-size: 2rem;
+				vertical-align: unset;
 			}
 
 			.plan-price__integer {
 				font-weight: 600;
+			}
+
+			.plan-price__term {
+				font-size: 0.75rem;
+				font-weight: 400;
 			}
 		}
 
@@ -959,6 +964,29 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 		.plan-features__mobile-plan {
 			max-width: 408px;
+		}
+
+		.plan-features__pricing {
+			margin: 0 20px;
+		}
+
+		.plan-features__header-annual-discount {
+			color: var(--studio-green-60);
+			font-size: 1rem;
+		}
+
+		.plan-features__actions {
+			border-bottom: 0;
+		}
+
+		.plan-features__description {
+			padding: 0 20px 10px;
+			border-bottom: solid 1px var(--color-neutral-0);
+		}
+
+		.plan-features__actions-button.is-current {
+			background-color: var(--studio-gray-5);
+			color: var(--color-neutral-70);
 		}
 	}
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -243,6 +243,7 @@ export class PlansFeaturesMain extends Component {
 					domainName={ domainName }
 					nonDotBlogDomains={ this.filterDotBlogDomains() }
 					isInSignup={ isInSignup }
+					flowName={ flowName }
 					isLandingPage={ isLandingPage }
 					isLaunchPage={ isLaunchPage }
 					onUpgradeClick={ onUpgradeClick }

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -259,9 +259,11 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	align-content: space-between;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
-		margin: 8px 16px 16px;
+		margin: 8px auto 16px;
 		max-width: 480px;
-
+		@media screen and ( max-width: 960px ) {
+			margin: 8px 16px 16px;
+		}
 		.segmented-control__link {
 			padding: 8px 12px;
 		}

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -259,7 +259,7 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	align-content: space-between;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
-		margin: 8px auto 16px;
+		margin: 8px 16px 16px;
 		max-width: 480px;
 
 		.segmented-control__link {

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -4,6 +4,7 @@ import {
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 } from '@automattic/calypso-products';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -29,6 +30,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );
+	const isDesktop = useDesktopBreakpoint();
 
 	const dispatch = useDispatch();
 
@@ -98,8 +100,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 				subHeaderText={ `Choose the plan that's right for you and reimagine what's possible with plugins` }
 				brandFont
 			/>
-
-			<div className="plans">
+			<div className="plans in-vertically-scrolled-plans-experiment">
 				<PlansFeaturesMain
 					basePlansPath="/plugins/plans"
 					showFAQ={ false }
@@ -108,7 +109,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					selectedPlan={ PLAN_BUSINESS }
 					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
 					flowName={ MARKETPLACE_FLOW }
-					shouldShowPlansFeatureComparison
+					shouldShowPlansFeatureComparison={ isDesktop }
 					isReskinned
 				/>
 			</div>

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -13,11 +13,12 @@
 	.promo-section__promos {
 		overflow: auto;
 		white-space: nowrap;
-		max-width: 820px;
+		max-width: 832px;
 		margin: auto;
 		margin-top: 50px;
 		margin-bottom: 50px;
 		display: block;
+		left: 0;
 
 		@media (max-width: 480px) {
 			padding-left: 20px;
@@ -35,7 +36,8 @@
 			box-shadow: none;
 			padding-left: 0;
 			padding-right: 0;
-			width: 255px;
+			width: calc(33% - 1em);
+			min-width: 250px;
 			display: inline-block;
 			vertical-align: top;
 


### PR DESCRIPTION
#### Proposed Changes

Following #67891, needs mobile view for plugins plans.

#### Testing Instructions

* Go to `/plugins/plans/:site` using mobile view
* Plans should look like the `After` screenshot.

#### Screenshot
![NfeH2w.gif](https://user-images.githubusercontent.com/402286/191601250-ee3f7bb2-583f-4acd-ad69-4783b71428b8.gif)

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Fixes #67961