### PR TITLE
VP Onboarding: clear onboarding site options on flow start and flow completion

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -28,7 +28,8 @@ export const videopress: Flow = {
 		}
 
 		const name = this.name;
-		const { setStepProgress, setSiteTitle, setSiteDescription } = useDispatch( ONBOARD_STORE );
+		const { setDomain, setSiteDescription, setSiteTitle, setStepProgress } =
+			useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
@@ -36,6 +37,7 @@ export const videopress: Flow = {
 		const clearOnboardingSiteOptions = () => {
 			setSiteTitle( '' );
 			setSiteDescription( '' );
+			setDomain( undefined );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -33,10 +33,15 @@ export const videopress: Flow = {
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const clearOnboardingSiteOptions = () => {
+			setSiteTitle( '' );
+			setSiteDescription( '' );
+		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
 				case 'intro':
+					clearOnboardingSiteOptions();
 					if ( userIsLoggedIn ) {
 						return navigate( 'options' );
 					}
@@ -71,6 +76,7 @@ export const videopress: Flow = {
 				}
 
 				case 'launchpad': {
+					clearOnboardingSiteOptions();
 					return redirect( `/page/${ siteSlug }/home` );
 				}
 			}


### PR DESCRIPTION
#### Proposed Changes

* clear out the site title and description on starting a new flow or completing a flow (landing on Launchpad) to prevent old site details from being pre-populated when creating a new site
<img width="300" alt="Screen Shot 2022-09-22 at 10 58 20 AM" src="https://user-images.githubusercontent.com/4081020/191781863-42e9ba7d-8587-406b-94f7-62ac87fa3d97.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit `setup/intro?flow=videopress`
* Click `Setup your video site`
* Enter a title and description, press `Continue`
* Return to `setup/options?flow=videopress`
* Your title and description should be populated
* Visit `setup/intro?flow=videopress` then click `Continue`
* Your title and description should be cleared out
* Go through the flow to the launchpad
* Try to return to `setup/options?flow=videopress`
* Your title and description should be cleared out (even though this backwards motion may not be totally allowed)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1341-gh-Automattic/greenhouse