### PR TITLE
Sites Management Page: Fix site list placeholder on mobile

### DIFF
--- a/client/sites-dashboard/components/sites-table-row-loading.tsx
+++ b/client/sites-dashboard/components/sites-table-row-loading.tsx
@@ -1,6 +1,7 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
+import { MEDIA_QUERIES } from '../utils';
 
 type cssSize = number | string;
 
@@ -25,6 +26,9 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	padding-block-end: 12px;
 	padding-inline-end: 24px;
 	vertical-align: middle;
+	${ MEDIA_QUERIES.mediumOrSmaller } {
+		${ ( props ) => props.mobileHidden && 'display: none;' };
+	}
 `;
 
 const TitleRow = styled.div`


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/68544#pullrequestreview-1129242531

## Proposed Changes

Fixes site list placeholder on mobile.

### Before

<img width="558" alt="image" src="https://user-images.githubusercontent.com/36432/193821690-68c7f6b3-317c-4ade-a42d-597de64921c9.png">

### After

<img width="544" alt="image" src="https://user-images.githubusercontent.com/36432/193821642-88519b7d-d49c-4704-8e87-9242722a5468.png">

## Testing Instructions

1. Navigate to `/sites`.
2. View the improved loading placeholder in all of its glory.