### PR TITLE
Launchpad: Fix domain text highlights

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -84,7 +84,7 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 				</h1>
 				<p className="launchpad__sidebar-description">{ subtitle }</p>
 				<div className="launchpad__url-box">
-					{ /* Google Chrome is adding an extra space after selected text. This extra wrapping div prevents that */ }
+					{ /* Google Chrome is adding an extra space after highlighted text. This extra wrapping div prevents that */ }
 					<div>
 						<span>{ siteName }</span>
 						<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -84,8 +84,11 @@ const Sidebar = ( { siteSlug, submit, goNext, goToStep }: SidebarProps ) => {
 				</h1>
 				<p className="launchpad__sidebar-description">{ subtitle }</p>
 				<div className="launchpad__url-box">
-					<span>{ siteName }</span>
-					<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
+					{ /* Google Chrome is adding an extra space after selected text. This extra wrapping div prevents that */ }
+					<div>
+						<span>{ siteName }</span>
+						<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
+					</div>
 				</div>
 				<Checklist tasks={ enhancedTasks } />
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -105,8 +105,9 @@
 	background: #f6f7f7;
 	border: 1px solid var(--studio-gray-0);
 	border-radius: 4px;
+	display: flex;
+	align-items: center;
 	height: 48px;
-	line-height: 48px;
 	margin: 32px 0;
 	padding: 0 20px;
 


### PR DESCRIPTION
### Proposed Changes

* Use flexbox to vertically center text instead of line height styling

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/28742426/191989340-e2da3c2b-7166-4938-a0b9-ab540d57853e.png)

#### After
![image](https://user-images.githubusercontent.com/28742426/191989280-07abf615-ca65-44e7-8a35-e4864f9ebd9b.png)


### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create link-in-bio or newsletter site https://wordpress.com/hp-2022-tailored-flows/
* Stop at the launchpad view
* Ensure that you're loading the local dev environment ( calypso.localhost:3000 )
* Verify that selecting the domain url text no longer highlights the full height of the container in chrome
* Verify that highlighting domain url text in other browsers continues to work as expected

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68214
