### PR TITLE
When "WordPress.com Editing Toolkit" plugin is deactivated, site becomes public but settings page still shows launch button

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -11,10 +11,16 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
+import {
+	getSite,
+	getSiteSlug,
+	isSitePreviewable,
+	getSiteOption,
+} from 'calypso/state/sites/selectors';
 
 import './style.scss';
 
@@ -115,7 +121,7 @@ class Site extends Component {
 	};
 
 	render() {
-		const { isSiteUnlaunched, site, translate } = this.props;
+		const { isSiteUnlaunched, site, translate, isAtomicAndEditingToolkitDeactivated } = this.props;
 
 		if ( ! site ) {
 			// we could move the placeholder state here
@@ -137,7 +143,8 @@ class Site extends Component {
 
 		// We show public coming soon badge only when the site is not private.
 		// Check for `! site.is_private` to ensure two Coming Soon badges don't appear while we introduce public coming soon.
-		const shouldShowPublicComingSoonSiteBadge = ! site.is_private && this.props.site.is_coming_soon;
+		const shouldShowPublicComingSoonSiteBadge =
+			! site.is_private && this.props.site.is_coming_soon && ! isAtomicAndEditingToolkitDeactivated;
 
 		// Cover the coming Soon v1 cases for sites still unlaunched and/or in Coming Soon private by default.
 		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
@@ -238,6 +245,9 @@ function mapStateToProps( state, ownProps ) {
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		isSiteP2: isSiteWPForTeams( state, siteId ),
 		isP2Hub: isSiteP2Hub( state, siteId ),
+		isAtomicAndEditingToolkitDeactivated:
+			isAtomicSite( state, siteId ) &&
+			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
 	};
 }
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -624,6 +624,7 @@ export class SiteSettingsFormGeneral extends Component {
 			siteIsJetpack,
 			siteIsAtomic,
 			translate,
+			isAtomicAndEditingToolkitDeactivated,
 		} = this.props;
 
 		const classes = classNames( 'site-settings__general-settings', {
@@ -652,7 +653,9 @@ export class SiteSettingsFormGeneral extends Component {
 					</form>
 				</Card>
 
-				{ this.props.isUnlaunchedSite ? this.renderLaunchSite() : this.privacySettings() }
+				{ this.props.isUnlaunchedSite && ! isAtomicAndEditingToolkitDeactivated
+					? this.renderLaunchSite()
+					: this.privacySettings() }
 
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">


### PR DESCRIPTION
#### Proposed Changes

* Don't show the Launch site panel in general settings when the site is atomic, and Editing Toolkit is deactivated. We show the Privacy panel instead.

This change solves an issue originally reported in https://github.com/Automattic/wp-calypso/issues/48316. When in an atomic site the Editing Toolkit plugin is disabled, the Comming soon feature is disabled too, and the site is made `public`, which is all expected. However, because the site was never launched, the general settings show the launch panel when it should show the Privacy panel to change the site's privacy.



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an atomic site that has not been launched, go to plugins and deactivate the plugin `WordPress.com Editing Toolkit`
* Go to settings/general 
* You should see the Privacy panel with the public/private options: 

<img width="737" alt="Screen Shot 2565-10-04 at 18 38 24" src="https://user-images.githubusercontent.com/1881481/193810794-ee2be67f-38d1-4d3c-b3e1-5108d0847b68.png">

* You should NOT see the Launch site panel:

<img width="733" alt="Screen Shot 2565-10-05 at 15 04 20" src="https://user-images.githubusercontent.com/1881481/194011352-e97d5f10-3031-4e30-ba4b-2b0615bcc111.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/52596
