### PR TITLE
Sidebar: Limit Site Switcher results to 50, including hidden sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -58,6 +58,7 @@ export class SiteSelector extends Component {
 		isReskinned: PropTypes.bool,
 		showManageSitesButton: PropTypes.bool,
 		showHiddenSites: PropTypes.bool,
+		maxResults: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -362,6 +363,7 @@ export class SiteSelector extends Component {
 
 		return (
 			<SitesList
+				maxResults={ this.props.maxResults }
 				addToVisibleSites={ ( siteId ) => this.visibleSites.push( siteId ) }
 				searchTerm={ this.state.searchTerm }
 				sites={ sites }
@@ -417,7 +419,7 @@ export class SiteSelector extends Component {
 					{ this.renderAllSites() }
 					{ this.renderSites( sites ) }
 					{ ! this.props.showHiddenSites && hiddenSitesCount > 0 && ! this.state.searchTerm && (
-						<span className="site-selector__hidden-sites-message">
+						<span className="site-selector__list-bottom-adornment">
 							{ this.props.translate(
 								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
 								'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
@@ -431,7 +433,6 @@ export class SiteSelector extends Component {
 										a: (
 											<a
 												href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
-												className="site-selector__manage-hidden-sites"
 												target="_blank"
 												rel="noopener noreferrer"
 											/>

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -57,6 +57,7 @@ export class SiteSelector extends Component {
 		navigateToSite: PropTypes.func.isRequired,
 		isReskinned: PropTypes.bool,
 		showManageSitesButton: PropTypes.bool,
+		showHiddenSites: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -64,6 +65,7 @@ export class SiteSelector extends Component {
 		showManageSitesButton: false,
 		showAddNewSite: false,
 		showAllSites: false,
+		showHiddenSites: false,
 		siteBasePath: false,
 		indicator: false,
 		hideSelected: false,
@@ -292,7 +294,10 @@ export class SiteSelector extends Component {
 	setSiteSelectorRef = ( component ) => ( this.siteSelectorRef = component );
 
 	sitesToBeRendered() {
-		let sites = this.state.searchTerm ? this.props.sites : this.props.visibleSites;
+		let sites =
+			this.state.searchTerm || this.props.showHiddenSites
+				? this.props.sites
+				: this.props.visibleSites;
 
 		if ( this.props.filter ) {
 			sites = sites.filter( this.props.filter );
@@ -411,7 +416,7 @@ export class SiteSelector extends Component {
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
 					{ this.renderAllSites() }
 					{ this.renderSites( sites ) }
-					{ hiddenSitesCount > 0 && ! this.state.searchTerm && (
+					{ ! this.props.showHiddenSites && hiddenSitesCount > 0 && ! this.state.searchTerm && (
 						<span className="site-selector__hidden-sites-message">
 							{ this.props.translate(
 								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',

--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -5,7 +5,6 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import Site from 'calypso/blocks/site';
-import { addQueryArgs } from 'calypso/lib/url';
 import {
 	SitesSortingPreferenceProps,
 	withSitesSortingPreference,
@@ -80,23 +79,14 @@ const SitesList = ( {
 									sprintf(
 										// translators: maxResults is the maximum number of list results.
 										__(
-											'This list is limited to the first %(maxResults)d results. Open the <a>sites page</a> to view more.'
+											'Only displaying the first %(maxResults)d sites.<br />Use search to refine.'
 										),
 										{
 											maxResults,
 										}
 									),
 									{
-										a: (
-											<a
-												href={ addQueryArgs(
-													{ search: searchTerm.length > 0 ? searchTerm : null },
-													'/sites'
-												) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
+										br: <br />,
 									}
 								) }
 							</span>

--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -1,8 +1,11 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { createSitesListComponent } from '@automattic/sites';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import Site from 'calypso/blocks/site';
+import { addQueryArgs } from 'calypso/lib/url';
 import {
 	SitesSortingPreferenceProps,
 	withSitesSortingPreference,
@@ -12,6 +15,7 @@ import {
 type SiteDetailsWithTitle = SiteDetails & { title: string };
 
 interface SitesListProps extends SitesSortingPreferenceProps {
+	maxResults?: number;
 	searchTerm: string;
 	addToVisibleSites( siteId: number ): void;
 	isReskinned?: boolean;
@@ -27,6 +31,7 @@ const SiteSelectorSitesList = createSitesListComponent( { grouping: false } );
 
 const SitesList = ( {
 	searchTerm,
+	maxResults,
 	sitesSorting,
 	addToVisibleSites,
 	isReskinned,
@@ -49,9 +54,11 @@ const SitesList = ( {
 					return <div className="site-selector__no-results">{ __( 'No sites found' ) }</div>;
 				}
 
+				const slicedSites = maxResults != null ? sites.slice( 0, maxResults ) : sites;
+
 				return (
 					<>
-						{ sites.map( ( site ) => {
+						{ slicedSites.map( ( site ) => {
 							addToVisibleSites( site.ID );
 
 							return (
@@ -67,6 +74,33 @@ const SitesList = ( {
 								/>
 							);
 						} ) }
+						{ slicedSites.length < sites.length && (
+							<span className="site-selector__list-bottom-adornment">
+								{ createInterpolateElement(
+									sprintf(
+										// translators: maxResults is the maximum number of list results.
+										__(
+											'This list is limited to the first %(maxResults)d results. Open the <a>sites page</a> to view more.'
+										),
+										{
+											maxResults,
+										}
+									),
+									{
+										a: (
+											<a
+												href={ addQueryArgs(
+													{ search: searchTerm.length > 0 ? searchTerm : null },
+													'/sites'
+												) }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									}
+								) }
+							</span>
+						) }
 					</>
 				);
 			} }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -204,13 +204,14 @@
 	border-bottom: 1px solid var(--color-neutral-10);
 }
 
-.site-selector__hidden-sites-message {
+.site-selector__list-bottom-adornment {
 	color: var(--color-text-subtle);
 	display: block;
 	font-size: $font-body-extra-small;
 	padding: 16px 16px 24px;
 
-	.site-selector__manage-hidden-sites {
+	a {
+		color: inherit;
 		text-decoration: underline;
 
 		&:hover {
@@ -219,6 +220,6 @@
 	}
 }
 
-.site-selector__no-results + .site-selector__hidden-sites-message {
+.site-selector__no-results + .site-selector__list-bottom-adornment {
 	display: none;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -201,8 +201,7 @@
 			color: var(--color-sidebar-text-alternative);
 		}
 
-		&__hidden-sites-message,
-		&__manage-hidden-sites {
+		&__list-bottom-adornment {
 			color: var(--color-sidebar-text);
 		}
 

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -21,7 +21,7 @@
 
 .migrate__card {
 	.site__content,
-	.site-selector__hidden-sites-message {
+	.site-selector__list-bottom-adornment {
 		border-bottom: 1px solid var(--color-neutral-10);
 		padding-left: 0;
 		padding-right: 0;

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -19,17 +19,23 @@ class MySitesNavigation extends Component {
 		};
 
 		let asyncSidebar = null;
-		let showManageSitesButton = null;
-		let showHiddenSites = null;
+		let sitePickerProps = {};
 
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
 			asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
-			showManageSitesButton = false;
-			showHiddenSites = false;
+
+			sitePickerProps = {
+				showManageSitesButton: false,
+				showHiddenSites: false,
+			};
 		} else {
 			asyncSidebar = <AsyncLoad require="calypso/my-sites/sidebar" { ...asyncProps } />;
-			showManageSitesButton = true;
-			showHiddenSites = true;
+
+			sitePickerProps = {
+				showManageSitesButton: true,
+				showHiddenSites: true,
+				maxResults: 50,
+			};
 		}
 
 		return (
@@ -38,8 +44,7 @@ class MySitesNavigation extends Component {
 					allSitesPath={ this.props.allSitesPath }
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
-					showManageSitesButton={ showManageSitesButton }
-					showHiddenSites={ showHiddenSites }
+					{ ...sitePickerProps }
 				/>
 				{ asyncSidebar }
 			</div>

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -20,12 +20,16 @@ class MySitesNavigation extends Component {
 
 		let asyncSidebar = null;
 		let showManageSitesButton = null;
+		let showHiddenSites = null;
+
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
 			asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
 			showManageSitesButton = false;
+			showHiddenSites = false;
 		} else {
 			asyncSidebar = <AsyncLoad require="calypso/my-sites/sidebar" { ...asyncProps } />;
 			showManageSitesButton = true;
+			showHiddenSites = true;
 		}
 
 		return (
@@ -35,6 +39,7 @@ class MySitesNavigation extends Component {
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
 					showManageSitesButton={ showManageSitesButton }
+					showHiddenSites={ showHiddenSites }
 				/>
 				{ asyncSidebar }
 			</div>

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -100,6 +100,7 @@ class SitePicker extends Component {
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
+					showHiddenSites={ this.props.showHiddenSites }
 					showManageSitesButton={ this.props.showManageSitesButton }
 					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -100,6 +100,7 @@ class SitePicker extends Component {
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
+					maxResults={ this.props.maxResults }
 					showHiddenSites={ this.props.showHiddenSites }
 					showManageSitesButton={ this.props.showManageSitesButton }
 					isPlaceholder={ ! this.state.isRendered }


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/68043. Fixes https://github.com/Automattic/wp-calypso/issues/67581. I decided to fix the latter issue in the same PR so we don't end up in an intermediary state where all hidden sites are shown, despite having no way to limit the results.

<img width="337" alt="image" src="https://user-images.githubusercontent.com/36432/192375734-3eb0d37e-1d40-4be7-b061-be2df432518b.png">

#### Testing Instructions

Considering you have more than 50 sites:

1. See that there is a 50 result limit, including some hidden sites, in the site switcher in the sidebar;
2. Type a single letter in the search box and check that even the filtered results are limited to 50.

If you don't, modify the value of `maxResults` to assert that the instructions hold true.