### PR TITLE
Disable scrolling sync when Site Picker is shown in SideBar

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -15,6 +15,7 @@
 	z-index: z-index("root", ".site-selector");
 	display: flex;
 	flex-direction: column;
+	height: calc(100vh - var(--masterbar-height));
 
 	&.is-large .search {
 		display: flex;
@@ -170,7 +171,6 @@
 // The actual list of sites
 .site-selector__sites {
 	flex: 1;
-	max-height: calc(100% - 93px);
 	overflow-y: auto;
 	background: var(--color-surface);
 

--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -41,9 +41,10 @@ function useBodyClass( prefix, value ) {
 /**
  * @param {{group?: string, section?: string, bodyClass?: string[]}} props
  */
-export default function BodySectionCssClass( { group, section, bodyClass } ) {
+export default function BodySectionCssClass( { group, section, layoutFocus, bodyClass } ) {
 	useBodyClass( 'is-group-', group );
 	useBodyClass( 'is-section-', section );
+	useBodyClass( 'is-focus-', layoutFocus );
 	useEffect( () => {
 		if ( ! Array.isArray( bodyClass ) || bodyClass.length === 0 ) {
 			return;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -260,6 +260,7 @@ class Layout extends Component {
 				<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />
 				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<BodySectionCssClass
+					layoutFocus={ this.props.currentLayoutFocus }
 					group={ this.props.sectionGroup }
 					section={ this.props.sectionName }
 					{ ...optionalBodyProps() }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -1,3 +1,12 @@
+// Disable scroll when Site Picker is active. In future,
+// the Site Picker's Site List could be made compatible
+// SidebarScrollSynchronizer. Currently, it is not and
+// sometimes fixed content gets rendered outside of the
+// viewport. See `BodySectionCssClass` also.
+body.is-focus-sites {
+	overflow: hidden;
+}
+
 /**
  * /*
  * 	Layout Elements
@@ -129,37 +138,8 @@
 	.has-no-sidebar & {
 		display: none;
 	}
-}
 
-// Setup the site-selector element. Its default
-// position is off screen.
-.layout__secondary .site-selector {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	pointer-events: none;
-	transform: translateX(calc(-1 * var(--sidebar-width-max)));
-
-	.site,
-	.all-sites {
-		.site__title,
-		.site__domain {
-			&::after {
-				@include long-content-fade( $color: var( --color-sidebar-background ) );
-			}
-		}
-	}
-
-	@include breakpoint-deprecated( "<660px" ) {
-		-webkit-overflow-scrolling: touch;
-		transform: translateX(-100%);
-	}
-}
-
-// Secondary Layout overrides
-.layout__secondary {
+	// Secondary Layout overrides
 	.site__title {
 		color: var(--color-sidebar-text);
 	}
@@ -174,6 +154,16 @@
 	}
 
 	.site-selector {
+		// Setup the site-selector element. Its default
+		// position is off screen.
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		transform: translateX(calc(-1 * var(--sidebar-width-max)));
+
 		&.is-large .site-selector__sites {
 			border-color: var(--color-sidebar-border);
 		}
@@ -208,6 +198,21 @@
 
 		.all-sites {
 			border-color: var(--color-sidebar-border);
+		}
+
+		.site,
+		.all-sites {
+			.site__title,
+			.site__domain {
+				&::after {
+					@include long-content-fade( $color: var( --color-sidebar-background ) );
+				}
+			}
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			-webkit-overflow-scrolling: touch;
+			transform: translateX(-100%);
 		}
 	}
 

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -17,12 +17,6 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 	const secondaryElHeight = secondaryEl?.scrollHeight;
 	const masterbarHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
 
-	// if the Site Picker is shown, don't sync scrolling. The Site Picker has a
-	// nested scroll window which is not currently compatible with the sync logic here
-	if ( secondaryEl?.querySelector( '.site-selector__sites' ) ) {
-		return;
-	}
-
 	// Check whether we need to adjust content height so that scroll events are triggered.
 	// Sidebar has overflow: initial and position:fixed, so content is our only chance for scroll events.
 	if ( contentEl && contentHeight && masterbarHeight && secondaryElHeight ) {

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -17,6 +17,12 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 	const secondaryElHeight = secondaryEl?.scrollHeight;
 	const masterbarHeight = document.getElementById( 'header' )?.getBoundingClientRect().height;
 
+	// if the Site Picker is shown, don't sync scrolling. The Site Picker has a
+	// nested scroll window which is not currently compatible with the sync logic here
+	if ( secondaryEl?.querySelector( '.site-selector__sites' ) ) {
+		return;
+	}
+
 	// Check whether we need to adjust content height so that scroll events are triggered.
 	// Sidebar has overflow: initial and position:fixed, so content is our only chance for scroll events.
 	if ( contentEl && contentHeight && masterbarHeight && secondaryElHeight ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68251

#### Proposed Changes

* There is some sync scrolling logic in [SidebarScrollSynchronizer](https://github.com/Automattic/wp-calypso/blob/262c9458981e15997154fc400d4b154f254ea843/client/layout/index.jsx#L55) which isn't currently compatible with the Site Picker when it's shown in the SideBar. This PR disables `body` scrolling when the Site Picker is active which effectively disables the problematic logic so that the search input and two buttons in the Site Picker view are always visible. You can check https://github.com/Automattic/wp-calypso/issues/68251 for more details about the issue that this PR addresses. 

**If you think the Site Picker's scroll view (Site List) should be synced with the `#content` element, as we do for the regular `SideBar` Admin Menu, please add a comment.**


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

First, reproduce the issue on the `trunk` branch.

1. Open the Admin Dashboard at `/home/:site`. Make sure the SideBar is open 
2. Click the "Switch site" button to enable the Site Picker
3. Confirm you can see Sites search input, the "Manage sites" button and the "Add new site" button
4. Scroll up/down the content section, and you should see that the "Add new site" button is not on screen as per the video above

Now check out this branch and run your local Calypso deployment. Verify the issue is no longer present and that the "Add new site" button is always visible. You can try testing this using:
-  different screen sizes, including mobile view
- navigating from different pages e.g. `/home/.:site` -> `Switch site`, `/inbox/:site` -> `Switch site` etc. 
- different browsers
- different scroll positions on the `#content` element (e.g. scroll halfway, scroll to bottom etc.).  

Tested with Chrome and Firefox. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
