### PR TITLE
Checkout: Create international fee notice component

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -8,6 +8,7 @@ import DomainRefundPolicy from './domain-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import { EbanxTermsOfService } from './ebanx-terms-of-service';
+import { InternationalFeeNotice } from './international-fee-notice';
 import TermsOfService from './terms-of-service';
 import ThirdPartyPluginsTermsOfService from './third-party-plugins-terms-of-service';
 import TitanTermsOfService from './titan-terms-of-service';
@@ -36,6 +37,7 @@ class CheckoutTerms extends Component {
 				<TitanTermsOfService cart={ cart } />
 				<ThirdPartyPluginsTermsOfService cart={ cart } />
 				<EbanxTermsOfService />
+				<InternationalFeeNotice />
 				<AdditionalTermsOfServiceInCart />
 			</Fragment>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
@@ -11,18 +10,7 @@ export const InternationalFeeNotice = () => {
 
 	if ( contactInfo.countryCode?.value !== 'US' ) {
 		const internationalFeeAgreement = translate(
-			`The selected country and postal code may be processed as an international transaction, you agree to pay any associated fees. {{link}}Learn more{{/link}}`,
-			{
-				components: {
-					link: (
-						<a
-							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
+			`Your issuing bank may choose to charge an international transaction fee or a currency exchange fee. Your bank may be able to provide more information as to when this is necessary.`
 		);
 		return <CheckoutTermsItem>{ internationalFeeAgreement }</CheckoutTermsItem>;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
@@ -1,0 +1,31 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
+import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
+
+export const InternationalFeeNotice = () => {
+	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
+		select( 'wpcom-checkout' ).getContactInfo()
+	);
+
+	if ( contactInfo.countryCode?.value !== 'US' ) {
+		const internationalFeeAgreement = translate(
+			`The selected country and postal code may be processed as an international transaction, you agree to pay any associated fees. {{link}}Learn more{{/link}}`,
+			{
+				components: {
+					link: (
+						<a
+							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
+		return <CheckoutTermsItem>{ internationalFeeAgreement }</CheckoutTermsItem>;
+	}
+
+	return null;
+};


### PR DESCRIPTION
#### Proposed Changes

This PR adds an InternationalFeeNotice component to the final step in checkout. 

When a customer sets their tax location to anything other than the US, this component will be displayed. 

The component will notify and link customers to our ToS describing how any transaction made from outside of the US may result in Stripe assessing an international conversion fee.

#### Testing Instructions

**Pre-reqs**
* Add any purchase to your cart
* Proceed to checkout and click on the 'Edit' link next to Billing Information

**Testing US checkout**
* Set your country to the US, add any postal code (i.e. 19301), save changes and proceed to Pick A Payment Method
* Note that there is no international fee notice

<img width="578" alt="image" src="https://user-images.githubusercontent.com/16580129/193706348-509bbcef-233f-4b45-9116-458ba6a23f55.png">

**Testing Non-US checkout**
* Click on Edit next to Billing Information again
* Change country to any other country besides the US (i.e. France)
* Enter a valid postal code (i.e. 75000)
* Note that the international fee notice now exists
 
<img width="602" alt="image" src="https://user-images.githubusercontent.com/16580129/193706311-8e93c883-2d7b-4ab1-a35a-210cdd110b71.png">

Related to https://github.com/Automattic/payments-shilling/issues/962
