### PR TITLE
Tailored Flows: (30" review) Newsletter flow Setup input labels and “Add site icon” CTA are black

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -39,7 +39,7 @@ $font-family: "SF Pro Text", $sans;
 	}
 
 	.form-label {
-		color: var(--studio-gray-100);
+		color: var(--studio-black);
 		margin-bottom: 8px;
 	}
 
@@ -74,7 +74,7 @@ $font-family: "SF Pro Text", $sans;
 		}
 
 		.components-form-file-upload .add {
-			color: var(--studio-gray-100);
+			color: var(--studio-black);
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -50,7 +50,7 @@ $border-radius: 4px;
 		}
 
 		.form-label {
-			color: var(--studio-gray-100);
+			color: var(--studio-black);
 			margin-bottom: 8px;
 		}
 
@@ -96,7 +96,7 @@ $border-radius: 4px;
 		}
 
 		.components-form-file-upload .add {
-			color: var(--studio-gray-100);
+			color: var(--studio-black);
 		}
 
 		.newsletter-setup__contrast-warning {


### PR DESCRIPTION
#### Proposed Changes

Change label and cta to --studio-black

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/setup?flow=newsletter`
* Check that the input labels and the icon cta are black

Fixes #68395
