### PR TITLE
Add test log for tailored flows

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -2,6 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
@@ -14,6 +15,7 @@ export const linkInBio: Flow = {
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_link_in_bio', { flow: this.name } );
 		}, [] );
 
 		return [ 'intro', 'linkInBioSetup', 'patterns', 'processing', 'launchpad' ] as StepPath[];
@@ -45,6 +47,7 @@ export const linkInBio: Flow = {
 					return window.location.assign( logInUrl );
 
 				case 'patterns':
+					recordFullStoryEvent( 'calypso_signup_start_renan_222', { flow: 'test' } );
 					return navigate( 'linkInBioSetup' );
 
 				case 'linkInBioSetup':

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -47,7 +47,6 @@ export const linkInBio: Flow = {
 					return window.location.assign( logInUrl );
 
 				case 'patterns':
-					recordFullStoryEvent( 'calypso_signup_start_renan_222', { flow: 'test' } );
 					return navigate( 'linkInBioSetup' );
 
 				case 'linkInBioSetup':

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -2,6 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
@@ -16,6 +17,7 @@ export const newsletter: Flow = {
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_newsletter', { flow: this.name } );
 		}, [] );
 
 		return [ 'intro', 'newsletterSetup', 'subscribers', 'launchpad' ] as StepPath[];


### PR DESCRIPTION
## Proposed Changes

This PR create and adds FullStory logs for LiB and Newsletter

##Testing instructions

Due the fact that FullStory api is disabled, we cannot test it at any moment. When this PR was being tested by me, I could see the new events being logged on fullStory, it was enabled quickly for testing.

**All the context is here on this thread p1664284273341429-slack-C02T4NVL4JJ**

The code changes are quite simple and the library was already added, all it does it Log.

After merging this PR and enable FullStory, every time an user opens the Newsletter or LiB flow, we should have it logged.
`calypso_signup_start_link_in_bio` or `calypso_signup_start_newsletter `