### PR TITLE
Theme/Plugin Bundling: Handling upgrading to purchase a bundled theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -171,12 +171,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		const designs = [ ...generatedDesigns.designs, ...staticDesigns.designs ];
 
-		for ( const design of designs ) {
-			if ( design.slug === themeFromQueryString ) {
-				setSelectedDesign( design );
-				setIsPreviewingDesign( true );
-			}
+		const requestedDesign = designs.find( ( design ) => design.slug === themeFromQueryString );
+		if ( ! requestedDesign ) {
+			return;
 		}
+
+		setSelectedDesign( requestedDesign );
+		setIsPreviewingDesign( true );
 	}, [ themeFromQueryString, allDesigns, setSelectedDesign ] );
 
 	function getEventPropsByDesign( design: Design, variation?: StyleVariation ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -25,6 +25,7 @@ import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
+import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -158,6 +159,25 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		setSelectedDesign( undefined );
 		setSelectedStyleVariation( undefined );
 	}, [] );
+
+	// When the theme query string parameter is present, automatically switch to previewing that theme (if it's a valid theme)
+	const themeFromQueryString = useQuery().get( 'theme' );
+	useEffect( () => {
+		if ( ! themeFromQueryString || ! allDesigns ) {
+			return;
+		}
+
+		const { generated: generatedDesigns, static: staticDesigns } = allDesigns;
+
+		const designs = [ ...generatedDesigns.designs, ...staticDesigns.designs ];
+
+		for ( const design of designs ) {
+			if ( design.slug === themeFromQueryString ) {
+				setSelectedDesign( design );
+				setIsPreviewingDesign( true );
+			}
+		}
+	}, [ themeFromQueryString, allDesigns, setSelectedDesign ] );
 
 	function getEventPropsByDesign( design: Design, variation?: StyleVariation ) {
 		const variationSlugSuffix =

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -1,5 +1,6 @@
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -229,6 +230,17 @@ export default function useCreatePaymentCompleteCallback( {
 				// We use window.location instead of page() so that the cookies are
 				// detected on fresh page load. Using page(url) will take us to the
 				// log-in page which we don't want.
+				absoluteRedirectThroughPending( url, {
+					siteSlug,
+					orderId: transactionResult.order_id,
+					receiptId: transactionResult.receipt_id,
+				} );
+				return;
+			}
+
+			// We need to do a hard redirect if we're redirecting to the stepper.
+			// Since stepper is self-contained, it doesn't load properly if we do a normal history state change
+			if ( isURL( url ) || url.includes( '/setup/' ) ) {
 				absoluteRedirectThroughPending( url, {
 					siteSlug,
 					orderId: transactionResult.order_id,

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -27,6 +27,7 @@ import {
 	getUrlFromParts,
 } from '@automattic/calypso-url';
 import { isTailoredSignupFlow } from '@automattic/onboarding';
+import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import {
 	getGoogleApps,
@@ -134,6 +135,12 @@ export default function getThankYouPageUrl( {
 	// (and WP.com's) paid blocks Upgrade Nudge.
 	if ( redirectTo ) {
 		const { protocol, hostname, port, pathname, searchParams } = getUrlParts( redirectTo );
+
+		// We need to do a hard redirect if we're redirecting to the stepper.
+		// Since stepper is self-contained, it doesn't load properly if we do a normal history state change
+		if ( isURL( redirectTo ) || redirectTo.startsWith( '/setup' ) ) {
+			window.location.href = redirectTo;
+		}
 
 		if ( resemblesUrl( redirectTo ) && isRedirectSameSite( redirectTo, siteSlug ) ) {
 			debug( 'has same site redirectTo, so returning that', redirectTo );

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -27,7 +27,6 @@ import {
 	getUrlFromParts,
 } from '@automattic/calypso-url';
 import { isTailoredSignupFlow } from '@automattic/onboarding';
-import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import {
 	getGoogleApps,
@@ -135,12 +134,6 @@ export default function getThankYouPageUrl( {
 	// (and WP.com's) paid blocks Upgrade Nudge.
 	if ( redirectTo ) {
 		const { protocol, hostname, port, pathname, searchParams } = getUrlParts( redirectTo );
-
-		// We need to do a hard redirect if we're redirecting to the stepper.
-		// Since stepper is self-contained, it doesn't load properly if we do a normal history state change
-		if ( isURL( redirectTo ) || redirectTo.startsWith( '/setup' ) ) {
-			window.location.href = redirectTo;
-		}
 
 		if ( resemblesUrl( redirectTo ) && isRedirectSameSite( redirectTo, siteSlug ) ) {
 			debug( 'has same site redirectTo, so returning that', redirectTo );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -86,7 +86,14 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			context: 'verb',
 			comment: 'label for selecting a site for which to upgrade a plan',
 		} ),
-		getUrl: ( state, themeId, siteId ) => `/checkout/${ getSiteSlug( state, siteId ) }/business`,
+		getUrl: ( state, themeId, siteId ) => {
+			const slug = getSiteSlug( state, siteId );
+			const redirectTo = encodeURIComponent(
+				`/setup/designSetup?siteSlug=${ slug }&theme=${ themeId }`
+			);
+
+			return `/checkout/${ slug }/business?redirect_to=${ redirectTo }`;
+		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			isJetpackSite( state, siteId ) ||
 			isSiteWpcomAtomic( state, siteId ) ||

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -87,9 +87,11 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			comment: 'label for selecting a site for which to upgrade a plan',
 		} ),
 		getUrl: ( state, themeId, siteId ) => {
+			const { origin = 'https://wordpress.com' } =
+				typeof window !== 'undefined' ? window.location : {};
 			const slug = getSiteSlug( state, siteId );
 			const redirectTo = encodeURIComponent(
-				`/setup/designSetup?siteSlug=${ slug }&theme=${ themeId }`
+				`${ origin }/setup/designSetup?siteSlug=${ slug }&theme=${ themeId }`
 			);
 
 			return `/checkout/${ slug }/business?redirect_to=${ redirectTo }`;


### PR DESCRIPTION
#### Proposed Changes

When purchasing a bundled theme from the showcase, the user needs to upgrade to a Business plan first.

After purchasing the Business plan, we redirect them to `designSetup` in stepper where they can activate the selected theme and finish the stepper Woo onboarding process.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Using a site on a Free/Personal/Premium plan
1. Go to `http://calypso.localhost:3000/themes/[site-slug]`
1. Pick the Thriving Artist theme
1. From the theme page, click "Upgrade to activate"
1. Go through the process of purchasing a Business plan
1. After checkout, you should be taken to Thriving Artist on `designSetup`
1. Click "Start with Thriving Artist"
1. You should be directed to the Woo stepper flow (starting with `storeAddress`)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
