### PR TITLE
[Jetpack Pricing Page rework]: Switch over to PlanPrice and update styling

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import { getCurrencyObject } from 'calypso/../packages/format-currency/src';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
+import PlanPrice from 'calypso/my-sites/plan-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useItemPriceCompact } from '../product-store/hooks/use-item-price-compact';
 import ItemPriceMessage from '../product-store/item-price/item-price-message';
@@ -29,11 +29,6 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 
 	const currentPrice = discountedPrice ? discountedPrice : originalPrice;
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
-	const priceObject = getCurrencyObject( currentPrice, currencyCode );
-	const currentPriceValue = `${ priceObject?.symbol }${ priceObject?.integer }${ priceObject?.fraction }`;
-
-	const originalPriceObject = getCurrencyObject( originalPrice, currencyCode );
-	const originalPriceValue = `${ originalPriceObject?.symbol }${ originalPriceObject?.integer }${ originalPriceObject?.fraction }`;
 
 	const labelClass = classNames(
 		'product-lightbox__variants-grey-label',
@@ -55,7 +50,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 					<div className="product-lightbox__variants-plan-card">
 						<div className={ labelClass } ref={ containerRef }>
 							<span className="product-lightbox__variants-plan-card-price">
-								{ currentPriceValue }
+								<PlanPrice rawPrice={ currentPrice } currencyCode={ currencyCode } />
 							</span>
 							<div
 								className={ classNames( 'product-lightbox__variants-timeframe', {
@@ -68,7 +63,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 						{ discountedPrice && (
 							<div className={ labelClass }>
 								<span className="product-lightbox__variants-plan-card-old-price">
-									{ originalPriceValue }
+									<PlanPrice original rawPrice={ originalPrice } currencyCode={ currencyCode } />
 								</span>
 								{ translate( '%(percentOff)d%% off the first year', {
 									args: {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -338,7 +338,7 @@
 		content: none;
 	}
 	.plan-price {
-		margin: 0;
+		margin: 0 0.2rem 0 0;
 		font-size: inherit;
 		line-height: inherit;
 		color: inherit;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -315,6 +315,36 @@
 	}
 }
 
+.product-lightbox__variants-plan-card-price,
+.product-lightbox__variants-plan-card-old-price {
+	h4 {
+		display: inherit;
+	}
+	.plan-price__fraction {
+		font-weight: inherit;
+		font-size: inherit;
+		vertical-align: inherit;
+	}
+	.plan-price__integer {
+		margin: 0;
+		font-weight: inherit;
+	}
+	.plan-price__currency-symbol {
+		color: inherit;
+		font-size: inherit;
+		vertical-align: inherit;
+	}
+	.plan-price.is-original::before {
+		content: none;
+	}
+	.plan-price {
+		margin: 0;
+		font-size: inherit;
+		line-height: inherit;
+		color: inherit;
+	}
+}
+
 .product-lightbox__variants-grey-label {
 	font-size: 0.75rem;
 	color: #646970;


### PR DESCRIPTION
#### Proposed Changes

In the Lightbox component, we switch to the `PlanPrice` component to have identical behaviour of price with the main page.

#### Testing Instructions
While proxied

- Use one method from
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - **OR** run this PR locally
        - download branch locally and run yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Look through product lightboxes by clicking the button `More about ...` and verify that prices are represented with the same values as on the main page (Especially ones with values without decimals).

| Before | After |
| ------ | ------ |
| <img width="273" alt="Screenshot 2022-09-22 at 17 46 43" src="https://user-images.githubusercontent.com/60262784/191780461-fa9312ea-6b13-4f4d-be51-19e2eb77e841.png"> | <img width="236" alt="Screenshot 2022-09-22 at 17 46 49" src="https://user-images.githubusercontent.com/60262784/191780647-0e80b85a-6c69-41a3-8484-140dc19d7440.png"> |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
0-as-1203030714907103/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203030714907103