### PR TITLE
i18n: Fix loading of Jetpack pricing header translation

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import { hideMasterbar } from 'calypso/state/ui/actions';
@@ -17,18 +17,23 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 		return;
 	}
 
+	const PricingHeader = () => {
+		const translate = useTranslate();
+		return (
+			<Header
+				urlQueryArgs={ urlQueryArgs }
+				title={
+					isEnabled( 'jetpack/pricing-page-rework-v1' )
+						? translate( 'Best-in-class products for your WordPress site' )
+						: translate( 'Security, performance, and marketing tools made for WordPress' )
+				}
+			/>
+		);
+	};
+
 	context.store.dispatch( hideMasterbar() );
 	context.nav = <JetpackComMasterbar pathname={ lang ? path.replace( `/${ lang }`, '' ) : path } />;
-	context.header = (
-		<Header
-			urlQueryArgs={ urlQueryArgs }
-			title={
-				isEnabled( 'jetpack/pricing-page-rework-v1' )
-					? translate( 'Best-in-class products for your WordPress site' )
-					: translate( 'Security, performance, and marketing tools made for WordPress' )
-			}
-		/>
-	);
+	context.header = <PricingHeader />;
 	context.footer = <JetpackComFooter />;
 	next();
 }


### PR DESCRIPTION
#### Proposed Changes

This fixes the loading of the translation of the headline on the Jetpacking pricing page.

`translate` was called statically before the translations were loaded, which led to the title being displayed as untranslated. Moving the `Header` into a small function component with `useTranslate` makes the translation show correctly.

Before: 
![image](https://user-images.githubusercontent.com/75777864/191776230-c6705c7b-44d5-4a06-b9ce-c3f8a25ec15a.png)

After: 
![image](https://user-images.githubusercontent.com/75777864/191776413-d62e3b7a-48ea-4e8d-80bd-ee9989e296e9.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn start-jetpack-cloud`
* Visit the pricing page for a non-English locale, e.g. http://jetpack.cloud.localhost:3000/fr/pricing, and verify that the headline is translated

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **N/A**
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? **N/A**
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)  **N/A**
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **N/A, already translated**

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 518-gh-Automattic/i18n-issues.
