### PR TITLE
Re-enable support__home test with calypso-pr group

### DIFF
--- a/test/e2e/specs/support/support__home.ts
+++ b/test/e2e/specs/support/support__home.ts
@@ -1,5 +1,5 @@
 /**
- * @group quarantined
+ * @group calypso-pr
  */
 
 import {


### PR DESCRIPTION
### Details
Related to issue [#62778](https://github.com/Automattic/wp-calypso/issues/62778). Running the `support__popover-invalid` and `support_home` tests previously resulted in flaky results. It appears that both tests pass consistently, so `support_home` is being re-enabled with the `calypso-pr` group (`support__popover-invalid` already has the group).
### Changes
- Updated the group of `support_home` from `quarantined` to `calypso-pr`.