### PR TITLE
Pricing page rework: Activate project feature-flag in production.

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -42,7 +42,7 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-rework-v1": false,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"layout/app-banner": false,

--- a/config/production.json
+++ b/config/production.json
@@ -60,7 +60,7 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pricing-page-rework-v1": false,
+		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Proposed Changes

This PR activates the  config "jetpack/pricing-page-rework-v1" feature-flag in production environments for Calypso blue and green.

Project thread: p1HpG7-gBI-p2
Project Asana board: 1202796695664022-asboard

#### Testing Instructions

Can't really be tested..  Just review the code.  Verify that the "jetpack/pricing-page-rework-v1" feature-flag is being set to `true` in production environments (`jetpack-cloud-production.json` & `production.json`).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203042942998888