### PR TITLE
Stepper Framework: Avoid calypso_signup_step_start event being fired multiple times

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -68,6 +68,10 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		if ( currentRoute ) {
 			recordStepStart( flow.name, kebabCase( currentRoute ), { intent } );
 		}
+
+		// We leave out intent from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
+		// This causes the intent to become empty, and thus this event being fired again.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ flow.name, currentRoute ] );
 
 	const assertCondition = flow.useAssertConditions?.() ?? { state: AssertConditionState.SUCCESS };

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -64,8 +64,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	}, [ location ] );
 
 	useEffect( () => {
-		recordStepStart( flow.name, kebabCase( currentRoute ), { intent } );
-	}, [ flow.name, currentRoute, intent ] );
+		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
+		if ( currentRoute ) {
+			recordStepStart( flow.name, kebabCase( currentRoute ), { intent } );
+		}
+	}, [ flow.name, currentRoute ] );
 
 	const assertCondition = flow.useAssertConditions?.() ?? { state: AssertConditionState.SUCCESS };
 


### PR DESCRIPTION
#### Proposed Changes

* Fix the `calypso_signup_step_start` event that is fired multiple times whenever the intent is changed. For example, when you finish the onboarding flow and enter the processing step, this event will be fired at the beginning. Next, calypso will reset the `ONBOARD_STORE` and the intent will become empty, and it leads to this event being fired again.
* Additionally, this event is fired even though the step is empty. I think it's weird, so this PR also addresses this issue.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* When you land on the goal screen, check the `calypso_signup_step_start` event is fired once.
* When you finish the onboarding flow (ex. Build flow) and enter the processing step, check the event is fired once too

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68531
