### PR TITLE
Global Styles: Rename events being sent to tracks.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -152,7 +152,7 @@ add_action( 'wp_print_styles', 'wpcom_global_styles_override_for_free_site' );
  */
 function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 	// If the post isn't updated then we know the gs cpt is being created.
-	$event_name = 'wpcom_global_styles_create';
+	$event_name = 'wpcom_core_global_styles_create';
 
 	if ( $updated ) {
 		// This is a fragile way of checking if the global styles cpt is being reset, we might need to update this condition in the future.
@@ -160,11 +160,11 @@ function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 		$is_empty_global_styles = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) === 0;
 
 		// By default, we know that we are at least updating.
-		$event_name = 'wpcom_global_styles_customize';
+		$event_name = 'wpcom_core_global_styles_customize';
 
 		// If we are updating to empty contents then we know for sure we are resetting the contents.
 		if ( $is_empty_global_styles ) {
-			$event_name = 'wpcom_global_styles_reset';
+			$event_name = 'wpcom_core_global_styles_reset';
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Renamed events as specified in the main task.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your sandbox run: `install-plugin.sh editing-toolkit add/rename-track-event-names`
Open the site editor and play around with global styles.
After some time you should see your event showing up in tracks live view with the new names.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/68480
