### PR TITLE
Marketplace Install Dialog: Eligibility warning improvements

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -49,8 +49,6 @@ interface ExternalProps {
 	eligibilityData?: EligibilityData;
 	currentContext?: string;
 	isMarketplace?: boolean;
-	title?: string;
-	primaryText?: string;
 }
 
 type Props = ExternalProps & ReturnType< typeof mergeProps > & LocalizeProps;
@@ -74,8 +72,6 @@ export const EligibilityWarnings = ( {
 	launchSite: launch,
 	makeSitePublic,
 	translate,
-	title,
-	primaryText,
 }: Props ) => {
 	const warnings = eligibilityData.eligibilityWarnings || [];
 	const listHolds = eligibilityData.eligibilityHolds || [];
@@ -91,7 +87,7 @@ export const EligibilityWarnings = ( {
 			'eligibility-warnings__placeholder': isPlaceholder,
 			'eligibility-warnings--with-indent': showWarnings,
 			'eligibility-warnings--blocking-hold': hasBlockingHold( listHolds ),
-			'eligibility-warnings--without-title': ! title && ! primaryText,
+			'eligibility-warnings--without-title': context !== 'plugin-details',
 		},
 		className
 	);

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -124,7 +124,10 @@ export const EligibilityWarnings = ( {
 
 	const blockingMessages = getBlockingMessages( translate );
 
-	const filteredHolds = listHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
+	let filteredHolds = listHolds;
+	if ( context === 'plugin-details' ) {
+		filteredHolds = listHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
+	}
 
 	return (
 		<div className={ classes }>
@@ -142,13 +145,19 @@ export const EligibilityWarnings = ( {
 					/>
 				</CompactCard>
 			) }
-			{ ( title || primaryText ) && (
+			{ ! isPlaceholder && context === 'plugin-details' && (
 				<CompactCard>
 					<div className="eligibility-warnings__header">
-						{ title && <div className="eligibility-warnings__title">{ title }</div> }
-						{ primaryText && (
-							<div className="eligibility-warnings__primary-text">{ primaryText }</div>
-						) }
+						<div className="eligibility-warnings__title">
+							{ translate( 'Upgrade your plan to install plugins' ) }
+						</div>
+						<div className="eligibility-warnings__primary-text">
+							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
+								? translate(
+										'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for $33/month.'
+								  )
+								: '' }
+						</div>
 					</div>
 				</CompactCard>
 			) }

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -7,6 +7,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_WPCOM_PRO,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
+	PLAN_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -23,6 +24,7 @@ import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
+import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import getRequest from 'calypso/state/selectors/get-request';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
@@ -129,6 +131,10 @@ export const EligibilityWarnings = ( {
 		filteredHolds = listHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
 	}
 
+	const monthlyCost = useSelector( ( state ) =>
+		getProductDisplayCost( state, PLAN_BUSINESS_MONTHLY )
+	);
+
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
@@ -154,7 +160,8 @@ export const EligibilityWarnings = ( {
 						<div className="eligibility-warnings__primary-text">
 							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
 								? translate(
-										'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for $33/month.'
+										'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for %(monthlyCost)s/month.',
+										{ args: { monthlyCost } }
 								  )
 								: '' }
 						</div>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -124,6 +124,8 @@ export const EligibilityWarnings = ( {
 
 	const blockingMessages = getBlockingMessages( translate );
 
+	const filteredHolds = listHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
+
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
@@ -151,11 +153,11 @@ export const EligibilityWarnings = ( {
 				</CompactCard>
 			) }
 
-			{ ( isPlaceholder || listHolds.length > 0 ) && (
+			{ ( isPlaceholder || filteredHolds.length > 0 ) && (
 				<CompactCard>
 					<HoldList
 						context={ context }
-						holds={ listHolds }
+						holds={ filteredHolds }
 						isPlaceholder={ isPlaceholder }
 						isMarketplace={ isMarketplace }
 					/>

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -227,6 +227,7 @@
 .eligibility-warnings__warnings-card {
 	background: #f6f7f7;
 	margin: 0 24px;
+	border-radius: 4px;
 
 	@media ( max-width: 480px ) {
 		margin: 0 16px;

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -12,7 +12,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { eligibilityHolds as eligibilityHoldsConstants } from 'calypso/state/automated-transfer/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
@@ -34,12 +33,7 @@ import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { getPeriodVariationValue } from '../plugin-price';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
 
-export default function CTAButton( {
-	plugin,
-	hasEligibilityMessages,
-	eligibilityHolds,
-	disabled,
-} ) {
+export default function CTAButton( { plugin, hasEligibilityMessages, disabled } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ showEligibility, setShowEligibility ] = useState( false );
@@ -140,15 +134,6 @@ export default function CTAButton( {
 			>
 				<EligibilityWarnings
 					currentContext={ 'plugin-details' }
-					title={ translate( 'Upgrade your plan to install plugins' ) }
-					primaryText={
-						eligibilityHolds &&
-						eligibilityHolds.indexOf( eligibilityHoldsConstants.NO_BUSINESS_PLAN ) !== -1
-							? translate(
-									'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for $33/month.'
-							  )
-							: ''
-					}
 					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
 					onProceed={ () =>

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -140,7 +140,7 @@ export default function CTAButton( {
 			>
 				<EligibilityWarnings
 					currentContext={ 'plugin-details' }
-					title={ translate( 'Flex your site with plugins' ) }
+					title={ translate( 'Upgrade your plan to install plugins' ) }
 					primaryText={
 						eligibilityHolds &&
 						eligibilityHolds.indexOf( eligibilityHoldsConstants.NO_BUSINESS_PLAN ) !== -1

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -288,7 +288,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 					<CTAButton
 						plugin={ plugin }
 						hasEligibilityMessages={ hasEligibilityMessages }
-						eligibilityHolds={ eligibilityHolds }
 						disabled={ incompatiblePlugin || userCantManageTheSite }
 					/>
 				) : (
@@ -465,11 +464,7 @@ function LegacyPluginDetailsCTA( {
 				</PluginPrice>
 			</div>
 			<div className="plugin-details-cta__install">
-				<CTAButton
-					plugin={ plugin }
-					hasEligibilityMessages={ hasEligibilityMessages }
-					eligibilityHolds={ eligibilityHolds }
-				/>
+				<CTAButton plugin={ plugin } hasEligibilityMessages={ hasEligibilityMessages } />
 			</div>
 			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 				<div className="plugin-details-cta__t-and-c">


### PR DESCRIPTION
#### Proposed Changes

Improve elegibility warning dialog.

![upgrade modal](https://user-images.githubusercontent.com/6586048/193276622-2e990b44-455c-4282-ab31-f3bc03b7b314.png)

#### Testing Instructions

1. Using a non-business site 
2. Try to install a paid plugin and in the dialog, check the list below:

#### Things to test

- [x] 4px radius corner in the modal at the grey (domain) box
- [x] Update the modal title to `Upgrade your plan to install plugins`
- [x] Filter out `NO_BUSINESS_PLAN` warnings at the modal:
- [x] Pricing that is displayed in the modal - must be dynamic, following the user’s currency and the actual monthly fee for Business Plan

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Fixes #68454
