### PR TITLE
Limit Global Styles: Show modal once

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -1,28 +1,17 @@
 /*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
 import './public-path';
 
-import { dispatch, select, subscribe } from '@wordpress/data';
+import { select, subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { render } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import GlobalStylesModal from './modal';
 import GlobalStylesNotice from './notice';
+import './store';
 
 const showGlobalStylesModal = () => {
-	const unsubscribe = subscribe( () => {
-		const currentSidebar =
-			select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-site' );
-		if ( currentSidebar !== 'edit-site/global-styles' ) {
-			return;
-		}
-		unsubscribe();
-
-		// Hide the welcome guide modal, so it doesn't conflict with our modal.
-		dispatch( 'core/preferences' ).set( 'core/edit-site', 'welcomeGuideStyles', false );
-
-		registerPlugin( 'wpcom-global-styles', {
-			render: () => <GlobalStylesModal />,
-		} );
+	registerPlugin( 'wpcom-global-styles', {
+		render: () => <GlobalStylesModal />,
 	} );
 };
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -19,10 +19,8 @@ const GlobalStylesModal = () => {
 
 	// Hide the welcome guide modal, so it doesn't conflict with our modal.
 	useEffect( () => {
-		if ( isVisible ) {
-			setPreference( 'core/edit-site', 'welcomeGuideStyles', false );
-		}
-	}, [ setPreference, isVisible ] );
+		setPreference( 'core/edit-site', 'welcomeGuideStyles', false );
+	}, [ setPreference ] );
 
 	if ( ! isVisible ) {
 		return null;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -1,7 +1,8 @@
 /* global wpcomGlobalStyles */
 
 import { Button, Modal } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import image from './image.svg';
@@ -9,7 +10,19 @@ import image from './image.svg';
 import './modal.scss';
 
 const GlobalStylesModal = () => {
-	const [ isVisible, setIsVisible ] = useState( true );
+	const isVisible = useSelect(
+		( select ) => select( 'automattic/wpcom-global-styles' ).isModalVisible(),
+		[]
+	);
+	const { dismissModal } = useDispatch( 'automattic/wpcom-global-styles' );
+	const { set: setPreference } = useDispatch( 'core/preferences' );
+
+	// Hide the welcome guide modal, so it doesn't conflict with our modal.
+	useEffect( () => {
+		if ( isVisible ) {
+			setPreference( 'core/edit-site', 'welcomeGuideStyles', false );
+		}
+	}, [ setPreference, isVisible ] );
 
 	if ( ! isVisible ) {
 		return null;
@@ -18,8 +31,9 @@ const GlobalStylesModal = () => {
 	return (
 		<Modal
 			className="wpcom-global-styles-modal"
-			open={ isVisible }
-			onRequestClose={ () => setIsVisible( false ) }
+			onRequestClose={ dismissModal }
+			// set to false so that 1Password's autofill doesn't automatically close the modal
+			shouldCloseOnClickOutside={ false }
 		>
 			<div className="wpcom-global-styles-modal__text">
 				<h1 className="wpcom-global-styles-modal__heading">
@@ -32,7 +46,7 @@ const GlobalStylesModal = () => {
 					) }
 				</p>
 				<div className="wpcom-global-styles-modal__actions">
-					<Button variant="secondary" onClick={ () => setIsVisible( false ) }>
+					<Button variant="secondary" onClick={ dismissModal }>
 						{ __( 'Try it out', 'full-site-editing' ) }
 					</Button>
 					<Button variant="primary" href={ wpcomGlobalStyles.upgradeUrl } target="_top">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
@@ -1,0 +1,35 @@
+import { createRegistrySelector, registerStore } from '@wordpress/data';
+
+const DEFAULT_STATE = {
+	isModalVisible: true,
+};
+
+registerStore( 'automattic/wpcom-global-styles', {
+	reducer: ( state = DEFAULT_STATE, action ) => {
+		switch ( action.type ) {
+			case 'DISMISS_MODAL':
+				return {
+					...state,
+					isModalVisible: false,
+				};
+		}
+
+		return state;
+	},
+
+	actions: {
+		dismissModal: () => ( {
+			type: 'DISMISS_MODAL',
+		} ),
+	},
+
+	selectors: {
+		isModalVisible: createRegistrySelector( ( select ) => ( state ) => {
+			const currentSidebar =
+				select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-site' );
+			return currentSidebar === 'edit-site/global-styles' && state.isModalVisible;
+		} ),
+	},
+
+	persist: true,
+} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/895

#### Proposed Changes

Ensures that the modal that alerts customers that Global Styles is a paid feature only shows up once.

Note that the dismissal is stored in the local storage of the browser, so technically the modal can show up more than once if the user clears up the browser local storage or uses a different browser.

As an aside, I tried looking into existing modals as advised by @Copons to see if we can reuse any mechanism for showing the modal twice before hiding it for real. I couldn't find anything like that, but I don't think it's a big deal since that's only an issue for cases where the user accidentally dismisses the modal before realizing it's a paid feature; something that it's unlikely to happen because we also show a notice informing about that before saving any GS change.

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit update/limit-gs-show-modal-once`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Make sure the upgrade modal shows up
- Dismiss it
- Close the sidebar and open it again
- Make sure the upgrade modal doesn't show up
- Reload the site editor
- Open the Global Styles sidebar
- Make sure the upgrade modal doesn't show up

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
