### PR TITLE
Tailored Flows-Newsletter: Jetpack logo should be stuck to the bottom

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -6,6 +6,7 @@
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/onboarding/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 /**
  * General onboarding styling
@@ -140,7 +141,7 @@ button {
 		}
 	}
 
-	@media ( min-width: 660px ) {
+	@include break-large {
 		height: 100%;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -147,6 +147,11 @@ button {
 	.step-container {
 		--color-accent: #117ac9;
 		--color-accent-60: #0e64a5;
+
+		@media ( min-width: 660px ) {
+			display: flex;
+			flex-direction: column;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -71,7 +71,6 @@ button {
 .subscribers,
 .blazepress,
 .intro {
-	height: 100%;
 	padding: 60px 0 0;
 	box-sizing: border-box;
 
@@ -139,6 +138,10 @@ button {
 				inset-inline-end: 24px;
 			}
 		}
+	}
+
+	@media ( min-width: 660px ) {
+		height: 100%;
 	}
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -10,6 +10,13 @@
 /**
  * General onboarding styling
  */
+
+html,
+body,
+.wpcom-site {
+	height: 100%;
+}
+
 body {
 	background-color: #fdfdfd;
 }
@@ -64,6 +71,7 @@ button {
 .subscribers,
 .blazepress,
 .intro {
+	height: 100%;
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -81,10 +81,6 @@
 		.step-container__header {
 			margin-bottom: 0;
 		}
-
-		.step-container__jetpack-powered {
-			margin: 20px 0 60px;
-		}
 	}
 
 	.intro__content {

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -56,6 +56,11 @@
 			svg.jetpack-logo {
 				margin-right: 6px;
 			}
+
+			@media ( min-width: 660px ) {
+				margin-top: auto;
+				margin-bottom: 10px;
+			}
 		}
 	}
 

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -9,6 +9,11 @@
 	max-width: 960px;
 	margin: 0 auto;
 
+	@media ( min-width: 660px ) {
+		display: flex;
+		flex-direction: column;
+	}
+
 	// Some steps (like plans) need a larger
 	// width column.
 	&.is-wide-layout {
@@ -264,6 +269,11 @@
 		font-weight: 400;
 		line-height: 20px;
 		margin: 1rem 0;
+
+		@media ( min-width: 660px ) {
+			margin-top: auto;
+			margin-bottom: 10px;
+		}
 
 		svg {
 			margin-inline-end: 6px;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -9,11 +9,6 @@
 	max-width: 960px;
 	margin: 0 auto;
 
-	@media ( min-width: 660px ) {
-		display: flex;
-		flex-direction: column;
-	}
-
 	// Some steps (like plans) need a larger
 	// width column.
 	&.is-wide-layout {


### PR DESCRIPTION
#### Proposed Changes

Jetpack logo should be stuck to the bottom (not floating)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/setup/intro?flow=newsletter`
* Check on desktop and mobile that the jetpack logo is on the bottom

Fixes #68213
