### PR TITLE
Sites Management Page: Fix status filter and overall dropdown voiceover experience

### DIFF
--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -61,6 +61,10 @@ Optional tabIndex setting to override tab order via keyboard navigation. By defa
 
 Used to determine whether the select dropdown is in a disabled state. When disabled it will not respond to interaction and will render to appear disabled.
 
+`ariaLabel`
+
+Optional dropdown header label that can be used to improve the accessibility for screen readers.
+
 #### Dropdown Item
 
 `selected`
@@ -88,6 +92,10 @@ Optional bool to disable dropdown item.
 `onClick`
 
 Optional callback that will be applied when a `SelectDropdown.Item` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.
+
+`ariaLabel`
+
+Optional dropdown item label that can be used to improve the accessibility for screen readers.
 
 ### Label
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -41,6 +41,7 @@ class SelectDropdown extends Component {
 			} )
 		),
 		isLoading: PropTypes.bool,
+		ariaLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -207,7 +208,7 @@ class SelectDropdown extends Component {
 					onClick={ this.toggleDropdown }
 				>
 					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
-						<span className="select-dropdown__header-text">
+						<span className="select-dropdown__header-text" aria-label={ this.props.ariaLabel }>
 							{ selectedIcon && [ Gridicon, MaterialIcon ].includes( selectedIcon.type )
 								? selectedIcon
 								: null }

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -15,6 +15,7 @@ class SelectDropdownItem extends Component {
 		count: PropTypes.number,
 		disabled: PropTypes.bool,
 		icon: PropTypes.element,
+		ariaLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -35,6 +36,11 @@ class SelectDropdownItem extends Component {
 			'has-icon': this.props.icon,
 		} );
 
+		const label = this.props.value || this.props.children;
+		const ariaLabel =
+			this.props.ariaLabel ||
+			( 'number' === typeof this.props.count ? `${ label } (${ this.props.count })` : label );
+
 		return (
 			<li className="select-dropdown__option">
 				<a
@@ -42,10 +48,11 @@ class SelectDropdownItem extends Component {
 					href={ this.props.path }
 					className={ optionClassName }
 					onClick={ this.props.disabled ? null : this.props.onClick }
-					data-bold-text={ this.props.value || this.props.children }
+					data-bold-text={ label }
 					role="menuitem"
 					tabIndex="0"
 					aria-current={ this.props.selected }
+					aria-label={ ariaLabel }
 					data-e2e-title={ this.props.e2eTitle }
 				>
 					<span className="select-dropdown__item-text">

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -69,6 +69,13 @@ describe( 'component rendering', () => {
 		await userEvent.keyboard( '[Space]' );
 		expect( btn ).toHaveAttribute( 'aria-expanded', 'true' );
 	} );
+
+	test( 'should render a header with custom label', () => {
+		renderDropdown( { ariaLabel: 'Custom Field Label' } );
+
+		const btn = screen.getByRole( 'button' );
+		expect( btn.firstChild.firstChild ).toHaveAttribute( 'aria-label', 'Custom Field Label' );
+	} );
 } );
 
 describe( 'selected items', () => {

--- a/client/components/select-dropdown/test/item.js
+++ b/client/components/select-dropdown/test/item.js
@@ -20,6 +20,28 @@ describe( 'item', () => {
 			expect( item.firstChild ).toHaveTextContent( 'Published' );
 			expect( item.firstChild ).toBe( link );
 		} );
+
+		test( 'should contain a default aria-label', () => {
+			render( <SelectDropdownItem>Published</SelectDropdownItem> );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			expect( link ).toHaveAttribute( 'aria-label', 'Published' );
+		} );
+
+		test( 'should default aria-label include a count', () => {
+			render( <SelectDropdownItem count={ 123 }>Published</SelectDropdownItem> );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			expect( link ).toHaveAttribute( 'aria-label', 'Published (123)' );
+		} );
+
+		test( 'should render custom aria-label if provided', () => {
+			render(
+				<SelectDropdownItem count={ 123 } ariaLabel={ 'My Custom Label' }>
+					Published
+				</SelectDropdownItem>
+			);
+			const link = screen.getByRole( 'menuitem', { name: /my custom label/i } );
+			expect( link ).toHaveAttribute( 'aria-label', 'My Custom Label' );
+		} );
 	} );
 
 	describe( 'when the component is clicked', () => {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -135,13 +135,17 @@ export const SitesContentControls = ( {
 					selectedText={ sprintf( __( 'Status: %(siteStatus)s' ), {
 						siteStatus: selectedStatus.title,
 					} ) }
-					ariaLabel={ sprintf(
-						// Translators: `siteStatus` is one of the site statuses specified in the Sites page.
-						__( 'Filtering by Status "%(siteStatus)s". Switch status filter.' ),
-						{
-							siteStatus: selectedStatus.title,
-						}
-					) }
+					ariaLabel={
+						'all' === selectedStatus.name
+							? __( 'Displaying all sites.' )
+							: sprintf(
+									// Translators: `siteStatus` is one of the site statuses specified in the Sites page.
+									__( 'Filtering to sites with status "%(siteStatus)s".' ),
+									{
+										siteStatus: selectedStatus.title,
+									}
+							  )
+					}
 				>
 					{ statuses.map( ( { name, title, count } ) => (
 						<SelectDropdown.Item

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -135,12 +135,24 @@ export const SitesContentControls = ( {
 					selectedText={ sprintf( __( 'Status: %(siteStatus)s' ), {
 						siteStatus: selectedStatus.title,
 					} ) }
+					ariaLabel={ sprintf(
+						// Translators: `siteStatus` is one of the site statuses specified in the Sites page.
+						__( 'Filtering by Status "%(siteStatus)s". Switch status filter.' ),
+						{
+							siteStatus: selectedStatus.title,
+						}
+					) }
 				>
 					{ statuses.map( ( { name, title, count } ) => (
 						<SelectDropdown.Item
 							key={ name }
 							selected={ name === selectedStatus.name }
 							count={ count }
+							// Translators: `siteStatus` is one of the site statuses specified in the Sites page. `count` is a number of sites of given status.
+							ariaLabel={ sprintf( __( '%(siteStatus)s (%(count)d sites)' ), {
+								siteStatus: title,
+								count,
+							} ) }
 							onClick={ () =>
 								handleQueryParamChange( {
 									status: 'all' !== name ? name : undefined,


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to:
* add default `aria-label` attribute value for the `SelectDropdownItem` component to:
  * fix the issue with the screen reader reading the label and item count two times
due to CSS "content" usage
  * allow the developer to provide a custom `aria-label` for each `SelectDropdownItem` component
* let developer set custom `aria-label` for the `SelectDropdown` component header
* add custom `aria-label` elements for the `SelectDropdown` component header and `SelectDropdownItem` components on the Sites Management Page to improve the screen reader experience.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable screen reader e.g. VoiceOver
2. Open the `/sites` page and check:
  - if it no longer reads duplicated status filter options ("Public Public Fifteen Fifteen")
  - if it reads a nicer message when the dropdown is selected

Screenshots showing VoiceOver captions:

![displaying-all-sites](https://user-images.githubusercontent.com/727413/193748851-edb6ef7a-564a-47cb-bc62-cf81157045a4.png)

![filtering-to-sites](https://user-images.githubusercontent.com/727413/193748870-6d9de1af-3c71-4b54-8d01-4cde66a37b0b.png)

![public-15-sites](https://user-images.githubusercontent.com/727413/193748879-65197a54-1c6e-4253-9598-fc48d31a13a9.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68021
