### PR TITLE
Tailored Flows: fix pattern picker navigation

### DIFF
--- a/packages/pattern-picker/src/styles.scss
+++ b/packages/pattern-picker/src/styles.scss
@@ -80,6 +80,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	direction: ltr;
 	padding: 20px;
 	box-sizing: border-box;
+	pointer-events: none;
 
 	@include break-small {
 		display: flex;
@@ -100,6 +101,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	display: flex;
 	box-shadow: 1px 1px 3px 0 rgb(0 0 0 / 18%);
 	transition: opacity 0.3s ease-in-out;
+	pointer-events: all;
 
 	cursor: pointer;
 
@@ -110,6 +112,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 
 	&.is-hidden {
 		visibility: hidden;
+		pointer-events: none;
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

* There is a strip in the middle of the screen where clicking doesn't do anything in the Pattern Picker. <img width="1923" alt="image" src="https://user-images.githubusercontent.com/17054134/192136613-2cda2b38-7f0c-4dd2-bdbe-f983cf5a4a3d.png">
* This fixes it by adding `pointer-events: none` to this strip. Allowing the clicks to pass through.

#### Testing Instructions

1. Using the live link below, go to /setup/patterns?flow=link-in-bio
2. Hover a design while having your pointer right between the nav arrows.
3. The cursor should be `pointer`. Click should work.
