### PR TITLE
Revert "Add PHP 8.2 to version switcher"

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -73,12 +73,6 @@ const WebServerSettingsCard = ( {
 				} ),
 				value: '8.1',
 			},
-			{
-				label: translate( '8.2 (release candidate)', {
-					comment: 'PHP Version for a version switcher',
-				} ),
-				value: '8.2',
-			},
 		];
 	};
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#68198

Wait for official launch.