### PR TITLE
Emails: fix availability of the `Add Email Forwarding` button

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -149,8 +149,8 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			};
 		}
 
+		// There is no "disabled" configuration since it's allowed adding/removing forwarding for every site admin
 		return {
-			disabled: ! canAddMailboxes,
 			path: emailManagementAddEmailForwards( selectedSite.slug, domain.name, currentRoute ),
 		};
 	}

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -149,7 +149,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			};
 		}
 
-		// There is no "disabled" configuration since it's allowed adding/removing forwarding for every site admin
+		// All site admins are allowed to add/remove email forwards
 		return {
 			path: emailManagementAddEmailForwards( selectedSite.slug, domain.name, currentRoute ),
 		};


### PR DESCRIPTION
#### Proposed Changes
Currently, it's forbidden to add new email forwardings for non-owner site admins, but removing them is allowed.
Unlike email subscriptions where cancelling the domain will result in orphaned subscriptions, cancelling a domain with email forward simply means all forwards will stop working (as expected). So we should provide opportunity for all site admins to add new email forwarding.

#### Testing Instructions
* Go to your dashboard
* Create site w/o an email subscription
* [Set up email forwarding](https://wordpress.com/support/add-email/email-forwarding/#:~:text=Set%20Up%20Email%20Forwarding,-If%20you%20already&text=From%20your%20dashboard%2C%20navigate%20to,to%20this%20email%20address%20field)
* In the left sidebar click on "Upgrades -> Emails" (if you have a few email, then chose your "Email Forwarding" email)

<table>
<tr>
	<td> BEFORE & AFTER
<tr>
	<td> "Add new email forwards" button is available (Despite "Verification required" status)
<tr>
	<td> <img width="1074" alt="Screenshot 2022-09-30 at 15 32 10" src="https://user-images.githubusercontent.com/5598437/193292941-b7faf2aa-b253-4d8a-92ae-a6eb94fed5bc.png">
</table>

* Share you site with another user (your account)
	* In the left sidebar click on "Users -> All Users -> Invites"
	* Invite as "Administrator"
* Login to that account
* In the left sidebar click on "Upgrades -> Emails" (if you have a few email, then chose your "Email Forwarding" email)

<table>
<tr>
	<td> BEFORE
	<td> AFTER
<tr>
	<td> Disabled
	<td> Enabled
<tr>
	<td> <img width="1068" alt="Screenshot 2022-09-30 at 15 39 03" src="https://user-images.githubusercontent.com/5598437/193294420-0e709300-3212-45dc-a9d0-885e6d6892fa.png">
	<td> <img width="1074" alt="Screenshot 2022-09-30 at 15 32 10" src="https://user-images.githubusercontent.com/5598437/193292941-b7faf2aa-b253-4d8a-92ae-a6eb94fed5bc.png">
</table>

* Change role for this user as: "Editor", "Author" and "Contributor"

<table>
<tr>
	<td> BEFORE & AFTER
<tr>
	<td> This user doesn't have access to "Upgrades -> Emails" page
<tr>
	<td> <img width="1585" alt="Screenshot 2022-09-30 at 15 41 32" src="https://user-images.githubusercontent.com/5598437/193294922-bfd0fb4c-9461-4bcf-8b62-1997c880f17b.png">
</table>


#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1203041217327548/f