### PR TITLE
Sites Management Page: Nag user for 'Coming soon' site

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -19,9 +19,10 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;
 
 export const SITE_EXCERPT_REQUEST_OPTIONS = [
-	'is_wpforteams_site',
-	'updated_at',
-	'is_redirect',
-	'unmapped_url',
 	'admin_url',
+	'is_redirect',
+	'is_wpforteams_site',
+	'site_intent',
+	'unmapped_url',
+	'updated_at',
 ] as const;

--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -22,6 +22,7 @@ export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'admin_url',
 	'is_redirect',
 	'is_wpforteams_site',
+	'launchpad_screen',
 	'site_intent',
 	'unmapped_url',
 	'updated_at',

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,5 +1,6 @@
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
+import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { AnchorHTMLAttributes, memo } from 'react';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -9,6 +10,7 @@ import { SitesGridTile } from './sites-grid-tile';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
+import { SiteLaunchNag } from './sites-site-launch-nag';
 import { SiteName } from './sites-site-name';
 import { SiteUrl, Truncated } from './sites-site-url';
 import { ThumbnailLink } from './thumbnail-link';
@@ -38,6 +40,12 @@ export const siteThumbnail = css( {
 	aspectRatio: '16 / 11',
 	width: '100%',
 	height: 'auto',
+} );
+
+const SitesGridItemSecondary = styled.div( {
+	display: 'flex',
+	gap: '32px',
+	justifyContent: 'space-between',
 } );
 
 const ellipsis = css( {
@@ -101,9 +109,12 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 				</>
 			}
 			secondary={
-				<SiteUrl href={ siteUrl } title={ siteUrl }>
-					<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
-				</SiteUrl>
+				<SitesGridItemSecondary>
+					<SiteUrl href={ siteUrl } title={ siteUrl }>
+						<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
+					</SiteUrl>
+					<SiteLaunchNag site={ site } />
+				</SitesGridItemSecondary>
 			}
 		/>
 	);

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,6 +1,9 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getSiteLaunchStatus } from '@automattic/sites';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { getDashboardUrl, getLaunchpadUrl } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -57,6 +60,14 @@ const SiteLaunchDonut = () => {
 
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const { __ } = useI18n();
+	const { ref, inView } = useInView();
+
+	useEffect( () => {
+		if ( inView ) {
+			recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_view' );
+		}
+	}, [ inView ] );
+
 	if ( 'coming-soon' !== getSiteLaunchStatus( site ) ) {
 		return null;
 	}
@@ -71,7 +82,13 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 		: getDashboardUrl( site.slug );
 	const text = site.options?.site_intent ? __( 'Launch guide' ) : __( 'Launch checklist' );
 	return (
-		<SiteLaunchNagLink href={ link }>
+		<SiteLaunchNagLink
+			ref={ ref }
+			href={ link }
+			onClick={ () => {
+				recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_click' );
+			} }
+		>
 			<SiteLaunchDonut /> <span>{ text }</span>
 		</SiteLaunchNagLink>
 	);

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -75,14 +75,17 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	}
 
 	const validSiteIntent =
-		site.options?.site_intent && -1 !== [ 'link-in-bio' ].indexOf( site.options?.site_intent )
-			? site.options?.site_intent
+		site.options.launchpad_screen === 'full' &&
+		site.options.site_intent &&
+		[ 'link-in-bio' ].includes( site.options.site_intent )
+			? site.options.site_intent
 			: false;
 
 	const link = validSiteIntent
 		? getLaunchpadUrl( site.slug, validSiteIntent )
 		: getDashboardUrl( site.slug );
