### PR TITLE
Stylelint: Remove needless and invalid disables

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,8 @@
 {
 	"extends": [ "@wordpress/stylelint-config/scss" ],
 	"plugins": [ "@signal-noise/stylelint-scales" ],
+	"reportInvalidScopeDisables": true,
+	"reportNeedlessDisables": true,
 	"rules": {
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -33,12 +33,10 @@ body.slider-width-workaround {
 		@include font-smoothing-antialiased;
 
 		// Overriding an existing core WP rule so the ID selector is necessary
-		// stylelint-disable-next-line selector-max-id
 		#wpwrap {
 			@include font-smoothing-antialiased;
 		}
 
-		// stylelint-disable-next-line selector-max-id
 		#wpadminbar * {
 			@include font-smoothing-antialiased;
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -140,7 +140,7 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading,
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
 	padding: $grid-unit-05 $grid-unit-20;
-	/* stylelint-disable-next-line scales/font-size, declaration-property-unit-allowed-list */
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 18px;
 	color: $white;
 	margin: 0 0 8px;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/nux-modal/style.scss
@@ -46,7 +46,7 @@
 	.wpcom-block-editor-nux-modal__title {
 		margin: 34px 0 0;
 		font-size: $font-headline-small;
-		font-weight: 500; // stylelint-disable-line scales/font-weights
+		font-weight: 500;
 		line-height: 1.2;
 
 		@include break-mobile {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
@@ -1,6 +1,3 @@
-// @TODO: remove the ignore rule and replace font sizes accordingly
-/* stylelint-disable scales/font-size */
-
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -43,7 +43,6 @@ $welcome-tour-card-media-extra-padding: 14%; // temporary value, to match the pa
 }
 
 // Adding it to hide the WelcomeTour when the W-icon is pressed on mobile
-// stylelint-disable-next-line selector-max-id
 #wpwrap.wp-responsive-open {
 
 	.tour-kit.wpcom-tour-kit {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -230,6 +230,8 @@
 		&:last-of-type {
 			border-right: 1px solid var(--color-neutral-light);
 			border-top-right-radius: 4px;
+			border-bottom-right-radius: 4px;
+
 
 			&.selected {
 				border-right-color: var(--color-primary);

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -223,14 +223,13 @@
 		}
 
 		&:first-of-type {
-			border-top-left-radius: 4px; /* stylelint-disable-line scales/radii */
-			border-bottom-left-radius: 4px; /* stylelint-disable-line scales/radii */
+			border-top-left-radius: 4px;
+			border-bottom-left-radius: 4px;
 		}
 
 		&:last-of-type {
 			border-right: 1px solid var(--color-neutral-light);
-			border-top-right-radius: 4px; /* stylelint-disable-line scales/radii */
-			border-bottom-right-radius: 4px; /* stylelint-disable-line scales/radii */
+			border-top-right-radius: 4px;
 
 			&.selected {
 				border-right-color: var(--color-primary);

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
@@ -1,7 +1,6 @@
 @import "@wordpress/base-styles/variables";
 
 @media ( max-width: 600px ) {
-	// stylelint-disable-next-line selector-max-id
 	.is-iframed #wpbody {
 		padding-top: 0;
 	}

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable selector-max-id */
-
 /**
  * General styles
  *

--- a/client/blocks/import/capture-retired/style.scss
+++ b/client/blocks/import/capture-retired/style.scss
@@ -66,7 +66,7 @@ $placeholder-color: #909398;
 		}
 
 		@include break-medium {
-			font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+			font-size: 2.75rem;
 		}
 
 		&::placeholder {

--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable scales/font-size */
-
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/calypso-color-schemes";

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -151,7 +151,6 @@
 
 .reader-full-post__story-content {
 	color: var(--color-neutral-70);
-	/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 	font-size: rem(17px);
 	line-height: 28px;
 }
@@ -242,7 +241,6 @@
 				height: 32px !important;
 				width: 32px !important;
 				line-height: 32px !important;
-				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 				font-size: rem(32px) !important;
 
 				.gridicon {
@@ -250,7 +248,6 @@
 						height: 32px !important;
 						width: 32px !important;
 						line-height: 32px !important;
-						/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 						font-size: rem(32px) !important;
 					}
 				}
@@ -334,7 +331,6 @@
 	.reader-share__button-label,
 	.comment-button__label,
 	.like-button__label {
-		/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 		font-size: rem(17px);
 	}
 }

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -173,7 +173,7 @@
 
 body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion.card {
 	border: none;
-	border-radius: 0; /* stylelint-disable-line scales/radii */
+	border-radius: 0;
 	margin: 0;
 	align-items: center;
 	background: #fff;
@@ -247,7 +247,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	&.featured-domain-suggestion--is-placeholder {
 		margin-bottom: 1px;
 		margin-top: 0;
-		border-radius: 0; /* stylelint-disable-line scales/radii */
+		border-radius: 0;
 		border-bottom: none;
 
 		@include break-mobile {

--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -18,7 +18,7 @@ $screen-options-icon-border-y: 7px;
 
 .screen-options-tab__button {
 	border: 1px solid var(--color-neutral-5);
-	border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+	border-radius: 0 0 4px 4px;
 	background-color: #fff;
 	font-size: $default-font-size;
 	padding: 3px 16px;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -143,12 +143,12 @@
 				border-bottom: 1px solid #343c3f;
 
 				&:first-child {
-					border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
+					border-radius: 4px 4px 0 0;
 				}
 
 				&:last-child {
 					border-bottom: none;
-					border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+					border-radius: 0 0 4px 4px;
 				}
 
 				.videos-ui__duration {

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -34,7 +34,7 @@
 
 			color: var(--color-text);
 
-			font-size: rem(21px); /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: rem(21px);
 
 			@include break-medium {
 				margin: 1.5rem 0 40px;

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -15,7 +15,7 @@
 	h2 {
 		line-height: inherit;
 	}
-	#header { /* stylelint-disable-line selector-max-id */
+	#header {
 		display: none;
 	}
 	.header {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -80,7 +80,7 @@ $break-design-preview: 1024px;
 				margin: 0;
 
 				@include break-xlarge {
-					font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+					font-size: 2.75rem;
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -41,7 +41,7 @@
 		margin: 0;
 
 		@include break-xlarge {
-			font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+			font-size: 2.75rem;
 		}
 	}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -607,7 +607,6 @@ $masterbar-color-secondary: #101517;
 	border-radius: 0 2px 2px 0;
 	position: relative;
 	transition: all 0.2s ease-out;
-	// stylelint-disable-next-line scales/font-weights
 	font-weight: 500;
 	color: $masterbar-color-primary;
 	font-size: $masterbar-font-size;

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -445,7 +445,6 @@ textarea.billing-history__billing-details-editable {
 	.is-section-me,
 	.is-section-billing,
 	.is-section-purchases {
-		// stylelint-disable-next-line selector-max-id
 		#secondary,
 		.masterbar,
 		.billing-history__receipt-links,

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -103,12 +103,12 @@
 .purchase-item__site,
 .membership-item {
 	.site-icon {
-		border-radius: 2px; /* stylelint-disable-line scales/radii */
+		border-radius: 2px;
 	}
 
 	.site-icon,
 	.site-icon__img {
-		border-radius: 2px; /* stylelint-disable-line scales/radii */
+		border-radius: 2px;
 		width: 36px;
 		height: 36px;
 	}
@@ -118,7 +118,7 @@
 	display: flex;
 	width: 36px;
 	height: 36px;
-	border-radius: 2px; /* stylelint-disable-line scales/radii */
+	border-radius: 2px;
 	background: var(--color-error-50);
 	align-items: center;
 	justify-content: center;

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -193,7 +193,6 @@
 		.new-account {
 			padding-bottom: 0.48em;
 			background: var(--color-surface);
-			// stylelint-disable-next-line selector-max-id
 			#content & {
 				font-size: 0.875rem;
 			}

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -16,7 +16,6 @@
 		.section-header__label {
 			font-size: $font-title-small;
 			line-height: 28px;
-			/* stylelint-disable-next-line scales/font-weights */
 			font-weight: 500;
 			color: var(--studio-gray-80);
 		}

--- a/client/my-sites/purchases/billing-history/style.scss
+++ b/client/my-sites/purchases/billing-history/style.scss
@@ -1,6 +1,5 @@
 @media print {
 	.billing-history {
-		// stylelint-disable-next-line selector-max-id
 		#secondary,
 		.masterbar,
 		.billing-history__receipt-links,

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -140,7 +140,6 @@ $font-size: rem(14px);
 
 			.sidebar__menu-link {
 				padding: 5px 12px;
-				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 				font-size: rem(13px);
 				line-height: 1.4;
 				font-weight: 400;
@@ -543,7 +542,6 @@ $font-size: rem(14px);
 		.sidebar__menu-link {
 			cursor: pointer;
 			color: var(--color-sidebar-text-alternative);
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			font-size: rem(13px);
 
 			&:hover,

--- a/client/signup/steps/p2-join-workspace/style.scss
+++ b/client/signup/steps/p2-join-workspace/style.scss
@@ -115,7 +115,7 @@
 	background: var(--p2-color-background-light);
 	padding: 1.2rem;
 	display: grid;
-	border-radius: 2px; /* stylelint-disable-line scales/radii */
+	border-radius: 2px;
 
 	@include break-small {
 		grid-template-columns: auto auto;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -468,7 +468,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
 
 			@include break-xlarge {
-				font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+				font-size: 2.75rem;
 			}
 		}
 
@@ -797,7 +797,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 				line-height: 2.5rem;
 
 				@include break-mobile {
-					font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+					font-size: 2.75rem;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 					line-height: 3rem;
 				}

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"install-if-no-packages": "node bin/install-if-no-packages.js",
 		"lint": "run-s -s 'lint:*'",
 		"lint:config-defaults": "node bin/validate-config-keys.js",
-		"lint:css": "stylelint --rd --risd \"**/*.{css,scss}\"",
+		"lint:css": "stylelint \"**/*.{css,scss}\"",
 		"lint:js": "eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json --cache .",
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.tsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"install-if-no-packages": "node bin/install-if-no-packages.js",
 		"lint": "run-s -s 'lint:*'",
 		"lint:config-defaults": "node bin/validate-config-keys.js",
-		"lint:css": "stylelint \"**/*.{css,scss}\"",
+		"lint:css": "stylelint --rd --risd \"**/*.{css,scss}\"",
 		"lint:js": "eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json --cache .",
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.tsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -85,8 +85,8 @@ $design-picker-category-filter-text-color-active: var(--studio-gray-100);
 	font-family: $sans;
 	font-size: $font-body-small;
 	line-height: 24px;
-	font-weight: 500; // stylelint-disable-line scales/font-weights
-	border-radius: 4px; // stylelint-disable-line scales/radii
+	font-weight: 500;
+	border-radius: 4px;
 	border: 1px solid #c3c4c7;
 	padding: 0 35px 0 10px;
 	margin-bottom: 32px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -62,7 +62,7 @@
 		max-width: 100%;
 		height: 22px;
 		border: 1px solid rgba(0, 0, 0, 0.12);
-		border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
+		border-radius: 4px 4px 0 0;
 		margin: 0 auto;
 		box-sizing: border-box;
 		transition: border-color 0.15s ease-in-out;
@@ -130,7 +130,7 @@
 		}
 
 		&.design-picker__image-frame-no-header {
-			border-radius: 0; /* stylelint-disable-line scales/radii */
+			border-radius: 0;
 		}
 
 		img {
@@ -162,7 +162,7 @@
 		}
 
 		&.design-picker__image-frame-no-header::after {
-			border-radius: 0; /* stylelint-disable-line scales/radii */
+			border-radius: 0;
 		}
 
 	}
@@ -636,7 +636,7 @@
 .generated-design-preview {
 	.generated-design-preview__header {
 		align-items: center;
-		border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
+		border-radius: 4px 4px 0 0;
 		border: 1px solid var(--studio-gray-5);
 		box-sizing: border-box;
 		display: flex;

--- a/packages/domain-picker/src/components/style.scss
+++ b/packages/domain-picker/src/components/style.scss
@@ -331,7 +331,6 @@ $accent-blue: #117ac9;
 	.domain-picker__badge {
 		color: var(--studio-green-80);
 		background-color: var(--studio-green-5);
-		// stylelint-disable-next-line scales/radii
 		border-radius: 4px;
 		text-transform: unset;
 		font-size: $font-body-extra-small;

--- a/packages/domain-picker/src/components/style.scss
+++ b/packages/domain-picker/src/components/style.scss
@@ -293,14 +293,12 @@ $accent-blue: #117ac9;
 	}
 
 	&.with-bold-text {
-		// stylelint-disable-next-line scales/font-weight
 		font-weight: 500;
 	}
 }
 
 .domain-picker__suggestion-item.type-individual-item {
 	.domain-picker__domain-tld {
-		// stylelint-disable-next-line scales/font-weight
 		font-weight: 500;
 		color: unset;
 	}
@@ -426,7 +424,6 @@ $accent-blue: #117ac9;
 		line-height: 20px;
 
 		strong {
-			// stylelint-disable-next-line scales/font-weight
 			font-weight: 500;
 		}
 	}

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -112,7 +112,6 @@
 		font-family: $default-font;
 		margin: 6px 12px;
 		color: $gray-600;
-		/* stylelint-disable-next-line scales/font-size */
 		font-size: 0.875rem;
 		text-transform: uppercase;
 	}

--- a/packages/launch/src/focused-launch/success/style.scss
+++ b/packages/launch/src/focused-launch/success/style.scss
@@ -39,7 +39,6 @@
 
 .focused-launch-success__url-wrapper,
 .focused-launch-success__url-copy-button {
-	// stylelint-disable-next-line scales/radii
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-5);
 }

--- a/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
+++ b/packages/launch/src/focused-launch/summary/focused-launch-summary-item/style.scss
@@ -41,7 +41,6 @@
 	.focused-launch-summary-item__leading-side-label {
 		color: inherit;
 		font-size: $font-body-small;
-		// stylelint-disable-next-line scales/font-weight
 		font-weight: 500;
 		line-height: 1;
 	}

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -85,7 +85,6 @@ button.action_buttons__button.components-button {
 		justify-content: flex-start;
 
 		text-decoration: underline;
-		// stylelint-disable-next-line scales/font-weight
 		font-weight: 600;
 		color: var(--mainColor);
 

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -91,7 +91,7 @@
 				margin: 0;
 
 				@include break-xlarge {
-					font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+					font-size: 2.75rem;
 				}
 			}
 

--- a/packages/pattern-picker/src/styles.scss
+++ b/packages/pattern-picker/src/styles.scss
@@ -93,7 +93,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	background: #fff;
 	border: 1px solid #eee;
 	align-items: center;
-	// stylelint-disable-next-line scales/radii
 	// stylelint-disable-next-line declaration-property-unit-allowed-list
 	border-radius: 50%;
 	opacity: 0.5;

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -4,9 +4,6 @@
 @import "@automattic/typography/styles/variables";
 @import "../variables.scss";
 
-/* stylelint-disable scales/font-size */
-// @TODO: re-enable lint rule in https://github.com/Automattic/wp-calypso/issues/44933
-
 .plans-table {
 	width: 100%;
 	display: flex;

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -221,7 +221,6 @@
 	font-size: $font-body-small;
 	color: var(--studio-gray-90);
 
-	// stylelint-disable-next-line scales/radii
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-10);
 

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -11,8 +11,6 @@
 
 @import "../variables.scss";
 
-/* stylelint-disable scales/font-size */
-
 .facebook-preview {
 	border: none;
 	display: flex;
@@ -42,7 +40,6 @@
 
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 16px;
-	/* stylelint-disable-next-line scales/font-weight */
 	font-weight: 600;
 	line-height: 20px;
 	max-height: 100px;

--- a/packages/social-previews/src/search-preview/style.scss
+++ b/packages/social-previews/src/search-preview/style.scss
@@ -11,8 +11,6 @@
 
 @import "../variables.scss";
 
-/* stylelint-disable scales/font-size */
-
 .search-preview__display {
 	border: 1px solid var(--color-neutral-0);
 	font-family: arial, sans-serif;

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -9,8 +9,6 @@
 
 @import "../variables.scss";
 
-/* stylelint-disable scales/font-size */
-
 .twitter-preview {
 	background-color: #fff;
 	padding: 20px;

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -48,7 +48,7 @@
 
 	.onboarding-title {
 		margin-bottom: 1.5rem;
-		font-size: 2.75rem; /* stylelint-disable-line scales/font-sizes */
+		font-size: 2.75rem;
 		line-height: 3.5rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 

--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -1,6 +1,3 @@
-// @TODO: remove the ignore rule and replace font sizes accordingly
-/* stylelint-disable scales/font-size */
-
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/calypso-color-schemes";


### PR DESCRIPTION
#### Proposed Changes

See #67467 

This PR removes the needless and invalid stylelint-disable comments

- Remove [`invalid-scope-disables`](https://stylelint.io/user-guide/usage/cli#--report-invalid-scope-disables---risd)
- Remove [`needless-disables`](https://stylelint.io/user-guide/usage/cli#--report-needless-disables---rd)
- Add reporting of needless and invalid disables to Stylelint config

#### Testing Instructions

- Do a sanity check on Calypso live link
