### PR TITLE
Launchpad: Update "Set up" task title

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -31,7 +31,7 @@ export function getEnhancedTasks(
 			switch ( task.id ) {
 				case 'setup_newsletter':
 					taskData = {
-						title: translate( 'Set up Newsletter' ),
+						title: translate( 'Personalize Newsletter' ),
 					};
 					break;
 				case 'plan_selected':
@@ -66,7 +66,7 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_link_in_bio':
 					taskData = {
-						title: translate( 'Set up Link in Bio' ),
+						title: translate( 'Personalize Link in Bio' ),
 						keepActive: true,
 						actionUrl: `/setup/linkInBioPostSetup?flow=link-in-bio-post-setup&siteSlug=${ siteSlug }`,
 					};


### PR DESCRIPTION
### Proposed Changes

* Changes "Set up Newsletter" and "Set up Link in Bio" task title to "Personalize Newsletter" and "Personalize Link in Bio"

### Screenshots
#### Before

<img width="1496" alt="Screen Shot 2022-09-26 at 12 56 24 PM" src="https://user-images.githubusercontent.com/5414230/192368073-e7ffad68-20ab-49af-852c-b632446d538a.png">

#### After

<img width="1496" alt="Screen Shot 2022-09-26 at 12 55 41 PM" src="https://user-images.githubusercontent.com/5414230/192367978-2bdf271a-8153-4470-adb4-0821a5065667.png">

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create link-in-bio or newsletter site https://wordpress.com/hp-2022-tailored-flows/
* Stop at the launchpad view
* Ensure that you're loading the local dev environment ( calypso.localhost:3000 )
* Verify that "Set up" task title has changed to "Personalize"

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68034
