### PR TITLE
Update/videopress onboarding v2 site creation

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -23,12 +23,6 @@ export default function useOnLogin(): void {
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	useEffect( () => {
-		console.log(isCreatingSite);
-		console.log(newSite);
-		console.log(currentUser);
-		console.log(shouldTriggerCreate);
-		console.log(isCreatingSite);
-		
 		if (
 			! isCreatingSite &&
 			! newSite &&
@@ -36,7 +30,6 @@ export default function useOnLogin(): void {
 			shouldTriggerCreate &&
 			! isAnchorFmSignup
 		) {
-			console.log('yo');
 			createSite( {
 				username: currentUser.username,
 				languageSlug: locale,

--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -23,6 +23,12 @@ export default function useOnLogin(): void {
 	const isAnchorFmSignup = useIsAnchorFm();
 
 	useEffect( () => {
+		console.log(isCreatingSite);
+		console.log(newSite);
+		console.log(currentUser);
+		console.log(shouldTriggerCreate);
+		console.log(isCreatingSite);
+		
 		if (
 			! isCreatingSite &&
 			! newSite &&
@@ -30,6 +36,7 @@ export default function useOnLogin(): void {
 			shouldTriggerCreate &&
 			! isAnchorFmSignup
 		) {
+			console.log('yo');
 			createSite( {
 				username: currentUser.username,
 				languageSlug: locale,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -33,7 +33,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 
 	const visibility = useNewSiteVisibility();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const { createSite } = useDispatch( ONBOARD_STORE );
+	const { createVideoPressSite } = useDispatch( ONBOARD_STORE );
 
 	const store = useStore();
 
@@ -64,7 +64,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 
 			//setSelectedPlanProductId( planId );
 
-			createSite( {
+			createVideoPressSite( {
 				username: currentUser!.username,
 				languageSlug: locale,
 				bearerToken: undefined,
@@ -72,43 +72,11 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 				anchorFmPodcastId: null,
 				anchorFmEpisodeId: null,
 				anchorFmSpotifyUrl: null,
-			} )
-			.then( ( newSite ) => {
-				const planObject = supportedPlans.find( ( plan ) => plan.productIds.indexOf( planId as number ) >= 0 );
-				if ( ! planObject ) {
-					///@todo whatever
-					return;
-				}
-				console.log( 'We have the plan object !' );
-				addPlanToCart(
-					() => {
-						submit?.( { newSite } );
-					},
-					{},
-					{ cartItem: { product_slug: planObject.periodAgnosticSlug } },
-					store
+			} ).then( ( newSite ) => {
+				const planObject = supportedPlans.find(
+					( plan ) => plan.productIds.indexOf( planId as number ) >= 0
 				);
-				/*
-				const productSlug = getDomainProductSlug( domain );
-				const domainItem = domainRegistration( { productSlug, domain: domain!.domain_name } );
-
-				addDomainToCart(
-					( error: any ) => {
-						if (error) {
-							///@todo whatever
-							return;
-						}
-
-						const planObject = supportedPlans.find( ( plan ) => planId as number in plan.productIds );
-						if ( ! planObject ) {
-							///@todo whatever
-							return;
-						}
-
-						
-					},
-					{ domainItem }
-				);*/
+				submit?.( { newSite, planObject, planId, domain } );
 			} );
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -56,11 +56,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 			createVideoPressSite( {
 				username: currentUser!.username,
 				languageSlug: locale,
-				bearerToken: undefined,
 				visibility,
-				anchorFmPodcastId: null,
-				anchorFmEpisodeId: null,
-				anchorFmSpotifyUrl: null,
 			} ).then( (/*newSite*/) => {
 				const planObject = supportedPlans.find(
 					( plan ) => plan.productIds.indexOf( planId as number ) >= 0

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -11,9 +11,10 @@ import PlanItem from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { PLANS_STORE } from 'calypso/landing/gutenboarding/stores/plans';
-import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { USER_STORE, ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import type { Step } from '../../types';
 
 import 'calypso/../packages/plans-grid/src/plans-grid/style.scss';
@@ -23,13 +24,6 @@ import './style.scss';
 const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
 	const isVideoPressFlow = 'videopress' === flow;
-	const { __ } = useI18n();
-	const locale = useLocale();
-
-	const visibility = useNewSiteVisibility();
-	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
-	const { createVideoPressSite } = useDispatch( ONBOARD_STORE );
 
 	const [ billingPeriod, setBillingPeriod ] =
 		React.useState< Plans.PlanBillingPeriod >( 'ANNUALLY' );
@@ -38,8 +32,17 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 	);
 	const [ allPlansExpanded, setAllPlansExpanded ] = React.useState( true );
 
-	const getPlanProduct = useSelect( ( select ) => select( PLANS_STORE ).getPlanProduct );
+	const { __ } = useI18n();
+	const locale = useLocale();
+	const visibility = useNewSiteVisibility();
 	const { supportedPlans, maxAnnualDiscount } = useSupportedPlans( locale, billingPeriod );
+
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
+	const getPlanProduct = useSelect( ( select ) => select( PLANS_STORE ).getPlanProduct );
+	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
+
+	const { createVideoPressSite, setSelectedSite } = useDispatch( ONBOARD_STORE );
 
 	const getDefaultStepContent = () => <h1>Choose a plan step</h1>;
 
@@ -50,74 +53,96 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 			);
 		} );
 
-		const onPlanSelect = ( planId: number | undefined ) => {
+		const onPlanSelect = async ( planId: number | undefined ) => {
 			/// @todo lock UI
 			setSelectedPlanProductId( planId );
-			createVideoPressSite( {
+			await createVideoPressSite( {
 				username: currentUser!.username,
 				languageSlug: locale,
 				visibility,
-			} ).then( (/*newSite*/) => {
-				const planObject = supportedPlans.find(
-					( plan ) => plan.productIds.indexOf( planId as number ) >= 0
-				);
-				submit?.( { planSlug: planObject?.periodAgnosticSlug } );
 			} );
+			const newSite = getNewSite();
+			setSelectedSite( newSite?.blogid );
+
+			const planObject = supportedPlans.find(
+				( plan ) => plan.productIds.indexOf( planId as number ) >= 0
+			);
+
+			if ( domain && domain.product_slug ) {
+				const registration = domainRegistration( {
+					domain: domain.domain_name,
+					productSlug: domain.product_slug as string,
+					extra: { privacy_available: domain.supports_privacy },
+				} );
+
+				const cartKey = await cartManagerClient.getCartKeyForSiteSlug(
+					newSite?.site_slug as string
+				);
+				cartManagerClient
+					.forCartKey( cartKey )
+					.actions.addProductsToCart( [ registration ] )
+					.then( () => {
+						submit?.( {
+							planSlug: planObject?.periodAgnosticSlug,
+							siteSlug: newSite?.site_slug,
+						} );
+					} );
+			} else {
+				submit?.( {
+					planSlug: planObject?.periodAgnosticSlug,
+					siteSlug: newSite?.site_slug,
+				} );
+			}
 		};
 
 		return (
-			<CalypsoShoppingCartProvider>
-				<div className="plans-grid">
-					<PlansIntervalToggle
-						intervalType={ billingPeriod }
-						onChange={ setBillingPeriod }
-						maxMonthlyDiscountPercentage={ maxAnnualDiscount }
-						className="plans-grid__toggle"
-					/>
+			<div className="plans-grid">
+				<PlansIntervalToggle
+					intervalType={ billingPeriod }
+					onChange={ setBillingPeriod }
+					maxMonthlyDiscountPercentage={ maxAnnualDiscount }
+					className="plans-grid__toggle"
+				/>
 
-					<div className="plans-grid__table">
-						<div className="plans-grid__table-container">
-							<div className="plans-table">
-								{ filteredPlans
-									.filter( ( plan ) => !! plan )
-									.map( ( plan, index ) => (
-										<>
-											<PlanItem
-												popularBadgeVariation={ 'ON_TOP' }
-												allPlansExpanded={ allPlansExpanded }
-												key={ plan.periodAgnosticSlug }
-												slug={ plan.periodAgnosticSlug }
-												domain={ domain }
-												CTAVariation={ 'NORMAL' }
-												features={ plan.features ?? [] }
-												billingPeriod={ billingPeriod }
-												isPopular={ 'business' === plan.periodAgnosticSlug }
-												isFree={ plan.isFree }
-												name={ plan?.title.toString() }
-												isSelected={
-													!! selectedPlanProductId &&
-													selectedPlanProductId ===
-														getPlanProduct( plan.periodAgnosticSlug, billingPeriod )?.productId
-												}
-												onSelect={ onPlanSelect }
-												onPickDomainClick={ undefined }
-												onToggleExpandAll={ () => setAllPlansExpanded( ( expand ) => ! expand ) }
-												CTAButtonLabel={ __( 'Get %s' ).replace( '%s', plan.title ) }
-												popularBadgeText={ __( 'Best for Video' ) }
-											/>
-											{ index < filteredPlans.length - 1 && (
-												<div
-													key={ 'plan-item-separator-' + index }
-													className="plan-separator"
-												></div>
-											) }
-										</>
-									) ) }
-							</div>
+				<div className="plans-grid__table">
+					<div className="plans-grid__table-container">
+						<div className="plans-table">
+							{ filteredPlans
+								.filter( ( plan ) => !! plan )
+								.map( ( plan, index ) => (
+									<>
+										<PlanItem
+											popularBadgeVariation={ 'ON_TOP' }
+											allPlansExpanded={ allPlansExpanded }
+											key={ plan.periodAgnosticSlug }
+											slug={ plan.periodAgnosticSlug }
+											domain={ domain }
+											CTAVariation={ 'NORMAL' }
+											features={ plan.features ?? [] }
+											billingPeriod={ billingPeriod }
+											isPopular={ 'business' === plan.periodAgnosticSlug }
+											isFree={ plan.isFree }
+											name={ plan?.title.toString() }
+											isSelected={
+												!! selectedPlanProductId &&
+												selectedPlanProductId ===
+													getPlanProduct( plan.periodAgnosticSlug, billingPeriod )?.productId
+											}
+											onSelect={ onPlanSelect }
+											onPickDomainClick={ undefined }
+											onToggleExpandAll={ () => setAllPlansExpanded( ( expand ) => ! expand ) }
+											CTAButtonLabel={ __( 'Get %s' ).replace( '%s', plan.title ) }
+											popularBadgeText={ __( 'Best for Video' ) }
+										/>
+										{ index < filteredPlans.length - 1 && (
+											<div key={ 'plan-item-separator-' + index } className="plan-separator"></div>
+										) }
+									</>
+								) ) }
 						</div>
 					</div>
 				</div>
-			</CalypsoShoppingCartProvider>
+			</div>
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -26,7 +26,7 @@ export const videopress: Flow = {
 			'chooseAPlan',
 			'completingPurchase',
 			'processing',
-			'launchpad'
+			'launchpad',
 		] as StepPath[];
 	},
 
@@ -65,11 +65,13 @@ export const videopress: Flow = {
 					return navigate( 'chooseAPlan' );
 
 				case 'chooseAPlan':
-					const { newSite } = providedDependencies;
-					console.log( newSite );
+					const { planObject, domain } = providedDependencies;
+					const siteSlug = domain.domain_name;
+					const { periodAgnosticSlug } = planObject;
 
-					return window.location.replace( '/checkout/' + siteSlug );
-					//return navigate( 'completingPurchase' );
+					return window.location.replace(
+						`/checkout/${ siteSlug }/${ periodAgnosticSlug }?signup=1&redirect_to=/setup/completing-purchase?flow=videopress`
+					);
 
 				case 'completingPurchase':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -9,6 +9,7 @@ import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
 import './internals/videopress.scss';
+import { NewSiteBlogDetails } from 'calypso/../packages/data-stores/src';
 
 export const videopress: Flow = {
 	name: VIDEOPRESS_FLOW,
@@ -18,7 +19,15 @@ export const videopress: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'options', 'completingPurchase', 'processing', 'launchpad' ] as StepPath[];
+		return [
+			'intro',
+			'options',
+			'chooseADomain',
+			'chooseAPlan',
+			'completingPurchase',
+			'processing',
+			'launchpad'
+		] as StepPath[];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -30,11 +39,12 @@ export const videopress: Flow = {
 		const name = this.name;
 		const { setStepProgress, setSiteTitle, setSiteDescription } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
+		const { createSite } = useDispatch( ONBOARD_STORE );
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 
-		function submit( providedDependencies: ProvidedDependencies = {} ) {
+		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
 				case 'intro':
 					if ( userIsLoggedIn ) {
@@ -48,20 +58,18 @@ export const videopress: Flow = {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
 					setSiteDescription( tagline as string );
-					// return navigate( 'chooseADomain' );
-					return window.location.replace(
-						`/start/${ name }/domains?new=${ encodeURIComponent(
-							siteTitle as string
-						) }&search=yes&hide_initial_query=yes`
-					);
+					return navigate( 'chooseADomain' );
 				}
 
-				case 'chooseADomain': {
+				case 'chooseADomain':
 					return navigate( 'chooseAPlan' );
-				}
 
 				case 'chooseAPlan':
-					return navigate( 'chooseAPlan' );
+					const { newSite } = providedDependencies;
+					console.log( newSite );
+
+					return window.location.replace( '/checkout/' + siteSlug );
+					//return navigate( 'completingPurchase' );
 
 				case 'completingPurchase':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -9,7 +9,6 @@ import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
 import './internals/videopress.scss';
-import { NewSiteBlogDetails } from 'calypso/../packages/data-stores/src';
 
 export const videopress: Flow = {
 	name: VIDEOPRESS_FLOW,
@@ -39,10 +38,10 @@ export const videopress: Flow = {
 		const name = this.name;
 		const { setStepProgress, setSiteTitle, setSiteDescription } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
-		const { createSite } = useDispatch( ONBOARD_STORE );
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -64,14 +63,14 @@ export const videopress: Flow = {
 				case 'chooseADomain':
 					return navigate( 'chooseAPlan' );
 
-				case 'chooseAPlan':
-					const { planObject, domain } = providedDependencies;
-					const siteSlug = domain.domain_name;
-					const { periodAgnosticSlug } = planObject;
+				case 'chooseAPlan': {
+					const { planSlug } = providedDependencies;
+					const siteSlug = domain?.domain_name;
 
 					return window.location.replace(
-						`/checkout/${ siteSlug }/${ periodAgnosticSlug }?signup=1&redirect_to=/setup/completing-purchase?flow=videopress`
+						`/checkout/${ siteSlug }/${ planSlug }?signup=1&redirect_to=/setup/completing-purchase?flow=videopress`
 					);
+				}
 
 				case 'completingPurchase':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -7,7 +7,6 @@ import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { redirect } from './internals/steps-repository/import/util';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
-
 import './internals/videopress.scss';
 
 export const videopress: Flow = {
@@ -39,9 +38,8 @@ export const videopress: Flow = {
 		const { setStepProgress, setSiteTitle, setSiteDescription } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );
-		const siteSlug = useSiteSlug();
+		const _siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
-		const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
@@ -64,8 +62,7 @@ export const videopress: Flow = {
 					return navigate( 'chooseAPlan' );
 
 				case 'chooseAPlan': {
-					const { planSlug } = providedDependencies;
-					const siteSlug = domain?.domain_name;
+					const { planSlug, siteSlug } = providedDependencies;
 
 					return window.location.replace(
 						`/checkout/${ siteSlug }/${ planSlug }?signup=1&redirect_to=/setup/completing-purchase?flow=videopress`
@@ -80,7 +77,7 @@ export const videopress: Flow = {
 				}
 
 				case 'launchpad': {
-					return redirect( `/page/${ siteSlug }/home` );
+					return redirect( `/page/${ _siteSlug }/home` );
 				}
 			}
 			return providedDependencies;
@@ -97,7 +94,7 @@ export const videopress: Flow = {
 		const goNext = () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					return window.location.replace( `/view/${ siteSlug }` );
+					return window.location.replace( `/view/${ _siteSlug }` );
 
 				default:
 					return navigate( 'intro' );

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -31,11 +31,14 @@ export const setPatternId = ( patternId: number ) => ( {
 	patternId,
 } );
 
-export interface CreateSiteActionParameters {
+export interface CreateSiteBaseActionParameters {
 	username: string;
 	languageSlug: string;
-	bearerToken?: string;
 	visibility: number;
+}
+
+export interface CreateSiteActionParameters extends CreateSiteBaseActionParameters {
+	bearerToken?: string;
 	anchorFmPodcastId: string | null;
 	anchorFmEpisodeId: string | null;
 	anchorFmSpotifyUrl: string | null;
@@ -44,12 +47,8 @@ export interface CreateSiteActionParameters {
 export function* createVideoPressSite( {
 	username,
 	languageSlug,
-	bearerToken = undefined,
 	visibility = Visibility.PublicNotIndexed,
-	anchorFmPodcastId = null,
-	anchorFmEpisodeId = null,
-	anchorFmSpotifyUrl = null,
-}: CreateSiteActionParameters ) {
+}: CreateSiteBaseActionParameters ) {
 	const { domain, selectedDesign, selectedFonts, siteTitle, selectedFeatures }: State =
 		yield select( STORE_KEY, 'getState' );
 
@@ -79,27 +78,19 @@ export function* createVideoPressSite( {
 			use_patterns: true,
 			selected_features: selectedFeatures,
 			wpcom_public_coming_soon: 1,
-			...( anchorFmPodcastId && {
-				anchor_fm_podcast_id: anchorFmPodcastId,
-			} ),
-			...( anchorFmEpisodeId && {
-				anchor_fm_episode_id: anchorFmEpisodeId,
-			} ),
-			...( anchorFmSpotifyUrl && {
-				anchor_fm_spotify_url: anchorFmSpotifyUrl,
-			} ),
 			...( selectedDesign && { is_blank_canvas: isBlankCanvasDesign( selectedDesign ) } ),
 		},
-		...( bearerToken && { authToken: bearerToken } ),
 	};
+
 	const success: NewSiteBlogDetails | undefined = yield dispatch(
 		SITE_STORE,
 		'createSite',
 		params
 	);
-	console.log( { success } );
+
 	return success;
 }
+
 export function* createSite( {
 	username,
 	languageSlug,


### PR DESCRIPTION
#### Proposed Changes

This PR creates a new site at the end of the VideoPress onboarding flow and adds the selected domain to the cart.

#### Testing Instructions
* Apply this PR
* Go to `http://calypso.localhost:3000/setup/intro?flow=videopress`
* Complete the steps until domain selection
* Select a domain name
* Select a plan
* ✅ You should be redirected to the checkout page
* ✅ You should see the selected domain in your cart (if not a .wordpress.com free subdomain)
* ✅ Your site should be created and ready to go, whether your complete checkout or not

Fixes  Automattic/greenhouse#1337
