### PR TITLE
[Paid Newsletters] Update openAddEditDialog logic for paid newsletters

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -497,7 +497,7 @@ class MembershipsSection extends Component {
 	renderStripeConnected() {
 		return (
 			<div>
-				{ this.props.query.stripe_connect_success === 'earn' && (
+				{ this.props?.query?.stripe_connect_success === 'earn' && (
 					<Notice
 						status="is-success"
 						showDismiss={ false }
@@ -600,7 +600,7 @@ class MembershipsSection extends Component {
 	renderConnectStripe() {
 		return (
 			<div>
-				{ this.props.query.stripe_connect_cancelled && (
+				{ this.props?.query?.stripe_connect_cancelled && (
 					<Notice
 						showDismiss={ false }
 						text={ this.props.translate(


### PR DESCRIPTION


#### Proposed Changes

* Make the user connect to Stripe before adding a new plan. Without this adding a  new plan will fail
* When adding a new plan and Stripe is already connected, enable emails in the Add Plan dialog

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/earn/payments-plans/{site_url}#add-newsletter-payment-plan` with a site that is not KYCed
2.  Notice that the user is redirected to view to connect stripe
3. Repeat step 1 with a KYCed site; notice Add Plan dialog is shown
4. Click on the "Email" tab the notice the "Email newly published posts to your customers." checkout is enabled.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