-	const text = site.options?.site_intent ? __( 'Launch guide' ) : __( 'Launch checklist' );
+	const text = validSiteIntent ? __( 'Launch guide' ) : __( 'Launch checklist' );
+
 	return (
 		<SiteLaunchNagLink
 			ref={ ref }

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -64,7 +64,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 
 	useEffect( () => {
 		if ( inView ) {
-			recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_view' );
+			recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_inview' );
 		}
 	}, [ inView ] );
 

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,0 +1,78 @@
+import { getSiteLaunchStatus } from '@automattic/sites';
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import { getDashboardUrl, getLaunchpadUrl } from '../utils';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+interface SiteLaunchNagProps {
+	site: SiteExcerptData;
+}
+
+const SiteLaunchDonutBase = styled.svg( {
+	position: 'absolute',
+	top: 0,
+	left: 0,
+	bottom: 0,
+	right: 0,
+} );
+
+const SiteLaunchDonutProgress = styled( SiteLaunchDonutBase )( {
+	zIndex: 1,
+} );
+
+const SiteLaunchDonutContainer = styled.div( {
+	position: 'relative',
+	width: '13px',
+	marginTop: '3px',
+	marginRight: '4px',
+} );
+
+const SiteLaunchNagLink = styled.a( {
+	display: 'flex',
+	fontSize: '12px',
+	lineHeight: '20px',
+	whiteSpace: 'nowrap',
+	'&:hover span': {
+		textDecoration: 'underline',
+	},
+} );
+
+const SiteLaunchDonut = () => {
+	return (
+		<SiteLaunchDonutContainer>
+			<SiteLaunchDonutProgress viewBox="0 0 26 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M0 13.5C0 20.6797 5.8203 26.5 13 26.5C20.1797 26.5 26 20.6797 26 13.5C26 6.3203 20.1797 0.5 13 0.5V2.5C19.0751 2.5 24 7.42487 24 13.5C24 19.5751 19.0751 24.5 13 24.5C6.92487 24.5 2 19.5751 2 13.5H0Z"
+					fill="currentColor"
+				/>
+			</SiteLaunchDonutProgress>
+			<SiteLaunchDonutBase viewBox="0 0 26 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<circle cx="13" cy="13.5" r="12" stroke="#DCDCDE" strokeWidth="2" />
+			</SiteLaunchDonutBase>
+		</SiteLaunchDonutContainer>
+	);
+};
+
+export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
+	const { __ } = useI18n();
+	if ( 'coming-soon' !== getSiteLaunchStatus( site ) ) {
+		return null;
+	}
+
+	const validSiteIntent =
+		site.options?.site_intent && -1 !== [ 'link-in-bio' ].indexOf( site.options?.site_intent )
+			? site.options?.site_intent
+			: false;
+
+	const link = validSiteIntent
+		? getLaunchpadUrl( site.slug, validSiteIntent )
+		: getDashboardUrl( site.slug );
+	const text = site.options?.site_intent ? __( 'Launch guide' ) : __( 'Launch checklist' );
+	return (
+		<SiteLaunchNagLink href={ link }>
+			<SiteLaunchDonut /> <span>{ text }</span>
+		</SiteLaunchNagLink>
+	);
+};

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { getDashboardUrl, getLaunchpadUrl } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -60,10 +60,12 @@ const SiteLaunchDonut = () => {
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const { __ } = useI18n();
 	const { ref, inView } = useInView();
+	const hasRecordedInView = useRef( false );
 
 	useEffect( () => {
-		if ( inView ) {
+		if ( inView && ! hasRecordedInView.current ) {
 			recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_inview' );
+			hasRecordedInView.current = true;
 		}
 	}, [ inView ] );
 

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getSiteLaunchStatus } from '@automattic/sites';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -68,7 +67,10 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 		}
 	}, [ inView ] );
 
