### PR TITLE
Pricing page: Remove hardcoded display price and currency in Jetpack social constant.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -155,8 +155,6 @@ export const EXTERNAL_PRODUCT_SOCIAL_BASIC = (): SelectorProduct => ( {
 	displayName: translate( 'Social' ),
 	shortName: translate( 'Social' ),
 	tagline: translate( 'Easily share your website content on your social media channels' ),
-	displayPrice: 10,
-	displayCurrency: 'USD',
 	description: translate(
 		'Easily share your website content on your social media channels from one place.'
 	),


### PR DESCRIPTION
### Description
Currently **Jetpack Social** price is displaying **$** even though the current currency is set to non-USD.

<img width="696" alt="Screen Shot 2022-09-27 at 6 28 12 PM" src="https://user-images.githubusercontent.com/56598660/192502557-2272fe51-39db-4f66-a978-a952d6727066.png">


#### Proposed Changes

* Remove hardcoded '**displayPrice**' and '**displayCurrency**' values in Jetpack Social constants to allow the page to fetch and load price from API.

#### Testing Instructions

1. * Run `git fetch && git checkout fix/jetpack-social-incorrect-currency`
    * Run `yarn start-jetpack-cloud`
2. Go to your store admin by using the link `https://wordpress.com/wp-admin/network/admin.php?page=store-admin&action=search&username=:username` and make sure you change `:username` to your wordpress account.
3. Set your currency to **GBP** or other currency that is not _USD_.
<img width="359" alt="Screen Shot 2022-09-27 at 6 24 16 PM" src="https://user-images.githubusercontent.com/56598660/192501686-fb31b8d8-ba54-441d-abec-064215b577b4.png">

4. Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
5. Confirm that the currency symbol displayed for **Jetpack Social** is correct.

<img width="652" alt="Screen Shot 2022-09-27 at 6 27 13 PM" src="https://user-images.githubusercontent.com/56598660/192502375-e3404dbe-9268-40c6-8057-18ec0d785bab.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202796695664022-as-1203054101668889

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203054101668889