### PR TITLE
Help Center: fix contact form for forum channel

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -18,6 +18,7 @@ import * as WPCOMFeatures from './wpcom-features';
 export { useHappinessEngineersQuery } from './queries/use-happiness-engineers-query';
 export { useHas3PC } from './queries/use-has-3rd-party-cookies';
 export { useSiteAnalysis } from './queries/use-site-analysis';
+export { useUserSites } from './queries/use-user-sites';
 export type { AnalysisReport } from './queries/use-site-analysis';
 export { useHasSeenWhatsNewModalQuery } from './queries/use-has-seen-whats-new-modal-query';
 export { useSiteIntent } from './queries/use-site-intent';

--- a/packages/data-stores/src/queries/use-is-wporg-site.ts
+++ b/packages/data-stores/src/queries/use-is-wporg-site.ts
@@ -1,0 +1,33 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+type Analysis = {
+	url: string;
+	platform: string;
+	meta: {
+		title: string;
+		favicon: string;
+	};
+	platform_data?: { is_wpcom: boolean };
+};
+
+export function useIsWpOrgSite( siteUrl: string | undefined, enabled = true ) {
+	return useQuery(
+		[ 'is-site-wporg-', siteUrl ],
+		async () => {
+			const analysis = await wpcomRequest< Analysis >( {
+				path: `/imports/analyze-url?site_url=${ encodeURIComponent( siteUrl as string ) }`,
+				apiNamespace: 'wpcom/v2',
+			} );
+			if ( analysis.platform === 'wordpress' && ! analysis.platform_data?.is_wpcom ) {
+				return true;
+			}
+			return false;
+		},
+		{
+			refetchOnWindowFocus: false,
+			staleTime: Infinity,
+			enabled: !! siteUrl && enabled,
+		}
+	);
+}

