### PR TITLE
Sites Management Page: Change default sort orders, always show hidden

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -137,7 +137,7 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
-	queryParams: { page = 1, perPage = 96, search, showHidden, status = 'all' },
+	queryParams: { page = 1, perPage = 96, search, status = 'all' },
 }: SitesDashboardProps ) {
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
@@ -208,7 +208,7 @@ export function SitesDashboard( {
 					sites={ allSites }
 					filtering={ { search } }
 					sorting={ sitesSorting }
-					grouping={ { status, showHidden } }
+					grouping={ { status, showHidden: true } }
 				>
 					{ ( { sites, statuses } ) => {
 						const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -2,6 +2,8 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useSelector } from 'react-redux';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 
 const container = css( {
@@ -11,11 +13,13 @@ const container = css( {
 
 type SitesDisplayMode = 'tile' | 'list';
 
-export const useSitesDisplayMode = () =>
-	useAsyncPreference< SitesDisplayMode >( {
-		defaultValue: 'tile',
+export const useSitesDisplayMode = () => {
+	const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
+	return useAsyncPreference< SitesDisplayMode >( {
+		defaultValue: siteCount && siteCount > 6 ? 'list' : 'tile',
 		preferenceName: 'sites-management-dashboard-display-mode',
 	} );
+};
 
 interface SitesDisplayModeSwitcherProps {
 	onDisplayModeChange( newValue: SitesDisplayMode ): void;

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -73,7 +73,6 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 						? parseInt( context.query[ 'per-page' ] )
 						: undefined,
 					search: context.query.search,
-					showHidden: context.query[ 'show-hidden' ] === 'true',
 					status: context.query.status,
 				} }
 			/>

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -1,12 +1,19 @@
 import { SitesSortOptions, SitesSortKey, SitesSortOrder, isValidSorting } from '@automattic/sites';
+import { useSelector } from 'react-redux';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 
 const SEPARATOR = '-' as const;
 
 type SitesSorting = `${ SitesSortKey }${ typeof SEPARATOR }${ SitesSortOrder }`;
 
-const DEFAULT_SITES_SORTING = {
-	sortKey: 'updatedAt',
+const ALPHABETICAL_SORTING = {
+	sortKey: 'alphabetically',
+	sortOrder: 'asc',
+} as const;
+
+const MAGIC_SORTING = {
+	sortKey: 'lastInteractedWith',
 	sortOrder: 'desc',
 } as const;
 
@@ -16,7 +23,7 @@ export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) =>
 	const sorting = { sortKey, sortOrder };
 
 	if ( ! isValidSorting( sorting ) ) {
-		return DEFAULT_SITES_SORTING;
+		return ALPHABETICAL_SORTING;
 	}
 
 	return sorting;
@@ -27,8 +34,12 @@ export const stringifySitesSorting = ( sorting: Required< SitesSortOptions > ): 
 };
 
 export const useSitesSorting = () => {
+	const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
+
 	const [ sitesSorting, onSitesSortingChange ] = useAsyncPreference< SitesSorting >( {
-		defaultValue: stringifySitesSorting( DEFAULT_SITES_SORTING ),
+		defaultValue: stringifySitesSorting(
+			siteCount && siteCount > 6 ? MAGIC_SORTING : ALPHABETICAL_SORTING
+		),
 		preferenceName: 'sites-sorting',
 	} );
 


### PR DESCRIPTION
Fixes #68173

## Proposed Changes

* If a user has six sites or less, the Sites Management Page defaults to tile + alphabetical sort.
* If a user has greater than six sites, the Sites Management Page defaults to list + 'magic' sort.
* Hidden sites are always shown on the Sites Management Page.

Note: the underlying hidden sites filtering will be removed later: https://github.com/Automattic/wp-calypso/issues/68043#issuecomment-1258127692

## Testing Instructions

1. Create a new WordPress.com user with a new free site. Change site title to `AAA`
2. Create a second free site for the WordPress.com user. Change site title to `BBB`.
3. Create a third free site for the WordPress.com user. Change site title to `CCC`.
4. Navigate to `/sites` page.
5. Verify the Sites page defaults to `Sort: Name` and tile view.
6. Create a fourth free site for the WordPress.com user. Change site title to `DDD`.
7. Create a fifth free site for the WordPress.com user. Change site title to `EEE`.
8. Create a sixth free site for the WordPress.com user. Change site title to `FFF`.
9. Create a seventh free site for the WordPress.com user. Change site title to `GGG`.
10. In your sandbox, clear the user's interactions: `wp user-attributes clear_user_interactions --user_login=<user>`.
11. Publish a new post on `EEE`.
12. Navigate to `/sites` page.
13. Verify the Sites page defaults to `Sort: Magic`/list view, and `EEE` appears at the beginning.
14. Change the sort order to 'Last updated' and display mode to 'tile'.
15. Refresh the page.
16. Verify 'Last updated' and 'tile' settings persist.