### PR TITLE
Add close button to Dialog component

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -130,6 +130,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 				isVisible={ showEligibility }
 				title={ translate( 'Eligibility' ) }
 				onClose={ () => setShowEligibility( false ) }
+				showCloseIcon={ true }
 			>
 				<EligibilityWarnings
 					currentContext={ 'plugin-details' }

--- a/packages/components/src/dialog/README.md
+++ b/packages/components/src/dialog/README.md
@@ -12,6 +12,8 @@ By controlling the dialog's visibility through the `isVisible` property, the dia
 providing any CSS transitions to animate the opening/closing of the dialog. This also keeps the parent's code clean and
 readable, with a minimal amount of boilerplate code required to show a dialog.
 
+The `showCloseIcon` property is used to show a `x` icon at the top right, closing the dialog once it's clicked.
+
 ## Basic Usage
 
 ```js

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import { useCallback } from 'react';
 import Modal from 'react-modal';
+import Gridicon from '../gridicon';
 import ButtonBar from './button-bar';
 import type { Button, BaseButton } from './button-bar';
 import type { PropsWithChildren } from 'react';
@@ -20,6 +21,7 @@ type Props = {
 	leaveTimeout?: number;
 	onClose: ( action?: string ) => void;
 	shouldCloseOnEsc?: boolean;
+	showCloseIcon?: boolean;
 };
 
 const Dialog = ( {
@@ -36,6 +38,7 @@ const Dialog = ( {
 	leaveTimeout = 200,
 	onClose,
 	shouldCloseOnEsc,
+	showCloseIcon = false,
 }: PropsWithChildren< Props > ) => {
 	const close = useCallback( () => onClose?.(), [ onClose ] );
 	const onButtonClick = useCallback(
@@ -71,6 +74,11 @@ const Dialog = ( {
 			role="dialog"
 			shouldCloseOnEsc={ shouldCloseOnEsc }
 		>
+			{ showCloseIcon && (
+				<button className="dialog__action-buttons-close" onClick={ () => onClose( this ) }>
+					<Gridicon icon={ 'cross' } size={ 24 } />
+				</button>
+			) }
 			<div className={ contentClassName } tabIndex={ -1 }>
 				{ children }
 			</div>

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -117,12 +117,7 @@
 	position: absolute;
 	z-index: 1;
 	right: 0;
-	opacity: 0.5;
 	cursor: pointer;
-}
-
-.dialog__action-buttons-close:hover {
-	opacity: 1;
 }
 
 .ReactModal__Body--open {

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -112,6 +112,19 @@
 	float: left;
 }
 
+.dialog__action-buttons-close {
+	padding: 15px 15px 5px 5px;
+	position: absolute;
+	z-index: 1;
+	right: 0;
+	opacity: 0.5;
+	cursor: pointer;
+}
+
+.dialog__action-buttons-close:hover {
+	opacity: 1;
+}
+
 .ReactModal__Body--open {
 	overflow: hidden;
 }


### PR DESCRIPTION
Props @paulopmt1, pulled this from https://github.com/Automattic/wp-calypso/pull/68048

#### Proposed Changes

* Adds optional close button to the Dialog component
* Enables close button on dialog for plugin install dialog

![Screenshot(24)](https://user-images.githubusercontent.com/811776/192422903-f707def1-5819-4655-a424-9e78905cb116.png)

#### Testing Instructions

* Trigger the go atomic modal by attempting to install a plugin on a simple site => You should see the new x button in the corner
* Trigger the dialog from another location, e.g. delete site in settings or delete subscription under purchases

![Screenshot(25)](https://user-images.githubusercontent.com/811776/192423097-af7b38bc-f33d-41bc-9f9c-d3e5b3d22aca.png)



Fixes #68246