### PR TITLE
Tailored flows: improve color picker UX in NL flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -59,7 +59,6 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const accentColorRef = React.useRef< HTMLInputElement >( null );
-
 	const site = useSite();
 	const usesSite = !! useSiteSlugParam();
 
@@ -161,13 +160,22 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 				position="top left"
 				onClose={ () => setColorPickerOpen( false ) }
 			>
-				<ColorPicker
-					disableAlpha
-					color={ accentColor.hex }
-					onChangeComplete={ ( { hex, rgb } ) =>
-						setAccentColor( { hex, rgb: rgb as unknown as RGB } )
-					}
-				/>
+				{ /* add a form so pressing enter in the color input field will close the picker */ }
+				<form
+					onSubmit={ ( event ) => {
+						event.preventDefault();
+						event.stopPropagation();
+						setColorPickerOpen( false );
+					} }
+				>
+					<ColorPicker
+						disableAlpha
+						color={ accentColor.hex }
+						onChangeComplete={ ( { hex, rgb } ) =>
+							setAccentColor( { hex, rgb: rgb as unknown as RGB } )
+						}
+					/>
+				</form>
 			</Popover>
 			<FormFieldset>
 				<FormLabel htmlFor="siteTitle">{ __( 'Site name' ) }</FormLabel>
@@ -208,7 +216,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					} }
 					name="accentColor"
 					id="accentColor"
-					onFocus={ () => setColorPickerOpen( ! colorPickerOpen ) }
+					onFocus={ () => setColorPickerOpen( true ) }
 					readOnly
 					value={ accentColor.hex }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -77,6 +77,7 @@ $border-radius: 4px;
 				/* Overwrites the transition value set by FormInput component.
 				It was the cause of the https://github.com/Automattic/wp-calypso/issues/67326 */
 				transition: none;
+				cursor: pointer;
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* This makes focusing on the color input field always open the color picker (instead of toggling). This results in a much more predictable UI. Since the popover does an excellent job handling the clicks outside the picker.
* This also wraps the picker with a form element for more accessibility. Now, pressing the enter button inside the picker's input field will submit the color and close the picker.
* It also gives the field a `pointer` cursor to entice clicking.

#### Testing Instructions

1. Go to /setup/?flow=newsletter.
2. Reach the setup step.
3. Play with the picker as much you can and see if you can break it.

Fixes: https://github.com/Automattic/wp-calypso/issues/68211