### PR TITLE
Launch flow: Populate search results

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -278,10 +278,10 @@ class RegisterDomainStep extends Component {
 			return;
 		}
 
-		const wpcomSubdomainWithRandomNumberSuffix = /^(.+?)([0-9]{5,})\.wordpress\.com$/i;
-		const [ , strippedHostname ] =
-			this.props.selectedSite.domain.match( wpcomSubdomainWithRandomNumberSuffix ) || [];
-		return strippedHostname ?? this.props.selectedSite.domain.split( '.' )[ 0 ];
+		const hostname = this.props.selectedSite.domain.split( '.' )[ 0 ];
+		const regexHostnameWithRandomNumberSuffix = /^(.+?)([0-9]{5,})/i;
+		const [ , strippedHostname ] = hostname.match( regexHostnameWithRandomNumberSuffix ) || [];
+		return strippedHostname ?? hostname;
 	}
 
 	componentDidMount() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -271,6 +271,13 @@ class RegisterDomainStep extends Component {
 			return;
 		}
 
+		if (
+			typeof this.props.selectedSite !== 'object' ||
+			typeof this.props.selectedSite.domain !== 'string'
+		) {
+			return;
+		}
+
 		const wpcomSubdomainWithRandomNumberSuffix = /^(.+?)([0-9]{5,})\.wordpress\.com$/i;
 		const [ , strippedHostname ] =
 			this.props.selectedSite.domain.match( wpcomSubdomainWithRandomNumberSuffix ) || [];

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -265,7 +265,17 @@ class RegisterDomainStep extends Component {
 
 	componentDidMount() {
 		const storedQuery = globalThis?.sessionStorage?.getItem( SESSION_STORAGE_QUERY_KEY );
-		const query = this.state.lastQuery || storedQuery;
+		let query = this.state.lastQuery || storedQuery;
+
+		// In the launch flow, the initial query could sometimes be missing if the user had
+		// created a site by skipping the domain step. In these cases, fire the initial search
+		// with the subdomain name.
+		if ( this.props.isInLaunchFlow && ! query ) {
+			const wpcomSubdomainWithRandomNumberSuffix = /^(.+?)([0-9]{5,})\.wordpress\.com$/i;
+			const [ , strippedHostname ] =
+				this.props.selectedSite.domain.match( wpcomSubdomainWithRandomNumberSuffix ) || [];
+			query = strippedHostname ?? this.props.selectedSite.domain.split( '.' )[ 0 ];
+		}
 
 		if ( query && ! this.state.searchResults && ! this.state.subdomainSearchResults ) {
 			this.onSearch( query );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -549,6 +549,7 @@ class DomainsStep extends Component {
 					}
 					isReskinned={ this.props.isReskinned }
 					reskinSideContent={ this.getSideContent() }
+					isInLaunchFlow={ 'launch-site' === this.props.flowName }
 				/>
 			</CalypsoShoppingCartProvider>
 		);


### PR DESCRIPTION
#### Proposed Changes

Fixes a bug in which under certain conditions, the launch site flow could open with no pre-populated search results. So, users are forced to type out a domain to proceed with launching a site. This issue is further described in https://github.com/Automattic/wp-calypso/issues/63050. 

**When does this happen?**

Under the following conditions, the launch flow can render the domain step with no search results on initial render:

* While signing up for a new account, click "Choose Domain Later" in the domain step.
* Launch site from Settings > General.

Another scenario which could cause this error:

* Signup for a new account.
* Launch site from Settings > General in a different device or browser, or from an incognito window.

**Why does this happen?**

The launch flow uses the last domain searched value to pre-populate the search results:

https://github.com/Automattic/wp-calypso/blob/665fb5ebace3d26cfcb988f9c3d7eccdd7909efb/client/components/domains/register-domain-step/index.jsx#L170-L176

The last search value could be empty under the following conditions:
* User never searched for a domain, they skipped the domain step in signup, and hence this value is empty.
* The last searched value is stored in local storage and this value could be unreadable if a different device or browser is used, or if an incognito window was used. 

**What's the proposed fix?**

To use the last searched value if it exists, otherwise pre-populate results from the site's subdomain name. WordPress.com subdomain's sometimes have random numbers appended to them, as part of the logic by which these are generated, so it would be nice to remove these random numbers when pre-populating the search results. We already do this in the [domain search page](https://github.com/Automattic/wp-calypso/blob/228dba2b750736763a0af52150327e2ad1743c0d/client/my-sites/domains/domain-search/index.jsx#L187) in Calypso.

**Launching From My Home**

As mentioned above, this issue is seen only when launching from the Settings page. The My Home page doesn't produce this bug, but I'm not convinced with the domain search term it uses to pre-populate the results. The domain search term when launching from My Home is not stripped off the random numbers I mentioned previously, and it doesn't read the last searched term if it exists. It defaults to using the subdomain as the search term, and there are many situations in which the subdomain is generated randomly. It would be a better experience to use the last searched term if it exists, since that directly aligns with the user's keyword interests. 
This PR doesn't modify the logic in My Home yet, but if it's agreeable, I'll make that change too. 



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Signup for a new site and in the domains step of signup flow, click "Choose domain later".
* In Settings > General, click on Launch Site and verify that the domain page is pre-populated with the subdomain as the search keyword.
* If the subdomain has several numbers, like mydomain32432423 .wordpress.com, then verify that the domain search term strips away these numbers, so the search keyword is simply "mydomain" as per the example I shared.


