### PR TITLE
Revert domain auto-population via URL param when launch.

### DIFF
--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -38,6 +38,10 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 		}
 
 		const siteSlug = getSiteSlug( getState(), siteId );
+
 		// TODO: consider using the `page` library instead of calling using `location.href` here
-		window.location.href = addQueryArgs( { siteSlug, source }, '/start/launch-site' );
+		window.location.href = addQueryArgs(
+			{ siteSlug, source, hide_initial_query: 'yes' },
+			'/start/launch-site'
+		);
 	};

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -38,17 +38,6 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 		}
 
 		const siteSlug = getSiteSlug( getState(), siteId );
-
-		// Adding domain queries auto-populate the domain suggestions in the domain step.
-		const domainQuery = {
-			new: siteSlug,
-			search: 'yes',
-			hide_initial_query: 'yes',
-		};
-
 		// TODO: consider using the `page` library instead of calling using `location.href` here
-		window.location.href = addQueryArgs(
-			{ siteSlug, source, ...domainQuery },
-			'/start/launch-site'
-		);
+		window.location.href = addQueryArgs( { siteSlug, source }, '/start/launch-site' );
 	};


### PR DESCRIPTION
#### Proposed Changes

* This patch reverts domain auto-population via URL param introduced by https://github.com/Automattic/wp-calypso/pull/65880.
* This patch is superseded by https://github.com/Automattic/wp-calypso/pull/68155.
* This patch is related to D88382-code.

#### Testing Instructions

* On an unlaunched site, go to My Home and click Launch Site.
* It should automatically populate domain based on the behaviour in https://github.com/Automattic/wp-calypso/pull/68155 behaviour.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68155