### PR TITLE
E2E: fix the Apple login spec.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -820,7 +820,7 @@ object AuthenticationE2ETests : E2EBuildType(
 	buildTriggers = {
 		schedule {
 			schedulingPolicy = cron {
-				hours = "*/3"
+				hours = "*/6"
 			}
 			branchFilter = "+:<default>"
 			triggerBuild = always()

--- a/packages/calypso-e2e/src/lib/pages/external/apple-login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/external/apple-login-page.ts
@@ -8,8 +8,7 @@ const selectors = {
 	// Inputs
 	emailInput: 'input[id="account_name_text_field"]',
 	passwordInput: 'input[id="password_text_field"]',
-	otpInput:
-		'input[aria-label="Enter verification code. After entering the verification code, the page gets updated automatically. Digit 1"]',
+	otpInput: 'input[maxlength="1"]', // Matches on the first OTP input field.
 
 	// Button
 	continueButton: 'button[aria-label="Continue"][aria-disabled="false"]',
@@ -90,7 +89,7 @@ export class AppleLoginPage {
 	 * @param {string} code 2FA code for the user.
 	 */
 	async enter2FACode( code: string ): Promise< void > {
-		const locator = this.page.locator( selectors.otpInput );
+		const locator = this.page.locator( selectors.otpInput ).first();
 		await locator.type( code, { delay: 150 } );
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the permanent failure of the Apple Login spec introduced by Apple changing their login selector.

Key changes:
- update the selector used to locate the 2FA authentication code.
- reduce frequency to every 6 hours to lesson demand on the SMS service.

Context:
p1664571600717079-slack-C0E1C5NCR

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Authentication E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #