### PR TITLE
Limit and shuffle generated designs in UDP

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
@@ -1,1 +1,2 @@
 export const STEP_NAME = 'design-setup';
+export const GENERATED_DESIGNS_LIMIT = 3;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -13,6 +13,7 @@ import { StepContainer } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import { shuffle } from 'lodash';
 import { useRef, useState, useEffect } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -29,7 +30,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
-import { STEP_NAME } from './constants';
+import { STEP_NAME, GENERATED_DESIGNS_LIMIT } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import PreviewToolbar from './preview-toolbar';
 import UpgradeModal from './upgrade-modal';
@@ -109,7 +110,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	);
 
-	const generatedDesigns = allDesigns?.generated?.designs || [];
+	const randomizeGeneratedDesigns = ( designs: Design[] ) => {
+		const shuffledDesigns = shuffle( designs );
+
+		if ( designs.length <= GENERATED_DESIGNS_LIMIT ) {
+			return shuffledDesigns;
+		}
+
+		return shuffledDesigns.slice( 0, GENERATED_DESIGNS_LIMIT );
+	};
+
+	const generatedDesigns = randomizeGeneratedDesigns( allDesigns?.generated?.designs || [] );
 	const staticDesigns = allDesigns?.static?.designs || [];
 
 	const hasTrackedView = useRef( false );


### PR DESCRIPTION
#### Proposed Changes

* Shuffle the generated designs using lodash
* Limit them to three using a constant in the frontend. I think is here because we want to get three randomized from the list of published recipes in that category. 

After merging this PR, we will publish the recipe `BLOG LAYOUT 4`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site, choose goals, and a vertical to get to the design picker step
* Check that we only display three generated designs when more are published. We can test locally by changing the value of the constant `GENERATED_DESIGNS_LIMIT` to `2` and testing that only two are displayed because if we publish more recipes they will be available in production.

<img width="1620" alt="Screen Shot 2565-09-22 at 17 15 29" src="https://user-images.githubusercontent.com/1881481/191721380-2150dbc2-99d7-4ae3-af11-6d41802cb228.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#115](115-gh-Automattic/ganon-issues)