### PR TITLE
Checkout: Convert CartFreeUserPlanUpsell to TypeScript

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -54,70 +54,72 @@ import type {
 	MinimalRequestCartProduct,
 } from '@automattic/shopping-cart';
 
-export function getAllCartItems( cart?: ResponseCart ): ResponseCartProduct[] {
+export type ObjectWithProducts = Pick< ResponseCart, 'products' >;
+
+export function getAllCartItems( cart?: ObjectWithProducts ): ResponseCartProduct[] {
 	return ( cart && cart.products ) || [];
 }
 
-export function getRenewalItems( cart: ResponseCart ): ResponseCartProduct[] {
+export function getRenewalItems( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter( isRenewal );
 }
 
 /**
  * Determines whether there is a DIFM (Do it for me) product in the shopping cart.
  */
-export function hasDIFMProduct( cart: ResponseCart ): boolean {
+export function hasDIFMProduct( cart: ObjectWithProducts ): boolean {
 	return cart && getAllCartItems( cart ).some( isDIFMProduct );
 }
 
 /**
  * Determines whether there is any kind of plan (e.g. Premium or Business) in the shopping cart.
  */
-export function hasPlan( cart: ResponseCart ): boolean {
+export function hasPlan( cart: ObjectWithProducts ): boolean {
 	return cart && getAllCartItems( cart ).some( isPlan );
 }
 
 /**
  * Determines whether there is a Jetpack plan in the shopping cart.
  */
-export function hasJetpackPlan( cart: ResponseCart ): boolean {
+export function hasJetpackPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isJetpackPlan );
 }
 
 /**
  * Determines whether there is a P2+ plan in the shopping cart.
  */
-export function hasP2PlusPlan( cart: ResponseCart ): boolean {
+export function hasP2PlusPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isP2Plus );
 }
 
 /**
  * Determines whether there is an ecommerce plan in the shopping cart.
  */
-export function hasEcommercePlan( cart: ResponseCart ): boolean {
+export function hasEcommercePlan( cart: ObjectWithProducts ): boolean {
 	return cart && getAllCartItems( cart ).some( isEcommerce );
 }
 
-export function hasBloggerPlan( cart: ResponseCart ): boolean {
+export function hasBloggerPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isBlogger );
 }
 
-export function hasPersonalPlan( cart: ResponseCart ): boolean {
+export function hasPersonalPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isPersonal );
 }
 
-export function hasPremiumPlan( cart: ResponseCart ): boolean {
+export function hasPremiumPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isPremium );
 }
 
-export function hasProPlan( cart: ResponseCart ): boolean {
+export function hasProPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isPro );
 }
 
-export function hasBusinessPlan( cart: ResponseCart ): boolean {
+export function hasBusinessPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isBusiness );
 }
 
-export function hasStarterPlan( cart: ResponseCart ): boolean {
+export function hasStarterPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isStarter );
 }
 
@@ -125,32 +127,32 @@ export function hasDomainCredit( cart: ResponseCart ): boolean {
 	return cart.has_bundle_credit || hasPlan( cart );
 }
 
-export function hasMonthlyCartItem( cart: ResponseCart ): boolean {
+export function hasMonthlyCartItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isMonthlyProduct );
 }
 
-export function hasBiennialCartItem( cart: ResponseCart ): boolean {
+export function hasBiennialCartItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isBiennially );
 }
 
 /**
  * Determines whether there is at least one item of a given product in the specified shopping cart.
  */
