### PR TITLE
Tailored Flows - adjust CTA heights in setup steps to match input fields

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -78,9 +78,9 @@ $font-family: "SF Pro Text", $sans;
 		background-color: var(--studio-blue-50);
 		border-radius: 4px;
 		font-weight: 500;
-		border: none;
 		width: 100%;
-		height: 40px;
+		// adds +2 px of padding to the button to match the input field height
+		padding: 10px 14px;
 		margin-top: 16px;
 
 		&:hover:not([disabled]) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -119,6 +119,8 @@ $border-radius: 4px;
 
 		.newsletter-setup__submit-button {
 			border-radius: $border-radius;
+			// adds +2 px of padding to the button to match the input field height
+			padding: 10px 14px;
 		}
 	}
 }


### PR DESCRIPTION
#### Testing Instructions

1. Go to /setup/?flow=newsletter.
2. Reach the setup step.
3. The submit button should have 44px height.
4. Go to /setup/?flow=link-in-bio.
2. Reach the setup step.
3. The submit button should have 44px height.

Fixes: https://github.com/Automattic/wp-calypso/issues/68210