### PR TITLE
LaunchPad - hide cookies popup from launchpad preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -20,6 +20,8 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 			theme_preview: true,
 			// hide the "Create your website with WordPress.com" banner
 			hide_banners: true,
+			// hide cookies popup
+			preview: true,
 			do_preview_no_interactions: true,
 		} );
 	}


### PR DESCRIPTION
This adds the pre-existing `preview: true` param to the launchpad site previews query args list. This param serves to hide cookie popups and other items that are not desired in previews.

Before:
![Screen Shot 2022-09-30 at 1 56 42 PM](https://user-images.githubusercontent.com/28742426/193330239-7df7d5db-b994-44f9-b7ad-e298ad75bbd5.png)

After:
![Screen Shot 2022-09-30 at 1 57 56 PM](https://user-images.githubusercontent.com/28742426/193330319-1245c120-a106-4633-b670-82f60a9e044b.png)


### To test
Im not entirely sure how to replicate the state where the cookie banner is shown in this preview, it does not seem to show up by default after creating a new site in the launchpad's onboarding flows. But I have noticed it while revisiting the launchpad for older test sites.

If you have an old test site and notice a cookie banner like above, run this build of calypso and verify it removes it.
Otherwise, you can try this on my test site shown above. You can find the URL in this slack message p1664566471282629/1664561307.367959-slack-CHN6J22MP