### PR TITLE
Pricing page rework: Fix text in licensing prompt dialog to make it clickable link

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -96,7 +96,22 @@ function LicensingPromptDialog( { siteId }: Props ) {
 					<li>
 						{ translate( 'You can find the license keys in your purchase confirmation email.' ) }
 					</li>
-					<li>{ translate( 'Or in Upgrades -> Purchases -> Active Upgrades' ) }</li>
+					<li>
+						{ translate( 'Or in {{purchases/}}', {
+							components: {
+								purchases: (
+									<Button
+										className="user-purchases-link"
+										href="/me/purchases"
+										target="_blank"
+										plain
+									>
+										{ 'https://wordpress.com/me/purchases' }
+									</Button>
+								),
+							},
+						} ) }
+					</li>
 				</ul>
 			</>
 		);

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -53,7 +53,12 @@
 .licensing-prompt-dialog .licensing-prompt-dialog__instructions {
 	font-size: $font-body;
 	margin-bottom: 1.5em;
+
+	.user-purchases-link {
+		text-decoration: underline;
+	}
 }
+
 
 .licensing-prompt-dialog__actions {
 	display: flex;


### PR DESCRIPTION
#### Proposed Changes

* This PR updates the instructions in licensing prompt dialog on Jetpack connection page when the user has a detached license.

#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Calypso Live link below and wait for the redirect to complete
    - or boot up this PR 
        - Run `git fetch && git checkout update/jp-pricing-rework/jetpack-connect-text`
        - Run `yarn start`
        - Goto [http://calypso.localhost:3000](http://calypso.localhost:3000)
- Goto [https://cloud.jetpack.com/pricing](https://cloud.jetpack.com/pricing) and purchase a product e.g. Backup but do not activate it for any site.
- Create a JN site
- While connecting Jetpack,  pause on the plans page i.e. `https://wordpress.com/jetpack/connect/plans/:site`
- Copy the URL and open it in another tab after replacing `https://wordpress.com` with `http://calypso.localhost:3000` or  Calypso Live URL above.
- Confirm that you see the license prompt dialog.
- Confirm that you see the instructions text changed to `Or in https://wordpress.com/me/purchases`
- Click on the link
- Confirm that it opens WPCOM purchases page in a new tab

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Completes: 0-as-1203036427386318/f

| BEFORE | AFTER |
| - | - |
| <img width="1009" alt="Screenshot 2022-09-23 at 4 58 24 PM" src="https://user-images.githubusercontent.com/18226415/191950963-a1d9d8ea-8300-440a-961d-1c74637b7e7e.png"> | <img width="991" alt="Screenshot 2022-09-23 at 4 39 24 PM" src="https://user-images.githubusercontent.com/18226415/191950948-90227d8c-0fbc-4fd8-b56f-528762a3c9d1.png"> |


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203036427386318