### PR TITLE
Help Center: Show to 10% of users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -387,10 +387,10 @@ function load_help_center() {
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
 	// phpcs:disable Squiz.PHP.CommentedOutCode.Found
-	// $current_segment = 30; // segment of existing users that will get the help center in %.
-	// $user_segment    = get_current_user_id() % 100;
+	$current_segment = 10; // segment of existing users that will get the help center in %.
+	$user_segment    = get_current_user_id() % 100;
 
-	if ( $is_proxied ) {
+	if ( $is_proxied || $user_segment < $current_segment ) {
 		require_once __DIR__ . '/help-center/class-help-center.php';
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,7 +386,6 @@ function load_help_center() {
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
-	// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 	$current_segment = 10; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -8,9 +8,9 @@ import { isWpMobileApp } from 'calypso/lib/mobile-app';
 export function shouldShowHelpCenterToUser( userId: number ) {
 	const isNonProdEnv = [ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) );
 
-	// const currentSegment = 30; //percentage of users that will see the Help Center, not the FAB
-	// const userSegment = userId % 100;
-	return isNonProdEnv; // || userSegment < currentSegment;
+	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
+	const userSegment = userId % 100;
+	return isNonProdEnv || userSegment < currentSegment;
 }
 
 export function shouldLoadInlineHelp( sectionName: string, currentRoute: string ) {


### PR DESCRIPTION
This enables the help-center back for 10% of our users.

Test while not proxied, you can use `testing10percentid` user to try it.

