### PR TITLE
Style selection: Update style indicator's color display

### DIFF
--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -49,12 +49,12 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 		>
 			<span
 				style={ {
-					backgroundColor: styles.color.background,
-					color: styles.color.foreground || styles.color.primary,
+					background: `linear-gradient(
+							to right,
+							${ styles.color.background } 0 50%,
+							${ styles.color.foreground || styles.color.primary } 50% 100%)`,
 				} }
-			>
-				A
-			</span>
+			/>
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -1,16 +1,16 @@
 .style-variation__badge-more-wrapper,
 .style-variation__badge-wrapper {
 	display: inline-block;
-	height: 24px;
+	height: 20px;
 	vertical-align: top;
-	width: 24px;
+	width: 20px;
 
 	> * {
 		align-items: center;
 		background: #fff;
 		border: none;
 		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		box-shadow: inset 0 0 0 1px rgb(0 0 0 / 5%);
+		box-shadow: inset 0 0 0 1px rgb(0 0 0 / 20%);
 		color: var(--studio-gray-80);
 		cursor: pointer;
 		display: inline-flex;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -233,7 +233,7 @@
 		justify-content: flex-end;
 		flex-grow: 1;
 		flex-wrap: wrap;
-		gap: 2px;
+		gap: 4px;
 	}
 
 	.design-picker__pricing-description {


### PR DESCRIPTION
#### Proposed Changes

According to the comment in 7l53h5fxAUNjVRBQ82YFwn-fi-1205%3A57097, we are updating how colors are displayed in the style variation indicator to be a circle with two colors. See screenshots for comparison:

Old version | New version
--- | ---
![Screen Shot 2022-09-26 at 2 00 38 PM](https://user-images.githubusercontent.com/797888/192203948-1986b4ae-660f-4f88-a524-8c49a3977f6f.png) | ![Screen Shot 2022-09-26 at 2 02 02 PM](https://user-images.githubusercontent.com/797888/192204133-28665059-71dc-4148-8cf0-b0544277a0b3.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Ensure that the style variation indicator is updated as described above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->