### PR TITLE
Global Styles: Add upgrade notice to launch bar

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -223,11 +223,9 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 
 	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug;
 
-	$title = __( 'Styles hidden', 'full-site-editing' );
-
 	$custom_controls[] = array(
-		'desktop_message'    => $title,
-		'mobile_message'     => $title,
+		'desktop_message'    => __( 'Styles hidden', 'full-site-editing' ),
+		'mobile_message'     => __( 'Styles', 'full-site-editing' ),
 		'track_button_name'  => 'wpcom_gs_notice',
 		'tooltip'            => __( 'You need to be on a paid plan for your style changes to be made public.', 'full-site-editing' ),
 		'tooltip_link_title' => __( 'Upgrade your plan', 'full-site-editing' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -200,3 +200,32 @@ function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 	}
 }
 add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
+
+/**
+ * Adds the global style notice banner to the custom launch bar controls.
+ *
+ * @param array $custom_controls List of custom controls.
+ *
+ * return array The collection of launch bar custom controls to render.
+ */
+function wpcom_display_global_styles_banner( $custom_controls ) {
+	// Do not show the banner if the user can use global styles.
+	if ( ! wpcom_should_limit_global_styles() ) {
+		return;
+	}
+
+	$title = __( 'Styles hidden', 'full-site-editing' );
+
+	$custom_controls[] = array(
+		'desktop_message'    => $title,
+		'mobile_message'     => $title,
+		'track_button_name'  => 'wpcom_gs_notice',
+		'tooltip'            => __( 'You need to be on a paid plan for your style changes to be made public.', 'full-site-editing' ),
+		'tooltip_link_title' => __( 'Upgrade your plan', 'full-site-editing' ),
+		'tooltip_link_url'   => 'https://www.google.com',
+		'icon_path'          => 'M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z',
+	);
+
+	return $custom_controls;
+}
+add_filter( 'wpcom_custom_launch_bar_controls', 'wpcom_display_global_styles_banner' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -214,6 +214,15 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 		return;
 	}
 
+	if ( method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
+		$site_slug = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+	} else {
+		$home_url  = home_url( '/' );
+		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
+	}
+
+	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug;
+
 	$title = __( 'Styles hidden', 'full-site-editing' );
 
 	$custom_controls[] = array(
@@ -222,8 +231,9 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 		'track_button_name'  => 'wpcom_gs_notice',
 		'tooltip'            => __( 'You need to be on a paid plan for your style changes to be made public.', 'full-site-editing' ),
 		'tooltip_link_title' => __( 'Upgrade your plan', 'full-site-editing' ),
-		'tooltip_link_url'   => 'https://www.google.com',
+		'tooltip_link_url'   => $upgrade_url,
 		'icon_path'          => 'M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z',
+		'icon_color'         => 'orange',
 	);
 
 	return $custom_controls;


### PR DESCRIPTION
These changes will actually add the notice to the list of custom buttons. This PR requires D88968-code if you want to test it. These changes can only be tested on WPCOM at the moment, I will add another PR in WPCOMSH so that we can test this on Atomic sites.

Fixes https://github.com/Automattic/dotcom-forge/issues/893

#### Proposed Changes

* Hooked into the `wpcom_custom_launch_bar_controls` so that we can show the GS upgrade notice on the launchbar.

#### Testing Instructions
* Apply D88968-code on your sandbox
* Run `install-plugin.sh editing-toolkit add/global-styles-banner-to-launch-bar` on your sandbox.
* You need to be logged in and open the site.
* Make sure your site isn't launched.
* You should see all the normal icons + the GS notice.
* Launch your site, you should only see the GS notice.
* Upgrade your plan, you should not see the GS notice and/or the launch bar.

##### Test evidence
https://user-images.githubusercontent.com/1989914/193775611-c3ae8143-69d2-4404-a395-7275600cadc4.mp4



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #