### PR TITLE
Move contact support link in eligibility warnings

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -153,16 +153,6 @@ export const EligibilityWarnings = ( {
 			) }
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
-					<div className="support-block">
-						<span>{ translate( 'Need help?' ) }</span>
-						<ExternalLink
-							href={ localizeUrl( 'https://wordpress.com/support' ) }
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Contact support' ) }
-						</ExternalLink>
-					</div>
 					<Button
 						primary={ true }
 						disabled={
@@ -175,6 +165,16 @@ export const EligibilityWarnings = ( {
 					>
 						{ getProceedButtonText( listHolds, translate ) }
 					</Button>
+					<div className="support-block">
+						<span>{ translate( 'Need help?' ) }</span>
+						<ExternalLink
+							href={ localizeUrl( 'https://wordpress.com/support' ) }
+							icon={ false }
+							target="_blank"
+						>
+							{ translate( 'Contact support' ) }
+						</ExternalLink>
+					</div>
 				</div>
 			</CompactCard>
 		</div>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -9,14 +9,13 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
 import page from 'page';
 import { connect, useSelector } from 'react-redux';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
-import ExternalLink from 'calypso/components/external-link';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -167,13 +166,11 @@ export const EligibilityWarnings = ( {
 					</Button>
 					<div className="support-block">
 						<span>{ translate( 'Need help?' ) }</span>
-						<ExternalLink
-							href={ localizeUrl( 'https://wordpress.com/support' ) }
-							icon={ false }
-							target="_blank"
-						>
-							{ translate( 'Contact support' ) }
-						</ExternalLink>
+						{ translate( '{{a}}Contact support{{/a}}', {
+							components: {
+								a: <ActionPanelLink href="/help/contact" />,
+							},
+						} ) }
 					</div>
 				</div>
 			</CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -9,12 +9,14 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
 import page from 'page';
 import { connect, useSelector } from 'react-redux';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import ExternalLink from 'calypso/components/external-link';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -151,6 +153,16 @@ export const EligibilityWarnings = ( {
 			) }
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
+					<div className="support-block">
+						<span>{ translate( 'Need help?' ) }</span>
+						<ExternalLink
+							href={ localizeUrl( 'https://wordpress.com/support' ) }
+							icon={ false }
+							target="_blank"
+						>
+							{ translate( 'Contact support' ) }
+						</ExternalLink>
+					</div>
 					<Button
 						primary={ true }
 						disabled={

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -148,7 +148,7 @@ export const EligibilityWarnings = ( {
 
 			{ showWarnings && (
 				<CompactCard className="eligibility-warnings__warnings-card">
-					<WarningList context={ context } warnings={ warnings } />
+					<WarningList context={ context } warnings={ warnings } showContact={ false } />
 				</CompactCard>
 			) }
 			<CompactCard>

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,6 +1,17 @@
 .eligibility-warnings {
 	margin-top: 16px;
 	font-size: $font-body-small;
+
+	.eligibility-warnings__confirm-buttons {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.support-block {
+		align-items: center;
+		display: flex;
+		gap: 5px;
+	}
 }
 
 .eligibility-warnings--with-indent {
@@ -45,13 +56,8 @@
 
 .eligibility-warnings__hold,
 .eligibility-warnings__warning {
-	align-items: center;
 	display: flex;
 	flex-direction: row;
-}
-
-.eligibility-warnings__hold,
-.eligibility-warnings__warning {
 	align-items: flex-start;
 	margin-bottom: 16px;
 

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -9,11 +9,12 @@ import type { EligibilityWarning } from 'calypso/state/automated-transfer/select
 interface ExternalProps {
 	context: string | null;
 	warnings: EligibilityWarning[];
+	showContact?: boolean;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-export const WarningList = ( { context, translate, warnings }: Props ) => (
+export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => (
 	<div>
 		<div className="eligibility-warnings__warning">
 			<Gridicon icon="notice-outline" size={ 24 } />
@@ -44,17 +45,19 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 			</div>
 		) ) }
 
-		<div className="eligibility-warnings__warning">
-			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-description">
-					{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					} ) }
-				</span>
+		{ showContact && (
+			<div className="eligibility-warnings__warning">
+				<div className="eligibility-warnings__message">
+					<span className="eligibility-warnings__message-description">
+						{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
+							components: {
+								a: <ActionPanelLink href="/help/contact" />,
+							},
+						} ) }
+					</span>
+				</div>
 			</div>
-		</div>
+		) }
 	</div>
 );
 

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
 import { Fragment } from 'react';
-import ActionPanelLink from 'calypso/components/action-panel/link';
 import ExternalLink from 'calypso/components/external-link';
 import type { EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
@@ -43,18 +42,6 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 				</div>
 			</div>
 		) ) }
-
-		<div className="eligibility-warnings__warning">
-			<div className="eligibility-warnings__message">
-				<span className="eligibility-warnings__message-description">
-					{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					} ) }
-				</span>
-			</div>
-		</div>
 	</div>
 );
 

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
 import { Fragment } from 'react';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 import ExternalLink from 'calypso/components/external-link';
 import type { EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
@@ -42,6 +43,18 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 				</div>
 			</div>
 		) ) }
