### PR TITLE
Don't pass `transparent` prop to `button` element

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -63,6 +63,7 @@ const cleanButtonProps = ( {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore Clean incorrect usage of the component
 	target,
+	transparent,
 	...buttonProps
 }: ButtonProps | AnchorProps ): ButtonProps => ( { ...buttonProps, type } as ButtonProps );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/68287

#### Proposed Changes

I noticed the error mentioned in  https://github.com/Automattic/wp-calypso/pull/68287 also and then realised it has been fixed. However, the `transparent` prop also needs to be cleaned when the `button` element is used. 

#### Testing Instructions

This only affects `Button` when it renders a `button`. We only use `transparent` on `Button` in this way in Storybook, for now, so you can do a before/after with `trunk` and this branch to verify the error is gone. You can run Storybook with `yarn workspace @automattic/components run storybook`.

![Screenshot 2565-09-27 at 14 30 19](https://user-images.githubusercontent.com/6851384/192462674-0ac8d072-47ba-4d57-b582-98f59e69a153.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
