### PR TITLE
[WordPress → Jetpack app branding] Update mobile setup task

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -4,11 +4,11 @@ import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { get } from 'lodash';
-import lottie from 'lottie-web/build/player/lottie_light';
 import PropTypes from 'prop-types';
-import { Component, useEffect, useRef } from 'react';
+import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
+import AnimatedIcon from 'calypso/components/animated-icon';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import versionCompare from 'calypso/lib/version-compare';
 import {
@@ -170,7 +170,7 @@ export class AppBanner extends Component {
 						statGroup="calypso_mobile_app_banner"
 						statName="impression"
 					/>
-					<BannerIcon icon={ icon } />
+					<AnimatedIcon className="app-banner__icon" icon={ icon } />
 					<div className="app-banner__text-content jetpack">
 						<div className="app-banner__title jetpack">
 							<span> { title } </span>
@@ -261,32 +261,6 @@ export class AppBanner extends Component {
 			? this.getJetpackAppBanner( this.props )
 			: this.getWordpressAppBanner( this.props );
 	}
-}
-
-function BannerIcon( { icon } ) {
-	const iconEl = useRef();
-
-	useEffect( () => {
-		const reducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
-
-		const animation = lottie.loadAnimation( {
-			container: iconEl.current,
-			renderer: 'svg',
-			loop: false,
-			autoplay: ! reducedMotion,
-			path: icon,
-		} );
-
-		if ( reducedMotion ) {
-			animation.addEventListener( 'config_ready', () => {
-				animation.goToAndPlay( animation.totalFrames, true );
-			} );
-		}
-
-		return () => animation.destroy();
-	}, [ icon ] );
-
-	return <div ref={ iconEl } className="app-banner__icon"></div>;
 }
 
 export function getiOSDeepLink( currentRoute, currentSection ) {

--- a/client/components/animated-icon/README.md
+++ b/client/components/animated-icon/README.md
@@ -1,0 +1,38 @@
+# Animated Icon
+
+`<AnimatedIcon />` is a component that enables the rendering of an Adobe After Effects animation. 
+
+The component imports the [Lottie library](https://airbnb.io/lottie/#/), which parses Adobe After Effects animations that have been exported as json with Bodymovin.
+
+## Usage
+
+Pass with an `icon` string to the animation's path:
+
+```jsx
+import AnimatedIcon from 'calypso/components/animated-icon';
+
+function render() {
+	return (
+		<AnimatedIcon
+			icon="/calypso/animations/app-promo/wp-to-jp.json"
+			className="example-component__icon"
+		/>
+	);
+}
+```
+
+## Props
+
+### `icon`
+
+- **Type:** `String`
+- **Required:** `yes`
+
+The path to the animated icon.
+
+### `className`
+
+- **Type:** `String`
+- **Required:** `no`
+
+The values of any additional CSS classes to apply to the icon's wrapper element.

--- a/client/components/animated-icon/index.jsx
+++ b/client/components/animated-icon/index.jsx
@@ -26,7 +26,7 @@ const AnimatedIcon = ( { icon, className } ) => {
 	}, [ icon ] );
 
 	return (
-		<div ref={ iconEl } className={ classNames( 'app-animated-icon__container', className ) }></div>
+		<div ref={ iconEl } className={ classNames( 'animated-icon', className ) }></div>
 	);
 };
 

--- a/client/components/animated-icon/index.jsx
+++ b/client/components/animated-icon/index.jsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames';
+import lottie from 'lottie-web/build/player/lottie_light';
+import { useEffect, useRef } from 'react';
+
+const AnimatedIcon = ( { icon, className } ) => {
+	const iconEl = useRef();
+
+	useEffect( () => {
+		const reducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+		const animation = lottie.loadAnimation( {
+			container: iconEl.current,
+			renderer: 'svg',
+			loop: false,
+			autoplay: ! reducedMotion,
+			path: icon,
+		} );
+
+		if ( reducedMotion ) {
+			animation.addEventListener( 'config_ready', () => {
+				animation.goToAndPlay( animation.totalFrames, true );
+			} );
+		}
+
+		return () => animation.destroy();
+	}, [ icon ] );
+
+	return (
+		<div ref={ iconEl } className={ classNames( 'app-animated-icon__container', className ) }></div>
+	);
+};
+
+export default AnimatedIcon;

--- a/client/components/animated-icon/index.jsx
+++ b/client/components/animated-icon/index.jsx
@@ -25,9 +25,7 @@ const AnimatedIcon = ( { icon, className } ) => {
 		return () => animation.destroy();
 	}, [ icon ] );
 
