### PR TITLE
Fix o2 blocks icon use

### DIFF
--- a/apps/o2-blocks/src/todo/editor.js
+++ b/apps/o2-blocks/src/todo/editor.js
@@ -3,7 +3,7 @@ import { Button } from '@wordpress/components';
 import { RichText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import Dashicon from '@wordpress/icon';
+import { Icon, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { ItemEditor } from './item';
 
@@ -201,7 +201,7 @@ const edit = class extends Component {
 				</ul>
 				<div class="add-new-todo-item-form">
 					<Button onClick={ this.addNewItem }>
-						<Dashicon icon="plus" /> Add new item
+						<Icon icon={ plus } /> Add new item
 					</Button>
 				</div>
 			</div>

--- a/apps/o2-blocks/src/todo/item.js
+++ b/apps/o2-blocks/src/todo/item.js
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { RichText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
-import Dashicon from '@wordpress/icon';
+import { Icon, check, cancelCircleFilled, arrowDown, arrowUp } from '@wordpress/icons';
 
 export const ItemEditor = class extends Component {
 	constructor() {
@@ -50,7 +50,7 @@ export const ItemEditor = class extends Component {
 			<li className={ classNames }>
 				{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */ }
 				<span className="item-status" onClick={ this.toggleDone } role="button" tabindex="0">
-					{ done && <Dashicon icon="yes" /> }
+					{ done && <Icon icon={ check } /> }
 				</span>
 				{ /* { 0 < item.level && <Button onClick={ moveLeft }>&lt;</Button> }
 				{ 2 > item.level && <Button onClick={ moveRight }>&gt;</Button> }
@@ -68,16 +68,16 @@ export const ItemEditor = class extends Component {
 				<span className="move-buttons">
 					{ canMoveUp && (
 						<Button onClick={ moveUp }>
-							<Dashicon icon="arrow-up-alt2" />
+							<Icon icon={ arrowUp } />
 						</Button>
 					) }
 					{ canMoveDown && (
 						<Button onClick={ moveDown }>
-							<Dashicon icon="arrow-down-alt2" />
+							<Icon icon={ arrowDown } />
 						</Button>
 					) }
 					<Button onClick={ onDelete }>
-						<Dashicon icon="no" />
+						<Icon icon={ cancelCircleFilled } />
 					</Button>
 				</span>
 			</li>


### PR DESCRIPTION
#### Proposed Changes

There are a lot of syntax issues with how `@wordpress/icons` were used in o2-blocks, causing all of o2 blocks to fail completely silently at multiple levels.

The root issue is a typo -- importing from `@wordpress/icon` means that the dependency extraction plugin happily extracts the package to the WordPress global, even though that script does not exist. Therefore, webpack does not fail. When WordPress goes to enqueue the script, it sees `wp-icon` as a script dependency and tries to find it. When that does not exist, it does not enqueue the script, but also doesn't show any errors or warnings.

So it's completely silent at multiple levels, making it a bit too hard to find the problem 😱 

_Note: this did not cause issues in prod, because o2-blocks has not been synced to wpcom for more than a year._

#### Testing Instructions
1. sync to sandbox
2. try to add the spoiler block, and it should work
