### PR TITLE
Display info about email subscription when transferring domain

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -1,23 +1,24 @@
 import { Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getSite, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 
 class TransferConfirmationDialog extends PureComponent {
 	static propTypes = {
+		disableDialogButtons: PropTypes.bool.isRequired,
+		domain: PropTypes.object.isRequired,
 		isMapping: PropTypes.bool.isRequired,
 		isVisible: PropTypes.bool.isRequired,
-		targetSiteId: PropTypes.number.isRequired,
-		disableDialogButtons: PropTypes.bool.isRequired,
-		domainName: PropTypes.string.isRequired,
-		onConfirmTransfer: PropTypes.func.isRequired,
 		onClose: PropTypes.func.isRequired,
+		onConfirmTransfer: PropTypes.func.isRequired,
 		primaryWithPlansOnly: PropTypes.bool,
+		targetSiteId: PropTypes.number.isRequired,
 	};
 
 	onConfirm = ( closeDialog ) => {
@@ -25,14 +26,15 @@ class TransferConfirmationDialog extends PureComponent {
 	};
 
 	getMessage() {
-		const { domainName, isMapping, targetSite, translate } = this.props;
-		const targetSiteTitle = get( targetSite, 'title', translate( 'Site Title' ) );
+		const { domain, isMapping, targetSite, translate } = this.props;
+		const targetSiteTitle = targetSite?.title || translate( 'Site Title' );
+
 		if ( isMapping ) {
 			return translate(
 				'Do you want to transfer domain connection of {{strong}}%(domainName)s{{/strong}} ' +
 					'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 				{
-					args: { domainName, targetSiteTitle },
+					args: { domainName: domain.name, targetSiteTitle },
 					components: { strong: <strong /> },
 				}
 			);
@@ -42,7 +44,7 @@ class TransferConfirmationDialog extends PureComponent {
 			'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
 				'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 			{
-				args: { domainName, targetSiteTitle },
+				args: { domainName: domain.name, targetSiteTitle },
 				components: { strong: <strong /> },
 			}
 		);
@@ -79,8 +81,21 @@ class TransferConfirmationDialog extends PureComponent {
 		) : null;
 	}
 
+	renderEmailSubscriptionInformation() {
+		const { domain, translate } = this.props;
+
+		return (
+			<p>
+				{ translate(
+					'The email subscription for %(domainName)s will be transferred along with the domain.',
+					{ args: { domainName: domain.name } }
+				) }
+			</p>
+		);
+	}
+
 	render() {
-		const { isMapping, translate } = this.props;
+		const { domain, isMapping, translate } = this.props;
 		const actionLabel = ! isMapping
 			? translate( 'Confirm Transfer' )
 			: translate( 'Confirm Domain Connection Transfer' );
@@ -99,10 +114,13 @@ class TransferConfirmationDialog extends PureComponent {
 			},
 		];
 
+		const hasEmailWithUs = hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain );
+
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
 				<h1>{ translate( 'Confirm Transfer' ) }</h1>
 				<p>{ this.getMessage() }</p>
+				{ hasEmailWithUs && this.renderEmailSubscriptionInformation() }
 				{ ! this.props.isTargetSiteOnPaidPlan && this.renderTargetSiteOnFreePlanWarnings() }
 			</Dialog>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -224,7 +224,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				{ this.state.targetSiteId && (
 					<TransferConfirmationDialog
 						disableDialogButtons={ this.state.disableDialogButtons }
-						domainName={ selectedDomainName }
+						domain={ domain }
 						isMapping={ this.props.isMapping }
 						isVisible={ this.state.showConfirmationDialog }
 						onConfirmTransfer={ this.handleConfirmTransfer }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
@@ -20,6 +20,19 @@
 	}
 }
 
+.transfer-to-other-user__notice {
+	color: var(--color-neutral-40);
+	margin: 16px 0;
+
+	.gridicon {
+		float: left;
+	}
+}
+.transfer-to-other-user__notice-copy {
+	font-size: $font-body-small;
+	margin-left: 24px;
+}
+
 body.transfer-to-other-user.theme-default.color-scheme {
 	--color-surface-backdrop: var(--studio-white);
 }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -1,4 +1,4 @@
-import { Dialog } from '@automattic/components';
+import { Dialog, Gridicon } from '@automattic/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -13,10 +13,12 @@ import Main from 'calypso/components/main';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
+import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import wpcom from 'calypso/lib/wp';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
-import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
+import AftermarketAuctionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
@@ -262,7 +264,7 @@ class TransferDomainToOtherUser extends Component {
 		}
 
 		if ( aftermarketAuction ) {
-			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
+			return <AftermarketAuctionNotice domainName={ selectedDomainName } />;
 		}
 
 		if ( isRedeemable ) {
@@ -284,6 +286,9 @@ class TransferDomainToOtherUser extends Component {
 		const saveButtonLabel = isMapping
 			? translate( 'Transfer domain connection' )
 			: translate( 'Transfer domain' );
+
+		const hasEmailWithUs =
+			hasTitanMailWithUs( selectedDomain ) || hasGSuiteWithUs( selectedDomain );
 
 		return (
 			<>
@@ -313,6 +318,17 @@ class TransferDomainToOtherUser extends Component {
 						) }
 					</FormSelect>
 				</FormFieldset>
+				{ hasEmailWithUs && (
+					<div className="transfer-to-other-user__notice">
+						<Gridicon icon="info-outline" size={ 18 } />
+						<p className="transfer-to-other-user__notice-copy">
+							{ translate(
+								'The email subscription for %(domainName)s will be transferred along with the domain.',
+								{ args: { domainName: selectedDomainName } }
+							) }
+						</p>
+					</div>
+				) }
 				{ ! isMapping && (
 					<DesignatedAgentNotice
 						domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }


### PR DESCRIPTION
#### Proposed Changes

Letero is working on some updates to the email management pages for domain non-owners (#68158, #68156). This change relates to that work.

When a domain is transferred, any associated email subscription will also be transferred to the same site/user. This PR adds text to both `TransferDomainToOtherSite` and `TransferDomainToOtherUser` that communicates this fact to the user. The goal is to make sure that users are well informed about the impacts of transferring the domain.

| Transfer to other site | Transfer to other user |
| - | - |
| ![transfer-to-other-site](https://user-images.githubusercontent.com/1101677/192782212-4014e091-c0cf-4c98-80ee-1a7982be4a0b.png) | ![transfer-to-other-user](https://user-images.githubusercontent.com/1101677/192782239-798c4e33-a52a-4373-ab9d-ef7b391dc49f.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with a domain+email
2. Add another admin user to that site
3. Navigate to `/domains/manage/:domain/transfer/:site_slug`
4. `Continue` to transfer to another user
5. Ensure that there is a notice saying `The email subscription for {{ domain }} will be transferred along with the domain.`
6. Go back, then `Continue` to transfer to another site
7. Click on a site
8. Ensure that a paragraph in the modal reads `The email subscription for {{ domain }} will be transferred along with the domain.`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
