### PR TITLE
document/meta: `theme-color` should respect color scheme (if not set by config)

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -13,7 +13,7 @@ const Head = ( { title = 'WordPress.com', children, branchName, inlineScriptNonc
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />
-			<meta name="theme-color" content="var(--color-masterbar-background)" />
+			<meta name="theme-color" content={ config( 'theme_color' ) } />
 			<meta name="referrer" content="origin" />
 
 			<link

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -13,12 +13,7 @@ const Head = ( { title = 'WordPress.com', children, branchName, inlineScriptNonc
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />
-			<meta
-				name="theme-color"
-				content={
-					! config( 'theme_color' ) ? 'var(--color-masterbar-background)' : config( 'theme_color' )
-				}
-			/>
+			<meta name="theme-color" content="var(--color-masterbar-background)" />
 			<meta name="referrer" content="origin" />
 
 			<link

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -15,7 +15,9 @@ const Head = ( { title = 'WordPress.com', children, branchName, inlineScriptNonc
 			<meta name="apple-mobile-web-app-capable" content="yes" />
 			<meta
 				name="theme-color"
-				content={ ! config( 'theme_color' ) ? '#016087' : config( 'theme_color' ) }
+				content={
+					! config( 'theme_color' ) ? 'var(--color-masterbar-background)' : config( 'theme_color' )
+				}
 			/>
 			<meta name="referrer" content="origin" />
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -156,7 +156,7 @@ class Layout extends Component {
 					.trim();
 				const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
 				// We only want to set `themeColor` if it's not set by a config value (i.e. for JetpackCloud)
-				if ( ! themeColorMeta.content ) {
+				if ( themeColorMeta && ! themeColorMeta.content ) {
 					themeColorMeta.content = themeColor;
 					themeColorMeta.setAttribute( 'data-colorscheme', 'true' );
 				}
@@ -181,7 +181,7 @@ class Layout extends Component {
 				.trim();
 			const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
 			// We only adjust the `theme-color` meta content value in case we set it in `componentDidMount`
-			if ( themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
+			if ( themeColorMeta && themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
 				themeColorMeta.content = themeColor;
 			}
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -155,7 +155,7 @@ class Layout extends Component {
 					.getPropertyValue( '--color-masterbar-background' )
 					.trim();
 				const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
-				// We only want to set `themeColor` if it's not set by some config value (i.e. for JetpackCloud)
+				// We only want to set `themeColor` if it's not set by a config value (i.e. for JetpackCloud)
 				if ( ! themeColorMeta.content ) {
 					themeColorMeta.content = themeColor;
 					themeColorMeta.setAttribute( 'data-colorscheme', 'true' );
@@ -180,8 +180,7 @@ class Layout extends Component {
 				.getPropertyValue( '--color-masterbar-background' )
 				.trim();
 			const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
-			// We only want to set `themeColor` if it's not set by some config value (i.e. for JetpackCloud)
-			// `data-colorscheme` is only set if there wasn't a pre-defined value on app boot
+			// We only adjust the `theme-color` meta content value in case we set it in `componentDidMount`
 			if ( themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
 				themeColorMeta.content = themeColor;
 			}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -150,6 +150,16 @@ class Layout extends Component {
 				document
 					.querySelector( 'body' )
 					.classList.add( `is-${ this.props.colorSchemePreference }` );
+
+				const themeColor = getComputedStyle( document.body )
+					.getPropertyValue( '--color-masterbar-background' )
+					.trim();
+				const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
+				// We only want to set `themeColor` if it's not set by some config value (i.e. for JetpackCloud)
+				if ( ! themeColorMeta.content ) {
+					themeColorMeta.content = themeColor;
+					themeColorMeta.setAttribute( 'data-colorscheme', 'true' );
+				}
 			}
 		}
 	}
@@ -165,6 +175,16 @@ class Layout extends Component {
 			const classList = document.querySelector( 'body' ).classList;
 			classList.remove( `is-${ prevProps.colorSchemePreference }` );
 			classList.add( `is-${ this.props.colorSchemePreference }` );
+
+			const themeColor = getComputedStyle( document.body )
+				.getPropertyValue( '--color-masterbar-background' )
+				.trim();
+			const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
+			// We only want to set `themeColor` if it's not set by some config value (i.e. for JetpackCloud)
+			// `data-colorscheme` is only set if there wasn't a pre-defined value on app boot
+			if ( themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
+				themeColorMeta.content = themeColor;
+			}
 		}
 
 		// intentionally don't remove these in unmount

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -173,7 +173,7 @@
 		}
 	],
 	"restricted_me_access": true,
-	"theme_color": "#055d9c",
+	"theme_color": "",
 	"reskinned_flows": [
 		"launch-site",
 		"onboarding",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -135,7 +135,6 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
-	"theme_color": "#2fb41f",
 	"google_analytics_key": "UA-10673494-20",
 	"hotjar_enabled": true
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -135,6 +135,7 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
+	"theme_color": "#2fb41f",
 	"google_analytics_key": "UA-10673494-20",
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -75,5 +75,6 @@
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
-	"hotjar_enabled": true
+	"hotjar_enabled": true,
+	"theme_color": "#2fb41f"
 }


### PR DESCRIPTION
#### Proposed Changes

Set the `content` value of the `theme-color` meta tag according to the color scheme chosen by the user. We don't set the value in case it was already set on the server by defining a config value (which is the case for Jetpack Cloud).

#### Testing Instructions

* Make sure https://github.com/Automattic/wp-calypso/issues/68570 is fixed on this branch (using calypso.live link provided below)
* Make sure the color doesn't change if you're on a section related to Jetpack Cloud (using the calypo.live link provided below)

Fixes #68570
