### PR TITLE
Update/show hidden sites on switcher

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -58,6 +58,7 @@ export class SiteSelector extends Component {
 		navigateToSite: PropTypes.func.isRequired,
 		isReskinned: PropTypes.bool,
 		showManageSitesButton: PropTypes.bool,
+		showHiddenSites: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -65,6 +66,7 @@ export class SiteSelector extends Component {
 		showManageSitesButton: false,
 		showAddNewSite: false,
 		showAllSites: false,
+		showHiddenSites: false,
 		siteBasePath: false,
 		indicator: false,
 		hideSelected: false,
@@ -298,7 +300,7 @@ export class SiteSelector extends Component {
 		if ( this.props.sitesFound ) {
 			sites = this.props.sitesFound;
 		} else {
-			sites = this.props.visibleSites;
+			sites = this.props.showHiddenSites ? this.props.sites : this.props.visibleSites;
 		}
 
 		if ( this.props.filter ) {
@@ -427,7 +429,7 @@ export class SiteSelector extends Component {
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
 					{ this.renderAllSites() }
 					{ this.renderSites( sites ) }
-					{ hiddenSitesCount > 0 && ! this.props.sitesFound && (
+					{ ! this.props.showHiddenSites && hiddenSitesCount > 0 && ! this.props.sitesFound && (
 						<span className="site-selector__hidden-sites-message">
 							{ this.props.translate(
 								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
+import searchSites from 'calypso/components/search-sites';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
 import allSitesMenu from 'calypso/my-sites/sidebar/static-data/all-sites-menu';
@@ -82,13 +83,13 @@ export class SiteSelector extends Component {
 	};
 
 	onSearch = ( terms ) => {
-		const trimmedTerm = terms.trim();
+		this.props.searchSites( terms );
 
 		this.setState( {
 			highlightedIndex: terms ? 0 : -1,
-			showSearch: trimmedTerm ? true : this.state.showSearch,
+			showSearch: terms ? true : this.state.showSearch,
 			isKeyboardEngaged: true,
-			searchTerm: trimmedTerm,
+			searchTerm: terms,
 		} );
 	};
 
@@ -292,7 +293,13 @@ export class SiteSelector extends Component {
 	setSiteSelectorRef = ( component ) => ( this.siteSelectorRef = component );
 
 	sitesToBeRendered() {
-		let sites = this.props.visibleSites;
+		let sites;
+
+		if ( this.props.sitesFound ) {
+			sites = this.props.sitesFound;
+		} else {
+			sites = this.props.visibleSites;
+		}
 
 		if ( this.props.filter ) {
 			sites = sites.filter( this.props.filter );
@@ -305,8 +312,8 @@ export class SiteSelector extends Component {
 		return sites;
 	}
 
-	renderAllSites( sites ) {
-		if ( ! this.props.showAllSites || sites.length > 0 || ! this.props.allSitesPath ) {
+	renderAllSites() {
+		if ( ! this.props.showAllSites || this.props.sitesFound || ! this.props.allSitesPath ) {
 			return null;
 		}
 
@@ -368,7 +375,6 @@ export class SiteSelector extends Component {
 		return (
 			<SitesList
 				addToVisibleSites={ ( siteId ) => this.visibleSites.push( siteId ) }
-				searchTerm={ this.state.searchTerm }
 				sites={ existingSites }
 				indicator={ this.props.indicator }
 				onSelect={ this.onSiteSelect }
@@ -419,9 +425,9 @@ export class SiteSelector extends Component {
 					isReskinned={ this.props.isReskinned }
 				/>
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
-					{ this.renderAllSites( sites ) }
+					{ this.renderAllSites() }
 					{ this.renderSites( sites ) }
-					{ hiddenSitesCount > 0 && ! this.state.searchTerm && (
+					{ hiddenSitesCount > 0 && ! this.props.sitesFound && (
 						<span className="site-selector__hidden-sites-message">
 							{ this.props.translate(
 								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
@@ -453,10 +459,7 @@ export class SiteSelector extends Component {
 							<Button
 								transparent
 								onClick={ this.onManageSitesClick }
-								href={ addQueryArgs(
-									{ search: this.state.searchTerm.length > 0 ? this.state.searchTerm : null },
-									'/sites'
-								) }
+								href={ addQueryArgs( { search: this.props.searchTerm }, '/sites' ) }
 							>
 								{ this.props.translate( 'Manage sites' ) }
 							</Button>
@@ -578,6 +581,7 @@ const mapState = ( state ) => {
 
 export default flow(
 	localize,
+	searchSites,
 	withSitesSortingPreference,
 	connect( mapState, { navigateToSite, recordTracksEvent } )
 )( SiteSelector );

--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -22,10 +22,9 @@ interface SitesListProps extends SitesSortingPreferenceProps {
 	isSelected( site: SiteDetailsWithTitle ): boolean;
 }
 
-const SiteSelectorSitesList = createSitesListComponent( { grouping: false } );
+const SiteSelectorSitesList = createSitesListComponent( { grouping: false, filtering: false } );
 
 const SitesList = ( {
-	searchTerm,
 	sitesSorting,
 	addToVisibleSites,
 	isReskinned,
@@ -37,11 +36,7 @@ const SitesList = ( {
 	isSelected,
 }: SitesListProps ) => {
 	return (
-		<SiteSelectorSitesList
-			filtering={ { search: searchTerm } }
-			sites={ originalSites }
-			sorting={ sitesSorting }
-		>
+		<SiteSelectorSitesList sites={ originalSites } sorting={ sitesSorting }>
 			{ ( { sites } ) => (
 				<>
 					{ sites.map( ( site ) => {

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -20,12 +20,16 @@ class MySitesNavigation extends Component {
 
 		let asyncSidebar = null;
 		let showManageSitesButton = null;
+		let showHiddenSites = null;
+
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
 			asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
 			showManageSitesButton = false;
+			showHiddenSites = false;
 		} else {
 			asyncSidebar = <AsyncLoad require="calypso/my-sites/sidebar" { ...asyncProps } />;
 			showManageSitesButton = true;
+			showHiddenSites = true;
 		}
 
 		return (
@@ -35,6 +39,7 @@ class MySitesNavigation extends Component {
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
 					showManageSitesButton={ showManageSitesButton }
+					showHiddenSites={ showHiddenSites }
 				/>
 				{ asyncSidebar }
 			</div>

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -100,6 +100,7 @@ class SitePicker extends Component {
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
+					showHiddenSites={ this.props.showHiddenSites }
 					showManageSitesButton={ this.props.showManageSitesButton }
 					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
