### PR TITLE
Jetpack Agency Dashboard: link site name to single-site activity page on large screen view

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
@@ -87,14 +87,27 @@ export default function SiteStatusContent( {
 			);
 		}
 
+		const siteUrl = value.url;
+
 		return (
 			<>
 				<SiteSetFavorite
 					isFavorite={ isFavorite }
 					siteId={ rows.site.value.blog_id }
-					siteUrl={ rows.site.value.url }
+					siteUrl={ siteUrl }
 				/>
-				<span className="sites-overview__row-text">{ value.url }</span>
+				{ isLargeScreen ? (
+					<Button
+						className="sites-overview__row-text"
+						borderless
+						compact
+						href={ `/activity-log/${ siteUrl }` }
+					>
+						{ siteUrl }
+					</Button>
+				) : (
+					<span className="sites-overview__row-text">{ siteUrl }</span>
+				) }
 				<span className="sites-overview__overlay"></span>
 				{ errorContent }
 			</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -111,12 +111,12 @@
 		width: calc(100% - 120px);
 		margin-inline-start: 8px;
 		margin-inline-end: 5px;
-		font-size: 1rem;
+		font-size: 1rem !important;
 	}
 	@include break-large() {
 		width: calc(100% - 55px);
 		margin-inline-start: 55px;
-		font-size: 0.875rem;
+		font-size: 0.875rem !important;
 	}
 }
 .sites-overview__overlay {


### PR DESCRIPTION
#### Proposed Changes

This PR adds a link(to a single-site activity page) to the site name in the agency dashboard only on the large screen(>960px) views.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/agency-dashboard-link-site-name` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on any site name and verify it takes you to the activity page of that site.

<img width="503" alt="Screenshot 2022-09-27 at 2 56 20 PM" src="https://user-images.githubusercontent.com/10586875/192491914-858a0a51-d514-4148-a19c-8feebfc06703.png">

4. Switch the small screen(<960px) view and verify that the link doesn't work and it toggles the collapsed content.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] ~~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [X] Have you checked for TypeScript, React or other console errors?
- [X] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [X] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203021202366977