### PR TITLE
E2E: Fix failing test after GB v14.2.0 upgrade

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
@@ -47,15 +47,16 @@ export class LayoutGridBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution.
 	 */
 	async configure( context: EditorContext ): Promise< void > {
+		await context.page.pause();
 		const twoColumnButtonLocator = context.editorLocator.locator( selectors.twoColumnButton );
 		await twoColumnButtonLocator.click();
 
 		/**
-		 * Workaround for the issue where the inline inserter of the Columns
+		 * Workaround for the issue where the inline inserter of the Layout Grid
 		 * block disappears when the "+" button is clicked too early after a
-		 * column count has been selected. This issue is not reproducible
-		 * manually (unless you're ⚡️ fast) and happens only with the testing
-		 * framework.
+		 * column count has been selected.
+		 *
+		 * @see {@link https://github.com/Automattic/block-experiments/issues/294}
 		 */
 		await context.page.waitForTimeout( 1000 );
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
@@ -50,6 +50,16 @@ export class LayoutGridBlockFlow implements BlockFlow {
 		const twoColumnButtonLocator = context.editorLocator.locator( selectors.twoColumnButton );
 		await twoColumnButtonLocator.click();
 
+		/**
+		 * Workaround for the issue where the inline inserter of the Columns
+		 * block disappears when the "+" button is clicked too early after a
+		 * column count has been selected. This issue is not reproducible
+		 * manually (unless you're ⚡️ fast) and happens only with the testing
+		 * framework.
+		 */
+		const page = twoColumnButtonLocator.page();
+		await page.evaluate( () => new Promise( ( r ) => setTimeout( r, 1000 ) ) );
+
 		await this.addTextToColumn(
 			{
 				columnNumber: 1,

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
@@ -57,8 +57,7 @@ export class LayoutGridBlockFlow implements BlockFlow {
 		 * manually (unless you're ⚡️ fast) and happens only with the testing
 		 * framework.
 		 */
-		const page = twoColumnButtonLocator.page();
-		await page.evaluate( () => new Promise( ( r ) => setTimeout( r, 1000 ) ) );
+		await context.page.waitForTimeout( 1000 );
 
 		await this.addTextToColumn(
 			{

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -5,7 +5,7 @@ interface ConfigurationData {
 	expectedTweetText: string;
 }
 
-const blockParentSelector = '[aria-label="Block: Embed"]:has-text("Twitter URL")';
+const blockParentSelector = '[aria-label="Block: Twitter"]:has-text("Twitter URL")';
 const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -5,7 +5,7 @@ interface ConfigurationData {
 	expectedVideoTitle: string;
 }
 
-const blockParentSelector = '[aria-label="Block: Embed"]:has-text("YouTube URL")';
+const blockParentSelector = '[aria-label="Block: YouTube"]:has-text("YouTube URL")';
 const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,


### PR DESCRIPTION
#### Proposed Changes

Fix tests that started failing after the GB v14.2.0 upgrade:
- YouTube block (`specs/blocks/blocks__core.ts`),
- Layout Grid block (`specs/blocks/blocks__core.ts`),
   Related: https://github.com/Automattic/block-experiments/issues/294
- Twitter block (`specs/blocks/blocks__core-jetpack-extended.ts`).

#### Testing Instructions

All the tests should be 🟢.