### PR TITLE
Add tracking events to the new pricing page

### DIFF
--- a/client/components/jetpack/licensing-activation-banner/index.tsx
+++ b/client/components/jetpack/licensing-activation-banner/index.tsx
@@ -24,7 +24,7 @@ function LicensingActivationBanner( { siteId }: Props ) {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_licensing_activation_banner_render', { site_id: siteId } )
 		);
-	}, [ dispatch, siteId ] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const onLinkClick = useCallback( () => {
 		dispatch(

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -68,10 +68,8 @@ const ProductLightbox: React.FC< Props > = ( {
 	const { getCheckoutURL, getIsMultisiteCompatible, isMultisite, getOnClickPurchase } =
 		useStoreItemInfoContext();
 
-	const onClickCta = getOnClickPurchase( product );
-	const onCheckoutClick = () => {
-		onClickCta();
-
+	const onCheckoutClick = useCallback( () => {
+		getOnClickPurchase( product )();
 		// Tracking when checkout is clicked
 		dispatch(
 			recordTracksEvent( 'calyspo_product_lightbox_checkout_click', {
@@ -79,7 +77,7 @@ const ProductLightbox: React.FC< Props > = ( {
 				product_slug: product.productSlug,
 			} )
 		);
-	};
+	}, [ dispatch, getOnClickPurchase, product, siteId ] );
 
 	const variantOptions = useMemo( () => {
 		const variants = JETPACK_RELATED_PRODUCTS_MAP[ product.productSlug ] || [];

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -3,7 +3,9 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import Modal from 'react-modal';
+import { useDispatch } from 'react-redux';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { useStoreItemInfoContext } from '../product-store/context/store-item-info-context';
 import { ProductStoreBaseProps } from '../product-store/types';
 import getProductIcon from '../product-store/utils/get-product-icon';
@@ -45,14 +47,39 @@ const ProductLightbox: React.FC< Props > = ( {
 	siteId,
 } ) => {
 	const close = useCallback( () => onClose?.(), [ onClose ] );
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const onChangeOption = useCallback(
-		( productSlug: string ) => onChangeProduct( slugToSelectorProduct( productSlug ) ),
-		[ onChangeProduct ]
+		( productSlug: string ) => {
+			onChangeProduct( slugToSelectorProduct( productSlug ) );
+
+			// Tracking when variant selected inside the lightbox
+			dispatch(
+				recordTracksEvent( 'calypso_product_lightbox_variant_select', {
+					site_id: siteId,
+					product_slug: productSlug,
+				} )
+			);
+		},
+		[ onChangeProduct, dispatch, siteId ]
 	);
 
-	const { getCheckoutURL, getIsMultisiteCompatible, isMultisite } = useStoreItemInfoContext();
+	const { getCheckoutURL, getIsMultisiteCompatible, isMultisite, getOnClickPurchase } =
+		useStoreItemInfoContext();
+
+	const onClickCta = getOnClickPurchase( product );
+	const onCheckoutClick = () => {
+		onClickCta();
+
+		// Tracking when checkout is clicked
+		dispatch(
+			recordTracksEvent( 'calyspo_product_lightbox_checkout_click', {
+				site_id: siteId,
+				product_slug: product.productSlug,
+			} )
+		);
+	};
 
 	const variantOptions = useMemo( () => {
 		const variants = JETPACK_RELATED_PRODUCTS_MAP[ product.productSlug ] || [];
@@ -115,6 +142,7 @@ const ProductLightbox: React.FC< Props > = ( {
 						/>
 						<Button
 							primary
+							onClick={ onCheckoutClick }
 							className="jetpack-product-card__button product-lightbox__checkout-button"
 							href={ isMultiSiteIncompatible ? '#' : getCheckoutURL( product ) }
 							disabled={ isMultiSiteIncompatible }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -22,7 +22,7 @@ export const useProductLightbox = () => {
 		( product: SelectorProduct ): VoidFunction => {
 			return () => {
 				dispatch(
-					recordTracksEvent( 'calypso_jetpack_product_more_about_product_click', {
+					recordTracksEvent( 'calypso_jetpack_product_store_more_about_product_click', {
 						product_slug: product.productSlug,
 					} )
 				);

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -1,11 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
 import slugToSelectorProduct from '../../slug-to-selector-product';
 import { SelectorProduct } from '../../types';
 import { sanitizeLocationHash } from '../utils/sanitize-location-hash';
 
 export const useProductLightbox = () => {
+	const dispatch = useDispatch();
 	const [ currentProduct, setCurrentProduct ] = useState< SelectorProduct | null >( () =>
 		slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) )
 	);
@@ -16,17 +18,22 @@ export const useProductLightbox = () => {
 		window.history.pushState( null, '', hash );
 	}, [] );
 
-	const onClickMoreInfoFactory = useCallback( ( product: SelectorProduct ): VoidFunction => {
-		return () => {
-			recordTracksEvent( 'calypso_product_more_about_product_click', {
-				product: product.productSlug,
-			} );
+	const onClickMoreInfoFactory = useCallback(
+		( product: SelectorProduct ): VoidFunction => {
+			return () => {
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_product_more_about_product_click', {
+						product_slug: product.productSlug,
+					} )
+				);
 
-			if ( ! EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
-				setCurrentProduct( product );
-			}
-		};
-	}, [] );
+				if ( ! EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
+					setCurrentProduct( product );
+				}
+			};
+		},
+		[ dispatch ]
+	);
 
 	return useMemo(
 		() => ( {

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,6 +1,7 @@
-import { useState } from '@wordpress/element';
-import { useSelector } from 'react-redux';
+import { useCallback, useState } from '@wordpress/element';
+import { useDispatch, useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StoreItemInfoContext from './context/store-item-info-context';
 import { useShowJetpackFree } from './hooks/use-show-jetpack-free';
@@ -26,6 +27,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	header,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
+	const dispatch = useDispatch();
 
 	const [ currentView, setCurrentView ] = useState< ViewType >( () => {
 		return urlQueryArgs?.view && [ 'products', 'bundles' ].includes( urlQueryArgs.view )
@@ -40,6 +42,19 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 		siteId,
 	} );
 
+	const onSwitchView = useCallback(
+		( view: ViewType ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_product_view_select', {
+					site_id: siteId,
+					view,
+				} )
+			);
+			setCurrentView( view );
+		},
+		[ dispatch, siteId ]
+	);
+
 	const showJetpackFree = useShowJetpackFree();
 
 	return (
@@ -50,7 +65,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 
 			<PricingBanner siteId={ siteId } duration={ duration } />
 
-			<ViewFilter currentView={ currentView } setCurrentView={ setCurrentView } />
+			<ViewFilter currentView={ currentView } setCurrentView={ onSwitchView } />
 			<StoreItemInfoContext.Provider value={ storeItemInfo }>
 				<ItemsList currentView={ currentView } duration={ duration } siteId={ siteId } />
 			</StoreItemInfoContext.Provider>

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -45,7 +45,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const onSwitchView = useCallback(
 		( view: ViewType ) => {
 			dispatch(
-				recordTracksEvent( 'calypso_jetpack_product_view_select', {
+				recordTracksEvent( 'calypso_jetpack_product_store_view_select', {
 					site_id: siteId,
 					view,
 				} )

--- a/client/my-sites/plans/jetpack-plans/product-store/see-all-features/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/see-all-features/index.tsx
@@ -11,7 +11,7 @@ export const SeeAllFeatures: React.FC = () => {
 	return (
 		<div className="jetpack-product-store__see-all-features">
 			<Button
-				onClick={ () => recordTracksEvent( 'calypso_product_see_all_features_click' ) }
+				onClick={ () => recordTracksEvent( 'calypso_product_store_see_all_features_click' ) }
 				href={ PLAN_COMPARISON_PAGE }
 				target="_blank"
 				rel="noreferrer"

--- a/client/my-sites/plans/jetpack-plans/product-store/see-all-features/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/see-all-features/index.tsx
@@ -1,17 +1,24 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PLAN_COMPARISON_PAGE } from '../../constants';
 
 import './style.scss';
 
 export const SeeAllFeatures: React.FC = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onButtonClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_product_store_see_all_features_click' ) );
+	}, [ dispatch ] );
 
 	return (
 		<div className="jetpack-product-store__see-all-features">
 			<Button
-				onClick={ () => recordTracksEvent( 'calypso_product_store_see_all_features_click' ) }
+				onClick={ onButtonClick }
 				href={ PLAN_COMPARISON_PAGE }
 				target="_blank"
 				rel="noreferrer"


### PR DESCRIPTION
#### Proposed Changes

Adding track events to the new pricing page:
- Switch view -> calypso_jetpack_product_store_view_select (site_id, view)
- More info click -> calypso_jetpack_product_store_more_about_product_click (product_slug)
- Lightbox checkout click -> calyspo_product_lightbox_checkout_click (site_id, product_slug)
- Lightbox change variant -> calypso_product_lightbox_variant_select (site_id, product_slug)
- Licensing activation banner rendered -> calypso_jetpack_licensing_activation_banner_render (site_id)
- Licensing activation banner clicked -> calypso_jetpack_licensing_activation_banner_clicked (site_id)
- See all features click (bundles) -> calypso_product_store_see_all_features_click

#### Testing Instructions
- Use one method from
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - **OR** run this PR locally
        - download branch locally and run yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- You could check React devTools for fired Actions (`ANALYTICS_PAGE_VIEW_RECORD`) for recorded events.
- Make sure that page still works as expected, all links should be clickable and perform as expected.
- You could also check events at Tracks tool. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1202796695664022-as-1202979370140255/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202979370140255