### PR TITLE
Plugins: Convert Plugin Icon file to Typescript

### DIFF
--- a/client/me/connected-application-icon/index.jsx
+++ b/client/me/connected-application-icon/index.jsx
@@ -6,17 +6,7 @@ import './style.scss';
 export default class extends Component {
 	static displayName = 'ConnectedApplicationIcon';
 
-	static defaultProps = {
-		size: 40,
-	};
-
 	render() {
-		return (
-			<PluginIcon
-				className="connected-application-icon"
-				image={ this.props.image }
-				size={ this.props.size }
-			/>
-		);
+		return <PluginIcon className="connected-application-icon" image={ this.props.image } />;
 	}
 }

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import './style.scss';
 
 declare interface PluginIconProps {
-	className: string,
-	image: string,
-	isPlaceholder: boolean
+	className: string;
+	image: string;
+	isPlaceholder: boolean;
 }
 
 const PluginIcon = ( { className, image, isPlaceholder }: PluginIconProps ) => {
@@ -14,7 +14,7 @@ const PluginIcon = ( { className, image, isPlaceholder }: PluginIconProps ) => {
 		{
 			'plugin-icon': true,
 			'is-placeholder': isPlaceholder,
-			'is-fallback': !image,
+			'is-fallback': ! image,
 		},
 		className
 	);

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
@@ -1,15 +1,20 @@
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import './style.scss';
 
-const PluginIcon = ( { className, image, isPlaceholder } ) => {
+declare interface PluginIconProps {
+	className: string,
+	image: string,
+	isPlaceholder: boolean
+}
+
+const PluginIcon = ( { className, image, isPlaceholder }: PluginIconProps ) => {
 	const classes = classNames(
 		{
 			'plugin-icon': true,
 			'is-placeholder': isPlaceholder,
-			'is-fallback': ! image,
+			'is-fallback': !image,
 		},
 		className
 	);
@@ -23,12 +28,6 @@ const PluginIcon = ( { className, image, isPlaceholder } ) => {
 			) }
 		</div>
 	);
-};
-
-PluginIcon.propTypes = {
-	image: PropTypes.string,
-	isPlaceholder: PropTypes.bool,
-	className: PropTypes.string,
 };
 
 export default PluginIcon;

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import './style.scss';
 
-declare interface PluginIconProps {
+interface PluginIconProps {
 	className?: string;
 	image?: string;
 	isPlaceholder?: boolean;

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import './style.scss';
 
 declare interface PluginIconProps {
-	className: string;
-	image: string;
-	isPlaceholder: boolean;
+	className?: string;
+	image?: string;
+	isPlaceholder?: boolean;
 }
 
 const PluginIcon = ( { className, image, isPlaceholder }: PluginIconProps ) => {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -38,7 +38,6 @@ const PluginsBrowserListElement = ( props ) => {
 		isPlaceholder,
 		site,
 		plugin = {},
-		iconSize = 40,
 		variant = PluginsBrowserElementVariant.Compact,
 		currentSites,
 		search,
@@ -152,7 +151,7 @@ const PluginsBrowserListElement = ( props ) => {
 
 	if ( isPlaceholder ) {
 		// eslint-disable-next-line no-use-before-define
-		return <Placeholder iconSize={ iconSize } />;
+		return <Placeholder />;
 	}
 
 	const classNames = classnames( 'plugins-browser-item', variant, {
@@ -173,7 +172,7 @@ const PluginsBrowserListElement = ( props ) => {
 				onClick={ trackPluginLinkClick }
 			>
 				<div className="plugins-browser-item__info">
-					<PluginIcon size={ iconSize } image={ plugin.icon } isPlaceholder={ isPlaceholder } />
+					<PluginIcon image={ plugin.icon } isPlaceholder={ isPlaceholder } />
 					<div className="plugins-browser-item__title">
 						<TextHighlight text={ plugin.name } highlight={ search } />
 					</div>
@@ -347,12 +346,12 @@ const InstalledInOrPricing = ( {
 	);
 };
 
-const Placeholder = ( { iconSize } ) => {
+const Placeholder = () => {
 	return (
 		<li className="plugins-browser-item is-placeholder">
 			<span className="plugins-browser-item__link">
 				<div className="plugins-browser-item__info">
-					<PluginIcon size={ iconSize } isPlaceholder={ true } />
+					<PluginIcon isPlaceholder={ true } />
 					<div className="plugins-browser-item__title">…</div>
 					<div className="plugins-browser-item__author">…</div>
 					<div className="plugins-browser-item__description">…</div>


### PR DESCRIPTION
Why: To reap the benefits of TypeScript (such as added safety and automation) for this file. Also, a good way to practice creating a PR for Calypso.

#### Proposed Changes

* Add interface to Plugin Icon file, remove PropTypes, and convert to a TypeScript file. 

#### Testing Instructions

1.  Run Calypso in your browser and navigate to Plugins on the sidebar
2. Verify that plugin icons are loading as expected. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
