### PR TITLE
Marketplace Install Dialog: update button copy

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -162,7 +162,7 @@ export const EligibilityWarnings = ( {
 						busy={ siteIsLaunching || siteIsSavingSettings }
 						onClick={ logEventAndProceed }
 					>
-						{ getProceedButtonText( listHolds, translate ) }
+						{ getProceedButtonText( listHolds, translate, isMarketplace ) }
 					</Button>
 					<div className="support-block">
 						<span>{ translate( 'Need help?' ) }</span>
@@ -193,8 +193,15 @@ function getSiteIsEligibleMessage(
 	}
 }
 
-function getProceedButtonText( holds: string[], translate: LocalizeProps[ 'translate' ] ) {
+function getProceedButtonText(
+	holds: string[],
+	translate: LocalizeProps[ 'translate' ],
+	isMarketplace = false
+) {
 	if ( siteRequiresUpgrade( holds ) ) {
+		if ( isMarketplace ) {
+			return translate( 'Upgrade and activate plugin' );
+		}
 		return translate( 'Upgrade and continue' );
 	}
 	if ( siteRequiresLaunch( holds ) ) {

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -162,7 +162,7 @@ export const EligibilityWarnings = ( {
 						busy={ siteIsLaunching || siteIsSavingSettings }
 						onClick={ logEventAndProceed }
 					>
-						{ getProceedButtonText( listHolds, translate, isMarketplace ) }
+						{ getProceedButtonText( listHolds, translate, context ) }
 					</Button>
 					<div className="support-block">
 						<span>{ translate( 'Need help?' ) }</span>
@@ -196,10 +196,10 @@ function getSiteIsEligibleMessage(
 function getProceedButtonText(
 	holds: string[],
 	translate: LocalizeProps[ 'translate' ],
-	isMarketplace = false
+	context: string | null
 ) {
 	if ( siteRequiresUpgrade( holds ) ) {
-		if ( isMarketplace ) {
+		if ( context === 'plugin-details' || context === 'plugins' ) {
 			return translate( 'Upgrade and activate plugin' );
 		}
 		return translate( 'Upgrade and continue' );


### PR DESCRIPTION
#### Proposed Changes

* Update button copy from "Upgrade and continue" -> "Upgrade and activate plugin"

After

![After](https://user-images.githubusercontent.com/6586048/192683520-1773cf00-9bc6-4a92-9e4a-ad1bca9a48e6.png)


Before

![Before](https://user-images.githubusercontent.com/6586048/192683494-b595f1f5-6924-4f74-8cd4-f70a46bcfcd5.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Using an account with plan that doesn't allow plugin
(free, premium, etc.)
* go to /plugins/:site
* click on a free plugin / click on a paid plugin
* click on the "Install and Activate"
* matches the after screenshot

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68252 