+
+		<div className="eligibility-warnings__warning">
+			<div className="eligibility-warnings__message">
+				<span className="eligibility-warnings__message-description">
+					{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					} ) }
+				</span>
+			</div>
+		</div>
 	</div>
 );
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -16,12 +16,12 @@
 	.eligibility-warnings {
 		margin: 0;
 
-		.eligibility-warnings__confirm-buttons {
-			flex-direction: row-reverse;
-		}
-
 		.card {
 			box-shadow: none;
+		}
+
+		.eligibility-warnings__confirm-buttons {
+			flex-direction: row-reverse;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -16,6 +16,10 @@
 	.eligibility-warnings {
 		margin: 0;
 
+		.eligibility-warnings__confirm-buttons {
+			flex-direction: row-reverse;
+		}
+
 		.card {
 			box-shadow: none;
 		}

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -3,9 +3,6 @@
 	.eligibility-warnings__warning {
 		max-width: 680px;
 	}
-	.eligibility-warnings__confirm-buttons {
-		padding-left: 40px;
-	}
 	.feature-example {
 		margin-top: 16px;
 	}
@@ -31,7 +28,7 @@
 	border: 1px solid var(--color-neutral-0);
 	margin-left: 24px;
 
-	@include breakpoint-deprecated( "<960px" ) {
+	@include breakpoint-deprecated("<960px") {
 		float: none;
 		margin-left: 0;
 		margin-bottom: 24px;


### PR DESCRIPTION
#### Proposed Changes

* Adds new contact support link in the button actions of eligibility warnings
* Removes old contact support link

Before (Plugins)
![Screenshot 2022-09-27 at 15-33-00 MailPoet – emails and newsletters in WordPress Plugin ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/192440472-f2a7f9c9-5e69-4cb8-9a2d-cd75abf91fe8.png)

After (Plugins)
![Screenshot 2022-09-27 at 15-32-45 MailPoet – emails and newsletters in WordPress Plugin ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/192440488-0f233ef9-86fe-4919-890e-112e5fd4a4c2.png)

Before (Themes)

![Screenshot 2022-09-27 at 15-29-53 Install Theme ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/192440892-1e981a45-7322-4d28-8ba4-8344dea7f34b.png)

After (Themes) 

![Screenshot 2022-09-27 at 19-32-36 Install Theme ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/192490435-df5441aa-b848-4e63-ad79-08712140535d.png)

Before (Jetpack modal)

![Screenshot 2022-09-27 at 15-21-44 Activate Jetpack Backup now ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/192441001-971018ad-593d-4d78-b057-ec7351232cf6.png)

After (Jetpack modal) - should not see change here - intentional/expected

![Screenshot 2022-09-27 at 16-39-57 Activate Jetpack Backup now ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/192451858-21823485-de9c-4e07-a3db-537c8a878778.png)

Todo: 
- [x] Add new contact support link to `WPCOMBusinessAT` which uses the warnings component but uses its own modal.
- Worked around this with [showContact](https://github.com/Automattic/wp-calypso/pull/68319/files?w=1#diff-827866d65c763d43d454d8b4d0a9946e9557ed2ec232f9dfaa605f410900f3d1R151), not great but really this needs a bigger fix design wise to resolve the differences (tried a few things this)
- [x] Needs to flip left/right alignment on existing inline rendering - suspect we should fix https://github.com/Automattic/wp-calypso/issues/68248 first - no longer blocked by this but there is a [conflict.](https://github.com/Automattic/wp-calypso/pull/68319#issuecomment-1259235699)
- [ ] Mobile (needs design)

#### Testing Instructions

Using simple site any plan:

* https://wordpress.com/plugins/mailpoet/test839891825.wordpress.com - Click install and activate

Using simple site with business plan:
 
* http://calypso.localhost:3000/backup/test839891825.wordpress.com click activate
* http://calypso.localhost:3000/hosting-config/test839891825.wordpress.com click activate
* http://calypso.localhost:3000/themes/test839891825.wordpress.com click install theme

Fixes #68249
