### PR TITLE
Fix bug in Jetpack prices calculation. (Fix price for Social).

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -132,7 +132,13 @@ const useItemPrice = (
 		? sitePrices.isFetching
 		: listPrices.isFetching || introductoryOfferPrices.isFetching;
 	const itemCost = siteId ? sitePrices.itemCost : listPrices.itemCost;
-	const monthlyItemCost = siteId ? sitePrices.monthlyItemCost : listPrices.monthlyItemCost;
+	/**
+	 * At one point we needed to use `monthlyItemCost` instead of calculating the monthly price
+	 * with getMonthlyPrice() because yearly prices were slightly incorrect in the pricing table.
+	 * See https://github.com/Automattic/wp-calypso/pull/60636.
+	 * I'm leaving `monthlyItemCost` here for now in case we need it again sometime.
+	 */
+	// const monthlyItemCost = siteId ? sitePrices.monthlyItemCost : listPrices.monthlyItemCost;
 
 	const priceTierList = useMemo(
 		() => ( siteId ? sitePrices.priceTierList : listPrices.priceTierList ),
@@ -153,7 +159,7 @@ const useItemPrice = (
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( item.term !== TERM_MONTHLY ) {
-			originalPrice = monthlyItemCost ?? getMonthlyPrice( itemCost );
+			originalPrice = getMonthlyPrice( itemCost ); // monthlyItemCost - See comment above.
 			discountedPrice = introductoryOfferPrices.introOfferCost
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;


### PR DESCRIPTION
#### Proposed Changes

This PR reverts a change that was made in https://github.com/Automattic/wp-calypso/pull/60636. At the time the change was made to fix an issue with the yearly (price per month) prices were off by about 1 cent. This was actually due to the yearly prices being slightly off (cents were truncated) in the pricing table.
This was causing the yearly price for Jetpack Social (the price per month) to show as $12/mo (the monthly price), instead of $10/mo (the correct yearly price per month).

Fixes: 1202796695664022-as-1203029862618656

#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout fix/jetpack-prices-calculation`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Verify the price for Jetpack Social is $10 /mo, billed yearly, as opposed to $12 /mo, billed yearly (see production).
- Verify the prices for all the other products are the same. Compare with production if needed.
- Bonus- Try switching to different currencies (In S/A), and verify all the prices look all good, the same.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203029862618656