### PR TITLE
Style selection: Design preview UI and copy improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -383,7 +383,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		const pickDesignText =
 			selectedDesign.design_type === 'vertical' || selectedDesignHasStyleVariations
-				? translate( 'Select and continue' )
+				? translate( 'Continue' )
 				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
 
 		const actionButtons = (

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -33,7 +33,8 @@ const Sidebar: React.FC< SidebarProps > = ( {
 
 			{ variations.length > 0 && (
 				<div className="design-preview__sidebar-variations">
-					<h2> { translate( 'Style variations' ) }</h2>
+					<h2>{ translate( 'Style variations' ) }</h2>
+					<h3>{ translate( 'Choose a variation to change the look of the site.' ) }</h3>
 					<div className="design-preview__sidebar-variations-grid">
 						<StyleVariationPreviews
 							variations={ variations }

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -34,7 +34,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 			{ variations.length > 0 && (
 				<div className="design-preview__sidebar-variations">
 					<h2>{ translate( 'Style variations' ) }</h2>
-					<h3>{ translate( 'Choose a variation to change the look of the site.' ) }</h3>
+					<p>{ translate( 'Choose a variation to change the look of the site.' ) }</p>
 					<div className="design-preview__sidebar-variations-grid">
 						<StyleVariationPreviews
 							variations={ variations }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -52,6 +52,13 @@ $break-design-preview: 1024px;
 			font-weight: 500;
 			margin-bottom: 0.5rem;
 		}
+
+		h3 {
+			color: var(--studio-gray-100);
+			display: none;
+			font-size: 0.875rem;
+			line-height: 20px;
+		}
 	}
 
 	.design-preview__sidebar-title {
@@ -67,8 +74,8 @@ $break-design-preview: 1024px;
 	.design-preview__sidebar-description {
 		p {
 			color: var(--studio-gray-80);
-			font-size: 0.875rem;
-			line-height: 20px;
+			font-size: 1rem;
+			line-height: 24px;
 		}
 	}
 
@@ -118,7 +125,8 @@ $break-design-preview: 1024px;
 			display: block;
 			margin: 2rem 0 0;
 
-			h2 {
+			h2,
+			h3 {
 				display: block;
 			}
 
@@ -133,7 +141,7 @@ $break-design-preview: 1024px;
 				display: grid;
 				gap: 12px;
 				grid-template-columns: repeat(2, 1fr);
-				margin: 0 -5px;
+				margin: 24px -5px 0;
 				padding: 2px;
 				width: 100%;
 
@@ -189,7 +197,7 @@ $break-design-preview: 1024px;
 
 	.edit-site-global-styles-preview__iframe {
 		border-radius: 3px; /* stylelint-disable-line scales/radii */
-		box-shadow: 0 0 1px rgba(0 0 0 / 25%);
+		box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
 		border: 0;
 		display: block;
 		max-height: 61.2903px;

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -52,13 +52,6 @@ $break-design-preview: 1024px;
 			font-weight: 500;
 			margin-bottom: 0.5rem;
 		}
-
-		h3 {
-			color: var(--studio-gray-100);
-			display: none;
-			font-size: 0.875rem;
-			line-height: 20px;
-		}
 	}
 
 	.design-preview__sidebar-title {
@@ -72,7 +65,7 @@ $break-design-preview: 1024px;
 	}
 
 	.design-preview__sidebar-description {
-		p {
+		> p {
 			color: var(--studio-gray-80);
 			font-size: 1rem;
 			line-height: 24px;
@@ -81,6 +74,13 @@ $break-design-preview: 1024px;
 
 	.design-preview__sidebar-variations {
 		display: block;
+
+		> p {
+			color: var(--studio-gray-100);
+			display: none;
+			font-size: 0.875rem;
+			line-height: 20px;
+		}
 
 		.design-preview__sidebar-variations-grid {
 			align-items: center;
@@ -126,7 +126,7 @@ $break-design-preview: 1024px;
 			margin: 2rem 0 0;
 
 			h2,
-			h3 {
+			&.design-preview__sidebar-variations > p {
 				display: block;
 			}
 


### PR DESCRIPTION
#### Proposed Changes

This PR adds several UI and copy improvements to the design preview based on tester feedback. The changes are as follows:

1. The primary action button will now say "Continue" instead of "Select and continue".

Old version | New version
--- | ---
![Screen Shot 2022-09-27 at 12 55 14 PM](https://user-images.githubusercontent.com/797888/192435412-2d0ce21a-293c-4fb0-9699-cace00239d26.png) | ![Screen Shot 2022-09-27 at 12 55 38 PM](https://user-images.githubusercontent.com/797888/192435456-9fe99a40-9643-4115-981c-0cfccea71f97.png)

2. Also, as seen in the screenshots above. We've added the instruction text "Choose a variation to change the look of the site." in the style variation section of the sidebar.

3. Lastly, we increased the style preview button border to improve contrast.

Old version | New version
--- | --- 
![Screen Shot 2022-09-27 at 12 58 48 PM](https://user-images.githubusercontent.com/797888/192435799-7b3a6dfc-7ead-44dd-a0bf-f8f5b5763151.png) | ![Screen Shot 2022-09-27 at 12 59 16 PM](https://user-images.githubusercontent.com/797888/192435853-be8375dc-c6d7-430b-b6bf-42b6099aeff9.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `/setup/designSetup?siteSlug=${site_slug}`
* Ensure that the changes work as described above, and that it doesn't impact the old design preview.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

