### PR TITLE
Help Center: fix sticky CTA when minimized

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -89,14 +89,25 @@
 }
 
 section.contact-form-submit {
-	position: fixed;
+	// this creates a border for the CTA.
+	// a simple border won't cut it because it would be padded in.
+	&::before {
+		content: " ";
+		display: block;
+		height: 1px;
+		background: rgba(0, 0, 0, 0.1);
+		position: absolute;
+		left: -16px;
+		top: 0;
+		width: calc(100% + 32px);
+	}
+	position: sticky;
 	bottom: 0;
 	left: 0;
 	width: 100%;
 	box-sizing: border-box;
 	background: #fff;
 	padding: 16px;
-	border-top: 1px solid rgba(0, 0, 0, 0.1);
 
 	.button.help-center-contact-form__site-picker-cta.is-primary {
 		background-color: var(--color-accent);

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -215,10 +215,6 @@ $head-foot-height: 50px;
 		> *:not(iframe) {
 			padding: 16px;
 		}
-
-		.help-center-contact-form {
-			margin-bottom: 87px;
-		}
 	}
 
 	.help-center-sibyl-articles__list {


### PR DESCRIPTION
#### Proposed Changes

* This makes the CTA sticky instead of fixed. It will be smarter now to only stick if it's under the fold. This gives a chance to other elements as well!

#### Testing Instructions

1. Run ETK by running `cd apps/editing-toolkit`.
2. Go to Gutenberg editor.
3. Open the Help Center. 
4. Go to the contact form.
5. The CTA should be sticky, but when you scroll down, it should sit in its normal place.
6. Minimize the Help Center. The button should disappear.

https://user-images.githubusercontent.com/17054134/191731083-4a006235-21a6-4bce-9ee2-0feca39c5375.mov



Fixes: https://github.com/Automattic/wp-calypso/issues/68142