### PR TITLE
Plugin Management: add test cases to the common components - table, card, and actions

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-actions.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-actions.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import PluginCommonActions from '../plugin-common/plugin-common-actions';
+import { plugin } from './utils/constants';
+
+const props = {
+	item: plugin,
+	renderActions: () => <div>Actions</div>,
+};
+
+describe( '<PluginCommonActions>', () => {
+	test( 'should render correctly and show the actions rendered', async () => {
+		render( <PluginCommonActions { ...props } /> );
+		const actionButton = screen.getByRole( 'button' );
+		await userEvent.click( actionButton );
+		expect( screen.getByText( 'Actions' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
+import PluginCommonCard from '../plugin-common/plugin-common-card';
+import PluginRowFormatter from '../plugin-row-formatter';
+import { plugin, site } from './utils/constants';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+const initialState = {
+	sites: { items: { [ site.ID ]: site } },
+	currentUser: {
+		capabilities: {},
+	},
+	plugins: {
+		installed: {
+			isRequesting: {},
+			isRequestingAll: false,
+			plugins: {
+				[ `${ site.ID }` ]: [ plugin ],
+			},
+			status: {
+				[ `${ site.ID }` ]: {
+					[ plugin.id ]: {
+						status: 'completed',
+						action: ACTIVATE_PLUGIN,
+					},
+				},
+			},
+		},
+	},
+};
+
+const props = {
+	item: plugin,
+	isLoading: false,
+	columns: [
+		{
+			key: 'plugin',
+			header: translate( 'Installed Plugins' ),
+		},
+	],
+	rowFormatter: function ( props ): React.ReactNode {
+		return <PluginRowFormatter { ...props } selectedSite={ site } updatePlugin={ noop } />;
+	},
+	selectedSite: site,
+	primaryKey: 'id',
+};
+
+describe( '<PluginCommonCard>', () => {
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	test( 'should render the columns provided and display plugin data', () => {
+		render(
+			<Provider store={ store }>
+				<PluginCommonCard { ...props } />
+			</Provider>
+		);
+		const pluginName = screen.getByRole( 'link', { name: plugin.name } );
+		expect( pluginName ).toHaveProperty(
+			'href',
+			`https://example.com/plugins/${ plugin.slug }/${ site.slug }`
+		);
+	} );
+} );

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
+import PluginCommonTable from '../plugin-common/plugin-common-table';
+import PluginRowFormatter from '../plugin-row-formatter';
+import { plugin, site } from './utils/constants';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+const initialState = {
+	sites: { items: { [ site.ID ]: site } },
+	currentUser: {
+		capabilities: {},
+	},
+	plugins: {
+		installed: {
+			isRequesting: {},
+			isRequestingAll: false,
+			plugins: {
+				[ `${ site.ID }` ]: [ plugin ],
+			},
+			status: {
+				[ `${ site.ID }` ]: {
+					[ plugin.id ]: {
+						status: 'completed',
+						action: ACTIVATE_PLUGIN,
+					},
+				},
+			},
+		},
+	},
+};
+
+const props = {
+	items: [ plugin ],
+	isLoading: false,
+	columns: [
+		{
+			key: 'plugin',
+			header: translate( 'Installed Plugins' ),
+		},
+	],
+	rowFormatter: function ( props ): React.ReactNode {
+		return <PluginRowFormatter { ...props } selectedSite={ site } updatePlugin={ noop } />;
+	},
+	primaryKey: 'id',
+};
+
+describe( '<PluginCommonTable>', () => {
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	test( 'should render the columns provided and display plugin data', () => {
+		render(
+			<Provider store={ store }>
+				<PluginCommonTable { ...props } />
+			</Provider>
+		);
+
+		const pluginName = screen.getByRole( 'link', { name: plugin.name } );
+
+		expect( pluginName ).toHaveProperty(
+			'href',
+			`https://example.com/plugins/${ plugin.slug }/${ site.slug }`
+		);
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

This PR adds test cases to the common components(table, card, and actions) that were added as a part of the plugin management project.

#### Testing Instructions

- Run `git checkout add/test-cases-to-plugin-mgmt-common-components && git pull`
- Run `yarn run test-client client/my-sites/plugins/plugin-management-v2/test` to run the tests.
- Verify the tests are passing, and code changes make sense

#### Pre-merge Checklist

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] ~~Have you checked for TypeScript, React, or other console errors?~~
- [x] ~~Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)~~
- [x] ~~Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202518759611394-as-1202979359232058