### PR TITLE
Add WooCommerce lost password screen

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -480,6 +480,7 @@ class Login extends Component {
 			isWoo,
 			translate,
 			isPartnerSignup,
+			action,
 		} = this.props;
 
 		if ( socialConnect ) {
@@ -488,6 +489,28 @@ class Login extends Component {
 					require="calypso/blocks/login/social-connect-prompt"
 					onSuccess={ this.handleValidLogin }
 				/>
+			);
+		}
+
+		if ( action === 'lostpassword' ) {
+			return (
+				<Fragment>
+					<AsyncLoad
+						require="calypso/blocks/login/lost-password-form"
+						redirectToAfterLoginUrl={ this.props.redirectTo }
+						oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
+						locale={ locale }
+					/>
+					<div className="login__lost-password-footer">
+						<p className="login__lost-password-no-account">
+							{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+								components: {
+									signupLink: <a href={ this.getSignupUrl() } />,
+								},
+							} ) }
+						</p>
+					</div>
+				</Fragment>
 			);
 		}
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -255,14 +255,12 @@ class Login extends Component {
 			isPartnerSignup,
 			isWoo,
 			action,
+			currentQuery,
 		} = this.props;
 
 		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
-		const currentUrl = new URL( window.location.href );
-		const displayLostPasswordConfirmation =
-			currentUrl.searchParams.get( 'lostpassword_flow' ) === 'true';
 
 		if ( isManualRenewalImmediateLoginAttempt ) {
 			headerText = translate( 'Log in to update your payment details and renew your subscription' );
@@ -329,7 +327,7 @@ class Login extends Component {
 					);
 				} else if ( this.props.twoFactorEnabled ) {
 					headerText = <h3>{ translate( 'Authenticate your login' ) }</h3>;
-				} else if ( displayLostPasswordConfirmation ) {
+				} else if ( currentQuery.lostpassword_flow ) {
 					headerText = null;
 					postHeader = (
 						<p className="login__header-subtitle">
@@ -366,7 +364,7 @@ class Login extends Component {
 				);
 
 				// If users arrived here from the lost password flow, show them a specific message about it
-				postHeader = displayLostPasswordConfirmation && (
+				postHeader = currentQuery.lostpassword_flow && (
 					<p className="login__form-post-header">
 						{ translate(
 							'Check your e-mail address linked to the account for the confirmation link, including the spam or junk folder.'

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -73,6 +73,7 @@ class Login extends Component {
 		redirectTo: PropTypes.string,
 		isPartnerSignup: PropTypes.bool,
 		loginEmailAddress: PropTypes.string,
+		action: PropTypes.string,
 	};
 
 	state = {
@@ -253,11 +254,15 @@ class Login extends Component {
 			isAnchorFmSignup,
 			isPartnerSignup,
 			isWoo,
+			action,
 		} = this.props;
 
 		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
+		const currentUrl = new URL( window.location.href );
+		const displayLostPasswordConfirmation =
+			currentUrl.searchParams.get( 'lostpassword_flow' ) === 'true';
 
 		if ( isManualRenewalImmediateLoginAttempt ) {
 			headerText = translate( 'Log in to update your payment details and renew your subscription' );
@@ -271,6 +276,15 @@ class Login extends Component {
 					service: capitalize( linkingSocialService ),
 				},
 			} );
+		} else if ( action === 'lostpassword' ) {
+			headerText = <h3>{ translate( 'Forgot your password?' ) }</h3>;
+			postHeader = (
+				<p className="login__header-subtitle">
+					{ translate(
+						'It happens to the best of us. Enter the email address associated with your WordPress.com account and we’ll send you a link to reset your password.'
+					) }
+				</p>
+			);
 		} else if ( privateSite ) {
 			headerText = translate( 'This is a private WordPress.com site' );
 		} else if ( oauth2Client ) {
@@ -315,6 +329,15 @@ class Login extends Component {
 					);
 				} else if ( this.props.twoFactorEnabled ) {
 					headerText = <h3>{ translate( 'Authenticate your login' ) }</h3>;
+				} else if ( displayLostPasswordConfirmation ) {
+					headerText = null;
+					postHeader = (
+						<p className="login__header-subtitle">
+							{ translate(
+								"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
+							) }
+						</p>
+					);
 				} else {
 					headerText = <h3>{ translate( 'Get started in minutes' ) }</h3>;
 					postHeader = (
@@ -343,9 +366,6 @@ class Login extends Component {
 				);
 
 				// If users arrived here from the lost password flow, show them a specific message about it
-				const currentUrl = new URL( window.location.href );
-				const displayLostPasswordConfirmation =
-					currentUrl.searchParams.get( 'lostpassword_flow' ) === 'true';
 				postHeader = displayLostPasswordConfirmation && (
 					<p className="login__form-post-header">
 						{ translate(

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -688,14 +688,19 @@ export class LoginForm extends Component {
 					{ this.props.isWoo && ! this.props.isPartnerSignup && (
 						<a
 							className="login__form-forgot-password"
-							href={ login( {
-								redirectTo,
-								locale,
-								action: 'lostpassword',
-								oauth2ClientId: oauth2Client && oauth2Client.id,
-							} ) }
-							onClick={ this.recordResetPasswordLinkClick }
-							rel="external"
+							href="/"
+							onClick={ ( event ) => {
+								event.preventDefault();
+								this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
+								page(
+									login( {
+										redirectTo,
+										locale,
+										action: 'lostpassword',
+										oauth2ClientId: oauth2Client && oauth2Client.id,
+									} )
+								);
+							} }
 						>
 							{ this.props.translate( 'Forgot password?' ) }
 						</a>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -19,7 +19,7 @@ import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { lostPassword } from 'calypso/lib/paths';
+import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
@@ -515,6 +515,7 @@ export class LoginForm extends Component {
 			showSocialLoginFormOnly,
 			isWoo,
 			isPartnerSignup,
+			redirectTo,
 		} = this.props;
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
@@ -687,7 +688,12 @@ export class LoginForm extends Component {
 					{ this.props.isWoo && ! this.props.isPartnerSignup && (
 						<a
 							className="login__form-forgot-password"
-							href={ lostPassword( this.props.locale ) }
+							href={ login( {
+								redirectTo,
+								locale,
+								action: 'lostpassword',
+								oauth2ClientId: oauth2Client && oauth2Client.id,
+							} ) }
 							onClick={ this.recordResetPasswordLinkClick }
 							rel="external"
 						>

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,0 +1,101 @@
+import { FormInputValidation } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useState } from 'react';
+import FormsButton from 'calypso/components/forms/form-button';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { login } from 'calypso/lib/paths';
+
+const LostPasswordForm = ( { redirectToAfterLoginUrl, oauth2ClientId, locale } ) => {
+	const translate = useTranslate();
+	const [ email, setEmail ] = useState( '' );
+	const [ error, setError ] = useState( null );
+
+	const validateEmail = () => {
+		if ( email.length === 0 || email.includes( '@' ) ) {
+			setError( null );
+		} else {
+			setError( translate( 'This email address is not valid. It must include a single @' ) );
+		}
+	};
+
+	const lostPasswordRequest = async () => {
+		const formData = new FormData();
+		formData.set( 'user_login', email );
+
+		const origin = typeof window !== 'undefined' ? window.location.origin : '';
+		const resp = await window.fetch( `${ origin }/wp-login.php?action=lostpassword`, {
+			method: 'POST',
+			body: formData,
+			credentials: 'include',
+		} );
+
+		if ( resp.status < 200 || resp.status >= 300 ) {
+			throw resp;
+		}
+		return await resp.text();
+	};
+
+	const onSubmit = async ( event ) => {
+		event.preventDefault();
+
+		try {
+			const result = await lostPasswordRequest();
+			if ( result.includes( 'Unable to reset password' ) ) {
+				return setError(
+					translate( "I'm sorry, but we weren't able to find a user with that login information." )
+				);
+			}
+
+			page(
+				login( {
+					oauth2ClientId,
+					locale,
+					redirectTo: redirectToAfterLoginUrl,
+					emailAddress: email,
+					lostpasswordFlow: true,
+				} )
+			);
+		} catch ( _httpError ) {
+			setError(
+				translate( 'There was an error sending the password reset email. Please try again.' )
+			);
+		}
+	};
+
+	const showError = !! error;
+	return (
+		<form
+			name="lostpasswordform"
+			className="login__lostpassword-form"
+			method="post"
+			onSubmit={ onSubmit }
+		>
+			<div className="login__form-userdata">
+				<FormLabel htmlFor="email">{ translate( 'Your email address' ) }</FormLabel>
+				<FormTextInput
+					autoCapitalize="off"
+					autoCorrect="off"
+					spellCheck="false"
+					autoComplete="email"
+					id="email"
+					name="email"
+					type="email"
+					value={ email }
+					isError={ showError }
+					onBlur={ validateEmail }
+					onChange={ ( event ) => setEmail( event.target.value.trim() ) }
+				/>
+				{ showError && <FormInputValidation isError text={ error } /> }
+			</div>
+			<div className="login__form-action">
+				<FormsButton primary type="submit" disabled={ email.length === 0 || showError }>
+					{ translate( 'Reset my password' ) }
+				</FormsButton>
+			</div>
+		</form>
+	);
+};
+
+export default LostPasswordForm;

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LostPasswordForm from 'calypso/blocks/login/lost-password-form';
+
+describe( 'LostPasswordForm', () => {
+	test( 'displays a lost password form without errors', () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		const email = screen.getByLabelText( /Your email address/i );
+		expect( email ).toBeInTheDocument();
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( btn ).toBeInTheDocument();
+		expect( btn ).toBeDisabled();
+
+		expect( screen.queryByRole( 'alert' ) ).toBeNull();
+	} );
+
+	test( 'displays an error message when email is invalid', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Your email address' } ),
+			'invalid email'
+		);
+		// The error message is displayed after the user blurs the input.
+		userEvent.tab();
+
+		expect( screen.getByRole( 'alert' ) ).toBeInTheDocument();
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( btn ).toBeDisabled();
+	} );
+
+	test( 'enable submit button when email is valid', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Your email address' } ),
+			'user@example.com'
+		);
+		// The error message is displayed after the user blurs the input.
+		userEvent.tab();
+
+		const btn = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( btn ).toBeEnabled();
+	} );
+
+	test( 'reset error message when email is valid', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Your email address' } ),
+			'invalid email'
+		);
+		// The error message is displayed after the user blurs the input.
+		userEvent.tab();
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Your email address' } ),
+			'user@example.com'
+		);
+		// The error message is displayed after the user blurs the input.
+		userEvent.tab();
+
+		expect( screen.queryByRole( 'alert' ) ).toBeNull();
+	} );
+
+	test( 'reset error message when email is empty', async () => {
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Your email address' } ),
+			'invalid email'
+		);
+		// The error message is displayed after the user blurs the input.
+		userEvent.tab();
+
+		await userEvent.clear( screen.getByRole( 'textbox', { name: 'Your email address' } ) );
+		// The error message is displayed after the user blurs the input.
+		userEvent.tab();
+
+		expect( screen.queryByRole( 'alert' ) ).toBeNull();
+	} );
+} );

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -501,7 +501,8 @@
 		}
 	}
 
-	.login__two-factor-footer {
+	.login__two-factor-footer,
+	.login__lost-password-footer {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -571,6 +572,14 @@
 
 	.logged-out-form__links {
 		text-align: center;
+	}
+
+	.login__lostpassword-form {
+		margin-top: 50px;
+
+		.login__form-action {
+			margin: 16px 0 52px;
+		}
 	}
 
 	// Signup styles

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -233,6 +233,7 @@
 		font-size: $font-body;
 		padding-bottom: 0;
 		margin: 0;
+		line-height: 24px;
 
 		a {
 			color: var(--studio-gray-100);

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -41,6 +41,7 @@ export function login( {
 	signupUrl = undefined,
 	useQRCode = undefined,
 	isPartnerSignup = undefined,
+	action = undefined,
 	lostpasswordFlow = undefined,
 } = {} ) {
 	let url = '/log-in';
@@ -63,6 +64,8 @@ export function login( {
 		url += '/link';
 	} else if ( useQRCode ) {
 		url += '/qr';
+	} else if ( action ) {
+		url += '/' + action;
 	}
 
 	if ( locale && locale !== 'en' ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -41,6 +41,7 @@ export function login( {
 	signupUrl = undefined,
 	useQRCode = undefined,
 	isPartnerSignup = undefined,
+	lostpasswordFlow = undefined,
 } = {} ) {
 	let url = '/log-in';
 
@@ -104,6 +105,10 @@ export function login( {
 
 	if ( isPartnerSignup ) {
 		url = addQueryArgs( { is_partner_signup: true }, url );
+	}
+
+	if ( lostpasswordFlow ) {
+		url = addQueryArgs( { lostpassword_flow: true }, url );
 	}
 
 	return url;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -12,7 +12,7 @@ import WPLogin from './wp-login';
 
 const enhanceContextWithLogin = ( context ) => {
 	const {
-		params: { flow, isJetpack, isGutenboarding, socialService, twoFactorAuthType },
+		params: { flow, isJetpack, isGutenboarding, socialService, twoFactorAuthType, action },
 		path,
 		query,
 		isServerSide,
@@ -48,6 +48,7 @@ const enhanceContextWithLogin = ( context ) => {
 
 	context.primary = (
 		<WPLogin
+			action={ action }
 			isJetpack={ isJetpack === 'jetpack' }
 			isGutenboarding={ isGutenboarding === 'new' }
 			isP2Login={ query && query.from === 'p2' }

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -99,6 +99,7 @@ export default ( router ) => {
 			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 			`/log-in/:isGutenboarding(new)/${ lang }`,
 			`/log-in/:isGutenboarding(new)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:action(lostpassword)/${ lang }`,
 			`/log-in/${ lang }`,
 		],
 		redirectJetpack,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -49,6 +49,7 @@ export class Login extends Component {
 		socialServiceResponse: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
+		action: PropTypes.string,
 	};
 
 	static defaultProps = { isJetpack: false, isGutenboarding: false, isLoginView: true };
@@ -233,6 +234,7 @@ export class Login extends Component {
 			isLoginView,
 			path,
 			signupUrl,
+			action,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
@@ -267,6 +269,7 @@ export class Login extends Component {
 
 		return (
 			<LoginBlock
+				action={ action }
 				twoFactorAuthType={ twoFactorAuthType }
 				socialConnect={ socialConnect }
 				privateSite={ privateSite }


### PR DESCRIPTION
#### Proposed Changes

* Add `/log-in/lostpassword` path
* Add lost password screen
* Update lost password link
* Add password reset confirmation texts

![Screen Shot 2022-10-04 at 14 42 30](https://user-images.githubusercontent.com/4344253/193751674-bb1140b7-d23c-4013-900d-409cf44f1a6c.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1 Create an SSL cert and add it to your trusted store

```bash
# These commands are for OSX and Chrome.
# In a different system you may need to change the path for 
# /System/Library/OpenSSL/openssl.cnf and manually trust
# the generated certificate
 
# Generate the certificate
openssl req \
    -newkey rsa:2048 \
    -x509 \
    -nodes \
    -keyout ./config/server/key.pem \
    -new \
    -out ./config/server/certificate.pem \
    -subj /CN=wordpress.com \
    -reqexts SAN \
    -extensions SAN \
    -config <(cat /System/Library/OpenSSL/openssl.cnf \
     <(printf '[SAN]\nsubjectAltName=DNS:wpcalypso.wordpress.com')) \
    -sha256 \
    -days 365
 
# Add it to the trusted certificates
sudo security add-trusted-cert -d -k $(security list-keychains | grep System | cut -d '"' -f 2 ) ./config/server/certificate.pem
```

2. Add 127.0.0.1 wpcalypso.wordpress.com to your /etc/hosts
3. Install nginx and use the following config (This is required because the lost password API doesn't allow cross-domain POST)

```nginx
server {
    listen 443 ssl;
    server_name wpcalypso.wordpress.com;

    ssl on;
    ssl_certificate <change_me>/wp-calypso/config/server/certificate.pem;
    ssl_certificate_key <change_me>/wp-calypso/config/server/key.pem;

    location / {
        proxy_pass https://wordpress.com;
        proxy_set_header Host $http_host;
    }

    location /calypso {
        proxy_pass http://127.0.0.1:3000;
    }

    location /cspreport {
       proxy_pass http://127.0.0.1:3000;
    }

    location /version {
        proxy_pass http://127.0.0.1:3000;
    }

    location /start {
        proxy_pass http://127.0.0.1:3000;
    }

    location /log-in {
        proxy_pass http://127.0.0.1:3000;
    }
}
```

4. Run `HOST=wpcalypso.wordpress.com yarn start`
5. Make sure you're logged out WordPress.com account.
6. Go to https://wpcalypso.wordpress.com/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db619bf885d5c3bdbd46a1a66ea64f94c670474617a86395365c12699fd779073%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%3D%26calypso_env%3Dproduction
7. Click "Frogot password?" link
8. Observer that the lost password screen should match the design - 4ixWMlzrxllx93tSFsCW6k-fi-2656%3A39861
9. Enter an invalid email address
10. Should display `This email address is not valid. It must include a single @`
11. Enter a valid email address but not a existing wp account such as `user-not-exist@example.com`
12. Should display `I'm sorry, but we weren't able to find a user with that login information.`
13. Enter an existing wp account's email address
14. Should be redirect to log in screen with the sub header text `Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account.` - 4ixWMlzrxllx93tSFsCW6k-fi-3304%3A47465
15. Should receive a reset password email in your inbox


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 85-gh-woocommerce/team-ghidorah