-	if ( 'coming-soon' !== getSiteLaunchStatus( site ) ) {
+	// Don't show nag to all Coming Soon sites, only those that are "unlaunched"
+	// That's because sites that have been previously launched before going back to
+	// Coming Soon mode don't have a launch checklist.
+	if ( 'unlaunched' !== site.launch_status ) {
 		return null;
 	}
 

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -10,6 +10,7 @@ import { displaySiteUrl, getDashboardUrl, isNotAtomicJetpack, MEDIA_QUERIES } fr
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
+import { SiteLaunchNag } from './sites-site-launch-nag';
 import { SiteName } from './sites-site-name';
 import { SiteUrl, Truncated } from './sites-site-url';
 import { ThumbnailLink } from './thumbnail-link';
@@ -129,7 +130,10 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					{ site.plan?.product_name_short }
 				</SitePlan>
 			</Column>
-			<Column mobileHidden>{ translatedStatus }</Column>
+			<Column mobileHidden>
+				{ translatedStatus }
+				<SiteLaunchNag site={ site } />
+			</Column>
 			<Column mobileHidden>
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -129,10 +129,10 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					{ site.plan?.product_name_short }
 				</SitePlan>
 			</Column>
+			<Column mobileHidden>{ translatedStatus }</Column>
 			<Column mobileHidden>
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
-			<Column mobileHidden>{ translatedStatus }</Column>
 			<Column style={ { width: '24px' } }>
 				<SitesEllipsisMenu site={ site } />
 			</Column>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -124,8 +124,8 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 				<Row>
 					<th style={ { width: '50%' } }>{ __( 'Site' ) }</th>
 					<th style={ { width: '20%' } }>{ __( 'Plan' ) }</th>
-					<th>{ __( 'Last Publish' ) }</th>
 					<th>{ __( 'Status' ) }</th>
+					<th>{ __( 'Last Publish' ) }</th>
 					<th style={ { width: '24px' } }></th>
 				</Row>
 			</THead>

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,5 +1,9 @@
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
 
+export const getLaunchpadUrl = ( slug: string, flow: string ) => {
+	return `/setup/launchpad?flow=${ flow }&siteSlug=${ slug }`;
+};
+
 export const getDashboardUrl = ( slug: string ) => {
 	return `/home/${ slug }`;
 };

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
 		"photon": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
+		"react-intersection-observer": "^9.4.0",
 		"reakit-utils": "^0.15.1",
 		"redux": "^4.1.2",
 		"request": "^2.88.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28706,6 +28706,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-intersection-observer@npm:^9.4.0":
+  version: 9.4.0
+  resolution: "react-intersection-observer@npm:9.4.0"
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0
+  checksum: abd076bbc0ed011c0a531deb6eacf27d05ff76c174b00c15cbe7a7bc064091f62813b7271bbfcee1bc3c90817a654075f35f9cbafa213ab547c7c92bdbf884aa
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.12.0 || ^17.0.0, react-is@npm:^17.0.0, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
@@ -35831,6 +35840,7 @@ swiper@4.5.1:
     prettier: "npm:wp-prettier@2.6.2"
     react: ^17.0.2
     react-dom: ^17.0.2
+    react-intersection-observer: ^9.4.0
     readline-sync: ^1.4.10
     reakit-utils: ^0.15.1
     recursive-copy: ^2.0.14


### PR DESCRIPTION
Fixes #68020

## Proposed Changes

Shows a new `<SiteLaunchNag />` component for 'Coming soon' sites:
* If a user is creating a 'Link In Bio' site and didn't complete the Launchpad, they see a nag for 'Launch guide'.
* If a user is creating some other site and hasn't completed the site checklist, they see a nag for 'Launch checklist'.

Fires `calypso_sites_dashboard_site_launch_nag_inview` when the element is in view, and `calypso_sites_dashboard_site_launch_nag_click` for a click.

Also moves the 'Status' column in front of 'Last Published'.

Lastly, because the last task for both the Launchpad and site checklist are _launching the site_, we only need to reference `[ 'link-in-bio' ].indexOf( site.options?.site_intent )` to determine whether it's a 'Link In Bio' site.

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/36432/193617856-b817d5ab-0370-45b7-8564-7b9bfc54539f.png">

<img width="934" alt="image" src="https://user-images.githubusercontent.com/36432/193617991-7972546a-418c-4654-bde7-ba564e350613.png">

## Testing Instructions

1. Create a new Link In Bio site: http://calypso.localhost:3000/setup/intro?flow=link-in-bio&ref=logged-out-homepage-lp
2. When you hit the Launchpad screen, open up `/sites` instead.
3. Verify your Link In Bio site uses 'Launch guide' as the link language.
4. Create a new site through the normal flow.
5. Once your site is created, navigate to `/sites`.
6. Verify your new standard site uses 'Launch checklist' as the link language.
7. Confirm styling with various browsers and device widths.
8. Create a new Newsletter site: http://calypso.localhost:3000/setup?flow=newsletter&ref=logged-out-homepage-lp
9. No launch nag appears for the new newsletter because this is created in a launched state