### PR TITLE
WPCOM Plugins: use software slug instead of slug

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -427,3 +427,25 @@ export function getProductSlugByPeriodVariation( periodVariation, productsList )
 	return Object.values( productsList ).find( ( product ) => product.product_id === productId )
 		?.product_slug;
 }
+
+/**
+ * @param  {object} plugin The plugin object
+ * @param  {boolean} isMarketplaceProduct Is this part of WP.com Marketplace or WP.org
+ * @returns {string} The software slug string
+ */
+export const getSoftwareSlug = ( plugin, isMarketplaceProduct ) =>
+	isMarketplaceProduct ? plugin.software_slug || plugin.org_slug : plugin.slug;
+
+/**
+ * @param  {object} plugin The plugin object
+ * @param  {Array} purchases An array of site purchases
+ * @param  {boolean} isMarketplaceProduct Is this part of WP.com Marketplace or WP.org
+ * @returns {string} The software slug string
+ */
+export const isPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) =>
+	isMarketplaceProduct &&
+	purchases.find( ( purchase ) =>
+		Object.values( plugin?.variations ).some(
+			( variation ) => variation.product_id === purchase.productId
+		)
+	)?.active;

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -440,12 +440,12 @@ export const getSoftwareSlug = ( plugin, isMarketplaceProduct ) =>
  * @param  {object} plugin The plugin object
  * @param  {Array} purchases An array of site purchases
  * @param  {boolean} isMarketplaceProduct Is this part of WP.com Marketplace or WP.org
- * @returns {string} The software slug string
+ * @returns {object} The purchase object, if found.
  */
-export const isPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) =>
+export const getPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) =>
 	isMarketplaceProduct &&
 	purchases.find( ( purchase ) =>
-		Object.values( plugin?.variations ).some(
+		Object.values( plugin?.variations )?.some(
 			( variation ) => variation.product_id === purchase.productId
 		)
-	)?.active;
+	);

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -113,6 +113,7 @@ export function getAllowedPluginData( plugin ) {
 		'sections',
 		'setup_url',
 		'slug',
+		'software_slug',
 		'support_URL',
 		'software_slug',
 		'tags',

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -442,10 +442,14 @@ export const getSoftwareSlug = ( plugin, isMarketplaceProduct ) =>
  * @param  {boolean} isMarketplaceProduct Is this part of WP.com Marketplace or WP.org
  * @returns {object} The purchase object, if found.
  */
-export const getPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) =>
-	isMarketplaceProduct &&
-	purchases.find( ( purchase ) =>
-		Object.values( plugin?.variations )?.some(
-			( variation ) => variation.product_id === purchase.productId
+export const getPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) => {
+	return (
+		isMarketplaceProduct &&
+		plugin?.variations &&
+		purchases.find( ( purchase ) =>
+			Object.values( plugin.variations ).some(
+				( variation ) => variation.product_id === purchase.productId
+			)
 		)
 	);
+};

--- a/client/my-sites/plugins/plugin-details-CTA/activation-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/activation-button.jsx
@@ -3,11 +3,13 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import { ACTIVATE_PLUGIN, DEACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
+import { getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import { togglePluginActivation } from 'calypso/state/plugins/installed/actions';
 import {
 	getPluginOnSite,
 	isPluginActionInProgress,
 } from 'calypso/state/plugins/installed/selectors';
+import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -17,14 +19,17 @@ export const ActivationButton = ( { plugin, active } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const pluginSlug = plugin.slug;
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, plugin.slug )
+	);
+	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
 
 	// Site type
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const sitePlugin = useSelector( ( state ) =>
-		getPluginOnSite( state, selectedSite?.ID, pluginSlug )
+		getPluginOnSite( state, selectedSite?.ID, softwareSlug )
 	);
 
 	const jetpackNonAtomic = isJetpack && ! isAtomic;
@@ -33,7 +38,7 @@ export const ActivationButton = ( { plugin, active } ) => {
 			siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS ) || jetpackNonAtomic
 	);
 	const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
-	const isManagedPlugin = isAtomic && autoManagedPlugins.includes( pluginSlug );
+	const isManagedPlugin = isAtomic && autoManagedPlugins.includes( softwareSlug );
 	const canManagePlugins = ( isJetpack && ! isAtomic ) || ( isAtomic && hasManagePlugins );
 
 	const activationInProgress = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { isPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-plugins-dialog';
@@ -50,16 +51,8 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, plugin.slug )
 	);
