### PR TITLE
Draft: Add/pa list animation lazy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/features.js
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/features.js
@@ -1,0 +1,2 @@
+import { domMax } from 'framer-motion';
+export default domMax;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -60,10 +60,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		if ( sectionPosition !== null ) {
 			setSections( [
 				...sections.slice( 0, sectionPosition ),
-				{
-					...pattern,
-					key: `${ incrementIndex }-${ pattern.id }`,
-				},
+				pattern,
 				...sections.slice( sectionPosition + 1 ),
 			] );
 		} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -54,15 +54,26 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		return pageTemplate;
 	};
 
+	let incrementIndex = 0;
 	const addSection = ( pattern: Pattern ) => {
+		incrementIndex++;
 		if ( sectionPosition !== null ) {
 			setSections( [
 				...sections.slice( 0, sectionPosition ),
-				pattern,
+				{
+					...pattern,
+					key: `${ incrementIndex }-${ pattern.id }`,
+				},
 				...sections.slice( sectionPosition + 1 ),
 			] );
 		} else {
-			setSections( [ ...( sections as Pattern[] ), pattern ] );
+			setSections( [
+				...( sections as Pattern[] ),
+				{
+					...pattern,
+					key: `${ incrementIndex }-${ pattern.id }`,
+				},
+			] );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { AnimatePresence, domMax, LazyMotion, m } from 'framer-motion';
+import { AnimatePresence, LazyMotion, m } from 'framer-motion';
 import { useTranslate } from 'i18n-calypso';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
@@ -35,6 +35,8 @@ const PatternLayout = ( {
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
 
+	const loadFeatures = () => import( './features.js' ).then( ( res ) => res.default );
+
 	return (
 		<div className="pattern-layout">
 			<div className="pattern-layout__header">
@@ -45,7 +47,7 @@ const PatternLayout = ( {
 					) }
 				</p>
 			</div>
-			<LazyMotion features={ domMax }>
+			<LazyMotion features={ loadFeatures }>
 				<div className="pattern-layout__body">
 					<ul>
 						{ header ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -20,12 +20,6 @@ type PatternLayoutProps = {
 	onContinueClick: () => void;
 };
 
-const spring = {
-	type: 'spring',
-	damping: 25,
-	stiffness: 120,
-};
-
 const PatternLayout = ( {
 	header,
 	sections,
@@ -41,6 +35,12 @@ const PatternLayout = ( {
 	onContinueClick,
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
+
+	const itemTransition = {
+		type: 'spring',
+		damping: 25,
+		stiffness: 120,
+	};
 
 	return (
 		<div className="pattern-layout">
@@ -74,8 +74,8 @@ const PatternLayout = ( {
 						return (
 							<motion.li
 								layout
-								transition={ spring }
-								key={ `${ index }-${ id }` }
+								transition={ itemTransition }
+								key={ `${ id }` }
 								className="pattern-layout__list-item pattern-layout__list-item--section"
 							>
 								<span className="pattern-layout__list-item-text" title={ name }>
@@ -93,18 +93,14 @@ const PatternLayout = ( {
 							</motion.li>
 						);
 					} ) }
-					<motion.li
-						layout
-						transition={ spring }
-						className="pattern-layout__list-item pattern-layout__list-item--section"
-					>
+					<li className="pattern-layout__list-item pattern-layout__list-item--section">
 						<Button onClick={ () => onSelectSection( null ) }>
 							<span className="pattern-layout__add-icon">+</span>{ ' ' }
 							{ sections?.length
 								? translate( 'Add another section' )
 								: translate( 'Add a first section' ) }
 						</Button>
-					</motion.li>
+					</li>
 					{ footer ? (
 						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
 							<span className="pattern-layout__list-item-text" title={ footer.name }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -92,11 +92,7 @@ const PatternLayout = ( {
 								);
 							} ) }
 						</AnimatePresence>
-						{ /* <AnimatePresence> */ }
-						<li
-							key={ `${ 'add-section-item' }` }
-							className="pattern-layout__list-item pattern-layout__list-item--section"
-						>
+						<li className="pattern-layout__list-item pattern-layout__list-item--section">
 							<Button onClick={ () => onSelectSection( null ) }>
 								<span className="pattern-layout__add-icon">+</span>{ ' ' }
 								{ sections?.length
@@ -104,7 +100,6 @@ const PatternLayout = ( {
 									: translate( 'Add a first section' ) }
 							</Button>
 						</li>
-						{ /* </AnimatePresence> */ }
 						{ footer ? (
 							<li className="pattern-layout__list-item pattern-layout__list-item--footer">
 								<span className="pattern-layout__list-item-text" title={ footer.name }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence, domAnimation, LazyMotion, m } from 'framer-motion';
 import { useTranslate } from 'i18n-calypso';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
@@ -56,74 +56,75 @@ const PatternLayout = ( {
 					) }
 				</p>
 			</div>
-			<div className="pattern-layout__body">
-				<ul>
-					{ header ? (
-						<li className="pattern-layout__list-item pattern-layout__list-item--header">
-							<span className="pattern-layout__list-item-text" title={ header.name }>
-								{ header.name }
-							</span>
-							<PatternActionBar onReplace={ onSelectHeader } onDelete={ onDeleteHeader } />
-						</li>
-					) : (
-						<li className="pattern-layout__list-item pattern-layout__list-item--header">
-							<Button onClick={ onSelectHeader }>
+			<LazyMotion features={ domAnimation }>
+				<div className="pattern-layout__body">
+					<ul>
+						{ header ? (
+							<li className="pattern-layout__list-item pattern-layout__list-item--header">
+								<span className="pattern-layout__list-item-text" title={ header.name }>
+									{ header.name }
+								</span>
+								<PatternActionBar onReplace={ onSelectHeader } onDelete={ onDeleteHeader } />
+							</li>
+						) : (
+							<li className="pattern-layout__list-item pattern-layout__list-item--header">
+								<Button onClick={ onSelectHeader }>
+									<span className="pattern-layout__add-icon">+</span>{ ' ' }
+									{ translate( 'Choose a header' ) }
+								</Button>
+							</li>
+						) }
+						{ sections?.map( ( section, index ) => {
+							const { id, name } = section;
+							return (
+								<AnimatePresence exitBeforeEnter>
+									<m.li
+										variants={ variantB }
+										key={ `${ id }` }
+										className="pattern-layout__list-item pattern-layout__list-item--section"
+									>
+										<span className="pattern-layout__list-item-text" title={ name }>
+											{ name }
+										</span>
+										<PatternActionBar
+											onReplace={ () => onSelectSection( index ) }
+											onDelete={ () => onDeleteSection( index ) }
+											onMoveUp={ () => onMoveUpSection( index ) }
+											onMoveDown={ () => onMoveDownSection( index ) }
+											enableMoving={ true }
+											disableMoveUp={ index === 0 }
+											disableMoveDown={ sections?.length === index + 1 }
+										/>
+									</m.li>
+								</AnimatePresence>
+							);
+						} ) }
+						<li className="pattern-layout__list-item pattern-layout__list-item--section">
+							<Button onClick={ () => onSelectSection( null ) }>
 								<span className="pattern-layout__add-icon">+</span>{ ' ' }
-								{ translate( 'Choose a header' ) }
+								{ sections?.length
+									? translate( 'Add another section' )
+									: translate( 'Add a first section' ) }
 							</Button>
 						</li>
-					) }
-					{ sections?.map( ( section, index ) => {
-						const { id, name } = section;
-						return (
-							<AnimatePresence>
-								<motion.li
-									variants={ variantB }
-									layout
-									key={ `${ id }` }
-									className="pattern-layout__list-item pattern-layout__list-item--section"
-								>
-									<span className="pattern-layout__list-item-text" title={ name }>
-										{ name }
-									</span>
-									<PatternActionBar
-										onReplace={ () => onSelectSection( index ) }
-										onDelete={ () => onDeleteSection( index ) }
-										onMoveUp={ () => onMoveUpSection( index ) }
-										onMoveDown={ () => onMoveDownSection( index ) }
-										enableMoving={ true }
-										disableMoveUp={ index === 0 }
-										disableMoveDown={ sections?.length === index + 1 }
-									/>
-								</motion.li>
-							</AnimatePresence>
-						);
-					} ) }
-					<li className="pattern-layout__list-item pattern-layout__list-item--section">
-						<Button onClick={ () => onSelectSection( null ) }>
-							<span className="pattern-layout__add-icon">+</span>{ ' ' }
-							{ sections?.length
-								? translate( 'Add another section' )
-								: translate( 'Add a first section' ) }
-						</Button>
-					</li>
-					{ footer ? (
-						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
-							<span className="pattern-layout__list-item-text" title={ footer.name }>
-								{ footer.name }
-							</span>
-							<PatternActionBar onReplace={ onSelectFooter } onDelete={ onDeleteFooter } />
-						</li>
-					) : (
-						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
-							<Button onClick={ onSelectFooter }>
-								<span className="pattern-layout__add-icon">+</span>{ ' ' }
-								{ translate( 'Choose a footer' ) }
-							</Button>
-						</li>
-					) }
-				</ul>
-			</div>
+						{ footer ? (
+							<li className="pattern-layout__list-item pattern-layout__list-item--footer">
+								<span className="pattern-layout__list-item-text" title={ footer.name }>
+									{ footer.name }
+								</span>
+								<PatternActionBar onReplace={ onSelectFooter } onDelete={ onDeleteFooter } />
+							</li>
+						) : (
+							<li className="pattern-layout__list-item pattern-layout__list-item--footer">
+								<Button onClick={ onSelectFooter }>
+									<span className="pattern-layout__add-icon">+</span>{ ' ' }
+									{ translate( 'Choose a footer' ) }
+								</Button>
+							</li>
+						) }
+					</ul>
+				</div>
+			</LazyMotion>
 			<div className="pattern-layout__footer">
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
 					{ translate( 'Continue' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -35,6 +35,7 @@ const PatternLayout = ( {
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
 
+	// Followed suggested practice to reduce the bundle size https://www.framer.com/docs/guide-reduce-bundle-size/
 	const loadFeatures = () => import( './features.js' ).then( ( res ) => res.default );
 
 	return (
@@ -47,7 +48,7 @@ const PatternLayout = ( {
 					) }
 				</p>
 			</div>
-			<LazyMotion features={ loadFeatures }>
+			<LazyMotion features={ loadFeatures } strict>
 				<div className="pattern-layout__body">
 					<ul>
 						{ header ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { AnimatePresence, domAnimation, LazyMotion, m } from 'framer-motion';
+import { AnimatePresence, domMax, LazyMotion, m } from 'framer-motion';
 import { useTranslate } from 'i18n-calypso';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
@@ -35,17 +35,6 @@ const PatternLayout = ( {
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
 
-	const variantB = {
-		initial: {
-			opacity: 0,
-		},
-		animate: {
-			opacity: 1,
-		},
-		exit: {
-			opacity: 0,
-		},
-	};
 	return (
 		<div className="pattern-layout">
 			<div className="pattern-layout__header">
@@ -56,7 +45,7 @@ const PatternLayout = ( {
 					) }
 				</p>
 			</div>
-			<LazyMotion features={ domAnimation }>
+			<LazyMotion features={ domMax }>
 				<div className="pattern-layout__body">
 					<ul>
 						{ header ? (
@@ -74,13 +63,14 @@ const PatternLayout = ( {
 								</Button>
 							</li>
 						) }
-						{ sections?.map( ( section, index ) => {
-							const { id, name } = section;
-							return (
-								<AnimatePresence exitBeforeEnter>
+						<AnimatePresence initial={ false }>
+							{ sections?.map( ( section, index ) => {
+								const { name, key } = section as Pattern;
+								return (
 									<m.li
-										variants={ variantB }
-										key={ `${ id }` }
+										layout={ 'position' }
+										exit={ { opacity: 0, x: -50, transition: { duration: 0.2 } } }
+										key={ `${ key }` }
 										className="pattern-layout__list-item pattern-layout__list-item--section"
 									>
 										<span className="pattern-layout__list-item-text" title={ name }>
@@ -96,10 +86,14 @@ const PatternLayout = ( {
 											disableMoveDown={ sections?.length === index + 1 }
 										/>
 									</m.li>
-								</AnimatePresence>
-							);
-						} ) }
-						<li className="pattern-layout__list-item pattern-layout__list-item--section">
+								);
+							} ) }
+						</AnimatePresence>
+						{ /* <AnimatePresence> */ }
+						<li
+							key={ `${ 'add-section-item' }` }
+							className="pattern-layout__list-item pattern-layout__list-item--section"
+						>
 							<Button onClick={ () => onSelectSection( null ) }>
 								<span className="pattern-layout__add-icon">+</span>{ ' ' }
 								{ sections?.length
@@ -107,6 +101,7 @@ const PatternLayout = ( {
 									: translate( 'Add a first section' ) }
 							</Button>
 						</li>
+						{ /* </AnimatePresence> */ }
 						{ footer ? (
 							<li className="pattern-layout__list-item pattern-layout__list-item--footer">
 								<span className="pattern-layout__list-item-text" title={ footer.name }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslate } from 'i18n-calypso';
 import PatternActionBar from './pattern-action-bar';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslate } from 'i18n-calypso';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
@@ -36,12 +36,17 @@ const PatternLayout = ( {
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
 
-	const itemTransition = {
-		type: 'spring',
-		damping: 25,
-		stiffness: 120,
+	const variantB = {
+		initial: {
+			opacity: 0,
+		},
+		animate: {
+			opacity: 1,
+		},
+		exit: {
+			opacity: 0,
+		},
 	};
-
 	return (
 		<div className="pattern-layout">
 			<div className="pattern-layout__header">
@@ -72,25 +77,27 @@ const PatternLayout = ( {
 					{ sections?.map( ( section, index ) => {
 						const { id, name } = section;
 						return (
-							<motion.li
-								layout
-								transition={ itemTransition }
-								key={ `${ id }` }
-								className="pattern-layout__list-item pattern-layout__list-item--section"
-							>
-								<span className="pattern-layout__list-item-text" title={ name }>
-									{ name }
-								</span>
-								<PatternActionBar
-									onReplace={ () => onSelectSection( index ) }
-									onDelete={ () => onDeleteSection( index ) }
-									onMoveUp={ () => onMoveUpSection( index ) }
-									onMoveDown={ () => onMoveDownSection( index ) }
-									enableMoving={ true }
-									disableMoveUp={ index === 0 }
-									disableMoveDown={ sections?.length === index + 1 }
-								/>
-							</motion.li>
+							<AnimatePresence>
+								<motion.li
+									variants={ variantB }
+									layout
+									key={ `${ id }` }
+									className="pattern-layout__list-item pattern-layout__list-item--section"
+								>
+									<span className="pattern-layout__list-item-text" title={ name }>
+										{ name }
+									</span>
+									<PatternActionBar
+										onReplace={ () => onSelectSection( index ) }
+										onDelete={ () => onDeleteSection( index ) }
+										onMoveUp={ () => onMoveUpSection( index ) }
+										onMoveDown={ () => onMoveDownSection( index ) }
+										enableMoving={ true }
+										disableMoveUp={ index === 0 }
+										disableMoveDown={ sections?.length === index + 1 }
+									/>
+								</motion.li>
+							</AnimatePresence>
 						);
 					} ) }
 					<li className="pattern-layout__list-item pattern-layout__list-item--section">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -20,6 +20,12 @@ type PatternLayoutProps = {
 	onContinueClick: () => void;
 };
 
+const spring = {
+	type: 'spring',
+	damping: 25,
+	stiffness: 120,
+};
+
 const PatternLayout = ( {
 	header,
 	sections,
@@ -66,7 +72,9 @@ const PatternLayout = ( {
 					{ sections?.map( ( section, index ) => {
 						const { id, name } = section;
 						return (
-							<li
+							<motion.li
+								layout
+								transition={ spring }
 								key={ `${ index }-${ id }` }
 								className="pattern-layout__list-item pattern-layout__list-item--section"
 							>
@@ -82,11 +90,12 @@ const PatternLayout = ( {
 									disableMoveUp={ index === 0 }
 									disableMoveDown={ sections?.length === index + 1 }
 								/>
-							</li>
+							</motion.li>
 						);
 					} ) }
 					<motion.li
-						whileHover={ { x: 10 } }
+						layout
+						transition={ spring }
 						className="pattern-layout__list-item pattern-layout__list-item--section"
 					>
 						<Button onClick={ () => onSelectSection( null ) }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@automattic/components';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { motion } from 'framer-motion';
 import { useTranslate } from 'i18n-calypso';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
@@ -83,14 +85,17 @@ const PatternLayout = ( {
 							</li>
 						);
 					} ) }
-					<li className="pattern-layout__list-item pattern-layout__list-item--section">
+					<motion.li
+						whileHover={ { x: 10 } }
+						className="pattern-layout__list-item pattern-layout__list-item--section"
+					>
 						<Button onClick={ () => onSelectSection( null ) }>
 							<span className="pattern-layout__add-icon">+</span>{ ' ' }
 							{ sections?.length
 								? translate( 'Add another section' )
 								: translate( 'Add a first section' ) }
 						</Button>
-					</li>
+					</motion.li>
 					{ footer ? (
 						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
 							<span className="pattern-layout__list-item-text" title={ footer.name }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,4 +1,5 @@
 export type Pattern = {
 	id: number;
 	name: string;
+	key?: string;
 };

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
 		"config": "^3.3.6",
 		"debug": "^4.3.3",
 		"enhanced-resolve": "5.9.3",
+		"framer-motion": "^6.2.8",
 		"i18n-calypso": "workspace:^",
 		"i18n-calypso-cli": "workspace:^",
 		"lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35783,6 +35783,7 @@ swiper@4.5.1:
     eslint-plugin-react-hooks: ^4.3.0
     eslint-plugin-wpcalypso: "workspace:^"
     eslint-plugin-you-dont-need-lodash-underscore: ^6.12.0
+    framer-motion: ^6.2.8
     fsevents: ^2.3.2
     gettext-parser: ^4.0.3
     glob: ^7.1.6


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
