### PR TITLE
Style selection: Enable signup/design-picker-style-selection flag for all environments

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -114,7 +114,7 @@
 		"signup/design-picker-pattern-assembler": false,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-premium-themes-checkout": true,
-		"signup/design-picker-style-selection": false,
+		"signup/design-picker-style-selection": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/ftm-flow-non-en": true,
 		"signup/goals-step": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -113,7 +113,7 @@
 		"signup/design-picker-pattern-assembler": false,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-premium-themes-checkout": true,
-		"signup/design-picker-style-selection": false,
+		"signup/design-picker-style-selection": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/ftm-flow-non-en": true,
 		"signup/goals-step": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -122,7 +122,7 @@
 		"signup/anchor-fm": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-premium-themes-checkout": true,
-		"signup/design-picker-style-selection": false,
+		"signup/design-picker-style-selection": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/ftm-flow-non-en": true,
 		"signup/goals-step": true,


### PR DESCRIPTION
#### Proposed Changes

This PR enables the flag `signup/design-picker-style-selection` for all environments, including production.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `/setup/designSetup?siteSlug=${site_slug}`.
* Ensure you see the style variation indicators without needing to add `&flags=signup/design-picker-style-selection`.
* Ensure you see the new theme preview for themes with style variations.
* Ensure you see the old theme preview for themes without style variations.
* Ensure style switching in the new theme preview works as intended.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

