### PR TITLE
Subscriber form improvements

### DIFF
--- a/packages/data-stores/src/subscriber/reducers.ts
+++ b/packages/data-stores/src/subscriber/reducers.ts
@@ -46,6 +46,7 @@ export const subscriber: Reducer< SubscriberState, Action > = ( state = {}, acti
 		return Object.assign( {}, state, {
 			import: {
 				inProgress: false,
+				error: undefined,
 			},
 		} );
 	}

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -202,7 +202,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	 */
 	function renderImportErrorMsg() {
 		const error = importSelector?.error;
-		if ( error?.code ) error.code = HANDLED_ERROR.IMPORT_LIMIT;
 
 		return (
 			error && (

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -276,7 +276,11 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					) }
 
 					{ showCsvUpload && isSelectedFileValid && ! selectedFile && (
-						<label>
+						<label
+							aria-label={ __(
+								'Or bring your mailing list from other newsletter services by uploading a CSV file.'
+							) }
+						>
 							{ createInterpolateElement(
 								__(
 									'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -39,6 +39,10 @@ interface Props {
 
 export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const __ = useTranslate();
+	const HANDLED_ERROR = {
+		IMPORT_LIMIT: 'subscriber_import_limit_reached',
+		IMPORT_BLOCKED: 'blocked_import',
+	};
 	const {
 		siteId,
 		flowName,
@@ -162,6 +166,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 		setIsSelectedFileValid( isValid );
 		isValid && setSelectedFile( file );
+		importCsvSubscribersUpdate( undefined );
 	}
 
 	function onFileRemoveClick() {
@@ -188,9 +193,144 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		! importSelector?.error && prevInProgress.current && ! inProgress && onImportFinished?.();
 	}
 
+	function includesHandledError() {
+		return Object.values( HANDLED_ERROR ).includes( importSelector?.error?.code as string );
+	}
+
 	/**
 	 * ↓ Templates
 	 */
+	function renderImportErrorMsg() {
+		const error = importSelector?.error;
+		if ( error?.code ) error.code = HANDLED_ERROR.IMPORT_LIMIT;
+
+		return (
+			error && (
+				<FormInputValidation icon={ 'tip' } isError={ false } isWarning={ true } text={ '' }>
+					<Icon icon={ tip } />
+					{ ( () => {
+						switch ( error.code ) {
+							case HANDLED_ERROR.IMPORT_LIMIT:
+								return createInterpolateElement(
+									__(
+										'We couldn’t import your subscriber list as you’ve hit the 100 email limit for our free plan. The good news? You can upload a list of any size after upgrading to any paid plan. If you’d like to import a smaller list now, you can <uploadBtn>upload a different file</uploadBtn>.'
+									),
+									{ uploadBtn: formFileUploadElement }
+								);
+
+							case HANDLED_ERROR.IMPORT_BLOCKED:
+								return __(
+									'We ran into a security issue with your subscriber list. It’s nothing to worry about. If you reach out to our support team when you’ve finished setting things up, they’ll help resolve this for you.'
+								);
+
+							default:
+								return error.message;
+						}
+					} )() }
+				</FormInputValidation>
+			)
+		);
+	}
+
+	function renderFileValidationMsg() {
+		return (
+			! isSelectedFileValid && (
+				<FormInputValidation isError={ true } text={ '' }>
+					{ createInterpolateElement(
+						__(
+							'Sorry, you can only upload CSV files right now. Most providers will let you export this from your settings. <uploadBtn>Select another file</uploadBtn>'
+						),
+						{ uploadBtn: formFileUploadElement }
+					) }
+				</FormInputValidation>
+			)
+		);
+	}
+
+	function renderEmailListInfoMsg() {
+		return (
+			emailControlMaxNum === isValidEmails.filter( ( x ) => x ).length && (
+				<FormInputValidation icon={ 'tip' } isError={ false } text={ '' }>
+					<Icon icon={ tip } />
+					{ __( 'Great start! You’ll be able to add more subscribers after setup.' ) }
+				</FormInputValidation>
+			)
+		);
+	}
+
+	function renderImportCsvDisclaimerMsg() {
+		return (
+			isSelectedFileValid &&
+			selectedFile && (
+				<p className={ 'add-subscriber__form--disclaimer' }>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: the first string variable shows CTA button name */
+							__(
+								'By clicking "%s", you represent that you\'ve obtained the appropriate consent to email each person on your list. <Button>Learn more</Button>'
+							),
+							submitBtnName
+						),
+						{
+							Button: createElement( Button, {
+								isLink: true,
+								target: '__blank',
+								href: localizeUrl( 'https://wordpress.com/support/user-roles/' ),
+							} ),
+						}
+					) }
+				</p>
+			)
+		);
+	}
+
+	function renderImportCsvLabel() {
+		return (
+			isSelectedFileValid &&
+			! selectedFile && (
+				<label
+					aria-label={ __(
+						'Or bring your mailing list from other newsletter services by uploading a CSV file.'
+					) }
+				>
+					{ createInterpolateElement(
+						__(
+							'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
+						),
+						{ uploadBtn: formFileUploadElement }
+					) }
+				</label>
+			)
+		);
+	}
+
+	function renderImportCsvSelectedFileLabel() {
+		return (
+			isSelectedFileValid &&
+			selectedFile && (
+				<label className={ 'add-subscriber__form-label-links' }>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: the first string variable shows a selected file name, Replace and Remove are links */
+							__(
+								'<strong>%s</strong> <uploadBtn>Replace</uploadBtn> | <removeBtn>Remove</removeBtn>'
+							),
+							selectedFile?.name
+						),
+						{
+							strong: createElement( 'strong' ),
+							uploadBtn: formFileUploadElement,
+							removeBtn: createElement( Button, {
+								isLink: true,
+								onClick: onFileRemoveClick,
+							} ),
+						}
+					) }
+				</label>
+			)
+		);
+	}
+
 	return (
 		<div className={ 'add-subscriber' }>
 			<div className={ 'add-subscriber__title-container' }>
@@ -201,12 +341,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			<div className={ 'add-subscriber__form--container' }>
 				{ inProgress && (
 					<Notice isDismissible={ false }>{ __( 'Your email list is being uploaded' ) }...</Notice>
-				) }
-
-				{ importSelector?.error && (
-					<Notice isDismissible={ false } status={ 'error' }>
-						{ importSelector.error.message as string }
-					</Notice>
 				) }
 
 				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>
@@ -235,81 +369,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						);
 					} ) }
 
