### PR TITLE
Redirect user to login screen if email exists for WooCommerce signup flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -161,12 +161,14 @@ class SignupForm extends Component {
 		debug( 'Mounted the SignupForm React component.' );
 
 		this.maybeRedirectToSocialConnect();
+		this.maybeRedirectToLogin();
 	}
 
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.step && this.props.step && prevProps.step.status !== this.props.step.status ) {
 			this.maybeRedirectToSocialConnect();
 		}
+		this.maybeRedirectToLogin();
 	}
 
 	autoFillUsername( form ) {
@@ -215,6 +217,24 @@ class SignupForm extends Component {
 			this.props.createSocialUserFailed( socialInfo, userExistsError, 'signup' );
 
 			page( login( { redirectTo: this.props.redirectToAfterLoginUrl } ) );
+		}
+	}
+
+	maybeRedirectToLogin() {
+		if ( ! this.props.isWoo ) {
+			return;
+		}
+
+		const messages = formState.getFieldErrorMessages( this.state.form, 'email' );
+		if ( ! messages ) {
+			return;
+		}
+
+		const emailExist = find( messages, ( _, error_code ) => error_code === 'taken' );
+		if ( emailExist ) {
+			page(
+				this.getLoginLink( { emailAddress: formState.getFieldValue( this.state.form, 'email' ) } )
+			);
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Redirect user to login screen if email exists (figma: 4ixWMlzrxllx93tSFsCW6k-fi-3304%3A47822)


https://user-images.githubusercontent.com/4344253/191925489-f5b17de4-12c2-4a30-9bb7-31fe4b8c7fce.mov



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Set up a local wpcalypso.wordpress.com environment https://github.com/Automattic/wp-calypso/pull/67537#pullrequestreview-1101745311

1. Log out WordPress.com or use incognito mode
2. Go to https://woocommerce.com/start/?nuxentrysource=signup_menu
3. Replace the URL https://wordpress.com/ with https://wpcalypso.wordpress.com/
4. Fill out the email address filed with an existing wp account email.
5. Observer that you're redirected to the login screen and email is pre-filled.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
