### PR TITLE
Theme Showcase: always return to Showcase from details page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -42,7 +42,6 @@ import ThemePreview from 'calypso/my-sites/themes/theme-preview';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isUserPaid } from 'calypso/state/purchases/selectors';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
@@ -640,12 +639,8 @@ class ThemeSheet extends Component {
 	};
 
 	goBack = () => {
-		const { previousRoute, backPath, locale, isLoggedIn } = this.props;
-		if ( previousRoute ) {
-			page.back( previousRoute );
-		} else {
-			page( localizeThemesPath( backPath, locale, ! isLoggedIn ) );
-		}
+		const { backPath, locale, isLoggedIn } = this.props;
+		page( localizeThemesPath( backPath, locale, ! isLoggedIn ) );
 	};
 
 	renderSheet = () => {
@@ -664,7 +659,6 @@ class ThemeSheet extends Component {
 			isVip,
 			translate,
 			canUserUploadThemes,
-			previousRoute,
 			isWPForTeamsSite,
 		} = this.props;
 
@@ -799,7 +793,7 @@ class ThemeSheet extends Component {
 				{ pageUpsellBanner }
 				<HeaderCake
 					className="theme__sheet-action-bar"
-					backText={ previousRoute ? translate( 'Back' ) : translate( 'All Themes' ) }
+					backText={ translate( 'All Themes' ) }
 					onClick={ this.goBack }
 				>
 					{ ! retired && ! hasWpOrgThemeUpsellBanner && ! isWPForTeamsSite && this.renderButton() }
@@ -918,7 +912,6 @@ export default connect(
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),
 			demoUrl: getThemeDemoUrl( state, id, siteId ),
-			previousRoute: getPreviousRoute( state ),
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 		};
 	},


### PR DESCRIPTION
#27160 introduced some logic to have the theme details "back" button pull the latest Calypso page from state, but [as pointed out in the comments](https://github.com/Automattic/wp-calypso/pull/27160#issuecomment-423181294), the button is intended to behave as an IA navigation link (more akin to breadcrumbs) rather than a browser's back button. Mimicking the browser's back button can leave users in a strange jailed state if they navigate to another Calypso page from the theme page (i.e. Checkout) and then return to the details page.

This PR effectively reverts #27160 by making the button's label read "All Themes" and having it navigate to the Showcase results page.

Reported: p1664318529084609-slack-C02KBT54T9T
Closes: #27348

**To test:**
- visit a theme detail page from the Showcase
- verify that the button reads "All Themes"
- verify that clicking the button returns the user to the Showcase page
- on a free site, visit a premium theme's detail page from the Showcase
- click on the "Pick this design" button to visit Checkout
- leave Checkout
- verify that the button on the theme details page reads "All Themes"
- verify that clicking the button returns the user to the Showcase page