### PR TITLE
Launchpad: Fix squared border radius

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -137,6 +137,13 @@
 
 .launchpad__progress-bar-container {
 	margin-bottom: 32px;
+
+	.launchpad__progress-bar.progress-bar.is-compact {
+		.progress-bar__progress {
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 4.5px;
+		}
+	}
 }
 
 .launchpad__progress-value {


### PR DESCRIPTION
### Context

* The progress bar shown on the LaunchPad should be rounded on both sides. Currently it is squared.
* The progress bar component, by default, has rounded borders
* A higher specificity selector in the stepper global.scss file overwrites the rounded borders

https://github.com/Automattic/wp-calypso/blob/61ee20f252625064db417ac1da60d672922aa0bb/client/landing/stepper/declarative-flow/internals/global.scss#L223-L230

### Proposed Changes

* Create a css selector with higher specificity to reset progress bar border radius

### Screenshots
#### Before
<img width="196" alt="Screen Shot 2022-09-23 at 10 29 43 AM" src="https://user-images.githubusercontent.com/5414230/192024195-020566e9-b562-43b7-827e-55b387dfaab1.png">

#### After
<img width="190" alt="Screen Shot 2022-09-23 at 10 28 59 AM" src="https://user-images.githubusercontent.com/5414230/192024067-c5aa8341-898a-43fd-ae8b-8c26bf06d366.png">

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site through the tailored onboarding flow ( newsletter or link in bio ) https://wordpress.com/hp-2022-tailored-flows/
* Step through the onboarding process until the launchpad
* Check out this branch and `yarn start`
* Make sure that you're loading the launchpad through the local dev environment calypso.localhost:3000
* Verify that the progress bar borders are rounded

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68036
