### PR TITLE
Update text for FIRST_POST_PUBLISHED task

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -270,7 +270,7 @@ export const getTask = (
 				timing: 10,
 				title: translate( 'Publish your first post' ),
 				description: translate(
-					"See how your site looks to site visitors. Remember, your blog is a work in progress — you can always choose a new theme or tweak your site's design."
+					"Get your thoughts together because it is time to start writing. After publishing, don't forget to share your first post with your networks on social media."
 				),
 				actionText: translate( 'Draft a post' ),
 				actionUrl: `/post/${ siteSlug }`,


### PR DESCRIPTION
#### Proposed Changes

Currently the text for the "Publish your first post" task is identical to the "Preview your blog" task, which does not make sense. This PR updates the copy.

| Before | After |
| -------|------|
|  <img width="701" alt="Screen Shot 2022-09-28 at 14 24 06" src="https://user-images.githubusercontent.com/1525580/192720961-176c5cd2-634e-45d2-942f-ee0ee93eaf13.png"> | <img width="706" alt="Screen Shot 2022-09-28 at 14 40 12" src="https://user-images.githubusercontent.com/1525580/192721402-7b842880-664a-4fec-8bd2-f536f00e7ece.png"> |


#### Testing Instructions

1. Start at wordpress.com/start
2. Select domain and plan
3. Select "Write and publish" on goals selection page.
5. Just click "Skip to dashboard"
6. In wordpress.com/home of the site, in the setup checklist to the right of the screen, click on "Preview your blog."
7. Check the "Publish your first post" card, and verify that the text is now correct.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #67331
