### PR TITLE
Help Center - reset scroll position on navigation

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -4,7 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CardBody } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { Route, useLocation } from 'react-router-dom';
@@ -22,6 +22,7 @@ import { SuccessScreen } from './ticket-success-screen';
 const HelpCenterContent: React.FC = () => {
 	const location = useLocation();
 	const className = classnames( 'help-center__container-content' );
+	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
 
 	useEffect( () => {
@@ -33,8 +34,15 @@ const HelpCenterContent: React.FC = () => {
 		} );
 	}, [ location, section ] );
 
+	// reset the scroll location on navigation
+	useEffect( () => {
+		if ( containerRef.current ) {
+			containerRef.current.scrollTo( 0, 0 );
+		}
+	}, [ location ] );
+
 	return (
-		<CardBody className={ className }>
+		<CardBody ref={ containerRef } className={ className }>
 			<Route exact path="/">
 				<HelpCenterSearch />
 			</Route>


### PR DESCRIPTION
#### Proposed Changes

* This reset the scroll position inside the help center when you navigate to resolve the issue explained in point 2 here: p7DVsv-fpN-p2#comment-42221

#### Testing Instructions

1. Open DevTools to make the viewport shorter (400px)
2. Open the HC.
3. Scroll down in the help center's home.
4. Click "Still need help?".
5. The Help Center should scroll up automatically.