### PR TITLE
Pattern Assembler - Scroll to a specific section in the preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -23,6 +23,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const [ footer, setFooter ] = useState< Pattern | null >( null );
 	const [ sections, setSections ] = useState< Pattern[] >( [] );
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
+	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
 	const { goBack, goNext, submit } = navigation;
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -54,6 +55,11 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		return pageTemplate;
 	};
 
+	const setScrollToSelectorByPosition = ( position: number ) => {
+		const patternPosition = header ? position + 1 : position;
+		setScrollToSelector( `.entry-content > .wp-block-group:nth-child( ${ patternPosition + 1 } )` );
+	};
+
 	const addSection = ( pattern: Pattern ) => {
 		if ( sectionPosition !== null ) {
 			setSections( [
@@ -61,8 +67,10 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				pattern,
 				...sections.slice( sectionPosition + 1 ),
 			] );
+			setScrollToSelectorByPosition( sectionPosition );
 		} else {
 			setSections( [ ...( sections as Pattern[] ), pattern ] );
+			setScrollToSelectorByPosition( sections.length );
 		}
 	};
 
@@ -121,9 +129,11 @@ const PatternAssembler: Step = ( { navigation } ) => {
 						footer={ footer }
 						onSelectHeader={ () => {
 							setShowPatternSelectorType( 'header' );
+							setScrollToSelector( null );
 						} }
 						onDeleteHeader={ () => {
 							setHeader( null );
+							setScrollToSelector( null );
 						} }
 						onSelectSection={ ( position: number | null ) => {
 							setSectionPosition( position );
@@ -131,18 +141,23 @@ const PatternAssembler: Step = ( { navigation } ) => {
 						} }
 						onDeleteSection={ ( position: number ) => {
 							deleteSection( position );
+							setScrollToSelectorByPosition( position - 1 );
 						} }
 						onMoveUpSection={ ( position: number ) => {
 							moveUpSection( position );
+							setScrollToSelectorByPosition( position - 1 );
 						} }
 						onMoveDownSection={ ( position: number ) => {
 							moveDownSection( position );
+							setScrollToSelectorByPosition( position + 1 );
 						} }
 						onSelectFooter={ () => {
 							setShowPatternSelectorType( 'footer' );
+							setScrollToSelector( 'footer' );
 						} }
 						onDeleteFooter={ () => {
 							setFooter( null );
+							setScrollToSelector( null );
 						} }
 						onContinueClick={ () => {
 							if ( siteSlugOrId ) {
@@ -161,7 +176,12 @@ const PatternAssembler: Step = ( { navigation } ) => {
 					/>
 				) }
 			</div>
-			<PatternAssemblerPreview header={ header } sections={ sections } footer={ footer } />
+			<PatternAssemblerPreview
+				header={ header }
+				sections={ sections }
+				footer={ footer }
+				scrollToSelector={ scrollToSelector }
+			/>
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -4,7 +4,7 @@ import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -20,17 +20,16 @@ interface Props {
 	header: Pattern | null;
 	sections: Pattern[];
 	footer: Pattern | null;
+	scrollToSelector: string | null;
 }
 
-const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => {
+const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelector }: Props ) => {
 	const locale = useLocale();
 	const translate = useTranslate();
 	const site = useSite();
 	const [ webPreviewFrameContainer, setWebPreviewFrameContainer ] = useState< Element | null >(
 		null
 	);
-	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
-	const prevSectionsRef: { current: undefined | Pattern[] } = useRef();
 	const hasSelectedPatterns = header || sections.length > 0 || footer;
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
@@ -50,44 +49,6 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 	useEffect( () => {
 		setWebPreviewFrameContainer( document.querySelector( '.web-preview__frame-wrapper' ) );
 	}, [] );
-
-	useEffect( () => {
-		setScrollToSelector( null );
-	}, [ header ] );
-
-	useEffect( () => {
-		setScrollToSelector( footer ? 'footer' : null );
-	}, [ footer ] );
-
-	useEffect( () => {
-		const prevSections = prevSectionsRef.current;
-		const setScrollToSelectorByPosition = ( position: number ) => {
-			const patternPosition = header ? position + 1 : position;
-			setScrollToSelector( `.entry-content > .wp-block-group:nth-child( ${ patternPosition } )` );
-		};
-
-		if ( ! prevSections || ! sections.length ) {
-			prevSectionsRef.current = sections;
-			setScrollToSelector( null );
-			return;
-		}
-
-		if ( prevSections.length === sections.length ) {
-			// Ordered
-			const orderedSectionIndex = sections.findIndex( ( section, index ) => {
-				return section.id !== prevSections[ index ].id;
-			} );
-			setScrollToSelectorByPosition( orderedSectionIndex + 1 );
-		} else if ( sections.length > prevSections.length ) {
-			// Added
-			setScrollToSelectorByPosition( sections.length );
-		} else {
-			// Removed
-			setScrollToSelector( null );
-		}
-
-		prevSectionsRef.current = sections;
-	}, [ sections, header ] );
 
 	return (
 		<div


### PR DESCRIPTION
#### Proposed Changes

* Scroll to a section in the preview using the class `.wp-block-group` and the position of the pattern.
* Trigger the scrolling when a section is added, ordered, or removed
* When the header is present the position is incremented by one because the header blocks have the class `.wp-block-group` too
* When a section is ordered up or down, we scroll to the section that ends on top after the ordering. 

#### Work in progress
When moving a pattern up/down the preview is not scrolling properly. This can be improved by passing a prop when the user moves a pattern down or up.

#### Testing Instructions

- Click on the Calypso Live (direct link) in the comment below.
- Type the URL `/setup?siteSlug={Site slug}&flags=signup/design-picker-pattern-assembler` in the Calypso Live domain
- Select the goal `Promote myself or business`
- Click on the Blank canvas CTA
- Add/remove/order patterns (header, sections, and footer)
- After a pattern is added or ordered, it should be visible in the preview because we scroll automatically to show it

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68182 
