### PR TITLE
Initial theme for ecommerce sites: twentytwentytwo (Redux)

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -201,8 +201,8 @@ export function generateSteps( {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			optionalDependencies: [ 'emailItem' ],
-			providesDependencies: [ 'cartItem' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 		// the only unique thing about plans-newsletter is that it provides themeSlugWithRepo and comingSoon dependencies

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -129,7 +129,7 @@ export class PlansStep extends Component {
 			const signupVals = { cartItem };
 
 			// Buying an eCommerce plan defaults to the pub/twentytwentytwo theme (All remaining flows)
-			if ( isEcommerce( cartItem ) ) {
+			if ( cartItem && isEcommerce( cartItem ) ) {
 				signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
 			}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	getPlan,
 	PLAN_FREE,
+	isEcommerce,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
@@ -125,9 +126,14 @@ export class PlansStep extends Component {
 			} );
 			this.props.goToNextStep();
 		} else {
-			this.props.submitSignupStep( step, {
-				cartItem,
-			} );
+			const signupVals = { cartItem };
+
+			// Buying an eCommerce plan defaults to the pub/twentytwentytwo theme (All remaining flows)
+			if ( isEcommerce( cartItem ) ) {
+				signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
+			}
+
+			this.props.submitSignupStep( step, signupVals );
 			this.props.goToNextStep();
 		}
 	};


### PR DESCRIPTION
#### Proposed Changes

* New ecommerce sites will now have their initial theme set separately compared to the rest of sites.
* That Initial theme for ecommerce sites will be twentytwentytwo.

#### Reimplementation

* I did not deploy #68164 because it failed pre-release e2e tests:
  * `CALYPSO_BASE_URL=http://calypso.localhost:3000/ yarn jest specs/onboarding/ftme__write.ts`
  * `CALYPSO_BASE_URL=http://calypso.localhost:3000/ yarn jest specs/plans/plans__signup-free.ts`

It turns out the root cause of the failure is `isCommerce` throwing an exception when it is passed `null`. This meant that clicking on "free" to make a free site only threw an exception and did not let the user continue.

Scope limited fix:
```diff
diff --git a/client/signup/steps/plans/index.jsx b/client/signup/steps/plans/index.jsx
index 3b9b0af44c..a7dae5af70 100644
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -129,7 +129,7 @@ export class PlansStep extends Component {
                        const signupVals = { cartItem };
 
                        // Buying an eCommerce plan defaults to the pub/twentytwentytwo theme (All remaining flows)
-                       if ( isEcommerce( cartItem ) ) {
+                       if ( cartItem && isEcommerce( cartItem ) ) {
                                signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
                        }
 ```

### Testing Instructions

* Use `/start` to create a new ecommerce site. It should have the 2022 theme.
* Use `/start` to create other sites, not using ecommerce. They should continue to have zoologist.
* Use `/start` to create free sites. This should continue to work.
* Anything else you can think of.

Related to #67562
Related to #68164
