### PR TITLE
Update the ThemesList component and its child to functional components

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 const noop = () => {};
 
-const ThemesList = ( props ) => {
+export const ThemesList = ( props ) => {
 	const fetchNextPage = useCallback(
 		( options ) => {
 			props.fetchNextPage( options );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -64,81 +64,89 @@ export class ThemesList extends Component {
 		);
 	}
 
-	renderTheme( theme, index ) {
-		if ( isEmpty( theme ) ) {
-			return null;
-		}
-		// Decide if we should pass ref for bookmark.
-		const { themesBookmark, siteId } = this.props;
-		const bookmarkRef = themesBookmark === theme.id ? this.props.bookmarkRef : null;
-
-		return (
-			<Theme
-				key={ 'theme-' + theme.id }
-				buttonContents={ this.props.getButtonOptions( theme.id ) }
-				screenshotClickUrl={
-					this.props.getScreenshotUrl && this.props.getScreenshotUrl( theme.id )
-				}
-				onScreenshotClick={ this.props.onScreenshotClick }
-				onMoreButtonClick={ this.props.onMoreButtonClick }
-				actionLabel={ this.props.getActionLabel( theme.id ) }
-				index={ index }
-				theme={ theme }
-				active={ this.props.isActive( theme.id ) }
-				price={ this.props.getPrice( theme.id ) }
-				installing={ this.props.isInstalling( theme.id ) }
-				upsellUrl={ this.props.upsellUrl }
-				bookmarkRef={ bookmarkRef }
-				siteId={ siteId }
-			/>
-		);
-	}
-
-	renderLoadingPlaceholders() {
-		return times( this.props.placeholderCount, function ( i ) {
-			return (
-				<Theme
-					key={ 'placeholder-' + i }
-					theme={ { id: 'placeholder-' + i, name: 'Loading…' } }
-					isPlaceholder={ true }
-				/>
-			);
-		} );
-	}
-
-	// Invisible trailing items keep all elements same width in flexbox grid.
-	renderTrailingItems() {
-		const NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
-		return times( NUM_SPACERS, function ( i ) {
-			return <div className="themes-list__spacer" key={ 'themes-list__spacer-' + i } />;
-		} );
-	}
-
-	renderEmpty() {
-		return (
-			this.props.emptyContent || (
-				<EmptyContent
-					title={ this.props.translate( 'Sorry, no themes found.' ) }
-					line={ this.props.translate( 'Try a different search or more filters?' ) }
-				/>
-			)
-		);
-	}
-
 	render() {
 		if ( ! this.props.loading && this.props.themes.length === 0 ) {
-			return this.renderEmpty();
+			return <Empty emptyContent={ this.props.emptyContent } translate={ this.props.translate } />;
 		}
 
 		return (
 			<div className="themes-list">
-				{ this.props.themes.map( this.renderTheme, this ) }
-				{ this.props.loading && this.renderLoadingPlaceholders() }
-				{ this.renderTrailingItems() }
+				{ this.props.themes.map( ( theme, index ) => (
+					<ThemeBlock
+						key={ 'theme-block' + index }
+						theme={ theme }
+						index={ index }
+						{ ...this.props }
+					/>
+				) ) }
+				{ this.props.loading && (
+					<LoadingPlaceholders placeholderCount={ this.props.placeholderCount } />
+				) }
+				{ /* Invisible trailing items keep all elements same width in flexbox grid. */ }
+				<TrailingItems />
 				<InfiniteScroll nextPageMethod={ this.fetchNextPage } />
 			</div>
 		);
 	}
+}
+
+function ThemeBlock( props ) {
+	const { theme, index } = props;
+	if ( isEmpty( theme ) ) {
+		return null;
+	}
+	// Decide if we should pass ref for bookmark.
+	const { themesBookmark, siteId } = props;
+	const bookmarkRef = themesBookmark === theme.id ? props.bookmarkRef : null;
+
+	return (
+		<Theme
+			key={ 'theme-' + theme.id }
+			buttonContents={ props.getButtonOptions( theme.id ) }
+			screenshotClickUrl={ props.getScreenshotUrl && props.getScreenshotUrl( theme.id ) }
+			onScreenshotClick={ props.onScreenshotClick }
+			onMoreButtonClick={ props.onMoreButtonClick }
+			actionLabel={ props.getActionLabel( theme.id ) }
+			index={ index }
+			theme={ theme }
+			active={ props.isActive( theme.id ) }
+			price={ props.getPrice( theme.id ) }
+			installing={ props.isInstalling( theme.id ) }
+			upsellUrl={ props.upsellUrl }
+			bookmarkRef={ bookmarkRef }
+			siteId={ siteId }
+		/>
+	);
+}
+
+function Empty( { emptyContent, translate } ) {
+	return (
+		emptyContent || (
+			<EmptyContent
+				title={ translate( 'Sorry, no themes found.' ) }
+				line={ translate( 'Try a different search or more filters?' ) }
+			/>
+		)
+	);
+}
+
+function LoadingPlaceholders( { placeholderCount } ) {
+	return times( placeholderCount, function ( i ) {
+		return (
+			<Theme
+				key={ 'placeholder-' + i }
+				theme={ { id: 'placeholder-' + i, name: 'Loading…' } }
+				isPlaceholder={ true }
+			/>
+		);
+	} );
+}
+
+function TrailingItems() {
+	const NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
+	return times( NUM_SPACERS, function ( i ) {
+		return <div className="themes-list__spacer" key={ 'themes-list__spacer-' + i } />;
+	} );
 }
 
 const mapStateToProps = ( state ) => ( {


### PR DESCRIPTION
#### Proposed Changes

* Update the ThemesList component to class from functional
* Move the `render*` methods inside ThemesList to a functional component.

#### Testing Instructions

* Go to the themes page. (`/themes/{site}`)
* Check if it still working as the prod version.
  * Check if the search is correctly showing the theme options
  * Search for an empty keyword and check if the message is being shown. Non-result keyword example: `abc`
  * Check if the placeholder is being shown while loading
  * Check if the grid is being properly displayed (width)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