--- a/packages/data-stores/src/queries/use-site-analysis.ts
+++ b/packages/data-stores/src/queries/use-site-analysis.ts
@@ -55,12 +55,18 @@ function urlMatches( trustedURL: string, userInputUrl: string | undefined ) {
 /**
  * Analyses a site to determine whether its a WPCOM site, and if yes, it would fetch and return the site information (SiteDetails).
  *
+ * @param userId the user ID
  * @param siteURL the site URL
+ * @param enabled whether the query is enabled
  */
-export function useSiteAnalysis( siteURL: string | undefined, enabled: boolean ): AnalysisReport {
+export function useSiteAnalysis(
+	userId: number | string,
+	siteURL: string | undefined,
+	enabled: boolean
+): AnalysisReport {
 	const [ debouncedSiteUrl ] = useDebounce( siteURL, 500 );
 	const isEnabled = isHost( debouncedSiteUrl ) && enabled;
-	const { data: userSites, isLoading: userSitesLoading } = useUserSites( isEnabled );
+	const { data: userSites, isLoading: userSitesLoading } = useUserSites( userId, isEnabled );
 	const { data: wpcomSite, isLoading: wpcomSiteLoading } = useWpcomSite(
 		debouncedSiteUrl,
 		isEnabled

--- a/packages/data-stores/src/queries/use-site-analysis.ts
+++ b/packages/data-stores/src/queries/use-site-analysis.ts
@@ -1,31 +1,55 @@
-import { useEffect, useState } from 'react';
 import { useDebounce } from 'use-debounce';
-import wpcomRequest from 'wpcom-proxy-request';
 import { SiteDetails } from '../site';
+import { useIsWpOrgSite } from './use-is-wporg-site';
+import { useUserSites } from './use-user-sites';
+import { useWpcomSite } from './use-wpcom-site';
 
-type ResultType = 'WPCOM' | 'WPORG' | 'UNKNOWN' | 'NOT_OWNED_BY_USER' | 'UNKNOWN';
+type ResultType =
+	| 'DISABLED'
+	| 'LOADING'
+	| 'OWNED_BY_USER'
+	| 'WPORG'
+	| 'UNKNOWN'
+	| 'NOT_OWNED_BY_USER'
+	| 'UNKNOWN';
 
 export type AnalysisReport = {
 	result: ResultType;
 	site?: SiteDetails;
-};
-
-type Analysis = {
-	url: string;
-	platform: string;
-	meta: {
-		title: string;
-		favicon: string;
-	};
-	platform_data?: { is_wpcom: boolean };
+	siteURL: string | undefined;
+	isWpcom: boolean;
 };
 
 // a simple way to check if a string is host to save on API calls
 function isHost( string: string | undefined ) {
 	if ( string ) {
-		return string.length > 4 && Boolean( string?.match( /\w{2,}\.\w{2,16}/ ) );
+		return string.length > 4 && Boolean( string?.match( /\w{2,}\.\w{2,32}/ ) );
 	}
 	return false;
+}
+
+function urlMatches( trustedURL: string, userInputUrl: string | undefined ) {
+	if ( ! trustedURL || ! userInputUrl ) {
+		return false;
+	}
+	const normalizedInputUrl = userInputUrl.trim().toLowerCase();
+
+	if ( trustedURL === normalizedInputUrl ) {
+		return true;
+	}
+	try {
+		const trustedURLObject = new URL( trustedURL );
+		if ( trustedURLObject.host === normalizedInputUrl ) {
+			return true;
+		}
+		const normalizedInputUrlObject = new URL( normalizedInputUrl );
+		if ( trustedURLObject.host === normalizedInputUrlObject.host ) {
+			return true;
+		}
+	} catch ( _e ) {
+		// couldn't build URL object
+		return false;
+	}
 }
 
 /**
@@ -33,46 +57,49 @@ function isHost( string: string | undefined ) {
  *
  * @param siteURL the site URL
  */
-export function useSiteAnalysis( siteURL: string | undefined ) {
-	const [ analysis, setAnalysis ] = useState< AnalysisReport | undefined >();
+export function useSiteAnalysis( siteURL: string | undefined, enabled: boolean ): AnalysisReport {
 	const [ debouncedSiteUrl ] = useDebounce( siteURL, 500 );
+	const isEnabled = isHost( debouncedSiteUrl ) && enabled;
+	const { data: userSites, isLoading: userSitesLoading } = useUserSites( isEnabled );
+	const { data: wpcomSite, isLoading: wpcomSiteLoading } = useWpcomSite(
+		debouncedSiteUrl,
+		isEnabled
+	);
+	const { data: isWporg, isLoading: wpOrgSiteLoading } = useIsWpOrgSite(
+		debouncedSiteUrl,
+		isEnabled
+	);
 
-	useEffect( () => {
-		setAnalysis( undefined );
-		if ( ! isHost( debouncedSiteUrl ) ) {
-			return;
+	if ( ! isEnabled ) {
+		return {
+			result: 'DISABLED',
+			siteURL,
+			isWpcom: false,
+		};
+	}
+
+	const usersOwned = Boolean(
+		userSites?.sites.find( ( s ) => urlMatches( s.URL, debouncedSiteUrl ) )
+	);
+
+	if ( usersOwned ) {
+		return { site: wpcomSite, result: 'OWNED_BY_USER', siteURL, isWpcom: true };
+	} else if ( wpcomSite ) {
+		// use the wpcomSite response URL instead of user input to
+		// double check if the wpcom site belongs to the user before dismissing
+		if ( userSites?.sites.find( ( s ) => urlMatches( s.URL, wpcomSite.URL ) ) ) {
+			return { site: wpcomSite, result: 'OWNED_BY_USER', siteURL, isWpcom: true };
 		}
-		if ( debouncedSiteUrl ) {
-			( async () => {
-				try {
-					const analysis = await wpcomRequest< Analysis >( {
-						path: `/imports/analyze-url?site_url=${ encodeURIComponent( debouncedSiteUrl ) }`,
-						apiNamespace: 'wpcom/v2',
-					} );
+		return { site: wpcomSite, result: 'NOT_OWNED_BY_USER', siteURL, isWpcom: true };
+	} else if ( isWporg ) {
+		return { result: 'WPORG', siteURL, isWpcom: false };
+	}
 
-					if ( analysis.platform_data?.is_wpcom ) {
-						try {
-							// if a wpcom site, get its info
-							const site = await wpcomRequest< SiteDetails >( {
-								path: '/sites/' + encodeURIComponent( debouncedSiteUrl ),
-								apiVersion: '1.1',
-							} );
-							setAnalysis( { site, result: 'WPCOM' } );
-						} catch ( error ) {
-							// wpcom site, but not owned by user
-							setAnalysis( { result: 'NOT_OWNED_BY_USER' } );
-						}
-					} else if ( analysis.platform === 'wordpress' ) {
-						setAnalysis( { result: 'WPORG' } );
-					} else {
-						setAnalysis( { result: 'UNKNOWN' } );
-					}
-				} catch ( error ) {
-					setAnalysis( { result: 'UNKNOWN' } );
-				}
-			} )();
-		}
-	}, [ debouncedSiteUrl ] );
+	const isLoading = [ userSitesLoading, wpOrgSiteLoading, wpcomSiteLoading ].some( Boolean );
 
-	return { ...analysis, isLoading: ! analysis };
+	return {
+		result: isLoading ? 'LOADING' : 'UNKNOWN',
+		siteURL,
+		isWpcom: false,
+	};
 }

--- a/packages/data-stores/src/queries/use-user-sites.ts
+++ b/packages/data-stores/src/queries/use-user-sites.ts
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteDetails } from '../site';
+
+export function useUserSites( enabled = true ) {
+	return useQuery(
+		'user-sites',
+		() =>
+			wpcomRequest< { sites: SiteDetails[] } >( {
+				path: '/me/sites/',
+				apiVersion: '1.1',
+			} ),
+		{
+			refetchOnWindowFocus: false,
+			staleTime: Infinity,
+			enabled,
+		}
+	);
+}

--- a/packages/data-stores/src/queries/use-user-sites.ts
+++ b/packages/data-stores/src/queries/use-user-sites.ts
@@ -2,9 +2,9 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteDetails } from '../site';
 
-export function useUserSites( enabled = true ) {
+export function useUserSites( userId: number | string, enabled = true ) {
 	return useQuery(
-		'user-sites',
+		[ 'user-sites', userId ],
 		() =>
 			wpcomRequest< { sites: SiteDetails[] } >( {
 				path: '/me/sites/',
@@ -12,7 +12,7 @@ export function useUserSites( enabled = true ) {
 			} ),
 		{
 			refetchOnWindowFocus: false,
-			staleTime: Infinity,
+			staleTime: 5 * 60 * 1000,
 			enabled,
 		}
 	);

--- a/packages/data-stores/src/queries/use-wpcom-site.ts
+++ b/packages/data-stores/src/queries/use-wpcom-site.ts
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteDetails } from '../site';
+
+export function useWpcomSite( siteId: number | string | undefined, enabled = true ) {
+	return useQuery(
+		[ 'wpcom-site', siteId ],
+		() =>
+			wpcomRequest< SiteDetails >( {
+				path: '/sites/' + encodeURIComponent( siteId as string ),
+				apiVersion: '1.1',
+			} ),
+		{
+			refetchOnWindowFocus: false,
+			staleTime: Infinity,
+			enabled: !! siteId && enabled,
+		}
+	);
+}

--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -1,5 +1,6 @@
 import { useMutation } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import { AnalysisReport } from '../queries/use-site-analysis';
 import { SiteDetails } from '../site';
 
 type ForumTopic = {
@@ -9,6 +10,7 @@ type ForumTopic = {
 	locale: string;
 	hideInfo: boolean;
 	userDeclaredSiteUrl?: string;
+	ownershipResult: AnalysisReport;
 };
 
 type Response = {
@@ -17,7 +19,15 @@ type Response = {
 
 export function useSubmitForumsMutation() {
 	return useMutation(
-		( { site, message, subject, locale, hideInfo, userDeclaredSiteUrl }: ForumTopic ) => {
+		( {
+			ownershipResult,
+			message,
+			subject,
+			locale,
+			hideInfo,
+			userDeclaredSiteUrl,
+		}: ForumTopic ) => {
+			const site = ownershipResult.site;
 			const blogHelpMessages = [];
 
 			if ( site ) {
@@ -25,10 +35,12 @@ export function useSubmitForumsMutation() {
 					blogHelpMessages.push( 'WP.com: Unknown' );
 					blogHelpMessages.push( 'Jetpack: Yes' );
 				} else {
-					blogHelpMessages.push( 'WP.com: Yes' );
+					blogHelpMessages.push( `WP.com: ${ ownershipResult.isWpcom ? 'Yes' : 'No' }` );
 				}
 
-				blogHelpMessages.push( 'Correct account: yes' );
+				blogHelpMessages.push(
+					`Correct account: ${ ownershipResult.result === 'OWNED_BY_USER' ? 'Yes' : 'No' }`
+				);
 			} else if ( userDeclaredSiteUrl ) {
 				blogHelpMessages.push( `Self-declared URL: ${ userDeclaredSiteUrl }` );
 			}

--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -36,6 +36,7 @@ export function useSubmitForumsMutation() {
 					blogHelpMessages.push( 'Jetpack: Yes' );
 				} else {
 					blogHelpMessages.push( `WP.com: ${ ownershipResult.isWpcom ? 'Yes' : 'No' }` );
+					blogHelpMessages.push( 'Jetpack: No' );
 				}
 
 				blogHelpMessages.push(
@@ -43,6 +44,8 @@ export function useSubmitForumsMutation() {
 				);
 			} else if ( userDeclaredSiteUrl ) {
 				blogHelpMessages.push( `Self-declared URL: ${ userDeclaredSiteUrl }` );
+				blogHelpMessages.push( 'Jetpack: Unknown' );
+				blogHelpMessages.push( 'WP.com: Unknown' );
 			}
 
 			const forumMessage = message + '\n\n' + blogHelpMessages.join( '\n' );

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -215,3 +215,20 @@ section.contact-form-submit {
 		fill: currentColor;
 	}
 }
+
+.help-center-contact-form__site-picker-forum-privacy-popover {
+	display: inline-block;
+	max-width: 200px;
+	padding: 5px;
+}
+
+.help-center-contact-form__site-picker-forum-privacy-info {
+	padding: 0;
+	margin: 0;
+	background: none;
+	border: none;
+}
+
+.help-center-contact-form__site-picker-privacy-popover {
+	z-index: 10000;
+}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -20,6 +20,7 @@ import { Icon, info } from '@wordpress/icons';
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -135,6 +136,7 @@ export const HelpCenterContactForm = () => {
 	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
 	const { data: userSites } = useUserSites();
 	const userWithNoSites = userSites?.sites.length === 0;
+	const userId = useSelector( getCurrentUserId );
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
@@ -189,6 +191,8 @@ export const HelpCenterContactForm = () => {
 	const currentSite = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
 
 	let ownershipResult: AnalysisReport = useSiteAnalysis(
+		// pass user email as query cache key
+		userId,
 		userDeclaredSiteUrl,
 		sitePickerChoice === 'OTHER_SITE'
 	);

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -134,9 +134,9 @@ export const HelpCenterContactForm = () => {
 	const locale = useLocale();
 	const { isLoading: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
 	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
-	const { data: userSites } = useUserSites();
-	const userWithNoSites = userSites?.sites.length === 0;
 	const userId = useSelector( getCurrentUserId );
+	const { data: userSites } = useUserSites( userId );
+	const userWithNoSites = userSites?.sites.length === 0;
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -171,7 +171,6 @@ export const HelpCenterContactForm = () => {
 	}, [ mode, sectionName ] );
 
 	useEffect( () => {
-		// the user has no sites,
 		if ( userWithNoSites ) {
 			setSitePickerChoice( 'OTHER_SITE' );
 		}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -8,6 +8,8 @@ import {
 	useSubmitTicketMutation,
 	useSubmitForumsMutation,
 	useSiteAnalysis,
+	useUserSites,
+	AnalysisReport,
 } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { SitePickerDropDown } from '@automattic/site-picker';
@@ -15,7 +17,7 @@ import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -75,20 +77,21 @@ const titles: {
 		trayText?: string;
 		formDisclaimer?: string;
 		buttonLabel: string;
-		buttonLoadingLabel: string;
+		buttonSubmittingLabel: string;
+		buttonLoadingLabel?: string;
 	};
 } = {
 	CHAT: {
 		formTitle: __( 'Start live chat', __i18n_text_domain__ ),
 		trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
 		buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
-		buttonLoadingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
+		buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
 	},
 	EMAIL: {
 		formTitle: __( 'Send us an email', __i18n_text_domain__ ),
 		trayText: __( 'Our WordPress experts will get back to you soon', __i18n_text_domain__ ),
 		buttonLabel: __( 'Email us', __i18n_text_domain__ ),
-		buttonLoadingLabel: __( 'Sending email', __i18n_text_domain__ ),
+		buttonSubmittingLabel: __( 'Sending email', __i18n_text_domain__ ),
 	},
 	DIRECTLY: {
 		formTitle: __( 'Start live chat with an expert', __i18n_text_domain__ ),
@@ -102,7 +105,7 @@ const titles: {
 			__i18n_text_domain__
 		),
 		buttonLabel: __( 'Ask an expert', __i18n_text_domain__ ),
-		buttonLoadingLabel: __( 'Connecting you to an expert', __i18n_text_domain__ ),
+		buttonSubmittingLabel: __( 'Connecting you to an expert', __i18n_text_domain__ ),
 	},
 	FORUM: {
 		formTitle: __( 'Ask in our community forums', __i18n_text_domain__ ),
@@ -111,7 +114,8 @@ const titles: {
 			__i18n_text_domain__
 		),
 		buttonLabel: __( 'Ask in the forums', __i18n_text_domain__ ),
-		buttonLoadingLabel: __( 'Posting in the forums', __i18n_text_domain__ ),
+		buttonSubmittingLabel: __( 'Posting in the forums', __i18n_text_domain__ ),
+		buttonLoadingLabel: __( 'Analyzing site…', __i18n_text_domain__ ),
 	},
 };
 
@@ -129,6 +133,8 @@ export const HelpCenterContactForm = () => {
 	const locale = useLocale();
 	const { isLoading: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
 	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
+	const { data: userSites } = useUserSites();
+	const userWithNoSites = userSites?.sites.length === 0;
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
@@ -155,12 +161,6 @@ export const HelpCenterContactForm = () => {
 		setMessage,
 	} = useDispatch( HELP_CENTER_STORE );
 
-	const {
-		result: ownershipResult,
-		isLoading: isAnalysisLoading,
-		site: userDeclaredSite,
-	} = useSiteAnalysis( userDeclaredSiteUrl );
-
 	useEffect( () => {
 		const supportVariation = getSupportVariationFromMode( mode );
 		recordTracksEvent( 'calypso_inlinehelp_contact_view', {
@@ -170,12 +170,12 @@ export const HelpCenterContactForm = () => {
 		} );
 	}, [ mode, sectionName ] );
 
-	// record the resolved site
 	useEffect( () => {
-		if ( userDeclaredSite ) {
-			setUserDeclaredSite( userDeclaredSite );
+		// the user has no sites,
+		if ( userWithNoSites ) {
+			setSitePickerChoice( 'OTHER_SITE' );
 		}
-	}, [ userDeclaredSite, setUserDeclaredSite ] );
+	}, [ userWithNoSites ] );
 
 	useEffect( () => {
 		if ( directlyData?.hasSession ) {
@@ -184,18 +184,41 @@ export const HelpCenterContactForm = () => {
 		}
 	}, [ directlyData, setShowHelpCenter ] );
 
-	const isSubmitting = submittingTicket || submittingTopic;
-
 	const formTitles = titles[ mode ];
 
 	const siteId = useSelector( getSelectedSiteId );
 	const currentSite = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
 
+	let ownershipResult: AnalysisReport = useSiteAnalysis(
+		userDeclaredSiteUrl,
+		sitePickerChoice === 'OTHER_SITE'
+	);
+
+	const ownershipStatusLoading = ownershipResult?.result === 'LOADING';
+	const isSubmitting = submittingTicket || submittingTopic;
+
+	// if the user picked a site from the picker, we don't need to analyze the ownership
+	if ( currentSite && sitePickerChoice === 'CURRENT_SITE' ) {
+		ownershipResult = {
+			result: 'OWNED_BY_USER',
+			isWpcom: true,
+			siteURL: currentSite.URL,
+			site: currentSite,
+		};
+	}
+
+	// record the resolved site
+	useEffect( () => {
+		if ( ownershipResult?.site && sitePickerChoice === 'OTHER_SITE' ) {
+			setUserDeclaredSite( ownershipResult?.site );
+		}
+	}, [ ownershipResult, setUserDeclaredSite, sitePickerChoice ] );
+
 	let supportSite: typeof currentSite;
 
 	// if the user picked "other site", force them to declare a site
 	if ( sitePickerChoice === 'OTHER_SITE' ) {
-		supportSite = userDeclaredSite;
+		supportSite = ownershipResult?.site;
 	} else {
 		supportSite = selectedSite || currentSite;
 	}
@@ -257,6 +280,7 @@ export const HelpCenterContactForm = () => {
 
 			case 'FORUM': {
 				submitTopic( {
+					ownershipResult,
 					site: supportSite,
 					message: message ?? '',
 					subject: subject ?? '',
@@ -292,35 +316,39 @@ export const HelpCenterContactForm = () => {
 	}
 
 	const InfoTip = () => {
-		const [ ref, setRef ] = useState< any >();
+		const ref = useRef< any >();
 		const [ isOpen, setOpen ] = useState( false );
 
 		return (
-			<>
-				<Button
-					borderless
-					ref={ ( reference ) => ref !== reference && setRef( reference ) }
+			<div>
+				<button
+					className="help-center-contact-form__site-picker-forum-privacy-info"
+					ref={ ref }
 					aria-haspopup
 					aria-label={ __( 'More information' ) }
 					onClick={ () => setOpen( ! isOpen ) }
 				>
 					<Icon icon={ info } size={ 18 } />
-				</Button>
-				<Popover isVisible={ isOpen } context={ ref } position="top left">
-					<span>
-						This may result in a longer response time,
-						<br />
-						but WordPress.com staff in the forums will
-						<br />
-						still be able to view your site's URL.
+				</button>
+				<Popover
+					className="help-center-contact-form__site-picker-privacy-popover"
+					isVisible={ isOpen }
+					context={ ref.current }
+					position="top left"
+				>
+					<span className="help-center-contact-form__site-picker-forum-privacy-popover">
+						{ __(
+							"This may result in a longer response time, but WordPress.com staff in the forums will still be able to view your site's URL.",
+							__i18n_text_domain__
+						) }
 					</span>
 				</Popover>
-			</>
+			</div>
 		);
 	};
 
 	const isCTADisabled = () => {
-		if ( isSubmitting || ! message ) {
+		if ( isSubmitting || ! message || ownershipStatusLoading ) {
 			return true;
 		}
 
@@ -331,6 +359,21 @@ export const HelpCenterContactForm = () => {
 				return ! supportSite || ! subject;
 			case 'FORUM':
 				return ! subject;
+		}
+	};
+
+	const getCTALabel = () => {
+		switch ( mode ) {
+			case 'CHAT':
+			case 'EMAIL':
+			case 'DIRECTLY':
+				return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
+			case 'FORUM': {
+				if ( ownershipStatusLoading ) {
+					return formTitles.buttonLoadingLabel;
+				}
+				return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
+			}
 		}
 	};
 
@@ -348,7 +391,7 @@ export const HelpCenterContactForm = () => {
 					{ formTitles.formDisclaimer }
 				</p>
 			) }
-			{ mode !== 'DIRECTLY' && (
+			{ mode !== 'DIRECTLY' && ! userWithNoSites && (
 				<section>
 					<HelpCenterSitePicker
 						enabled={ mode === 'FORUM' }
@@ -372,13 +415,7 @@ export const HelpCenterContactForm = () => {
 							onChange={ setUserDeclaredSiteUrl }
 						/>
 					</section>
-					{ ownershipResult && (
-						<HelpCenterOwnershipNotice
-							ownershipResult={ ownershipResult }
-							isAnalysisLoading={ isAnalysisLoading }
-							userDeclaredSite={ userDeclaredSite }
-						/>
-					) }
+					<HelpCenterOwnershipNotice ownershipResult={ ownershipResult } />
 				</>
 			) }
 
@@ -429,7 +466,7 @@ export const HelpCenterContactForm = () => {
 					primary
 					className="help-center-contact-form__site-picker-cta"
 				>
-					{ isSubmitting ? formTitles.buttonLoadingLabel : formTitles.buttonLabel }
+					{ getCTALabel() }
 				</Button>
 				{ hasSubmittingError && (
 					<FormInputValidation

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -92,12 +92,12 @@ export function SibylArticles( { message = '', supportSite }: Props ) {
 				className="help-center-sibyl-articles__list"
 				aria-labelledby="help-center--contextual_help"
 			>
-				{ articles.map( ( article ) => {
+				{ articles.map( ( article, index ) => {
 					if ( 'type' in article && [ 'video', 'tour' ].includes( article.type ) ) {
 						return;
 					}
 					return (
-						<li key={ article.link }>
+						<li key={ article.link + index }>
 							<ConfigurableLink
 								to={ getPostUrl( article as Article, message ) }
 								external={ 'en' !== locale }

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -98,6 +98,9 @@ declare module 'calypso/state/selectors/has-cancelable-user-purchases' {
 declare module 'calypso/state/current-user/selectors' {
 	export const getCurrentUserEmail: ( state: unknown ) => string;
 }
+declare module 'calypso/state/current-user/selectors' {
+	export const getCurrentUserId: ( state: unknown ) => string;
+}
 
 declare module 'calypso/state/inline-help/selectors/get-admin-help-results' {
 	const getAdminHelpResults: (


### PR DESCRIPTION
#### Proposed Changes

This PR cleans the forum channel in contact form. It does a few changes. 

* It cleans up and divides the site analysis logic into smaller chunks. 
* It fixes the messages we submit in the forum topics we send. It now has accurate “Is WPCOM?”, “Is Jetpack”, “is correct owner” flags.
* It shows a loading indicator when the site is being analyzed.
* It hides the site picker when the user has no sites and defaults to the site input field.
* It fixes the info popover next to “Don’t display my site’s URL publicly”.

#### Testing Instructions

To test this, you need to free users. One with no sites at all. And one with at least one site.

**Using the user without a site:**
1. Go to http://calypso.localhost:3000/read.
2. Open the Help Center.
3. Go to the contact form.
4. The site picker should be invisible and only “Site address” field should be there.
5. Type any simple wpcom site (eg: officetoday.wordpress.com). You should get "officetoday.wordpress.com is linked to another WordPress.com account....".
6. Type any wporg site like (obama.org), you should get "Your site is not [hosted with our services(opens in a new tab)](https://wordpress.com/support/com-vs-org/)....".

**Using the free user with a site:**
1. Open the Help Center anywhere.
2. You should see a site picker that shows the current site, and "Other site".
3. Pick Other site, and repeat the tests above.
4. Type the URL of site that the user actually owns, the name or URL of that site should be rendered under the field.
 
Fixes: https://github.com/Automattic/wp-calypso/issues/68150, https://github.com/Automattic/wp-calypso/issues/68144 and https://github.com/Automattic/wp-calypso/issues/68100