### PR TITLE
Change default accent color for newsletter

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -34,8 +34,8 @@ type AccentColor = {
 };
 
 const defaultAccentColor = {
-	hex: '#0675C4',
-	rgb: { r: 6, g: 117, b: 196 },
+	hex: '#113AF5',
+	rgb: { r: 17, g: 58, b: 245 },
 	default: true,
 };
 


### PR DESCRIPTION
## Proposed Changes

Change default Newsletter's Accent color.

## Testing Instructions

- Start a brand new session ( incognito )
- Navigate to `/setup/newsletterSetup?flow=newsletter`
- Check if the default accent color is 
<img width="403" alt="image" src="https://user-images.githubusercontent.com/2653810/192522292-415ace0c-d212-4241-b2cc-21374ec4c142.png">


Related to #68299
Fixes #68299
