### PR TITLE
Initial theme for ecommerce sites: twentytwentytwo

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -201,8 +201,8 @@ export function generateSteps( {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			optionalDependencies: [ 'emailItem' ],
-			providesDependencies: [ 'cartItem' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 		// the only unique thing about plans-newsletter is that it provides themeSlugWithRepo and comingSoon dependencies

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	getPlan,
 	PLAN_FREE,
+	isEcommerce,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
@@ -124,17 +125,15 @@ export class PlansStep extends Component {
 				themeSlugWithRepo: 'pub/lynx',
 			} );
 			this.props.goToNextStep();
-		} else if ( flowName === 'onboarding' && cartItem?.product_slug === 'ecommerce-bundle' ) {
-			// Buying ecommerce-bundle at signup gives you pub/twentytwentytwo
-			this.props.submitSignupStep( step, {
-				cartItem,
-				themeSlugWithRepo: 'pub/twentytwentytwo',
-			} );
-			this.props.goToNextStep();
 		} else {
-			this.props.submitSignupStep( step, {
-				cartItem,
-			} );
+			const signupVals = { cartItem };
+
+			// Buying an eCommerce plan defaults to the pub/twentytwentytwo theme (All remaining flows)
+			if ( isEcommerce( cartItem ) ) {
+				signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
+			}
+
+			this.props.submitSignupStep( step, signupVals );
 			this.props.goToNextStep();
 		}
 	};

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -124,6 +124,13 @@ export class PlansStep extends Component {
 				themeSlugWithRepo: 'pub/lynx',
 			} );
 			this.props.goToNextStep();
+		} else if ( flowName === 'onboarding' && cartItem?.product_slug === 'ecommerce-bundle' ) {
+			// Buying ecommerce-bundle at signup gives you pub/twentytwentytwo
+			this.props.submitSignupStep( step, {
+				cartItem,
+				themeSlugWithRepo: 'pub/twentytwentytwo',
+			} );
+			this.props.goToNextStep();
 		} else {
 			this.props.submitSignupStep( step, {
 				cartItem,


### PR DESCRIPTION
### Proposed Changes

* New ecommerce sites will now have their initial theme set separately compared to the rest of sites.
* That Initial theme for ecommerce sites will be twentytwentytwo.

### Mechanisms 

There are multiple mechanisms for determining a new site's initial theme. We can use a `themeSlugWithRepo`, or a `siteTypeTheme`.

https://github.com/Automattic/wp-calypso/blob/633f99cb0f1c248ac8fb1934d84518a643fb5484/client/lib/signup/step-actions/index.js#L134-L142

### Mechanisms (siteType)

One possibility (`siteTypeTheme`) is determining a site's "type", then looking that up in a predefined list, and finding the theme that corresponds to that site type.
https://github.com/Automattic/wp-calypso/blob/633f99cb0f1c248ac8fb1934d84518a643fb5484/client/lib/signup/step-actions/index.js#L129
https://github.com/Automattic/wp-calypso/blob/633f99cb0f1c248ac8fb1934d84518a643fb5484/client/lib/signup/site-type.js#L62-L66

When creating a new site on `/start`, in my testing, the siteType is always empty string:
https://github.com/Automattic/wp-calypso/blob/633f99cb0f1c248ac8fb1934d84518a643fb5484/client/lib/signup/step-actions/index.js#L127

The `/start` flow doesn't seem to set siteTypes at all, only the older `/new` flow. I could have set the siteType, but it's not clear to me exactly what a siteType is, or what other effects setting a `siteType` would have. So I tried the other mechanism:

### Mechanisms (themeSlugWithRepo)

Another possibility is the `themeSlugWithRepo`. This is a dependency in some of the flows contained in the older onboarding framework. It can be set and passed like so:

https://github.com/Automattic/wp-calypso/blob/633f99cb0f1c248ac8fb1934d84518a643fb5484/client/signup/steps/plans/index.jsx#L111-L119

That area of the plans step seemed to be a collection of 'default theme overrides', so I thought it was a good place to put this fix. We look for ecommerce in the cart on the default onboarding flow and pass along the `themeSlugWithRepo` dependency to the new theme we want.

I had to add `themeSlugWithRepo` to both the `providesDependencies` and `optionalDependencies` attributes of the plans step in order to be able to pass this around. (To make something optional, you have to add it to both).

https://github.com/Automattic/wp-calypso/blob/633f99cb0f1c248ac8fb1934d84518a643fb5484/client/signup/README.md#L42-L43


### Testing Instructions

* Use `/start` to create a new ecommerce site. It should have the 2022 theme.
* Use `/start` to create other sites, not using ecommerce. They should continue to have zoologist.
* Anything else you can think of.

BTW, I'm not very familiar with this area of the code.

Related to #67562
