### PR TITLE
Fix Stylelint error for rule: `selector-type-no-unknown`

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -50,12 +50,6 @@
 	}
 }
 
-// center twitter widgets. these use a fancy custom element on modern browsers
-.reader-full-post twitterwidget {
-	margin: 0 auto;
-	margin-bottom: 24px !important; // override element style from twitter
-}
-
 // Hides Jetpack RP in Reader
 .reader-full-post .jp-relatedposts-headline,
 .reader-full-post .jp-relatedposts {

--- a/client/components/advanced-credentials/style.scss
+++ b/client/components/advanced-credentials/style.scss
@@ -65,7 +65,7 @@
 .connection-status__disconnected,
 .connection-status__loading {
 	display: flex;
-	*:not(first-child) {
+	*:not(:first-child) {
 		margin-left: 8px;
 	}
 	svg {

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -41,7 +41,7 @@
 	}
 
 	.content-card__action-button,
-	content-card__alternate-action-button {
+	.content-card__alternate-action-button {
 		margin-bottom: 40px;
 	}
 


### PR DESCRIPTION
Related to: #67467 

#### Proposed Changes

Original PR for this was closed due to issues with the branch #67996

There was only one error for `selector-type-no-unknown` when running `yarn lint:css`. Since the selector was broken and we have blocks now, the CSS isn't being used. So to fix this error, I'm proposing to remove the CSS which will keep trunk looking the same while removing the stylelint error. 


#### Testing Instructions

1. TeamCity
2. Smoke test calypso.live and verify styles are generally correct 