### PR TITLE
Emails: add domain upsell button to email page when no plan and domain

### DIFF
--- a/client/my-sites/email/email-management/home/email-no-domain.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.tsx
@@ -24,8 +24,12 @@ const EmailNoDomain = ( {
 
 	const isFreePlanProduct = isFreePlan( selectedSite?.plan?.product_slug ?? '' );
 
-	const trackEvent = () => {
-		recordEmailUpsellTracksEvent( source, isFreePlanProduct ? 'plan' : 'domain' );
+	const trackEventForPlan = () => {
+		recordEmailUpsellTracksEvent( source, 'plan' );
+	};
+
+	const trackEventForDomain = () => {
+		recordEmailUpsellTracksEvent( source, 'domain' );
 	};
 
 	const trackImpression = ( noDomainContext: string ) => {
@@ -53,8 +57,11 @@ const EmailNoDomain = ( {
 		return (
 			<EmptyContent
 				action={ translate( 'Upgrade to a plan' ) }
-				actionCallback={ trackEvent }
+				actionCallback={ trackEventForPlan }
 				actionURL={ `/plans/${ selectedSite.slug }` }
+				secondaryAction={ translate( 'Just search for a domain' ) }
+				secondaryActionCallback={ trackEventForDomain }
+				secondaryActionURL={ `/domains/add/${ selectedSite.slug }` }
 				illustration={ Illustration }
 				line={ translate(
 					'Upgrade to a plan now, set up your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
@@ -70,7 +77,7 @@ const EmailNoDomain = ( {
 		return (
 			<EmptyContent
 				action={ translate( 'Add a Domain' ) }
-				actionCallback={ trackEvent }
+				actionCallback={ trackEventForDomain }
 				actionURL={ `/domains/add/${ selectedSite.slug }` }
 				illustration={ Illustration }
 				line={ translate(
@@ -87,7 +94,7 @@ const EmailNoDomain = ( {
 		<EmptyContent
 			action={ translate( 'Add a Domain' ) }
 			actionURL={ `/domains/add/${ selectedSite.slug }` }
-			actionCallback={ trackEvent }
+			actionCallback={ trackEventForDomain }
 			illustration={ Illustration }
 			line={ translate(
 				'Set up or buy your domain, pick from one of our flexible email options, and start getting emails today.'


### PR DESCRIPTION
#### Proposed Changes
Add domain upsell button to "Email Management" / "Inbox" pages, when a user doesn't have neither plan nor domain.

*The current experience is not intuitive for users. Given the user landed on the no domain landing page by visiting /email/:site and /inbox, the user is clearly interested in exploring the email product. However, the current setup upsell path for sites without a paid plan does not allow users to make an email purchase.*

#### Testing Instructions
* Go to your dashboard
* Create new site w/o plan and w/o domain
	* In the top left corner click on "Switch site"
	* In the bottom left corner click on "Add new site"
	* In the right sidebar click on "Choose my domain later" to skip choosing domain
	* Select any plan and pay for it
	* Cancel your plan subscription - in the top right corner click on you avatar, then choose "Purchases" in the left sidebar
* Go to "Upgrades -> Emails" (The same should be on "Inbox" page)

<table>
<tr>
	<td> BEFORE
	<td> AFTER
<tr>
	<td>
	<td> Domain upsell button is shown
<tr>
	<td> <img width="1075" alt="Screenshot 2022-10-03 at 12 21 12" src="https://user-images.githubusercontent.com/5598437/193565037-9b5c0ec5-853e-49ac-936e-0f7f7b93e238.png">
	<td> <img width="1084" alt="Screenshot 2022-10-03 at 12 21 31" src="https://user-images.githubusercontent.com/5598437/193565087-dcbe7611-5c7c-4f71-9e96-4de9c015d970.png">
</table>

* Click on "Just search for a domain"
**RESULT**: You are landed to `/domains/add/:site_slug` AND event "calypso_email_upsell" is tracked with context as `domain`.
* Since in the PR we have a bit changed code for tracking plan/domain events - let's test this change too
	* Come back to the previous page on click on "Upgrade to a plan"
	**RESULT**: You are landed to `/plans/:site_slug` AND event `calypso_email_upsell` is tracked with context as `plan`.
	* Add plan to your site, come back again to "Upgrades -> Emails" and click on "Add a Domain"
	**RESULT**: You are landed to `/domains/add/:site_slug` AND event `calypso_email_upsell` is tracked with context as `domain`.





#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
1200182182542585-as-1203067993935862/f