### PR TITLE
CI: update artifact upload rules for MarTech build configuration.

### DIFF
--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -29,6 +29,9 @@ object ToSAcceptanceTracking: BuildType ({
 
 	artifactRules = """
 		tos_screenshots => tos_screenshots
+		logs.tgz => logs.tgz
+		recording => recording
+		trace => trace
 	""".trimIndent()
 
 	vcs {
@@ -54,7 +57,7 @@ object ToSAcceptanceTracking: BuildType ({
 				# Decrypt secrets
 				# Must do before build so the secrets are in the dist output
 				E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%" yarn workspace @automattic/calypso-e2e decrypt-secrets
-				
+
 				# Build packages
 				yarn workspace @automattic/calypso-e2e build
 			""".trimIndent()
@@ -85,6 +88,15 @@ object ToSAcceptanceTracking: BuildType ({
 
 				mkdir -p tos_screenshots
 				find test/e2e -type f -path '*tos*.png' -print0 | xargs -r -0 mv -t tos_screenshots
+
+				mkdir -p recording
+				find test/e2e/results -type f \( -iname \*.webm \) -print0 | xargs -r -0 mv -t recording
+
+				mkdir -p logs
+				find test/e2e/ -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+
+				mkdir -p trace
+				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the artifact rules used by TeamCity to look for and upload artifacts.

Key changes:
- update the martech build configuration's artifact rule to include traces and recordings.

Context: p1664788005938449-slack-C0313NGSK8R

#### Testing Instructions

Run the following build configuration:
  - [ ] ToS Screenshot 

When the build configuration finishes, under the "Artifacts tab" there are logs (always) and recordings (if there is a failure).

Example failed run:
![image](https://user-images.githubusercontent.com/6549265/193703352-f5d7025b-7379-4092-8a81-73af321c81ed.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #