### PR TITLE
Stepper flows: Add flow name to recordSubmitStep

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -20,11 +20,12 @@ export const anchorFmFlow: Flow = {
 	},
 
 	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
 		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
 		const siteSlugParam = useSiteSlugParam();
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, 'anchor-fm', currentStep );
+			recordSubmitStep( providedDependencies, 'anchor-fm', flowName, currentStep );
 			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
 
 			switch ( currentStep ) {

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-submit-step.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-submit-step.ts
@@ -6,6 +6,7 @@ import { ProvidedDependencies } from '../types';
 export function recordSubmitStep(
 	providedDependencies: ProvidedDependencies = {},
 	intent: string,
+	flow: string,
 	step: string
 ) {
 	const device = resolveDeviceTypeByViewPort();
@@ -34,6 +35,7 @@ export function recordSubmitStep(
 
 	recordTracksEvent( 'calypso_signup_actions_submit_step', {
 		device,
+		flow,
 		step,
 		intent,
 		...inputs,

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -13,10 +13,11 @@ export const linkInBioPostSetup: Flow = {
 	},
 
 	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
 		const siteSlug = useSiteSlug();
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, 'link-in-bio-post-setup', currentStep );
+			recordSubmitStep( providedDependencies, 'link-in-bio-post-setup', flowName, currentStep );
 
 			switch ( currentStep ) {
 				case 'linkInBioPostSetup':

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -6,6 +6,7 @@ import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -22,9 +23,9 @@ export const linkInBio: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		const name = this.name;
+		const flowName = this.name;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
@@ -37,6 +38,7 @@ export const linkInBio: Flow = {
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 			const logInUrl = getStartUrl();
 
 			switch ( _currentStep ) {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -53,7 +53,7 @@ export const linkInBio: Flow = {
 
 				case 'linkInBioSetup':
 					return window.location.assign(
-						`/start/${ name }/domains?new=${ encodeURIComponent(
+						`/start/${ flowName }/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string
 						) }&search=yes&hide_initial_query=yes`
 					);

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -24,13 +24,13 @@ export const newsletter: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		const name = this.name;
+		const flowName = this.name;
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const siteSlug = useSiteSlug();
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( {
 			stepName: _currentStep,
-			flowName: name,
+			flowName,
 		} );
 		setStepProgress( flowProgress );
 		const locale = useLocale();
@@ -42,7 +42,7 @@ export const newsletter: Flow = {
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, '', _currentStep );
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 			const logInUrl = getStartUrl();
 
 			switch ( _currentStep ) {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -54,7 +54,7 @@ export const newsletter: Flow = {
 
 				case 'newsletterSetup':
 					return window.location.assign(
-						`/start/${ name }/domains?new=${ encodeURIComponent(
+						`/start/${ flowName }/domains?new=${ encodeURIComponent(
 							providedDependencies.siteTitle as string
 						) }&search=yes&hide_initial_query=yes` +
 							( typeof providedDependencies.siteAccentColor === 'string' &&

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -56,6 +56,7 @@ export const pluginBundleFlow: Flow = {
 		return steps.concat( bundlePluginSteps );
 	},
 	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -132,7 +133,7 @@ export const pluginBundleFlow: Flow = {
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
-			recordSubmitStep( providedDependencies, intent, currentStep );
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 
 			switch ( currentStep ) {
 				case 'storeAddress':

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -76,6 +76,7 @@ export const siteSetupFlow: Flow = {
 		] as StepPath[];
 	},
 	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -160,7 +161,7 @@ export const siteSetupFlow: Flow = {
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
-			recordSubmitStep( providedDependencies, intent, currentStep );
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 
 			switch ( currentStep ) {
 				case 'options': {


### PR DESCRIPTION
#### Proposed Changes

`calypso_signup_step_start` event includes `flow` & `step` properties while `calypso_signup_actions_submit_step` only includes step. 
This PR aims to add flow to the second event.

Moreover, link in bio flow wasn't sending the `calypso_signup_actions_submit_step` event

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/setup?flow=newsletter` and `http://calypso.localhost:3000/setup?flow=link-in-bio`
* `calypso_signup_actions_submit_step` should be fired, with the correct props, while using the flow

Fixes #68378
