### PR TITLE
Show path to captured artifacts when tests fail

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -147,8 +147,13 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 
 		// Create folders for test artifacts.
 		await fs.mkdir( env.ARTIFACTS_PATH, { recursive: true } );
+		const date = new Date()
+			.toISOString()
+			.split( 'Z' )[ 0 ]
+			.replace( /[.:+]/g, '-' )
+			.replace( 'T', '_' );
 		this.testArtifactsPath = await fs.mkdtemp(
-			path.join( env.ARTIFACTS_PATH, `${ this.testFilename }__${ Date.now() }-` )
+			path.join( env.ARTIFACTS_PATH, `${ this.testFilename }__${ date }-` )
 		);
 		const logFilePath = path.join( this.testArtifactsPath, `${ this.testFilename }.log` );
 
@@ -271,6 +276,9 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 			case 'test_fn_failure': {
 				this.failure = { type: 'test', name: event.test.name };
 				this.allure?.failTestStep( event.error );
+				// Print path to captured artifacts for faster triaging.
+				console.log( `Artifacts for failed test "${ event.test.name }":` );
+				console.log( this.testArtifactsPath );
 				break;
 			}
 			case 'test_done': {

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -279,7 +279,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				this.failure = { type: 'test', name: event.test.name };
 				this.allure?.failTestStep( event.error );
 				// Store the failing test's artifact path if it hasn't yet.
-				if ( this.testFailureArtifacts.indexOf( this.testArtifactsPath ) === -1 ) {
+				if ( ! this.testFailureArtifacts.includes( this.testArtifactsPath ) ) {
 					this.testFailureArtifacts.push( this.testArtifactsPath );
 				}
 				break;


### PR DESCRIPTION
### Context
Sorry for the delay on this one. This PR is for #64429 (Playwright: show path to the locally captured artifacts if a test fails).
### Changes
- Added a `console.log()` to output the artifact folder of a failed test.
- Updated the name of each artifact folder to include a more readable date/time format.
### Examples
The folder names have been changed from this date format:
> fse__temp-smoke-test__**1663877978808**-3kqWDH

To this:

> fse__temp-smoke-test__**2022-09-28_19-28-05-119**-8VGAye

After each failed test, the following output will now appear in the console:
`Artifacts for failed test "Navigate to Full Site Editor":`
`USER_DIRECTORY/wp-calypso/test/e2e/results/fse__temp-smoke-test__2022-09-28_19-28-05-119-8VGAye`

### Notes/Concerns
- I couldn't figure out how to print the path at the **very** end (after the final test results are shown). It prints right before it.
- Folder names are bit longer now, but much easier to look up the latest run. Please let me know if the folder name length might be an issue!
- The date/time is in ISO format, which matches the actual log output (shown below):
`2022-09-28T17:36:05.636Z 43971 api info: <= locator.fill succeeded`