### PR TITLE
Style selection: Improve UI/UX for full-screen theme preview

### DIFF
--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -1,8 +1,9 @@
+import { Spinner } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
-import { ReactChild, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import { DEVICE_TYPE } from '../../constants';
 import Toolbar from './toolbar';
@@ -16,7 +17,6 @@ interface Viewport {
 
 interface ThemePreviewProps {
 	url: string;
-	loadingMessage?: string | ReactChild;
 	inlineCss?: string;
 	viewportWidth?: number;
 	isFitHeight?: boolean;
@@ -27,7 +27,6 @@ interface ThemePreviewProps {
 
 const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	url,
-	loadingMessage,
 	inlineCss,
 	viewportWidth,
 	isFitHeight,
@@ -109,8 +108,10 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			{ containerResizeListener }
 			{ isShowDeviceSwitcher && <Toolbar device={ device } onDeviceClick={ handleDeviceClick } /> }
 			<div className="theme-preview__frame-wrapper">
-				{ ! isLoaded && loadingMessage && (
-					<div className="theme-preview__frame-message">{ loadingMessage }</div>
+				{ ! isLoaded && (
+					<div className="theme-preview__frame-message">
+						<Spinner />
+					</div>
 				) }
 				<iframe
 					ref={ iframeRef }

--- a/packages/design-picker/src/components/theme-preview/style.scss
+++ b/packages/design-picker/src/components/theme-preview/style.scss
@@ -49,6 +49,11 @@
 				display: flex;
 				flex-direction: column;
 				justify-content: center;
+
+				svg {
+					height: 20px;
+					width: 20px;
+				}
 			}
 		}
 	}

--- a/packages/design-preview/src/components/site-preview.tsx
+++ b/packages/design-preview/src/components/site-preview.tsx
@@ -1,5 +1,4 @@
 import { ThemePreview } from '@automattic/design-picker';
-import { translate } from 'i18n-calypso';
 
 interface SitePreviewProps {
 	url: string;
@@ -16,9 +15,6 @@ const SitePreview: React.FC< SitePreviewProps > = ( {
 		<div className="design-preview__site-preview">
 			<ThemePreview
 				url={ url }
-				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
-					components: { strong: <strong /> },
-				} ) }
 				inlineCss={ inlineCss }
 				isShowFrameBorder
 				isShowDeviceSwitcher

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -173,13 +173,13 @@ $break-design-preview: 1024px;
 	&:hover,
 	&:focus-visible {
 		&::after {
-			box-shadow: 0 0 0 2px var(--studio-gray);
+			box-shadow: 0 0 0 2px var(--studio-blue-50);
 		}
 	}
 
 	&--is-selected {
 		&::after {
-			box-shadow: 0 0 0 2px var(--studio-blue-50);
+			box-shadow: 0 0 0 2px var(--studio-gray);
 		}
 	}
 

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -160,7 +160,6 @@ $break-design-preview: 1024px;
 		&::after {
 			border-radius: 3px; /* stylelint-disable-line scales/radii */
 			bottom: -3px;
-			box-shadow: 0 0 0 2px var(--studio-blue-50);
 			content: "";
 			display: block;
 			left: -3px;
@@ -168,6 +167,19 @@ $break-design-preview: 1024px;
 			position: absolute;
 			right: -3px;
 			top: -3px;
+		}
+	}
+
+	&:hover,
+	&:focus-visible {
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-gray);
+		}
+	}
+
+	&--is-selected {
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-blue-50);
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This PR addresses two feedback regarding the UI/UX of the full-screen theme preview.

1. Style variation preview button now has a gray border on hover/focus, instead of the same border color as the selected button.

Before | After
--- | ---
![Screen Shot 2022-09-26 at 5 13 19 PM](https://user-images.githubusercontent.com/797888/192239068-31f2d884-812e-4223-8545-acdc0bbf33f4.png) |  ![Screen Shot 2022-09-26 at 5 13 33 PM](https://user-images.githubusercontent.com/797888/192239125-a32b5ef1-a151-4746-99c5-310e07c24b68.png)

2. Site preview will now show a spinner while it's loading, instead of the text message "One moment please... loading your site". This is to achieve more consistency between loading states across Calypso, read more here p1663833727740809-slack-C03E1LGV796

Before | After
--- | ---
![Screen Shot 2022-09-26 at 5 16 19 PM](https://user-images.githubusercontent.com/797888/192239818-6e4abd43-d866-4a69-81cb-700f2fe921e4.png) |  ![Screen Shot 2022-09-26 at 5 16 37 PM](https://user-images.githubusercontent.com/797888/192239867-1976fda8-8350-4502-8a6a-274a961d414f.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Ensure that the UI/UX is updated as described above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
