### PR TITLE
Delete Site confirmation: fix CSS specificity for label

### DIFF
--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -48,7 +48,7 @@ h1.delete-site__confirm-header {
 	color: var(--color-neutral-70);
 }
 
-.delete-site__confirm-label {
+.form-label.delete-site__confirm-label {
 	margin-bottom: 8px;
 	line-height: 24px;
 	color: var(--color-text-subtle);


### PR DESCRIPTION
When deleting a site, there is a confirmation modal that's supposed to look like this:

<img width="477" alt="Screenshot 2022-09-30 at 9 39 15" src="https://user-images.githubusercontent.com/664258/193235350-079c46cf-2136-435c-a257-2a2b58b94816.png">

There is a text with a normal (as opposed to bold) font weight. But it currently sometimes looks like this, where the text is bold:

<img width="1032" alt="Screenshot 2022-09-30 at 9 38 21" src="https://user-images.githubusercontent.com/664258/193235519-9e815c27-d383-4a74-afdd-50d952e1dc3f.png">

That's because of CSS specificity mismatch. The base `.form-label` class specifies bold, the specific `.delete-site__confirm-label` resets the weight back to normal, but it's not specific enough to always win.

This PR fixes the CSS selector to be reliably more specific than `.form-label`.