### PR TITLE
Tailored Flow: fix LiB pattern picker Safari

### DIFF
--- a/packages/onboarding/src/mshots-image/style.scss
+++ b/packages/onboarding/src/mshots-image/style.scss
@@ -6,6 +6,7 @@
 
 .mshots-image__container {
 	height: 100%;
+	width: 100%;
 }
 
 .hover-scroll {


### PR DESCRIPTION
## Proposed Changes

The pattern picker in LiB flow appears distorted while in Safari. This PR adds width to the mshots container.

| Before | After |
| - | - |
| <img width="1300" alt="testing-mshots" src="https://user-images.githubusercontent.com/33258733/192278731-cee3bd7c-7110-4af9-83bb-246c67bd4e52.png"> | <img width="1446" alt="Markup 2022-09-26 at 14 44 37" src="https://user-images.githubusercontent.com/33258733/192279770-2d56c0bb-69e1-4cf0-be5c-4978972e9b42.png"> |

## Testing Instructions

1. Pull branch and run `yarn start`
2. Open safari and go to http://calypso.localhost:3000/setup/patterns?flow=link-in-bio
3. Observe the patterns load in the correct size.
4. Open this from Chrome, Firefox, or other browser to make sure there is no regression.
5. Also feel free to check another area pattern-picker is being used to ensure no other regression.

Fixes #68188 