### PR TITLE
i18n: Wrap BlazePress strings in `translate()`

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -1,5 +1,4 @@
 import { Dialog } from '@automattic/components';
-import { __ } from '@wordpress/i18n';
 import { TranslateOptionsText, useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -67,11 +66,11 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 		{
 			action: 'cancel',
 			isPrimary: true,
-			label: __( 'No, let me finish' ),
+			label: translate( 'No, let me finish' ),
 		},
 		{
 			action: 'close',
-			label: __( 'Yes, quit' ),
+			label: translate( 'Yes, quit' ),
 			onClick: async () => {
 				setShowCancelDialog( false );
 				onClose();
@@ -90,7 +89,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				<BlankCanvas className={ 'blazepress-widget' }>
 					<div className={ 'blazepress-widget__header-bar' }>
 						<WordPressLogo />
-						<h2>Advertising</h2>
+						<h2>{ translate( 'Advertising' ) }</h2>
 						<span
 							role="button"
 							className={ 'blazepress-widget__cancel' }
@@ -98,7 +97,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 							tabIndex={ 0 }
 							onClick={ () => setShowCancelDialog( true ) }
 						>
-							Cancel
+							{ translate( 'Cancel' ) }
 						</span>
 					</div>
 					<div
@@ -111,8 +110,8 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 							buttons={ cancelDialogButtons }
 							onClose={ () => setShowCancelDialog( false ) }
 						>
-							<h1>{ __( 'Are you sure you want to quit?' ) }</h1>
-							<p>{ __( 'All progress in this session will be lost.' ) }</p>
+							<h1>{ translate( 'Are you sure you want to quit?' ) }</h1>
+							<p>{ translate( 'All progress in this session will be lost.' ) }</p>
 						</Dialog>
 						{ isLoading && <LoadingEllipsis /> }
 						<div className={ 'blazepress-widget__widget-container' } ref={ widgetContainer }></div>

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -5,6 +5,9 @@ import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
+// Import translatable strings so that translations get associated with the module and loaded properly.
+import './string';
+
 declare global {
 	interface Window {
 		BlazePress?: {

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -1,5 +1,5 @@
 import './style.scss';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import SitePreview from 'calypso/blocks/site-preview';
@@ -33,6 +33,8 @@ export default function PromotedPosts( { tab }: Props ) {
 
 	const campaigns = useCampaignsQuery( selectedSiteId ?? 0 );
 	const { isLoading: campaignsIsLoading, data: campaignsData, isError } = campaigns;
+
+	const translate = useTranslate();
 
 	const tabs: TabOption[] = [
 		{ id: 'posts', name: translate( 'Ready to promote' ) },
@@ -111,15 +113,17 @@ export default function PromotedPosts( { tab }: Props ) {
 
 			<div className="promote-post__footer">
 				<p>
-					By promoting your post you agree to{ ' ' }
-					<a href="https://wordpress.com/tos/" target={ '_blank' } rel="noreferrer">
-						WordPress.com Terms
-					</a>{ ' ' }
-					and{ ' ' }
-					<a href="https://automattic.com/privacy/" target={ 'blank' }>
-						Advertising Terms
-					</a>
-					.
+					{ translate(
+						'By promoting your post you agree to {{tosLink}}WordPress.com Terms{{/tosLink}} and {{advertisingTerms}}Advertising Terms{{/advertisingTerms}}.',
+						{
+							components: {
+								tosLink: (
+									<a href="https://wordpress.com/tos/" target={ '_blank' } rel="noreferrer" />
+								),
+								advertisingTerms: <a href="https://automattic.com/privacy/" target={ 'blank' } />,
+							},
+						}
+					) }
 				</p>
 			</div>
 		</Main>


### PR DESCRIPTION
#### Proposed Changes

* Wrap English strings with `translate()`.
* Import `client/lib/promote-post/strings.ts` into `client/lib/promote-post/index.ts` so that strings get included in the output bundle.

#### Testing Instructions

* Code review
* Go to `/posts` and select "Promote Post" from the post actions menu (the three dots):
![CleanShot 2022-09-23 at 12 29 06](https://user-images.githubusercontent.com/2722412/191932233-9c3a4a6b-2ae2-4bb7-87b1-1b8961fcabf0.png)
* Confirm the strings inside BlazePress widget are being translated. _Note that some strings might still not be translated due to `translate` not being used on the BlazePress widget's end._
* Confirm new strings that have been wrapped in `translate()` are being extracted.


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to 520-gh-Automattic/i18n-issues
