### PR TITLE
Pricing page rework: Fix pricing page from shifting to the right when lightbox is displayed.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -72,7 +72,7 @@ const ProductLightbox: React.FC< Props > = ( {
 			overlayClassName="product-lightbox__modal-overlay"
 			isOpen={ isVisible }
 			onRequestClose={ close }
-			htmlOpenClassName="ReactModal__Html--open"
+			htmlOpenClassName="ReactModal__Html--open lightbox-mode"
 		>
 			<div className="product-lightbox__content-wrapper">
 				<Button className="product-lightbox__close-button" plain onClick={ close }>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -445,3 +445,7 @@
 	margin-block-start: 1rem;
 	margin-block-end: 0;
 }
+
+.ReactModal__Html--open.lightbox-mode .layout__content {
+	overflow-y: scroll;
+}


### PR DESCRIPTION
### Description
When lightbox is activated, the page shifts to the right due to the scrollbar getting hidden. 

<img width="2560" alt="Screen Shot 2022-09-23 at 4 49 47 PM" src="https://user-images.githubusercontent.com/56598660/191924995-9b33b074-1210-440d-b3ba-16f0b7447ca5.png">
<img width="2558" alt="Screen Shot 2022-09-23 at 4 50 01 PM" src="https://user-images.githubusercontent.com/56598660/191925116-231331a8-22e9-4818-bb92-f1d0cceba618.png">


#### Proposed Changes

* Update the UI to make sure the layout container's overflow-y is set to scrollable when lightbox is activated to prevent the page from shifting.

#### Testing Instructions

1. * Run `git fetch && git checkout fix/shifting-page-when-lightbox-is-active`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
3. Click any 'More info' links to display the lightbox.
4. Confirm the page doesn't shift to the right when lightbox is active.

<img width="2559" alt="Screen Shot 2022-09-23 at 5 02 56 PM" src="https://user-images.githubusercontent.com/56598660/191927247-030dcc56-6909-4b70-acdb-2af8fbee570a.png">
<img width="2559" alt="Screen Shot 2022-09-23 at 5 03 06 PM" src="https://user-images.githubusercontent.com/56598660/191927427-44ef3759-8a3f-4542-b5a5-7f725f1c3a73.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203034869214534

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203029862618672
  - 0-as-1203034869214534