-	const softwareSlug = isMarketplaceProduct ? plugin.software_slug || plugin.org_slug : plugin.slug;
+	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-
-	const currentPurchase =
-		isMarketplaceProduct &&
-		purchases.find( ( purchase ) =>
-			Object.values( plugin?.variations ).some(
-				( variation ) => variation.product_id === purchase.productId
-			)
-		);
 
 	// Site type
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
@@ -90,7 +83,9 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const isPluginInstalledOnsite =
 		sitesWithPlugins.length && ! requestingPluginsForSites ? !! sitePlugin : false;
 	const isPluginInstalledOnsiteWithSubscription =
-		isPluginInstalledOnsite && ! isMarketplaceProduct ? true : currentPurchase?.active;
+		isPluginInstalledOnsite && ! isMarketplaceProduct
+			? true
+			: isPluginPurchased( plugin, purchases, isMarketplaceProduct );
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, softwareSlug )
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -6,8 +6,9 @@ import {
 import { Gridicon, Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import { Fragment, useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-plugins-dialog';
@@ -24,6 +25,7 @@ import {
 	getPluginOnSite,
 } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -39,18 +41,27 @@ import PluginDetailsCTAPreinstalledPremiumPlugins from './preinstalled-premium-p
 import './style.scss';
 
 const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
-	const pluginSlug = plugin.slug;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const selectedSite = useSelector( getSelectedSite );
 	const billingPeriod = useSelector( getBillingInterval );
 
 	const isMarketplaceProduct = useSelector( ( state ) =>
-		isMarketplaceProductSelector( state, pluginSlug )
+		isMarketplaceProductSelector( state, plugin.slug )
 	);
+	const softwareSlug = isMarketplaceProduct ? plugin.software_slug || plugin.org_slug : plugin.slug;
+	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
+
+	const currentPurchase =
+		isMarketplaceProduct &&
+		purchases.find( ( purchase ) =>
+			Object.values( plugin?.variations ).some(
+				( variation ) => variation.product_id === purchase.productId
+			)
+		);
 
 	// Site type
-	const selectedSite = useSelector( getSelectedSite );
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
 
@@ -60,11 +71,11 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const pluginFeature = isMarketplaceProduct
 		? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 		: FEATURE_INSTALL_PLUGINS;
-	const incompatiblePlugin = ! isJetpackSelfHosted && ! isCompatiblePlugin( pluginSlug );
+	const incompatiblePlugin = ! isJetpackSelfHosted && ! isCompatiblePlugin( softwareSlug );
 	const userCantManageTheSite = ! userCan( 'manage_options', selectedSite );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const sitePlugin = useSelector( ( state ) =>
-		getPluginOnSite( state, selectedSite?.ID, pluginSlug )
+		getPluginOnSite( state, selectedSite?.ID, softwareSlug )
 	);
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 
@@ -78,8 +89,10 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 
 	const isPluginInstalledOnsite =
 		sitesWithPlugins.length && ! requestingPluginsForSites ? !! sitePlugin : false;
+	const isPluginInstalledOnsiteWithSubscription =
+		isPluginInstalledOnsite && ! isMarketplaceProduct ? true : currentPurchase?.active;
 	const sitesWithPlugin = useSelector( ( state ) =>
-		getSiteObjectsWithPlugin( state, siteIds, pluginSlug )
+		getSiteObjectsWithPlugin( state, siteIds, softwareSlug )
 	);
 	const installedOnSitesQuantity = sitesWithPlugin.length;
 
@@ -134,7 +147,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		return (
 			<div className="plugin-details-cta__container">
 				<PluginDetailsCTAPreinstalledPremiumPlugins
-					isPluginInstalledOnsite={ isPluginInstalledOnsite }
+					isPluginInstalledOnsite={ isPluginInstalledOnsiteWithSubscription }
 					plugin={ plugin }
 				/>
 			</div>
@@ -145,7 +158,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		return <PluginDetailsCTAPlaceholder />;
 	}
 
-	if ( isPluginInstalledOnsite && sitePlugin ) {
+	if ( isPluginInstalledOnsiteWithSubscription && sitePlugin ) {
 		// Check if already instlaled on the site
 		const activeText = translate( '{{span}}active{{/span}}', {
 			components: {
@@ -232,87 +245,94 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	}
 
 	return (
-		<div className="plugin-details-cta__container">
-			<div className="plugin-details-cta__price">
-				<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
-					{ ( { isFetching, price, period } ) =>
-						isFetching ? (
-							<div className="plugin-details-cta__price-placeholder">...</div>
-						) : (
-							<>
-								{ price ? (
-									<>
-										{ price + ' ' }
-										<span className="plugin-details-cta__period">{ period }</span>
-									</>
-								) : (
-									translate( 'Free' )
-								) }
-							</>
-						)
-					}
-				</PluginPrice>
-			</div>
-			{ isMarketplaceProduct && (
-				<BillingIntervalSwitcher
-					billingPeriod={ billingPeriod }
-					onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
-					plugin={ plugin }
-				/>
-			) }
-			<div className="plugin-details-cta__install">
-				{ isLoggedIn ? (
-					<CTAButton
-						plugin={ plugin }
-						hasEligibilityMessages={ hasEligibilityMessages }
-						disabled={ incompatiblePlugin || userCantManageTheSite }
-					/>
-				) : (
-					<Button
-						type="a"
-						className="plugin-details-CTA__install-button"
-						primary
-						onClick={ ( e ) => e.stopPropagation() }
-						href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
-					>
-						{ translate( 'View plans' ) }
-					</Button>
-				) }
-			</div>
-			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
-				<div className="plugin-details-cta__t-and-c">
-					{ translate(
-						'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
-						{
-							components: {
-								a: (
-									<a target="_blank" rel="noopener noreferrer" href="https://wordpress.com/tos/" />
-								),
-								thirdPartyTos: (
-									<a
-										target="_blank"
-										rel="noopener noreferrer"
-										href="https://wordpress.com/third-party-plugins-terms/"
-									/>
-								),
-							},
+		<Fragment>
+			<QuerySitePurchases siteId={ selectedSite?.ID } />
+			<div className="plugin-details-cta__container">
+				<div className="plugin-details-cta__price">
+					<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
+						{ ( { isFetching, price, period } ) =>
+							isFetching ? (
+								<div className="plugin-details-cta__price-placeholder">...</div>
+							) : (
+								<>
+									{ price ? (
+										<>
+											{ price + ' ' }
+											<span className="plugin-details-cta__period">{ period }</span>
+										</>
+									) : (
+										translate( 'Free' )
+									) }
+								</>
+							)
 						}
+					</PluginPrice>
+				</div>
+				{ isMarketplaceProduct && (
+					<BillingIntervalSwitcher
+						billingPeriod={ billingPeriod }
+						onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
+						plugin={ plugin }
+					/>
+				) }
+				<div className="plugin-details-cta__install">
+					{ isLoggedIn ? (
+						<CTAButton
+							plugin={ plugin }
+							hasEligibilityMessages={ hasEligibilityMessages }
+							disabled={ incompatiblePlugin || userCantManageTheSite }
+						/>
+					) : (
+						<Button
+							type="a"
+							className="plugin-details-CTA__install-button"
+							primary
+							onClick={ ( e ) => e.stopPropagation() }
+							href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
+						>
+							{ translate( 'View plans' ) }
+						</Button>
 					) }
 				</div>
-			) }
-			{ shouldUpgrade && isLoggedIn && (
-				<div className="plugin-details-cta__upgrade-required">
-					<span className="plugin-details-cta__upgrade-required-icon">
-						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						<Gridicon icon="notice-outline" size={ 20 } />
-						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-					</span>
-					<span className="plugin-details-cta__upgrade-required-text">
-						{ translate( 'You need to upgrade your plan to install plugins.' ) }
-					</span>
-				</div>
-			) }
-		</div>
+				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
+					<div className="plugin-details-cta__t-and-c">
+						{ translate(
+							'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
+							{
+								components: {
+									a: (
+										<a
+											target="_blank"
+											rel="noopener noreferrer"
+											href="https://wordpress.com/tos/"
+										/>
+									),
+									thirdPartyTos: (
+										<a
+											target="_blank"
+											rel="noopener noreferrer"
+											href="https://wordpress.com/third-party-plugins-terms/"
+										/>
+									),
+								},
+							}
+						) }
+					</div>
+				) }
+				{ shouldUpgrade && isLoggedIn && (
+					<div className="plugin-details-cta__upgrade-required">
+						<span className="plugin-details-cta__upgrade-required-icon">
+							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+							<Gridicon icon="notice-outline" size={ 20 } />
+							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+						</span>
+						<span className="plugin-details-cta__upgrade-required-text">
+							{ translate( 'You need to upgrade your plan to install plugins.' ) }
+						</span>
+					</div>
+				) }
+			</div>
+		</Fragment>
 	);
 };
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -9,7 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import { isPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
+import { getPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-plugins-dialog';
@@ -85,7 +85,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const isPluginInstalledOnsiteWithSubscription =
 		isPluginInstalledOnsite && ! isMarketplaceProduct
 			? true
-			: isPluginPurchased( plugin, purchases, isMarketplaceProduct );
+			: getPluginPurchased( plugin, purchases, isMarketplaceProduct )?.active;
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, softwareSlug )
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
@@ -3,8 +3,10 @@ import { useSelector } from 'react-redux';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { getPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import PluginRemoveButton from 'calypso/my-sites/plugins/plugin-remove-button';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -12,18 +14,14 @@ export const ManagePluginMenu = ( { plugin } ) => {
 	const translate = useTranslate();
 
 	const site = useSelector( getSelectedSite );
-	const pluginOnSite = useSelector( ( state ) => getPluginOnSite( state, site.ID, plugin.slug ) );
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, plugin.slug )
+	);
+	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
+	const pluginOnSite = useSelector( ( state ) => getPluginOnSite( state, site.ID, softwareSlug ) );
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
-	const currentPurchase =
-		plugin.isMarketplaceProduct &&
-		purchases.find( ( purchase ) =>
-			Object.values( plugin?.variations ).some(
-				( variation ) =>
-					variation.product_slug === purchase.productSlug ||
-					variation.product_id === purchase.productId
-			)
-		);
+	const currentPurchase = getPluginPurchased( plugin, purchases, isMarketplaceProduct );
 	const settingsLink = pluginOnSite?.action_links?.Settings ?? null;
 
 	return (

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import type { Plugin } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -17,16 +18,7 @@ export default function PluginManageSubcription( { site, plugin }: Props ): Reac
 	const translate = useTranslate();
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
-
-	const currentPurchase =
-		plugin.isMarketplaceProduct &&
-		purchases.find( ( purchase ) =>
-			Object.values( plugin?.variations ).some(
-				( variation: any ) =>
-					variation.product_slug === purchase.productSlug ||
-					variation.product_id === purchase.productId
-			)
-		);
+	const currentPurchase = getPluginPurchased( plugin, purchases, plugin.isMarketplaceProduct );
 
 	return currentPurchase?.id ? (
 		<>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
@@ -14,11 +14,19 @@ interface Props {
 	plugin: Plugin;
 }
 
+type Purchase = {
+	id?: number;
+};
+
 export default function PluginManageSubcription( { site, plugin }: Props ): ReactElement | null {
 	const translate = useTranslate();
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
-	const currentPurchase = getPluginPurchased( plugin, purchases, plugin.isMarketplaceProduct );
+	const currentPurchase: Purchase = getPluginPurchased(
+		plugin,
+		purchases,
+		plugin.isMarketplaceProduct
+	);
 
 	return currentPurchase?.id ? (
 		<>

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -7,6 +7,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { INSTALL_PLUGIN } from 'calypso/lib/plugins/constants';
+import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import PluginActivateToggle from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
@@ -35,15 +36,7 @@ const PluginSiteJetpack = ( { isAutoManaged = false, site, plugin, allowedAction
 	);
 	const [ isMobileLayout, setIsMobileLayout ] = useState();
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
-	const currentPurchase =
-		plugin.isMarketplaceProduct &&
-		purchases.find( ( purchase ) =>
-			Object.values( plugin?.variations ).some(
-				( variation ) =>
-					variation.product_slug === purchase.productSlug ||
-					variation.product_id === purchase.productId
-			)
-		);
+	const currentPurchase = getPluginPurchased( plugin, purchases, plugin.isMarketplaceProduct );
 
 	useEffect( () => {
 		if ( isWithinBreakpoint( '<1040px' ) ) {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -11,6 +11,7 @@ import Badge from 'calypso/components/badge';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
+import { isPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import version_compare from 'calypso/lib/version-compare';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -54,7 +55,7 @@ const PluginsBrowserListElement = ( props ) => {
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, plugin.slug || '' )
 	);
-	const softwareSlug = isMarketplaceProduct ? plugin.software_slug || plugin.org_slug : plugin.slug;
+	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
 	const sitesWithPlugin = useSelector( ( state ) =>
 		currentSites
 			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), softwareSlug )
@@ -280,18 +281,12 @@ const InstalledInOrPricing = ( {
 		getPluginOnSites( state, [ selectedSiteId ], softwareSlug )
 	)?.active;
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
-
-	const currentPurchase =
-		isMarketplaceProduct &&
-		purchases.find( ( purchase ) =>
-			Object.values( plugin?.variations ).some(
-				( variation ) => variation.product_id === purchase.productId
-			)
-		);
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
 	const active = isWpcomPreinstalled || isPluginActive;
 	const isPluginActiveOnsiteWithSubscription =
-		active && ! isMarketplaceProduct ? true : currentPurchase?.active;
+		active && ! isMarketplaceProduct
+			? true
+			: isPluginPurchased( plugin, purchases, isMarketplaceProduct );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	let checkmarkColorClass = 'checkmark--active';
 

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -11,7 +11,7 @@ import Badge from 'calypso/components/badge';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
-import { isPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
+import { getPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import version_compare from 'calypso/lib/version-compare';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -286,7 +286,7 @@ const InstalledInOrPricing = ( {
 	const isPluginActiveOnsiteWithSubscription =
 		active && ! isMarketplaceProduct
 			? true
-			: isPluginPurchased( plugin, purchases, isMarketplaceProduct );
+			: getPluginPurchased( plugin, purchases, isMarketplaceProduct )?.active;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	let checkmarkColorClass = 'checkmark--active';
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
@@ -129,6 +130,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		<MainComponent wideLayout>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
+			<QuerySitePurchases siteId={ selectedSite?.ID } />
 			<PageViewTrackerWrapper
 				category={ category }
 				selectedSiteId={ selectedSite?.ID }

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -100,23 +100,44 @@ describe( 'Search view', () => {
 	const myProps = {
 		search: 'searchterm',
 	};
+	const initialState = {
+		purchases: {
+			data: [],
+			error: null,
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: false,
+		},
+	};
 
 	test( 'should show NoResults when there are no results', () => {
-		render( <PluginsBrowser { ...myProps } /> );
+		render( <PluginsBrowser { ...myProps } />, { initialState } );
 		expect( screen.getByText( /no plugins match your search/i ) ).toBeVisible();
 	} );
 	test( 'should show plugin list when there are results', () => {
 		mockPlugins = [ {} ];
-		render( <PluginsBrowser { ...myProps } /> );
+		render( <PluginsBrowser { ...myProps } />, { initialState } );
 		expect( screen.getByText( /found 0 plugins for/i ) ).toBeVisible();
 	} );
 } );
 
 describe( 'Upsell Nudge should get appropriate plan constant', () => {
+	const purchases = {
+		data: [],
+		error: null,
+		isFetchingSitePurchases: false,
+		isFetchingUserPurchases: false,
+		hasLoadedSitePurchasesFromServer: true,
+		hasLoadedUserPurchasesFromServer: false,
+	};
 	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ] )(
 		`Business 1 year for (%s)`,
 		( product_slug ) => {
-			const initialState = { sites: { items: { 1: { jetpack: false, plan: { product_slug } } } } };
+			const initialState = {
+				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+				purchases,
+			};
 			render( <PluginsBrowser />, { initialState } );
 			const nudge = screen.getByTestId( 'upsell-nudge' );
 			expect( nudge ).toBeVisible();
@@ -129,6 +150,7 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 		( product_slug ) => {
 			const initialState = {
 				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+				purchases,
 			};
 			render( <PluginsBrowser />, { initialState } );
 			const nudge = screen.getByTestId( 'upsell-nudge' );
@@ -139,14 +161,25 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 } );
 
 describe( 'PluginsBrowser basic tests', () => {
+	const purchases = {
+		data: [],
+		error: null,
+		isFetchingSitePurchases: false,
+		isFetchingUserPurchases: false,
+		hasLoadedSitePurchasesFromServer: true,
+		hasLoadedUserPurchasesFromServer: false,
+	};
+
 	test( 'should not blow up and have proper CSS class', () => {
-		render( <PluginsBrowser /> );
+		const initialState = { purchases };
+		render( <PluginsBrowser />, { initialState } );
 		const main = screen.getByRole( 'main' );
 		expect( main ).toBeVisible();
 	} );
 
 	test( 'should show upsell nudge when appropriate', () => {
-		render( <PluginsBrowser /> );
+		const initialState = { purchases };
+		render( <PluginsBrowser />, { initialState } );
 		expect( screen.getByTestId( 'upsell-nudge' ) ).toBeVisible();
 	} );
 

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -48,6 +48,11 @@ jest.mock( '@automattic/languages', () => [
 	},
 ] );
 
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	getUserPurchases: jest.fn(),
+	isFetchingSitePurchases: jest.fn( () => false ),
+} ) );
+
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -100,43 +105,24 @@ describe( 'Search view', () => {
 	const myProps = {
 		search: 'searchterm',
 	};
-	const initialState = {
-		purchases: {
-			data: [],
-			error: null,
-			isFetchingSitePurchases: false,
-			isFetchingUserPurchases: false,
-			hasLoadedSitePurchasesFromServer: true,
-			hasLoadedUserPurchasesFromServer: false,
-		},
-	};
 
 	test( 'should show NoResults when there are no results', () => {
-		render( <PluginsBrowser { ...myProps } />, { initialState } );
+		render( <PluginsBrowser { ...myProps } /> );
 		expect( screen.getByText( /no plugins match your search/i ) ).toBeVisible();
 	} );
 	test( 'should show plugin list when there are results', () => {
 		mockPlugins = [ {} ];
-		render( <PluginsBrowser { ...myProps } />, { initialState } );
+		render( <PluginsBrowser { ...myProps } /> );
 		expect( screen.getByText( /found 0 plugins for/i ) ).toBeVisible();
 	} );
 } );
 
 describe( 'Upsell Nudge should get appropriate plan constant', () => {
-	const purchases = {
-		data: [],
-		error: null,
-		isFetchingSitePurchases: false,
-		isFetchingUserPurchases: false,
-		hasLoadedSitePurchasesFromServer: true,
-		hasLoadedUserPurchasesFromServer: false,
-	};
 	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ] )(
 		`Business 1 year for (%s)`,
 		( product_slug ) => {
 			const initialState = {
 				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-				purchases,
 			};
 			render( <PluginsBrowser />, { initialState } );
 			const nudge = screen.getByTestId( 'upsell-nudge' );
@@ -150,7 +136,6 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 		( product_slug ) => {
 			const initialState = {
 				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-				purchases,
 			};
 			render( <PluginsBrowser />, { initialState } );
 			const nudge = screen.getByTestId( 'upsell-nudge' );
@@ -161,25 +146,14 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 } );
 
 describe( 'PluginsBrowser basic tests', () => {
-	const purchases = {
-		data: [],
-		error: null,
-		isFetchingSitePurchases: false,
-		isFetchingUserPurchases: false,
-		hasLoadedSitePurchasesFromServer: true,
-		hasLoadedUserPurchasesFromServer: false,
-	};
-
 	test( 'should not blow up and have proper CSS class', () => {
-		const initialState = { purchases };
-		render( <PluginsBrowser />, { initialState } );
+		render( <PluginsBrowser /> );
 		const main = screen.getByRole( 'main' );
 		expect( main ).toBeVisible();
 	} );
 
 	test( 'should show upsell nudge when appropriate', () => {
-		const initialState = { purchases };
-		render( <PluginsBrowser />, { initialState } );
+		render( <PluginsBrowser /> );
 		expect( screen.getByTestId( 'upsell-nudge' ) ).toBeVisible();
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

* Uses the `software_slug` to identify if a premium plugin is installed
* checks against the `software_slug` and plugin purchase to show whether plugin is installed "correctly"

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a site with premium plugins purchased verify that they correctly state installed and active status
* Visit `http://calypso.localhost:3000/plugins/browse/paid/visualcomposertesting.wpcomstaging.com` and `http://calypso.localhost:3000/plugins/visualcomposer-wpcom/visualcomposertesting.wpcomstaging.com` and verify that visual composer correctly displays as installed and active.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67535
