### PR TITLE
Track email upsell clicks from email-forwarding

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -11,6 +11,7 @@ import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { canAddMailboxesToEmailSubscription } from 'calypso/lib/emails';
 import {
 	getGoogleAdminUrl,
@@ -56,6 +57,7 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	return (
 		<VerticalNavItem
 			path={ emailManagementPurchaseNewEmailAccount( selectedSiteSlug, domain.name, currentRoute ) }
+			onClick={ () => recordTracksEvent( 'calypso_upsell_email', { context: 'email-forwarding' } ) }
 		>
 			{ translate( 'Upgrade to a hosted email' ) }
 		</VerticalNavItem>


### PR DESCRIPTION
#### Proposed Changes

Currently, there is no click tracking in place for the "Upgrade to Hosted Email" link in the Email Forwarding page, which makes it difficult to determine the conversion from email forwarding to a paid email solution. This change enables click tracking for the "Upgrade to Hosted Email" link triggering a `calypso_email_upsell` event with property `context: email-forwarding`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a site with Email Forwarding setup
* Go to Upgrades > Email (`/email/:domain/manage/:site`)
* Click on "Upgrade to Hosted Email"
* **Expected Outcome:** the `calypso_email_upsell` event should be fired, sending the `context: email-forwarding` property. Here's a screenshot of the call in [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) 
<img width="678" alt="Screen Shot 2022-09-21 at 9 04 49 PM" src="https://user-images.githubusercontent.com/104910361/191636129-4775d1c8-d521-4123-a9ce-612e57f3c27f.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
