### PR TITLE
Fix number format in promote post stat page 

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
@@ -11,7 +11,7 @@ import {
 import { useRouteModal } from 'calypso/lib/route-modal';
 import { getPost } from 'calypso/state/posts/selectors';
 
-function PostActionsEllipsisMenuPromote( { globalId, postId, bumpStatKey, status } ) {
+function PostActionsEllipsisMenuPromote( { globalId, postId, bumpStatKey, status, type } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -38,7 +38,7 @@ function PostActionsEllipsisMenuPromote( { globalId, postId, bumpStatKey, status
 
 	return (
 		<PopoverMenuItem onClick={ showDSPWidget } icon={ 'speaker' }>
-			{ translate( 'Promote Post' ) }
+			{ type === 'post' ? translate( 'Promote Post' ) : translate( 'Promote Page' ) }
 		</PopoverMenuItem>
 	);
 }

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -13,6 +13,7 @@ import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-pos
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import {
 	canCancelCampaign,
+	formatCents,
 	getCampaignAudienceString,
 	getCampaignBudgetData,
 	getCampaignClickthroughRate,
@@ -72,7 +73,9 @@ export default function CampaignItem( { campaign }: Props ) {
 		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
 		[ budget_cents, spent_budget_cents ]
 	);
-	const totalBudgetLeftString = totalBudgetLeft ? `($${ totalBudgetLeft } ${ __( 'left' ) })` : '';
+	const totalBudgetLeftString = totalBudgetLeft
+		? `($${ formatCents( totalBudgetLeft ) } ${ __( 'left' ) })`
+		: '';
 
 	const estimatedImpressions = useMemo(
 		() => getCampaignEstimatedImpressions( display_delivery_estimate ),

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -55,7 +55,7 @@ export default function CampaignItem( { campaign }: Props ) {
 	} = campaign;
 
 	const overallSpending = useMemo(
-		() => getCampaignOverallSpending( spent_budget_cents, start_date, end_date ),
+		() => getCampaignOverallSpending( spent_budget_cents, budget_cents, start_date, end_date ),
 		[ spent_budget_cents, start_date, end_date ]
 	);
 

--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -97,7 +97,7 @@ export const getCampaignOverallSpending = (
 export const getCampaignClickthroughRate = ( clicks_total: number, impressions_total: number ) => {
 	const clickthroughRate = ( clicks_total * 100 ) / impressions_total || 0;
 	const formattedRate = clickthroughRate.toLocaleString( undefined, {
-		useGrouping: false,
+		useGrouping: true,
 		minimumFractionDigits: 0,
 		maximumFractionDigits: 2,
 	} );
@@ -130,6 +130,14 @@ export const getCampaignBudgetData = (
 		totalBudgetUsed,
 		totalBudgetLeft,
 	};
+};
+
+export const formatCents = ( amount: number ) => {
+	return amount.toLocaleString( undefined, {
+		useGrouping: true,
+		minimumFractionDigits: amount % 1 !== 0 ? 2 : 0,
+		maximumFractionDigits: 2,
+	} );
 };
 
 export const getCampaignEstimatedImpressions = ( displayDeliveryEstimate: string ) => {

--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -77,16 +77,21 @@ export const getCampaignDurationDays = ( start_date: string, end_date: string ) 
 
 export const getCampaignOverallSpending = (
 	spent_budget_cents: number,
+	budget_cents: number,
 	start_date: string,
 	end_date: string
 ) => {
 	if ( ! spent_budget_cents ) {
 		return '-';
 	}
-
-	const totalBudgetUsed = spent_budget_cents / 100;
-	let daysRun = moment().diff( moment( start_date ), 'days' );
 	const campaignDays = getCampaignDurationDays( start_date, end_date );
+	const spentBudgetCents =
+		spent_budget_cents > budget_cents * campaignDays
+			? budget_cents * campaignDays
+			: spent_budget_cents;
+
+	const totalBudgetUsed = spentBudgetCents / 100;
+	let daysRun = moment().diff( moment( start_date ), 'days' );
 	daysRun = daysRun > campaignDays ? campaignDays : daysRun;
 
 	/* translators: %1$s: Amount, %2$s: Days. eg: $3 over 2 days */
@@ -122,8 +127,14 @@ export const getCampaignBudgetData = (
 	end_date: string,
 	spent_budget_cents: number
 ) => {
-	const totalBudget = ( budget_cents * getCampaignDurationDays( start_date, end_date ) ) / 100;
-	const totalBudgetUsed = spent_budget_cents / 100;
+	const campaignDays = getCampaignDurationDays( start_date, end_date );
+	const spentBudgetCents =
+		spent_budget_cents > budget_cents * campaignDays
+			? budget_cents * campaignDays
+			: spent_budget_cents;
+
+	const totalBudget = ( budget_cents * campaignDays ) / 100;
+	const totalBudgetUsed = spentBudgetCents / 100;
 	const totalBudgetLeft = totalBudget - totalBudgetUsed;
 	return {
 		totalBudget,


### PR DESCRIPTION
- Fixes the number displayed in budget left in Promote post stats page
- Changes "Promote Post" to "Promote Page" in page list


#### Testing Instructions
* Open the Promote Post stats page and check if the number in "Budget left" is correctly displayed
* Open the Page list, click on the Hamburger button in a Page. The "Promote" content should display "Promote Page"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Related to #
