### PR TITLE
Enable caching for react-query client for SSR routes

### DIFF
--- a/client/data/marketplace/constants.ts
+++ b/client/data/marketplace/constants.ts
@@ -1,4 +1,3 @@
-export const BASE_STALE_TIME = 1000 * 60 * 60 * 2; // 2 hours
 export const DEFAULT_PAGE_SIZE = 20;
 export const DEFAULT_CATEGORY = 'all';
 

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -5,7 +5,7 @@ import {
 	normalizePluginData,
 } from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
-import { BASE_STALE_TIME } from './constants';
+import { BASE_STALE_TIME } from 'calypso/state/initial-state';
 
 type Type = 'all' | 'featured';
 

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -16,7 +16,8 @@ import {
 } from 'calypso/lib/plugins/utils';
 import { fetchPluginsList } from 'calypso/lib/wporg';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { BASE_STALE_TIME, WPORG_CACHE_KEY } from './constants';
+import { BASE_STALE_TIME } from 'calypso/state/initial-state';
+import { WPORG_CACHE_KEY } from './constants';
 import { Plugin, PluginQueryOptions } from './types';
 import { getPluginsListKey } from './utils';
 

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
 import { setSectionMiddleware } from 'calypso/controller';
 import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
-import { createServerQueryClient } from 'calypso/state/query-client';
+import { createQueryClientSSR } from 'calypso/state/query-client-ssr';
 import { setRoute } from 'calypso/state/route/actions';
 
 const debug = debugFactory( 'calypso:pages' );
@@ -76,7 +76,7 @@ async function getEnhancedContext( req, res ) {
 		isServerSide: true,
 		originalUrl: req.originalUrl,
 		path: req.url,
-		queryClient: await createServerQueryClient(),
+		queryClient: await createQueryClientSSR(),
 		pathname: req.path,
 		params: req.params,
 		query: req.query,

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
 import { setSectionMiddleware } from 'calypso/controller';
 import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
-import { createQueryClient } from 'calypso/state/query-client';
+import { createServerQueryClient } from 'calypso/state/query-client';
 import { setRoute } from 'calypso/state/route/actions';
 
 const debug = debugFactory( 'calypso:pages' );
@@ -76,7 +76,7 @@ async function getEnhancedContext( req, res ) {
 		isServerSide: true,
 		originalUrl: req.originalUrl,
 		path: req.url,
-		queryClient: await createQueryClient(),
+		queryClient: await createServerQueryClient(),
 		pathname: req.path,
 		params: req.params,
 		query: req.query,

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -19,6 +19,7 @@ const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
 export const SERIALIZE_THROTTLE = 5000;
 export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
+export const BASE_STALE_TIME = 2 * HOUR_IN_MS;
 
 // Store the timestamp at which the module loads as a proxy for the timestamp
 // when the server data (if any) was generated.

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -1,0 +1,14 @@
+import { QueryClient, QueryCache } from 'react-query';
+import { BASE_STALE_TIME } from 'calypso/data/marketplace/constants';
+import { MAX_AGE } from 'calypso/state/initial-state';
+
+const sharedCache = new QueryCache();
+
+export function createQueryClientSSR() {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { cacheTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
+		queryCache: sharedCache,
+	} );
+
+	return queryClient;
+}

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -1,6 +1,5 @@
 import { QueryClient, QueryCache } from 'react-query';
-import { BASE_STALE_TIME } from 'calypso/data/marketplace/constants';
-import { MAX_AGE } from 'calypso/state/initial-state';
+import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
 
 const sharedCache = new QueryCache();
 

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -1,9 +1,21 @@
 import { throttle } from 'lodash';
-import { QueryClient } from 'react-query';
+import { QueryClient, QueryCache } from 'react-query';
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
+import { BASE_STALE_TIME } from 'calypso/data/marketplace/constants';
 import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
 import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
 import { shouldDehydrateQuery } from './should-dehydrate-query';
+
+const sharedCache = new QueryCache();
+
+export function createServerQueryClient() {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { cacheTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
+		queryCache: sharedCache,
+	} );
+
+	return queryClient;
+}
 
 export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
 	const queryClient = new QueryClient( {

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -1,21 +1,9 @@
 import { throttle } from 'lodash';
-import { QueryClient, QueryCache } from 'react-query';
+import { QueryClient } from 'react-query';
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
-import { BASE_STALE_TIME } from 'calypso/data/marketplace/constants';
 import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
 import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
 import { shouldDehydrateQuery } from './should-dehydrate-query';
-
-const sharedCache = new QueryCache();
-
-export function createServerQueryClient() {
-	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { cacheTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
-		queryCache: sharedCache,
-	} );
-
-	return queryClient;
-}
 
 export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
 	const queryClient = new QueryClient( {


### PR DESCRIPTION
#### Proposed Changes

This is a [follow-up](https://github.com/Automattic/wp-calypso/pull/67747#discussion_r972008737) to #67747 and allows react-query data to be cached and reused between (logged-out) SSR requests. 
This is needed for the SSR Plugins section which uses react-query for fetching most of the data.

#### Testing Instructions

* Log out and disable JavaScript
* Go to `/plugins`
* You should still be able to see the Plugins landing page with the 3 sections Paid, Editor's Pick, and Free 
