### PR TITLE
SMP: Add translator coment for "Magic" sort mode

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -4,7 +4,6 @@ import { Button, Dropdown, MenuItemsChoice } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMemo } from 'react';
 import {
 	stringifySitesSorting,
 	parseSitesSorting,
@@ -33,57 +32,39 @@ export const SitesSortingDropdown = ( {
 	const isSmallScreen = useMediaQuery( SMALL_MEDIA_QUERY );
 	const { __ } = useI18n();
 
-	const currentSorting = useMemo( () => {
-		if ( ! hasSitesSortingPreferenceLoaded ) {
-			return null;
-		}
-
-		const { sortKey, sortOrder } = sitesSorting;
-		const SEPARATOR = '-';
-
-		switch ( `${ sortKey }${ SEPARATOR }${ sortOrder }` ) {
-			case `lastInteractedWith${ SEPARATOR }desc`:
-				return __( 'Magic' );
-
-			case `alphabetically${ SEPARATOR }asc`:
-				return __( 'Name' );
-
-			case `updatedAt${ SEPARATOR }desc`:
-				return __( 'Last published' );
-
-			default:
-				throw new Error( `invalid sort value ${ sitesSorting }` );
-		}
-	}, [ __, sitesSorting, hasSitesSortingPreferenceLoaded ] );
-
-	const choices = useMemo( () => {
-		return [
-			{
-				value: stringifySitesSorting( {
-					sortKey: 'alphabetically',
-					sortOrder: 'asc',
-				} ),
-				label: __( 'Name' ),
-			},
-			{
-				value: stringifySitesSorting( {
-					sortKey: 'lastInteractedWith',
-					sortOrder: 'desc',
-				} ),
-				label: __( 'Magic' ),
-			},
-			{
-				value: stringifySitesSorting( {
-					sortKey: 'updatedAt',
-					sortOrder: 'desc',
-				} ),
-				label: __( 'Last published' ),
-			},
-		];
-	}, [ __ ] );
-
 	if ( ! hasSitesSortingPreferenceLoaded ) {
 		return null;
+	}
+
+	const choices = [
+		{
+			value: stringifySitesSorting( {
+				sortKey: 'alphabetically',
+				sortOrder: 'asc',
+			} ),
+			label: __( 'Name' ),
+		},
+		{
+			value: stringifySitesSorting( {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'desc',
+			} ),
+			label: __( 'Magic' ),
+		},
+		{
+			value: stringifySitesSorting( {
+				sortKey: 'updatedAt',
+				sortOrder: 'desc',
+			} ),
+			label: __( 'Last published' ),
+		},
+	];
+
+	const currentSortingValue = stringifySitesSorting( sitesSorting );
+	const currentSortingLabel = choices.find( ( { value } ) => value === currentSortingValue )?.label;
+
+	if ( currentSortingLabel === undefined ) {
+		throw new Error( `invalid sort value ${ sitesSorting }` );
 	}
 
 	return (
@@ -94,20 +75,20 @@ export const SitesSortingDropdown = ( {
 					icon={ <SortingButtonIcon icon={ isOpen ? 'chevron-up' : 'chevron-down' } /> }
 					iconSize={ 16 }
 					// translators: %s is the current sorting mode.
-					aria-label={ sprintf( __( 'Sorting by %s. Switch sorting mode' ), currentSorting ) }
+					aria-label={ sprintf( __( 'Sorting by %s. Switch sorting mode' ), currentSortingLabel ) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 				>
 					{
 						// translators: %s is the current sorting mode.
-						sprintf( __( 'Sort: %s' ), currentSorting )
+						sprintf( __( 'Sort: %s' ), currentSortingLabel )
 					}
 				</SortingButton>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<MenuItemsChoice
-					value={ stringifySitesSorting( sitesSorting ) }
-					onSelect={ ( value: Parameters< typeof parseSitesSorting >[ 0 ] ) => {
+					value={ currentSortingValue }
+					onSelect={ ( value: typeof choices[ 0 ][ 'value' ] ) => {
 						onSitesSortingChange( parseSitesSorting( value ) );
 						onClose();
 					} }

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -49,6 +49,7 @@ export const SitesSortingDropdown = ( {
 				sortKey: 'lastInteractedWith',
 				sortOrder: 'desc',
 			} ),
+			/* translators: name of sorting mode where the details about how best to sort sites are left up to the software */
 			label: __( 'Magic' ),
 		},
 		{


### PR DESCRIPTION
#### Proposed Changes

The PR is mostly about this comment: 959df8245d20cd2bfc413341a84279b435d28bf4

* Refactors `<SitesSortingDropdown>` so the label is no longer duplicated
* Add a translator note for "Magic"

I also thought about adding a "context" parameter for the translation (e.g. `_x( 'Magic', 'sorting' )`) since it's a special usage of the word "Magic". But I decided not to because it appears to be best to leave the context parameter out unless you're working in tandem with a translator. PCYsg-56e-p2

The refactor removes the duplicate definitions of sort mode labels and string IDs. I no longer felt we needed the memoisation because there isn't anything particularly expensive about the operations being done. I think there was a time that one set of strings was like `'Sort by: Magic'` and the other was just `'Magic'`. But that distinction has since gone away. And combining them made it easier to add the translator comment.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test `/sites` and everything should work just as before. This is just for adding a translator comment to glotpress.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
