### PR TITLE
Sort plugins by update

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -678,16 +678,7 @@ export class PluginsList extends Component {
 		plugins.sort( ( a, b ) => {
 			const updateA = !! a.update;
 			const updateB = !! b.update;
-
-			if ( updateA && ! updateB ) {
-				return -1;
-			}
-
-			if ( ! updateA && updateB ) {
-				return 1;
-			}
-
-			return 0;
+			return Number( updateB ) - Number( updateA );
 		} );
 
 		return plugins;

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -661,7 +661,7 @@ export class PluginsList extends Component {
 	}
 
 	getPlugins() {
-		return this.props.plugins.map( ( plugin ) => {
+		const plugins = this.props.plugins.map( ( plugin ) => {
 			const selectThisPlugin = this.togglePlugin.bind( this, plugin );
 			const allowedPluginActions = this.getAllowedPluginActions( plugin );
 			const isSelectable =
@@ -673,6 +673,24 @@ export class PluginsList extends Component {
 				...{ onClick: selectThisPlugin, isSelected: this.isSelected( plugin ), isSelectable },
 			};
 		} );
+
+		// Plugins which require an update sort first, otherwise the original order is kept.
+		plugins.sort( ( a, b ) => {
+			const updateA = !! a.update;
+			const updateB = !! b.update;
+
+			if ( updateA && ! updateB ) {
+				return -1;
+			}
+
+			if ( ! updateA && updateB ) {
+				return 1;
+			}
+
+			return 0;
+		} );
+
+		return plugins;
 	}
 
 	getAllowedPluginActions( plugin ) {


### PR DESCRIPTION
#### Proposed Changes

This PR adjusts the plugins sort order so that plugins which require an update come first in this list. When the list of plugins is very long this will help to make the ones which require an action more visible.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/plugins/manage` and `/plugins/manage/:site_slug` with some plugins which require an update. Verify that the plugins which require an update sort to the top of the displayed list.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1203013909059830