### PR TITLE
Boost product: Move 'Automated critical CSS' to top of features list.

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -634,12 +634,16 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Quick and accurate spelling correction' ),
 	];
 	const boostIncludesInfo = [
+		translate( '{{strong}}Automated critical CSS{{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} ),
 		translate( 'Site performance scores' ),
 		translate( 'One-click optimization' ),
 		translate( 'Defer non-essential JavaScript' ),
 		translate( 'Optimize CSS loading' ),
 		translate( 'Lazy image loading' ),
-		translate( 'Automated critical CSS (Paid feature)' ),
 	];
 	const socialIncludesInfo = [
 		translate( 'Automatically share your posts and products on social media' ),


### PR DESCRIPTION
#### Proposed Changes

In the pricing page product lightbox for the Boost product, this PR removes the "(Paid feature)" from the "Automated critical CSS" feature and moved the feature up to the top. Also makes it bold because this feature is the difference between the paid product and the free one.  (See before & after screenshots):

Fixes: 1202796695664022-as-1203029862618675

BEFORE | AFTER
--- | ---
![Markup 2022-09-25 at 10 56 06](https://user-images.githubusercontent.com/11078128/192150402-72bd30ad-90f8-44e2-8dab-d4701b83f035.png) | ![Markup 2022-09-25 at 10 56 50](https://user-images.githubusercontent.com/11078128/192150406-a8a3b186-3229-4789-b226-05177b653770.png)

#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout update/boost-product-includes-info`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Go to the "Boost" product and click "More about Boost" to open the lightbox.
- In the "Includes" section, verify that the "Automated critical CSS" feature has been moved to the top. Verify the "(Paid feature)" text has been removed.  (See before & after screenshots above.)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203029862618675