### PR TITLE
Marketplace: Nudge description and CTA update

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -134,13 +134,15 @@ const UpgradeNudge = ( {
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className={ 'plugins-discovery-page__upsell' }
-			callToAction={ translate( 'Upgrade now' ) }
+			callToAction={ translate( 'Upgrade to Business' ) }
 			icon={ 'notice-outline' }
 			showIcon={ true }
 			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
-			title={ translate( 'Upgrade to the Business plan to install plugins.' ) }
+			title={ translate(
+				'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
+			) }
 		/>
 	);
 };

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -9,6 +9,8 @@ import {
 	TYPE_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
+import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -57,6 +59,8 @@ const UpgradeNudge = ( {
 	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
 
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
+	const locale = useLocale();
 
 	if (
 		jetpackNonAtomic ||
@@ -129,6 +133,18 @@ const UpgradeNudge = ( {
 		);
 	}
 
+	let title = translate( 'You need to upgrade your plan to install plugins.' );
+	if (
+		'en' === locale ||
+		hasTranslation(
+			'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
+		)
+	) {
+		title = translate(
+			'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
+		);
+	}
+
 	// This banner upsells the ability to install free and paid plugins on a Business plan.
 	return (
 		<UpsellNudge
@@ -140,9 +156,7 @@ const UpgradeNudge = ( {
 			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
-			title={ translate(
-				'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
-			) }
+			title={ title }
 		/>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

Replace the nudge's description and CTA on the discovery page.

#### Testing Instructions

- Use a not `Business` account.
- Go to `/plugins`
- Nudge description and CTA should look like the `after` screenshot

#### Screenshots
| Before | After |
| --- | --- |
| <img width="1070" alt="image" src="https://user-images.githubusercontent.com/402286/193697787-44e15114-fb21-4311-9d67-14ebead414f3.png"> | <img width="1070" alt="image" src="https://user-images.githubusercontent.com/402286/193697899-dde9edd9-6d4c-4c9e-8aa1-eb582469752e.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68540
