### PR TITLE
Limit Global Styles: Show pre-save notice

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/README.md
@@ -6,3 +6,4 @@ Functionality that limits the Global Styles feature on WordPress.com sites to pa
 
 - The site editor displays a modal after opening the Global Styles panel to alert customers that it is a paid feature.
 - When the site's plan isn't a paid plan we will override the Global Styles loaded and will return the default Global Styles for the active theme.
+- The pre-save panel of the site editor displays a notice to alert customers that any Global Styles change won't be public.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -2,12 +2,19 @@
 import './public-path';
 
 import { dispatch, select, subscribe } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+import { render } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import GlobalStylesModal from './modal';
+import GlobalStylesNotice from './notice';
 
-const unsubscribe = subscribe( () => {
-	const currentSidebar = select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-site' );
-	if ( currentSidebar === 'edit-site/global-styles' ) {
+const showGlobalStylesModal = () => {
+	const unsubscribe = subscribe( () => {
+		const currentSidebar =
+			select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-site' );
+		if ( currentSidebar !== 'edit-site/global-styles' ) {
+			return;
+		}
 		unsubscribe();
 
 		// Hide the welcome guide modal, so it doesn't conflict with our modal.
@@ -16,5 +23,59 @@ const unsubscribe = subscribe( () => {
 		registerPlugin( 'wpcom-global-styles', {
 			render: () => <GlobalStylesModal />,
 		} );
+	} );
+};
+
+const showGlobalStylesNotice = async () => {
+	const globalStylesConfig = select( 'core' ).getEntityConfig( 'root', 'globalStyles' );
+	if ( ! globalStylesConfig ) {
+		return;
 	}
+
+	const getEditorActions = async () =>
+		new Promise( ( resolve ) => {
+			const unsubscribe = subscribe( () => {
+				const editorActions = document.querySelector(
+					'.interface-interface-skeleton .interface-interface-skeleton__actions'
+				);
+
+				if ( editorActions ) {
+					unsubscribe();
+					resolve( editorActions );
+				}
+			} );
+		} );
+	const editorActions = await getEditorActions();
+
+	const entitiesPreSavePanelObserver = new window.MutationObserver( ( mutations ) => {
+		const isEntitiesPreSavePanel = ( node ) =>
+			node.classList.contains( 'entities-saved-states__panel' );
+
+		for ( const record of mutations ) {
+			for ( const node of record.addedNodes ) {
+				if ( ! isEntitiesPreSavePanel( node ) ) {
+					continue;
+				}
+
+				const noticeContainer = document.createElement( 'div' );
+				const entitiesTitles = node.querySelectorAll( '.components-panel__body-title' );
+				for ( const entityTitle of entitiesTitles ) {
+					if ( entityTitle.textContent !== globalStylesConfig.label ) {
+						continue;
+					}
+
+					entityTitle.parentElement.append( noticeContainer );
+				}
+
+				render( <GlobalStylesNotice />, noticeContainer );
+				break;
+			}
+		}
+	} );
+	entitiesPreSavePanelObserver.observe( editorActions, { childList: true } );
+};
+
+domReady( () => {
+	showGlobalStylesModal();
+	showGlobalStylesNotice();
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -65,7 +65,7 @@ const showGlobalStylesNotice = async () => {
 					}
 
 					entityTitle.parentElement.append( noticeContainer );
-					return;
+					break;
 				}
 
 				render( <GlobalStylesNotice />, noticeContainer );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -65,10 +65,11 @@ const showGlobalStylesNotice = async () => {
 					}
 
 					entityTitle.parentElement.append( noticeContainer );
+					return;
 				}
 
 				render( <GlobalStylesNotice />, noticeContainer );
-				break;
+				return;
 			}
 		}
 	} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -63,17 +63,18 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 
 	$calypso_domain = 'https://wordpress.com';
 	if (
-		! empty( $_GET['origin'] ) &&
+		! empty( $_GET['origin'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		in_array(
-			$_GET['origin'],
+			$_GET['origin'], // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			array(
 				'http://calypso.localhost:3000',
 				'https://wpcalypso.wordpress.com',
-				'https://horizon.wordpress.com'
-			)
+				'https://horizon.wordpress.com',
+			),
+			true
 		)
 	) {
-		$calypso_domain = $_GET['origin'];
+		$calypso_domain = $_GET['origin']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	$site_slug = method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' )
@@ -93,7 +94,7 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 		'wpcomGlobalStyles',
 		array(
 			'assetsUrl'  => plugins_url( 'dist/', __FILE__ ),
-			'upgradeUrl' => "$calypso_domain/plans/$site_slug"
+			'upgradeUrl' => "$calypso_domain/plans/$site_slug",
 		)
 	);
 	wp_enqueue_style(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -61,6 +61,25 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 	$dependencies = $asset['dependencies'] ?? array();
 	$version      = $asset['version'] ?? filemtime( plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles.min.js' );
 
+	$calypso_domain = 'https://wordpress.com';
+	if (
+		! empty( $_GET['origin'] ) &&
+		in_array(
+			$_GET['origin'],
+			array(
+				'http://calypso.localhost:3000',
+				'https://wpcalypso.wordpress.com',
+				'https://horizon.wordpress.com'
+			)
+		)
+	) {
+		$calypso_domain = $_GET['origin'];
+	}
+
+	$site_slug = method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' )
+		? \WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() )
+		: wp_parse_url( home_url( '/' ), PHP_URL_HOST );
+
 	wp_enqueue_script(
 		'wpcom-global-styles-editor',
 		plugins_url( 'dist/wpcom-global-styles.min.js', __FILE__ ),
@@ -71,8 +90,11 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
 	wp_localize_script(
 		'wpcom-global-styles-editor',
-		'wpcomGlobalStylesAssetsUrl',
-		plugins_url( 'dist/', __FILE__ )
+		'wpcomGlobalStyles',
+		array(
+			'assetsUrl'  => plugins_url( 'dist/', __FILE__ ),
+			'upgradeUrl' => "$calypso_domain/plans/$site_slug"
+		)
 	);
 	wp_enqueue_style(
 		'wpcom-global-styles-editor',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -1,3 +1,5 @@
+/* global wpcomGlobalStyles */
+
 import { Button, Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -12,17 +14,6 @@ const GlobalStylesModal = () => {
 	if ( ! isVisible ) {
 		return null;
 	}
-
-	const searchParams = new URLSearchParams( window.location.search );
-	const params = Object.fromEntries( searchParams.entries() );
-	const { origin } = params;
-	const calypsoDomain = [
-		'http://calypso.localhost:3000',
-		'https://wpcalypso.wordpress.com',
-		'https://horizon.wordpress.com',
-	].includes( origin )
-		? origin
-		: 'https://wordpress.com';
 
 	return (
 		<Modal
@@ -44,11 +35,7 @@ const GlobalStylesModal = () => {
 					<Button variant="secondary" onClick={ () => setIsVisible( false ) }>
 						{ __( 'Try it out', 'full-site-editing' ) }
 					</Button>
-					<Button
-						variant="primary"
-						href={ `${ calypsoDomain }/plans/${ window._currentSiteId ?? '' }` }
-						target="_top"
-					>
+					<Button variant="primary" href={ wpcomGlobalStyles.upgradeUrl } target="_top">
 						{ __( 'Upgrade plan', 'full-site-editing' ) }
 					</Button>
 				</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -1,14 +1,30 @@
-import { Notice } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import './notice.scss';
 
 const GlobalStylesNotice = () => {
+	const { editEntityRecord } = useDispatch( 'core' );
+	const globalStylesId = useSelect(
+		( select ) => select( 'core' ).__experimentalGetCurrentGlobalStylesId(),
+		[]
+	);
+	const resetGlobalStyles = () => {
+		editEntityRecord( 'root', 'globalStyles', globalStylesId, {
+			styles: {},
+			settings: {},
+		} );
+	};
 	return (
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
-			{ __(
-				"Your style changes won't be public until you upgrade your plan. You can revert your styles.",
-				'full-site-editing'
+			{ createInterpolateElement(
+				__(
+					"Your style changes won't be public until you upgrade your plan. You can <a>revert your styles</a>.",
+					'full-site-editing'
+				),
+				{ a: <Button variant="link" onClick={ resetGlobalStyles } /> }
 			) }
 		</Notice>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -1,0 +1,15 @@
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const GlobalStylesNotice = () => {
+	return (
+		<Notice status="warning" isDismissible={ false }>
+			{ __(
+				"Your style changes won't be public until you upgrade your plan. Uou can revert your styles.",
+				'full-site-editing'
+			) }
+		</Notice>
+	);
+};
+
+export default GlobalStylesNotice;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -1,9 +1,11 @@
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import './notice.scss';
+
 const GlobalStylesNotice = () => {
 	return (
-		<Notice status="warning" isDismissible={ false }>
+		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ __(
 				"Your style changes won't be public until you upgrade your plan. You can revert your styles.",
 				'full-site-editing'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -5,7 +5,7 @@ const GlobalStylesNotice = () => {
 	return (
 		<Notice status="warning" isDismissible={ false }>
 			{ __(
-				"Your style changes won't be public until you upgrade your plan. Uou can revert your styles.",
+				"Your style changes won't be public until you upgrade your plan. You can revert your styles.",
 				'full-site-editing'
 			) }
 		</Notice>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -1,3 +1,5 @@
+/* global wpcomGlobalStyles */
+
 import { Button, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -21,10 +23,15 @@ const GlobalStylesNotice = () => {
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
 				__(
-					"Your style changes won't be public until you upgrade your plan. You can <a>revert your styles</a>.",
+					"Your style changes won't be public until you <upgradeLink>upgrade your plan</upgradeLink>. You can <revertLink>revert your styles</revertLink>.",
 					'full-site-editing'
 				),
-				{ a: <Button variant="link" onClick={ resetGlobalStyles } /> }
+				{
+					upgradeLink: (
+						<Button variant="link" href={ wpcomGlobalStyles.upgradeUrl } target="_top" />
+					),
+					revertLink: <Button variant="link" onClick={ resetGlobalStyles } />,
+				}
 			) }
 		</Notice>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -8,31 +8,65 @@ import { __ } from '@wordpress/i18n';
 import './notice.scss';
 
 const GlobalStylesNotice = () => {
+	const { globalStylesId, otherDirtyEntityRecords } = useSelect( ( select ) => {
+		const { __experimentalGetCurrentGlobalStylesId, __experimentalGetDirtyEntityRecords } =
+			select( 'core' );
+		return {
+			globalStylesId: __experimentalGetCurrentGlobalStylesId
+				? __experimentalGetCurrentGlobalStylesId()
+				: null,
+			otherDirtyEntityRecords: __experimentalGetDirtyEntityRecords
+				? __experimentalGetDirtyEntityRecords().filter( ( { name } ) => name !== 'globalStyles' )
+				: [],
+		};
+	}, [] );
+
 	const { editEntityRecord } = useDispatch( 'core' );
-	const globalStylesId = useSelect(
-		( select ) => select( 'core' ).__experimentalGetCurrentGlobalStylesId(),
-		[]
-	);
-	const resetGlobalStyles = () => {
+	const canRevertGlobalStyles = !! globalStylesId;
+	const revertGlobalStyles = () => {
+		if ( ! canRevertGlobalStyles ) {
+			return;
+		}
+
 		editEntityRecord( 'root', 'globalStyles', globalStylesId, {
 			styles: {},
 			settings: {},
 		} );
+
+		if ( ! otherDirtyEntityRecords.length ) {
+			/*
+			 * Closes the sidebar if there are no more changes to be saved.
+			 *
+			 * This uses a fragile CSS selector to target the cancel button which might be broken on
+			 * future releases of Gutenberg. Unfortunately, Gutenberg doesn't provide any mechanism
+			 * for closing the sidebar – everything is handled using an internal state that it is not
+			 * exposed publicly.
+			 *
+			 * See https://github.com/WordPress/gutenberg/blob/0b30a4cb34d39c9627b6a3795a18aee21019ce25/packages/edit-site/src/components/editor/index.js#L137-L138.
+			 */
+			const closeSidebarButton = document.querySelector(
+				'.entities-saved-states__panel-header button:last-child'
+			);
+			closeSidebarButton?.click();
+		}
 	};
+
 	return (
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
 				__(
-					"Your style changes won't be public until you <upgradeLink>upgrade your plan</upgradeLink>. You can <revertLink>revert your styles</revertLink>.",
+					"Your style changes won't be public until you <a>upgrade your plan</a>.",
 					'full-site-editing'
 				),
 				{
-					upgradeLink: (
-						<Button variant="link" href={ wpcomGlobalStyles.upgradeUrl } target="_top" />
-					),
-					revertLink: <Button variant="link" onClick={ resetGlobalStyles } />,
+					a: <Button variant="link" href={ wpcomGlobalStyles.upgradeUrl } target="_top" />,
 				}
 			) }
+			&nbsp;
+			{ canRevertGlobalStyles &&
+				createInterpolateElement( __( 'You can <a>revert your styles</a>.', 'full-site-editing' ), {
+					a: <Button variant="link" onClick={ revertGlobalStyles } />,
+				} ) }
 		</Notice>
 	);
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -1,6 +1,10 @@
 .wpcom-global-styles-notice {
 	margin: 16px 0 0;
 
+	.components-notice__content {
+		margin-right: 0;
+	}
+
 	a {
 		display: inline;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -1,0 +1,3 @@
+.wpcom-global-styles-notice {
+	margin: 16px 0 0;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -1,3 +1,7 @@
 .wpcom-global-styles-notice {
 	margin: 16px 0 0;
+
+	a {
+		display: inline;
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/public-path.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/public-path.js
@@ -6,7 +6,7 @@
  *
  * @see https://webpack.js.org/guides/public-path/#on-the-fly
  */
-if ( typeof window === 'object' && window.wpcomGlobalStylesAssetsUrl ) {
+if ( typeof window === 'object' && window.wpcomGlobalStyles?.assetsUrl ) {
 	// eslint-disable-next-line no-global-assign
-	__webpack_public_path__ = window.wpcomGlobalStylesAssetsUrl;
+	__webpack_public_path__ = window.wpcomGlobalStyles.assetsUrl;
 }


### PR DESCRIPTION
Fixes 829-gh-Automattic/dotcom-forge

#### Proposed Changes

Displays a notice before saving any Global Style change to inform users that it won't be public unless they upgrade the site plan.

<img width="277" alt="Screen Shot 2022-09-29 at 13 20 28" src="https://user-images.githubusercontent.com/1233880/193018547-23428a39-a023-43fd-b1ac-fb7418c3ca4f.png">

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit update/limit-global-styles-notice`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Change some styles
- Click on the "Save" button
- Make sure the pre-save panel displays a notice
- Make sure the "upgrade your plan" link redirects you to the "Upgrades > Plans" page
- Make sure the "revert your styles" link resets the styles to default

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
