### PR TITLE
Tailored Flows: add transition to contrast warning

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
 import React, { FormEvent, useEffect } from 'react';
 import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -213,18 +214,22 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					value={ accentColor.hex }
 				/>
 			</FormFieldset>
-			{ ! hasMinContrast( accentColor.rgb ) && (
-				<div className="newsletter-setup__contrast-warning" style={ { display: 'flex' } }>
-					<div className="newsletter-setup__contrast-warning-icon-container">
-						<Icon icon={ tip } size={ 20 } />
-					</div>
-					<div>
-						{ __(
-							'The accent color chosen may make your buttons and links illegible. Consider picking a darker color.'
-						) }
-					</div>
+			<div
+				className={ classNames( 'newsletter-setup__contrast-warning', {
+					'is-visible': ! hasMinContrast( accentColor.rgb ),
+				} ) }
+				aria-hidden={ hasMinContrast( accentColor.rgb ) }
+				role="alert"
+			>
+				<div className="newsletter-setup__contrast-warning-icon-container">
+					<Icon icon={ tip } size={ 20 } />
 				</div>
-			) }
+				<div>
+					{ __(
+						'The accent color chosen may make your buttons and links illegible. Consider picking a darker color.'
+					) }
+				</div>
+			</div>
 			<Button className="newsletter-setup__submit-button" type="submit" primary>
 				{ __( 'Continue' ) }
 			</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -87,7 +87,14 @@ $border-radius: 4px;
 		.newsletter-setup__contrast-warning {
 			display: flex;
 			font-size: $font-body-small;
-			margin-bottom: 32px;
+			height: 0;
+			transition: height 0.5s ease-in-out, opacity 0.5s ease-in-out;
+			opacity: 0;
+
+			&.is-visible {
+				height: 80px;
+				opacity: 1;
+			}
 
 			.newsletter-setup__contrast-warning-icon-container {
 				margin-top: 4px;


### PR DESCRIPTION
#### Proposed Changes

* This adds a transition when showing the color contrast warning.

#### Testing Instructions

1. Go to /setup?flow=newsletter.
2. Reach the site setup step.
3. Play with the color picker.

https://user-images.githubusercontent.com/17054134/192143206-1e9dd00b-0b78-4527-823c-089f9bd27c3d.mov

Fixes: https://github.com/Automattic/wp-calypso/issues/68212