### PR TITLE
Launchpad: Fix task disabled logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -127,23 +127,21 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 }
 
 // This function will determine whether we want to disable or enable a task on the checklist
+// If a task depends on the completion of other tasks, we want to check if all dependencies are finished:
+//    ^ If all the dependencies are done ( true ), then the task is enabled
+//    ^ If at least one of the dependencies is unfinished ( false ), then we check the proceeding conditions
 // If a task is set to keepActive, we keep it enabled. It allows a task to be revisited when completed
 // If a task is completed, we disable it
-// If a task is NOT completed AND the task contains dependencies, we want to check if all dependencies are set to true:
-//    ^ If all the dependencies are true, then the task is enabled
-//    ^ If at least one of the dependencies is false, then the task is disabled
 export function isTaskDisabled( task: Task ) {
+	if ( hasIncompleteDependencies( task ) ) {
+		return true;
+	}
+
 	if ( task.keepActive ) {
 		return false;
 	}
 
-	if ( task.isCompleted ) {
-		return task.isCompleted;
-	}
-
-	if ( task.dependencies ) {
-		return hasIncompleteDependencies( task );
-	}
+	return task.isCompleted;
 }
 
 export function hasIncompleteDependencies( task: Task ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -64,12 +64,6 @@ describe( 'Task Helpers', () => {
 		} );
 	} );
 	describe( 'isTaskDisabled', () => {
-		describe( 'when a task is complete', () => {
-			it( 'then the task is disabled', () => {
-				const task = getTask( { isCompleted: true } );
-				expect( isTaskDisabled( task ) ).toBe( true );
-			} );
-		} );
 		describe( 'when a given task has other, dependent tasks that should be completed first', () => {
 			describe( 'and the other tasks are incomplete', () => {
 				it( 'then the given task is disabled', () => {
@@ -79,10 +73,24 @@ describe( 'Task Helpers', () => {
 				} );
 			} );
 			describe( 'and the other tasks are complete', () => {
-				it( 'then the given task is enabled', () => {
-					const dependencies = [ true, true ];
-					const task = getTask( { dependencies, isCompleted: false } );
-					expect( isTaskDisabled( task ) ).toBe( false );
+				const dependencies = [ true, true ];
+				describe( 'and the task can be revisited', () => {
+					it( 'then the task is enabled', () => {
+						const task = getTask( { dependencies, keepActive: true, isCompleted: false } );
+						expect( isTaskDisabled( task ) ).toBe( false );
+					} );
+				} );
+				describe( 'and the given task complete', () => {
+					it( 'then the task is disabled', () => {
+						const task = getTask( { dependencies, keepActive: false, isCompleted: true } );
+						expect( isTaskDisabled( task ) ).toBe( true );
+					} );
+				} );
+				describe( 'and the given task is incomplete', () => {
+					it( 'then the given task is enabled', () => {
+						const task = getTask( { dependencies, keepActive: false, isCompleted: false } );
+						expect( isTaskDisabled( task ) ).toBe( false );
+					} );
 				} );
 			} );
 		} );


### PR DESCRIPTION
#### Context

- Created in response to this disucssion https://github.com/Automattic/wp-calypso/pull/68053#discussion_r976911856
- "Should we move the dependency check to happen before the keepActive check? Right now it reads as if we have a task that is both meant to remain active after completion (keepEnabled), but also requires dependencies to be met before we first enable it, that it will never be disabled because of keepEnabled even if dependencies are not yet met?"

#### Proposed Changes

* Fixes gaps in logic for the `taskDisabled` helper method

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site through the tailored onboarding flow ( newsletter or link in bio ) https://wordpress.com/hp-2022-tailored-flows/
* Step through the onboarding process until the launchpad
* Check out this branch and `yarn start`
* Make sure that you're loading the launchpad through the local dev environment calypso.localhost:3000
* Verify that tasks behave as expected 
  * Tasks are enabled and disabled properly when they are completed
  * Tasks that have dependencies ( Ex. Launch Link in bio ) are disabled until their other, dependent tasks are completed
  * Tasks that are kept active ( Ex. Add Links ) are enabled, even after completion

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
