### PR TITLE
Fix Added plan information steps issue

### DIFF
--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -13,6 +13,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MainComponent from 'calypso/components/main';
+import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
+import { Gridicon } from 'calypso/devdocs/design/playground-scope';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
@@ -59,6 +61,32 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 		);
 	}, [ dispatch, translate, selectedSite, breadcrumbs.length, intervalType ] );
 
+	const promos: PromoSectionProps = {
+		promos: [
+			{
+				title: translate( 'Flex your site with plugins' ),
+				body: translate(
+					'Install plugins and extend functionality for your site with access to more than 50,000 plugins.'
+				),
+				image: <Gridicon icon="plugins" />,
+			},
+			{
+				title: translate( 'Money back guarantee' ),
+				body: translate(
+					'Try WordPress.com for 14 days and if you are not 100% satisfied, get your money back.'
+				),
+				image: <Gridicon icon="money" />,
+			},
+			{
+				title: translate( 'Essential features' ),
+				body: translate(
+					"We guarantee site's performance and protect it from spammers detailing all activity records."
+				),
+				image: <Gridicon icon="plans" />,
+			},
+		],
+	};
+
 	return (
 		<MainComponent wideLayout>
 			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
@@ -70,6 +98,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 				subHeaderText={ `Choose the plan that's right for you and reimagine what's possible with plugins` }
 				brandFont
 			/>
+
 			<div className="plans">
 				<PlansFeaturesMain
 					basePlansPath="/plugins/plans"
@@ -83,6 +112,9 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					isReskinned
 				/>
 			</div>
+
+			<PromoSection { ...promos } />
+
 			<ActionCard
 				classNames="plugin-plans"
 				headerText=""

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -88,7 +88,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	};
 
 	return (
-		<MainComponent wideLayout>
+		<MainComponent className="plugin-plans" wideLayout>
 			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
 			<FixedNavigationHeader navigationItems={ breadcrumbs } />

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -88,7 +88,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	};
 
 	return (
-		<MainComponent className="plugin-plans" wideLayout>
+		<MainComponent className="plugin-plans-main" wideLayout>
 			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
 			<FixedNavigationHeader navigationItems={ breadcrumbs } />

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -1,9 +1,72 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .plugin-plans-header {
 	.formatted-header__title {
 		font-size: $font-title-large;
 	}
 	.formatted-header__subtitle {
 		font-size: $font-body;
+	}
+}
+
+.promo-section {
+	.promo-section__promos {
+		overflow: auto;
+		white-space: nowrap;
+		max-width: 820px;
+		margin: auto;
+		margin-top: 50px;
+		margin-bottom: 50px;
+		display: block;
+
+		@media (max-width: 480px) {
+			padding-left: 20px;
+		}
+
+		.action-panel__figure.align-left {
+			float: none;
+		}
+
+		.action-panel__figure {
+			float: none;
+		}
+
+		.promo-card {
+			box-shadow: none;
+			padding-left: 0;
+			padding-right: 0;
+			width: 255px;
+			display: inline-block;
+			vertical-align: top;
+
+
+			.action-panel__figure {
+				text-align: left;
+			}
+
+			.action-panel__title {
+				font-weight: normal;
+				font-size: $font-body;
+				color: var(--studio-gray-100);
+
+			}
+
+			.gridicon {
+				height: 25px;
+				width: 25px;
+				padding: 10px;
+				background: #f0f7fc;
+				border-radius: 8px; /* stylelint-disable-line scales/radii */
+			}
+
+			.action-panel__body {
+				font-size: $font-body-small;
+
+				p {
+					white-space: pre-wrap;
+				}
+			}
+		}
 	}
 }
 

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -9,15 +9,16 @@
 	}
 }
 
-.plugin-plans .promo-section {
+.plugin-plans-main .promo-section {
 	.promo-section__promos {
 		overflow: auto;
 		white-space: nowrap;
-		max-width: 820px;
+		max-width: 832px;
 		margin: auto;
 		margin-top: 50px;
 		margin-bottom: 50px;
 		display: block;
+		left: 0;
 
 		@media (max-width: 480px) {
 			padding-left: 20px;
@@ -35,7 +36,8 @@
 			box-shadow: none;
 			padding-left: 0;
 			padding-right: 0;
-			width: 255px;
+			width: calc(33% - 1em);
+			min-width: 250px;
 			display: inline-block;
 			vertical-align: top;
 

--- a/client/my-sites/plugins/plans/style.scss
+++ b/client/my-sites/plugins/plans/style.scss
@@ -9,7 +9,7 @@
 	}
 }
 
-.promo-section {
+.plugin-plans .promo-section {
 	.promo-section__promos {
 		overflow: auto;
 		white-space: nowrap;


### PR DESCRIPTION
task-related: https://github.com/Automattic/wp-calypso/pull/68058

Fix the bug found here https://github.com/Automattic/wp-calypso/pull/68177

### Test instructions

- After checkout this branch, open the new plugins plan page: [http://calypso.localhost:3000/plugins/woocommerce-subscriptions/mysimplesimplesite.wordpress.com?flags=plugins-plans-page](http://calypso.localhost:3000/plugins/woocommerce-subscriptions/mysimplesimplesite.wordpress.com?flags=plugins-plans-page) and make sure it works as expected:

	![image](https://user-images.githubusercontent.com/1044309/191958735-cf40b708-9a84-4307-91a1-b96947b8ca58.png)

- Open "Tools" > "Earn" page and make sure it work as expected:

	![image](https://user-images.githubusercontent.com/1044309/191958370-ba25dfbc-7556-4903-80fd-f3ff6f65fbc6.png)

