### PR TITLE
Marketplace: use isInMarketplace prop

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -62,7 +62,6 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
-import { isMarketplaceFlow } from '../plugins/flows';
 import PlanTypeSelector from './plan-type-selector';
 import PlanFAQ from './plansStepFaq';
 import WpcomFAQ from './wpcom-faq';
@@ -366,7 +365,7 @@ export class PlansFeaturesMain extends Component {
 			selectedPlan,
 			plansWithScroll,
 			isAllPaidPlansShown,
-			flowName,
+			isInMarketplace,
 			sitePlanSlug,
 		} = this.props;
 
@@ -401,7 +400,7 @@ export class PlansFeaturesMain extends Component {
 
 		const withIntervalSelector = this.getKindOfPlanTypeSelector( this.props ) === 'interval';
 
-		if ( isMarketplaceFlow( flowName ) ) {
+		if ( isInMarketplace ) {
 			// workaround to show free plan on both monthly/yearly toggle
 			if ( sitePlanSlug === PLAN_FREE && ! plans.includes( PLAN_FREE ) ) {
 				// elements are rendered in order, needs to be the first one

--- a/client/my-sites/plugins/flows.ts
+++ b/client/my-sites/plugins/flows.ts
@@ -1,4 +1,0 @@
-export const MARKETPLACE_FLOW = 'marketplace';
-export const isMarketplaceFlow = ( flowName: string | null ) => {
-	return MARKETPLACE_FLOW === flowName;
-};

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -18,7 +18,6 @@ import { Gridicon } from 'calypso/devdocs/design/playground-scope';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
-import { MARKETPLACE_FLOW } from 'calypso/my-sites/plugins/flows';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -107,7 +106,7 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					intervalType={ intervalType }
 					selectedPlan={ PLAN_BUSINESS }
 					planTypes={ [ currentPlanType, TYPE_BUSINESS, TYPE_ECOMMERCE ] }
-					flowName={ MARKETPLACE_FLOW }
+					isInMarketplace
 					shouldShowPlansFeatureComparison
 					isReskinned
 				/>


### PR DESCRIPTION
#### Proposed Changes

* According to [comment](https://github.com/Automattic/wp-calypso/pull/68123#discussion_r978415718), we should not use `flowName` and instead use `isInMarketplace`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Site should be on the free plan
* Go to /plugins/plans/:site?flags=plugins-plans-page
* Toggle between yearly/monthly and check if the free plan is still there

Related to #68228
