### PR TITLE
Editor: Fix incorrect site id after redirect

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -517,8 +517,7 @@ export function siteSelection( context, next ) {
 					const unmappedSlug = withoutHttp( getSiteOption( getState(), site.ID, 'unmapped_url' ) );
 
 					if ( unmappedSlug !== siteSlug && unmappedSlug === siteFragment ) {
-						const basePath = sectionify( context.path, siteFragment );
-						return page.redirect( `${ basePath }/${ siteSlug }` );
+						return page.redirect( context.path.replace( siteFragment, siteSlug ) );
 					}
 				}
 
@@ -543,9 +542,10 @@ export function siteSelection( context, next ) {
 					navigate( getJetpackAuthorizeURL( context, site ) );
 				} else {
 					// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
+					const siteFragmentOffset = context.path.indexOf( `/${ siteFragment }` );
 					const allSitesPath = addQueryArgs(
 						{ site: siteFragment },
-						sectionify( context.path, siteFragment )
+						context.path.substring( 0, siteFragmentOffset )
 					);
 					page.redirect( allSitesPath );
 				}


### PR DESCRIPTION
#### Proposed Changes

When you access the URL with a site fragment but you're not the owner of that site, you will be redirected to all site selections where the site id is correct. For example, if you go to the following URL below

* `/post/<not-your-site>/2391`
* `/purchases/subscriptions/<not-your-site>/1011650`

You will land on in the end
* `/post?site=2391`
* `/purchases/subscriptions?site=1011650`

The issue is that we want to redirect the user to `allSitesPath`. However, the `sectionify` function only removes the site fragment from the URL, and you're still redirected to a path where the site doesn't belong to you. Therefore, you get a redirection again and the site id is incorrect this time.

So, this PR tries to remove all the characters after the site fragment to avoid this situation. It might be better to implement this logic inside the `sectionify` function but the impact might be too much...

Any thoughts?

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/post/<not-your-site>/2391`
* You will be redirected to all sites selection where the URL should be `/post?site=<not-your-site>`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61729#issuecomment-1257637926
