### PR TITLE
SMP: mShots can take snapshots of Coming Soon sites using ?mshots

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -17,9 +17,6 @@ function should_show_coming_soon_page() {
 		return false;
 	}
 
-	l( 'http referer ' . $_SERVER['HTTP_REFERER'] );
-	l( 'remote host ' . $_SERVER['REMOTE_HOST'] );
-
 	// mShots should be able to take screenshots of coming soon sites, in the
 	// same way RSS readers have access to coming soon sites.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -17,6 +17,9 @@ function should_show_coming_soon_page() {
 		return false;
 	}
 
+	l( 'http referer ' . $_SERVER['HTTP_REFERER'] );
+	l( 'remote host ' . $_SERVER['REMOTE_HOST'] );
+
 	// mShots should be able to take screenshots of coming soon sites, in the
 	// same way RSS readers have access to coming soon sites.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -17,6 +17,13 @@ function should_show_coming_soon_page() {
 		return false;
 	}
 
+	// mShots should be able to take screenshots of coming soon sites, in the
+	// same way RSS readers have access to coming soon sites.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['mshots'] ) ) {
+		return false;
+	}
+
 	$should_show = ( (int) get_option( 'wpcom_public_coming_soon' ) === 1 );
 
 	// Everyone from Administrator to Subscriber will be able to see the site.


### PR DESCRIPTION
#### Proposed Changes

Part of Automattic/dotcom-forge#815
More Discussion here pdKhl6-Os-p2

* Add `?mshots` flag to Coming Soon feature

This flag will allow mShots to take screenshots of Coming Soon sites.

This code only ever runs on public sites. If a site is coming soon _and_ private then that request is handled by `private.php`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It's not possible to test this end-to-end with mshots because mshots will always make requests to production servers, not to your sandbox. You can test that the `?mshots` flag is working though.

* `yarn dev --sync` these changes to your sandbox
* Create a testing coming soon site
* Open the test site in incognito mode
	* Coming Soon notice should still appear by default
	* Add `?mshots` query param, refresh page and the notice shouldn't be there
* Test that it works on launched sites that have been put back into Coming Soon mode
* Test on a private site that is also somehow in Coming Soon mode
	* Set your site to Coming Soon mode
	* Flip the site privacy option using some other method e.g. `wp option set blog_public -1`
	* Confirm that you can't use `?mshots` to bypass Coming Soon when the site is private.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #