### PR TITLE
Site Switcher: Fix error when 'Manage Sites' button is loaded

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -41,6 +41,7 @@ const cleanAnchorProps = ( {
 	primary,
 	scary,
 	plain,
+	transparent,
 	...anchorProps
 }: ButtonProps | AnchorProps ): AnchorProps => anchorProps as AnchorProps;
 


### PR DESCRIPTION
## Proposed Changes

Prevents the following error from occurring when the Site Switcher is loaded:

<img width="887" alt="image" src="https://user-images.githubusercontent.com/36432/192321148-236acf69-6228-44e0-bca6-2e6be9112845.png">

## Testing Instructions

1. Refresh the page.
2. Navigate to and open the Site Switcher.
3. Verify the error doesn't appear in your console.