### PR TITLE
Help Center: send Plan name and term, not slug to email tickets

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -3,6 +3,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { getPlanTermLabel } from '@automattic/calypso-products';
 import { Button, FormInputValidation, Popover } from '@automattic/components';
 import {
 	useSubmitTicketMutation,
@@ -263,10 +264,18 @@ export const HelpCenterContactForm = () => {
 
 			case 'EMAIL': {
 				if ( supportSite ) {
-					const ticketMeta = [
-						'Site I need help with: ' + supportSite.URL,
-						'Plan: ' + supportSite.plan?.product_slug,
-					];
+					let planName = supportSite.plan?.product_slug;
+
+					if ( supportSite.plan ) {
+						planName = `${ supportSite.plan.product_id } - ${
+							supportSite.plan.product_name_short
+						} (${ getPlanTermLabel(
+							supportSite.plan.product_slug,
+							( val ) => val // Passing an identity function instead of `translate` to always return the English string
+						) })`;
+					}
+
+					const ticketMeta = [ 'Site I need help with: ' + supportSite.URL, 'Plan: ' + planName ];
 
 					const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
 


### PR DESCRIPTION
#### Proposed Changes

* Title says it all. 

#### Testing Instructions

1. Run calypso from this branch.
2. Open the Help Center by going to http://calypso.localhost:3000/pages/ or any page.
3. Go to email contact option.
4. Open DevTools and set yourself offline.
5. Submit a ticket. 
6. Check the sent message, it should have the correct phrasing of the plan name (eg: `1 - Free plan (Annual subscription)`).

Fixed: https://github.com/Automattic/wp-calypso/issues/68294