### PR TITLE
Newsletter flow: default accent color and svgs stroke color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -161,7 +161,7 @@ button {
 				border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 				font-family: "SF Pro Text", $sans;
 				transition: ease 300ms;
-				border: 1px solid var(--studio-gray-10);
+				border: 1px solid rgba($color: #000, $alpha: 0.2);
 
 				svg {
 					transition: ease 300ms;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -46,7 +46,7 @@ const defaultAccentColor = {
  * @returns a value for background-image
  */
 function generateSwatchSVG( color: string | undefined ) {
-	return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='10' stroke='%23ccc' stroke-width='1' fill='${ encodeURIComponent(
+	return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='10' stroke='%23000' stroke-opacity='0.2' stroke-width='1' fill='${ encodeURIComponent(
 		color || '#fff'
 	) }'%3E%3C/circle%3E${
 		// render a line when a color isn't selected

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -34,8 +34,8 @@ type AccentColor = {
 };
 
 const defaultAccentColor = {
-	hex: '#113AF5',
-	rgb: { r: 17, g: 58, b: 245 },
+	hex: '#1D39EB',
+	rgb: { r: 29, g: 57, b: 235 },
 	default: true,
 };
 


### PR DESCRIPTION
#### Proposed Changes

Using the default Lettre theme color #1D39EB as the default accent color. The stroke on the color swatch and upload icon has 20% Black opacity instead of solid gray.
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `http://calypso.localhost:3000/setup?flow=newsletter`
* Check that everything is correct

Fixes #68397
