### PR TITLE
Style selection: Add background/color transition to style preview

### DIFF
--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -15,6 +15,8 @@ interface PreviewProps {
 	recordDeviceClick: ( device: string ) => void;
 }
 
+const INJECTED_CSS = `body{ transition: background-color 0.2s linear, color 0.2s linear; };`;
+
 const getVariationBySlug = ( variations: StyleVariation[], slug: string ) =>
 	variations.find( ( variation ) => variation.slug === slug );
 
@@ -30,10 +32,11 @@ const Preview: React.FC< PreviewProps > = ( {
 } ) => {
 	const sitePreviewInlineCss = useMemo( () => {
 		if ( selectedVariation ) {
-			return (
+			const inlineCss =
 				selectedVariation.inline_css ??
-				( getVariationBySlug( variations, selectedVariation.slug )?.inline_css || '' )
-			);
+				( getVariationBySlug( variations, selectedVariation.slug )?.inline_css || '' );
+
+			return inlineCss + INJECTED_CSS;
 		}
 
 		return '';


### PR DESCRIPTION
#### Proposed Changes

This PR injects CSS to add background/color transition to the theme preview. This is done with the intention of smoothening the style switching process. See recording for a reference of the transition effect:

https://user-images.githubusercontent.com/797888/192253442-67c9ead1-4b82-488a-ad59-b1999cfda94a.mp4

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Ensure that the style switching process has a transition like demonstrated in the recording above.
 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
