### PR TITLE
Fix: search component redirects to using previous route

### DIFF
--- a/client/lib/query-args/index.ts
+++ b/client/lib/query-args/index.ts
@@ -5,7 +5,7 @@ function getRelativeUrlWithParameters(
 	queryArgs: object,
 	clearExistingParameters = false
 ): string {
-	const url = new URL( window.location.href );
+	const url = new URL( page.current || window.location.href, window.location.origin );
 
 	if ( clearExistingParameters ) {
 		url.searchParams.forEach( ( value, key ) => url.searchParams.delete( key ) );

--- a/client/lib/query-args/index.ts
+++ b/client/lib/query-args/index.ts
@@ -5,7 +5,7 @@ function getRelativeUrlWithParameters(
 	queryArgs: object,
 	clearExistingParameters = false
 ): string {
-	const url = new URL( page.current || window.location.href, window.location.origin );
+	const url = new URL( window.location.href );
 
 	if ( clearExistingParameters ) {
 		url.searchParams.forEach( ( value, key ) => url.searchParams.delete( key ) );

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -9,7 +9,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import './style.scss';
 
 function pageToSearch( s ) {
-	page.show( page.current );
+	page.show( page.current ); // Ensures location.href is up to date before setQueryArgs uses it to construct the redirect.
 	setQueryArgs( '' !== s ? { s } : {} );
 }
 

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,5 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
@@ -8,6 +9,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import './style.scss';
 
 function pageToSearch( s ) {
+	page.show( page.current );
 	setQueryArgs( '' !== s ? { s } : {} );
 }
 


### PR DESCRIPTION
#### Proposed Changes

In certain situations, the Plugins Search component redirects using a previous route ([more info](https://github.com/Automattic/wp-calypso/pull/67989#pullrequestreview-1113387970))
This fixes the issue by trying to use the current route instead of `window.location.href`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* enable "plugins-plans-page" config feature
* On a plan lower than Business
* Go to `/plugins`
* Search for a term (or use one of the keywords)
* Select a plugin
* Try to install and end up on the Plugins Plans page
* Click on the `Search Results` breadcrumb
* You should return to the previous Search Result page 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68115
