### PR TITLE
Tailored Flows: fix pattern picker on Safari

### DIFF
--- a/packages/pattern-picker/src/item.tsx
+++ b/packages/pattern-picker/src/item.tsx
@@ -71,14 +71,12 @@ export function Item( { style, onClick, pattern, className }: Props ) {
 				style={ style }
 				className={ cx( 'pattern-picker__item', className ) }
 			>
-				<div className="pattern-picker__item-iframe-wrapper">
-					<MShotsImage
-						url={ getPatternPreviewUrl( pattern ) }
-						options={ { w: 400, vpw: 400, vph: 872, format: 'png' } }
-						alt={ pattern.title }
-						aria-labelledby=""
-					/>
-				</div>
+				<MShotsImage
+					url={ getPatternPreviewUrl( pattern ) }
+					options={ { w: 400, vpw: 400, vph: 872, format: 'png' } }
+					alt={ pattern.title }
+					aria-labelledby=""
+				/>
 			</button>
 		</div>
 	);

--- a/packages/pattern-picker/src/styles.scss
+++ b/packages/pattern-picker/src/styles.scss
@@ -41,6 +41,12 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 		filter: blur(0);
 	}
 
+	.mshots-image__container {
+		display: block;
+		height: 100%;
+		width: 100%;
+	}
+
 	.mshots-image-visible {
 		max-width: 100%;
 

--- a/packages/pattern-picker/src/styles.scss
+++ b/packages/pattern-picker/src/styles.scss
@@ -49,10 +49,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 
 	.mshots-image-visible {
 		max-width: 100%;
-
-		@media ( max-height: 375px ) {
-			margin-top: 16px;
-		}
 	}
 }
 

--- a/packages/pattern-picker/src/styles.scss
+++ b/packages/pattern-picker/src/styles.scss
@@ -50,9 +50,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	.mshots-image-visible {
 		max-width: 100%;
 
-		// compensate for the item border to avoid cropping the image's top.
-		margin-top: 10px;
-
 		@media ( max-height: 375px ) {
 			margin-top: 16px;
 		}


### PR DESCRIPTION
#### Proposed Changes

* This removes an unneeded div in pattern-picker. Which also fixes [this issue](https://github.com/Automattic/wp-calypso/issues/68188).
* I gives the mshots containers width: 100% and height: 100% for a nicer loading experience when the images are being loaded.

#### Testing Instructions

1. Go to /setup/patterns?flow=link-in-bio
2. Patterns should look perfect in Chrome desktop, Chrome mobile, Safari desktop, and Safari mobile.

Closes #68188
