### PR TITLE
Global styles: Add track events for the different statuses in the GS lifecycle

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -137,3 +137,35 @@ function wpcom_global_styles_override_for_free_site( $blog_id = 0 ) {
 	}
 }
 add_action( 'wp_print_styles', 'wpcom_global_styles_override_for_free_site' );
+
+/**
+ * Tracks when global styles are updated or reset after the post has actually been saved.
+ *
+ * @param int     $blog_id Blog ID.
+ * @param WP_Post $post    Post data.
+ * @param bool    $updated This value is true if the post existed and was updated.
+ */
+function wpcom_track_global_styles( $blog_id, $post, $updated ) {
+	require_lib( 'tracks/client' );
+
+	// If the post isn't updated then we know the gs cpt is being created.
+	if ( ! $updated ) {
+		tracks_record_event( get_current_user_id(), 'wpcom_global_styles_create' );
+		return;
+	}
+
+	// This is a fragile way of checking if the global styles cpt is being reset, we might need to update this condition in the future.
+	$global_style_keys      = array_keys( json_decode( $post->post_content, true ) ?? array() );
+	$is_empty_global_styles = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) === 0;
+
+	// By default, we know that we are at least updating.
+	$event_name = 'wpcom_global_styles_update';
+
+	// If we are updating to empty contents then we know for sure we are resetting the contents.
+	if ( $is_empty_global_styles ) {
+		$event_name = 'wpcom_global_styles_reset';
+	}
+
+	tracks_record_event( get_current_user_id(), $event_name );
+}
+add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -159,7 +159,7 @@ function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 	$is_empty_global_styles = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) === 0;
 
 	// By default, we know that we are at least updating.
-	$event_name = 'wpcom_global_styles_update';
+	$event_name = 'wpcom_global_styles_customize';
 
 	// If we are updating to empty contents then we know for sure we are resetting the contents.
 	if ( $is_empty_global_styles ) {


### PR DESCRIPTION
#### Proposed Changes

We now trigger track events during the various lifecycle of Global Styles. I've hooked into the `save_post_wp_global_styles` and performed some checks that determine if we should send one of  the following events:
- wpcom_global_styles_create, this event will be triggered when the GS post is created for the first time.
- wpcom_global_styles_customize, this event is triggered when an existing GS gets customized.
- wpcom_global_styles_reset, this event is triggered when an existing GS post is reset.

#### Testing Instructions
- In your sandbox run: `install-plugin.sh editing-toolkit add/track-global-styles-interactions`
- Open the site editor and play around with global styles.
- After some time you should see your event showing up in tracks live view.
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
