### PR TITLE
Pricing page rework: Fix /jetpack/connect/plans page CSS breakpoint 

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -11,7 +11,7 @@ $wpcom-menu-collapse: 783px;
 	--jetpack-corners-soft: 4px;
 }
 
-:is(.is-group-sites.is-section-plans, .is-section-jetpack-connect) .jetpack-product-store {
+.is-group-sites.is-section-plans .jetpack-product-store {
 
 	:is(.button[disabled], .button:disabled, .button.disabled) {
 		background-color: var(--studio-gray-5);

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -72,3 +72,10 @@ $wpcom-menu-collapse: 783px;
 		}
 	}
 }
+
+// Remove extra padding on wordpress.com/jetpack/connect/plans/:site page (to match the same
+// padding on the cloud.jetpack.com/pricing page) (limited browser support with :has()).
+.is-section-jetpack-connect.has-no-sidebar .layout__content:has(.jetpack-pricing-page-rework-v1) {
+	padding-left: 0;
+	padding-right: 0;
+}


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an incorrect CSS breakpoint issue on the /jetpack/connect/plans page where the "most popular" products split into 2 columns much to late (viewport too wide).(See image).
The styles/breakpoint causing this issue works well for the wordpress.com/plans page because of the existence of the wpcom sidebar menu, but the /jetpack/connect/plans page does not have the sidebar menu and therefore this style/breakpoint should not be applied to the jetpack/connect/plans page.

BEFORE | AFTER
--- | ---
![Screenshot on 2022-09-25 at 10-28-33](https://user-images.githubusercontent.com/11078128/192149013-c919cb58-984e-45bc-9b8e-5ec32d77e674.png) | ![Screenshot on 2022-09-25 at 10-29-01](https://user-images.githubusercontent.com/11078128/192149022-256536b0-9a81-4ead-b9ff-a9dac365048d.png)

Fixes: 1202796695664022-as-1203029862618676

#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Calypso Live link below and wait for the redirect to complete, then go to `/jetpack/connect/plans:site` (where `: site` is the site slug of a connected Jetpack site you own that does not own any products or plans (has only Jetpack Free))
    - or boot up this PR 
        - Run `git fetch && git checkout fix/jetpack-connect-plans-breakpoint`
        - Run `yarn start`
        - Goto go to `wordpress.com/jetpack/connect/plans:site` (where `: site` is the site slug of a connected Jetpack site you own that does not own any products or plans (has only Jetpack Free))
- Verify that the breakpoint now works correctly and looks good (Compared to wordpress.com staging)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203029862618676