### PR TITLE
Style selection: Support premium/WooCommerce badges in the new theme preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -589,6 +589,17 @@ $break-design-preview: 1024px;
 			@include break-design-preview {
 				display: none;
 			}
+
+			.design-picker-design-title__container {
+				.premium-badge,
+				.woocommerce-bundled-badge {
+					display: none;
+
+					@include break-small {
+						display: inline-flex;
+					}
+				}
+			}
 		}
 
 		.step-container__navigation {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -418,7 +418,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 						require="@automattic/design-preview"
 						placeholder={ null }
 						previewUrl={ previewUrl }
-						title={ designTitle }
+						title={ headerDesignTitle }
 						description={ selectedDesign.description }
 						variations={ selectedDesignDetails?.style_variations }
 						selectedVariation={ selectedStyleVariation }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -62,6 +62,20 @@ $break-design-preview: 1024px;
 			letter-spacing: -0.4px;
 			line-height: 32px;
 		}
+
+		.design-picker-design-title__container {
+			align-items: flex-start;
+			display: flex;
+			flex-direction: column-reverse;
+			gap: 16px;
+			justify-content: center;
+
+			.premium-badge,
+			.woocommerce-bundled-badge {
+				letter-spacing: 0.2px;
+				margin: 0;
+			}
+		}
 	}
 
 	.design-preview__sidebar-description {


### PR DESCRIPTION
#### Proposed Changes

This PR adds support to Premium/WooCommerce badges in the new theme preview. See screenshot for reference:
![Screen Shot 2022-10-04 at 12 00 15 PM](https://user-images.githubusercontent.com/797888/193731433-154c6985-44f4-42f2-84c7-5c00ba592310.png)

Note that currently, there are no WooCommerce-bundled themes with style variations. And for premium themes with style variations, there's only the theme Varese.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Click any theme with style variations that has a badge, and ensure that the theme preview will also have the badge.
* Ensure that the old theme preview isn't affected by this PR.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68440