### PR TITLE
Help Center: make the HC fixed on Desktop as well (not only mobile). 

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -7,7 +7,7 @@ $head-foot-height: 50px;
 
 .help-center {
 	.components-card.help-center__container {
-		position: absolute;
+		position: fixed;
 		background-color: #fff;
 		color: #000;
 		z-index: 9999;
@@ -94,7 +94,6 @@ $head-foot-height: 50px;
 			.help-center__container-content {
 				flex-grow: 1;
 				height: calc(80vh - #{$head-foot-height} * 2);
-				position: relative;
 			}
 
 			&.is-minimized {
@@ -310,7 +309,6 @@ $head-foot-height: 50px;
 			}
 
 			.help-center__container.is-desktop {
-				position: fixed;
 				top: calc(var(--masterbar-height) + 16px);
 			}
 


### PR DESCRIPTION
#### Changes

This makes the Help Center fixed instead of absolute which makes more sense. 

#### Testing Instructions
1. Open the Help Center in a long page like http://calypso.localhost:3000/plans/.
2. Scroll down, the Help Center should stay in place.
3. Try when minimized.
4. Try on simulated mobile. The Help Center should look as before.
