### PR TITLE
chore: enable ESLint autofix in pre-commit hook.

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -188,7 +188,7 @@ if ( toStylelint.length ) {
 
 // then eslint
 if ( toEslint.length ) {
-	const lintResult = spawnSync( './node_modules/.bin/eslint', [ '--quiet', ...toEslint ], {
+	const lintResult = spawnSync( './node_modules/.bin/eslint', [ '--quiet', '--fix', ...toEslint ], {
 		shell: true,
 		stdio: 'inherit',
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR adds the `--fix` parameter to the pre-commit hook ESLint in an attempt to automatically fix warnings.

**Context:**
Our `Check code style` build shows a persistent number of warnings and errors that could have been fixed automatically. For instance, [this file](https://github.com/Automattic/wp-calypso/blob/c836e55d75407c44eaabc190112c6b5de9297186/packages/data-stores/src/plans/types.ts) has a warning that can be auto-fixed by ESLint but the warning persists in our codebase, adding to the number of issues in the Check Code Style build.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Code Style
  - [ ] Unit Tests

Manually test the changes:

1. make changes to a file that will result in a autofixable warning (eg. [jsdoc/multiline-blocks](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-multiline-blocks))
2. add file to staging.
3. commit changes.

The warning should be autofixed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
