### PR TITLE
Stepper: Deprecate goNext, goBack, and goToStep methods

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -403,7 +403,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			return;
 		}
 
-		goBack();
+		goBack?.();
 	}
 
 	function recordDeviceClick( device: string ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -73,7 +73,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 						siteSlug,
 					} )
 				);
-				goNext();
+				goNext?.();
 			} else {
 				debug(
 					'Redirected because theme has no bundled software',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
@@ -1,12 +1,13 @@
 import { StepContainer } from '@automattic/onboarding';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
 type GoalsCaptureContainerProps = {
 	welcomeText: string;
 	whatAreYourGoalsText: string;
 	subHeaderText: string;
 	stepName: string;
-	goNext: () => void;
+	goNext: NavigationControls[ 'goNext' ];
 	skipLabelText: string;
 	skipButtonAlign?: 'top' | 'bottom';
 	hideBack: boolean;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -76,7 +76,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		 */
 		function onGoBack() {
 			resetImportJob( getImportJob( importer ) );
-			navigation.goBack();
+			navigation.goBack?.();
 		}
 
 		function fetchImporters() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -155,7 +155,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 					direction="forward"
 					handleClick={ () => {
 						recordTracksEvent( 'calypso_launchpad_go_to_admin_clicked', { flow: flow } );
-						goNext();
+						goNext?.();
 					} }
 					label={ translate( 'Go to Admin' ) }
 					borderless={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -176,7 +176,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			pattern_count: patterns.length,
 		} );
 
-		goBack();
+		goBack?.();
 	};
 
 	const getSelectedPattern = () => {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -6,20 +6,38 @@ import type { StepPath } from './steps-repository';
 export type NavigationControls = {
 	/**
 	 * Call this function if you want to go to the previous step.
+	 *
+	 * @deprecated Avoid this method. Use submit() instead.
+	 * If you need to navigate back and forth between
+	 * stepper screens, consider adding screen(s) to a new
+	 * stepper flow and linking directly between flows/screens.
 	 */
-	goBack: () => void;
+	goBack?: () => void;
+
 	/**
 	 * Call this function if you want to go to the proceed down the flow.
+	 *
+	 * @deprecated Avoid this method. Use submit() instead.
 	 */
-	goNext: () => void;
+	goNext?: () => void;
+
 	/**
 	 * Call this function if you want to jump to a certain step.
+	 *
+	 * @deprecated Avoid this method. Use submit() instead.
+	 * If you need to skip forward several screens in
+	 * a stepper flow, handle that logic in submit().
+	 * If you need to navigate backwards, consider adding
+	 * screen(s) to a new stepper flow and linking directly
+	 * between flows/screens.
 	 */
 	goToStep?: ( step: StepPath | `${ StepPath }?${ string }` ) => void;
+
 	/**
 	 * Submits the answers provided in the flow
 	 */
 	submit?: ( providedDependencies?: ProvidedDependencies, ...params: string[] ) => void;
+
 	/**
 	 * Exits the flow and continue to the given path
 	 */

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -15,7 +15,7 @@ export const linkInBioPostSetup: Flow = {
 		return [ 'linkInBioPostSetup' ] as StepPath[];
 	},
 
-	useStepNavigation( currentStep, navigate ) {
+	useStepNavigation( currentStep ) {
 		const flowName = this.name;
 		const siteSlug = useSiteSlug();
 
@@ -28,18 +28,6 @@ export const linkInBioPostSetup: Flow = {
 			}
 		}
 
-		const goBack = () => {
-			return;
-		};
-
-		const goNext = () => {
-			return;
-		};
-
-		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
-			navigate( step );
-		};
-
-		return { goNext, goBack, goToStep, submit };
+		return { submit };
 	},
 };


### PR DESCRIPTION
### Proposed Changes

Resolves: https://github.com/Automattic/wp-calypso/issues/68165

This PR makes three changes: 
* Makes two Stepper methods (goNext, goBack) optional in NavigationControls type.
* Adds JSDocs deprecation notices to goNext, goBack, and goToStep methods in the NavigationControls type.
* Removes these methods from the useStepNavigation hook in the link-in-bio-post-setup flow. These methods are not used in this flow. But before, removing them would have generated TypeScript errors because the methods were required as part of the NavigationsControls type. 

### Testing Instructions

The methods in question are still valid, and this PR should not affect any code logic. The methods should simply show as deprecated when they are used in code. 

1. Checkout this branch and run yarn and yarn start if needed. 

2. Confirm that methods are deprecated. First go to the client/landing/stepper/declarative-flow/internals/types.ts, hover over the deprecated types, and you should see a deprecated notice like this: 
![deprecated types](https://user-images.githubusercontent.com/21228350/191823766-061a52e3-dc5e-4c34-ac25-28c21d8f9869.gif)

3. Where these methods are actually used in current stepper screens, if VS Code is configured to show JSDoc deprecation, the methods will now have a strikethrough. It looks like this on the launchpad index.ts screen: 
<img width="1404" alt="deprecated types 2" src="https://user-images.githubusercontent.com/21228350/191823922-3c47c30d-c0fd-48cb-adf9-036cfc266d89.png">

4. Confirm that there are no TypeScript errors in `client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts` where the methods have been deleted from the useStepNavigation hook. 

5. Confirm that there are no other TypeScript errors in files where these methods are still used that would prevent TS compiling.

5. Test the Newsletter flow, which uses the deprecated methods, to confirm no regressions or breakages. Note we may want to refactor flows to avoid using these methods, but for now, we should confirm that all flows still work as expected 
  * Go to https://wordpress.com/hp-2022-tailored-flows/ and choose the Newsletter flow.
  * On one of early screens, replace https://wordpress.com with http://calypso.localhost:3000 to ensure you are running your local branch. 
  * Go through the flow until the Launchpad screen. Click the Add Subscribers task (uses deprecated goToStep method), and confirm you are properly redirected to the Add Subscribers page. 
  * Navigate back to Launchpad and click the Go to Admin screen (uses deprecated goNext method) and confirm you are properly redirected to admin. 