### PR TITLE
Update woo account creation font style

### DIFF
--- a/client/layout/masterbar/typekit.js
+++ b/client/layout/masterbar/typekit.js
@@ -1,0 +1,37 @@
+/* global Typekit */
+import { isCalypsoLive } from '@automattic/calypso-config';
+
+if ( typeof document !== 'undefined' && typeof isCalypsoLive === 'function' && ! isCalypsoLive() ) {
+	// Load fonts - https://helpx.adobe.com/fonts/using/embed-codes.html
+	( function ( d ) {
+		const config = {
+			kitId: 'ivy2obh',
+			scriptTimeout: 3000,
+			async: true,
+		};
+		const h = d.documentElement;
+		const t = setTimeout( function () {
+			h.className = h.className.replace( /\bwf-loading\b/g, '' ) + ' wf-inactive';
+		}, config.scriptTimeout );
+		const tk = d.createElement( 'script' );
+		let f = false;
+		const s = d.getElementsByTagName( 'script' )[ 0 ];
+		let a;
+
+		h.className += ' wf-loading';
+		tk.src = 'https://use.typekit.net/' + config.kitId + '.js';
+		tk.async = true;
+		tk.onload = tk.onreadystatechange = function () {
+			a = this.readyState;
+			if ( f || ( a && 'complete' !== a && 'loaded' !== a ) ) {
+				return;
+			}
+			f = true;
+			clearTimeout( t );
+			try {
+				Typekit.load( config );
+			} catch ( e ) {}
+		};
+		s.parentNode.insertBefore( tk, s );
+	} )( document );
+}

--- a/client/layout/masterbar/woo.jsx
+++ b/client/layout/masterbar/woo.jsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import WooLogo from 'calypso/assets/images/icons/woocommerce-logo.svg';
 import SVGIcon from 'calypso/components/svg-icon';
+import './typekit';
 import './woo.scss';
 
 const WooOauthMasterbar = () => {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -470,9 +470,9 @@
 		padding: 0 0 8px;
 	}
 
-	.logged-out-form label,
-	.login__form-userdata label {
-		font-weight: 500;
+	.logged-out-form label.form-label,
+	.login__form-userdata label.form-label {
+		font-weight: normal;
 		font-size: $woo-font-size-base;
 		line-height: 20px;
 		color: $woo-label-color;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -18,6 +18,7 @@
 
 		.masterbar__login-back-link {
 			margin-top: -10px;
+			font-weight: 500;
 
 			@media screen and ( max-width: 660px ) {
 				display: none;
@@ -30,6 +31,7 @@
 	color: var(--studio-gray-100);
 	text-decoration: none;
 	display: flex;
+	font-weight: 500;
 }
 
 .masterbar__woo-mobile-nav {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -77,6 +77,10 @@
 	background: #fdfdfd;
 	min-height: 100%;
 
+	* {
+		font-family: proxima-nova, sans-serif;
+	}
+
 	&.layout.is-section-login {
 		min-height: 100%;
 		padding-bottom: 0;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -64,9 +64,9 @@
 	$woo-label-color: #50575e;
 	$woo-gray-100: #101517;
 	$woo-gray-40: #787c82;
-	$woo-font-size-small: 12px;
-	$woo-font-size-base: 14px;
-	$woo-font-size-input: 14px;
+	$woo-font-size-small: $font-body-extra-small;
+	$woo-font-size-base: $font-body-small;
+	$woo-font-size-input: $font-body-small;
 	$woo-radius-input: 4px;
 	$woo-form-whitespace: 60px;
 	$woo-form-whitespace-660: 20px;
@@ -212,16 +212,7 @@
 		text-align: center;
 		margin: 0 auto;
 		line-height: 28px;
-		> p {
-			color: $woo-gray-40;
-			font-size: $woo-font-size-base;
-			font-weight: 400;
-			line-height: 18px;
-			margin: 0;
-			a {
-				font-size: inherit;
-			}
-		}
+
 		h3 {
 			font-weight: 600;
 			font-size: 2.75rem;
@@ -237,12 +228,14 @@
 	.login__header-subtitle,
 	.formatted-header__subtitle {
 		color: $gray-60;
-		font-size: $woo-font-size-base;
+		font-size: $font-body;
 		padding-bottom: 0;
+		margin: 0;
 
 		a {
 			color: var(--studio-gray-100);
 			font-weight: 400;
+			font-size: 1rem;
 		}
 
 		@media screen and ( max-width: 660px ) {
@@ -533,18 +526,6 @@
 		display: none;
 	}
 
-	.wp-login__footer {
-		background: #fff;
-		a,
-		a:visited {
-			color: $woo-purple-60;
-			font-weight: 500;
-			font-size: $woo-font-size-base;
-			line-height: 28px;
-			padding: 0 14px;
-		}
-	}
-
 	.login__divider span {
 		padding: 0 27px;
 		background-color: #fdfdfd;
@@ -572,29 +553,7 @@
 		color: $gray-50;
 		margin-bottom: 32px;
 		font-weight: 400;
-	}
-
-	.wp-login__links,
-	.logged-out-form__links,
-	.magic-login__footer {
-		margin-top: 16px;
-
-		a,
-		a:visited,
-		button,
-		.logged-out-form__link-item {
-			border: none;
-			font-weight: 400;
-			font-size: $woo-font-size-base;
-			line-height: 28px;
-			text-align: center;
-			color: $woo-purple-60;
-			padding: 8px 24px;
-			text-decoration: none;
-			&:hover {
-				text-decoration: underline;
-			}
-		}
+		margin-top: -14px;
 	}
 
 	.logged-out-form__footer {


### PR DESCRIPTION
#### Proposed Changes

* Load typekit.js in the same way as Woo nux.
* Use `proxima-nova` font
* Use global font variables
* Change label font-weight from **medium** to **regular** to align it with the new Dotcom style.
* Remove unneeded styles

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Log out WordPress.com or use incognito mode
2. Go to https://woocommerce.com/start/?nuxentrysource=signup_menu
3. Replace the URL https://wordpress.com/ with your local calypso host such as https://wpcalypso.wordpress.com/
4. Observe that the `font-family` is `proxima-nova, sans-serif;` and label font-weight is `normal` 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
