### PR TITLE
Fix onboarding step horizontal layout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -155,6 +155,10 @@ button {
 		@media ( min-width: 660px ) {
 			display: flex;
 			flex-direction: column;
+
+			&.is-horizontal-layout {
+				flex-direction: row;
+			}
 		}
 	}
 }

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -5,7 +5,7 @@
 /**
  *	General
  */
-.step-container {
+.site-setup .step-container {
 	max-width: 960px;
 	margin: 0 auto;
 
@@ -35,6 +35,7 @@
 		@include break-small {
 			margin-top: 25vh;
 			display: flex;
+			flex-direction: row;
 
 			.step-container__header {
 				margin-top: 0;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -5,7 +5,7 @@
 /**
  *	General
  */
-.site-setup .step-container {
+.step-container {
 	max-width: 960px;
 	margin: 0 auto;
 
@@ -35,7 +35,6 @@
 		@include break-small {
 			margin-top: 25vh;
 			display: flex;
-			flex-direction: row;
 
 			.step-container__header {
 				margin-top: 0;


### PR DESCRIPTION
## Proposed Changes

* Update style for `.step-container` so the `.is-horizontal` layout will display correctly

## Testing Instructions

* Click on the Calypso Live (direct link) in the comment below.
* Type the URL /setup?siteSlug={Site slug} in the Calypso Live domain
* Make sure the screen with horizontal layout is displaying correctly: /vertical, /options, /bloggerStartingPoint...
Recording:

https://user-images.githubusercontent.com/10071857/192915427-cf4e373f-b416-4718-aad6-8166a44e0f70.mp4


## Reference
Related to #68423
