### PR TITLE
Strip subfolders from base URL in site preview URL field

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -127,7 +127,12 @@ class PreviewMain extends Component {
 	}
 
 	updateSiteLocation = ( pathname ) => {
-		const externalUrl = this.props.site.URL + ( pathname === '/' ? '' : pathname );
+		let externalUrl;
+		try {
+			externalUrl = new URL( this.props.site.URL ).origin + ( pathname === '/' ? '' : pathname );
+		} catch ( e ) {
+			externalUrl = this.props.site.URL + ( pathname === '/' ? '' : pathname );
+		}
 		this.setState( { externalUrl } );
 		this.props.recordTracksEvent( 'calypso_view_site_page_view', {
 			full_url: externalUrl,


### PR DESCRIPTION
#### Proposed Changes

Currently in the site preview URL field, the base URL is defined as `this.props.site.URL`, which can be problematic as this includes the subfolder of a WP installation for Jetpack connected sites

The `pathname` property is appended to this base URL, and in instances where a Jetpack site has WordPress installed in a subfolder, this creates a duplicate subfolder path, i.e., `https://foo.com/sub/sub/`

This PR uses the `URL` constructor and `origin` property to strip the subfolder from the base URL, preventing the `pathname` operator from creating a duplicate subfolder in the URL displayed in site preview URL field.

In first iteration #67772 (had to create a new PR due to an issue with a rebase), @tyxla recommended using a try/catch statement because the URL constructor can throw a TypeError. I've implemented this into this commit, opting to fall back to the original code if there is an error. If you have any additional suggestions, or a better way to approach this, I'm happy to look!

Big thanks to @fullofcaffeine for pointing me to to the URL.origin property: https://developer.mozilla.org/en-US/docs/Web/API/URL/origin

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new WP installation in a subfolder and connect it to Jetpack. You can use https://jurassic.ninja/specialops/ with the "Launch Multisite on subdirs" option. Then add a site in the Network Admin Sites screen: https://wordpress.org/support/article/network-admin-sites-screen/
* Navigate to https://wordpress.com, click "Switch Site" in upper left, and select your newly created site
* Preview the site by clicking the Site URL/Title in the upper left hand corner of Calypso
* Verify that URL is properly updated with the correct path when clicking on pages/posts in the site's preview
* Test on Simple, Atomic, and Jetpack connected sites (with root WP install)

#### BEFORE:
<img width="1264" alt="before" src="https://user-images.githubusercontent.com/65082164/190023177-bc0c9f68-db05-495f-9eb7-4e9e9eda52e2.png">


#### AFTER:
<img width="1263" alt="after" src="https://user-images.githubusercontent.com/65082164/190023199-2c584807-5cfb-4d5b-bce8-08c3ab5112cf.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67563
