### PR TITLE
Fix React error

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -1,5 +1,4 @@
-import { Button } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -219,7 +218,7 @@ class AutoRenewToggle extends Component {
 				'…'
 			) : (
 				<Button
-					link
+					isLink
 					className="is-link"
 					onClick={ this.onToggleAutoRenew }
 					disabled={ shouldDisable }


### PR DESCRIPTION
#### Proposed Changes

This will fix a React error spotted by @ciprianimike. 

The change will use the WordPress button with isLink property instead of the Automattic button with the missing link property.

#### Testing Instructions

1. With the Store Sandbox enabled, purchase a plan and go to /me/purchases
2. Click the purchase details page
3. Check the auto-renew ON link
4. It has to look like a link, has to be clickable, and it has to be possible to switch around between it and other links with a tab
5. Check the console for any errors. There should be no errors.

<img width="316" alt="Screenshot 2022-09-29 at 18 22 12" src="https://user-images.githubusercontent.com/82778/193072474-52bcc8a3-9d39-4e3d-809b-688d6a4ab474.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
