### PR TITLE
Sign Up: Use 'Back to My Home' when user only has 1 site

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -37,7 +37,7 @@ import {
 	recordGoogleEvent,
 	recordTracksEvent,
 } from 'calypso/state/analytics/actions';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	recordAddDomainButtonClick,
 	recordAddDomainButtonClickInMapDomain,
@@ -766,7 +766,7 @@ class DomainsStep extends Component {
 			return null;
 		}
 
-		const { isAllDomains, translate, isReskinned } = this.props;
+		const { isAllDomains, translate, isReskinned, userSiteCount } = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;
 		const source = this.props.queryObject?.source;
@@ -775,7 +775,11 @@ class DomainsStep extends Component {
 		let isExternalBackUrl = false;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
-		const sitesBackLabelText = translate( 'Back to Sites' );
+		const sitesBackLabelText =
+			userSiteCount && userSiteCount === 1
+				? translate( 'Back to My Home' )
+				: translate( 'Back to Sites' );
+		const defaultBackUrl = userSiteCount && userSiteCount === 1 ? `/home` : `/sites`;
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;
@@ -796,10 +800,10 @@ class DomainsStep extends Component {
 				backUrl = `/settings/general/${ siteSlug }`;
 				backLabelText = translate( 'Back to General Settings' );
 			} else if ( 'sites-dashboard' === source ) {
-				backUrl = '/sites';
+				backUrl = defaultBackUrl;
 				backLabelText = sitesBackLabelText;
 			} else if ( backUrl === this.removeQueryParam( this.props.path ) ) {
-				backUrl = '/sites/';
+				backUrl = defaultBackUrl;
 				backLabelText = sitesBackLabelText;
 			}
 
@@ -891,6 +895,7 @@ export default connect(
 			siteType: getSiteType( state ),
 			selectedSite,
 			sites: getSitesItems( state ),
+			userSiteCount: getCurrentUserSiteCount( state ),
 			isPlanSelectionAvailableLaterInFlow:
 				( ! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ) ) ||
 				[ 'pro', 'starter' ].includes( flowName ),

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -775,11 +775,10 @@ class DomainsStep extends Component {
 		let isExternalBackUrl = false;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
-		const sitesBackLabelText =
+		const [ sitesBackLabelText, defaultBackUrl ] =
 			userSiteCount && userSiteCount === 1
-				? translate( 'Back to My Home' )
-				: translate( 'Back to Sites' );
-		const defaultBackUrl = userSiteCount && userSiteCount === 1 ? `/home` : `/sites`;
+				? [ translate( 'Back to My Home' ), '/home' ]
+				: [ translate( 'Back to Sites' ), '/sites' ];
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/901

## Proposed Changes

Defaults to 'Back to My Home' when a user only has one site, but 'Back to Sites' when user has zero or more than one site.

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/36432/193701301-a57568c6-01fe-43cb-9208-32a3ecc14ca3.png">

## Testing Instructions

1. Create a new WordPress.com account and a new site.
2. Click on 'Add new site' from the My Home sidebar.
3. Verify back link displays as 'Back to My Home'.
4. Proceed to create another site.
5. Once you've created your second site, click on 'Add new site' from the Site Switcher.
6. Verify back link displays as 'Back to Sites'.