### PR TITLE
Send a track event when there is an empty themes search

### DIFF
--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -29,6 +29,7 @@ const defaultProps = deepFreeze( {
 	],
 	lastPage: true,
 	loading: false,
+	isRequestFulfilled: true,
 	fetchNextPage: noop,
 	getButtonOptions: noop,
 	onScreenshotClick: noop,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -17,6 +17,7 @@ import {
 	getPremiumThemePrice,
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
+	isFulfilledThemesForQuery,
 	isRequestingThemesForQuery,
 	isThemesLastPageForQuery,
 	isThemeActive,
@@ -163,6 +164,7 @@ class ThemesSelection extends Component {
 					upsellUrl={ upsellUrl }
 					themes={ this.props.customizedThemesList || this.props.themes }
 					fetchNextPage={ this.fetchNextPage }
+					recordTracksEvent={ this.props.recordTracksEvent }
 					onMoreButtonClick={ this.recordSearchResultsClick }
 					getButtonOptions={ this.getOptions }
 					onScreenshotClick={ this.onScreenshotClick }
@@ -170,12 +172,14 @@ class ThemesSelection extends Component {
 					getActionLabel={ this.props.getActionLabel }
 					isActive={ this.props.isThemeActive }
 					getPrice={ this.props.getPremiumThemePrice }
+					isRequestFulfilled={ this.props.isRequestFulfilled }
 					isInstalling={ this.props.isInstallingTheme }
 					loading={ this.props.isRequesting }
 					emptyContent={ this.props.emptyContent }
 					placeholderCount={ this.props.placeholderCount }
 					bookmarkRef={ this.props.bookmarkRef }
 					siteId={ siteId }
+					searchTerm={ query.search }
 				/>
 			</div>
 		);
@@ -254,6 +258,7 @@ export const ConnectedThemesSelection = connect(
 			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
 			isRequesting:
 				isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
+			isRequestFulfilled: isFulfilledThemesForQuery( state, sourceSiteId, query ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: isUserLoggedIn( state ),
 			isThemeActive: bindIsThemeActive( state, siteId ),

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -44,6 +44,7 @@ export { hasAutoLoadingHomepageModalAccepted } from 'calypso/state/themes/select
 export { isActivatingTheme } from 'calypso/state/themes/selectors/is-activating-theme';
 export { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors/is-ambiguous-theme-filter-term';
 export { isDownloadableFromWpcom } from 'calypso/state/themes/selectors/is-downloadable-from-wpcom';
+export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-fulfilled-request-themes-for-query';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-requesting-active-theme';

--- a/client/state/themes/selectors/is-fulfilled-request-themes-for-query.js
+++ b/client/state/themes/selectors/is-fulfilled-request-themes-for-query.js
@@ -1,0 +1,17 @@
+import { getSerializedThemesQuery } from 'calypso/state/themes/utils';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Returns true if currently the themes query was already fullfiled, or false
+ * otherwise.
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId Site ID
+ * @param  {object}  query  Theme query object
+ * @returns {boolean}        Whether themes are being requested
+ */
+export function isFulfilledThemesForQuery( state, siteId, query ) {
+	const serializedQuery = getSerializedThemesQuery( query, siteId );
+	return state.themes.queryRequests[ serializedQuery ] === false;
+}


### PR DESCRIPTION
#### Proposed Changes

* Create a selector to identify when the theme search by the query is fulfilled
* Check if the request is fulfilled and there are no results
  * If yes, send the track event `calypso_themeshowcase_search_empty`

#### Testing Instructions

##### Positive Validation
* On the browser console terminal enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
* Go to themes page: `/themes/{site}`
* Search for a value that will return an empty list. Ex: `abc`
* Check if the event `calypso_themeshowcase_search_empty` is logged in console
* Check if the properties are filled: `search_term` and `blog_id`

##### Negative Validation
* Search for a value that won't return an empty list. Ex: `a`
* Verify the event IS NOT being sent
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68284
