### PR TITLE
Fix Help Center masterbar item style on non-default theme

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -866,10 +866,6 @@ a.masterbar__quick-language-switcher {
 	svg {
 		fill: var(--color-masterbar-text);
 	}
-
-	&.is-active {
-		background: #1e1e1e;
-	}
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
When I have the "Light" Calypso color theme enabled and open the Help Center item in Masterbar, the background color of the item is wrong:

<img width="433" alt="Screenshot 2022-09-29 at 16 22 39" src="https://user-images.githubusercontent.com/664258/193225811-eacd366d-6670-422f-b53a-ec9eae620217.png">

The black color is valid only in the default theme, in other themes it should respect that theme's choice:

<img width="434" alt="Screenshot 2022-09-30 at 10 20 16" src="https://user-images.githubusercontent.com/664258/193226004-29f8d491-20fa-4cb8-95ed-67a9f3ef26f8.png">

Here I'm fixing this by removing the custom style for `.masterbar__item-help.is-active`. Then only the default `.masterbar__item.is-active` style is applied, which uses the theme's `--color-masterbar-item-active-background` CSS variable.