### PR TITLE
[a8c-blocks] Generate .min.js by default for o2-blocks JS assets

### DIFF
--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -41,7 +41,7 @@ function a8c_editor_assets() {
 
 	wp_enqueue_script(
 		'a8c-blocks-js',
-		plugins_url( 'dist/editor.js', __FILE__ ),
+		plugins_url( 'dist/editor.min.js', __FILE__ ),
 		$assets['dependencies'],
 		$assets['version'],
 		true

--- a/apps/o2-blocks/index.php
+++ b/apps/o2-blocks/index.php
@@ -37,7 +37,7 @@
  * Load editor assets.
  */
 function a8c_editor_assets() {
-	$assets = require plugin_dir_path( __FILE__ ) . 'dist/editor.asset.php';
+	$assets = require plugin_dir_path( __FILE__ ) . 'dist/editor.min.asset.php';
 
 	wp_enqueue_script(
 		'a8c-blocks-js',
@@ -61,7 +61,7 @@ function a8c_editor_assets() {
  */
 function a8c_view_assets() {
 	if ( ! is_admin() ) {
-		$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.asset.php';
+		$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.min.asset.php';
 
 		$style_file = 'dist/view' . ( is_rtl() ? '.rtl.css' : '.css' );
 		wp_enqueue_style(

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -47,6 +47,7 @@
 	"devDependencies": {
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
+		"@wordpress/readable-js-assets-webpack-plugin": "^1.0.4",
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"postcss": "^8.4.5",

--- a/apps/o2-blocks/webpack.config.js
+++ b/apps/o2-blocks/webpack.config.js
@@ -3,17 +3,23 @@
  */
 
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
 
-module.exports = () => {
-	return getBaseWebpackConfig(
-		{
-			WP: true,
+function getWebpackConfig( env, argv ) {
+	const webpackConfig = getBaseWebpackConfig( { ...env, WP: true }, argv );
+
+	return {
+		...webpackConfig,
+		entry: {
+			editor: './src/editor.js',
+			view: './src/view.js',
 		},
-		{
-			entry: {
-				editor: './src/editor.js',
-				view: './src/view.js',
-			},
-		}
-	);
-};
+		output: {
+			...webpackConfig.output,
+			filename: '[name].min.js',
+		},
+		plugins: [ ...webpackConfig.plugins, new ReadableJsAssetsWebpackPlugin() ],
+	};
+}
+
+module.exports = getWebpackConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,6 +1057,7 @@ __metadata:
     "@wordpress/icons": ^9.5.0
     "@wordpress/is-shallow-equal": ^4.9.0
     "@wordpress/primitives": ^3.7.0
+    "@wordpress/readable-js-assets-webpack-plugin": ^1.0.4
     classnames: ^2.3.1
     enzyme: ^3.11.0
     jest: ^27.3.1


### PR DESCRIPTION
#### Proposed Changes

See for the following PR for a full explanation of why this PR exists: 39-gh-Automattic/coblocks-builder.

Outputs `.min.js` for all generated o2-blocks JS assets. Also generates unminified (and without the `.min` extension prefix) JS assets to follow the pattern adopted by other Calypso apps, such as ETK, see: https://github.com/Automattic/wp-calypso/pull/64622/.

**NOTE:** We might as well not generate an unminified `.js` asset (as in, remove the `ReadableJsAssetsWebpackPlugin` plugin)  and only leave the change to rename the output to `.min.js`. This is up for discussion.


#### Testing Instructions

From your sanbox, install the custom build from this branch using `install-plugin`:

```
install-plugin.sh o2b use/min.js-convention-to-skip-wpcom-minifier-for-o2-blocks
```

Sandbox a P2 site like cl4cA-p2 and add a few O2 blocks. Make sure the P2 nor the blocks broke.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #