### PR TITLE
Sites Management Page: Remove feature flag from codebase

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -97,8 +97,7 @@ export function createNavigation( context ) {
 		basePath = sectionify( context.pathname );
 	}
 
-	let allSitesPath =
-		config.isEnabled( 'build/sites-dashboard' ) && basePath === '/home' ? '/sites' : basePath;
+	let allSitesPath = basePath === '/home' ? '/sites' : basePath;
 
 	// Update allSitesPath if it is plugins page in Jetpack Cloud
 	if ( isJetpackCloud() && basePath.startsWith( '/plugins' ) ) {

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getSiteBySlug, getSiteHomeUrl } from 'calypso/state/sites/selectors';
@@ -13,11 +12,6 @@ export default function () {
 		const siteId = site?.ID;
 		page.redirect( getSiteHomeUrl( state, siteId ) );
 	} );
-
-	if ( ! isEnabled( 'build/sites-dashboard' ) ) {
-		page( '/sites', '/home' );
-		return;
-	}
 
 	page( '/sites', sanitizeQueryParameters, sitesDashboard, makeLayout, clientRender );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -28,7 +28,6 @@
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
-		"build/sites-dashboard": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
-		"build/sites-dashboard": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -18,7 +18,6 @@
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,
-		"build/sites-dashboard": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,6 @@
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
-		"build/sites-dashboard": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
-		"build/sites-dashboard": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,6 @@
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
-		"build/sites-dashboard": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,


### PR DESCRIPTION
## Proposed Changes

Removes the `build/sites-dashboard` feature flag from the codebase, now that `/sites` is fully available.

## Testing Instructions

1. Verify `/sites` is still accessible.