### PR TITLE
Add monthly business plan cost to copy

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
+	PLAN_BUSINESS_MONTHLY,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
@@ -22,6 +23,7 @@ import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/prefe
 import {
 	isMarketplaceProduct as isMarketplaceProductSelector,
 	getProductsList,
+	getProductDisplayCost,
 } from 'calypso/state/products-list/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
@@ -105,6 +107,10 @@ export default function CTAButton( {
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
 	const pluginsPlansPage = `/plugins/plans/${ plugin.slug }/yearly/${ selectedSite?.slug }`;
 
+	const monthlyCost = useSelector( ( state ) =>
+		getProductDisplayCost( state, PLAN_BUSINESS_MONTHLY )
+	);
+
 	return (
 		<>
 			<PluginCustomDomainDialog
@@ -145,7 +151,8 @@ export default function CTAButton( {
 						eligibilityHolds &&
 						eligibilityHolds.indexOf( eligibilityHoldsConstants.NO_BUSINESS_PLAN ) !== -1
 							? translate(
-									'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for $33/month.'
+									'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for %(monthlyCost)s/month.',
+									{ args: { monthlyCost } }
 							  )
 							: ''
 					}


### PR DESCRIPTION
#### Proposed Changes

* Adds dynamic/localized monthly plan cost to plugin install dialog

#### Testing Instructions

* Using a non business plan
* Attempt to install a plugin
* You should see your localized monthly business plan cost in this copy:

![Screenshot(32)](https://user-images.githubusercontent.com/811776/193194689-75501fb0-70a9-4004-8d85-2adceb8b63f2.png)

![Screenshot(31)](https://user-images.githubusercontent.com/811776/193194627-2ca32631-a1f9-4033-8275-0c2b58d0606c.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68454
