### PR TITLE
Pattern Assembler - Scroll to the bottom of the preview when choosing a footer

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -64,7 +64,7 @@ export default class WebPreviewContent extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { previewUrl, inlineCss } = this.props;
+		const { previewUrl, inlineCss, scrollToSelector } = this.props;
 		const { loaded } = this.state;
 
 		this.setIframeUrl( previewUrl );
@@ -100,6 +100,17 @@ export default class WebPreviewContent extends Component {
 					channel: `preview-${ this.previewId }`,
 					type: 'inline-css',
 					inline_css: inlineCss,
+				},
+				'*'
+			);
+		}
+
+		if ( scrollToSelector && loaded && ! prevState.loaded ) {
+			this.iframe.contentWindow?.postMessage(
+				{
+					channel: `preview-${ this.previewId }`,
+					type: 'scroll-to-selector',
+					scroll_to_selector: scrollToSelector,
 				},
 				'*'
 			);
@@ -307,7 +318,6 @@ export default class WebPreviewContent extends Component {
 			}, loadingTimeout );
 		} else {
 			this.setState( { loaded: true, isLoadingSubpage: false } );
-
 			if ( this.loadingTimeoutTimer ) {
 				debug( 'preview loaded before timeout' );
 				clearTimeout( this.loadingTimeoutTimer );
@@ -486,6 +496,8 @@ WebPreviewContent.propTypes = {
 	fixedViewportWidth: PropTypes.number,
 	// Injects CSS in the iframe after the content is loaded.
 	inlineCss: PropTypes.string,
+	// Uses the CSS selector to scroll to it
+	scrollToSelector: PropTypes.string,
 };
 
 WebPreviewContent.defaultProps = {
@@ -510,4 +522,5 @@ WebPreviewContent.defaultProps = {
 	toolbarComponent: Toolbar,
 	autoHeight: false,
 	inlineCss: null,
+	scrollToSelector: null,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -29,6 +29,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 	const [ webPreviewFrameContainer, setWebPreviewFrameContainer ] = useState< Element | null >(
 		null
 	);
+	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
 
 	const hasSelectedPatterns = header || sections.length > 0 || footer;
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -49,6 +50,14 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 	useEffect( () => {
 		setWebPreviewFrameContainer( document.querySelector( '.web-preview__frame-wrapper' ) );
 	}, [] );
+
+	useEffect( () => {
+		setScrollToSelector( null );
+	}, [ header, sections ] );
+
+	useEffect( () => {
+		setScrollToSelector( footer ? 'footer' : null );
+	}, [ footer ] );
 
 	return (
 		<div
@@ -91,6 +100,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 				url={ site?.URL }
 				translate={ translate }
 				recordTracksEvent={ recordTracksEvent }
+				scrollToSelector={ scrollToSelector }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

* WebPreview support for scroll to selector 
* Pattern assembler preview scrolls to footer

[Screen Recording on 2022-09-22 at 15_56_15.webm](https://user-images.githubusercontent.com/1881481/191706336-2fb9c569-2fd8-49ce-828f-f8fdb2d0c3e4.webm)

### Testing instructions
- Sandbox the API using D88290-code
- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain
- Select the goal Promote myself or business
- Select the category `Show all`
- Click on the Blank canvas CTA
- Add a header, sections and a footer
- When a footer is added or replaced, the footer should be visible because the preview scrolls down

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#68070](https://github.com/Automattic/wp-calypso/issues/68070)