### PR TITLE
Jetpack Agency Dashboard: use total favorites count to show pagination in the favorites tab

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -107,7 +107,7 @@ export default function SitesOverview() {
 		]
 	);
 
-	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
+	const selectedTab = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
 	const hasAppliedFilter = !! search || filter?.issueTypes?.length > 0;
 	const showEmptyState = ! isLoading && ! isError && ! data?.sites?.length;
 
@@ -121,6 +121,8 @@ export default function SitesOverview() {
 			emptyStateMessage = translate( 'No results found. Please try refining your search.' );
 		}
 	}
+
+	const isFavoritesTab = selectedTab.key === 'favorites';
 
 	return (
 		<div className="sites-overview">
@@ -143,19 +145,16 @@ export default function SitesOverview() {
 							applyUpdatedStyles
 							selectedText={
 								<span>
-									{ selectedItem.label }
-									<Count count={ selectedItem.count } compact={ true } />
+									{ selectedTab.label }
+									<Count count={ selectedTab.count } compact={ true } />
 								</span>
 							}
-							selectedCount={ selectedItem.count }
+							selectedCount={ selectedTab.count }
 							className={ classNames(
-								isMobile &&
-									highlightTab &&
-									selectedItem.key === 'favorites' &&
-									'sites-overview__highlight-tab'
+								isMobile && highlightTab && isFavoritesTab && 'sites-overview__highlight-tab'
 							) }
 						>
-							<NavTabs selectedText={ selectedItem.label } selectedCount={ selectedItem.count }>
+							<NavTabs selectedText={ selectedTab.label } selectedCount={ selectedTab.count }>
 								{ navItems.map( ( props ) => (
 									<NavItem { ...props } compactCount={ true } />
 								) ) }
@@ -176,7 +175,12 @@ export default function SitesOverview() {
 						{ showEmptyState ? (
 							<div className="sites-overview__no-sites">{ emptyStateMessage }</div>
 						) : (
-							<SiteContent data={ data } isLoading={ isLoading } currentPage={ currentPage } />
+							<SiteContent
+								data={ data }
+								isLoading={ isLoading }
+								currentPage={ currentPage }
+								isFavoritesTab={ isFavoritesTab }
+							/>
 						) }
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -16,12 +16,13 @@ const addPageArgs = ( pageNumber: number ) => {
 };
 
 interface Props {
-	data: { sites: Array< any >; total: number; perPage: number } | undefined;
+	data: { sites: Array< any >; total: number; perPage: number; totalFavorites: number } | undefined;
 	isLoading: boolean;
 	currentPage: number;
+	isFavoritesTab: boolean;
 }
 
-export default function SiteContent( { data, isLoading, currentPage }: Props ) {
+export default function SiteContent( { data, isLoading, currentPage, isFavoritesTab }: Props ) {
 	const isMobile = useMobileBreakpoint();
 
 	const sites = formatSites( data?.sites );
@@ -54,7 +55,7 @@ export default function SiteContent( { data, isLoading, currentPage }: Props ) {
 					compact={ isMobile }
 					page={ currentPage }
 					perPage={ data.perPage }
-					total={ data.total }
+					total={ isFavoritesTab ? data.totalFavorites : data.total }
 					pageClick={ handlePageClick }
 				/>
 			) }


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue in the agency dashboard where the pagination is being shown in the favorites tab even when the no of favorite sites is less than 20(pagination count)

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/pagination-in-agency-dashboard-favorites-tab` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Make sure you have 20+ sites or follow the steps to reduce the pagination count - 2dbab-pb.
4. Verify that pagination is shown in the `All` tab. 
5. Select one site as a favorite(should be less than the pagination count).
6. Click on the `Favorites` tab, and verify that the pagination is not being shown. 

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1116" alt="Screenshot 2022-09-28 at 3 27 09 PM" src="https://user-images.githubusercontent.com/10586875/192750210-f4f6c800-58f0-4c28-b177-b10d33c01c7f.png">
</td>
<td>
<img width="1116" alt="Screenshot 2022-09-28 at 3 27 18 PM" src="https://user-images.githubusercontent.com/10586875/192750284-e6b0cce8-5123-42bc-83b3-f778dc0154cf.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [X] ~~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [X] Have you checked for TypeScript, React or other console errors?
- [X] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [X] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1202574303760478