### PR TITLE
Marketplace: Fix current plan on plan information step

### DIFF
--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -87,7 +87,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 	getAnnualDiscount() {
 		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
 
-		if ( ! isMonthlyPlan ) {
+		if ( ! isMonthlyPlan && annualPricePerMonth ) {
 			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
 
 			const discountRate = Math.round(


### PR DESCRIPTION
#### Proposed Changes

Make the current plan show as the screenshot.
Figma: HOg65lHD0QOfaq0QtzKQbC-fi-428%3A16141

#### Testing Instructions

* Switch to a site with Free, Personal or Premium site
* Go to `/plugins/plans/yearly/:site`
* Current plan should look like the screenshot.

#### Screenshot
| Before | After | 
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/191645272-69ddcf72-0406-4a01-8eb7-88f436498bfe.png) | ![image](https://user-images.githubusercontent.com/402286/191645109-dc4c5423-a99c-4ac2-8861-057d8886829a.png) |

##### Acceptance
- [ ] Show "Your current plan" pill before the plan name.
- [ ] Show "Your current plan" instead of "Select".
- [ ] Button and Pill should be the same color `#DCDCDE`

#### Extra fixes
- [x] Fix the grey "loading" bar before the button

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Fixes #68120