-					{ emailControlMaxNum === isValidEmails.filter( ( x ) => x ).length && (
-						<FormInputValidation icon={ 'tip' } isError={ false } isWarning={ true } text={ '' }>
-							<Icon icon={ tip } />
-							{ __( 'Great start! You’ll be able to add more subscribers after setup.' ) }
-						</FormInputValidation>
-					) }
+					{ renderEmailListInfoMsg() }
+					{ renderFileValidationMsg() }
+					{ renderImportErrorMsg() }
 
-					{ ! isSelectedFileValid && (
-						<FormInputValidation isError={ true } text={ '' }>
-							{ createInterpolateElement(
-								__(
-									'Sorry, you can only upload CSV files right now. Most providers will let you export this from your settings. <uploadBtn>Select another file</uploadBtn>'
-								),
-								{ uploadBtn: formFileUploadElement }
-							) }
-						</FormInputValidation>
-					) }
-
-					{ isSelectedFileValid && selectedFile && (
-						<label className={ 'add-subscriber__form-label-links' }>
-							{ createInterpolateElement(
-								sprintf(
-									/* translators: the first string variable shows a selected file name, Replace and Remove are links" */
-									__(
-										'<strong>%s</strong> <uploadBtn>Replace</uploadBtn> | <removeBtn>Remove</removeBtn>'
-									),
-									selectedFile?.name
-								),
-								{
-									strong: createElement( 'strong' ),
-									uploadBtn: formFileUploadElement,
-									removeBtn: createElement( Button, {
-										isLink: true,
-										onClick: onFileRemoveClick,
-									} ),
-								}
-							) }
-						</label>
-					) }
-
-					{ showCsvUpload && isSelectedFileValid && ! selectedFile && (
-						<label
-							aria-label={ __(
-								'Or bring your mailing list from other newsletter services by uploading a CSV file.'
-							) }
-						>
-							{ createInterpolateElement(
-								__(
-									'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
-								),
-								{ uploadBtn: formFileUploadElement }
-							) }
-						</label>
-					) }
-
-					{ showCsvUpload && isSelectedFileValid && selectedFile && (
-						<p className={ 'add-subscriber__form--disclaimer' }>
-							{ createInterpolateElement(
-								sprintf(
-									/* translators: the first string variable shows CTA button name */
-									__(
-										'By clicking "%s", you represent that you\'ve obtained the appropriate consent to email each person on your list. <Button>Learn more</Button>'
-									),
-									submitBtnName
-								),
-								{
-									Button: createElement( Button, {
-										isLink: true,
-										target: '__blank',
-										href: localizeUrl( 'https://wordpress.com/support/user-roles/' ),
-									} ),
-								}
-							) }
-						</p>
-					) }
+					{ ! includesHandledError() && renderImportCsvSelectedFileLabel() }
+					{ showCsvUpload && ! includesHandledError() && renderImportCsvLabel() }
+					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
 
 					<NextButton
 						type={ 'submit' }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -45,7 +45,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		showTitleEmoji,
 		showSkipBtn,
 		showCsvUpload,
