### PR TITLE
Fix excerpt text in reader

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -17,9 +17,9 @@ const ReaderExcerpt = ( { post } ) => {
 		if ( paragraph.length !== 0 ) {
 			// Remove paragraph closing tag
 			let p = paragraph.replaceAll( '</p>', '' );
-			// Remove any newline chars
+			// Clean up any newline chars
 			p = p.replaceAll( '\n', '' );
-			// Replace <br> and \n with break tag
+			// Replace <br> tags with proper break tag
 			p = p.replaceAll( '<br>', '<br />' );
 
 			// Now split this text into lines based on break tags

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -3,8 +3,37 @@ import AutoDirection from 'calypso/components/auto-direction';
 
 import './style.scss';
 
-const ReaderExcerpt = ( { post, isDiscover } ) => {
-	let excerpt = post.content_no_html || post.excerpt;
+const ReaderExcerpt = ( { post } ) => {
+	let excerpt = post.better_excerpt || post.excerpt;
+
+	// Excerpt is set to use webkit-line-clamp to limit number of lines of text to show inside container
+	// If we use an excerpt with no html, then text that contains <br> will appear on the same line with incorrect spacing.
+	// If we use an excerpt with html, we need to remove the paragraph tags to avoid multiple containers that are subject to webkit-line-clamp
+	const paragraphs = excerpt.split( '<p>' );
+	const lines = [];
+
+	// Split html text into paragraphs
+	paragraphs.forEach( ( paragraph ) => {
+		if ( paragraph.length !== 0 ) {
+			// Remove paragraph closing tag
+			let p = paragraph.replaceAll( '</p>', '' );
+
+			// Replace <br> and \n with break tag
+			p = p.replaceAll( '<br>', '<br />' );
+			p = p.replaceAll( '\n', '<br />' );
+
+			// Now split this text into lines based on break tags
+			const breaks = p.split( '<br />' );
+
+			// Append lines to array
+			breaks.map( ( line ) => {
+				lines.push( line );
+			} );
+		}
+	} );
+
+	// Re-join the lines into a html string with breaks
+	excerpt = lines.join( '<br />' );
 
 	return (
 		<AutoDirection>

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -17,10 +17,10 @@ const ReaderExcerpt = ( { post } ) => {
 		if ( paragraph.length !== 0 ) {
 			// Remove paragraph closing tag
 			let p = paragraph.replaceAll( '</p>', '' );
-
+			// Remove any newline chars
+			p = p.replaceAll( '\n', '' );
 			// Replace <br> and \n with break tag
 			p = p.replaceAll( '<br>', '<br />' );
-			p = p.replaceAll( '\n', '<br />' );
 
 			// Now split this text into lines based on break tags
 			const breaks = p.split( '<br />' );


### PR DESCRIPTION
The reader isn't rendering the post excerpt correctly. 

We have set it to output the no html text but this removes all tags, including the `<br>` tags. This means text that was meant to be on a new line is now on the same line and with incorrect spacing.

Example from [here](http://calypso.localhost:3000/read/feeds/44887617) with [update/reader-card-refresh](https://github.com/Automattic/wp-calypso/tree/update/reader-card-refresh) branch
<img width="604" alt="Screenshot 2022-09-22 at 17 15 29" src="https://user-images.githubusercontent.com/5560595/191799254-d87b8b54-21b1-4622-892c-389cf28e1331.png">

With this PR
<img width="604" alt="Screenshot 2022-09-22 at 17 16 56" src="https://user-images.githubusercontent.com/5560595/191799550-52358ea9-39f3-437c-b1c5-a5c60d9de739.png">