-	return (
-		<div ref={ iconEl } className={ classNames( 'animated-icon', className ) }></div>
-	);
+	return <div ref={ iconEl } className={ classNames( 'animated-icon', className ) }></div>;
 };
 
 export default AnimatedIcon;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -1,7 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
-import AnimatedIcon from 'calypso/components/animated-icon';
 import Badge from 'calypso/components/badge';
 
 const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout } ) => {
@@ -22,9 +21,7 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 						} ) }
 					</div>
 				) }
-				{ currentTask.icon && (
-					<AnimatedIcon icon={ currentTask.icon } className="site-setup-list__task-icon" />
-				) }
+				{ currentTask.icon }
 				{ ! useAccordionLayout && (
 					<h3 className="site-setup-list__task-title task__title">
 						{ currentTask.subtitle || currentTask.title }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -6,11 +6,7 @@ import Badge from 'calypso/components/badge';
 const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout } ) => {
 	return (
 		<div className="site-setup-list__task task" role="tabpanel">
-			<div
-				className={ classnames( 'site-setup-list__task-text', 'task__text', {
-					'has-icon': currentTask.icon,
-				} ) }
-			>
+			<div className="site-setup-list__task-text task__text">
 				{ currentTask.isCompleted && ! currentTask.hideLabel && (
 					<Badge type="info" className="site-setup-list__task-badge task__badge">
 						{ translate( 'Complete' ) }
@@ -26,12 +22,12 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 					</div>
 				) }
 				{ ! useAccordionLayout && (
-					<div class="site-setup-list__header">
+					<>
 						{ currentTask.icon }
 						<h3 className="site-setup-list__task-title task__title">
 							{ currentTask.subtitle || currentTask.title }
 						</h3>
-					</div>
+					</>
 				) }
 				<p className="site-setup-list__task-description task__description">
 					{ currentTask.description }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -1,6 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
+import AnimatedIcon from 'calypso/components/animated-icon';
 import Badge from 'calypso/components/badge';
 
 const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout } ) => {
@@ -21,8 +22,13 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 						} ) }
 					</div>
 				) }
+				{ currentTask.icon && (
+					<AnimatedIcon icon={ currentTask.icon } className="site-setup-list__task-icon" />
+				) }
 				{ ! useAccordionLayout && (
-					<h3 className="site-setup-list__task-title task__title">{ currentTask.title }</h3>
+					<h3 className="site-setup-list__task-title task__title">
+						{ currentTask.subtitle || currentTask.title }
+					</h3>
 				) }
 				<p className="site-setup-list__task-description task__description">
 					{ currentTask.description }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -6,7 +6,11 @@ import Badge from 'calypso/components/badge';
 const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout } ) => {
 	return (
 		<div className="site-setup-list__task task" role="tabpanel">
-			<div className="site-setup-list__task-text task__text">
+			<div
+				className={ classnames( 'site-setup-list__task-text', 'task__text', {
+					'has-icon': currentTask.icon,
+				} ) }
+			>
 				{ currentTask.isCompleted && ! currentTask.hideLabel && (
 					<Badge type="info" className="site-setup-list__task-badge task__badge">
 						{ translate( 'Complete' ) }
@@ -21,11 +25,13 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 						} ) }
 					</div>
 				) }
-				{ currentTask.icon }
 				{ ! useAccordionLayout && (
-					<h3 className="site-setup-list__task-title task__title">
-						{ currentTask.subtitle || currentTask.title }
-					</h3>
+					<div class="site-setup-list__header">
+						{ currentTask.icon }
+						<h3 className="site-setup-list__task-title task__title">
+							{ currentTask.subtitle || currentTask.title }
+						</h3>
+					</div>
 				) }
 				<p className="site-setup-list__task-description task__description">
 					{ currentTask.description }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -36,6 +36,7 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 						<Button
 							className={ classnames( 'site-setup-list__task-action', 'task__action', {
 								'is-link': currentTask.actionIsLink,
+								'is-jetpack-branded': currentTask.jetpackBranding,
 							} ) }
 							primary={ ! currentTask.actionIsLink }
 							onClick={ () => startTask() }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import AnimatedIcon from 'calypso/components/animated-icon';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
