### PR TITLE
Pattern Assembler - Transitions for pattern list items

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/animate-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/animate-list.tsx
@@ -1,0 +1,16 @@
+import { Animation } from '@automattic/components';
+
+const { AnimatePresence, LazyMotion, m, loadFramerFeatures } = Animation;
+
+interface Props {
+	featureName: 'domMax' | 'domAnimation';
+	children: ( m: any ) => JSX.Element;
+}
+
+const AnimateList = ( { featureName, children }: Props ) => (
+	<LazyMotion features={ () => loadFramerFeatures( featureName ) } strict>
+		<AnimatePresence initial={ false }>{ children( m ) }</AnimatePresence>
+	</LazyMotion>
+);
+
+export default AnimateList;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,6 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
@@ -23,6 +23,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const [ footer, setFooter ] = useState< Pattern | null >( null );
 	const [ sections, setSections ] = useState< Pattern[] >( [] );
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
+	const incrementIndexRef = useRef( 0 );
 	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
 	const { goBack, goNext, submit } = navigation;
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -98,15 +99,25 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	};
 
 	const addSection = ( pattern: Pattern ) => {
+		incrementIndexRef.current++;
 		if ( sectionPosition !== null ) {
 			setSections( [
 				...sections.slice( 0, sectionPosition ),
-				pattern,
+				{
+					...pattern,
+					key: sections[ sectionPosition ].key,
+				},
 				...sections.slice( sectionPosition + 1 ),
 			] );
 			setScrollToSelectorByPosition( sectionPosition );
 		} else {
-			setSections( [ ...( sections as Pattern[] ), pattern ] );
+			setSections( [
+				...( sections as Pattern[] ),
+				{
+					...pattern,
+					key: `${ incrementIndexRef.current }-${ pattern.id }`,
+				},
+			] );
 			setScrollToSelectorByPosition( sections.length );
 		}
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import AsyncLoad from 'calypso/components/async-load';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
 
@@ -71,29 +72,35 @@ const PatternLayout = ( {
 							</Button>
 						</li>
 					) }
-					{ sections?.map( ( section, index ) => {
-						const { id, name } = section;
-						return (
-							<li
-								key={ `${ index }-${ id }` }
-								className="pattern-layout__list-item pattern-layout__list-item--section"
-							>
-								<span className="pattern-layout__list-item-text" title={ name }>
-									{ name }
-								</span>
-								<PatternActionBar
-									patternType="section"
-									onReplace={ () => onReplaceSection( index ) }
-									onDelete={ () => onDeleteSection( index ) }
-									onMoveUp={ () => onMoveUpSection( index ) }
-									onMoveDown={ () => onMoveDownSection( index ) }
-									enableMoving={ true }
-									disableMoveUp={ index === 0 }
-									disableMoveDown={ sections?.length === index + 1 }
-								/>
-							</li>
-						);
-					} ) }
+					<AsyncLoad require="./animate-list" featureName={ 'domMax' }>
+						{ ( m: any ) =>
+							sections?.map( ( section, index ) => {
+								const { name, key } = section as Pattern;
+								return (
+									<m.li
+										layout={ 'position' }
+										exit={ { opacity: 0, x: -50, transition: { duration: 0.2 } } }
+										key={ `${ key }` }
+										className="pattern-layout__list-item pattern-layout__list-item--section"
+									>
+										<span className="pattern-layout__list-item-text" title={ name }>
+											{ name }
+										</span>
+										<PatternActionBar
+											patternType="section"
+											onReplace={ () => onReplaceSection( index ) }
+											onDelete={ () => onDeleteSection( index ) }
+											onMoveUp={ () => onMoveUpSection( index ) }
+											onMoveDown={ () => onMoveDownSection( index ) }
+											enableMoving={ true }
+											disableMoveUp={ index === 0 }
+											disableMoveDown={ sections?.length === index + 1 }
+										/>
+									</m.li>
+								);
+							} )
+						}
+					</AsyncLoad>
 					<li className="pattern-layout__list-item pattern-layout__list-item--section">
 						<Button onClick={ () => onAddSection() }>
 							<span className="pattern-layout__add-icon">+</span>{ ' ' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,4 +1,5 @@
 export type Pattern = {
 	id: number;
 	name: string;
+	key?: string;
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/base-styles": "^4.5.0",
 		"classnames": "^2.3.1",
 		"enzyme": "^3.11.0",
+		"framer-motion": "6.2.8",
 		"gridicons": "^3.4.0",
 		"i18n-calypso": "workspace:^",
 		"lodash": "^4.17.21",

--- a/packages/components/src/animation/features/domAnimation.ts
+++ b/packages/components/src/animation/features/domAnimation.ts
@@ -1,0 +1,2 @@
+import { domAnimation } from 'framer-motion';
+export default domAnimation;

--- a/packages/components/src/animation/features/domMax.ts
+++ b/packages/components/src/animation/features/domMax.ts
@@ -1,0 +1,2 @@
+import { domMax } from 'framer-motion';
+export default domMax;

--- a/packages/components/src/animation/features/index.ts
+++ b/packages/components/src/animation/features/index.ts
@@ -1,4 +1,4 @@
-const loadFramerFeatures = async ( feature: string ) => {
+export const loadFramerFeatures = async ( feature: string ) => {
 	let featurePath = '';
 	switch ( feature ) {
 		case 'domAnimation':
@@ -11,5 +11,3 @@ const loadFramerFeatures = async ( feature: string ) => {
 	const mod = await import( `${ featurePath }` );
 	return mod.default;
 };
-
-export default loadFramerFeatures;

--- a/packages/components/src/animation/features/index.ts
+++ b/packages/components/src/animation/features/index.ts
@@ -1,0 +1,15 @@
+const loadFramerFeatures = async ( feature: string ) => {
+	let featurePath = '';
+	switch ( feature ) {
+		case 'domAnimation':
+			featurePath = './domAnimation';
+			break;
+		case 'domMax':
+			featurePath = './domMax';
+			break;
+	}
+	const mod = await import( `${ featurePath }` );
+	return mod.default;
+};
+
+export default loadFramerFeatures;

--- a/packages/components/src/animation/index.ts
+++ b/packages/components/src/animation/index.ts
@@ -1,0 +1,4 @@
+import { AnimatePresence, LazyMotion, m } from 'framer-motion';
+import loadFramerFeatures from './features';
+
+export default { AnimatePresence, LazyMotion, m, loadFramerFeatures };

--- a/packages/components/src/animation/index.ts
+++ b/packages/components/src/animation/index.ts
@@ -1,4 +1,2 @@
-import { AnimatePresence, LazyMotion, m } from 'framer-motion';
-import loadFramerFeatures from './features';
-
-export default { AnimatePresence, LazyMotion, m, loadFramerFeatures };
+export { AnimatePresence, LazyMotion, m } from 'framer-motion';
+export { loadFramerFeatures } from './features';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,5 +1,5 @@
 export { default as Button } from './button';
-export { default as Animation } from './animation';
+export * as Animation from './animation';
 export { default as Card } from './card';
 export { default as CompactCard } from './card/compact';
 export { default as Dialog } from './dialog';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Button } from './button';
+export { default as Animation } from './animation';
 export { default as Card } from './card';
 export { default as CompactCard } from './card/compact';
 export { default as Dialog } from './dialog';

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,6 +396,7 @@ __metadata:
     "@wordpress/base-styles": ^4.5.0
     classnames: ^2.3.1
     enzyme: ^3.11.0
+    framer-motion: 6.2.8
     gridicons: ^3.4.0
     i18n-calypso: "workspace:^"
     lodash: ^4.17.21
@@ -18336,6 +18337,26 @@ __metadata:
   dependencies:
     map-cache: ^0.2.2
   checksum: 5891d1c1d1d5e1a7fb3ccf28515c06731476fa88f7a50f4ede8a0d8d239a338448e7f7cc8b73db48da19c229fa30066104fe6489862065a4f1ed591c42fbeabf
+  languageName: node
+  linkType: hard
+
+"framer-motion@npm:6.2.8":
+  version: 6.2.8
+  resolution: "framer-motion@npm:6.2.8"
+  dependencies:
+    "@emotion/is-prop-valid": ^0.8.2
+    framesync: 6.0.1
+    hey-listen: ^1.0.8
+    popmotion: 11.0.3
+    style-value-types: 5.0.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: ">=16.8 || ^17.0.0 || ^18.0.0"
+    react-dom: ">=16.8 || ^17.0.0 || ^18.0.0"
+  dependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+  checksum: 148ee1be89f214f3d4d2d0ce5592b850a5577974673a4efe8528f50ff6722e9855cf8e4fdc32036981a0d55c95d474e1ac23380634da1f2fb481b7243da66454
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

*   Apply transition for pattern list in PA using `framer-motion` 
*   Update the pattern key using increment index to make sure `AnimatePresence` working correctly while still allowing user to select the same pattern more than 1 time

#### Testing Instructions

*   Click on the Calypso Live (direct link) in the comment below.
*   Type the URL /setup?siteSlug={Site slug} in the Calypso Live domain
*   Follow steps to access the Pattern Selector screen
*   Add more patterns in Section and try to re-order or remove the pattern to see the transition

Recordings
<video src="https://user-images.githubusercontent.com/10071857/193162771-c9a90494-4647-4962-9482-726617eae69e.mp4  "></video>

Related to [#68258](https://github.com/Automattic/wp-calypso/issues/68258)