### PR TITLE
Remove button from premium design description in UDP

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -96,20 +96,13 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				? __( 'Included in your plan' )
 				: __( 'Available with WordPress.com Business' );
 		} else if ( isPremium && shouldUpgrade ) {
-			if ( isEnabled( 'signup/seller-upgrade-modal' ) ) {
-				text = sprintf(
-					/* translators: %(price)s - the price of the theme */
-					__( '%(price)s per year or included in WordPress.com Premium' ),
-					{
-						price: design.price,
-					}
-				);
-			} else {
-				text =
-					'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
-						? __( 'Included in WordPress.com Premium' )
-						: __( 'Upgrade to Premium' );
-			}
+			text = sprintf(
+				/* translators: %(price)s - the price of the theme */
+				__( '%(price)s per year or included in WordPress.com Premium' ),
+				{
+					price: design.price,
+				}
+			);
 		} else if ( isPremium && ! shouldUpgrade && hasPurchasedTheme ) {
 			text = __( 'Purchased on an annual subscription' );
 		} else if ( isPremium && ! shouldUpgrade && ! hasPurchasedTheme ) {

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -3,9 +3,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_WOOP } from '@automattic/calypso-products';
 import { MShotsImage } from '@automattic/onboarding';
-import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -79,7 +77,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	design,
 	isPremiumThemeAvailable = false,
 	hasPurchasedTheme = false,
-	onCheckout,
 	verticalId,
 	currentPlanFeatures,
 } ) => {
@@ -100,35 +97,18 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				: __( 'Available with WordPress.com Business' );
 		} else if ( isPremium && shouldUpgrade ) {
 			if ( isEnabled( 'signup/seller-upgrade-modal' ) ) {
-				text = createInterpolateElement(
-					sprintf(
-						/* translators: %(price)s - the price of the theme */
-						__( '%(price)s per year or <button>included in WordPress.com Premium</button>' ),
-						{
-							price: design.price,
-						}
-					),
+				text = sprintf(
+					/* translators: %(price)s - the price of the theme */
+					__( '%(price)s per year or included in WordPress.com Premium' ),
 					{
-						button: (
-							<Button
-								isLink={ true }
-								className="design-picker__button-link"
-								onClick={ ( e: any ) => {
-									e.stopPropagation();
-									onCheckout?.();
-								} }
-							/>
-						),
+						price: design.price,
 					}
 				);
 			} else {
-				text = (
-					<Button isLink={ true } className="design-picker__button-link">
-						{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
-							? __( 'Included in WordPress.com Premium' )
-							: __( 'Upgrade to Premium' ) }
-					</Button>
-				);
+				text =
+					'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
+						? __( 'Included in WordPress.com Premium' )
+						: __( 'Upgrade to Premium' );
 			}
 		} else if ( isPremium && ! shouldUpgrade && hasPurchasedTheme ) {
 			text = __( 'Purchased on an annual subscription' );

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -4,7 +4,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_WOOP } from '@automattic/calypso-products';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
-import { sprintf, hasTranslation } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';


### PR DESCRIPTION
#### Proposed Changes

1. Remove the button element with a direct link to the checkout on premium design descriptions in the Unified Design Picker. We keep the text and remove the button and the direct link when the flag `signup/seller-upgrade-modal` is enabled, or not.

The direct link to the checkout was removed from one of the buttons in https://github.com/Automattic/wp-calypso/pull/67158. Therefore I believe the whole button and the direct link can be removed whether the flag `signup/seller-upgrade-modal` is enabled or not. Note that the flag is disabled in the config for all environments except for wp-calypso.

##### With `signup/seller-upgrade-modal` disabled
|Before|After|
|-------|-----|
|<img width="456" alt="Screen Shot 2565-09-28 at 11 59 37" src="https://user-images.githubusercontent.com/1881481/192701888-0dbe2340-8764-4144-a1f0-a2e5de2dea81.png">|<img width="504" alt="Screen Shot 2565-09-28 at 13 12 26" src="https://user-images.githubusercontent.com/1881481/192701867-d693e02c-2d14-4221-a88a-a70b92673fdf.png">|

##### With `signup/seller-upgrade-modal` enabled
|Before|After|
|-------|-----|
|<img width="498" alt="Screen Shot 2565-09-28 at 13 22 24" src="https://user-images.githubusercontent.com/1881481/192703292-5d795c67-92ee-48da-a0dc-dd15588853df.png">|<img width="495" alt="Screen Shot 2565-09-28 at 12 49 49" src="https://user-images.githubusercontent.com/1881481/192702093-7def519e-1061-4d1d-9dca-e64312cd53cf.png">|

2. Thanks to this change, we are fixing the following React warning `<button> can not appear as a descendant of <button>`

![image](https://user-images.githubusercontent.com/1881481/192700566-be5a2761-d159-4645-b6c7-ec02d1ad5655.png)

<img width="812" alt="Screen Shot 2565-09-28 at 11 53 04" src="https://user-images.githubusercontent.com/1881481/192700617-36f76e2c-370a-43d8-b7f9-521fa6e55d16.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup/designSetup?siteSlug=[YOUR_SITE]`.
- Find a Premium theme.
- Click on the description `Included in the WordPress.com Premium`.
- Verify that the theme preview is opened with and without this param in the URL `&flags=signup/seller-upgrade-modal`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65364
