### PR TITLE
Theme bundling: Added WooCommerce badge to design preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
@@ -5,4 +5,7 @@
 	.premium-badge {
 		font-family: $sans;
 	}
+	.woocommerce-bundled-badge {
+		margin-left: 10px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -25,8 +25,7 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 	);
 
 	const showBundledBadge =
-		isEnabled( 'themes/plugin-bundling' ) &&
-		( selectedDesign.software_sets || [] ).some( ( { slug } ) => slug === 'woo-on-plans' );
+		isEnabled( 'themes/plugin-bundling' ) && selectedDesign.is_bundled_with_woo_commerce;
 
 	let badge: React.ReactNode = null;
 	if ( showBundledBadge ) {
@@ -35,7 +34,7 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 		badge = <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />;
 	}
 
-	if ( selectedDesign.is_premium ) {
+	if ( badge ) {
 		return (
 			<div className="design-picker-design-title__container">
 				{ designTitle }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,6 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
+import WooCommerceBundledBadge from '../../../../../../../packages/design-picker/src/components/woocommerce-bundled-badge';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { Design } from '@automattic/design-picker';
@@ -22,11 +24,22 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 		)
 	);
 
+	const showBundledBadge =
+		isEnabled( 'themes/plugin-bundling' ) &&
+		( selectedDesign.software_sets || [] ).some( ( { slug } ) => slug === 'woo-on-plans' );
+
+	let badge: React.ReactNode = null;
+	if ( showBundledBadge ) {
+		badge = <WooCommerceBundledBadge />;
+	} else if ( selectedDesign.is_premium ) {
+		badge = <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />;
+	}
+
 	if ( selectedDesign.is_premium ) {
 		return (
 			<div className="design-picker-design-title__container">
 				{ designTitle }
-				<PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />
+				{ badge }
 			</div>
 		);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -218,9 +218,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	);
 
 	const isPluginBundleEligible = useIsPluginBundleEligible();
-	const isBundledWithWooCommerce = ( selectedDesign?.software_sets || [] ).some(
-		( set ) => set.slug === 'woo-on-plans'
-	);
+	const isBundledWithWooCommerce = selectedDesign?.is_bundled_with_woo_commerce;
 
 	const shouldUpgrade =
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -84,6 +84,10 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
 
+	const is_bundled_with_woo_commerce = ( design.software_sets || [] ).some(
+		( { slug } ) => slug === 'woo-on-plans'
+	);
+
 	return {
 		slug,
 		title,
@@ -91,6 +95,7 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		recipe,
 		categories,
 		is_premium,
+		is_bundled_with_woo_commerce,
 		price,
 		software_sets,
 		design_type: is_premium ? 'premium' : 'standard',

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -86,8 +86,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 
 	const showBundledBadge =
-		isEnabled( 'themes/plugin-bundling' ) &&
-		( design.software_sets || [] ).some( ( { slug } ) => slug === 'woo-on-plans' );
+		isEnabled( 'themes/plugin-bundling' ) && design.is_bundled_with_woo_commerce;
 
 	function getPricingDescription() {
 		let text: React.ReactNode = null;

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -93,6 +93,7 @@ export interface Design {
 	price?: string;
 	verticalizable?: boolean;
 	software_sets?: SoftwareSet[];
+	is_bundled_with_woo_commerce?: boolean;
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
#### Proposed Changes

* Added WooCommerce badge to themes with bundled plugins.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site with these flags on: `themes/plugin-bundling, signup/seller-upgrade-modal`
- On the design picker choose Thriving Artist (that has bundling)
- Check the badge
![image](https://user-images.githubusercontent.com/3801502/193046469-52e2b3a2-1278-4600-818d-c795d74f5dbf.png)



Related to https://github.com/Automattic/wp-calypso/issues/66654