### PR TITLE
Plugin Management: implement plugin page header changes in WP.com

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -364,7 +364,7 @@ export class PluginsMain extends Component {
 		this.props.recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' );
 	};
 
-	renderUploadPluginButton( isMobile ) {
+	renderUploadPluginButton() {
 		const { selectedSiteSlug, translate, hasUploadPlugins } = this.props;
 		const uploadUrl = '/plugins/upload' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 
@@ -375,7 +375,7 @@ export class PluginsMain extends Component {
 		return (
 			<Button href={ uploadUrl } onClick={ this.handleUploadPluginButtonClick }>
 				<Icon className="plugins__button-icon" icon={ upload } width={ 18 } height={ 18 } />
-				{ ! isMobile && translate( 'Upload' ) }
+				{ translate( 'Upload' ) }
 			</Button>
 		);
 	}
@@ -447,10 +447,6 @@ export class PluginsMain extends Component {
 				<QuerySiteFeatures siteIds={ this.props.siteIds } />
 				{ this.renderPageViewTracking() }
 				{ ! isJetpackCloud && (
-					// <FixedNavigationHeader
-					// 	className="plugins__page-heading"
-					// 	navigationItems={ this.getNavigationItems() }
-					// ></FixedNavigationHeader>
 					<FixedNavigationHeader
 						className="plugin__header"
 						compactBreadcrumb={ false }
@@ -479,7 +475,7 @@ export class PluginsMain extends Component {
 							{ ! isJetpackCloud && (
 								<div className="plugins__header-right-content">
 									{ this.renderAddPluginButton() }
-									{ this.renderUploadPluginButton( this.state.isMobile ) }
+									{ this.renderUploadPluginButton() }
 									<UpdatePlugins plugins={ currentPlugins } />
 								</div>
 							) }

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -51,6 +51,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
+import UpdatePlugins from './plugin-management-v2/update-plugins';
 import PluginsList from './plugins-list';
 
 import './style.scss';
@@ -333,8 +334,6 @@ export class PluginsMain extends Component {
 			<PluginsList
 				header={ this.props.translate( 'Installed Plugins' ) }
 				plugins={ currentPlugins }
-				pluginUpdateCount={ this.props.pluginUpdateCount }
-				pluginsWithUpdates={ this.props.pluginsWithUpdates }
 				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
 				isLoading={ this.props.requestingPluginsForSites }
 				isJetpackCloud={ this.props.isJetpackCloud }
@@ -354,12 +353,8 @@ export class PluginsMain extends Component {
 		const browserUrl = '/plugins' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 
 		return (
-			<Button
-				className="plugins__button"
-				href={ browserUrl }
-				onClick={ this.handleAddPluginButtonClick }
-			>
-				<span className="plugins__button-text">{ translate( 'Browse plugins' ) }</span>
+			<Button href={ browserUrl } onClick={ this.handleAddPluginButtonClick }>
+				{ translate( 'Browse plugins' ) }
 			</Button>
 		);
 	}
@@ -378,13 +373,9 @@ export class PluginsMain extends Component {
 		}
 
 		return (
-			<Button
-				className="plugins__button"
-				href={ uploadUrl }
-				onClick={ this.handleUploadPluginButtonClick }
-			>
+			<Button href={ uploadUrl } onClick={ this.handleUploadPluginButtonClick }>
 				<Icon className="plugins__button-icon" icon={ upload } width={ 18 } height={ 18 } />
-				{ ! isMobile && <span className="plugins__button-text">{ translate( 'Upload' ) }</span> }
+				{ ! isMobile && translate( 'Upload' ) }
 			</Button>
 		);
 	}
@@ -434,7 +425,7 @@ export class PluginsMain extends Component {
 			return <NavItem { ...attr }>{ filterItem.title }</NavItem>;
 		} );
 
-		const { isJetpackCloud, selectedSite } = this.props;
+		const { isJetpackCloud, selectedSite, currentPlugins } = this.props;
 
 		const pageTitle = isJetpackCloud
 			? this.props.translate( 'Plugins', { textOnly: true } )
@@ -456,15 +447,15 @@ export class PluginsMain extends Component {
 				<QuerySiteFeatures siteIds={ this.props.siteIds } />
 				{ this.renderPageViewTracking() }
 				{ ! isJetpackCloud && (
+					// <FixedNavigationHeader
+					// 	className="plugins__page-heading"
+					// 	navigationItems={ this.getNavigationItems() }
+					// ></FixedNavigationHeader>
 					<FixedNavigationHeader
-						className="plugins__page-heading"
+						className="plugin__header"
+						compactBreadcrumb={ false }
 						navigationItems={ this.getNavigationItems() }
-					>
-						<div className="plugins__main-buttons">
-							{ this.renderAddPluginButton() }
-							{ this.renderUploadPluginButton( this.state.isMobile ) }
-						</div>
-					</FixedNavigationHeader>
+					/>
 				) }
 				<div
 					className={ classNames( 'plugins__top-container', {
@@ -473,16 +464,25 @@ export class PluginsMain extends Component {
 				>
 					<div className="plugins__content-wrapper">
 						<div className="plugins__page-title-container">
-							<h2 className="plugins__page-title">{ pageTitle }</h2>
-							<div className="plugins__page-subtitle">
-								{ this.props.selectedSite
-									? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
-											args: {
-												selectedSite: this.props.selectedSite.domain,
-											},
-									  } )
-									: this.props.translate( 'Manage plugins installed on all sites' ) }
+							<div className="plugins__header-left-content">
+								<h2 className="plugins__page-title">{ pageTitle }</h2>
+								<div className="plugins__page-subtitle">
+									{ this.props.selectedSite
+										? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
+												args: {
+													selectedSite: this.props.selectedSite.domain,
+												},
+										  } )
+										: this.props.translate( 'Manage plugins installed on all sites' ) }
+								</div>
 							</div>
+							{ ! isJetpackCloud && (
+								<div className="plugins__header-right-content">
+									{ this.renderAddPluginButton() }
+									{ this.renderUploadPluginButton( this.state.isMobile ) }
+									<UpdatePlugins plugins={ currentPlugins } />
+								</div>
+							) }
 						</div>
 
 						<div className="plugins__main plugins__main-updated">

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -476,7 +476,7 @@ export class PluginsMain extends Component {
 								<div className="plugins__header-right-content">
 									{ this.renderAddPluginButton() }
 									{ this.renderUploadPluginButton() }
-									<UpdatePlugins plugins={ currentPlugins } />
+									<UpdatePlugins isWpCom plugins={ currentPlugins } />
 								</div>
 							) }
 						</div>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -38,9 +38,7 @@ export class PluginsListHeader extends PureComponent {
 		isBulkManagementActive: PropTypes.bool,
 		isWpComAtomic: PropTypes.bool,
 		toggleBulkManagement: PropTypes.func.isRequired,
-		updateAllPluginsNotice: PropTypes.func.isRequired,
 		updateSelected: PropTypes.func.isRequired,
-		pluginUpdateCount: PropTypes.number.isRequired,
 		activateSelected: PropTypes.func.isRequired,
 		deactiveAndDisconnectSelected: PropTypes.func.isRequired,
 		deactivateSelected: PropTypes.func.isRequired,
@@ -121,34 +119,7 @@ export class PluginsListHeader extends PureComponent {
 		const autoupdateButtons = [];
 		const activateButtons = [];
 
-		if ( ! this.props.isBulkManagementActive ) {
-			if ( 0 < this.props.pluginUpdateCount ) {
-				rightSideButtons.push(
-					<ButtonGroup key="plugin-list-header__buttons-update-all">
-						<Button compact primary onClick={ this.props.updateAllPluginsNotice }>
-							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
-								context: 'button label',
-								count: this.props.pluginUpdateCount,
-								args: {
-									numUpdates: this.props.pluginUpdateCount,
-								},
-							} ) }
-						</Button>
-					</ButtonGroup>
-				);
-			}
-			rightSideButtons.push(
-				<ButtonGroup key="plugin-list-header__buttons-bulk-management">
-					<Button
-						className="plugin-list-header__buttons-action-button"
-						compact
-						onClick={ this.toggleBulkManagement }
-					>
-						{ translate( 'Edit All', { context: 'button label' } ) }
-					</Button>
-				</ButtonGroup>
-			);
-		} else {
+		if ( this.props.isBulkManagementActive ) {
 			const updateButton = (
 				<Button
 					key="plugin-list-header__buttons-update"

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -128,10 +128,14 @@ export class PluginsListHeader extends PureComponent {
 		const leftSideButtons = [];
 		const autoupdateButtons = [];
 		const activateButtons = [];
-
 		if ( ! isBulkManagementActive ) {
-			{
-				isJetpackCloud && <UpdatePlugins plugins={ plugins } />;
+			if ( isJetpackCloud ) {
+				const updateButton = (
+					<UpdatePlugins key="plugin-list-header__buttons-update-all" plugins={ plugins } />
+				);
+				if ( updateButton ) {
+					rightSideButtons.push( updateButton );
+				}
 			}
 			rightSideButtons.push(
 				<ButtonGroup key="plugin-list-header__buttons-bulk-management">

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -16,6 +16,7 @@ import getSites from 'calypso/state/selectors/get-sites';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import UpdatePlugins from '../plugin-management-v2/update-plugins';
 
 import './style.scss';
 
@@ -53,6 +54,7 @@ export class PluginsListHeader extends PureComponent {
 		updatePluginNotice: PropTypes.func.isRequired,
 		plugins: PropTypes.array.isRequired,
 		selected: PropTypes.array.isRequired,
+		isJetpackCloud: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -106,7 +108,15 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	renderCurrentActionButtons() {
-		const { hasManagePluginsFeature, isWpComAtomic, translate, siteId } = this.props;
+		const {
+			hasManagePluginsFeature,
+			isWpComAtomic,
+			translate,
+			siteId,
+			isJetpackCloud,
+			isBulkManagementActive,
+			plugins,
+		} = this.props;
 		const buttons = [];
 
 		if ( siteId && isWpComAtomic && ! hasManagePluginsFeature ) {
@@ -119,7 +129,22 @@ export class PluginsListHeader extends PureComponent {
 		const autoupdateButtons = [];
 		const activateButtons = [];
 
-		if ( this.props.isBulkManagementActive ) {
+		if ( ! isBulkManagementActive ) {
+			{
+				isJetpackCloud && <UpdatePlugins plugins={ plugins } />;
+			}
+			rightSideButtons.push(
+				<ButtonGroup key="plugin-list-header__buttons-bulk-management">
+					<Button
+						className="plugin-list-header__buttons-action-button"
+						compact
+						onClick={ this.toggleBulkManagement }
+					>
+						{ translate( 'Edit All', { context: 'button label' } ) }
+					</Button>
+				</ButtonGroup>
+			);
+		} else {
 			const updateButton = (
 				<Button
 					key="plugin-list-header__buttons-update"

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,12 +1,13 @@
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { ReactElement, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import ButtonGroup from 'calypso/components/button-group';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { resetPluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import PluginsList from './plugins-list';
+import UpdatePlugins from './update-plugins';
 import type { Plugin } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -18,11 +19,10 @@ interface Props {
 	selectedSite: SiteDetails;
 	searchTerm: string;
 	isBulkManagementActive: boolean;
-	pluginUpdateCount: number;
 	toggleBulkManagement: () => void;
-	updateAllPluginsNotice: () => void;
 	removePluginNotice: ( plugin: Plugin ) => void;
 	updatePlugin: ( plugin: Plugin ) => void;
+	isJetpackCloud: boolean;
 }
 export default function PluginManagementV2( {
 	plugins,
@@ -30,12 +30,11 @@ export default function PluginManagementV2( {
 	selectedSite,
 	searchTerm,
 	isBulkManagementActive,
-	pluginUpdateCount,
 	toggleBulkManagement,
-	updateAllPluginsNotice,
 	removePluginNotice,
 	updatePlugin,
-}: Props ) {
+	isJetpackCloud,
+}: Props ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -52,19 +51,7 @@ export default function PluginManagementV2( {
 
 		return (
 			<div className="plugin-common-table__bulk-actions">
-				{ !! pluginUpdateCount && (
-					<ButtonGroup className="plugin-management-v2__table-button-group">
-						<Button compact primary onClick={ updateAllPluginsNotice }>
-							{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
-								context: 'button label',
-								count: pluginUpdateCount,
-								args: {
-									numUpdates: pluginUpdateCount,
-								},
-							} ) }
-						</Button>
-					</ButtonGroup>
-				) }
+				{ isJetpackCloud && <UpdatePlugins plugins={ plugins } /> }
 				<ButtonGroup className="plugin-management-v2__table-button-group">
 					<Button compact onClick={ toggleBulkManagement }>
 						{ translate( 'Edit All', { context: 'button label' } ) }

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -7,6 +7,7 @@ import acceptDialog from 'calypso/lib/accept';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getPlugins, getPluginsOnSites } from 'calypso/state/plugins/installed/selectors';
+import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -54,6 +55,7 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 			handleUpdatePlugins( plugins, updateAction, pluginsOnSites );
 			recordEvent( 'Clicked Update all Plugins' );
 			recordTracksEvent( 'calypso_plugins_update_all_click' );
+			dispatch( removePluginStatuses( 'completed', 'error' ) );
 		}
 	}
 

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -1,0 +1,99 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'react-redux';
+import acceptDialog from 'calypso/lib/accept';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { updatePlugin } from 'calypso/state/plugins/installed/actions';
+import { getPlugins, getPluginsOnSites } from 'calypso/state/plugins/installed/selectors';
+import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import getSites from 'calypso/state/selectors/get-sites';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import {
+	getPluginActionDailogMessage,
+	handleUpdatePlugins,
+	siteObjectsToSiteIds,
+} from '../../utils';
+import type { Plugin } from '../types';
+import type { ReactElement } from 'react';
+
+import '../style.scss';
+
+interface Props {
+	plugins: Array< Plugin >;
+}
+
+export default function UpdatePlugins( { plugins }: Props ): ReactElement | null {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
+	const siteIds = useSelector( () => siteObjectsToSiteIds( sites ) ) ?? [];
+	const pluginsWithUpdates = useSelector( ( state ) => getPlugins( state, siteIds, 'updates' ) );
+	const allSites = useSelector( getSites );
+
+	const pluginsOnSites = useSelector( ( state ) => getPluginsOnSites( state, plugins ) );
+	const selectedSite = useSelector( getSelectedSite );
+
+	const pluginUpdateCount = pluginsWithUpdates.length;
+
+	const updateAction = ( siteId: number, sitePlugin: Plugin ) => {
+		dispatch( updatePlugin( siteId, sitePlugin ) );
+	};
+
+	function recordEvent( eventAction: string ) {
+		eventAction += selectedSite ? '' : ' on Multisite';
+		const pluginSlugs = pluginsWithUpdates.map( ( plugin: Plugin ) => plugin.slug );
+		dispatch( recordGoogleEvent( 'Plugins', eventAction, 'Plugins', pluginSlugs ) );
+	}
+
+	function updateAllPlugins( accepted: boolean ) {
+		if ( accepted ) {
+			handleUpdatePlugins( plugins, updateAction, pluginsOnSites );
+			recordEvent( 'Clicked Update all Plugins' );
+			recordTracksEvent( 'calypso_plugins_update_all_click' );
+		}
+	}
+
+	function updateAllPluginsNotice() {
+		let pluginName;
+		const hasOnePlugin = pluginUpdateCount === 1;
+
+		if ( hasOnePlugin ) {
+			const [ { name, slug } ] = pluginsWithUpdates;
+			pluginName = name || slug;
+		}
+
+		const dialogOptions = {
+			additionalClassNames: 'plugins__confirmation-modal',
+		};
+
+		const heading = hasOnePlugin
+			? translate( 'Update %(pluginName)s', { args: { pluginName } } )
+			: translate( 'Update %(pluginUpdateCount)d plugins', {
+					args: { pluginUpdateCount },
+			  } );
+
+		acceptDialog(
+			getPluginActionDailogMessage( allSites, pluginsWithUpdates, heading, 'update' ),
+			( accepted: boolean ) => updateAllPlugins( accepted ),
+			heading,
+			null,
+			dialogOptions
+		);
+	}
+
+	return pluginUpdateCount ? (
+		// <ButtonGroup className="plugin-management-v2__table-button-group">
+		<Button primary onClick={ updateAllPluginsNotice }>
+			{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
+				context: 'button label',
+				count: pluginUpdateCount,
+				args: {
+					numUpdates: pluginUpdateCount,
+				},
+			} ) }
+		</Button>
+	) : // </ButtonGroup>
+	null;
+}

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
+import ButtonGroup from 'calypso/components/button-group';
 import acceptDialog from 'calypso/lib/accept';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
@@ -21,9 +22,10 @@ import '../style.scss';
 
 interface Props {
 	plugins: Array< Plugin >;
+	isWpCom?: boolean;
 }
 
-export default function UpdatePlugins( { plugins }: Props ): ReactElement | null {
+export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactElement | null {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -83,9 +85,8 @@ export default function UpdatePlugins( { plugins }: Props ): ReactElement | null
 		);
 	}
 
-	return pluginUpdateCount ? (
-		// <ButtonGroup className="plugin-management-v2__table-button-group">
-		<Button primary onClick={ updateAllPluginsNotice }>
+	const buttonContent = (
+		<Button primary compact={ ! isWpCom } onClick={ updateAllPluginsNotice }>
 			{ translate( 'Update %(numUpdates)d Plugin', 'Update %(numUpdates)d Plugins', {
 				context: 'button label',
 				count: pluginUpdateCount,
@@ -94,6 +95,17 @@ export default function UpdatePlugins( { plugins }: Props ): ReactElement | null
 				},
 			} ) }
 		</Button>
-	) : // </ButtonGroup>
-	null;
+	);
+
+	if ( ! pluginUpdateCount ) {
+		return null;
+	}
+
+	return isWpCom ? (
+		buttonContent
+	) : (
+		<ButtonGroup className="plugin-management-v2__table-button-group">
+			{ buttonContent }
+		</ButtonGroup>
+	);
 }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -29,7 +29,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PluginManagementV2 from '../plugin-management-v2';
-import { getPluginActionDailogMessage } from '../utils';
+import { getPluginActionDailogMessage, getSitePlugin, handleUpdatePlugins } from '../utils';
 
 import './style.scss';
 
@@ -59,7 +59,6 @@ export class PluginsList extends Component {
 		hasManagePlugins: PropTypes.bool,
 		header: PropTypes.string.isRequired,
 		isPlaceholder: PropTypes.bool.isRequired,
-		pluginUpdateCount: PropTypes.number,
 		selectedSite: PropTypes.object,
 		selectedSiteSlug: PropTypes.string,
 		siteIsAtomic: PropTypes.bool,
@@ -71,7 +70,7 @@ export class PluginsList extends Component {
 	};
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		const propsToCheck = [ 'plugins', 'sites', 'selectedSite', 'pluginUpdateCount' ];
+		const propsToCheck = [ 'plugins', 'sites', 'selectedSite' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
 		}
@@ -160,7 +159,7 @@ export class PluginsList extends Component {
 		active( plugin ) {
 			if ( this.isSelected( plugin ) ) {
 				return Object.keys( plugin.sites ).some( ( siteId ) => {
-					const sitePlugin = this.getSitePlugin( plugin, siteId );
+					const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
 					return sitePlugin?.active;
 				} );
 			}
@@ -169,7 +168,7 @@ export class PluginsList extends Component {
 		inactive( plugin ) {
 			if ( this.isSelected( plugin ) && plugin.slug !== 'jetpack' ) {
 				return Object.keys( plugin.sites ).some( ( siteId ) => {
-					const sitePlugin = this.getSitePlugin( plugin, siteId );
+					const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
 					return ! sitePlugin?.active;
 				} );
 			}
@@ -178,7 +177,7 @@ export class PluginsList extends Component {
 		updates( plugin ) {
 			if ( this.isSelected( plugin ) ) {
 				return Object.keys( plugin.sites ).some( ( siteId ) => {
-					const sitePlugin = this.getSitePlugin( plugin, siteId );
+					const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
 					const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );
 					return sitePlugin?.update?.new_version && site.canUpdateFiles;
 				} );
@@ -267,56 +266,12 @@ export class PluginsList extends Component {
 		} );
 	}
 
-	getSitePlugin = ( plugin, siteId ) => {
-		return {
-			...plugin,
-			...this.props.pluginsOnSites[ plugin.slug ]?.sites[ siteId ],
-		};
-	};
-
 	pluginHasUpdate = ( plugin ) => {
 		return Object.keys( plugin.sites ).some( ( siteId ) => {
-			const sitePlugin = this.getSitePlugin( plugin, siteId );
+			const sitePlugin = getSitePlugin( plugin, siteId, this.props.pluginsOnSites );
 			const site = this.props.allSites.find( ( s ) => s.ID === parseInt( siteId ) );
 			return sitePlugin?.update && site?.canUpdateFiles;
 		} );
-	};
-
-	handleUpdatePlugins = ( plugins ) => {
-		this.removePluginStatuses();
-
-		const updatedPlugins = new Set();
-		const updatedSites = new Set();
-
-		plugins
-			// only consider plugins needing an update
-			.filter( ( plugin ) => plugin.update )
-			.forEach( ( plugin ) => {
-				Object.entries( plugin.sites )
-					// only consider the sites where the those plugins are installed
-					.filter( ( [ , sitePlugin ] ) => sitePlugin.update?.new_version )
-					.forEach( ( [ siteId ] ) => {
-						updatedPlugins.add( plugin.slug );
-						updatedSites.add( siteId );
-
-						const sitePlugin = this.getSitePlugin( plugin, siteId );
-						return this.props.updatePlugin( siteId, sitePlugin );
-					} );
-			} );
-
-		recordTracksEvent( 'calypso_plugins_bulk_action_execute', {
-			action: 'updating',
-			plugins: [ ...updatedPlugins ].join( ',' ),
-			sites: [ ...updatedSites ].join( ',' ),
-		} );
-	};
-
-	updateAllPlugins = ( accepted ) => {
-		if ( accepted ) {
-			this.handleUpdatePlugins( this.props.plugins );
-			this.recordEvent( 'Clicked Update all Plugins', true );
-			recordTracksEvent( 'calypso_plugins_update_all_click' );
-		}
 	};
 
 	updateSelected = ( accepted ) => {
@@ -327,7 +282,7 @@ export class PluginsList extends Component {
 	};
 
 	updatePlugin = ( selectedPlugin ) => {
-		this.handleUpdatePlugins( [ selectedPlugin ] );
+		handleUpdatePlugins( [ selectedPlugin ], this.props.updatePlugin, this.props.pluginsOnSites );
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
 	};
 
@@ -505,36 +460,6 @@ export class PluginsList extends Component {
 		}
 	};
 
-	updateAllPluginsDialog = () => {
-		const { pluginUpdateCount, translate, pluginsWithUpdates, allSites } = this.props;
-
-		let pluginName;
-		const hasOnePlugin = pluginUpdateCount === 1;
-
-		if ( hasOnePlugin ) {
-			const [ { name, slug } ] = pluginsWithUpdates;
-			pluginName = name || slug;
-		}
-
-		const dialogOptions = {
-			additionalClassNames: 'plugins__confirmation-modal',
-		};
-
-		const heading = hasOnePlugin
-			? translate( 'Update %(pluginName)s', { args: { pluginName } } )
-			: translate( 'Update %(pluginUpdateCount)d plugins', {
-					args: { pluginUpdateCount },
-			  } );
-
-		acceptDialog(
-			getPluginActionDailogMessage( allSites, pluginsWithUpdates, heading, 'update' ),
-			( accepted ) => this.updateAllPlugins( accepted ),
-			heading,
-			null,
-			dialogOptions
-		);
-	};
-
 	removePluginDialog = ( selectedPlugin ) => {
 		this.bulkActionDialog( 'remove', selectedPlugin );
 	};
@@ -626,9 +551,7 @@ export class PluginsList extends Component {
 					plugins={ this.props.plugins }
 					selected={ this.getSelected() }
 					toggleBulkManagement={ this.toggleBulkManagement }
-					updateAllPlugins={ this.updateAllPlugins }
 					updateSelected={ this.updateSelected }
-					pluginUpdateCount={ this.props.pluginUpdateCount }
 					activateSelected={ this.activateSelected }
 					deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
 					deactivateSelected={ this.deactivateSelected }
@@ -641,7 +564,6 @@ export class PluginsList extends Component {
 					autoupdateEnablePluginNotice={ () => this.bulkActionDialog( 'enableAutoupdates' ) }
 					autoupdateDisablePluginNotice={ () => this.bulkActionDialog( 'disableAutoupdates' ) }
 					updatePluginNotice={ () => this.bulkActionDialog( 'update' ) }
-					updateAllPluginsNotice={ () => this.updateAllPluginsDialog() }
 				/>
 				<PluginManagementV2
 					plugins={ this.getPlugins() }
@@ -649,12 +571,10 @@ export class PluginsList extends Component {
 					selectedSite={ this.props.selectedSite }
 					searchTerm={ this.props.searchTerm }
 					isBulkManagementActive={ this.state.bulkManagementActive }
-					pluginUpdateCount={ this.props.pluginUpdateCount }
 					toggleBulkManagement={ this.toggleBulkManagement }
-					updateAllPlugins={ this.updateAllPlugins }
-					updateAllPluginsNotice={ this.updateAllPluginsDialog }
 					removePluginNotice={ this.removePluginDialog }
 					updatePlugin={ this.updatePlugin }
+					isJetpackCloud={ this.props.isJetpackCloud }
 				/>
 			</div>
 		);

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -564,6 +564,7 @@ export class PluginsList extends Component {
 					autoupdateEnablePluginNotice={ () => this.bulkActionDialog( 'enableAutoupdates' ) }
 					autoupdateDisablePluginNotice={ () => this.bulkActionDialog( 'disableAutoupdates' ) }
 					updatePluginNotice={ () => this.bulkActionDialog( 'update' ) }
+					isJetpackCloud={ this.props.isJetpackCloud }
 				/>
 				<PluginManagementV2
 					plugins={ this.getPlugins() }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -283,6 +283,7 @@ export class PluginsList extends Component {
 
 	updatePlugin = ( selectedPlugin ) => {
 		handleUpdatePlugins( [ selectedPlugin ], this.props.updatePlugin, this.props.pluginsOnSites );
+		this.removePluginStatuses();
 		this.recordEvent( 'Clicked Update Plugin(s)', true );
 	};
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -330,23 +330,39 @@ body.is-section-plugins header .select-dropdown__item {
 	flex-direction: row;
 	.plugins__header-left-content {
 		display: none;
-		width: 40%;
 		@include breakpoint-deprecated( ">660px" ) {
 			display: block;
+			width: 100%;
+		}
+		@include break-xlarge {
+			width: 45%;
 		}
 	}
 	.plugins__header-right-content {
-		text-align: right;
-		width: 60%;
+		width: 100%;
+		margin: 12px 0;
 		.button {
 			height: 40px;
 			display: inline-flex;
 			&:not(:last-child) {
-				margin-right: 5px;
+				margin-inline-end: 8px;
 			}
 			.plugins__button-icon {
-				margin-right: 5px;
+				margin-inline-end: 5px;
 			}
+			// Move button to next line if there are 3 buttons on devices <425px
+			&:nth-child(3) {
+				margin-block-start: 12px;
+				display: block;
+				@media ( min-width: 425px ) {
+					display: initial;
+					margin-block-start: initial;
+				}
+			}
+		}
+		@include break-xlarge {
+			width: 55%;
+			text-align: right;
 		}
 	}
 }
@@ -494,7 +510,11 @@ body.is-section-plugins header .select-dropdown__item {
 	background-color: var(--color-surface-backdrop) !important;
 
 	@include breakpoint-deprecated( ">660px" ) {
-		inset-inline-start: calc(var(--sidebar-width-min) + 1px) !important;
+		inset-inline-start: 10px !important;
+	}
+
+	@media ( min-width: 782px ) {
+		inset-inline-start: calc(var(--sidebar-width-min) + 10px) !important;
 	}
 
 	@include break-large {
@@ -502,7 +522,6 @@ body.is-section-plugins header .select-dropdown__item {
 	}
 
 	@include break-xlarge {
-
 		> div {
 			max-width: 1530px;
 			margin: auto;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -81,33 +81,6 @@ body.is-section-plugins.theme-default.color-scheme {
 	margin: 0;
 }
 
-.plugins__main-buttons {
-	display: flex;
-	align-items: center;
-
-	@media screen and ( max-width: 1280px ) {
-		.plugins__button {
-			border: none;
-		}
-	}
-
-	.plugins__button {
-		white-space: nowrap;
-		display: flex;
-		align-items: center;
-		height: 32px;
-
-		.plugins__button-icon {
-			margin-right: 5px;
-		}
-
-		&:not(:last-child) {
-			@include breakpoint-deprecated( ">480px" ) {
-				margin-right: 10px;
-			}
-		}
-	}
-}
 
 .plugins__more-header {
 	font-size: $font-body-small;
@@ -352,11 +325,32 @@ body.is-section-plugins header .select-dropdown__item {
 	margin-bottom: 8px;
 }
 .plugins__page-title-container {
-	display: none;
-	@include breakpoint-deprecated( ">660px" ) {
-		display: block;
+	display: flex;
+	flex-wrap: wrap;
+	flex-direction: row;
+	.plugins__header-left-content {
+		display: none;
+		width: 40%;
+		@include breakpoint-deprecated( ">660px" ) {
+			display: block;
+		}
+	}
+	.plugins__header-right-content {
+		text-align: right;
+		width: 60%;
+		.button {
+			height: 40px;
+			display: inline-flex;
+			&:not(:last-child) {
+				margin-right: 5px;
+			}
+			.plugins__button-icon {
+				margin-right: 5px;
+			}
+		}
 	}
 }
+
 .plugins__main-updated {
 	.plugins__main-header .section-nav {
 		border-width: 1px;
@@ -419,6 +413,7 @@ body.is-section-plugins header .select-dropdown__item {
 	}
 	.search.is-open {
 		box-shadow: none;
+		z-index: 0;
 	}
 }
 
@@ -490,6 +485,27 @@ body.is-section-plugins header .select-dropdown__item {
 			padding: 7px;
 			font-size: 0.75rem;
 			line-height: 1;
+		}
+	}
+}
+
+.plugin__header {
+	border-bottom: none !important;
+	background-color: var(--color-surface-backdrop) !important;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		inset-inline-start: calc(var(--sidebar-width-min) + 1px) !important;
+	}
+
+	@include break-large {
+		inset-inline-start: calc(var(--sidebar-width-min) + 20px) !important;
+	}
+
+	@include break-xlarge {
+
+		> div {
+			max-width: 1530px;
+			margin: auto;
 		}
 	}
 }

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -4,7 +4,6 @@ import { useTranslate, translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 
 export function siteObjectsToSiteIds( sites ) {
 	return sites?.map( ( site ) => site.ID ) ?? [];
@@ -126,8 +125,6 @@ export function getSitePlugin( plugin, siteId, pluginsOnSites ) {
 }
 
 export function handleUpdatePlugins( plugins, updateAction, pluginsOnSites ) {
-	removePluginStatuses( 'completed', 'error' );
-
 	const updatedPlugins = new Set();
 	const updatedSites = new Set();
 

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,8 +1,10 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isMagnificentLocale } from '@automattic/i18n-utils';
 import { useTranslate, translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 
 export function siteObjectsToSiteIds( sites ) {
 	return sites?.map( ( site ) => site.ID ) ?? [];
@@ -115,3 +117,38 @@ export const getPluginActionDailogMessage = ( sites, selectedPlugins, heading, a
 		</div>
 	);
 };
+
+export function getSitePlugin( plugin, siteId, pluginsOnSites ) {
+	return {
+		...plugin,
+		...pluginsOnSites[ plugin.slug ]?.sites[ siteId ],
+	};
+}
+
+export function handleUpdatePlugins( plugins, updateAction, pluginsOnSites ) {
+	removePluginStatuses( 'completed', 'error' );
+
+	const updatedPlugins = new Set();
+	const updatedSites = new Set();
+
+	plugins
+		// only consider plugins needing an update
+		.filter( ( plugin ) => plugin.update )
+		.forEach( ( plugin ) => {
+			Object.entries( plugin.sites )
+				// only consider the sites where the those plugins are installed
+				.filter( ( [ , sitePlugin ] ) => sitePlugin.update?.new_version )
+				.forEach( ( [ siteId ] ) => {
+					updatedPlugins.add( plugin.slug );
+					updatedSites.add( siteId );
+					const sitePlugin = getSitePlugin( plugin, siteId, pluginsOnSites );
+					return updateAction( siteId, sitePlugin );
+				} );
+		} );
+
+	recordTracksEvent( 'calypso_plugins_bulk_action_execute', {
+		action: 'updating',
+		plugins: [ ...updatedPlugins ].join( ',' ),
+		sites: [ ...updatedSites ].join( ',' ),
+	} );
+}


### PR DESCRIPTION
#### Proposed Changes

This PR makes necessary changes to the plugins' view page header 
- Move buttons like `Browse Plugins` & `Upload` from the top fixed header to the page header only in Calypso Blue.
- Move the `Update X Plugins` button from the table header to the page header only in Calypso Blue.
- Make some UI enhancements to the top fixed header.


<img width="1167" alt="Screenshot 2022-09-26 at 3 19 07 PM" src="https://user-images.githubusercontent.com/10586875/192261277-b59e74e3-bf4c-483a-97b9-00662ce11cdd.png">


#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency to test the changes in Calypso Green - 2c49b-pb. Make sure to switch it back to the previous type. 

**Instructions**

1. Run `git checkout update/plugin-header-calypso-blue` and `yarn start`
2. After it is done, run `yarn start-jetpack-cloud-p`.
5. Open http://calypso.localhost:3000/plugins/manage and verify that the top fixed header buttons are moved to the page header along with the `Update X Plugins` button; also verify these buttons work as expected. You can also compare the changes with WP.com(production)

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1645" alt="Screenshot 2022-09-26 at 4 18 06 PM" src="https://user-images.githubusercontent.com/10586875/192258762-e14e480d-2770-47b4-bf3f-75da5d6f081b.png">
</td>
<td>
<img width="1167" alt="Screenshot 2022-09-26 at 3 19 07 PM" src="https://user-images.githubusercontent.com/10586875/192258964-4f60661f-72a6-4fa5-900a-22cf321393f6.png">
</td>
</tr>
</table>

**Other views**

768px

<img width="775" alt="Screenshot 2022-09-26 at 3 35 31 PM" src="https://user-images.githubusercontent.com/10586875/192259365-075fea73-1a64-4931-b722-18cf4ff9d430.png">

Mobile view

<img width="402" alt="Screenshot 2022-09-26 at 3 35 19 PM" src="https://user-images.githubusercontent.com/10586875/192259336-2ec35f0a-2862-4d09-9c85-242376dca13d.png">

6. Open http://calypso.localhost:3000/plugins/manage/:site, and verify that the top fixed header buttons are moved to the page header along with the `Update X Plugins` button; also verify these buttons work as expected. You can also compare the changes with WP.com(production)


<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1649" alt="Screenshot 2022-09-26 at 4 19 12 PM" src="https://user-images.githubusercontent.com/10586875/192259837-9d49e858-b8be-4ca0-9882-847afcd70291.png">
</td>
<td>
<img width="1169" alt="Screenshot 2022-09-26 at 3 36 40 PM" src="https://user-images.githubusercontent.com/10586875/192259890-61c5ca6b-6de2-4b0e-937a-0a28d17ec588.png">
</td>
</tr>
</table>

**Other views**

768px

<img width="788" alt="Screenshot 2022-09-26 at 3 36 18 PM" src="https://user-images.githubusercontent.com/10586875/192259988-723c7c91-5071-482b-b0bc-a7d8c9cf690e.png">

Mobile view

>` >425px`

<img width="462" alt="Screenshot 2022-09-26 at 4 32 06 PM" src="https://user-images.githubusercontent.com/10586875/192260635-fb5fa376-ad76-49a6-ad8e-a7731dd8e196.png">

> `<425px`

<img width="324" alt="Screenshot 2022-09-26 at 3 36 31 PM" src="https://user-images.githubusercontent.com/10586875/192260008-dee53a51-2e4d-48a7-8a8d-d9c4018a5934.png">

7. Verify these changes are not affected in Calypso Green; in short - the Update X Plugins should be in the table header itself, and buttons `Update X Plugins` and `Edit All` should work as expected. You also can compare the changes in Jetpack Cloud(production)
8. Click on any plugin update and verify it works as expected.

<img width="267" alt="Screenshot 2022-09-26 at 4 44 13 PM" src="https://user-images.githubusercontent.com/10586875/192262793-3e2aec5f-2a7c-4b2d-a520-c25fa31cfa6b.png">

#### Pre-merge Checklist

Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Will be added later - 1202518759611394-as-1202627702018877
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202518759611394-as-1202993209552913