### PR TITLE
Domains: Update `SiteAddressChanger` component to handle managed subdomains

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -10,6 +10,7 @@ import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import {
@@ -61,7 +62,10 @@ export class SiteAddressChanger extends Component {
 		const { domainFieldValue, newDomainSuffix } = this.state;
 		const { currentDomain, currentDomainSuffix, siteId } = this.props;
 		const oldDomain = get( currentDomain, 'name', null );
-		const type = '.wordpress.com' === currentDomainSuffix ? 'blog' : 'dotblog';
+		const type =
+			'.wordpress.com' === currentDomainSuffix
+				? freeSiteAddressType.BLOG
+				: freeSiteAddressType.MANAGED;
 
 		this.props.requestSiteAddressChange(
 			siteId,
@@ -196,7 +200,8 @@ export class SiteAddressChanger extends Component {
 			return;
 		}
 
-		const type = '.wordpress.com' === newDomainSuffix ? 'blog' : 'dotblog';
+		const type =
+			'.wordpress.com' === newDomainSuffix ? freeSiteAddressType.BLOG : freeSiteAddressType.MANAGED;
 
 		this.props.requestSiteAddressAvailability(
 			this.props.siteId,

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -122,3 +122,8 @@ export const domainInfoContext = {
 	DOMAIN_ROW: 'DOMAIN_ROW',
 	PAGE_TITLE: 'PAGE_TITLE',
 };
+
+export const freeSiteAddressType = {
+	MANAGED: 'managed',
+	BLOG: 'blog',
+};

--- a/client/my-sites/domains/domain-management/list/free-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.jsx
@@ -30,8 +30,7 @@ export default function FreeDomainItem( {
 
 	const renderSiteAddressChanger = () => {
 		const domainName = domain?.name ?? '';
-		const dotblogSubdomain = domainName.match( /\.\w+\.blog$/ );
-		const currentDomainSuffix = dotblogSubdomain ? dotblogSubdomain[ 0 ] : '.wordpress.com';
+		const currentDomainSuffix = domainName.match( /\.\w+\.\w+$/ )[ 0 ];
 
 		return (
 			<SiteAddressChanger


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Depends on D88326-code.
This PR enables the `SiteAddressChanger` component to handle managed subdomains - including any other managed subdomains we might add in the future, and not only the `.blog` and `.wordpress.com` ones.

#### Preview
https://user-images.githubusercontent.com/18705930/193083736-56c22e1d-1b1d-4b58-ab03-be55b65727f5.mov

#### Testing instructions
- Apply the back-end patch locally;
  - (Optional): Hack it so that the free domain has a name other than the `.wordpress.com` and `.<subdomain>.blog` ones;
- Go to the domains page; 
- Make sure you see the correct suffix when clicking the "change site address" button.