### PR TITLE
Allow SSR react-query data to be shared with the client

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -6,7 +6,6 @@ import debugFactory from 'debug';
 import page from 'page';
 import ReactDom from 'react-dom';
 import Modal from 'react-modal';
-import { hydrate } from 'react-query';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
 import { ProviderWrappedLayout } from 'calypso/controller';
@@ -39,15 +38,15 @@ import { initConnection as initHappychatConnection } from 'calypso/state/happych
 import wasHappychatRecentlyActive from 'calypso/state/happychat/selectors/was-happychat-recently-active';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
-import {
-	getDehydratedReactQueryState,
-	getInitialState,
-	getStateFromCache,
-	persistOnChange,
-} from 'calypso/state/initial-state';
+import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import { init as pushNotificationsInit } from 'calypso/state/push-notifications/actions';
-import { createQueryClient } from 'calypso/state/query-client';
+import {
+	createQueryClient,
+	getInitialQueryState,
+	hydrateBrowserState,
+	hydrateServerState,
+} from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { setRoute } from 'calypso/state/route/actions';
@@ -414,10 +413,11 @@ const boot = async ( currentUser, registerRoutes ) => {
 	saveOauthFlags();
 	utils();
 	await loadPersistedState();
-	const queryClient = await createQueryClient( currentUser?.ID );
+	const queryClient = createQueryClient();
 
-	const dehydratedReactQueryState = getDehydratedReactQueryState();
-	hydrate( queryClient, dehydratedReactQueryState );
+	await hydrateBrowserState( queryClient, currentUser?.ID );
+	const initialQueryState = getInitialQueryState();
+	hydrateServerState( queryClient, initialQueryState );
 
 	const initialState = getInitialState( initialReducer, currentUser?.ID );
 	const reduxStore = createReduxStore( initialState, initialReducer );

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -6,6 +6,7 @@ import debugFactory from 'debug';
 import page from 'page';
 import ReactDom from 'react-dom';
 import Modal from 'react-modal';
+import { hydrate } from 'react-query';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
 import { ProviderWrappedLayout } from 'calypso/controller';
@@ -38,7 +39,12 @@ import { initConnection as initHappychatConnection } from 'calypso/state/happych
 import wasHappychatRecentlyActive from 'calypso/state/happychat/selectors/was-happychat-recently-active';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
-import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
+import {
+	getDehydratedReactQueryState,
+	getInitialState,
+	getStateFromCache,
+	persistOnChange,
+} from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import { init as pushNotificationsInit } from 'calypso/state/push-notifications/actions';
 import { createQueryClient } from 'calypso/state/query-client';
@@ -409,6 +415,10 @@ const boot = async ( currentUser, registerRoutes ) => {
 	utils();
 	await loadPersistedState();
 	const queryClient = await createQueryClient( currentUser?.ID );
+
+	const dehydratedReactQueryState = getDehydratedReactQueryState();
+	hydrate( queryClient, dehydratedReactQueryState );
+
 	const initialState = getInitialState( initialReducer, currentUser?.ID );
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( currentUser?.ID ) );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -30,7 +30,7 @@ class Document extends Component {
 			head,
 			i18nLocaleScript,
 			initialReduxState,
-			dehydratedReactQueryState,
+			initialQueryState,
 			entrypoint,
 			manifests,
 			lang,
@@ -73,10 +73,8 @@ class Document extends Component {
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`
 				: '' ) +
-			( dehydratedReactQueryState
-				? `var dehydratedReactQueryState = ${ jsonStringifyForHtml(
-						dehydratedReactQueryState
-				  ) };\n`
+			( initialQueryState
+				? `var initialQueryState = ${ jsonStringifyForHtml( initialQueryState ) };\n`
 				: '' ) +
 			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };\n` : '' ) +
 			( languageRevisions

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -30,6 +30,7 @@ class Document extends Component {
 			head,
 			i18nLocaleScript,
 			initialReduxState,
+			dehydratedReactQueryState,
 			entrypoint,
 			manifests,
 			lang,
@@ -71,6 +72,11 @@ class Document extends Component {
 			( app ? `var app = ${ jsonStringifyForHtml( app ) };\n` : '' ) +
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`
+				: '' ) +
+			( dehydratedReactQueryState
+				? `var dehydratedReactQueryState = ${ jsonStringifyForHtml(
+						dehydratedReactQueryState
+				  ) };\n`
 				: '' ) +
 			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };\n` : '' ) +
 			( languageRevisions

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -53,8 +53,8 @@ function setRouteMiddleware( context, next ) {
 }
 
 function combineMiddlewares( ...middlewares ) {
-	return async function ( req, res, expressNext ) {
-		req.context = await getEnhancedContext( req, res );
+	return function ( req, res, expressNext ) {
+		req.context = getEnhancedContext( req, res );
 		applyMiddlewares(
 			req.context,
 			...middlewares,
@@ -71,12 +71,12 @@ function combineMiddlewares( ...middlewares ) {
 }
 
 // TODO: Maybe merge into getDefaultContext().
-async function getEnhancedContext( req, res ) {
+function getEnhancedContext( req, res ) {
 	return Object.assign( {}, req.context, {
 		isServerSide: true,
 		originalUrl: req.originalUrl,
 		path: req.url,
-		queryClient: await createQueryClientSSR(),
+		queryClient: createQueryClientSSR(),
 		pathname: req.path,
 		params: req.params,
 		query: req.query,

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -7,6 +7,7 @@ import { get, pick } from 'lodash';
 import Lru from 'lru';
 import { createElement } from 'react';
 import ReactDomServer from 'react-dom/server';
+import { dehydrate } from 'react-query';
 import superagent from 'superagent';
 import {
 	getLanguageFileUrl,
@@ -227,6 +228,10 @@ export function serverRender( req, res ) {
 			req.error ? req.error.message : cacheKey,
 			req
 		);
+	}
+
+	if ( context.queryClient ) {
+		context.dehydratedReactQueryState = dehydrate( context.queryClient );
 	}
 
 	if ( context.store ) {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -7,7 +7,6 @@ import { get, pick } from 'lodash';
 import Lru from 'lru';
 import { createElement } from 'react';
 import ReactDomServer from 'react-dom/server';
-import { dehydrate } from 'react-query';
 import superagent from 'superagent';
 import {
 	getLanguageFileUrl,
@@ -22,6 +21,7 @@ import {
 	getDocumentHeadMeta,
 	getDocumentHeadLink,
 } from 'calypso/state/document-head/selectors';
+import { dehydrateQueryClient } from 'calypso/state/query-client-ssr';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
 import { serialize } from 'calypso/state/utils';
@@ -230,9 +230,7 @@ export function serverRender( req, res ) {
 		);
 	}
 
-	if ( context.queryClient ) {
-		context.dehydratedReactQueryState = dehydrate( context.queryClient );
-	}
+	context.initialQueryState = dehydrateQueryClient( context.queryClient );
 
 	if ( context.store ) {
 		attachHead( context );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -159,15 +159,6 @@ function getInitialServerState( initialReducer ) {
 	return pick( serverState, Object.keys( window.initialReduxState ) );
 }
 
-// Retrieve the dehydrated react-query client.
-export function getDehydratedReactQueryState() {
-	if ( typeof window !== 'object' || ! window.dehydratedReactQueryState || isSupportSession() ) {
-		return null;
-	}
-
-	return window.dehydratedReactQueryState;
-}
-
 // Retrieve the initial persisted state from the cached local client data.
 // This function only handles legacy Redux state for the monolithic root reducer
 // `loadPersistedState` must have completed first.

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -159,6 +159,15 @@ function getInitialServerState( initialReducer ) {
 	return pick( serverState, Object.keys( window.initialReduxState ) );
 }
 
+// Retrieve the dehydrated react-query client.
+export function getDehydratedReactQueryState() {
+	if ( typeof window !== 'object' || ! window.dehydratedReactQueryState || isSupportSession() ) {
+		return null;
+	}
+
+	return window.dehydratedReactQueryState;
+}
+
 // Retrieve the initial persisted state from the cached local client data.
 // This function only handles legacy Redux state for the monolithic root reducer
 // `loadPersistedState` must have completed first.

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -13,8 +13,8 @@ class QueryCacheSSR extends QueryCache {
 		state?: QueryState< TData, TError >
 	): Query< TQueryFnData, TError, TData, TQueryKey > {
 		const query = super.build( client, options, state );
-		if ( client instanceof QueryClientSSR ) {
-			client.addFetchedQueryKey( query.queryHash );
+		if ( client instanceof QueryClientSSR && ( options as any ).enabled !== false ) {
+			client.fetchedQueryKeys.add( query.queryHash );
 		}
 		return query;
 	}

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -3,7 +3,7 @@ import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
 import type { Query, QueryState } from 'react-query/types/core/query';
 
 class QueryClientSSR extends QueryClient {
-	fetchedQueryKeys = new Set< string >();
+	fetchedQueryHashes = new Set< string >();
 }
 
 class QueryCacheSSR extends QueryCache {
@@ -13,8 +13,8 @@ class QueryCacheSSR extends QueryCache {
 		state?: QueryState< TData, TError >
 	): Query< TQueryFnData, TError, TData, TQueryKey > {
 		const query = super.build( client, options, state );
-		if ( client instanceof QueryClientSSR && ( options as any ).enabled !== false ) {
-			client.fetchedQueryKeys.add( query.queryHash );
+		if ( client instanceof QueryClientSSR && query.state.status === 'success' ) {
+			client.fetchedQueryHashes.add( query.queryHash );
 		}
 		return query;
 	}
@@ -37,8 +37,8 @@ export function dehydrateQueryClient( queryClient: QueryClientSSR ) {
 	}
 
 	return dehydrate( queryClient, {
-		shouldDehydrateQuery: ( { queryHash: queryKey } ) => {
-			return queryClient.fetchedQueryKeys.has( queryKey );
+		shouldDehydrateQuery: ( { queryHash } ) => {
+			return queryClient.fetchedQueryHashes.has( queryHash );
 		},
 	} );
 }

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -3,15 +3,7 @@ import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
 import type { Query, QueryState } from 'react-query/types/core/query';
 
 class QueryClientSSR extends QueryClient {
-	private fetchedQueryKeys: { [ hash: string ]: boolean } = {};
-
-	addFetchedQueryKey( queryKey: string ) {
-		this.fetchedQueryKeys[ queryKey ] = true;
-	}
-
-	getFetchedQueryKey( queryKey: string ) {
-		return this.fetchedQueryKeys[ queryKey ];
-	}
+	fetchedQueryKeys = new Set< string >();
 }
 
 class QueryCacheSSR extends QueryCache {
@@ -46,7 +38,7 @@ export function dehydrateQueryClient( queryClient: QueryClientSSR ) {
 
 	return dehydrate( queryClient, {
 		shouldDehydrateQuery: ( { queryHash: queryKey } ) => {
-			return !! queryClient.getFetchedQueryKey( queryKey );
+			return queryClient.fetchedQueryKeys.has( queryKey );
 		},
 	} );
 }

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -2,19 +2,30 @@ import { QueryClient, QueryCache, dehydrate, QueryOptions, QueryKey } from 'reac
 import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
 import type { Query, QueryState } from 'react-query/types/core/query';
 
-class QueryClientSSR extends QueryClient {
-	fetchedQueryHashes = new Set< string >();
+const fetchedQueryHashes = new WeakMap< QueryClient, Set< string > >();
+
+function addQueryHash( client: QueryClient, queryHash: string ) {
+	let queryHashes = fetchedQueryHashes.get( client );
+	if ( ! queryHashes ) {
+		queryHashes = new Set();
+		fetchedQueryHashes.set( client, queryHashes );
+	}
+	queryHashes.add( queryHash );
+}
+
+function hasQueryHash( client: QueryClient, queryHash: string ) {
+	return fetchedQueryHashes.get( client )?.has( queryHash ) ?? false;
 }
 
 class QueryCacheSSR extends QueryCache {
 	build< TQueryFnData, TError, TData, TQueryKey extends QueryKey >(
-		client: QueryClient | QueryClientSSR,
+		client: QueryClient,
 		options: QueryOptions< TQueryFnData, TError, TData, TQueryKey >,
 		state?: QueryState< TData, TError >
 	): Query< TQueryFnData, TError, TData, TQueryKey > {
 		const query = super.build( client, options, state );
-		if ( client instanceof QueryClientSSR && query.state.status === 'success' ) {
-			client.fetchedQueryHashes.add( query.queryHash );
+		if ( query.state.status === 'success' ) {
+			addQueryHash( client, query.queryHash );
 		}
 		return query;
 	}
@@ -23,7 +34,7 @@ class QueryCacheSSR extends QueryCache {
 const sharedCache = new QueryCacheSSR();
 
 export function createQueryClientSSR() {
-	const queryClient = new QueryClientSSR( {
+	const queryClient = new QueryClient( {
 		defaultOptions: { queries: { cacheTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
 		queryCache: sharedCache,
 	} );
@@ -31,14 +42,14 @@ export function createQueryClientSSR() {
 	return queryClient;
 }
 
-export function dehydrateQueryClient( queryClient: QueryClientSSR ) {
+export function dehydrateQueryClient( queryClient: QueryClient ) {
 	if ( ! queryClient ) {
 		return null;
 	}
 
 	return dehydrate( queryClient, {
 		shouldDehydrateQuery: ( { queryHash } ) => {
-			return queryClient.fetchedQueryHashes.has( queryHash );
+			return hasQueryHash( queryClient, queryHash );
 		},
 	} );
 }

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -1,6 +1,5 @@
-import { QueryClient, QueryCache } from 'react-query';
+import { QueryClient, QueryCache, dehydrate } from 'react-query';
 import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
-
 const sharedCache = new QueryCache();
 
 export function createQueryClientSSR() {
@@ -10,4 +9,11 @@ export function createQueryClientSSR() {
 	} );
 
 	return queryClient;
+}
+
+export function dehydrateQueryClient( queryClient?: QueryClient ) {
+	if ( ! queryClient ) {
+		return null;
+	}
+	return dehydrate( queryClient );
 }

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -1,11 +1,11 @@
-import { QueryClient, QueryCache, dehydrate, hashQueryKey, TQueryKey } from 'react-query';
+import { QueryClient, QueryCache, dehydrate, hashQueryKey } from 'react-query';
 import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
 const sharedCache = new QueryCache();
 
 class QueryClientSSR extends QueryClient {
 	fetchedQueryKeys: { [ hash: string ]: boolean } = {};
 
-	fetchQuery( queryKey: TQueryKey, ...args: any[] ) {
+	fetchQuery( queryKey: any, ...args: any[] ) {
 		const queryHash = hashQueryKey( queryKey );
 		this.fetchedQueryKeys[ queryHash ] = true;
 		return super.fetchQuery( queryKey, ...args );

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -1,9 +1,19 @@
-import { QueryClient, QueryCache, dehydrate } from 'react-query';
+import { QueryClient, QueryCache, dehydrate, hashQueryKey, TQueryKey } from 'react-query';
 import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
 const sharedCache = new QueryCache();
 
+class QueryClientSSR extends QueryClient {
+	fetchedQueryKeys: { [ hash: string ]: boolean } = {};
+
+	fetchQuery( queryKey: TQueryKey, ...args: any[] ) {
+		const queryHash = hashQueryKey( queryKey );
+		this.fetchedQueryKeys[ queryHash ] = true;
+		return super.fetchQuery( queryKey, ...args );
+	}
+}
+
 export function createQueryClientSSR() {
-	const queryClient = new QueryClient( {
+	const queryClient = new QueryClientSSR( {
 		defaultOptions: { queries: { cacheTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
 		queryCache: sharedCache,
 	} );
@@ -11,9 +21,14 @@ export function createQueryClientSSR() {
 	return queryClient;
 }
 
-export function dehydrateQueryClient( queryClient?: QueryClient ) {
+export function dehydrateQueryClient( queryClient?: QueryClientSSR ) {
 	if ( ! queryClient ) {
 		return null;
 	}
-	return dehydrate( queryClient );
+
+	return dehydrate( queryClient, {
+		shouldDehydrateQuery: ( { queryHash } ) => {
+			return !! queryClient.fetchedQueryKeys[ queryHash ];
+		},
+	} );
 }

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -1,15 +1,22 @@
 import { throttle } from 'lodash';
-import { QueryClient } from 'react-query';
+import { hydrate, QueryClient } from 'react-query';
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
 import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
 import { getPersistedStateItem, storePersistedStateItem } from 'calypso/state/persisted-state';
 import { shouldDehydrateQuery } from './should-dehydrate-query';
 
-export async function createQueryClient( userId: number | undefined ): Promise< QueryClient > {
+export function createQueryClient(): QueryClient {
 	const queryClient = new QueryClient( {
 		defaultOptions: { queries: { cacheTime: MAX_AGE } },
 	} );
 
+	return queryClient;
+}
+
+export async function hydrateBrowserState(
+	queryClient: QueryClient,
+	userId: number | undefined
+): Promise< void > {
 	if ( shouldPersist() ) {
 		const storeKey = `query-state-${ userId ?? 'logged-out' }`;
 		const persistor = {
@@ -32,5 +39,17 @@ export async function createQueryClient( userId: number | undefined ): Promise< 
 			},
 		} );
 	}
-	return queryClient;
+}
+
+export function hydrateServerState( queryClient: QueryClient, dehydratedState?: unknown ): void {
+	hydrate( queryClient, dehydratedState );
+}
+
+// Retrieve the dehydrated react-query client.
+export function getInitialQueryState() {
+	if ( typeof window !== 'object' || ! ( window as any ).initialQueryState || ! shouldPersist() ) {
+		return null;
+	}
+
+	return ( window as any ).initialQueryState;
 }


### PR DESCRIPTION
#### Proposed Changes

This is a [follow-up](https://github.com/Automattic/wp-calypso/pull/67747#discussion_r972008737) to #67747 This dehydrates the react-query data fetched on the server (logged-out) and passes it to the client so it doesn't re-fetch the same data. 


#### Testing Instructions

* Open Incognito Mode and disable JavaScript
* Open the Network tab
* Go to `/plugins`
* You should still be able to see the Plugins landing page with the 3 sections Paid, Editor's Pick, and Free 
* Make sure fetch requests have not been sent to:
  * https://api.wordpress.org/plugins/info/1.2/?action=query_plugins
  * https://public-api.wordpress.com/wpcom/v2/marketplace/products
  * https://public-api.wordpress.com/wpcom/v2/plugins/featured 

