### PR TITLE
Hosting Configuration: Do not ask for a reason if the user is clearing the cache for the same site in less than 24 hours

### DIFF
--- a/client/my-sites/hosting/miscellaneous-card/index.js
+++ b/client/my-sites/hosting/miscellaneous-card/index.js
@@ -9,12 +9,14 @@ import MaterialIcon from 'calypso/components/material-icon';
 import { clearWordPressCache } from 'calypso/state/hosting/actions';
 import getRequest from 'calypso/state/selectors/get-request';
 import { isAtomicClearCacheEnabled } from 'calypso/state/selectors/is-atomic-clear-cache-enabled';
+import { shouldProvideReasonToClearAtomicCache } from 'calypso/state/selectors/should-provide-reason-to-clear-atomic-cache';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 const MiscellaneousCard = ( {
 	disabled,
+	shouldProvideReasonToClearCache,
 	clearAtomicWordPressCache,
 	isClearCacheEnabled,
 	isClearingCache,
@@ -25,7 +27,10 @@ const MiscellaneousCard = ( {
 	const [ reason, setReason ] = useState( '' );
 
 	const clearCache = () => {
-		clearAtomicWordPressCache( siteId, reason );
+		clearAtomicWordPressCache(
+			siteId,
+			shouldProvideReasonToClearCache ? reason : 'Clearing again in less than 24 hours.'
+		);
 		setShowDialog( false );
 		setReason( '' );
 	};
@@ -68,7 +73,7 @@ const MiscellaneousCard = ( {
 					) }
 				</p>
 				<Button
-					onClick={ showConfirmationDialog }
+					onClick={ shouldProvideReasonToClearCache ? showConfirmationDialog : clearCache }
 					busy={ isClearingCache }
 					disabled={ disabled || isClearingCache }
 				>
@@ -124,6 +129,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			shouldProvideReasonToClearCache: shouldProvideReasonToClearAtomicCache( state, siteId ),
 			isClearCacheEnabled: isAtomicClearCacheEnabled( state, siteId ),
 			isClearingCache: getRequest( state, clearWordPressCache( siteId ) )?.isLoading ?? false,
 			siteId,

--- a/client/state/hosting/reducer.js
+++ b/client/state/hosting/reducer.js
@@ -5,8 +5,14 @@ import {
 	HOSTING_SFTP_USERS_SET,
 	HOSTING_SSH_ACCESS_SET,
 	HOSTING_STATIC_FILE_404_SET,
+	HOSTING_CLEAR_CACHE_REQUEST,
 } from 'calypso/state/action-types';
-import { combineReducers, keyedReducer } from 'calypso/state/utils';
+import {
+	combineReducers,
+	keyedReducer,
+	withPersistence,
+	withSchemaValidation,
+} from 'calypso/state/utils';
 
 export const sftpUsers = ( state = {}, { type, users } ) => {
 	if ( type === HOSTING_SFTP_USERS_SET ) {
@@ -53,11 +59,24 @@ const staticFile404 = ( state = null, { type, setting } ) => {
 	return state;
 };
 
+const lastCacheClearTimestamp = withSchemaValidation(
+	{ type: 'integer' },
+	withPersistence( ( state = null, { type } ) => {
+		switch ( type ) {
+			case HOSTING_CLEAR_CACHE_REQUEST:
+				return new Date().valueOf();
+		}
+
+		return state;
+	} )
+);
+
 const atomicHostingReducer = combineReducers( {
 	phpVersion,
 	sftpUsers,
 	sshAccess,
 	staticFile404,
+	lastCacheClearTimestamp,
 } );
 
 const reducer = keyedReducer( 'siteId', atomicHostingReducer );

--- a/client/state/hosting/reducer.js
+++ b/client/state/hosting/reducer.js
@@ -59,7 +59,7 @@ const staticFile404 = ( state = null, { type, setting } ) => {
 	return state;
 };
 
-const lastCacheClearTimestamp = withSchemaValidation(
+export const lastCacheClearTimestamp = withSchemaValidation(
 	{ type: 'integer' },
 	withPersistence( ( state = null, { type } ) => {
 		switch ( type ) {

--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -1,9 +1,39 @@
 import deepFreeze from 'deep-freeze';
-import { HOSTING_SFTP_USERS_SET, HOSTING_SFTP_USER_UPDATE } from 'calypso/state/action-types';
-import reducer, { sftpUsers } from '../reducer';
+import {
+	HOSTING_CLEAR_CACHE_REQUEST,
+	HOSTING_SFTP_USERS_SET,
+	HOSTING_SFTP_USER_UPDATE,
+} from 'calypso/state/action-types';
+import reducer, { lastCacheClearTimestamp, sftpUsers } from '../reducer';
 
 describe( 'reducer', () => {
 	jest.spyOn( console, 'warn' ).mockImplementation();
+
+	describe( '#lastCacheClearTimestamp', () => {
+		const timestamp = 1664397666661;
+
+		beforeAll( () => {
+			jest.useFakeTimers( 'modern' ).setSystemTime( timestamp );
+		} );
+
+		afterAll( () => {
+			jest.useRealTimers();
+		} );
+
+		test( 'should default to null', () => {
+			const state = lastCacheClearTimestamp( undefined, {} );
+
+			expect( state ).toEqual( null );
+		} );
+
+		test( 'should update to the current time whenever `HOSTING_CLEAR_CACHE_REQUEST` is dispatched', () => {
+			const state = lastCacheClearTimestamp( undefined, {
+				type: HOSTING_CLEAR_CACHE_REQUEST,
+			} );
+
+			expect( state ).toEqual( timestamp );
+		} );
+	} );
 
 	describe( '#sftpUsers()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -92,6 +92,7 @@ describe( 'reducer', () => {
 
 		expect( state ).toEqual( {
 			12345678: {
+				lastCacheClearTimestamp: null,
 				phpVersion: null,
 				sftpUsers: [ 1, 2, 3 ],
 				sshAccess: null,
@@ -103,6 +104,7 @@ describe( 'reducer', () => {
 	test( 'should accumulate sites', () => {
 		const previousState = {
 			12345678: {
+				lastCacheClearTimestamp: null,
 				phpVersion: null,
 				sftpUsers: [ 1, 2, 3 ],
 				sshAccess: null,
@@ -117,12 +119,14 @@ describe( 'reducer', () => {
 
 		expect( state ).toEqual( {
 			12345678: {
+				lastCacheClearTimestamp: null,
 				phpVersion: null,
 				sftpUsers: [ 1, 2, 3 ],
 				sshAccess: null,
 				staticFile404: null,
 			},
 			9876543: {
+				lastCacheClearTimestamp: null,
 				phpVersion: null,
 				sftpUsers: [ 9, 8, 7 ],
 				sshAccess: null,

--- a/client/state/selectors/should-provide-reason-to-clear-atomic-cache.js
+++ b/client/state/selectors/should-provide-reason-to-clear-atomic-cache.js
@@ -1,0 +1,16 @@
+import 'calypso/state/hosting/init';
+
+const ONE_DAY_IN_MILLISECONDS = 86400 * 1000;
+
+export function shouldProvideReasonToClearAtomicCache( state, siteId ) {
+	const lastCacheCleared = state.atomicHosting?.[ siteId ]?.lastCacheClearTimestamp;
+
+	if ( ! lastCacheCleared ) {
+		return true;
+	}
+
+	const oneDayAgo = new Date().valueOf() - ONE_DAY_IN_MILLISECONDS;
+	const wasCleanedMoreThanOneDayAgo = oneDayAgo > lastCacheCleared;
+
+	return wasCleanedMoreThanOneDayAgo;
+}

--- a/client/state/selectors/test/should-provide-reason-to-clear-atomic-cache.js
+++ b/client/state/selectors/test/should-provide-reason-to-clear-atomic-cache.js
@@ -1,0 +1,48 @@
+import { shouldProvideReasonToClearAtomicCache } from 'calypso/state/selectors/should-provide-reason-to-clear-atomic-cache';
+
+const ONE_DAY_IN_MILLISECONDS = 86400 * 1000;
+const ONE_SECOND = 1000;
+const SITE_ID = 123;
+const TIMESTAMP = 1234567890;
+
+const generateState = ( { timestamp } ) => ( {
+	atomicHosting: {
+		[ SITE_ID ]: {
+			lastCacheClearTimestamp: timestamp,
+		},
+	},
+} );
+
+describe( 'shouldProvideReasonToClearAtomicCache', () => {
+	beforeAll( () => {
+		jest.useFakeTimers( 'modern' ).setSystemTime( TIMESTAMP );
+	} );
+
+	afterAll( () => {
+		jest.useRealTimers();
+	} );
+
+	test( 'should return true if there is no stored timestamp', () => {
+		expect(
+			shouldProvideReasonToClearAtomicCache( generateState( { timestamp: null } ), SITE_ID )
+		).toBe( true );
+	} );
+
+	test( 'should return true if the cache was cleared more than 24 hours ago', () => {
+		expect(
+			shouldProvideReasonToClearAtomicCache(
+				generateState( { timestamp: TIMESTAMP - ONE_DAY_IN_MILLISECONDS - ONE_SECOND } ),
+				SITE_ID
+			)
+		).toBe( true );
+	} );
+
+	test( 'should return false if the cache was cleared less than 24 hours ago', () => {
+		expect(
+			shouldProvideReasonToClearAtomicCache(
+				generateState( { timestamp: TIMESTAMP - ONE_DAY_IN_MILLISECONDS } ),
+				SITE_ID
+			)
+		).toBe( false );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/67749.

>Every time you want to clear the cache, there's a popup that requires you to enter a reason why you want to clear the cache. We obviously try to keep cache clearing to a minimum, but when doing certain types of work, we may need to clear it a few times, and this gets really tedious.

From that feedback, we don't want to keep asking for reasons if the user wants to iterate faster. This is why we're storing the last cache clear timestamp and compare with the previous day to decide whether to show the reason feedback dialog or not.

#### Testing Instructions

1. Open any Atomic site's Hosting Configuration;
2. Clear the cache -- you should be asked to provide the reason why you're clearing the cache;
3. Refresh the page;
4. Click the clear cache button again;
5. You shouldn't be prompted again.