### PR TITLE
[Jetpack pricing page]: Add tracking event on lightbox open

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -1,7 +1,7 @@
 import { JetpackTag, JETPACK_RELATED_PRODUCTS_MAP } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import Modal from 'react-modal';
 import { useDispatch } from 'react-redux';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
@@ -78,6 +78,15 @@ const ProductLightbox: React.FC< Props > = ( {
 			} )
 		);
 	}, [ dispatch, getOnClickPurchase, product, siteId ] );
+
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_product_lightbox_open', {
+				site_id: siteId,
+				product_slug: product.productSlug,
+			} )
+		);
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const variantOptions = useMemo( () => {
 		const variants = JETPACK_RELATED_PRODUCTS_MAP[ product.productSlug ] || [];


### PR DESCRIPTION
#### Proposed Changes

Adding track events to the new pricing page (addition to #68412):
-  Lightbox opened -> calypso_product_lightbox_open (site_id, product_slug)

#### Testing Instructions
- Use one method from
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - **OR** run this PR locally
        - download branch locally and run yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- You could check React devTools for fired Actions (`ANALYTICS_PAGE_VIEW_RECORD`) for recorded events.
- Check that `calypso_product_lightbox_open` is fired when lightbox is opened
- You could also check events at Tracks tool. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1202796695664022-as-1202979370140255/f
