### PR TITLE
HelpCenter: Show support language message to users

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -80,7 +80,6 @@
 	width: 100%;
 	display: block;
 	box-sizing: border-box;
-	margin-bottom: 8px;
 
 	&:focus {
 		box-shadow: none;
@@ -135,6 +134,10 @@ section.contact-form-submit {
 			border-color: var(--color-neutral-5) !important;
 			color: var(--color-neutral-20) !important;
 		}
+	}
+
+	.components-tip {
+		margin-top: 8px;
 	}
 }
 

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -80,6 +80,7 @@
 	width: 100%;
 	display: block;
 	box-sizing: border-box;
+	margin-bottom: 8px;
 
 	&:focus {
 		box-shadow: none;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -16,7 +16,7 @@ import {
 } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { SitePickerDropDown } from '@automattic/site-picker';
-import { TextControl, CheckboxControl } from '@wordpress/components';
+import { TextControl, CheckboxControl, Tip } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
@@ -539,7 +539,7 @@ export const HelpCenterContactForm = () => {
 					className="help-center-contact-form__message"
 				/>
 				{ shouldShowHelpLanguagePrompt() && (
-					<b>{ __( 'Note: Support is only available in English at the moment.' ) }</b>
+					<Tip>{ __( 'Note: Support is only available in English at the moment.' ) }</Tip>
 				) }
 			</section>
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -530,9 +530,6 @@ export const HelpCenterContactForm = () => {
 					onInput={ ( event ) => setMessage( event.currentTarget.value ) }
 					className="help-center-contact-form__message"
 				/>
-				{ shouldShowHelpLanguagePrompt() && (
-					<Tip>{ __( 'Note: Support is only available in English at the moment.' ) }</Tip>
-				) }
 			</section>
 
 			{ mode === 'FORUM' && (
@@ -557,6 +554,9 @@ export const HelpCenterContactForm = () => {
 				>
 					{ getCTALabel() }
 				</Button>
+				{ ! hasSubmittingError && shouldShowHelpLanguagePrompt() && (
+					<Tip>{ __( 'Note: Support is only available in English at the moment.' ) }</Tip>
+				) }
 				{ hasSubmittingError && (
 					<FormInputValidation
 						isError

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -388,12 +388,9 @@ export const HelpCenterContactForm = () => {
 		);
 
 		switch ( supportType ) {
-			case SUPPORT_HAPPYCHAT:
+			case 'CHAT':
 				return ! isLiveChatLanguageSupported;
-
-			case SUPPORT_TICKET:
-			case SUPPORT_CHAT_OVERFLOW:
-			case SUPPORT_UPWORK_TICKET:
+			case 'EMAIL':
 				return ! isLanguageSupported && ! [ 'en', 'en-gb' ].includes( locale );
 
 			default:
@@ -402,8 +399,7 @@ export const HelpCenterContactForm = () => {
 	};
 
 	const shouldShowHelpLanguagePrompt = () => {
-		const supportType = getSupportVariationFromMode( mode );
-		return getSupportedLanguages( supportType, locale );
+		return getSupportedLanguages( mode, locale );
 	};
 
 	const getCTALabel = () => {
@@ -433,7 +429,6 @@ export const HelpCenterContactForm = () => {
 
 		return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
 	};
-<<<<<<< HEAD
 
 	return showingSibylResults ? (
 		<div className="help-center__sibyl-articles-page">
@@ -466,9 +461,6 @@ export const HelpCenterContactForm = () => {
 			</section>
 		</div>
 	) : (
-=======
-	return (
->>>>>>> a31baa6fb8 (Add support language message)
 		<main className="help-center-contact-form">
 			<BackButton />
 			<h1 className="help-center-contact-form__site-picker-title">{ formTitles.formTitle }</h1>

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -377,6 +377,29 @@ export const HelpCenterContactForm = () => {
 		}
 	};
 
+	const getSupportedLanguages = ( supportType: string, locale: string ) => {
+		switch ( supportType ) {
+			case SUPPORT_HAPPYCHAT:
+				return ! window.configData.livechat_support_locales.includes( locale );
+
+			case SUPPORT_TICKET:
+			case SUPPORT_CHAT_OVERFLOW:
+			case SUPPORT_UPWORK_TICKET:
+				return (
+					! window.configData.upwork_support_locales.includes( locale ) &&
+					! [ 'en', 'en-gb' ].includes( locale )
+				);
+
+			default:
+				return false;
+		}
+	};
+
+	const shouldShowHelpLanguagePrompt = () => {
+		const supportType = getSupportVariationFromMode( mode );
+		return getSupportedLanguages( supportType, locale );
+	};
+
 	const getCTALabel = () => {
 		if ( ! showingSibylResults && sibylArticles && sibylArticles.length > 0 ) {
 			return __( 'Continue', __i18n_text_domain__ );
@@ -404,6 +427,7 @@ export const HelpCenterContactForm = () => {
 
 		return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
 	};
+<<<<<<< HEAD
 
 	return showingSibylResults ? (
 		<div className="help-center__sibyl-articles-page">
@@ -436,6 +460,9 @@ export const HelpCenterContactForm = () => {
 			</section>
 		</div>
 	) : (
+=======
+	return (
+>>>>>>> a31baa6fb8 (Add support language message)
 		<main className="help-center-contact-form">
 			<BackButton />
 			<h1 className="help-center-contact-form__site-picker-title">{ formTitles.formTitle }</h1>
@@ -505,6 +532,9 @@ export const HelpCenterContactForm = () => {
 					onInput={ ( event ) => setMessage( event.currentTarget.value ) }
 					className="help-center-contact-form__message"
 				/>
+				{ shouldShowHelpLanguagePrompt() && (
+					<b>{ __( 'Note: Support is only available in English at the moment.' ) }</b>
+				) }
 			</section>
 
 			{ mode === 'FORUM' && (

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -398,9 +398,7 @@ export const HelpCenterContactForm = () => {
 		}
 	};
 
-	const shouldShowHelpLanguagePrompt = () => {
-		return getSupportedLanguages( mode, locale );
-	};
+	const shouldShowHelpLanguagePrompt = getSupportedLanguages( mode, locale ); 
 
 	const getCTALabel = () => {
 		if ( ! showingSibylResults && sibylArticles && sibylArticles.length > 0 ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -3,6 +3,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { getPlanTermLabel } from '@automattic/calypso-products';
 import { Button, FormInputValidation, Popover } from '@automattic/components';
 import {
@@ -378,17 +379,22 @@ export const HelpCenterContactForm = () => {
 	};
 
 	const getSupportedLanguages = ( supportType: string, locale: string ) => {
+		const isLiveChatLanguageSupported = (
+			config( 'livechat_support_locales' ) as Array< string >
+		 ).includes( locale );
+
+		const isLanguageSupported = ( config( 'upwork_support_locales' ) as Array< string > ).includes(
+			locale
+		);
+
 		switch ( supportType ) {
 			case SUPPORT_HAPPYCHAT:
-				return ! window.configData.livechat_support_locales.includes( locale );
+				return ! isLiveChatLanguageSupported;
 
 			case SUPPORT_TICKET:
 			case SUPPORT_CHAT_OVERFLOW:
 			case SUPPORT_UPWORK_TICKET:
-				return (
-					! window.configData.upwork_support_locales.includes( locale ) &&
-					! [ 'en', 'en-gb' ].includes( locale )
-				);
+				return ! isLanguageSupported && ! [ 'en', 'en-gb' ].includes( locale );
 
 			default:
 				return false;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -120,6 +120,26 @@ function useFormTitles( mode: Mode ): {
 	}[ mode ];
 }
 
+const getSupportedLanguages = ( supportType: string, locale: string ) => {
+	const isLiveChatLanguageSupported = (
+		config( 'livechat_support_locales' ) as Array< string >
+	 ).includes( locale );
+
+	const isLanguageSupported = ( config( 'upwork_support_locales' ) as Array< string > ).includes(
+		locale
+	);
+
+	switch ( supportType ) {
+		case 'CHAT':
+			return ! isLiveChatLanguageSupported;
+		case 'EMAIL':
+			return ! isLanguageSupported && ! [ 'en', 'en-gb' ].includes( locale );
+
+		default:
+			return false;
+	}
+};
+
 type Mode = 'CHAT' | 'EMAIL' | 'FORUM';
 
 export const HelpCenterContactForm = () => {
@@ -363,6 +383,8 @@ export const HelpCenterContactForm = () => {
 		);
 	};
 
+	const shouldShowHelpLanguagePrompt = getSupportedLanguages( mode, locale );
+
 	const isCTADisabled = () => {
 		if ( isSubmitting || ! message || ownershipStatusLoading ) {
 			return true;
@@ -377,28 +399,6 @@ export const HelpCenterContactForm = () => {
 				return ! subject;
 		}
 	};
-
-	const getSupportedLanguages = ( supportType: string, locale: string ) => {
-		const isLiveChatLanguageSupported = (
-			config( 'livechat_support_locales' ) as Array< string >
-		 ).includes( locale );
-
-		const isLanguageSupported = ( config( 'upwork_support_locales' ) as Array< string > ).includes(
-			locale
-		);
-
-		switch ( supportType ) {
-			case 'CHAT':
-				return ! isLiveChatLanguageSupported;
-			case 'EMAIL':
-				return ! isLanguageSupported && ! [ 'en', 'en-gb' ].includes( locale );
-
-			default:
-				return false;
-		}
-	};
-
-	const shouldShowHelpLanguagePrompt = getSupportedLanguages( mode, locale ); 
 
 	const getCTALabel = () => {
 		if ( ! showingSibylResults && sibylArticles && sibylArticles.length > 0 ) {
@@ -552,7 +552,7 @@ export const HelpCenterContactForm = () => {
 				>
 					{ getCTALabel() }
 				</Button>
-				{ ! hasSubmittingError && shouldShowHelpLanguagePrompt() && (
+				{ ! hasSubmittingError && shouldShowHelpLanguagePrompt && (
 					<Tip>{ __( 'Note: Support is only available in English at the moment.' ) }</Tip>
 				) }
 				{ hasSubmittingError && (


### PR DESCRIPTION
##  Proposed Changes

The HelpCenter is not showing a message informing the user about the available support languages, [more context].(https://href.li/?https://wp.me/p7DVsv-fpN#comment-42221)

This PR adds the message. Please see more detail described on the [issue](https://github.com/Automattic/wp-calypso/issues/68270)


## Testing Instructions

- Check out this branch.
- Run yarn start.
- Go to your site and open the Help Center.
- Click on `still need help button`, you should see this: 
<img width="414" alt="image" src="https://user-images.githubusercontent.com/2653810/193842155-7226e653-2c9a-478e-af1c-4714c453a6a2.png">


- If the user chooses email 
It should show the message if the default users's language is not English OR Deutsch

- If the user chooses live chat 
It should show the message if the default users's language is not English

![I8JTsF.png](https://user-images.githubusercontent.com/2653810/193852106-e15cbcdb-1bee-4951-af48-2d20db93b061.png)

If your locale ( default language ) is english, you should never see 

Related to #68270
Fixes #68270