### PR TITLE
Tailored Flows: Replace Calypso input fields with Wordpress/TextControl

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -234,9 +234,9 @@ button {
 			border-radius: 4px;
 			border: 1px solid var(--studio-gray-10);
 
-			&:focus {
-				box-shadow: 0 0 0 2px #e2eaf1;
-			}
+			// &:focus {
+			// 	box-shadow: 0 0 0 2px #e2eaf1;
+			// }
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -233,10 +233,6 @@ button {
 			font-size: $font-body-small;
 			border-radius: 4px;
 			border: 1px solid var(--studio-gray-10);
-
-			// &:focus {
-			// 	box-shadow: 0 0 0 2px #e2eaf1;
-			// }
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -227,13 +227,6 @@ button {
 			font-size: $font-body;
 			color: var(--studio-gray-60);
 		}
-
-		input[type="text"].form-text-input,
-		textarea.form-textarea {
-			font-size: $font-body-small;
-			border-radius: 4px;
-			border: 1px solid var(--studio-gray-10);
-		}
 	}
 
 	.progress-bar {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -5,6 +5,7 @@
 	background-size: 25px, auto;
 	background-position: left 13px center, 95% !important;
 	background-repeat: no-repeat, no-repeat !important;
+	height: 44px;
 
 	/* Overwrites the transition value set by FormInput component.
     It was the cause of the https://github.com/Automattic/wp-calypso/issues/67326 */
@@ -39,6 +40,7 @@
 		width: 100%;
 
 		.select-dropdown__header {
+			height: 44px;
 			border-radius: 4px;
 			font-weight: 400;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -63,15 +63,6 @@ const SetupForm = ( {
 		reader.onerror = () => setBase64Image( null );
 	};
 
-	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
-		switch ( event.currentTarget.name ) {
-			case 'setup-form-input-name':
-				return setComponentSiteTitle( event.currentTarget.value );
-			case 'setup-form-input-description':
-				return setTagline( event.currentTarget.value );
-		}
-	};
-
 	useEffect( () => {
 		if ( siteTitle.trim().length && invalidSiteTitle ) {
 			setInvalidSiteTitle( false );
@@ -96,9 +87,8 @@ const SetupForm = ( {
 					name="setup-form-input-name"
 					id="setup-form-input-name"
 					value={ siteTitle }
-					onChange={ onChange }
+					onChange={ ( value ) => setComponentSiteTitle( value ) }
 					placeholder={ translatedText?.titlePlaceholder || __( 'My Site Name' ) }
-					isError={ invalidSiteTitle }
 				/>
 				{ invalidSiteTitle && (
 					<FormInputValidation
@@ -118,7 +108,9 @@ const SetupForm = ( {
 					value={ tagline }
 					placeholder={ translatedText?.taglinePlaceholder || __( 'Add a short description here' ) }
 					enableAutoFocus={ false }
-					onChange={ onChange }
+					onChange={ ( event: React.FormEvent< HTMLInputElement > ) =>
+						setTagline( event.currentTarget.value )
+					}
 				/>
 			</FormFieldset>
 			{ children }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button, FormInputValidation } from '@automattic/components';
+import { TextControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { Dispatch, FormEvent, ReactChild, SetStateAction, useEffect } from 'react';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
 import { ForwardedAutoresizingFormTextarea } from 'calypso/blocks/comments/autoresizing-form-textarea';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormInput from 'calypso/components/forms/form-text-input';
 import { SiteIconWithPicker } from 'calypso/components/site-icon-with-picker';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 
@@ -91,8 +91,8 @@ const SetupForm = ( {
 				selectedFile={ selectedFile }
 			/>
 			<FormFieldset>
-				<FormLabel htmlFor="setup-form-input-name">{ __( 'Site name' ) }</FormLabel>
-				<FormInput
+				<TextControl
+					label={ __( 'Site name' ) }
 					name="setup-form-input-name"
 					id="setup-form-input-name"
 					value={ siteTitle }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -22,15 +22,12 @@
 	}
 
 	label,
-	input,
 	textarea {
 		font-family: "SF Pro Text", $sans;
 		font-weight: 400;
 	}
 
-	input,
-	textarea,
-	input[type="text"].form-text-input,
+	textarea.form-textarea,
 	pre {
 		color: var(--studio-gray-100);
 		font-size: $font-body-small;
@@ -40,6 +37,11 @@
 		border-radius: 4px;
 		background-repeat: no-repeat;
 		background-position: 95%;
+		&:focus {
+			border-color: var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			outline: 2px solid transparent;
+		}
 	}
 
 	.form-input-validation {
@@ -47,7 +49,7 @@
 	}
 
 	.form-label {
-		color: var(--studio-black);
+		color: var(--studio-gray-60);
 		margin-bottom: 8px;
 	}
 
@@ -56,8 +58,12 @@
 		font-size: $font-body;
 	}
 
-	input {
-		height: 44px;
+	input[type="text"] {
+		border-color: var(--studio-gray-10);
+		border-radius: 4px;
+		box-sizing: border-box;
+		font-size: 0.875rem;
+		padding: 0.875rem 1rem;
 	}
 
 	.setup-form__submit {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -72,6 +72,7 @@
 		box-sizing: border-box;
 		font-size: 0.875rem;
 		padding: 0.875rem 1rem;
+		height: 44px;
 	}
 
 	.setup-form__submit {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -44,6 +44,14 @@
 		}
 	}
 
+	pre {
+		border: none;
+	}
+
+	textarea.form-textarea {
+		overflow: hidden;
+	}
+
 	.form-input-validation {
 		padding-bottom: 0;
 	}


### PR DESCRIPTION
## Proposed Changes

Remove [calypso input](https://github.com/Automattic/wp-calypso/blob/2f1bc6bf722d1ac2296382366841d864432662f0/client/components/forms/form-text-input/index.jsx) and use [Wordpress input](https://developer.wordpress.org/block-editor/reference-guides/components/text-control/) for setup steps ( LiB and NL ).

The main idea is to have all the input text behaving and looking the same ( when possible )


## Testing Instructions
- Check this branch and navigate to both Flow, NL and LiB
- Compare if it looks the same as a production
- It should have the correct hover states for the inputs.

Related to #68298
Fixes #68298
