### PR TITLE
Import: Skip plans page in JPC flow if user comes from migration flow (in-product flow)

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
-import { Interval, EVERY_TEN_SECONDS } from 'calypso/lib/interval';
+import { Interval, EVERY_TEN_SECONDS, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { urlToSlug } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -194,27 +194,33 @@ export class SectionMigrate extends Component {
 		this.setState( { siteInfo }, () => {
 			const selectedSiteSlug = urlToSlug( siteInfo.site_url.replace( /\/$/, '' ) );
 			this.setState( { selectedSiteSlug } );
-			wpcom
-				.site( selectedSiteSlug )
-				.get( {
-					apiVersion: '1.2',
-				} )
-				.then( ( site ) => {
-					if ( ! ( site && site.capabilities ) ) {
-						// A site isn't connected if we cannot manage it.
-						return this.setState( { isJetpackConnected: false } );
-					}
-
-					// Update the site in the state tree.
-					this.props.receiveSite( omit( site, '_headers' ) );
-					this.setState( { isJetpackConnected: true } );
-				} )
-				.catch( () => {
-					// @TODO: Do we need to better handle this? It most-likely means the site isn't connected.
-					this.setState( { isJetpackConnected: false } );
-				} )
-				.finally( callback );
+			this.updateSiteInfo( selectedSiteSlug, callback );
 		} );
+	};
+
+	updateSiteInfo = ( selectedSiteSlug, callback = () => {} ) => {
+		selectedSiteSlug = selectedSiteSlug || this.state.selectedSiteSlug;
+		if ( ! selectedSiteSlug ) return;
+		return wpcom
+			.site( selectedSiteSlug )
+			.get( {
+				apiVersion: '1.2',
+			} )
+			.then( ( site ) => {
+				if ( ! ( site && site.capabilities ) ) {
+					// A site isn't connected if we cannot manage it.
+					return this.setState( { isJetpackConnected: false } );
+				}
+
+				// Update the site in the state tree.
+				this.props.receiveSite( omit( site, '_headers' ) );
+				this.setState( { isJetpackConnected: true } );
+			} )
+			.catch( () => {
+				// @TODO: Do we need to better handle this? It most-likely means the site isn't connected.
+				this.setState( { isJetpackConnected: false } );
+			} )
+			.finally( callback );
 	};
 
 	setSourceSiteId = ( sourceSiteId ) => {
@@ -625,14 +631,17 @@ export class SectionMigrate extends Component {
 						break;
 					case 'migrateOrImport':
 						migrationElement = (
-							<StepImportOrMigrate
-								onJetpackSelect={ this.handleJetpackSelect }
-								sourceSiteInfo={ this.state.siteInfo }
-								targetSite={ targetSite }
-								targetSiteSlug={ targetSiteSlug }
-								sourceHasJetpack={ this.state.isJetpackConnected }
-								isTargetSiteAtomic={ this.props.isTargetSiteAtomic }
-							/>
+							<>
+								<Interval onTick={ this.updateSiteInfo } period={ EVERY_FIVE_SECONDS } />
+								<StepImportOrMigrate
+									onJetpackSelect={ this.handleJetpackSelect }
+									sourceSiteInfo={ this.state.siteInfo }
+									targetSite={ targetSite }
+									targetSiteSlug={ targetSiteSlug }
+									sourceHasJetpack={ this.state.isJetpackConnected }
+									isTargetSiteAtomic={ this.props.isTargetSiteAtomic }
+								/>
+							</>
 						);
 						break;
 					case 'upgrade':

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -1,5 +1,6 @@
 import { FEATURE_UPLOAD_THEMES_PLUGINS, planHasFeature } from '@automattic/calypso-products';
 import { Button, CompactCard } from '@automattic/components';
+import { Button as WpButton } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -64,11 +65,18 @@ class StepImportOrMigrate extends Component {
 		return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
 	};
 
+	installJetpack = () => {
+		// recordTracksEvent( 'calypso_site_importer_install_jetpack' );
+		const { sourceSiteInfo } = this.props;
+		const sourceSiteDomain = get( sourceSiteInfo, 'site_url', '' );
+		const source = 'import';
+		window.open( `/jetpack/connect/?url=${ sourceSiteDomain }&source=${ source }`, '_blank' );
+	};
+
 	getJetpackOrUpgradeMessage = () => {
-		const { sourceSiteInfo, sourceHasJetpack, isTargetSiteAtomic, translate } = this.props;
+		const { sourceHasJetpack, isTargetSiteAtomic, translate } = this.props;
 
 		if ( ! sourceHasJetpack ) {
-			const sourceSiteDomain = get( sourceSiteInfo, 'site_url', '' );
 			return (
 				<p>
 					{ translate(
@@ -78,9 +86,7 @@ class StepImportOrMigrate extends Component {
 							' Jetpack{{/jetpackInstallLink}}.',
 						{
 							components: {
-								jetpackInstallLink: (
-									<a href={ `https://wordpress.com/jetpack/connect/?url=${ sourceSiteDomain }` } />
-								),
+								jetpackInstallLink: <WpButton isLink onClick={ this.installJetpack } />,
 							},
 						}
 					) }

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -66,7 +66,7 @@ class StepImportOrMigrate extends Component {
 	};
 
 	installJetpack = () => {
-		// recordTracksEvent( 'calypso_site_importer_install_jetpack' );
+		this.props.recordTracksEvent( 'calypso_site_importer_install_jetpack' );
 		const { sourceSiteInfo } = this.props;
 		const sourceSiteDomain = get( sourceSiteInfo, 'site_url', '' );
 		const source = 'import';


### PR DESCRIPTION
#### Proposed Changes

We don't need to upsell Jetpack plans if a user is coming to JPC flow from the migration flow, the purpose of this PR is to skip the plans page if a user is from the migration flow in the product page. This PR is mirroring what we've done for the onboarding flow. Relate PR #67247

Currently install Jetpack inside the product page (Tools > Import > WordPress) is a link. To create a better user experience we want to open the JPC flow via javascript in a new tab, so we can close it automatically after the authorization is done.

We also update the functionality inside the product page so it fetches the latest site status every five seconds.

#### Testing Instructions

1. Creating a self-hosted site via `jurassic-ninja` or use your own self-hosted site(should be disconnected).
2. Navigate to http://calypso.localhost:3000/import/${SITE_SLUG}.
3. Choose WordPress and enter your test self-hosted site URL and click "Continue".
4. Because your site is not connected at this point, the import everything option is not available for you. Click install Jetpack link.
5. It should open a new tab for JPC flow, the url should be something like `http://calypso.localhost:3000/jetpack/connect?url=${YOUR_SELF_HOSTED_SITE}&source=import` and it'll run the site connection automatically.
6. If you haven't login to your self-hosted site before, it'll land on a login screen asking for the credential of your self-hosted site. Please don't enter the credential yet. Beware that at this point your URL is `https://wordpress.com/jetpack/install`. For testing purposes, we need to replace the URL with `http://calypso.localhost:3000/jetpack/connect?forceInstall=1&url=${YOUR_SELF_HOSTED_SITEURL}`
7. Enter your login credential for your self-hosted site and click the Install Jetpack button.
8. If you're facing 503 on your test Jurassic Ninja site please ignore it and refresh the page again.
9. You'll be landed on a completing setup page. Please replace the `https://wordpress.com` part with `http://calypso.localhost:3000` then hit the Approve button.
10. Once it's finished the JPC flow window will close by itself and you can continue with the importing process. The site status should be updated automatically in five seconds so you'll be able to choose import everything option now.
If you'd like to see the testing process in action, please check out the video below:


https://user-images.githubusercontent.com/4074459/193243382-db52afe6-baee-45b7-a88a-30907b7aca20.mp4



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68004
