### PR TITLE
Revert "Added plan information steps"

### DIFF
--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -13,8 +13,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MainComponent from 'calypso/components/main';
-import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
-import { Gridicon } from 'calypso/devdocs/design/playground-scope';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
@@ -61,32 +59,6 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 		);
 	}, [ dispatch, translate, selectedSite, breadcrumbs.length, intervalType ] );
 
-	const promos: PromoSectionProps = {
-		promos: [
-			{
-				title: translate( 'Flex your site with plugins' ),
-				body: translate(
-					'Install plugins and extend functionality for your site with access to more than 50,000 plugins.'
-				),
-				image: <Gridicon icon="plugins" />,
-			},
-			{
-				title: translate( 'Money back guarantee' ),
-				body: translate(
-					'Try WordPress.com for 14 days and if you are not 100% satisfied, get your money back.'
-				),
-				image: <Gridicon icon="money" />,
-			},
-			{
-				title: translate( 'Essential features' ),
-				body: translate(
-					"We guarantee site's performance and protect it from spammers detailing all activity records."
-				),
-				image: <Gridicon icon="plans" />,
-			},
-		],
-	};
-
 	return (
 		<MainComponent wideLayout>
 			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
@@ -98,7 +70,6 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 				subHeaderText={ `Choose the plan that's right for you and reimagine what's possible with plugins` }
 				brandFont
 			/>
-
 			<div className="plans">
 				<PlansFeaturesMain
 					basePlansPath="/plugins/plans"
@@ -112,9 +83,6 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					isReskinned
 				/>
 			</div>
-
-			<PromoSection { ...promos } />
-
 			<ActionCard
 				classNames="plugin-plans"
 				headerText=""

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -1,72 +1,9 @@
-@import "@wordpress/base-styles/breakpoints";
-
 .plugin-plans-header {
 	.formatted-header__title {
 		font-size: $font-title-large;
 	}
 	.formatted-header__subtitle {
 		font-size: $font-body;
-	}
-}
-
-.promo-section {
-	.promo-section__promos {
-		overflow: auto;
-		white-space: nowrap;
-		max-width: 820px;
-		margin: auto;
-		margin-top: 50px;
-		margin-bottom: 50px;
-		display: block;
-
-		@media (max-width: 480px) {
-			padding-left: 20px;
-		}
-
-		.action-panel__figure.align-left {
-			float: none;
-		}
-
-		.action-panel__figure {
-			float: none;
-		}
-
-		.promo-card {
-			box-shadow: none;
-			padding-left: 0;
-			padding-right: 0;
-			width: 255px;
-			display: inline-block;
-			vertical-align: top;
-
-
-			.action-panel__figure {
-				text-align: left;
-			}
-
-			.action-panel__title {
-				font-weight: normal;
-				font-size: $font-body;
-				color: var(--studio-gray-100);
-
-			}
-
-			.gridicon {
-				height: 25px;
-				width: 25px;
-				padding: 10px;
-				background: #f0f7fc;
-				border-radius: 8px; /* stylelint-disable-line scales/radii */
-			}
-
-			.action-panel__body {
-				font-size: $font-body-small;
-
-				p {
-					white-space: pre-wrap;
-				}
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

Reverts Automattic/wp-calypso#68058

#### Testing Instructions

- Visit /plugins
- Click "WooCommerce" or "Tools > Earn"
- The promo styles shouldn't be messed up

Before

![Screenshot 2022-09-23 at 13-13-21 WooCommerce ‹ test — WordPress com](https://user-images.githubusercontent.com/811776/191885982-491b6ad0-4e1a-4783-9e70-01e4d9bbc2f9.png)

After

![Screenshot 2022-09-23 at 13-17-33 test — WordPress com](https://user-images.githubusercontent.com/811776/191886017-29ed6bf1-ac32-452b-9521-9830f845915b.png)
