### PR TITLE
Add/pattern assembler metrics

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -10,6 +10,7 @@ import {
 } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -302,7 +303,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign, selectedStyleVariation ),
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
-				is_mobile_device: isMobile,
+				device_type: resolveDeviceTypeByViewPort(),
 			} );
 
 			if ( _selectedDesign.verticalizable ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -302,6 +302,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign, selectedStyleVariation ),
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
+				is_mobile_device: isMobile,
 			} );
 
 			if ( _selectedDesign.verticalizable ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -303,7 +303,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign, selectedStyleVariation ),
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
-				device_type: resolveDeviceTypeByViewPort(),
+				device: resolveDeviceTypeByViewPort(),
 			} );
 
 			if ( _selectedDesign.verticalizable ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -33,6 +33,9 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 
+	const getPatterns = () =>
+		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
+
 	const trackEventPattern = ( {
 		patternType,
 		patternId,
@@ -56,7 +59,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	};
 
 	const trackEventContinue = () => {
-		const patterns = [ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
+		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_bcpa_donecontinue_click', {
 			pattern_ids: patterns.map( ( { id } ) => id ),
 			pattern_names: patterns.map( ( { name } ) => name ),
@@ -157,6 +160,12 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			setShowPatternSelectorType( null );
 		} else {
 			goBack();
+
+			const patterns = getPatterns();
+			recordTracksEvent( 'calypso_signup_bcpa_back_click', {
+				has_selected_patterns: patterns.length > 0,
+				pattern_count: patterns.length,
+			} );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -61,8 +61,8 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_bcpa_donecontinue_click', {
-			pattern_ids: patterns.map( ( { id } ) => id ),
-			pattern_names: patterns.map( ( { name } ) => name ),
+			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
+			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 			pattern_count: patterns.length,
 		} );
 		patterns.forEach( ( { id, name } ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -36,6 +36,12 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const getPatterns = () =>
 		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
 
+	const trackEventPatternAdd = ( patternType: string ) => {
+		recordTracksEvent( 'calypso_signup_bcpa_pattern_add_click', {
+			pattern_type: patternType,
+		} );
+	};
+
 	const trackEventPatternSelect = ( {
 		patternType,
 		patternId,
@@ -43,20 +49,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		patternType: string;
 		patternId: number;
 	} ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_select_pattern_click', {
-			pattern_type: patternType,
-			pattern_id: patternId,
-		} );
-	};
-
-	const trackEventPatternDelete = ( {
-		patternType,
-		patternId,
-	}: {
-		patternType: string;
-		patternId: number;
-	} ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_delete_pattern_click', {
+		recordTracksEvent( 'calypso_signup_bcpa_pattern_select_click', {
 			pattern_type: patternType,
 			pattern_id: patternId,
 		} );
@@ -64,7 +57,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
-		recordTracksEvent( 'calypso_signup_bcpa_donecontinue_click', {
+		recordTracksEvent( 'calypso_signup_bcpa_continue_click', {
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 			pattern_count: patterns.length,
@@ -75,16 +68,6 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				pattern_name: name,
 			} );
 		} );
-	};
-
-	const showPatternSelector = ( type: string ) => {
-		if ( type ) {
-			recordTracksEvent( 'calypso_signup_bcpa_show_pattern_selector_click', {
-				pattern_type: type,
-			} );
-		}
-
-		setShowPatternSelectorType( type );
 	};
 
 	const getDesign = () =>
@@ -186,27 +169,26 @@ const PatternAssembler: Step = ( { navigation } ) => {
 						header={ header }
 						sections={ sections }
 						footer={ footer }
-						onSelectHeader={ () => {
-							showPatternSelector( 'header' );
+						onAddHeader={ () => {
+							trackEventPatternAdd( 'header' );
+							setShowPatternSelectorType( 'header' );
+						} }
+						onReplaceHeader={ () => {
+							setShowPatternSelectorType( 'header' );
 						} }
 						onDeleteHeader={ () => {
-							if ( header ) {
-								trackEventPatternDelete( {
-									patternType: 'header',
-									patternId: header.id,
-								} );
-							}
 							setHeader( null );
 						} }
-						onSelectSection={ ( position: number | null ) => {
+						onAddSection={ () => {
+							trackEventPatternAdd( 'section' );
+							setSectionPosition( null );
+							setShowPatternSelectorType( 'section' );
+						} }
+						onReplaceSection={ ( position: number ) => {
 							setSectionPosition( position );
-							showPatternSelector( 'section' );
+							setShowPatternSelectorType( 'section' );
 						} }
 						onDeleteSection={ ( position: number ) => {
-							trackEventPatternDelete( {
-								patternType: 'section',
-								patternId: sections[ position ].id,
-							} );
 							deleteSection( position );
 						} }
 						onMoveUpSection={ ( position: number ) => {
@@ -215,16 +197,14 @@ const PatternAssembler: Step = ( { navigation } ) => {
 						onMoveDownSection={ ( position: number ) => {
 							moveDownSection( position );
 						} }
-						onSelectFooter={ () => {
-							showPatternSelector( 'footer' );
+						onAddFooter={ () => {
+							trackEventPatternAdd( 'header' );
+							setShowPatternSelectorType( 'footer' );
+						} }
+						onReplaceFooter={ () => {
+							setShowPatternSelectorType( 'footer' );
 						} }
 						onDeleteFooter={ () => {
-							if ( footer ) {
-								trackEventPatternDelete( {
-									patternType: 'footer',
-									patternId: footer.id,
-								} );
-							}
 							setFooter( null );
 						} }
 						onContinueClick={ () => {
@@ -259,6 +239,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			hideSkip={ true }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }
+			stepSectionName={ showPatternSelectorType ? 'pattern-selector' : undefined }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -95,6 +95,10 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			if ( 'header' === showPatternSelectorType ) setHeader( pattern );
 			if ( 'footer' === showPatternSelectorType ) setFooter( pattern );
 			if ( 'section' === showPatternSelectorType ) addSection( pattern );
+
+			recordTracksEvent( 'calypso_signup_bcpa_show_pattern_selector_click', {
+				pattern_type: showPatternSelectorType,
+			} );
 		}
 		setShowPatternSelectorType( null );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -198,7 +198,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 							moveDownSection( position );
 						} }
 						onAddFooter={ () => {
-							trackEventPatternAdd( 'header' );
+							trackEventPatternAdd( 'footer' );
 							setShowPatternSelectorType( 'footer' );
 						} }
 						onReplaceFooter={ () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -37,7 +37,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
 
 	const trackEventPatternAdd = ( patternType: string ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_pattern_add_click', {
+		recordTracksEvent( 'calypso_signup_bcpa_add_pattern_click', {
 			pattern_type: patternType,
 		} );
 	};
@@ -49,7 +49,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		patternType: string;
 		patternId: number;
 	} ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_pattern_select_click', {
+		recordTracksEvent( 'calypso_signup_bcpa_select_pattern_click', {
 			pattern_type: patternType,
 			pattern_id: patternId,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -37,7 +37,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
 
 	const trackEventPatternAdd = ( patternType: string ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_add_pattern_click', {
+		recordTracksEvent( 'calypso_signup_bcpa_pattern_add_click', {
 			pattern_type: patternType,
 		} );
 	};
@@ -49,7 +49,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		patternType: string;
 		patternId: number;
 	} ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_select_pattern_click', {
+		recordTracksEvent( 'calypso_signup_bcpa_pattern_select_click', {
 			pattern_type: patternType,
 			pattern_id: patternId,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -213,6 +213,15 @@ const PatternAssembler: Step = ( { navigation } ) => {
 								);
 
 								submit?.();
+
+								const patterns = [ header, ...sections, footer ].filter(
+									( pattern ) => pattern
+								) as Pattern[];
+								recordTracksEvent( 'calypso_signup_bcpa_donecontinue_click', {
+									pattern_ids: patterns.map( ( { id } ) => id ),
+									pattern_names: patterns.map( ( { name } ) => name ),
+									pattern_count: patterns.length,
+								} );
 							}
 						} }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -39,7 +39,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move up' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_bcpa_moveup_pattern_click' );
+							recordTracksEvent( 'calypso_signup_bcpa_pattern_moveup_click' );
 							onMoveUp?.();
 						} }
 						icon={ chevronUp }
@@ -51,7 +51,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move down' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_bcpa_movedown_pattern_click' );
+							recordTracksEvent( 'calypso_signup_bcpa_pattern_movedown_click' );
 							onMoveDown?.();
 						} }
 						icon={ chevronDown }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { chevronUp, chevronDown, closeSmall, edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 type PatternActionBarProps = {
 	onReplace: () => void;
@@ -10,6 +11,7 @@ type PatternActionBarProps = {
 	disableMoveUp?: boolean;
 	disableMoveDown?: boolean;
 	enableMoving?: boolean;
+	patternType: string;
 };
 
 const PatternActionBar = ( {
@@ -20,6 +22,7 @@ const PatternActionBar = ( {
 	disableMoveUp,
 	disableMoveDown,
 	enableMoving,
+	patternType,
 }: PatternActionBarProps ) => {
 	const translate = useTranslate();
 	return (
@@ -35,7 +38,12 @@ const PatternActionBar = ( {
 						disabled={ disableMoveUp }
 						role="menuitem"
 						label={ translate( 'Move up' ) }
-						onClick={ onMoveUp }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_signup_bcpa_pattern_moveup_click', {
+								pattern_type: patternType,
+							} );
+							onMoveUp?.();
+						} }
 						icon={ chevronUp }
 						iconSize={ 23 }
 					/>
@@ -44,7 +52,12 @@ const PatternActionBar = ( {
 						disabled={ disableMoveDown }
 						role="menuitem"
 						label={ translate( 'Move down' ) }
-						onClick={ onMoveDown }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_signup_bcpa_pattern_movedown_click', {
+								pattern_type: patternType,
+							} );
+							onMoveDown?.();
+						} }
 						icon={ chevronDown }
 						iconSize={ 23 }
 					/>
@@ -54,7 +67,12 @@ const PatternActionBar = ( {
 				className="pattern-action-bar__block pattern-action-bar__action"
 				role="menuitem"
 				label={ translate( 'Replace' ) }
-				onClick={ onReplace }
+				onClick={ () => {
+					recordTracksEvent( 'calypso_signup_bcpa_pattern_replace_click', {
+						pattern_type: patternType,
+					} );
+					onReplace();
+				} }
 				icon={ edit }
 				iconSize={ 20 }
 			/>
@@ -62,7 +80,12 @@ const PatternActionBar = ( {
 				className="pattern-action-bar__block pattern-action-bar__action"
 				role="menuitem"
 				label={ translate( 'Delete' ) }
-				onClick={ onDelete }
+				onClick={ () => {
+					recordTracksEvent( 'calypso_signup_bcpa_pattern_delete_click', {
+						pattern_type: patternType,
+					} );
+					onDelete();
+				} }
 				icon={ closeSmall }
 				iconSize={ 23 }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -39,9 +39,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move up' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_bcpa_pattern_moveup_click', {
-								pattern_type: patternType,
-							} );
+							recordTracksEvent( 'calypso_signup_bcpa_moveup_pattern_click' );
 							onMoveUp?.();
 						} }
 						icon={ chevronUp }
@@ -53,9 +51,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move down' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_bcpa_pattern_movedown_click', {
-								pattern_type: patternType,
-							} );
+							recordTracksEvent( 'calypso_signup_bcpa_movedown_pattern_click' );
 							onMoveDown?.();
 						} }
 						icon={ chevronDown }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -101,6 +101,9 @@ const PatternAssemblerPreview = ( { header, sections = [], footer }: Props ) => 
 				translate={ translate }
 				recordTracksEvent={ recordTracksEvent }
 				scrollToSelector={ scrollToSelector }
+				onDeviceUpdate={ ( device: string ) => {
+					recordTracksEvent( 'calypso_signup_bcpa_preview_device_click', { device } );
+				} }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -7,13 +7,16 @@ type PatternLayoutProps = {
 	header: Pattern | null;
 	sections: Pattern[] | null;
 	footer: Pattern | null;
-	onSelectHeader: () => void;
+	onAddHeader: () => void;
+	onReplaceHeader: () => void;
 	onDeleteHeader: () => void;
-	onSelectSection: ( position: number | null ) => void;
+	onAddSection: () => void;
+	onReplaceSection: ( position: number ) => void;
 	onDeleteSection: ( position: number ) => void;
 	onMoveUpSection: ( position: number ) => void;
 	onMoveDownSection: ( position: number ) => void;
-	onSelectFooter: () => void;
+	onAddFooter: () => void;
+	onReplaceFooter: () => void;
 	onDeleteFooter: () => void;
 	onContinueClick: () => void;
 };
@@ -22,13 +25,16 @@ const PatternLayout = ( {
 	header,
 	sections,
 	footer,
-	onSelectHeader,
+	onAddHeader,
+	onReplaceHeader,
 	onDeleteHeader,
-	onSelectSection,
+	onAddSection,
+	onReplaceSection,
 	onDeleteSection,
 	onMoveUpSection,
 	onMoveDownSection,
-	onSelectFooter,
+	onAddFooter,
+	onReplaceFooter,
 	onDeleteFooter,
 	onContinueClick,
 }: PatternLayoutProps ) => {
@@ -51,11 +57,15 @@ const PatternLayout = ( {
 							<span className="pattern-layout__list-item-text" title={ header.name }>
 								{ header.name }
 							</span>
-							<PatternActionBar onReplace={ onSelectHeader } onDelete={ onDeleteHeader } />
+							<PatternActionBar
+								patternType="header"
+								onReplace={ onReplaceHeader }
+								onDelete={ onDeleteHeader }
+							/>
 						</li>
 					) : (
 						<li className="pattern-layout__list-item pattern-layout__list-item--header">
-							<Button onClick={ onSelectHeader }>
+							<Button onClick={ onAddHeader }>
 								<span className="pattern-layout__add-icon">+</span>{ ' ' }
 								{ translate( 'Choose a header' ) }
 							</Button>
@@ -72,7 +82,8 @@ const PatternLayout = ( {
 									{ name }
 								</span>
 								<PatternActionBar
-									onReplace={ () => onSelectSection( index ) }
+									patternType="section"
+									onReplace={ () => onReplaceSection( index ) }
 									onDelete={ () => onDeleteSection( index ) }
 									onMoveUp={ () => onMoveUpSection( index ) }
 									onMoveDown={ () => onMoveDownSection( index ) }
@@ -84,7 +95,7 @@ const PatternLayout = ( {
 						);
 					} ) }
 					<li className="pattern-layout__list-item pattern-layout__list-item--section">
-						<Button onClick={ () => onSelectSection( null ) }>
+						<Button onClick={ () => onAddSection() }>
 							<span className="pattern-layout__add-icon">+</span>{ ' ' }
 							{ sections?.length
 								? translate( 'Add another section' )
@@ -96,11 +107,15 @@ const PatternLayout = ( {
 							<span className="pattern-layout__list-item-text" title={ footer.name }>
 								{ footer.name }
 							</span>
-							<PatternActionBar onReplace={ onSelectFooter } onDelete={ onDeleteFooter } />
+							<PatternActionBar
+								patternType="footer"
+								onReplace={ onReplaceFooter }
+								onDelete={ onDeleteFooter }
+							/>
 						</li>
 					) : (
 						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
-							<Button onClick={ onSelectFooter }>
+							<Button onClick={ onAddFooter }>
 								<span className="pattern-layout__add-icon">+</span>{ ' ' }
 								{ translate( 'Choose a footer' ) }
 							</Button>


### PR DESCRIPTION
### Proposed Changes

**Tracking the Blank canvas CTA**

* In the existing event `calypso_signup_select_design` add the prop
  - `device: computer | tablet | phone`

**Tracking Back button**

* Track the event `calypso_signup_pattern_assembler_back_click` when going back from the PA to the UDP with the props 
  - `has_selected_patterns` 
  - `pattern_count`.
* Don't track the existing event `calypso_signup_previous_step_button_click` when going back from the pattern selector to the PA list because we don't go back to the previous step. 

**Tracking pattern feature usage** 

* Track the event `calypso_signup_pattern_assembler_pattern_add_click` and `calypso_signup_pattern_assembler_pattern_replace_click` with the prop:
  - `pattern_type: header | section | footer`  
* Track the event `calypso_signup_pattern_assembler_pattern_moveup_click` and `calypso_signup_pattern_assembler_pattern_movedown_click` without props.

**Tracking selected and deleted patterns** 

* Track the event `calypso_signup_pattern_assembler_pattern_select_click` and `calypso_signup_pattern_assembler_pattern_delete_click` with the props: 
  - `pattern_type: header | section | footer`
  - `pattern_id`

**Tracking device preview feature** 

* Track the event `calypso_signup_pattern_assembler_preview_device_click` with a prop
  - `device: computer | tablet | phone `

**Tracking Continue button and finally selected patterns** 
 
* Track the event `calypso_signup_pattern_assembler_continue_click` with the props 
  - `pattern_ids` separated by comma
  - `pattern_names` separated by comma
  - `pattern_count`
* Track the event `calypso_signup_pattern_assembler_pattern_final_select` for every pattern with the props 
  - `pattern_id`
  - `pattern_name`


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the [Chrome extension Tracks vigilante ](https://github.com/Automattic/tracks-chrome-extension)
* Access the URL `/setup?siteSlug=[ YOUR SITE ]`
* Don't select a goal, or vertical and get to the design picker
* Scroll down to see the Blank canvas CTA and click on it. You should see the event `calypso_signup_select_design` appear in Tracks vigilante with the prop `device`.

* Click to switch the device viewport from the top of the preview. You should see the event `calypso_signup_pattern_assembler_preview_device_click` with the `device` prop.

* Click on the back button and you should see the event `calypso_signup_pattern_assembler_back_click` with the props `has_selected_patterns` and `pattern_count`. Check that the event `calypso_signup_previous_step_button_click` is not tracked when going back from the pattern selector to the PA list.

* Click on add and replace a header, section, and footer and you should see the event `calypso_signup_pattern_assembler_add_pattern_click` and `calypso_signup_pattern_assembler_replace_pattern_click` with the `pattern_type` prop.

* Click to choose one of the patterns in the list and you should see the event `calypso_signup_pattern_assembler_select_pattern_click` with the `pattern_id` and `pattern_type`.

* Click on the button to delete a pattern and you should see the event `calypso_signup_pattern_assembler_delete_pattern_click` with the `pattern_id` and `pattern_type`.

* Click on Continue and you should see the event `calypso_signup_pattern_assembler_continue_click` with a `pattern_count`, `pattern_ids`, and `pattern_names`.

Also you should see an event `calypso_signup_pattern_assembler_pattern_final_select` per each selected pattern with its `pattern_id` and `pattern_name`.

<img width="777" alt="Screen Shot 2565-10-03 at 13 39 51" src="https://user-images.githubusercontent.com/1881481/193515382-5daa394a-1fe0-4700-b566-7a60c90d0cbb.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/822
