### PR TITLE
Rename the Themes search empty results event

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -28,7 +28,7 @@ export const ThemesList = ( props ) => {
 
 	useEffect( () => {
 		if ( noThemesFound && props.searchTerm ) {
-			props.recordTracksEvent( 'calypso_themeshowcase_search_empty', {
+			props.recordTracksEvent( 'calypso_themeshowcase_search_empty_results', {
 				search_term: props.searchTerm,
 				blog_id: props.siteId,
 			} );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -21,7 +21,7 @@ export const ThemesList = ( props ) => {
 		[ props.fetchNextPage ]
 	);
 
-	if ( props.isLoading && props.themes.length === 0 ) {
+	if ( ! props.loading && props.themes.length === 0 ) {
 		return <Empty emptyContent={ props.emptyContent } translate={ props.translate } />;
 	}
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,7 +1,7 @@
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
@@ -21,21 +21,7 @@ export const ThemesList = ( props ) => {
 		[ props.fetchNextPage ]
 	);
 
-	const noThemesFound = useMemo(
-		() => props.isRequestFulfilled && props.themes.length === 0,
-		[ props.isRequestFulfilled, props.themes.length ]
-	);
-
-	useEffect( () => {
-		if ( noThemesFound && props.searchTerm ) {
-			props.recordTracksEvent( 'calypso_themeshowcase_search_empty_results', {
-				search_term: props.searchTerm,
-				blog_id: props.siteId,
-			} );
-		}
-	}, [ noThemesFound, props.searchTerm ] );
-
-	if ( noThemesFound ) {
+	if ( props.isLoading && props.themes.length === 0 ) {
 		return <Empty emptyContent={ props.emptyContent } translate={ props.translate } />;
 	}
 
@@ -56,7 +42,6 @@ ThemesList.propTypes = {
 	themes: PropTypes.array.isRequired,
 	emptyContent: PropTypes.element,
 	loading: PropTypes.bool.isRequired,
-	isRequestFulfilled: PropTypes.bool.isRequired,
 	recordTracksEvent: PropTypes.func.isRequired,
 	fetchNextPage: PropTypes.func.isRequired,
 	getButtonOptions: PropTypes.func,
@@ -80,7 +65,6 @@ ThemesList.propTypes = {
 
 ThemesList.defaultProps = {
 	loading: false,
-	isRequestFulfilled: false,
 	searchTerm: '',
 	themes: [],
 	recordTracksEvent: noop,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -17,7 +17,6 @@ import {
 	getPremiumThemePrice,
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
-	isFulfilledThemesForQuery,
 	isRequestingThemesForQuery,
 	isThemesLastPageForQuery,
 	isThemeActive,
@@ -172,7 +171,6 @@ class ThemesSelection extends Component {
 					getActionLabel={ this.props.getActionLabel }
 					isActive={ this.props.isThemeActive }
 					getPrice={ this.props.getPremiumThemePrice }
-					isRequestFulfilled={ this.props.isRequestFulfilled }
 					isInstalling={ this.props.isInstallingTheme }
 					loading={ this.props.isRequesting }
 					emptyContent={ this.props.emptyContent }
@@ -258,7 +256,6 @@ export const ConnectedThemesSelection = connect(
 			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
 			isRequesting:
 				isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
-			isRequestFulfilled: isFulfilledThemesForQuery( state, sourceSiteId, query ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: isUserLoggedIn( state ),
 			isThemeActive: bindIsThemeActive( state, siteId ),

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -79,6 +79,18 @@ export function requestThemes( siteId, query = {}, locale ) {
 						results_first_page: themes.map( property( 'id' ) ).join(),
 					} );
 					dispatch( trackShowcaseSearch );
+
+					if ( found === 0 ) {
+						const trackShowcaseEmptySearch = recordTracksEvent(
+							'calypso_themeshowcase_search_empty_results',
+							{
+								search_term: search_term || null,
+								response_time_in_ms: responseTime,
+							}
+						);
+
+						dispatch( trackShowcaseEmptySearch );
+					}
 				}
 
 				dispatch( receiveThemes( themes, siteId, query, found ) );


### PR DESCRIPTION
#### Proposed Changes

* Rename the themes search empty results event
* Update the place of firing this event, from the component to the request handler.

#### Testing Instructions

* On the browser console terminal enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
* Go to themes page: `/themes/{site}`
* Search for a value that will return an empty list. Ex: `abc`
* Check if the event `calypso_themeshowcase_search_empty_results` is logged in console
* Check if the properties are filled: `search_term` and `response_time_in_ms`

---

Related to pdh6GB-2dC-p2#comment-3007