### PR TITLE
Signup: Allow theme slug as a default dependency in plans step

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1178,18 +1178,31 @@ export function isAddOnsFulfilled( stepName, defaultDependencies, nextProps ) {
 
 export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 	const { isPaidPlan, sitePlanSlug, submitSignupStep } = nextProps;
-	let fulfilledDependencies = [];
+	const fulfilledDependencies = [];
+	const defaultedDependencies = {};
+
+	// Check for plan-specific default theme
+	if ( defaultDependencies && defaultDependencies.themeSlugWithRepo ) {
+		fulfilledDependencies.push( 'themeSlugWithRepo' );
+		defaultedDependencies.themeSlugWithRepo = defaultDependencies.themeSlugWithRepo;
+	}
 
 	if ( isPaidPlan ) {
 		const cartItem = undefined;
-		submitSignupStep( { stepName, cartItem, wasSkipped: true }, { cartItem } );
+		submitSignupStep(
+			{ stepName, cartItem, wasSkipped: true },
+			{ cartItem, ...defaultedDependencies }
+		);
 		recordExcludeStepEvent( stepName, sitePlanSlug );
-		fulfilledDependencies = [ 'cartItem' ];
+		fulfilledDependencies.push( 'cartItem' );
 	} else if ( defaultDependencies && defaultDependencies.cartItem ) {
 		const cartItem = getCartItemForPlan( defaultDependencies.cartItem );
-		submitSignupStep( { stepName, cartItem, wasSkipped: true }, { cartItem } );
+		submitSignupStep(
+			{ stepName, cartItem, wasSkipped: true },
+			{ cartItem, ...defaultedDependencies }
+		);
 		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
-		fulfilledDependencies = [ 'cartItem' ];
+		fulfilledDependencies.push( 'cartItem' );
 	}
 
 	if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1179,19 +1179,19 @@ export function isAddOnsFulfilled( stepName, defaultDependencies, nextProps ) {
 export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 	const { isPaidPlan, sitePlanSlug, submitSignupStep } = nextProps;
 	const fulfilledDependencies = [];
-	const defaultedDependencies = {};
+	const dependenciesFromDefaults = {};
 
 	// Check for plan-specific default theme
 	if ( defaultDependencies && defaultDependencies.themeSlugWithRepo ) {
 		fulfilledDependencies.push( 'themeSlugWithRepo' );
-		defaultedDependencies.themeSlugWithRepo = defaultDependencies.themeSlugWithRepo;
+		dependenciesFromDefaults.themeSlugWithRepo = defaultDependencies.themeSlugWithRepo;
 	}
 
 	if ( isPaidPlan ) {
 		const cartItem = undefined;
 		submitSignupStep(
 			{ stepName, cartItem, wasSkipped: true },
-			{ cartItem, ...defaultedDependencies }
+			{ cartItem, ...dependenciesFromDefaults }
 		);
 		recordExcludeStepEvent( stepName, sitePlanSlug );
 		fulfilledDependencies.push( 'cartItem' );
@@ -1199,7 +1199,7 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 		const cartItem = getCartItemForPlan( defaultDependencies.cartItem );
 		submitSignupStep(
 			{ stepName, cartItem, wasSkipped: true },
-			{ cartItem, ...defaultedDependencies }
+			{ cartItem, ...dependenciesFromDefaults }
 		);
 		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
 		fulfilledDependencies.push( 'cartItem' );

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -235,7 +235,7 @@ export function generateSteps( {
 			stepName: 'plans-ecommerce',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
 				hideFreePlan: true,
@@ -314,9 +314,10 @@ export function generateSteps( {
 			apiRequestFunction: addPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			defaultDependencies: {
 				cartItem: PLAN_ECOMMERCE,
+				themeSlugWithRepo: 'pub/twentytwentytwo',
 			},
 		},
 
@@ -684,9 +685,10 @@ export function generateSteps( {
 			apiRequestFunction: addPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			defaultDependencies: {
 				cartItem: PLAN_ECOMMERCE_MONTHLY,
+				themeSlugWithRepo: 'pub/twentytwentytwo',
 			},
 		},
 


### PR DESCRIPTION
#### Proposed Changes

* This PR adds support for the plans step to specify `themeSlugWithRepo` as a default dependency, which is accomplished by adding some logic to the `isPlanFulfilled()` function to add `defaultDependencies?.themeSlugWithRepo` to the submitted step data if the value is present
* This PR also specifies `themeSlugWithRepo` to be `pub/twentytwentytwo` for the `ecommerce` and `ecommerce-monthly` flows, where the plans step is not actually shown to users, so the changes from https://github.com/Automattic/wp-calypso/pull/68411 don't apply, because the `onSelectPlan()` callback is never triggered

#### Testing Instructions

* Open the live testing branch and navigate to `/start/ecommerce` to start the `ecommerce` signup flow (this is normally triggered from the [Ecommerce landing page](https://wordpress.com/ecommerce/) )
* Work through the flow and verify that your site is created with the Twenty Twenty Two theme
* Repeat the test above starting from `/start/ecommerce-monthly`, and verify that you also get a site created with the Twenty Twenty Two theme.
* Navigate to `/start` and work through the main signup flow - verify that there are no changes to any of those steps. (There shouldn't be, as the only steps that have added `themeSlugWithRepo` to `defaultDependencies` are the two I modified!)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #67562