-		submitBtnName,
+		submitBtnName = __( 'Add subscribers' ),
 		allowEmptyFormSubmit,
 		recordTracksEvent,
 		onSkipBtnClick,
@@ -289,8 +289,12 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					{ showCsvUpload && isSelectedFileValid && selectedFile && (
 						<p className={ 'add-subscriber__form--disclaimer' }>
 							{ createInterpolateElement(
-								__(
-									'By clicking "continue", you represent that you\'ve obtained the appropriate consent to email each person on your list. <Button>Learn more</Button>'
+								sprintf(
+									/* translators: the first string variable shows CTA button name */
+									__(
+										'By clicking "%s", you represent that you\'ve obtained the appropriate consent to email each person on your list. <Button>Learn more</Button>'
+									),
+									submitBtnName
 								),
 								{
 									Button: createElement( Button, {
@@ -309,7 +313,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						isBusy={ inProgress }
 						disabled={ inProgress }
 					>
-						{ submitBtnName || __( 'Add subscribers' ) }
+						{ submitBtnName }
 					</NextButton>
 					{ showSkipBtn && (
 						<SkipButton

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -70,6 +70,7 @@
 		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		color: var(--color-text);
 		text-decoration: underline;
+		border: none;
 
 		&:hover {
 			color: var(--color-text-subtle);
@@ -163,8 +164,16 @@
 			margin-inline-start: -2rem;
 		}
 
-		&.is-warning {
+		&:not(.is-error):not(.is-warning) {
 			color: var(--studio-gray-40);
+		}
+
+		&.is-warning {
+			color: var(--studio-gray-100);
+
+			svg * {
+				stroke: var(--studio-yellow-40);
+			}
 		}
 
 		&:not(.is-error) {


### PR DESCRIPTION
#### Proposed Changes

<table>
   <tr><td colspan="2">Added aria-label attribute to support screen reader for more accurate description of upload CSV feature</td></tr>
   <tr><td colspan="2">Disclaimer text is changed based on the CTA button name 👇 </td></tr>
  <tr>
    <td width="50%">
<img width="397" alt="Screenshot 2022-09-28 at 15 55 21" src="https://user-images.githubusercontent.com/1241413/192803828-7ec28bd4-76f7-4646-a4ea-005bf6ce786e.png">
    </td>
    <td width="50%">
<img width="385" alt="Screenshot 2022-09-28 at 16 00 47" src="https://user-images.githubusercontent.com/1241413/192803866-f7149055-e24d-45d8-bb47-1687715a2097.png">
</td>
  </tr>
   <tr><td colspan="2">Handle subscribers_limit_reached and blocked_imports errors 👇 </td></tr>
  <tr>
    <td width="50%">
<img width="416" alt="Screenshot 2022-09-30 at 15 25 10" src="https://user-images.githubusercontent.com/1241413/193281478-89394308-e476-4d23-bcfa-5e05d3ab590c.png">
    </td>
    </td>
    <td width="50%">
<img width="408" alt="Screenshot 2022-09-30 at 15 12 15" src="https://user-images.githubusercontent.com/1241413/193281458-1b553014-3892-4ed2-8965-fcd6a39362fb.png">
  </tr>

</table>

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/subscribers?flow=newsletter&siteSlug={SLUG}`
* or `/people/add-subscribers/{SLUG}`
* Check if the listed changes are there
    * If you don't have a screen reader installed, there is a [Screen Reader google chrome extension](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #68337
Closes #68389
Closes #68391
