### PR TITLE
Emails: enhance the link - Upgrade to a hosted email

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -4,6 +4,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import titleCase from 'to-title-case';
+import Badge from 'calypso/components/badge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
@@ -47,6 +48,8 @@ import {
 } from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
+import './style.scss';
+
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
 
@@ -59,7 +62,8 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 			path={ emailManagementPurchaseNewEmailAccount( selectedSiteSlug, domain.name, currentRoute ) }
 			onClick={ () => recordTracksEvent( 'calypso_upsell_email', { context: 'email-forwarding' } ) }
 		>
-			{ translate( 'Upgrade to a hosted email' ) }
+			{ translate( 'Upgrade to Professional Email' ) }
+			<Badge type="info-green">{ translate( 'Try 3 months free' ) }</Badge>
 		</VerticalNavItem>
 	);
 };

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -22,7 +22,12 @@ import {
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
-import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import {
+	getTitanProductName,
+	getTitanSubscriptionId,
+	hasTitanMailWithUs,
+	isDomainEligibleForTitanIntroductoryOffer,
+} from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
@@ -63,7 +68,9 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 			onClick={ () => recordTracksEvent( 'calypso_upsell_email', { context: 'email-forwarding' } ) }
 		>
 			{ translate( 'Upgrade to Professional Email' ) }
-			<Badge type="info-green">{ translate( 'Try 3 months free' ) }</Badge>
+			{ isDomainEligibleForTitanIntroductoryOffer( domain ) && (
+				<Badge type="info-green">{ translate( 'Try 3 months free' ) }</Badge>
+			) }
 		</VerticalNavItem>
 	);
 };

--- a/client/my-sites/email/email-management/home/email-plan/style.scss
+++ b/client/my-sites/email/email-management/home/email-plan/style.scss
@@ -1,0 +1,10 @@
+.email-plan__actions {
+	.vertical-nav-item.card {
+		padding-bottom: 28px;
+		padding-top: 28px;
+
+		.badge {
+			margin-left: 10px;
+		}
+	}
+}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -171,12 +171,6 @@
 	}
 }
 
-.email-plan__actions .vertical-nav-item.card,
-.email-plan-mailboxes-list__mailbox-list-item.card.is-compact {
-	padding-bottom: 28px;
-	padding-top: 28px;
-}
-
 .email-plan-header__status {
 	display: flex;
 	align-items: center;
@@ -266,7 +260,7 @@
 		}
 
 		> svg {
-			fill: white;
+			fill: #fff;
 		}
 	}
 
@@ -278,6 +272,8 @@
 .email-plan-mailboxes-list__mailbox-list-item.card.is-compact {
 	flex-direction: column;
 	display: flex;
+	padding-bottom: 28px;
+	padding-top: 28px;
 
 	@include break-xlarge {
 		flex-direction: row;


### PR DESCRIPTION
#### Proposed Changes
Enhance the "Upgrade to a hosted email" link to improve conversion from Email Forwarding to paid Email solution

#### Testing Instructions
* Go to your dashboard
* Set up new site with domain, but w/o any email subscription
* Proceed with setting up Forwarded email - [instruction](https://wordpress.com/support/add-email/email-forwarding/#:~:text=Set%20Up%20Email%20Forwarding,-If%20you%20already&text=From%20your%20dashboard%2C%20navigate%20to,to%20this%20email%20address%20field)
* In the left sidebar click on "Upgrades -> Emails" (if you have a few email, then chose your "Email Forwarding" email)

<table>
<tr>
	<td> BEFORE
	<td> 
	<td> <img width="1072" alt="Screenshot 2022-09-28 at 11 49 04" src="https://user-images.githubusercontent.com/5598437/192760556-b9a3a7c2-9ae3-48b5-a35b-937db02903f9.png">
<tr>
	<td> AFTER
	<td> Appeared badge and copy is changed
	<td> <img width="1081" alt="Screenshot 2022-09-28 at 11 50 13" src="https://user-images.githubusercontent.com/5598437/192760788-3d9a026e-ecd8-4b1a-b84b-3bbcd64407fc.png">
</table>

* Since if a user had Private Email subscription and canceled it, then they would not be eligible for Titan free 3 months, so - choose you site with professional email subscription or create new one
* Cancel subscription
* [Set up forwarding email](https://wordpress.com/support/add-email/email-forwarding/#:~:text=Set%20Up%20Email%20Forwarding,-If%20you%20already&text=From%20your%20dashboard%2C%20navigate%20to,to%20this%20email%20address%20field)
* In the left sidebar click on "Upgrades -> Emails" (if you have a few email, then chose your "Email Forwarding" email)
<table>
<tr>
	<td> BEFORE
	<td> 
	<td> <img width="1072" alt="Screenshot 2022-09-28 at 11 49 04" src="https://user-images.githubusercontent.com/5598437/192760556-b9a3a7c2-9ae3-48b5-a35b-937db02903f9.png">
<tr>
	<td> AFTER
	<td> Copy remains the same, but badge disappeared
	<td> <img width="1085" alt="Screenshot 2022-09-30 at 14 59 58" src="https://user-images.githubusercontent.com/5598437/193286442-19f3b778-5c31-4c44-b1f5-e767f4a8e954.png">
</table>

#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1203041217327552/f