### PR TITLE
Only add entry button for posts stats item, not others.

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -183,14 +183,16 @@ class StatsListItem extends Component {
 				}
 			}, this );
 
-			actionItems.push(
-				<Promote
-					postId={ data.id }
-					key={ 'promote-post-' + data.id }
-					moduleName={ moduleName }
-					onToggleVisibility={ onTogglePromoteWidget }
-				/>
-			);
+			if ( this.props.moduleName === 'posts' ) {
+				actionItems.push(
+					<Promote
+						postId={ data.id }
+						key={ 'promote-post-' + data.id }
+						moduleName={ moduleName }
+						onToggleVisibility={ onTogglePromoteWidget }
+					/>
+				);
+			}
 
 			if ( actionItems.length > 0 ) {
 				actionList = <ul className={ actionClassSet }>{ actionItems }</ul>;


### PR DESCRIPTION
#### Proposed Changes
The `<StatsListItem>` component is shared for multiple places on the stats page: posts, followers, etc. We really only want to add the `promote` entry button to posts type.
 

#### Testing Instructions
Before:
The button shows up for followers section as well.
![image](https://user-images.githubusercontent.com/6070516/193713267-bfd210b5-c8e0-444d-aa2e-deee38ab4acc.png)
After:
The speaker button only show up for posts section.
![image](https://user-images.githubusercontent.com/6070516/193713304-7774033e-c866-4bf0-972b-0b0026d28211.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
