### PR TITLE
Help Center: show the Help Center in my home

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -243,7 +243,9 @@ class Layout extends Component {
 		};
 
 		const loadHelpCenter =
-			shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute ) &&
+			// we want to show only the Help center in my home
+			( this.props.sectionName === 'home' ||
+				shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute ) ) &&
 			this.props.userAllowedToHelpCenter;
 
 		const loadInlineHelp =


### PR DESCRIPTION
#### Proposed Changes

* The inline help has a lot of overlap with the help widget in my home. But the Help Center has little to do with.
* Hiding the Help center in my home is making the master bar inconsistent across pages, something the inline-help isn't affected by.
* This PR shows the Help Center in my home.

#### Testing Instructions

1. Check out this branch. 
2. Run yarn start.
3. Go to my Home.
4. The Help Center should be visible.