### PR TITLE
Theme/plugin bundling: Use software_sets field from starter designs endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -218,13 +218,15 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	);
 
 	const isPluginBundleEligible = useIsPluginBundleEligible();
-	const hasThemeSoftwareSet = ( selectedDesign?.software_sets || [] ).some(
+	const isBundledWithWooCommerce = ( selectedDesign?.software_sets || [] ).some(
 		( set ) => set.slug === 'woo-on-plans'
 	);
 
 	const shouldUpgrade =
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
-		( isEnabled( 'themes/plugin-bundling' ) && ! isPluginBundleEligible && hasThemeSoftwareSet );
+		( isEnabled( 'themes/plugin-bundling' ) &&
+			! isPluginBundleEligible &&
+			isBundledWithWooCommerce );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -28,7 +28,6 @@ import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundl
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
-import { useThemeDetails } from '../../../../hooks/use-theme-details';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
@@ -219,8 +218,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	);
 
 	const isPluginBundleEligible = useIsPluginBundleEligible();
-	const themeDetails = useThemeDetails( selectedDesign?.slug || '' );
-	const hasThemeSoftwareSet = themeDetails?.data?.taxonomies?.theme_software_set?.length;
+	const hasThemeSoftwareSet = ( selectedDesign?.software_sets || [] ).some(
+		( set ) => set.slug === 'woo-on-plans'
+	);
 
 	const shouldUpgrade =
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -7,6 +7,7 @@ import type {
 	Category,
 	Design,
 	DesignRecipe,
+	SoftwareSet,
 	StyleVariation,
 } from '@automattic/design-picker/src/types';
 
@@ -35,6 +36,7 @@ interface StaticDesign {
 	categories: Category[];
 	price?: string;
 	style_variations?: StyleVariation[];
+	software_sets?: SoftwareSet[];
 }
 
 interface GeneratedDesign {
@@ -77,7 +79,8 @@ function fetchStarterDesigns(
 }
 
 function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
-	const { slug, title, description, recipe, categories, price, style_variations } = design;
+	const { slug, title, description, recipe, categories, price, style_variations, software_sets } =
+		design;
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
 
@@ -89,6 +92,7 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		categories,
 		is_premium,
 		price,
+		software_sets,
 		design_type: is_premium ? 'premium' : 'standard',
 		style_variations,
 		verticalizable: isThemeVerticalizable( recipe.stylesheet ),

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -61,6 +61,10 @@ export interface DesignRecipe {
 	footer_pattern_ids?: number[] | string[];
 }
 
+export interface SoftwareSet {
+	slug: string;
+}
+
 export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
 
 /**
@@ -88,6 +92,7 @@ export interface Design {
 	style_variations?: StyleVariation[];
 	price?: string;
 	verticalizable?: boolean;
+	software_sets?: SoftwareSet[];
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
#### Proposed Changes

* Use `software_sets` field from starter designs endpoint (D88069-code)
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with these flags on: `themes/plugin-bundling`,`signup/seller-upgrade-modal` 
* Choose a plan with access to premium themes, but not WooCommerce.
* On the design picker choose Thriving Artist (that has bundling)
* Check that the Upgrade Modal is still shown

Related to #67120
