### PR TITLE
Subscriber form: turn on the CSV upload on the stage env

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -131,6 +131,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
+		"subscriber-csv-upload": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,


### PR DESCRIPTION
#### Proposed Changes

* Turn on the CSV upload on the `stage` environment

#### Testing Instructions

* Go to `http://wordpress.com/setup/subscribers?flow=newsletter&siteSlug={SLUG}` [staging]
* Check if there is "upload CSV" functionality

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
