### PR TITLE
Hide initial domain search query in the launch flow

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -547,7 +547,9 @@ export class SiteSettingsFormGeneral extends Component {
 			querySiteDomainsComponent = '';
 		} else {
 			btnComponent = (
-				<Button href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings` }>
+				<Button
+					href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&hide_initial_query=yes` }
+				>
 					{ btnText }
 				</Button>
 			);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -483,6 +483,7 @@ class DomainsStep extends Component {
 
 		// Search using the initial query but do not show the query on the search input field.
 		const hideInitialQuery = get( this.props, 'queryObject.hide_initial_query', false ) === 'yes';
+		initialState.hideInitialQuery = hideInitialQuery;
 
 		if (
 			// If we landed here from /domains Search or with a suggested domain.
@@ -497,7 +498,6 @@ class DomainsStep extends Component {
 				// filter before counting length
 				initialState.loadingResults =
 					getDomainSuggestionSearch( getFixedDomainSearch( initialQuery ) ).length >= 2;
-				initialState.hideInitialQuery = hideInitialQuery;
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* As suggested in [this comment](https://github.com/Automattic/wp-calypso/pull/68155#pullrequestreview-1118333866), the initial domain search query will be hidden in the launch flow.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on "Launch site" button in the Settings > General and verify that on initial load of the domain step in the launch flow, the search query is hidden.
