### PR TITLE
Adjust lightbox close button stacking order(z-index) to top.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -378,6 +378,11 @@
 	.product-lightbox__variants-options {
 		margin: 0;
 	}
+
+	.product-lightbox__close-button {
+		z-index: 1;
+		background-color: #fff;
+	}
 }
 
 @media screen and ( max-height: 630px ) and ( orientation: landscape ) {


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the lightbox close button(X), where on mobile (portrait), the close button(X) was getting covered up when scrolling the content inside the lightbox.

This issue was reported here: p1HpG7-i4a-p2#comment-57141
Completes task: 1202796695664022-as-1203005354786566

#### Screenshots

BEFORE | AFTER
--- | ---
![Markup 2022-09-21 at 16 33 00](https://user-images.githubusercontent.com/11078128/191605896-1812529c-dd01-452f-9f81-c349d8731ca2.png) | ![Markup 2022-09-21 at 16 33 56](https://user-images.githubusercontent.com/11078128/191605956-e25758a1-a9e0-4817-9533-6b378adf74d1.png)

#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout fix/lightbox-button-stacking-order`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Using dev tools, simulate mobile device portrait view.
- Select "More about VideoPress" (and/or other products too) to open the product lightbox.
- Expand the contents in the "Includes:" section and the "Benefits:" section.
- Scroll the contents up and verify the content is not covering up the close button(X).
- You can compare with wordpress.com to view the original regression.
- See screenshot above ^^


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203005354786566