### PR TITLE
Tailored flows: switch LiB to PNG previews

### DIFF
--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -19,6 +19,7 @@ export type MShotsOptions = {
 	w: number;
 	h?: number;
 	screen_height?: number;
+	format?: 'png' | 'jpeg';
 };
 
 const debug = debugFactory( 'design-picker:mshots-image' );

--- a/packages/pattern-picker/src/item.tsx
+++ b/packages/pattern-picker/src/item.tsx
@@ -74,7 +74,7 @@ export function Item( { style, onClick, pattern, className }: Props ) {
 				<div className="pattern-picker__item-iframe-wrapper">
 					<MShotsImage
 						url={ getPatternPreviewUrl( pattern ) }
-						options={ { w: 400, vpw: 400, vph: 872 } }
+						options={ { w: 400, vpw: 400, vph: 872, format: 'png' } }
 						alt={ pattern.title }
 						aria-labelledby=""
 					/>


### PR DESCRIPTION
#### Proposed Changes

* This uses PNGs for the pattern picker previews for better quality.
