### PR TITLE
Pattern Assembler: Create custom home page template and use it as the default one

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,17 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const STYLE_SHEET = 'pub/blank-canvas-blocks';
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
+
+export const CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT = {
+	HEADER: '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->',
+	MAIN: `
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
+<main class="wp-block-group">
+
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
+</main>
+<!-- /wp:group -->
+`,
+	FOOTER:
+		'<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->',
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -3,7 +3,7 @@ export const STYLE_SHEET = 'pub/blank-canvas-blocks';
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 
-export const CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT = {
+export const CUSTOM_HOME_PAGE_TEMPLATE_CONTENT = {
 	HEADER: '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->',
 	MAIN: `
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -12,7 +12,7 @@ import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
-import { encodePatternId, makeCustomizedHomePageTemplateContent } from './utils';
+import { encodePatternId, makeCustomHomePageTemplateContent } from './utils';
 import type { Step } from '../../types';
 import type { Pattern } from './types';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
@@ -144,9 +144,9 @@ const PatternAssembler: Step = ( { navigation } ) => {
 									createTemplate(
 										siteSlugOrId,
 										design.recipe!.stylesheet!,
-										'customized-home',
-										translate( 'Customized Home' ),
-										makeCustomizedHomePageTemplateContent( !! header, !! footer )
+										'custom-home',
+										translate( 'Custom Home' ),
+										makeCustomHomePageTemplateContent( !! header, !! footer )
 									)
 										.then( ( { slug } ) =>
 											setDesignOnSite( siteSlugOrId, design, { pageTemplate: slug } )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -11,20 +12,21 @@ import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
-import { encodePatternId } from './utils';
+import { encodePatternId, makeCustomizedHomePageTemplateContent } from './utils';
 import type { Step } from '../../types';
 import type { Pattern } from './types';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 const PatternAssembler: Step = ( { navigation } ) => {
+	const translate = useTranslate();
 	const [ showPatternSelectorType, setShowPatternSelectorType ] = useState< string | null >( null );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
 	const [ footer, setFooter ] = useState< Pattern | null >( null );
 	const [ sections, setSections ] = useState< Pattern[] >( [] );
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const { goBack, goNext, submit } = navigation;
-	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const { setDesignOnSite, createTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -43,16 +45,6 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				footer_pattern_ids: footer ? [ encodePatternId( footer.id ) ] : undefined,
 			} as DesignRecipe,
 		} as Design );
-
-	const getPageTemplate = () => {
-		let pageTemplate = 'footer-only';
-
-		if ( header ) {
-			pageTemplate = 'header-footer-only';
-		}
-
-		return pageTemplate;
-	};
 
 	const addSection = ( pattern: Pattern ) => {
 		if ( sectionPosition !== null ) {
@@ -147,12 +139,19 @@ const PatternAssembler: Step = ( { navigation } ) => {
 						onContinueClick={ () => {
 							if ( siteSlugOrId ) {
 								const design = getDesign();
-								const pageTemplate = getPageTemplate();
 
 								setPendingAction( () =>
-									setDesignOnSite( siteSlugOrId, design, { pageTemplate } ).then( () =>
-										reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
+									createTemplate(
+										siteSlugOrId,
+										design.recipe!.stylesheet!,
+										'customized-home',
+										translate( 'Customized Home' ),
+										makeCustomizedHomePageTemplateContent( !! header, !! footer )
 									)
+										.then( ( { slug } ) =>
+											setDesignOnSite( siteSlugOrId, design, { pageTemplate: slug } )
+										)
+										.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 								);
 
 								submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,5 +1,10 @@
 import { addQueryArgs } from '@wordpress/url';
-import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL, STYLE_SHEET } from './constants';
+import {
+	PATTERN_SOURCE_SITE_ID,
+	PREVIEW_PATTERN_URL,
+	STYLE_SHEET,
+	CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT,
+} from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
@@ -18,3 +23,12 @@ export const handleKeyboard =
 	( { key }: { key: string } ) => {
 		if ( key === 'Enter' || key === ' ' ) callback();
 	};
+
+export const makeCustomizedHomePageTemplateContent = ( hasHeader: boolean, hasFooter: boolean ) =>
+	[
+		hasHeader && CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT.HEADER,
+		CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT.MAIN,
+		hasFooter && CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT.FOOTER,
+	]
+		.filter( Boolean )
+		.join( '\n' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -3,7 +3,7 @@ import {
 	PATTERN_SOURCE_SITE_ID,
 	PREVIEW_PATTERN_URL,
 	STYLE_SHEET,
-	CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT,
+	CUSTOM_HOME_PAGE_TEMPLATE_CONTENT,
 } from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
@@ -24,11 +24,11 @@ export const handleKeyboard =
 		if ( key === 'Enter' || key === ' ' ) callback();
 	};
 
-export const makeCustomizedHomePageTemplateContent = ( hasHeader: boolean, hasFooter: boolean ) =>
+export const makeCustomHomePageTemplateContent = ( hasHeader: boolean, hasFooter: boolean ) =>
 	[
-		hasHeader && CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT.HEADER,
-		CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT.MAIN,
-		hasFooter && CUSTOMIZED_HOME_PAGE_TEMPLATE_CONTENT.FOOTER,
+		hasHeader && CUSTOM_HOME_PAGE_TEMPLATE_CONTENT.HEADER,
+		CUSTOM_HOME_PAGE_TEMPLATE_CONTENT.MAIN,
+		hasFooter && CUSTOM_HOME_PAGE_TEMPLATE_CONTENT.FOOTER,
 	]
 		.filter( Boolean )
 		.join( '\n' );

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -349,6 +349,32 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 	}
 
+	function* createTemplate(
+		siteSlug: string,
+		stylesheet: string,
+		slug: string,
+		title: string,
+		content: string
+	) {
+		const templateSlug = `wp-custom-template-${ slug }`;
+		const response: { slug: string } = yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/templates`,
+			apiNamespace: 'wp/v2',
+			body: {
+				id: `${ stylesheet }//${ templateSlug }`,
+				slug: templateSlug,
+				theme: stylesheet,
+				title,
+				content,
+				status: 'publish',
+				is_wp_suggestion: false,
+			},
+			method: 'POST',
+		} );
+
+		return response;
+	}
+
 	const setSiteSetupError = ( error: string, message: string ) => ( {
 		type: 'SET_SITE_SETUP_ERROR',
 		error,
@@ -545,6 +571,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		resetNewSiteFailed,
 		setThemeOnSite,
 		setDesignOnSite,
+		createTemplate,
 		createSite,
 		receiveSite,
 		receiveSiteFailed,


### PR DESCRIPTION
#### Proposed Changes

* This PR tries to create a customized home page template on the fly to eliminate the confusion of the template name such as “Header and Footer Only” or “Footer Only”.
* The current approach is to create a template based on the selected theme (ex. blank-canvas-blocks in PA). Additionally, we will customize the content according to the user's selection. That is, we insert the template parts only when the user selects a header or footer.

![image](https://user-images.githubusercontent.com/13596067/193237953-7a8795d1-99b3-4333-8de1-e20c9acdd49d.png)

**Caveats**

* The template slug might be duplicated. However, normal users go through the onboarding flow only once, so I think we could ignore this case.
* When you click on the "Customized Home", it's a bit weird as the description is `Give the template a title that indicates its purpose, e.g. "Full Width".`. Our customers might feel confused that “what's the template?”, “is it not a home page?” 😓
  ![image](https://user-images.githubusercontent.com/13596067/193238169-cb4318b2-6c40-4175-a37e-8fa7df06e10d.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Select “Promote myself or business”
* When you land on the Design Picker, pick “Blank Canvas” CTA
* When you land on Pattern Assembler, select a header, sections and footer, and click "Continue"
* When you land on the site editor, you have to see the “Customized Home” which is the name of the customized template.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1664503702896599/1664449686.617609-slack-CRWCHQGUB