### PR TITLE
Update ThemesSelection approach to reset the intended state instead of change the key of the main component

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,5 +1,5 @@
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { compact, isEqual, property, snakeCase } from 'lodash';
+import { compact, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import * as React from 'react';
@@ -284,8 +284,8 @@ class ThemesSelectionWithPage extends React.Component {
 		if (
 			nextProps.search !== this.props.search ||
 			nextProps.tier !== this.props.tier ||
-			! isEqual( nextProps.filter, this.props.filter ) ||
-			! isEqual( nextProps.vertical, this.props.vertical )
+			nextProps.filter !== this.props.filter ||
+			nextProps.vertical !== this.props.vertical
 		) {
 			this.resetPage();
 		}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,5 +1,5 @@
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { compact, property, snakeCase } from 'lodash';
+import { compact, isEqual, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import * as React from 'react';
@@ -280,8 +280,23 @@ class ThemesSelectionWithPage extends React.Component {
 		page: 1,
 	};
 
+	componentDidUpdate( nextProps ) {
+		if (
+			nextProps.search !== this.props.search ||
+			nextProps.tier !== this.props.tier ||
+			! isEqual( nextProps.filter, this.props.filter ) ||
+			! isEqual( nextProps.vertical, this.props.vertical )
+		) {
+			this.resetPage();
+		}
+	}
+
 	incrementPage = () => {
 		this.setState( ( prevState ) => ( { page: prevState.page + 1 } ) );
+	};
+
+	resetPage = () => {
+		this.setState( { page: 1 } );
 	};
 
 	render() {
@@ -295,21 +310,4 @@ class ThemesSelectionWithPage extends React.Component {
 	}
 }
 
-/**
- * Key component instances by search, tier, filter and vertical
- * to ensure that as any of them is changed, pagination is reset.
- */
-function KeyedThemesSelectionWithPage( { search, tier, filter, vertical, ...restProps } ) {
-	return (
-		<ThemesSelectionWithPage
-			key={ `themes-selection-${ search }-${ tier }-${ filter }-${ vertical }` }
-			search={ search }
-			tier={ tier }
-			filter={ filter }
-			vertical={ vertical }
-			{ ...restProps }
-		/>
-	);
-}
-
-export default KeyedThemesSelectionWithPage;
+export default ThemesSelectionWithPage;


### PR DESCRIPTION
#### Proposed Changes

Refactor the ThemesSelection component to a similar approach used in the past, but without the `UNSAFE_componentWillReceiveProps` method, using `componentDidUpdate` instead. 

This component was already refactored at https://github.com/Automattic/wp-calypso/commit/d6a7cd9c7dcd4b60d06bffe197810707c2deab7c, but the current approach changes the key property of the main component, which recreates the component at every change of the filters, which is an expensive operation and makes it hard to trust the componentDidMount or useEffect options on the child elements.

This change is being worked as part of #68284 .

#### Testing Instructions (Same as #62135)

* Go to `/themes/:site` on a site with a paid plan.
* Click on "All Themes".
* Play with various filters and search queries and verify that as you change them, you land on the first page of themes just like you did before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