@@ -56,6 +57,7 @@ export const getTask = (
 		userEmail,
 		isBlogger,
 		isFSEActive,
+		isRtl,
 	} = {}
 ) => {
 	let taskData = {};
@@ -65,7 +67,12 @@ export const getTask = (
 	const jetpackAppBanner = displayJetpackAppBranding && {
 		title: translate( 'Try the Jetpack app' ),
 		subtitle: translate( 'Put your site in your pocket' ),
-		icon: '/calypso/animations/app-promo/wp-to-jp.json',
+		icon: (
+			<AnimatedIcon
+				icon={ `/calypso/animations/app-promo/wp-to-jp${ isRtl ? '-rtl' : '' }.json` }
+				className="site-setup-list__task-icon"
+			/>
+		),
 		description: translate(
 			'Write posts, view your stats, reply to comments, and upload media anywhere, anytime.'
 		),

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -58,6 +59,18 @@ export const getTask = (
 	} = {}
 ) => {
 	let taskData = {};
+
+	const displayJetpackAppBranding = config.isEnabled( 'jetpack/app-branding' );
+
+	const jetpackAppBanner = displayJetpackAppBranding && {
+		title: translate( 'Try the Jetpack app' ),
+		subtitle: translate( 'Put your site in your pocket' ),
+		icon: '/calypso/animations/app-promo/wp-to-jp.json',
+		description: translate(
+			'Write posts, view your stats, reply to comments, and upload media anywhere, anytime.'
+		),
+	};
+
 	switch ( task.id ) {
 		case CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED:
 			taskData = {
@@ -133,6 +146,7 @@ export const getTask = (
 					actionDispatchArgs: [ siteId, task.id ],
 				} ),
 				isSkippable: true,
+				...jetpackAppBanner,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.WOOCOMMERCE_SETUP:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -76,6 +76,7 @@ export const getTask = (
 		description: translate(
 			'Write posts, view your stats, reply to comments, and upload media anywhere, anytime.'
 		),
+		jetpackBranding: true,
 	};
 
 	switch ( task.id ) {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -64,7 +64,16 @@ export const getTask = (
 
 	const displayJetpackAppBranding = config.isEnabled( 'jetpack/app-branding' );
 
-	const jetpackAppBanner = displayJetpackAppBranding && {
+	const wpAppBanner = {
+		title: translate( 'Try the WordPress app' ),
+		description: isBlogger
+			? translate( 'Write posts, check stats, and reply to comments on the go!' )
+			: translate(
+					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
+			  ),
+	};
+
+	const jetpackAppBanner = {
 		title: translate( 'Try the Jetpack app' ),
 		subtitle: translate( 'Put your site in your pocket' ),
 		icon: (
@@ -138,13 +147,8 @@ export const getTask = (
 			break;
 		case CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:
 			taskData = {
+				...( displayJetpackAppBranding ? jetpackAppBanner : wpAppBanner ),
 				timing: 3,
-				title: translate( 'Try the WordPress app' ),
-				description: isBlogger
-					? translate( 'Write posts, check stats, and reply to comments on the go!' )
-					: translate(
-							'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
-					  ),
 				actionText: isBlogger
 					? translate( 'Download the app' )
 					: translate( 'Download mobile app' ),
@@ -154,7 +158,6 @@ export const getTask = (
 					actionDispatchArgs: [ siteId, task.id ],
 				} ),
 				isSkippable: true,
-				...jetpackAppBanner,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.WOOCOMMERCE_SETUP:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -1,7 +1,7 @@
 import { Card, Spinner } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import classnames from 'classnames';
-import { translate } from 'i18n-calypso';
+import { translate, useRtl } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -131,6 +131,7 @@ const SiteSetupList = ( {
 
 	const siteIntent = useSiteOption( 'site_intent' );
 	const isBlogger = siteIntent === 'write';
+	const isRtl = useRtl();
 
 	// Move to first incomplete task on first load.
 	useEffect( () => {
@@ -188,6 +189,7 @@ const SiteSetupList = ( {
 				userEmail,
 				isBlogger,
 				isFSEActive,
+				isRtl,
 			} );
 			setCurrentTask( newCurrentTask );
 			trackTaskDisplay( dispatch, newCurrentTask, siteId, isPodcastingSite );
@@ -207,6 +209,7 @@ const SiteSetupList = ( {
 		userEmail,
 		isBlogger,
 		isFSEActive,
+		isRtl,
 	] );
 
 	useEffect( () => {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -193,12 +193,6 @@
 		}
 	}
 
-	.site-setup-list__task-text.has-icon {
-		.task__description {
-			margin-top: -22px;
-		}
-	}
-
 	.site-setup-list__task-actions {
 		margin-top: 0;
 	}
@@ -206,7 +200,6 @@
 	.site-setup-list__task-icon {
 		width: 67px;
 		height: 35px;
-		margin-bottom: 25px;
 	}
 
 	.site-setup-list__task-skip {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -256,6 +256,7 @@
 		display: block;
 	}
 }
+
 .button.is-primary.is-jetpack-branded {
 	background-color: var(--studio-jetpack-green-40);
 	border-color: var(--studio-jetpack-green-40);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -197,6 +197,11 @@
 		margin-top: 0;
 	}
 
+	.site-setup-list__task-icon {
+		width: 67px;
+		height: 35px;
+	}
+
 	.site-setup-list__task-skip {
 		&:focus-visible {
 			box-shadow: 0 0 0 2px var(--color-primary);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -193,6 +193,12 @@
 		}
 	}
 
+	.site-setup-list__task-text.has-icon {
+		.task__description {
+			margin-top: -22px;
+		}
+	}
+
 	.site-setup-list__task-actions {
 		margin-top: 0;
 	}
@@ -200,6 +206,7 @@
 	.site-setup-list__task-icon {
 		width: 67px;
 		height: 35px;
+		margin-bottom: 25px;
 	}
 
 	.site-setup-list__task-skip {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -251,3 +251,12 @@
 		display: block;
 	}
 }
+.button.is-primary.is-jetpack-branded {
+	background-color: var(--studio-jetpack-green-40);
+	border-color: var(--studio-jetpack-green-40);
+
+	&:hover,
+	&:focus {
+		background-color: var(--studio-jetpack-green-60);
+	}
+}


### PR DESCRIPTION
_Context:_ Following the plans to [refocus the WordPress apps on core features](https://make.wordpress.org/mobile/2022/07/27/refocusing-the-wordpress-app-on-core-features/), we plan to move features that are specific to WordPress.com to the Jetpack app. As such, we will eventually replace all mentions of the WordPress app in Calypso with Jetpack.

#### Proposed Changes

The main focus of this PR involves updating the mobile set up task in Calypso's _My Home_ section to mention the Jetpack, rather than the WordPress, mobile app. 

<details>
 <summary>Code notes ⤵️</summary>

* The `jetpack/app-branding` feature flag (added in https://github.com/Automattic/wp-calypso/pull/66814) is used to only display the new Jetpack app mentions when the flag is set to true (currently only for wpcalypso and development builds).
* The animated icon added to the app banners in https://github.com/Automattic/wp-calypso/pull/67013 has been separated into its own component, to make it easier to re-use in other places in Calypso.

</details>


#### Testing Instructions

* Verify that the mobile setup task appears as expected when navigating to the _My Home_ page in Calypso.

It'd also be useful to verify the banner works as expected with the following:

* Different browsers.
* Different Calypso colour schemes.
* Different locales, including RTL.
* Note, the mobile setup task doesn't appear on mobile devices, so mobile testing isn't required though it'd still be useful to verify its appearance for smaller desktop screens.

#### Screenshots

<details>
 <summary>Design vs. Actual ⤵️</summary>
 
| Design  | Actual |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/193865317-61400cc6-1e54-44b6-a034-ebb7caa7f4bf.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/194390382-57a1bca8-8793-4953-80b3-fe72da1d3073.png" width="100%"> |

</details>

<details>
 <summary>Before vs. After ⤵️</summary>

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/193865120-37900238-2654-4caf-90e5-e8fab5f7a600.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/194390382-57a1bca8-8793-4953-80b3-fe72da1d3073.png" width="100%"> |

</details>



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
