### PR TITLE
update: lightbox checkmark position

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -163,6 +163,7 @@
 		font-weight: 400;
 		font-size: $font-body;
 		color: #3c434a;
+		background-position-y: 5px;
 	}
 
 	.foldable-card.card {


### PR DESCRIPTION
#### Proposed Changes

Small adjustment to lightbox checkmark position

#### Testing Instructions
- Use one method from
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - **OR** run this PR locally
        - download branch locally and run yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Verify `Includes` and `Benefits` sections checkmarks are inline with text

| Before | After |
| ------ | ------ |
| <img width="75" alt="Screenshot 2022-09-26 at 14 15 20" src="https://user-images.githubusercontent.com/60262784/192263358-3bcfa16f-a2d5-4344-ad92-a629a7c7dc0d.png"> | <img width="66" alt="Screenshot 2022-09-26 at 14 15 13" src="https://user-images.githubusercontent.com/60262784/192263403-a3e85ccf-76b0-4f32-a61c-7a66f438f044.png"> |
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1202796695664022-as-1203002889297446/f