### PR TITLE
Allow payment methods to be collected for free trials.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -16,7 +16,13 @@ export default function filterAppropriatePaymentMethods( {
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	responseCart: ResponseCart;
 } ): PaymentMethod[] {
-	const isPurchaseFree = responseCart.total_cost_integer === 0;
+	const jetpackFreeTrialProducts = [ 2504, 2504 ];
+	const isAFreeTrialPurchase =
+		responseCart.products &&
+		responseCart.products.some(
+			( product ) => jetpackFreeTrialProducts.indexOf( product.product_id ) !== -1
+		);
+	const isPurchaseFree = responseCart.total_cost_integer === 0 && ! isAFreeTrialPurchase;
 	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
 
 	return paymentMethodObjects


### PR DESCRIPTION
#### Proposed Changes

* Free trial plans don't accept a payment method as of now, since they are essentially a free purchase. This PR introduces a change to accept payment methods

#### Testing Instructions
* Checkout to the http://calypso.localhost:3000/checkout/jetpack/jetpack_social_basic_monthly plan and make sure you enable the store sandbox method PCYsg-IA-p2#sandbox method on your sandbox 
* Put in a new credit card, test credit card numbers can be found on the same FG page.
* Ensure you're able to save the credit card details and subscribe to the plan


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before

<img width="866" alt="Screenshot 2022-09-27 at 8 56 20 PM" src="https://user-images.githubusercontent.com/6594561/192568819-46fc5742-7869-42b8-91c0-b9f3dcba4f53.png">

After

<img width="850" alt="Screenshot 2022-09-27 at 9 01 23 PM" src="https://user-images.githubusercontent.com/6594561/192569973-b9e6e80e-fe73-4fe4-ae97-b45deb359953.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #