### PR TITLE
Limit Global Styles: Sanitize origin param

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -74,7 +74,7 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 			true
 		)
 	) {
-		$calypso_domain = $_GET['origin']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$calypso_domain = sanitize_text_field( wp_unslash( $_GET['origin'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	$site_slug = method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' )


### PR DESCRIPTION
#### Proposed Changes

Fixes the following linting errors introduced by the ETK changes in https://github.com/Automattic/wp-calypso/pull/68409:

```
(PHPCS-CHANGED WordPress.Security.ValidatedSanitizedInput.MissingUnslash) $_GET data not unslashed before sanitization. Use wp_unslash() or similar
    $_GET data not unslashed before sanitization. Use wp_unslash() or similar


(PHPCS-CHANGED WordPress.Security.ValidatedSanitizedInput.InputNotSanitized) Detected usage of a non-sanitized input variable: $_GET['origin']
    Detected usage of a non-sanitized input variable: $_GET['origin']
```

#### Testing Instructions

N/A

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

