### PR TITLE
VideoPress Onboarding: Use plan product for checkout URL instead of periodAgnosticSlug

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -125,6 +125,8 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 					( plan ) => plan.productIds.indexOf( planId as number ) >= 0
 				);
 
+				const planProductObject = getPlanProduct( planObject?.periodAgnosticSlug, billingPeriod );
+
 				if ( domain && domain.product_slug ) {
 					const registration = domainRegistration( {
 						domain: domain.domain_name,
@@ -145,7 +147,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 				setProgress( 1.0 );
 
 				window.location.replace(
-					`/checkout/${ newSite?.site_slug }/${ planObject?.periodAgnosticSlug }?signup=1&redirect_to=/setup/completing-purchase?flow=videopress`
+					`/checkout/${ newSite?.site_slug }/${ planProductObject?.storeSlug }?signup=1&redirect_to=/setup/completing-purchase?flow=videopress`
 				);
 			} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR uses plan product slug instead of periodAgnosticSlug to generate the checkout URL.

#### Testing Instructions

* Apply PR
* Go to `http://calypso.localhost:3000/setup/intro?flow=videopress`
* Complete the flow until plan selection
* Choose a monthly plan
* ✅ Once the site is generated, the checkout page should have your monthly plan in the cart
* Test again with an annual plan

Fix Automattic/greenhouse#1349