### PR TITLE
Site Selector: Apply search on whole list instead of only within visible sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -292,7 +292,7 @@ export class SiteSelector extends Component {
 	setSiteSelectorRef = ( component ) => ( this.siteSelectorRef = component );
 
 	sitesToBeRendered() {
-		let sites = this.props.visibleSites;
+		let sites = this.state.searchTerm ? this.props.sites : this.props.visibleSites;
 
 		if ( this.props.filter ) {
 			sites = sites.filter( this.props.filter );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -305,8 +305,8 @@ export class SiteSelector extends Component {
 		return sites;
 	}
 
-	renderAllSites( sites ) {
-		if ( ! this.props.showAllSites || sites.length > 0 || ! this.props.allSitesPath ) {
+	renderAllSites() {
+		if ( ! this.props.showAllSites || this.state.searchTerm || ! this.props.allSitesPath ) {
 			return null;
 		}
 
@@ -419,7 +419,7 @@ export class SiteSelector extends Component {
 					isReskinned={ this.props.isReskinned }
 				/>
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
-					{ this.renderAllSites( sites ) }
+					{ this.renderAllSites() }
 					{ this.renderSites( sites ) }
 					{ hiddenSitesCount > 0 && ! this.state.searchTerm && (
 						<span className="site-selector__hidden-sites-message">

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -355,21 +355,11 @@ export class SiteSelector extends Component {
 			return <SitePlaceholder key="site-placeholder" />;
 		}
 
-		const existingSites = sites.filter( Boolean );
-
-		if ( ! existingSites.length ) {
-			return (
-				<div className="site-selector__no-results">
-					{ this.props.translate( 'No sites found' ) }
-				</div>
-			);
-		}
-
 		return (
 			<SitesList
 				addToVisibleSites={ ( siteId ) => this.visibleSites.push( siteId ) }
 				searchTerm={ this.state.searchTerm }
-				sites={ existingSites }
+				sites={ sites }
 				indicator={ this.props.indicator }
 				onSelect={ this.onSiteSelect }
 				onMouseEnter={ this.onSiteHover }

--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -1,5 +1,6 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { createSitesListComponent } from '@automattic/sites';
+import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import Site from 'calypso/blocks/site';
 import {
@@ -36,32 +37,39 @@ const SitesList = ( {
 	isHighlighted,
 	isSelected,
 }: SitesListProps ) => {
+	const { __ } = useI18n();
 	return (
 		<SiteSelectorSitesList
 			filtering={ { search: searchTerm } }
 			sites={ originalSites }
 			sorting={ sitesSorting }
 		>
-			{ ( { sites } ) => (
-				<>
-					{ sites.map( ( site ) => {
-						addToVisibleSites( site.ID );
+			{ ( { sites } ) => {
+				if ( sites.length === 0 ) {
+					return <div className="site-selector__no-results">{ __( 'No sites found' ) }</div>;
+				}
 
-						return (
-							<Site
-								site={ site }
-								key={ 'site-' + site.ID }
-								indicator={ indicator }
-								onSelect={ onSelect }
-								onMouseEnter={ onMouseEnter }
-								isHighlighted={ isHighlighted( site.ID ) }
-								isSelected={ isSelected( site ) }
-								isReskinned={ isReskinned }
-							/>
-						);
-					} ) }
-				</>
-			) }
+				return (
+					<>
+						{ sites.map( ( site ) => {
+							addToVisibleSites( site.ID );
+
+							return (
+								<Site
+									site={ site }
+									key={ 'site-' + site.ID }
+									indicator={ indicator }
+									onSelect={ onSelect }
+									onMouseEnter={ onMouseEnter }
+									isHighlighted={ isHighlighted( site.ID ) }
+									isSelected={ isSelected( site ) }
+									isReskinned={ isReskinned }
+								/>
+							);
+						} ) }
+					</>
+				);
+			} }
 		</SiteSelectorSitesList>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

On https://github.com/Automattic/wp-calypso/pull/68175, a new abstraction was introduced and it broke searching. As it filters the provided list, only the subset of visible sites was taken into account when searching.

This PR changes that. If there is a search term defined, we'll give the `SitesList` component the whole set of sites, including the hidden ones, restoring the intended behavior.

It also fixes an issue where the "All sites" button was not being displayed due to wrong logic changes. We only want to disable this site if we're searching, not if there are sites.

#### Testing Instructions

1. Look for a hidden site;
2. Try searching for it in the site switcher.

You should see it when searching, but not on the list by default.

3. Open any site;
4. Open the "Stats" page for the site;
5. Open the site switcher.

Verify the "View stats for all sites" button shows up at the top.

Related to https://github.com/Automattic/wp-calypso/issues/68043.