-export function hasProduct( cart: ResponseCart, productSlug: string ): boolean {
+export function hasProduct( cart: ObjectWithProducts, productSlug: string ): boolean {
 	return getAllCartItems( cart ).some( function ( cartItem ) {
 		return cartItem.product_slug === productSlug;
 	} );
 }
 
-export function hasDomainRegistration( cart: ResponseCart ): boolean {
+export function hasDomainRegistration( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainRegistration );
 }
 
-export function hasNewDomainRegistration( cart: ResponseCart ): boolean {
+export function hasNewDomainRegistration( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isNewDomainRegistration );
 }
 
-export function hasDomainRenewal( cart: ResponseCart ): boolean {
+export function hasDomainRenewal( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainRenewal );
 }
 
@@ -165,21 +167,21 @@ function isDomainRenewal( cartItem: ResponseCartProduct ): boolean {
 	return isRenewal( cartItem ) && isDomainRegistration( cartItem );
 }
 
-export function hasDomainBeingUsedForPlan( cart: ResponseCart ): boolean {
+export function hasDomainBeingUsedForPlan( cart: ObjectWithProducts ): boolean {
 	return getDomainRegistrations( cart ).some( ( registration ) =>
 		isDomainBeingUsedForPlan( cart, registration.meta )
 	);
 }
 
-export function hasRenewalItem( cart: ResponseCart ): boolean {
+export function hasRenewalItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isRenewal );
 }
 
-export function hasTransferProduct( cart: ResponseCart ): boolean {
+export function hasTransferProduct( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainTransfer );
 }
 
-export function getDomainTransfers( cart: ResponseCart ): ResponseCartProduct[] {
+export function getDomainTransfers( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter(
 		( product ) => product.product_slug === domainProductSlugs.TRANSFER_IN
 	);
@@ -190,11 +192,11 @@ export function getDomainTransfers( cart: ResponseCart ): ResponseCartProduct[] 
  *
  * Ignores partial credits, which aren't really a line item in this sense.
  */
-export function hasOnlyRenewalItems( cart: ResponseCart ): boolean {
+export function hasOnlyRenewalItems( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).every( ( item ) => isRenewal( item ) || isPartialCredits( item ) );
 }
 
-export function hasConciergeSession( cart: ResponseCart ): boolean {
+export function hasConciergeSession( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isConciergeSession );
 }
 
@@ -217,7 +219,7 @@ export function getCartItemBillPeriod( cartItem: ResponseCartProduct ): number {
  *
  * Will return false if the cart is empty.
  */
-export function hasRenewableSubscription( cart: ResponseCart ): boolean {
+export function hasRenewableSubscription( cart: ObjectWithProducts ): boolean {
 	return (
 		cart.products &&
 		getAllCartItems( cart ).some( ( cartItem ) => getCartItemBillPeriod( cartItem ) > 0 )
@@ -352,7 +354,7 @@ export function domainTransfer( properties: {
 /**
  * Retrieves all the items in the specified shopping cart for G Suite or Google Workspace.
  */
-export function getGoogleApps( cart: ResponseCart ): ResponseCartProduct[] {
+export function getGoogleApps( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter( isGSuiteOrExtraLicenseOrGoogleWorkspace );
 }
 
@@ -444,11 +446,11 @@ export function titanMailMonthly( properties: TitanProductProps ): MinimalReques
 	return titanMailProduct( properties, TITAN_MAIL_MONTHLY_SLUG );
 }
 
-export function hasGoogleApps( cart: ResponseCart ): boolean {
+export function hasGoogleApps( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
 }
 
-export function hasTitanMail( cart: ResponseCart ): boolean {
+export function hasTitanMail( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isTitanMail );
 }
 
@@ -509,14 +511,14 @@ export function renewableProductItem( slug: string ): MinimalRequestCartProduct 
 /**
  * Retrieves all the domain registration items in the specified shopping cart.
  */
-export function getDomainRegistrations( cart: ResponseCart ): ResponseCartProduct[] {
+export function getDomainRegistrations( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter( ( product ) => product.is_domain_registration === true );
 }
 
 /**
  * Retrieves all the domain mapping items in the specified shopping cart.
  */
-export function getDomainMappings( cart: ResponseCart ): ResponseCartProduct[] {
+export function getDomainMappings( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter( ( product ) => product.product_slug === 'domain_map' );
 }
 
@@ -628,7 +630,7 @@ export function getRenewalItemFromCartItem< T extends MinimalRequestCartProduct 
 	};
 }
 
-export function hasDomainInCart( cart: ResponseCart, domain: string ): boolean {
+export function hasDomainInCart( cart: ObjectWithProducts, domain: string ): boolean {
 	return getAllCartItems( cart ).some( ( product ) => {
 		return product.is_domain_registration === true && product.meta === domain;
 	} );
@@ -682,7 +684,7 @@ export function isDomainBundledWithPlan( cart?: ResponseCart, domain?: string ):
 /**
  * Returns true if cart contains a plan and also a domain that comes for free with that plan
  */
-export function isDomainBeingUsedForPlan( cart?: ResponseCart, domain?: string ): boolean {
+export function isDomainBeingUsedForPlan( cart?: ObjectWithProducts, domain?: string ): boolean {
 	if ( ! cart || ! domain ) {
 		return false;
 	}
@@ -747,7 +749,7 @@ export function shouldBundleDomainWithPlan(
  */
 export function hasToUpgradeToPayForADomain(
 	selectedSite: undefined | { plan: { product_slug?: string } },
-	cart: ResponseCart,
+	cart: ObjectWithProducts,
 	domain?: string
 ): boolean {
 	if ( ! domain || ! getTld( domain ) ) {
@@ -862,7 +864,7 @@ export function getDomainPriceRule(
 /**
  * Determines whether any items in the cart were added more than X time ago (10 minutes)
  */
-export function hasStaleItem( cart: ResponseCart ): boolean {
+export function hasStaleItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( function ( cartItem ) {
 		// time_added_to_cart is in seconds, Date.now() returns milliseconds
 		return (

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -8,7 +8,6 @@ import {
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -59,7 +58,7 @@ class CartFreeUserPlanUpsell extends Component {
 
 	getUpgradeText() {
 		const { cart, planPrice, translate, eligibleForProPlan } = this.props;
-		const firstDomain = find( getAllCartItems( cart ), this.isRegistrationOrTransfer );
+		const firstDomain = getAllCartItems( cart ).find( this.isRegistrationOrTransfer );
 
 		if ( planPrice > firstDomain.cost ) {
 			const extraToPay = planPrice - firstDomain.cost;

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -7,10 +7,9 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
+import { localize, useTranslate } from 'i18n-calypso';
 import { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
@@ -26,25 +25,37 @@ import { isRequestingPlans } from 'calypso/state/plans/selectors';
 import { getPlanPrice } from 'calypso/state/products-list/selectors';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getAllCartItems } from '../../../lib/cart-values/cart-items';
+import type { SiteDetails } from '@automattic/data-stores';
+import type {
+	ResponseCart,
+	MinimalRequestCartProduct,
+	ResponseCartProduct,
+} from '@automattic/shopping-cart';
+import type { AppState } from 'calypso/types';
 
-class CartFreeUserPlanUpsell extends Component {
-	static propTypes = {
-		cart: PropTypes.object,
-		isCartPendingUpdate: PropTypes.bool,
-		addItemToCart: PropTypes.func.isRequired,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
-		hasPaidPlan: PropTypes.bool,
-		hasPlanInCart: PropTypes.bool,
-		isPlansListFetching: PropTypes.bool,
-		isRegisteringOrTransferringDomain: PropTypes.bool,
-		isSitePlansListFetching: PropTypes.bool,
-		upsellPlan: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
-		planPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.bool ] ),
-		showPlanUpsell: PropTypes.bool,
-		translate: PropTypes.func.isRequired,
-	};
+export interface CartFreeUserPlanUpsellProps {
+	cart: Pick< ResponseCart, 'products' >;
+	isCartPendingUpdate?: boolean;
+	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
+}
 
+interface CartFreeUserPlanUpsellHocProps {
+	selectedSite?: SiteDetails | null;
+	hasPaidPlan?: boolean;
+	hasPlanInCart?: boolean;
+	isPlansListFetching?: boolean;
+	isRegisteringOrTransferringDomain?: boolean;
+	isSitePlansListFetching?: boolean;
+	planPrice: number | false | null | undefined;
+	showPlanUpsell?: boolean;
+	translate: ReturnType< typeof useTranslate >;
+	eligibleForProPlan?: boolean;
+	clickUpsellAddToCart: () => void;
+}
+
+class CartFreeUserPlanUpsell extends Component<
+	CartFreeUserPlanUpsellProps & CartFreeUserPlanUpsellHocProps
+> {
 	isLoading() {
 		const { isCartPendingUpdate: isLoadingCart } = this.props;
 		const isLoadingPlans = this.props.isPlansListFetching;
@@ -52,15 +63,15 @@ class CartFreeUserPlanUpsell extends Component {
 		return isLoadingCart || isLoadingPlans || isLoadingSitePlans;
 	}
 
-	isRegistrationOrTransfer = ( item ) => {
+	isRegistrationOrTransfer = ( item: ResponseCartProduct ) => {
 		return isDomainRegistration( item ) || isDomainTransfer( item );
 	};
 
 	getUpgradeText() {
 		const { cart, planPrice, translate, eligibleForProPlan } = this.props;
-		const firstDomain = getAllCartItems( cart ).find( this.isRegistrationOrTransfer );
+		const firstDomain = cart.products.find( this.isRegistrationOrTransfer );
 
-		if ( planPrice > firstDomain.cost ) {
+		if ( planPrice && firstDomain && planPrice > firstDomain.cost ) {
 			const extraToPay = planPrice - firstDomain.cost;
 			return eligibleForProPlan
 				? translate(
@@ -87,7 +98,7 @@ class CartFreeUserPlanUpsell extends Component {
 							},
 						}
 				  );
-		} else if ( planPrice < firstDomain.cost ) {
+		} else if ( planPrice && firstDomain && planPrice < firstDomain.cost ) {
 			const savings = firstDomain.cost - planPrice;
 			return eligibleForProPlan
 				? translate(
@@ -194,7 +205,7 @@ class CartFreeUserPlanUpsell extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { cart, addItemToCart } ) => {
+const mapStateToProps = ( state: AppState, { cart }: CartFreeUserPlanUpsellProps ) => {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = selectedSite ? selectedSite.ID : null;
 	const isPlansListFetching = isRequestingPlans( state );
@@ -207,19 +218,18 @@ const mapStateToProps = ( state, { cart, addItemToCart } ) => {
 		isPlansListFetching,
 		isRegisteringOrTransferringDomain: hasDomainRegistration( cart ) || hasTransferProduct( cart ),
 		isSitePlansListFetching: isRequestingSitePlans( state ),
-		upsellPlan,
 		planPrice:
 			! isPlansListFetching &&
 			selectedSiteId &&
+			upsellPlan &&
 			getPlanPrice( state, selectedSiteId, upsellPlan, false ),
 		selectedSite,
 		showPlanUpsell: !! selectedSiteId,
-		addItemToCart,
 		eligibleForProPlan,
 	};
 };
 
-const mapDispatchToProps = ( dispatch ) => {
+const mapDispatchToProps = ( dispatch: ReturnType< typeof useDispatch > ) => {
 	return {
 		clickUpsellAddToCart: () =>
 			dispatch( recordTracksEvent( 'calypso_non_dwpo_checkout_plan_upsell_add_to_cart', {} ) ),

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -7,11 +7,11 @@ import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-re
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { ResponseCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
-export type PartialCart = Pick< ResponseCart, 'products' >;
+export type PartialCart = Partial< ResponseCart > & Pick< ResponseCart, 'products' >;
 interface Props {
 	responseCart: PartialCart;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
-	isCartPendingUpdate: boolean;
+	isCartPendingUpdate?: boolean;
 }
 
 type DivProps = {

--- a/client/my-sites/checkout/composite-checkout/components/test/lib/fixtures.ts
+++ b/client/my-sites/checkout/composite-checkout/components/test/lib/fixtures.ts
@@ -1,8 +1,11 @@
+import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import moment from 'moment';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
-export const responseCartWithRenewal = {
+export const responseCartWithRenewal: Pick< ResponseCart, 'products' > = {
 	products: [
 		{
+			...getEmptyResponseCartProduct(),
 			product_id: 74,
 			product_name: '.live Domain Registration',
 			product_slug: 'dotlive_domain',
@@ -13,13 +16,8 @@ export const responseCartWithRenewal = {
 			currency: 'USD',
 			volume: 1,
 			extra: {
-				purchaseId: '1234',
 				purchaseType: 'renewal',
 				context: 'calypstore',
-				registrar: 'OpenSRS',
-				domain_registration_agreement_url:
-					'https://opensrs.com/wp-content/uploads/Tucows_ExhibitA.html',
-				privacy_available: true,
 				premium: false,
 			},
 			is_domain_registration: true,
@@ -31,7 +29,6 @@ export const responseCartWithRenewal = {
 			subscription_id: '3',
 			is_renewal: true,
 			uuid: '123',
-			price: 38000,
 			product_type: 'dotlive_domain',
 			included_domain_purchase_amount: 3800,
 		},

--- a/client/state/plans/selectors/get-plan-raw-price.ts
+++ b/client/state/plans/selectors/get-plan-raw-price.ts
@@ -1,5 +1,6 @@
 import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
 import { getPlan } from './plan';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/plans/init';
 
@@ -11,7 +12,11 @@ import 'calypso/state/plans/init';
  * @param  {boolean} isMonthly if true, returns monthly price
  * @returns {number|null}  plan price
  */
-export function getPlanRawPrice( state, productId, isMonthly = false ) {
+export function getPlanRawPrice(
+	state: AppState,
+	productId: number,
+	isMonthly?: boolean
+): number | null {
 	const plan = getPlan( state, productId );
 	const rawPrice = plan?.raw_price ?? -1;
 	const origCost = plan?.orig_cost ?? 0;

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.ts
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.ts
@@ -23,7 +23,7 @@ export interface FullAndMonthlyPrices {
 
 type PlanOrProductSlug = PlanSlug | ProductSlug;
 type Optional< T, K extends keyof T > = Pick< Partial< T >, K > & Omit< T, K >;
-type PlanObject = Optional< Pick< Plan, 'group' | 'getProductId' >, 'group' > & {
+export type PlanObject = Optional< Pick< Plan, 'group' | 'getProductId' >, 'group' > & {
 	getStoreSlug: () => PlanOrProductSlug;
 };
 

--- a/client/state/products-list/selectors/get-plan-price.ts
+++ b/client/state/products-list/selectors/get-plan-price.ts
@@ -1,5 +1,7 @@
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
+import type { Plan } from '@automattic/calypso-products';
+import type { AppState } from 'calypso/types';
 
 /**
  * Computes a price based on plan slug/constant, including any discounts available.
@@ -8,9 +10,14 @@ import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
  * @param {number|undefined} siteId Site ID to consider
  * @param {object} planObject Plan object returned by getPlan() from @automattic/calypso-products
  * @param {boolean} isMonthly Flag - should return a monthly price?
- * @returns {number} Requested price
+ * @returns {number|null} Requested price
  */
-export const getPlanPrice = ( state, siteId, planObject, isMonthly ) => {
+export const getPlanPrice = (
+	state: AppState,
+	siteId: number | undefined,
+	planObject: Plan,
+	isMonthly?: boolean
+): number | null => {
 	return (
 		getPlanDiscountedRawPrice( state, siteId, planObject.getStoreSlug(), { isMonthly } ) ||
 		getPlanRawPrice( state, planObject.getProductId(), isMonthly )

--- a/client/state/products-list/selectors/get-plan-price.ts
+++ b/client/state/products-list/selectors/get-plan-price.ts
@@ -1,6 +1,6 @@
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
-import type { Plan } from '@automattic/calypso-products';
+import type { PlanObject } from './compute-full-and-monthly-prices-for-plan';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -15,7 +15,7 @@ import type { AppState } from 'calypso/types';
 export const getPlanPrice = (
 	state: AppState,
 	siteId: number | undefined,
-	planObject: Plan,
+	planObject: Pick< PlanObject, 'getStoreSlug' | 'getProductId' >,
 	isMonthly?: boolean
 ): number | null => {
 	return (


### PR DESCRIPTION
#### Proposed Changes

This PR converts the `CartFreeUserPlanUpsell` component to TypeScript. To do this properly, a few other selectors needed to be converted or adjusted as well, notably `getPlanPrice()` and `getPlanRawPrice()`.

#### Testing Instructions

There are automated tests covering this component. 