### PR TITLE
Import flow: fix issue with rendering step contentr

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -122,7 +122,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		/**
 	 	↓ Renders
 		 */
-		function renderStepContent() {
+		function StepContent() {
 			if ( isLoading() ) {
 				return <LoadingEllipsis />;
 			} else if ( ! siteSlug || ! siteItem || ! siteId ) {
@@ -168,7 +168,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 					hideFormattedHeader={ true }
 					goBack={ onGoBack }
 					isWideLayout={ true }
-					stepContent={ renderStepContent() }
+					stepContent={ <StepContent /> }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			</>


### PR DESCRIPTION
#### Proposed Changes

Before this commit, there was a problem with the import flow flickering screens between steps. (switching between loading states)
It is a simple fix rendering the JSX component instead of another render method calls.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import?siteSlug={SLUG}`
* Provide a WordPress web address (ex. jurassic.ninja)
* Uncontrolled switching from screen to loading screen will no longer occur.

#### Screenshot
![Screen Capture on 2022-09-22 at 15-35-30](https://user-images.githubusercontent.com/1241413/191764439-2ac89379-202a-4dc4-b83a-d4f00f182e00.gif)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
