### PR TITLE
Pricing page rework: Make Jetpack Social "Coming soon!".

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -32,7 +32,10 @@ import {
 	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
+	PRODUCT_JETPACK_SOCIAL_BASIC,
+	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
+	SOCIAL_SHARES_1000,
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
 	JETPACK_BACKUP_PRODUCTS,
@@ -140,12 +143,48 @@ export const EXTERNAL_PRODUCT_CRM_MONTHLY = (): SelectorProduct => ( {
 	costProductSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 } );
 
+export const EXTERNAL_PRODUCT_SOCIAL_BASIC = (): SelectorProduct => ( {
+	// This is a virtual, non-purchasable product for Jetpack Social that
+	// points to an external landing page.
+	productSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
+	term: TERM_ANNUALLY,
+	type: ITEM_TYPE_PRODUCT,
+	costProductSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
+	monthlyProductSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
+	iconSlug: 'jetpack_crm',
+	displayName: translate( 'Social' ),
+	shortName: translate( 'Social' ),
+	tagline: translate( 'Easily share your website content on your social media channels' ),
+	displayPrice: 10,
+	displayCurrency: 'USD',
+	description: translate(
+		'Easily share your website content on your social media channels from one place.'
+	),
+	shortDescription: translate( 'Write once, post everywhere.' ),
+	buttonLabel: translate( 'Get Social' ),
+	features: {
+		items: buildCardFeaturesFromItem( [ SOCIAL_SHARES_1000 ] ),
+	},
+	hidePrice: true,
+	externalUrl: 'https://jetpack.com/social/',
+} );
+
+export const EXTERNAL_PRODUCT_SOCIAL_BASIC_MONTHLY = (): SelectorProduct => ( {
+	...EXTERNAL_PRODUCT_SOCIAL_BASIC(),
+	productSlug: PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
+	term: TERM_MONTHLY,
+	displayTerm: TERM_ANNUALLY,
+	costProductSlug: PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
+} );
+
 // List of products showcased in the Plans grid but not sold through Calypso
 export const EXTERNAL_PRODUCTS_LIST = [
 	PRODUCT_JETPACK_CRM_FREE,
 	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	PRODUCT_JETPACK_CRM,
 	PRODUCT_JETPACK_CRM_MONTHLY,
+	PRODUCT_JETPACK_SOCIAL_BASIC,
+	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
 ];
 
 // External Product slugs to SelectorProduct.
@@ -154,6 +193,8 @@ export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct >
 	[ PRODUCT_JETPACK_CRM_FREE_MONTHLY ]: EXTERNAL_PRODUCT_CRM_FREE_MONTHLY,
 	[ PRODUCT_JETPACK_CRM ]: EXTERNAL_PRODUCT_CRM,
 	[ PRODUCT_JETPACK_CRM_MONTHLY ]: EXTERNAL_PRODUCT_CRM_MONTHLY,
+	[ PRODUCT_JETPACK_SOCIAL_BASIC ]: EXTERNAL_PRODUCT_SOCIAL_BASIC,
+	[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: EXTERNAL_PRODUCT_SOCIAL_BASIC_MONTHLY,
 };
 
 /**

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -199,6 +199,7 @@ export const useStoreItemInfo = ( {
 	const getCustomLabel = useCallback(
 		( item: SelectorProduct ) => {
 			if (
+				! getIsOwned( item ) &&
 				getIsExternal( item ) &&
 				( [ ...JETPACK_SOCIAL_PRODUCTS ] as ReadonlyArray< string > ).includes( item.productSlug )
 			) {
@@ -206,7 +207,7 @@ export const useStoreItemInfo = ( {
 			}
 			return null;
 		},
-		[ translate ]
+		[ getIsOwned, translate ]
 	);
 
 	return useMemo(

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -3,6 +3,7 @@ import {
 	JetpackPurchasableItemSlug,
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_SCAN_PRODUCTS,
+	JETPACK_SOCIAL_PRODUCTS,
 	planHasFeature,
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -191,6 +192,23 @@ export const useStoreItemInfo = ( {
 		]
 	);
 
+	/**
+	 * This is a temporary custom label for Jetpack Social product only.
+	 * TODO: Remove 'getCustomLabel' in the near future when Social is ready for purchase.
+	 */
+	const getCustomLabel = useCallback(
+		( item: SelectorProduct ) => {
+			if (
+				getIsExternal( item ) &&
+				( [ ...JETPACK_SOCIAL_PRODUCTS ] as ReadonlyArray< string > ).includes( item.productSlug )
+			) {
+				return translate( 'Coming soon!' );
+			}
+			return null;
+		},
+		[ translate ]
+	);
+
 	return useMemo(
 		() => ( {
 			getCheckoutURL,
@@ -208,6 +226,7 @@ export const useStoreItemInfo = ( {
 			getOnClickPurchase,
 			getPurchase,
 			isMultisite,
+			getCustomLabel,
 		} ),
 		[
 			getCheckoutURL,
@@ -222,6 +241,7 @@ export const useStoreItemInfo = ( {
 			getOnClickPurchase,
 			getPurchase,
 			isMultisite,
+			getCustomLabel,
 		]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -29,6 +29,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		getIsUserPurchaseOwner,
 		getOnClickPurchase,
 		isMultisite,
+		getCustomLabel,
 	} = useStoreItemInfoContext();
 
 	const wrapperClassName = classNames( 'jetpack-product-store__all-items', className );
@@ -52,6 +53,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						( ( isOwned || isIncludedInPlan ) && ! getIsUserPurchaseOwner( item ) );
 
 					const ctaLabel = getCtaLabel( item );
+					const customLabel = getCustomLabel( item );
 
 					const hideMoreInfoLink = isDeprecated || isOwned || isIncludedInPlanOrSuperseded;
 
@@ -93,6 +95,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 							onClickCta={ getOnClickPurchase( item ) }
 							price={ price }
 							title={ item.displayName }
+							customLabel={ customLabel }
 						/>
 					);
 				} ) }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
@@ -14,6 +14,7 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 	onClickCta,
 	price,
 	title,
+	customLabel,
 } ) => {
 	return (
 		<div className="simple-item-card">
@@ -24,6 +25,11 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 						<h3 className="simple-item-card__title">{ title }</h3>
 						<div className="simple-item-card__price">{ price }</div>
 					</div>
+					{ customLabel && (
+						<div className="simple-item-card__custom-label">
+							<span>{ customLabel }</span>
+						</div>
+					) }
 					<Button
 						className="simple-item-card__cta"
 						onClick={ onClickCta }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -65,3 +65,16 @@
 	line-height: rem(24px);
 	padding: 8px 0 16px;
 }
+
+.simple-item-card__custom-label {
+	span {
+		display: inline-block;
+		padding: 0.125rem 0.5rem;
+		margin: 0.4rem 1rem 0 0;
+		background-color: var(--studio-yellow-10);
+		border-radius: 4px;
+		font-size: 0.875rem;
+		font-weight: 500;
+		white-space: nowrap;
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useStoreItemInfo } from './hooks/use-store-item-info';
 import type {
 	QueryArgs,
@@ -99,6 +100,7 @@ export type FeaturedItemCardProps = {
 	onClickCta?: VoidFunction;
 	price: React.ReactNode;
 	title: React.ReactNode;
+	customLabel?: React.ReactNode;
 };
 
 export type SimpleItemCardProps = Omit< FeaturedItemCardProps, 'hero' > & {

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
@@ -14,11 +14,11 @@ const setProductsInPosition = ( slugs: ReadonlyArray< string >, position: number
 	slugs.reduce( ( map, slug ) => ( { ...map, [ slug ]: position } ), {} );
 
 const DISPLAYABLE_PRODUCT_POSITION_MAP: Record< string, number > = {
-	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 1 ),
-	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 2 ),
-	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 3 ),
-	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 4 ),
-	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 5 ),
+	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 1 ),
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 2 ),
+	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 3 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 4 ),
+	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 5 ),
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 6 ),
 	// Featured products at the end
 	...setProductsInPosition( JETPACK_BACKUP_PRODUCTS, 7 ),


### PR DESCRIPTION
#### Proposed Changes

This PR makes the Jetpack Social product display a "Coming soon!" label and makes the CTA's point to the Social landing page (https://jetpack.com/social), per Slack discussion: p1663858843090969-slack-C02JJ910CNL

Completes task: 1202796695664022-as-1203042942998884/f

#### Screenshots:

**DESKTOP** | **MOBILE**
--- | ---
![Markup 2022-09-26 at 16 42 39](https://user-images.githubusercontent.com/11078128/192376612-b09babfe-0fc3-4238-b976-16da55e19464.png) | ![Markup 2022-09-26 at 16 44 09](https://user-images.githubusercontent.com/11078128/192376666-12514508-1d76-411e-9546-6c490229011c.png)


#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout  update/make-social-product-coming-soon`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Examine the "Social" product.
- Verify the "Get" button points to the https://jetpack.com/social landing page.
- Verify the "More about Social" link is an external link pointing to the https://jetpack.com/social landing page.
- Verify the Social product has a "Coming soon!" label. (See screenshots).
- Verify the Social product card looks good in all devices (viewport sizes).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203042942998884