### PR TITLE
Change Ecommerce "Thank you" action URL

### DIFF
--- a/client/state/sites/selectors/get-site-woocommerce-wizard-url.js
+++ b/client/state/sites/selectors/get-site-woocommerce-wizard-url.js
@@ -9,9 +9,5 @@ import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
  * @returns {?string}       Full URL to WooCommerce Wizard plugin in wp-admin
  */
 export default function getSiteWooCommerceWizardUrl( state, siteId ) {
-	return getSiteAdminUrl(
-		state,
-		siteId,
-		'admin.php?page=wc-admin&from-calypso&path=%2Fsetup-wizard'
-	);
+	return getSiteAdminUrl( state, siteId, 'admin.php?page=wc-admin&from-calypso' );
 }


### PR DESCRIPTION
#### Proposed Changes

Currently, Calypso is redirecting all ecom customers to the WC OBW. We need to isolate the onboarding UX inside the WC side completely.

This PR aims to change the return of the `getSiteWooCommerceWizardUrl()` function to point to the main WC Admin Home page. I've changed the URL to reflect that, although I was wondering if anyone knows what's the purpose of the `from-calypso` argument.

#### Testing Instructions

* Create a new ecom site and follow the steps.
* On the "thank you" step click the "Create your store!" button.
* You should navigate to WC admin home page instead of the full-screen OBW.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
