### PR TITLE
Add more section patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -64,32 +64,16 @@ const sectionPatterns: Pattern[] = [
 		name: 'Call to Action',
 	},
 	{
-		id: 7156,
-		name: 'Media and text with image on the right',
-	},
-	{
-		id: 1053,
-		name: 'Contact',
-	},
-	{
-		id: 7135,
-		name: 'Three columns with images and text',
+		id: 1751,
+		name: 'Call to Action',
 	},
 	{
 		id: 7138,
 		name: 'Centered headline and text',
 	},
 	{
-		id: 5634,
-		name: 'Contact Info with Map',
-	},
-	{
 		id: 7140,
 		name: 'Left-aligned headline',
-	},
-	{
-		id: 7143,
-		name: 'Full-width image',
 	},
 	{
 		id: 7146,
@@ -100,6 +84,38 @@ const sectionPatterns: Pattern[] = [
 		name: 'Two column image grid',
 	},
 	{
+		id: 7135,
+		name: 'Three columns with images and text',
+	},
+	{
+		id: 737,
+		name: 'Logos',
+	},
+	{
+		id: 1213,
+		name: 'Quotes',
+	},
+	{
+		id: 5676,
+		name: 'Paragraph and properties',
+	},
+	{
+		id: 789,
+		name: 'Numbered List',
+	},
+	{
+		id: 7143,
+		name: 'Full-width image',
+	},
+	{
+		id: 7159,
+		name: 'Cover image with centered text and a button',
+	},
+	{
+		id: 7156,
+		name: 'Media and text with image on the right',
+	},
+	{
 		id: 7153,
 		name: 'Media and text with image on the left',
 	},
@@ -108,12 +124,24 @@ const sectionPatterns: Pattern[] = [
 		name: 'Cover image with left-aligned call to action',
 	},
 	{
-		id: 7159,
-		name: 'Cover image with centered text and a button',
-	},
-	{
 		id: 7161,
 		name: 'Two testimonials side by side',
+	},
+	{
+		id: 3255,
+		name: 'About me',
+	},
+	{
+		id: 1053,
+		name: 'Contact',
+	},
+	{
+		id: 194,
+		name: 'Contact',
+	},
+	{
+		id: 5634,
+		name: 'Contact Info with Map',
 	},
 ];
 


### PR DESCRIPTION
#### Proposed Changes

* Added section patterns from this [comment](https://github.com/Automattic/wp-calypso/issues/66789#issuecomment-1260350649)
* Changed the order of the patterns to group them by their category

#### Testing Instructions
* Create a new site, don't choose any goal, and a vertical, in the design picker step scroll down to click on the Blank canvas CTA
* Click on `Add a first section`
* Confirm the patterns in this [comment](https://github.com/Automattic/wp-calypso/issues/66789#issuecomment-1260350649) are displayed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66789
