### PR TITLE
Help Center - cache support history for 30 mins

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -18,9 +18,10 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import React, { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -146,6 +147,9 @@ export const HelpCenterContactForm = () => {
 	const userId = useSelector( getCurrentUserId );
 	const { data: userSites } = useUserSites( userId );
 	const userWithNoSites = userSites?.sites.length === 0;
+	const queryClient = useQueryClient();
+	const email = useSelector( getCurrentUserEmail );
+
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
@@ -282,6 +286,12 @@ export const HelpCenterContactForm = () => {
 							} );
 							history.push( '/success' );
 							resetStore();
+							// reset support-history cache
+							setTimeout( () => {
+								// wait 30 seconds until support-history endpoint actually updates
+								// yup, it takes that long (tried 5, and 10)
+								queryClient.invalidateQueries( [ `activeSupportTickets`, email ] );
+							}, 30000 );
 						} )
 						.catch( () => {
 							setHasSubmittingError( true );

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -37,7 +37,9 @@ export const HelpCenterContactPage: React.FC = () => {
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
 	const email = useSelector( getCurrentUserEmail );
-	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email );
+	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
+		staleTime: 30 * 60 * 1000,
+	} );
 
 	if ( renderChat.isLoading || isLoadingTickets ) {
 		return (


### PR DESCRIPTION
#### Proposed Changes

* Querying `support-history` API is expensive. This caches the result of the call for 30 mins and invalidates the cache when the user submits a ticket.

#### Testing Instructions

1. Open DevTools and to network and clear history then filter by "support-history".
2. Open the Help Center, click Still need help. You should see one request.
3. Go back to HC's homepage, and click Still need help again.
4. No request should be issued. 
5. Submit a ticket. 
6. Wait 30 seconds, then close and re-open the Help Center.
7. Click "Still need help".
8. You should see that you have an open ticket warning.

Fixes: https://github.com/Automattic/wp-calypso/issues/68266
