### PR TITLE
Sites Management Page: Fix vertical alignment for loading placeholder

### DIFF
--- a/client/sites-dashboard/components/sites-table-row-loading.tsx
+++ b/client/sites-dashboard/components/sites-table-row-loading.tsx
@@ -24,8 +24,12 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
 	padding-inline-end: 24px;
-	vertical-align: block-start;
+	vertical-align: top;
 `;
+
+const DetailColumn = styled( Column )( {
+	verticalAlign: 'middle',
+} );
 
 const TitleRow = styled.div`
 	display: flex;
@@ -77,9 +81,9 @@ export default function SitesTableRowLoading( {
 			{ Array( columns - 1 )
 				.fill( null )
 				.map( ( _, i ) => (
-					<Column mobileHidden key={ i }>
+					<DetailColumn mobileHidden key={ i }>
 						<LoadingPlaceholder className={ css( { maxWidth: 70 } ) } delayMS={ delayMS } />
-					</Column>
+					</DetailColumn>
 				) ) }
 		</Row>
 	);

--- a/client/sites-dashboard/components/sites-table-row-loading.tsx
+++ b/client/sites-dashboard/components/sites-table-row-loading.tsx
@@ -24,15 +24,12 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
 	padding-inline-end: 24px;
-	vertical-align: top;
+	vertical-align: middle;
 `;
-
-const DetailColumn = styled( Column )( {
-	verticalAlign: 'middle',
-} );
 
 const TitleRow = styled.div`
 	display: flex;
+	align-items: center;
 `;
 
 const FullWidth = styled.div`
@@ -81,9 +78,9 @@ export default function SitesTableRowLoading( {
 			{ Array( columns - 1 )
 				.fill( null )
 				.map( ( _, i ) => (
-					<DetailColumn mobileHidden key={ i }>
+					<Column mobileHidden key={ i }>
 						<LoadingPlaceholder className={ css( { maxWidth: 70 } ) } delayMS={ delayMS } />
-					</DetailColumn>
+					</Column>
 				) ) }
 		</Row>
 	);


### PR DESCRIPTION
## Proposed Changes

Fixes vertical alignment for loading placeholder on 'List' view (broken in https://github.com/Automattic/wp-calypso/pull/66897/files#diff-fa8dc364ba83ce81db7a80ee5a9aa47b06cff9b586f485912620e66614059369R27)

### Before

<img width="1363" alt="image" src="https://user-images.githubusercontent.com/36432/193698001-3596e2d6-d26d-45b1-a5a0-6403901f1c74.png">

### After

<img width="1373" alt="image" src="https://user-images.githubusercontent.com/36432/193697896-166db164-5be2-4e9e-8741-6c4c868bad94.png">

## Testing Instructions

1. Navigate to `/sites`.
2. View the improved loading placeholder in all of its glory.