### PR TITLE
Pricing page: Add Website firewall first bullet in Jetpack Scan included features.

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -622,6 +622,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Flexible API that works with any type of site' ),
 	];
 	const scanIncludesInfo = [
+		translate( 'Website firewall (WAF beta)' ),
 		translate( 'Automated daily scanning' ),
 		translate( 'One-click fixes for most issues' ),
 		translate( 'Instant email threat notifications' ),


### PR DESCRIPTION
#### Proposed Changes

* Add 'Website firewall (WAF beta)' in Jetpack Scan included features.

#### Testing Instructions

1. * Run `git fetch && git checkout add/scan-waf-info-in-lightbox`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
3. Click 'More about Scan' links to display the lightbox.
4. Confirm the first bullet says 'Website Firewall (WAF beta)' in the `includes` list.

<img width="1100" alt="Screen Shot 2022-09-26 at 5 08 36 PM" src="https://user-images.githubusercontent.com/56598660/192240483-7507ec18-d9c8-4ab5-9780-7122856ffa1c.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203044533476980

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203044533476980