### PR TITLE
E2E: use only the test spec basename for Allure.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -253,7 +253,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				// Use `test_fn_start` event instead of `test_start` to filter
 				// out hooks.
 				// See https://github.com/facebook/jest/blob/main/packages/jest-types/src/Circus.ts#L132-L133
-				this.allure?.startTestStep( event.test, state, this.testFilePath );
+				this.allure?.startTestStep( event.test, state, this.testFilename );
 				// If a test has failed, skip rest of the steps.
 				if ( this.failure?.type === 'test' ) {
 					event.test.mode = 'skip';
@@ -261,7 +261,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				break;
 			}
 			case 'test_skip':
-				this.allure?.startTestStep( event.test, state, this.testFilePath );
+				this.allure?.startTestStep( event.test, state, this.testFilename );
 				this.allure?.pendingTestStep( event.test );
 				break;
 			case 'test_fn_success': {


### PR DESCRIPTION
#### Proposed Changes

This PR makes a minor update to one of the parameters sent to Allure functions.

Key changes:
- use only the testfile basename for the argument to startTestStep, instead of the entire file path.

Before:
`"home > teamcity-2 > buildAgent > work > c4a9d5b38c1dacde > test > e2e > specs > infrastructure"`

After:
`infrastructure__ssr-enabled`

#### Testing Instructions

1. pull this branch
2. navigate to `test/e2e`
3. run the following: 
```
HEADLESS=true ALLURE_RESULTS_PATH=allure-results yarn jest specs/infrastructure/infrastructure__ssr-enabled.ts
```

Ensure that the resulting report shows something like this:

![image](https://user-images.githubusercontent.com/6549265/192948515-f361be9c-b9c5-46af-970d-95d95b309743.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
