### PR TITLE
Tailored Flows: make input label and add site icon black

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -39,6 +39,7 @@ $font-family: "SF Pro Text", $sans;
 	}
 
 	.form-label {
+		color: var(--studio-gray-100);
 		margin-bottom: 8px;
 	}
 
@@ -70,6 +71,10 @@ $font-family: "SF Pro Text", $sans;
 
 		input {
 			height: 44px;
+		}
+
+		.components-form-file-upload .add {
+			color: var(--studio-gray-100);
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -50,7 +50,7 @@ $border-radius: 4px;
 		}
 
 		.form-label {
-			color: var(--studio-black);
+			color: var(--studio-gray-100);
 			margin-bottom: 8px;
 		}
 
@@ -93,6 +93,10 @@ $border-radius: 4px;
 
 		input {
 			height: 44px;
+		}
+
+		.components-form-file-upload .add {
+			color: var(--studio-gray-100);
 		}
 
 		.newsletter-setup__contrast-warning {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -50,6 +50,7 @@ $border-radius: 4px;
 		}
 
 		.form-label {
+			color: var(--studio-black);
 			margin-bottom: 8px;
 		}
 


### PR DESCRIPTION
Awaiting feedback from design

#### Proposed Changes

* Change newsletter setup input labels to be  Grey 100, or #101517
* Change 'Add site icon' to be  Grey 100, or #101517

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter`
* Check that the labels and 'Add site icon' are black


Fixes #68207
