### PR TITLE
Marketplace: Add plugins plans for small screen sizes

### DIFF
--- a/client/components/plans/plan-pill/index.jsx
+++ b/client/components/plans/plan-pill/index.jsx
@@ -1,7 +1,14 @@
+import classNames from 'classnames';
 import './style.scss';
 
 export default ( props ) => (
-	<div className={ `plan-pill${ props.isInSignup ? ' is-in-signup' : '' }` }>
+	<div
+		className={ classNames( 'plan-pill', {
+			'is-in-signup': props.isInSignup,
+			'is-current-plan': props.isCurrentPlan,
+			'is-in-marketplace': props.isInMarketplace,
+		} ) }
+	>
 		{ props.children }
 	</div>
 );

--- a/client/components/plans/plan-pill/style.scss
+++ b/client/components/plans/plan-pill/style.scss
@@ -27,3 +27,13 @@
 	border-radius: 10px; /* stylelint-disable-line scales/radii */
 	background-color: var(--color-neutral-100);
 }
+
+.plan-pill.is-in-marketplace {
+	padding: 4px 10px;
+	background-color: var(--color-neutral-100);
+}
+
+.plan-pill.is-current-plan {
+	background-color: var(--studio-gray-5);
+	color: var(--studio-gray-80);
+}

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -15,15 +15,6 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const noop = () => {};
-const PlanFeaturesActions = ( props ) => {
-	return (
-		<div className="plan-features__actions">
-			<div className="plan-features__actions-buttons">
-				<PlanFeaturesActionsButton { ...props } />
-			</div>
-		</div>
-	);
-};
 
 const PlanFeaturesActionsButton = ( {
 	availableForPurchase = true,
@@ -182,6 +173,16 @@ const PlanFeaturesActionsButton = ( {
 	}
 
 	return null;
+};
+
+const PlanFeaturesActions = ( props ) => {
+	return (
+		<div className="plan-features__actions">
+			<div className="plan-features__actions-buttons">
+				<PlanFeaturesActionsButton { ...props } />
+			</div>
+		</div>
+	);
 };
 
 PlanFeaturesActions.propTypes = {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -46,6 +46,7 @@ const PlanFeaturesActionsButton = ( {
 	selectedPlan,
 	recordTracksEvent: trackTracksEvent,
 	translate,
+	isInMarketplace,
 	...props
 } ) => {
 	const classes = classNames(
@@ -71,6 +72,21 @@ const PlanFeaturesActionsButton = ( {
 
 		onUpgradeClick();
 	};
+
+	if ( isInMarketplace ) {
+		if ( current ) {
+			return (
+				<Button className={ classes } disabled>
+					{ translate( 'Your current plan' ) }
+				</Button>
+			);
+		}
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ translate( 'Select' ) }
+			</Button>
+		);
+	}
 
 	if ( current && ! isInSignup && planType !== PLAN_P2_FREE ) {
 		return (
@@ -184,6 +200,7 @@ PlanFeaturesActions.propTypes = {
 	planType: PropTypes.string,
 	primaryUpgrade: PropTypes.bool,
 	selectedPlan: PropTypes.string,
+	isInMarketplace: PropTypes.bool,
 };
 
 export default connect(

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -36,8 +36,13 @@ const PLANS_LIST = getPlans();
 
 export class PlanFeaturesHeader extends Component {
 	render() {
-		const { isInSignup, plansWithScroll, planType, isInVerticalScrollingPlansExperiment } =
-			this.props;
+		const {
+			isInSignup,
+			plansWithScroll,
+			planType,
+			isInVerticalScrollingPlansExperiment,
+			isInMarketplace,
+		} = this.props;
 
 		if ( planType === PLAN_P2_FREE ) {
 			return this.renderPlansHeaderP2Free();
@@ -52,6 +57,10 @@ export class PlanFeaturesHeader extends Component {
 			}
 			return this.renderSignupHeader();
 		}
+		if ( isInMarketplace ) {
+			return this.renderPlansHeaderNoTabs();
+		}
+
 		return this.renderPlansHeader();
 	}
 
@@ -124,21 +133,32 @@ export class PlanFeaturesHeader extends Component {
 			title,
 			audience,
 			translate,
+			isInMarketplace,
 		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isPillInCorner = this.resolveIsPillInCorner();
+		const isCurrent = this.isPlanCurrent();
 
 		return (
 			<span>
 				<header className={ headerClasses }>
 					<h4 className="plan-features__header-title">{ title }</h4>
 					<div className="plan-features__audience">{ audience }</div>
-					{ planLevelsMatch( selectedPlan, planType ) && availableForPurchase && (
-						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Suggested' ) }</PlanPill>
+					{ isInMarketplace && isCurrent && (
+						<PlanPill isCurrentPlan={ true } isInMarketplace={ isInMarketplace }>
+							{ translate( 'Your current plan' ) }
+						</PlanPill>
 					) }
-					{ popular && ! selectedPlan && (
-						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Popular' ) }</PlanPill>
+					{ ! isInMarketplace &&
+						planLevelsMatch( selectedPlan, planType ) &&
+						availableForPurchase && (
+							<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Suggested' ) }</PlanPill>
+						) }
+					{ popular && ( ! selectedPlan || isInMarketplace ) && (
+						<PlanPill isInSignup={ isPillInCorner } isInMarketplace={ isInMarketplace }>
+							{ translate( 'Popular' ) }
+						</PlanPill>
 					) }
 					{ newPlan && ! selectedPlan && (
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'New' ) }</PlanPill>
@@ -351,6 +371,7 @@ export class PlanFeaturesHeader extends Component {
 			plansWithScroll,
 			isLoggedInMonthlyPricing,
 			isMonthlyPlan,
+			isInMarketplace,
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -360,7 +381,7 @@ export class PlanFeaturesHeader extends Component {
 			'is-logged-in-monthly-pricing': isLoggedInMonthlyPricing,
 		} );
 		const perMonthDescription = this.getPerMonthDescription() || billingTimeFrame;
-		if ( isInSignup || plansWithScroll ) {
+		if ( isInSignup || plansWithScroll || isInMarketplace ) {
 			return (
 				<div className={ 'plan-features__header-billing-info' }>
 					<span>{ perMonthDescription }</span>
@@ -565,6 +586,7 @@ PlanFeaturesHeader.propTypes = {
 	discountPrice: PropTypes.number,
 	isInJetpackConnect: PropTypes.bool,
 	isInSignup: PropTypes.bool,
+	isInMarketplace: PropTypes.bool,
 	isJetpack: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	newPlan: PropTypes.bool,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -99,13 +99,22 @@ export class PlanFeatures extends Component {
 	}
 
 	render() {
-		const { isInSignup, planProperties, plans, selectedPlan, withScroll, translate } = this.props;
+		const {
+			isInSignup,
+			planProperties,
+			plans,
+			selectedPlan,
+			withScroll,
+			translate,
+			isInMarketplace,
+		} = this.props;
 		const tableClasses = classNames(
 			'plan-features__table',
 			`has-${ planProperties.length }-cols`
 		);
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
+			'plan-features--marketplace': isInMarketplace,
 		} );
 		const planWrapperClasses = classNames( {
 			'plans-wrapper': isInSignup,
@@ -374,6 +383,7 @@ export class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
+				isInMarketplace,
 			} = properties;
 			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
 			const planDescription = getPlanDescriptionForMobile( {
@@ -408,6 +418,7 @@ export class PlanFeatures extends Component {
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
+						isInMarketplace={ isInMarketplace }
 					/>
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions
@@ -433,6 +444,7 @@ export class PlanFeatures extends Component {
 						planType={ planName }
 						primaryUpgrade={ primaryUpgrade }
 						selectedPlan={ selectedPlan }
+						isInMarketplace={ isInMarketplace }
 					/>
 					<FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
 						{ this.renderMobileFeatures( features ) }
@@ -853,6 +865,7 @@ PlanFeatures.propTypes = {
 	canPurchase: PropTypes.bool.isRequired,
 	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
 	isInSignup: PropTypes.bool,
+	isInMarketplace: PropTypes.bool,
 	isJetpack: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	// either you specify the plans prop or isPlaceholder prop
@@ -873,6 +886,7 @@ PlanFeatures.propTypes = {
 PlanFeatures.defaultProps = {
 	basePlansPath: null,
 	isInSignup: false,
+	isInMarketplace: false,
 	isJetpack: false,
 	selectedSiteSlug: '',
 	siteId: null,
@@ -922,6 +936,7 @@ const ConnectedPlanFeatures = connect(
 			popularPlanSpec,
 			kindOfPlanTypeSelector,
 			isInVerticalScrollingPlansExperiment,
+			isInMarketplace,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -1051,6 +1066,7 @@ const ConnectedPlanFeatures = connect(
 					rawPrice,
 					relatedMonthlyPlan,
 					siteIsPrivateAndGoingAtomic,
+					isInMarketplace,
 				};
 			} )
 		);

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -11,7 +11,8 @@ $plan-features-sidebar-width: 272px;
 	// need to be moved to the corresponding selectors
 
 	// To be moved to line 651 approximately
-	.plan-features--signup {
+	.plan-features--signup,
+	.plan-features--marketplace {
 		.plan-features__table {
 			@media ( max-width: 1040px ) {
 				display: none;
@@ -28,9 +29,9 @@ $plan-features-sidebar-width: 272px;
 				.plan-features__summary,
 				.plan-features__description {
 					padding: 16px 33px;
-
 				}
-				.plan-features--signup .plan-features__pricing {
+				.plan-features--signup .plan-features__pricing,
+				.plan-features--marketplace .plan-features__pricing {
 					padding: 0 7px;
 				}
 			}
@@ -103,6 +104,20 @@ $plan-features-sidebar-width: 272px;
 
 			.plan-features__mobile-plan {
 				max-width: 408px;
+			}
+		}
+	}
+
+	.plan-features--marketplace {
+		.plan-features__mobile {
+			.plan-features__header {
+				display: block;
+				position: relative;
+				text-align: left;
+				box-sizing: border-box;
+				border-top: solid 1px;
+				border-radius: 2px 2px 0 0;
+				padding: 20px;
 			}
 		}
 	}
@@ -737,7 +752,8 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	overflow-x: auto;
 }
 
-.plan-features--signup {
+.plan-features--signup,
+.plan-features--marketplace {
 	margin: 0 auto;
 
 	.signup__steps & {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -62,7 +62,6 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
-import { isMarketplaceFlow } from '../plugins/flows';
 import PlanTypeSelector from './plan-type-selector';
 import PlanFAQ from './plansStepFaq';
 import WpcomFAQ from './wpcom-faq';
@@ -191,6 +190,7 @@ export class PlansFeaturesMain extends Component {
 			translate,
 			locale,
 			flowName,
+			isInMarketplace,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -263,6 +263,7 @@ export class PlansFeaturesMain extends Component {
 					siteId={ siteId }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
+					isInMarketplace={ isInMarketplace }
 				/>
 			</div>
 		);
@@ -366,7 +367,7 @@ export class PlansFeaturesMain extends Component {
 			selectedPlan,
 			plansWithScroll,
 			isAllPaidPlansShown,
-			flowName,
+			isInMarketplace,
 			sitePlanSlug,
 		} = this.props;
 
@@ -401,7 +402,7 @@ export class PlansFeaturesMain extends Component {
 
 		const withIntervalSelector = this.getKindOfPlanTypeSelector( this.props ) === 'interval';
 
-		if ( isMarketplaceFlow( flowName ) ) {
+		if ( isInMarketplace ) {
 			// workaround to show free plan on both monthly/yearly toggle
 			if ( sitePlanSlug === PLAN_FREE && ! plans.includes( PLAN_FREE ) ) {
 				// elements are rendered in order, needs to be the first one
@@ -549,6 +550,7 @@ PlansFeaturesMain.propTypes = {
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
+	isInMarketplace: PropTypes.bool,
 
 	onUpgradeClick: PropTypes.func,
 	redirectTo: PropTypes.string,

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -262,6 +262,10 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 		margin: 8px auto 16px;
 		max-width: 480px;
 
+		@media screen and ( max-width: 960px ) {
+			margin: 8px 16px 16px;
+		}
+
 		.segmented-control__link {
 			padding: 8px 12px;
 		}

--- a/client/my-sites/plugins/flows.ts
+++ b/client/my-sites/plugins/flows.ts
@@ -1,4 +1,0 @@
-export const MARKETPLACE_FLOW = 'marketplace';
-export const isMarketplaceFlow = ( flowName: string | null ) => {
-	return MARKETPLACE_FLOW === flowName;
-};

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -4,6 +4,8 @@ import {
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 } from '@automattic/calypso-products';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,7 +18,6 @@ import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
-import { MARKETPLACE_FLOW } from 'calypso/my-sites/plugins/flows';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -27,6 +28,11 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );
+	const isDesktop = useDesktopBreakpoint();
+
+	const planClasses = classNames( 'plans', {
+		'in-vertically-scrolled-plans-experiment': ! isDesktop,
+	} );
 
 	const dispatch = useDispatch();
 
@@ -70,7 +76,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 				subHeaderText={ `Choose the plan that's right for you and reimagine what's possible with plugins` }
 				brandFont
 			/>
-			<div className="plans">
+			<div className={ planClasses }>
 				<PlansFeaturesMain
 					basePlansPath="/plugins/plans"
 					showFAQ={ false }
@@ -78,8 +84,9 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					intervalType={ intervalType }
 					selectedPlan={ PLAN_BUSINESS }
 					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
-					flowName={ MARKETPLACE_FLOW }
-					shouldShowPlansFeatureComparison
+					isInMarketplace
+					shouldShowPlansFeatureComparison={ isDesktop }
+					isInVerticalScrollingPlansExperiment={ isDesktop }
 					isReskinned
 				/>
 			</div>


### PR DESCRIPTION
#### Proposed Changes

Following suggestions on #68123 and using same design as `/starts/plans`, we show plans on `/plugins/plans/:site` using small devices. 

#### Acceptance criteria

- We have a mobile view of the /plugin/plans page
- It works when a given plugin purchase is selected on /plugins page
- It works when we use the business upsell nudge of /plugins page

#### Testing Instructions

* Go to `/plugins/plans/:site` using mobile view
* Compare mobile & desktop view to confirm data is correct.
* Check the design look like the screenshot (on mobile devices).

#### Screenshot
![image](https://user-images.githubusercontent.com/402286/192040155-b812ad1c-7616-4698-991c-5a153bccb7ba.png)

#### Important

The Interval selector shows different designs depending on which device you start viewing the page, If you start on desktop view, you will see the first one. If you start on mobile view, you will see the second.
| Desktop | Mobile |
| --- | --- |
| <img width="270" alt="image" src="https://user-images.githubusercontent.com/402286/192040534-a7a12c5b-2f89-4125-bfe8-9fa0abe4e292.png"> | <img width="270" alt="image" src="https://user-images.githubusercontent.com/402286/192040470-772612ca-4547-4fdf-b1eb-64c562c76eb5.png"> |



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67961 