### PR TITLE
Tailored Flows: Fix Newsletter submit button 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -94,13 +94,13 @@ $border-radius: 4px;
 		}
 
 		.newsletter-setup__contrast-warning {
-			z-index: 1;
 			display: flex;
 			font-size: $font-body-small;
 			height: 0;
 			transition: height 0.5s ease-in-out, opacity 0.5s ease-in-out;
 			opacity: 0;
 			margin-top: 16px;
+			overflow: hidden;
 
 			&.is-visible {
 				height: 80px;
@@ -119,7 +119,6 @@ $border-radius: 4px;
 
 		.newsletter-setup__submit-button {
 			border-radius: $border-radius;
-			z-index: 2;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -94,6 +94,7 @@ $border-radius: 4px;
 		}
 
 		.newsletter-setup__contrast-warning {
+			z-index: 1;
 			display: flex;
 			font-size: $font-body-small;
 			height: 0;
@@ -118,6 +119,7 @@ $border-radius: 4px;
 
 		.newsletter-setup__submit-button {
 			border-radius: $border-radius;
+			z-index: 2;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

On NL setup step, the submit button ( continue ) is not clickable sometimes because [another element](https://github.com/Automattic/wp-calypso/blob/5d12ab0aba139cabd74d2301d7be1b5d2aa9ef85/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx#L224) is on top of it.
This PR set's the z-index on the button to be on top of the other element

## Testing Instructions

- Navigate to `/setup/newsletterSetup?flow=newsletter`
- Play with the form and check if the button is always clickable.

Related to #68342
Fixes #68342
