### PR TITLE
Domains: Add `w.link` subdomain to `isFreeUrlDomainName` function

### DIFF
--- a/client/lib/domains/utils/is-free-url-domain-name.ts
+++ b/client/lib/domains/utils/is-free-url-domain-name.ts
@@ -1,5 +1,5 @@
 /**
- * Returns true if a domain is a managed WPCOM subdomain such as fine.art.blog, cool.tech.blog or
+ * Checks wheter a domain is a managed WPCOM subdomain such as fine.art.blog, cool.tech.blog or
  * mylinkinbio.w.link.
  *
  * We need to update this function every time a new free managed subdomain is added to WPCOM.

--- a/client/lib/domains/utils/is-free-url-domain-name.ts
+++ b/client/lib/domains/utils/is-free-url-domain-name.ts
@@ -1,4 +1,10 @@
-export function isFreeUrlDomainName( domainName ) {
+/**
+ * Returns true if a domain is a managed WPCOM subdomain such as fine.art.blog, cool.tech.blog or
+ * mylinkinbio.w.link.
+ *
+ * We need to update this function every time a new free managed subdomain is added to WPCOM.
+ */
+export function isFreeUrlDomainName( domainName: string ): boolean {
 	const freeDotBlogSubdomains = [
 		'art',
 		'business',
@@ -34,7 +40,7 @@ export function isFreeUrlDomainName( domainName ) {
 	const freeUrlDomainNames = freeDotBlogSubdomains.map(
 		( dotBlogSubdomain ) => `.${ dotBlogSubdomain }.blog`
 	);
-	freeUrlDomainNames.unshift( '.wordpress.com', '.wpcomstaging.com' );
+	freeUrlDomainNames.unshift( '.w.link', '.wordpress.com', '.wpcomstaging.com' );
 
 	return freeUrlDomainNames.some( ( freeUrlDomainName ) =>
 		domainName.endsWith( freeUrlDomainName )


### PR DESCRIPTION
#### Proposed Changes

This PR adds the `w.link` subdomain to the `isFreeUrlDomainName` function. We wanted to use the domain object's `isWpcomDomain` property to check that but we don't have access to it at that point in the code.

#### Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to the domain settings page for a domain you own, e.g. `/domains/manage/my-cool-domain.com/edit/my-site-slug.com`
- Change the domain for a w.link domain, e.g. `/domains/manage/myawesomepage.w.link/edit/my-site-slug.com`
- Ensure you are redirected to the site's domains list page

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

