### PR TITLE
Add client_id prop to `calypso_signup_social_button_click` event

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -57,6 +57,7 @@ class SocialSignupForm extends Component {
 	trackSocialSignup = ( service ) => {
 		this.props.recordTracksEvent( 'calypso_signup_social_button_click', {
 			social_account_type: service,
+			client_id: this.props.oauth2Client?.id,
 		} );
 	};
 
@@ -146,6 +147,7 @@ class SocialSignupForm extends Component {
 export default connect(
 	( state ) => ( {
 		currentRoute: getCurrentRoute( state ),
+		oauth2Client: getCurrentOAuth2Client( state ),
 		isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
 	} ),
 	{ recordTracksEvent }


### PR DESCRIPTION
#### Proposed Changes

* Add client_id prop to `calypso_signup_social_button_click` event so we can filter the event records by the oauth client.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a local https://wpcalypso.wordpress.com environment 
* Go to https://wpcalypso.wordpress.com/start/wpcc/oauth2-user?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db619bf885d5c3bdbd46a1a66ea64f94c670474617a86395365c12699fd779073%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%3D%26calypso_env%3Dproduction
* Enable logging `window.localStorage.setItem('debug', 'calypso:analytics')` in dev console
* Turn on "Preserve log" option in dev console
* Click "Contine with Google"
* Observe that `calypso_signup_social_button_click` is record with `cleint_id=50916` and `social_account_type=google`
* Click "Contine with Apple" 
* Observe that `calypso_signup_social_button_click` is record with `cleint_id=50916` and `social_account_type=apple`


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 94-gh-woocommerce/team-ghidorah