### PR TITLE
HelpCenter: replace fake-faces with real names

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -33,10 +33,19 @@ import './help-center-contact-form.scss';
 
 export const SITE_STORE = 'automattic/site';
 
-const fakeFaces = Array.from(
-	{ length: 10 },
-	( _, index ) => `https://s0.wp.com/i/fake-faces/face-${ index }.jpg`
-);
+const fakeFaces = [
+	'john',
+	'joe',
+	'julia',
+	'emily',
+	'ashley',
+	'daphne',
+	'megan',
+	'omar',
+	'vivian',
+	'sam',
+	'tony',
+].map( ( name ) => `https://s0.wp.com/i/support-engineers/${ name }.jpg` );
 const randomTwoFaces = fakeFaces.sort( () => Math.random() - 0.5 ).slice( 0, 2 );
 
 const HelpCenterSitePicker: React.FC< SitePicker > = ( {


### PR DESCRIPTION
## Proposed Changes

Replace the fake-faces imgs used for the contact form with a more believable scenario.

## Testing Instructions

1. Pull branch and patch this diff D88334-code
2. Sandbox CDN (s0 s1 s2 wordpress.com)
3. Open help center and open contact form

Fixes #68012