### PR TITLE
Update PluginsMain to use breadcrumbs state

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -74,6 +74,7 @@ export class PluginsMain extends Component {
 			selectedSiteSlug,
 			hasInstallPurchasedPlugins,
 			hasManagePlugins,
+			search,
 		} = this.props;
 
 		currentPlugins.map( ( plugin ) => {
@@ -102,12 +103,37 @@ export class PluginsMain extends Component {
 				return;
 			}
 		}
+
+		if ( prevProps.search !== search ) {
+			if ( search ) {
+				this.props.appendBreadcrumb( {
+					label: this.props.translate( 'Search Results' ),
+					href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
+					id: 'plugins-site-search',
+				} );
+			} else {
+				this.resetBreadcrumbs();
+			}
+		}
 	}
 
 	componentDidMount() {
+		this.resetBreadcrumbs();
+
+		// Change the isMobile state when the size of the browser changes.
+		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
+			this.setState( { isMobile } );
+		} );
+	}
+
+	componentWillUnmount() {
+		this.unsubscribe();
+	}
+
+	resetBreadcrumbs() {
 		const { selectedSiteSlug, search } = this.props;
 
-		const navigationItems = [
+		this.props.updateBreadcrumbs( [
 			{
 				label: this.props.translate( 'Plugins' ),
 				href: `/plugins/${ selectedSiteSlug || '' }`,
@@ -119,23 +145,15 @@ export class PluginsMain extends Component {
 				label: this.props.translate( 'Installed Plugins' ),
 				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
 			},
-		];
+		] );
+
 		if ( search ) {
-			navigationItems.push( {
+			this.props.appendBreadcrumb( {
 				label: this.props.translate( 'Search Results' ),
 				href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
+				id: 'plugins-site-search',
 			} );
 		}
-		this.props.updateBreadcrumbs( navigationItems );
-
-		// Change the isMobile state when the size of the browser changes.
-		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
-			this.setState( { isMobile } );
-		} );
-	}
-
-	componentWillUnmount() {
-		this.unsubscribe();
 	}
 
 	getCurrentPlugins() {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -108,7 +108,7 @@ export class PluginsMain extends Component {
 			if ( search ) {
 				this.props.appendBreadcrumb( {
 					label: this.props.translate( 'Search Results' ),
-					href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
+					href: `/plugins/manage/${ selectedSiteSlug || '' }?s=${ search }`,
 					id: 'plugins-site-search',
 				} );
 			} else {
@@ -150,7 +150,7 @@ export class PluginsMain extends Component {
 		if ( search ) {
 			this.props.appendBreadcrumb( {
 				label: this.props.translate( 'Search Results' ),
-				href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
+				href: `/plugins/manage/${ selectedSiteSlug || '' }?s=${ search }`,
 				id: 'plugins-site-search',
 			} );
 		}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -26,6 +26,8 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import urlSearch from 'calypso/lib/url-search';
 import { getVisibleSites, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { appendBreadcrumb, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import {
 	getPlugins,
 	isRequestingForSites,
@@ -103,6 +105,29 @@ export class PluginsMain extends Component {
 	}
 
 	componentDidMount() {
+		const { selectedSiteSlug, search } = this.props;
+
+		const navigationItems = [
+			{
+				label: this.props.translate( 'Plugins' ),
+				href: `/plugins/${ selectedSiteSlug || '' }`,
+				helpBubble: this.props.translate(
+					'Add new functionality and integrations to your site with plugins.'
+				),
+			},
+			{
+				label: this.props.translate( 'Installed Plugins' ),
+				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
+			},
+		];
+		if ( search ) {
+			navigationItems.push( {
+				label: this.props.translate( 'Search Results' ),
+				href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
+			} );
+		}
+		this.props.updateBreadcrumbs( navigationItems );
+
 		// Change the isMobile state when the size of the browser changes.
 		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
 			this.setState( { isMobile } );
@@ -380,31 +405,6 @@ export class PluginsMain extends Component {
 		);
 	}
 
-	getNavigationItems() {
-		const { search, selectedSiteSlug } = this.props;
-		const navigationItems = [
-			{
-				label: this.props.translate( 'Plugins' ),
-				href: `/plugins/${ selectedSiteSlug || '' }`,
-				helpBubble: this.props.translate(
-					'Add new functionality and integrations to your site with plugins.'
-				),
-			},
-			{
-				label: this.props.translate( 'Installed Plugins' ),
-				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
-			},
-		];
-		if ( search ) {
-			navigationItems.push( {
-				label: this.props.translate( 'Search Results' ),
-				href: `/plugins/${ selectedSiteSlug || '' }?s=${ search }`,
-			} );
-		}
-
-		return navigationItems;
-	}
-
 	render() {
 		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
 			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
@@ -450,7 +450,7 @@ export class PluginsMain extends Component {
 					<FixedNavigationHeader
 						className="plugin__header"
 						compactBreadcrumb={ false }
-						navigationItems={ this.getNavigationItems() }
+						navigationItems={ this.props.breadcrumbs }
 					/>
 				) }
 				<div
@@ -540,6 +540,8 @@ export default flow(
 				siteHasFeature( state, selectedSiteId, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ) ||
 				jetpackNonAtomic;
 
+			const breadcrumbs = getBreadcrumbs( state );
+
 			return {
 				hasJetpackSites: hasJetpackSites( state ),
 				sites,
@@ -567,8 +569,15 @@ export default flow(
 				hasUploadPlugins: hasUploadPlugins,
 				hasInstallPurchasedPlugins: hasInstallPurchasedPlugins,
 				isJetpackCloud,
+				breadcrumbs,
 			};
 		},
-		{ wporgFetchPluginData, recordTracksEvent, recordGoogleEvent }
+		{
+			wporgFetchPluginData,
+			recordTracksEvent,
+			recordGoogleEvent,
+			appendBreadcrumb,
+			updateBreadcrumbs,
+		}
 	)
 )( PluginsMain );


### PR DESCRIPTION
#### Proposed Changes

This updates `PluginMain` so that it uses the breadcrumbs state which will help it to work in coordination with other components.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/plugins/manage` and navigate to and away from various plugins, and make sure that the breadcrumbs are always correct.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
