### PR TITLE
Components: refactor LocaleSuggestions from enzyme to testing library 

### DIFF
--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { render } from '@testing-library/react';
 import { shallow } from 'enzyme';
 import { getLocaleSlug } from 'i18n-calypso';
 import { LocaleSuggestions } from '../';
@@ -9,7 +10,7 @@ import { LocaleSuggestions } from '../';
 jest.mock( 'calypso/lib/i18n-utils', () => ( { addLocaleToPath: ( locale ) => locale } ) );
 jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
 
-jest.mock( 'calypso/components/notice', () => ( props ) => [ ...props.children ] );
+jest.mock( 'calypso/components/notice', () => ( { children } ) => <>{ children }</> );
 
 describe( 'LocaleSuggestions', () => {
 	const defaultProps = {

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -12,6 +12,10 @@ jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
 jest.mock( 'calypso/components/notice', () => ( { children } ) => <>{ children }</> );
 
 describe( 'LocaleSuggestions', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	const defaultProps = {
 		path: '',
 		locale: 'x',
@@ -58,5 +62,11 @@ describe( 'LocaleSuggestions', () => {
 		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toBeVisible();
 		expect( screen.getByRole( 'link', { name: 'English' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: 'Français' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should set the locale if it changes', () => {
+		const { rerender } = render( <LocaleSuggestions { ...defaultProps } /> );
+		rerender( <LocaleSuggestions { ...defaultProps } locale="x" /> );
+		expect( defaultProps.setLocale ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -6,9 +6,7 @@ import { render, screen } from '@testing-library/react';
 import { getLocaleSlug } from 'i18n-calypso';
 import { LocaleSuggestions } from '../';
 
-jest.mock( 'calypso/lib/i18n-utils', () => ( { addLocaleToPath: ( locale ) => locale } ) );
 jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
-
 jest.mock( 'calypso/components/notice', () => ( { children } ) => <>{ children }</> );
 
 describe( 'LocaleSuggestions', () => {
@@ -33,11 +31,15 @@ describe( 'LocaleSuggestions', () => {
 	} );
 
 	// check that content within a card renders correctly
-	test( 'should render suggestions', () => {
+	test( 'should render suggestions with language name and language code in path', () => {
 		render( <LocaleSuggestions { ...defaultProps } /> );
 		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toBeVisible();
 		expect( screen.getByRole( 'link', { name: 'Français' } ) ).toBeVisible();
 		expect( screen.getByRole( 'link', { name: 'English' } ) ).toBeVisible();
+
+		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toHaveAttribute( 'href', '/es' );
+		expect( screen.getByRole( 'link', { name: 'Français' } ) ).toHaveAttribute( 'href', '/fr' );
+		expect( screen.getByRole( 'link', { name: 'English' } ) ).toHaveAttribute( 'href', '/en' );
 	} );
 
 	test( 'should not render children with the same locale', () => {

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -2,8 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render } from '@testing-library/react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { getLocaleSlug } from 'i18n-calypso';
 import { LocaleSuggestions } from '../';
 
@@ -25,44 +24,39 @@ describe( 'LocaleSuggestions', () => {
 	};
 
 	test( 'should not render without suggestions', () => {
-		const wrapper = shallow( <LocaleSuggestions path="" locale="x" setLocale={ () => {} } /> );
-		expect( wrapper.type() ).toBe( null );
-	} );
-
-	test( 'should have `locale-suggestions` class', () => {
-		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.hasClass( 'locale-suggestions' ) ).toBe( true );
+		render( <LocaleSuggestions path="" locale="x" setLocale={ () => {} } /> );
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
 
 	// check that content within a card renders correctly
 	test( 'should render suggestions', () => {
-		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			defaultProps.localeSuggestions.length
-		);
+		render( <LocaleSuggestions { ...defaultProps } /> );
+		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Français' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'English' } ) ).toBeVisible();
 	} );
 
 	test( 'should not render children with the same locale', () => {
 		getLocaleSlug.mockReturnValue( 'en' );
-		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			defaultProps.localeSuggestions.length - 1
-		);
+		render( <LocaleSuggestions { ...defaultProps } /> );
+		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Français' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'English' } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should not render "en" when locale is "en-gb"', () => {
 		getLocaleSlug.mockReturnValue( 'en-gb' );
-		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			defaultProps.localeSuggestions.length - 1
-		);
+		render( <LocaleSuggestions { ...defaultProps } /> );
+		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Français' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'English' } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should not render "fr" when locale is "fr-ca"', () => {
 		getLocaleSlug.mockReturnValue( 'fr-ca' );
-		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			defaultProps.localeSuggestions.length - 1
-		);
+		render( <LocaleSuggestions { ...defaultProps } /> );
+		expect( screen.getByRole( 'link', { name: 'Español' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'English' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Français' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -70,5 +70,6 @@ describe( 'LocaleSuggestions', () => {
 		const { rerender } = render( <LocaleSuggestions { ...defaultProps } /> );
 		rerender( <LocaleSuggestions { ...defaultProps } locale="x" /> );
 		expect( defaultProps.setLocale ).toHaveBeenCalledTimes( 1 );
+		expect( defaultProps.setLocale ).toHaveBeenCalledWith( 'x' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `LocaleSuggestions` component to use `@testing-library/react` instead of `enzyme`. Other changes:

- Removed test that checked for a static CSS class as it isn't needed. 
- Added test to check `setLocale` is called if locale changes. 
- Added assertions to make sure locale is added to paths.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify tests still pass: `client/components/locale-suggestions/test/index.jsx`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
