### PR TITLE
Calypso: Update Permalinks and Excerpt "Learn More" Links 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -11,8 +11,10 @@ declare global {
 function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
 	switch ( text ) {
 		case 'https://wordpress.org/support/article/excerpt/':
+		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':
 			return 'https://wordpress.com/support/excerpts/';
 		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
+		case 'https://wordpress.org/support/article/settings-sidebar/#permalink':
 			return 'https://wordpress.com/support/permalinks-and-slugs/';
 		case 'https://wordpress.org/support/article/wordpress-editor/':
 			return 'https://wordpress.com/support/wordpress-editor/';


### PR DESCRIPTION
#### Proposed Changes

Context: https://github.com/Automattic/wp-calypso/issues/52191#issuecomment-1251864383

In Calypso, "Learn More" links in the editor, in the sidebar, point to .org articles. This will point them to .com articles.

 **Permalinks**: `https://wordpress.org/support/article/settings-sidebar/#permalink` -> https://wordpress.com/support/permalinks-and-slugs/
 **Excerpt**: `https://wordpress.org/support/article/settings-sidebar/#excerpt` -> https://wordpress.com/support/excerpts/

These are the links:
![immagine](https://user-images.githubusercontent.com/52076348/193084569-37b51660-47e8-4d0d-88c9-06a3b8cb4f81.png)
![immagine](https://user-images.githubusercontent.com/52076348/193084603-e613762c-8a27-473b-a88c-78566ecc37f4.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn dev --sync` from `apps/editing-toolkit`
* Go to the editor
* Open settings
* Find the links and check that they bring you to the correct url

Fixes #68009
