### PR TITLE
Newsletter/LiB flows: (30" review) underline decoration on the “Add a site icon”

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -75,6 +75,7 @@ $font-family: "SF Pro Text", $sans;
 
 		.components-form-file-upload .add {
 			color: var(--studio-black);
+			text-decoration: underline;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -97,6 +97,7 @@ $border-radius: 4px;
 
 		.components-form-file-upload .add {
 			color: var(--studio-black);
+			text-decoration: underline;
 		}
 
 		.newsletter-setup__contrast-warning {


### PR DESCRIPTION
#### Proposed Changes

Add underline decoration on `Add a site icon` (Newsletter) and `Upload a profile image` (LiB)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup?flow=newsletter and http://calypso.localhost:3000/setup?flow=link-in-bio
* Reach the setup step
* Check that the logo/profile image CTA is underlined

Fixes #68398
