### PR TITLE
E2E (Atomic): Fix Media block upload tests

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/file-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/file-block.ts
@@ -40,7 +40,7 @@ export class FileBlock {
 		// It can lead to the filename placeholder text not being replaced with the uploaded file name.
 		await Promise.all( [
 			page.waitForResponse(
-				( response: Response ) => response.url().includes( 'media?' ) && response.status() === 200
+				( response: Response ) => response.url().includes( 'media?' ) && response.ok()
 			),
 			input.setInputFiles( path ),
 		] );

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -36,16 +36,16 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	let editorPage: EditorPage;
 	let page: Page;
 	let testFiles: {
-		image_modal: TestFile;
-		image_reserved_name: TestFile;
+		image: TestFile;
+		imageReservedName: TestFile;
 		audio: TestFile;
 	};
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testFiles = {
-			image_modal: await MediaHelper.createTestFile( TEST_IMAGE_PATH ),
-			image_reserved_name: await MediaHelper.createTestFile( TEST_IMAGE_PATH, {
+			image: await MediaHelper.createTestFile( TEST_IMAGE_PATH ),
+			imageReservedName: await MediaHelper.createTestFile( TEST_IMAGE_PATH, {
 				postfix: 'filewith#?#?reservedurlchars',
 			} ),
 			audio: await MediaHelper.createTestFile( TEST_AUDIO_PATH ),
@@ -55,13 +55,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		await testAccount.authenticate( page );
 
 		editorPage = new EditorPage( page, { target: features.siteType } );
-	} );
-
-	it( 'Go to new post page', async function () {
 		await editorPage.visit( 'post' );
-	} );
-
-	it( 'Enter post title', async function () {
 		await editorPage.enterTitle( DataHelper.getRandomPhrase() );
 	} );
 
@@ -72,7 +66,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 				ImageBlock.blockEditorSelector
 			);
 			const imageBlock = new ImageBlock( blockHandle );
-			await imageBlock.upload( testFiles.image_reserved_name.fullpath );
+			await imageBlock.upload( testFiles.imageReservedName.fullpath );
 		} );
 
 		it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
@@ -81,9 +75,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 				ImageBlock.blockEditorSelector
 			);
 			const imageBlock = new ImageBlock( blockHandle );
-
-			await imageBlock.selectImageSource( 'Media Library' );
-			await imageBlock.uploadFromModal( testFiles.image_modal.fullpath );
+			await imageBlock.uploadThroughMediaLibrary( testFiles.image.fullpath );
 		} );
 
 		it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
@@ -113,12 +105,12 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	describe( 'Validate published post', function () {
 		it( `Image with reserved characters in filename is visible`, async function () {
 			await ImageBlock.validatePublishedContent( page, [
-				testFiles.image_reserved_name.filename.replace( /[^a-zA-Z ]/g, '' ),
+				testFiles.imageReservedName.filename.replace( /[^a-zA-Z ]/g, '' ),
 			] );
 		} );
 
 		it( 'Image added via Calypso modal is visible', async function () {
-			await ImageBlock.validatePublishedContent( page, [ testFiles.image_modal.filename ] );
+			await ImageBlock.validatePublishedContent( page, [ testFiles.image.filename ] );
 		} );
 
 		it( `Audio block is visible`, async function () {


### PR DESCRIPTION
Tracking issue: #65906


### Proposed Changes

Make the following test compatible with Atomic environment:

> **upload image file using Calypso media modal**
> specs/blocks/blocks__media.ts: Blocks: Media (Upload): Populate post with media blocks: Image block

> **upload audio file**
> specs/blocks/blocks__media.ts: Blocks: Media (Upload): Populate post with media blocks: Audio block

> **upload audio file**
> specs/blocks/blocks__media.ts: Blocks: Media (Upload): Populate post with media blocks: File block

> **Publish and visit post**
> specs/blocks/blocks__media.ts: Blocks: Media (Upload): Populate post with media blocks


### Why was it failing?

Two incompatibilities:

1. Media Gallery modal on Simple sites is a bit different than the Atomic one. The difference that failed the test is that the button to insert selected images is named `Insert` on Simple sites, while on Atomic it says `Select`. Our selector was label-based, so we needed to account for the difference.
2. To validate if a file has been successfully uploaded we were checking if the media upload response status code is `200`. For Atomic sites it's a tiny bit different, because the returned status is `201` (resource created), so now we're just checking if the `response` is `ok`. 😉

   Example reponse URLs for a file upload (File block):
   - Simple site: `https://public-api.wordpress.com/wp/v2/sites/168063301/media?_envelope=1&environment-id=stage&_gutenberg_nonce=4a95da166f&_locale=user`, status `200`
   - Atomic site: `https://YOUR_SITE.wpcomstaging.com/wp-json/wp/v2/media?_locale=user`, status `201`

/cc @tyxla @griffbrad - regarding p.2 above, what do you think about the difference in the response code? Would it be worth the effort to make it the same for both envs? also cc @david-binda 🙏 


### Testing instruction

The fixed tests should pass for both Simple and Atomic sites (production).