### PR TITLE
WPCOM SSH: Allow a user to upload a SSH key to their account

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -53,7 +54,7 @@ class SecurityCheckupComponent extends Component {
 					<SecurityCheckupTwoFactorBackupCodes />
 					<SecurityCheckupAccountRecoveryEmail />
 					<SecurityCheckupAccountRecoveryPhone />
-					<SecurityCheckupSSHKey />
+					{ isEnabled( 'hosting/ssh-keys' ) && <SecurityCheckupSSHKey /> }
 				</VerticalNav>
 
 				<SectionHeader label={ translate( 'Connections' ) } className="security-checkup__info" />

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -17,6 +17,7 @@ import SecurityCheckupAccountRecoveryPhone from './account-recovery-phone';
 import SecurityCheckupConnectedApplications from './connected-applications';
 import SecurityCheckupPassword from './password';
 import SecurityCheckupSocialLogins from './social-logins';
+import { SecurityCheckupSSHKey } from './ssh-key';
 import SecurityCheckupTwoFactorAuthentication from './two-factor-authentication';
 import SecurityCheckupTwoFactorBackupCodes from './two-factor-backup-codes';
 
@@ -52,6 +53,7 @@ class SecurityCheckupComponent extends Component {
 					<SecurityCheckupTwoFactorBackupCodes />
 					<SecurityCheckupAccountRecoveryEmail />
 					<SecurityCheckupAccountRecoveryPhone />
+					<SecurityCheckupSSHKey />
 				</VerticalNav>
 
 				<SectionHeader label={ translate( 'Connections' ) } className="security-checkup__info" />

--- a/client/me/security-checkup/ssh-key.tsx
+++ b/client/me/security-checkup/ssh-key.tsx
@@ -1,0 +1,28 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { useSSHKeyQuery } from 'calypso/me/security-ssh-key/use-ssh-key-query';
+import { getOKIcon, getWarningIcon } from './icons';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+export const SecurityCheckupSSHKey = () => {
+	const { data, isLoading } = useSSHKeyQuery();
+	const hasSSHKey = !! data && data.length > 0;
+
+	const { __ } = useI18n();
+
+	if ( isLoading ) {
+		return <SecurityCheckupNavigationItem isPlaceholder={ true } />;
+	}
+
+	return (
+		<SecurityCheckupNavigationItem
+			path={ '/me/security/ssh-key' }
+			materialIcon={ hasSSHKey ? getOKIcon() : getWarningIcon() }
+			text={ __( 'SSH Key' ) }
+			description={
+				hasSSHKey
+					? __( 'You have added a SSH key to your account.' )
+					: __( 'You do not have a SSH key added to your account.' )
+			}
+		/>
+	);
+};

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -5,7 +5,7 @@ import i18n from 'i18n-calypso';
 import { ChangeEvent, useReducer } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormTextarea from 'calypso/components/forms/form-textarea';
+import TextareaAutosize from 'calypso/components/textarea-autosize';
 
 const PUBLIC_SSH_KEY_INPUT_ID = 'public_ssh_key';
 
@@ -67,7 +67,7 @@ export const AddSSHKeyForm = ( { addSSHKey, isAdding }: AddSSHKeyFormProps ) => 
 		>
 			<FormFieldset>
 				<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'Public SSH key' ) }</FormLabel>
-				<FormTextarea
+				<TextareaAutosize
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }
 					disabled={ isAdding }

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -6,17 +6,9 @@ import { ChangeEvent, useReducer } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
+import { SSH_KEY_FORMATS } from './use-ssh-key-query';
 
 const PUBLIC_SSH_KEY_INPUT_ID = 'public_ssh_key';
-
-const keyFormats = [
-	'ssh-rsa',
-	'ssh-ed25519',
-	'ssh-dss',
-	'ecdsa-sha2-nistp256',
-	'ecdsa-sha2-nistp384',
-	'ecdsa-sha2-nistp521',
-];
 
 const initialState = {
 	touched: false,
@@ -24,7 +16,7 @@ const initialState = {
 	value: '',
 };
 
-const sshKeyValidation = new RegExp( `^(?:${ keyFormats.join( '|' ) })\\s.+` );
+const sshKeyValidation = new RegExp( `^(?:${ SSH_KEY_FORMATS.join( '|' ) })\\s.+` );
 
 type ReducerAction = { type: 'setValue'; value: string };
 
@@ -54,7 +46,7 @@ export const AddSSHKeyForm = ( { addSSHKey, isAdding }: AddSSHKeyFormProps ) => 
 	const formats = new Intl.ListFormat( i18n.getLocaleSlug() ?? 'en', {
 		style: 'long',
 		type: 'disjunction',
-	} ).format( keyFormats );
+	} ).format( SSH_KEY_FORMATS );
 
 	const showSSHKeyError = touched && ! isValid;
 

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -44,9 +44,10 @@ const sshKeyFormReducer = ( state = initialState, action: ReducerAction ): typeo
 
 interface AddSSHKeyFormProps {
 	addSSHKey( args: { name: string; key: string } ): void;
+	isAdding: boolean;
 }
 
-export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
+export const AddSSHKeyForm = ( { addSSHKey, isAdding }: AddSSHKeyFormProps ) => {
 	const [ { isValid, touched, value }, dispatch ] = useReducer( sshKeyFormReducer, initialState );
 
 	const { __ } = useI18n();
@@ -69,6 +70,7 @@ export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
 				<FormTextarea
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }
+					disabled={ isAdding }
 					value={ value }
 					isError={ showSSHKeyError }
 					placeholder={ sprintf(
@@ -95,7 +97,7 @@ export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
 					/>
 				) }
 			</FormFieldset>
-			<Button primary type="submit" disabled={ ! isValid }>
+			<Button busy={ isAdding } primary type="submit" disabled={ ! isValid || isAdding }>
 				{ __( 'Save SSH key' ) }
 			</Button>
 		</form>

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -1,11 +1,22 @@
 import { Button } from '@automattic/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import i18n from 'i18n-calypso';
 import { ChangeEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 
 const PUBLIC_SSH_KEY_INPUT_ID = 'public_ssh_key';
+
+const keyFormats = [
+	'ssh-rsa',
+	'ssh-ed25519',
+	'ssh-dss',
+	'ecdsa-sha2-nistp256',
+	'ecdsa-sha2-nistp384',
+	'ecdsa-sha2-nistp521',
+];
 
 interface AddSSHKeyFormProps {
 	addSSHKey( args: { name: string; key: string } ): void;
@@ -29,7 +40,16 @@ export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }
 					value={ publicSSHKey }
-					placeholder={ __( 'Paste the public key here' ) }
+					placeholder={ sprintf(
+						// translators: "formats" is a list of SSH-key formats.
+						__( 'Paste the public key here. It should begin with %(formats)s…' ),
+						{
+							formats: new Intl.ListFormat( i18n.getLocaleSlug() ?? 'en', {
+								style: 'long',
+								type: 'disjunction',
+							} ).format( keyFormats ),
+						}
+					) }
 					onChange={ ( event: ChangeEvent< HTMLTextAreaElement > ) =>
 						setPublicSSHKey( event.target.value )
 					}

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { ChangeEvent, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+
+const PUBLIC_SSH_KEY_INPUT_ID = 'public_ssh_key';
+
+interface AddSSHKeyFormProps {
+	addSSHKey( args: { name: string; key: string } ): void;
+}
+
+export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
+	const [ publicSSHKey, setPublicSSHKey ] = useState( '' );
+
+	const { __ } = useI18n();
+
+	return (
+		<form
+			onSubmit={ ( event ) => {
+				event.preventDefault();
+				addSSHKey( { name: 'default', key: publicSSHKey } );
+			} }
+		>
+			<FormFieldset>
+				<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'Public SSH key' ) }</FormLabel>
+				<FormTextarea
+					required
+					id={ PUBLIC_SSH_KEY_INPUT_ID }
+					value={ publicSSHKey }
+					onChange={ ( event: ChangeEvent< HTMLTextAreaElement > ) =>
+						setPublicSSHKey( event.target.value )
+					}
+				/>
+			</FormFieldset>
+			<Button primary type="submit">
+				{ __( 'Save SSH key' ) }
+			</Button>
+		</form>
+	);
+};

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -29,6 +29,7 @@ export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }
 					value={ publicSSHKey }
+					placeholder={ __( 'Paste the public key here' ) }
 					onChange={ ( event: ChangeEvent< HTMLTextAreaElement > ) =>
 						setPublicSSHKey( event.target.value )
 					}

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -1,8 +1,8 @@
-import { Button } from '@automattic/components';
+import { Button, FormInputValidation } from '@automattic/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import i18n from 'i18n-calypso';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useReducer } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextarea from 'calypso/components/forms/form-textarea';
@@ -18,20 +18,50 @@ const keyFormats = [
 	'ecdsa-sha2-nistp521',
 ];
 
+const initialState = {
+	touched: false,
+	isValid: false,
+	value: '',
+};
+
+const sshKeyValidation = new RegExp( `^(?:${ keyFormats.join( '|' ) })\\s.+` );
+
+type ReducerAction = { type: 'setValue'; value: string };
+
+const sshKeyFormReducer = ( state = initialState, action: ReducerAction ): typeof initialState => {
+	switch ( action.type ) {
+		case 'setValue':
+			return {
+				touched: true,
+				isValid: sshKeyValidation.test( action.value ),
+				value: action.value,
+			};
+
+		default:
+			return state;
+	}
+};
+
 interface AddSSHKeyFormProps {
 	addSSHKey( args: { name: string; key: string } ): void;
 }
 
 export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
-	const [ publicSSHKey, setPublicSSHKey ] = useState( '' );
+	const [ { isValid, touched, value }, dispatch ] = useReducer( sshKeyFormReducer, initialState );
 
 	const { __ } = useI18n();
+	const formats = new Intl.ListFormat( i18n.getLocaleSlug() ?? 'en', {
+		style: 'long',
+		type: 'disjunction',
+	} ).format( keyFormats );
+
+	const showSSHKeyError = touched && ! isValid;
 
 	return (
 		<form
 			onSubmit={ ( event ) => {
 				event.preventDefault();
-				addSSHKey( { name: 'default', key: publicSSHKey } );
+				addSSHKey( { name: 'default', key: value } );
 			} }
 		>
 			<FormFieldset>
@@ -39,23 +69,33 @@ export const AddSSHKeyForm = ( { addSSHKey }: AddSSHKeyFormProps ) => {
 				<FormTextarea
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }
-					value={ publicSSHKey }
+					value={ value }
+					isError={ showSSHKeyError }
 					placeholder={ sprintf(
 						// translators: "formats" is a list of SSH-key formats.
 						__( 'Paste the public key here. It should begin with %(formats)s…' ),
 						{
-							formats: new Intl.ListFormat( i18n.getLocaleSlug() ?? 'en', {
-								style: 'long',
-								type: 'disjunction',
-							} ).format( keyFormats ),
+							formats,
 						}
 					) }
 					onChange={ ( event: ChangeEvent< HTMLTextAreaElement > ) =>
-						setPublicSSHKey( event.target.value )
+						dispatch( { type: 'setValue', value: event.target.value } )
 					}
 				/>
+				{ showSSHKeyError && (
+					<FormInputValidation
+						isError
+						text={ sprintf(
+							// translators: "formats" is a list of SSH-key formats.
+							__( 'Invalid public key. It should begin with %(formats)s.' ),
+							{
+								formats,
+							}
+						) }
+					/>
+				) }
 			</FormFieldset>
-			<Button primary type="submit">
+			<Button primary type="submit" disabled={ ! isValid }>
 				{ __( 'Save SSH key' ) }
 			</Button>
 		</form>

--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -1,0 +1,56 @@
+import { Button, CompactCard } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import accept from 'calypso/lib/accept';
+import { SSHKeyData } from './use-ssh-key-query';
+
+type SSHKeyProps = { sshKey: SSHKeyData } & Pick< ManageSSHKeyProps, 'onDelete' >;
+
+const SSHKeyItemCard = styled( CompactCard )( {
+	display: 'flex',
+	alignItems: 'center',
+} );
+
+const SSHPublicKey = styled.code( {
+	flex: 1,
+	position: 'relative',
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+	marginRight: '1rem',
+} );
+
+const SSHKey = ( { sshKey, onDelete }: SSHKeyProps ) => {
+	const { __ } = useI18n();
+	const handleDeleteClick = () => {
+		accept( __( 'Are you sure you want to remove this SSH key?' ), ( accepted: boolean ) => {
+			if ( accepted ) {
+				onDelete( sshKey.name );
+			}
+		} );
+	};
+
+	return (
+		<SSHKeyItemCard>
+			<SSHPublicKey>{ sshKey.key }</SSHPublicKey>
+			<Button scary onClick={ handleDeleteClick } style={ { marginLeft: 'auto' } }>
+				{ __( 'Remove SSH key' ) }
+			</Button>
+		</SSHKeyItemCard>
+	);
+};
+
+interface ManageSSHKeyProps {
+	sshKeys: SSHKeyData[];
+	onDelete( name: string ): void;
+}
+
+export const ManageSSHKeys = ( { sshKeys, onDelete }: ManageSSHKeyProps ) => {
+	return (
+		<>
+			{ sshKeys.map( ( sshKey ) => (
+				<SSHKey key={ sshKey.key } sshKey={ sshKey } onDelete={ onDelete } />
+			) ) }
+		</>
+	);
+};

--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -35,7 +35,7 @@ const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 
 	return (
 		<SSHKeyItemCard>
-			<SSHPublicKey>{ sshKey.key }</SSHPublicKey>
+			<SSHPublicKey>{ sshKey.sha256 }</SSHPublicKey>
 			<Button
 				busy={ keyBeingDeleted === sshKey.name }
 				disabled={ !! keyBeingDeleted }

--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -4,7 +4,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import accept from 'calypso/lib/accept';
 import { SSHKeyData } from './use-ssh-key-query';
 
-type SSHKeyProps = { sshKey: SSHKeyData } & Pick< ManageSSHKeyProps, 'onDelete' >;
+type SSHKeyProps = { sshKey: SSHKeyData } & Pick<
+	ManageSSHKeyProps,
+	'onDelete' | 'keyBeingDeleted'
+>;
 
 const SSHKeyItemCard = styled( CompactCard )( {
 	display: 'flex',
@@ -20,7 +23,7 @@ const SSHPublicKey = styled.code( {
 	marginRight: '1rem',
 } );
 
-const SSHKey = ( { sshKey, onDelete }: SSHKeyProps ) => {
+const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 	const { __ } = useI18n();
 	const handleDeleteClick = () => {
 		accept( __( 'Are you sure you want to remove this SSH key?' ), ( accepted: boolean ) => {
@@ -33,7 +36,13 @@ const SSHKey = ( { sshKey, onDelete }: SSHKeyProps ) => {
 	return (
 		<SSHKeyItemCard>
 			<SSHPublicKey>{ sshKey.key }</SSHPublicKey>
-			<Button scary onClick={ handleDeleteClick } style={ { marginLeft: 'auto' } }>
+			<Button
+				busy={ keyBeingDeleted === sshKey.name }
+				disabled={ !! keyBeingDeleted }
+				scary
+				onClick={ handleDeleteClick }
+				style={ { marginLeft: 'auto' } }
+			>
 				{ __( 'Remove SSH key' ) }
 			</Button>
 		</SSHKeyItemCard>
@@ -43,13 +52,19 @@ const SSHKey = ( { sshKey, onDelete }: SSHKeyProps ) => {
 interface ManageSSHKeyProps {
 	sshKeys: SSHKeyData[];
 	onDelete( name: string ): void;
+	keyBeingDeleted: string | null;
 }
 
-export const ManageSSHKeys = ( { sshKeys, onDelete }: ManageSSHKeyProps ) => {
+export const ManageSSHKeys = ( { sshKeys, onDelete, keyBeingDeleted }: ManageSSHKeyProps ) => {
 	return (
 		<>
 			{ sshKeys.map( ( sshKey ) => (
-				<SSHKey key={ sshKey.key } sshKey={ sshKey } onDelete={ onDelete } />
+				<SSHKey
+					key={ sshKey.key }
+					sshKey={ sshKey }
+					onDelete={ onDelete }
+					keyBeingDeleted={ keyBeingDeleted }
+				/>
 			) ) }
 		</>
 	);

--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -1,6 +1,8 @@
 import { Button, CompactCard } from '@automattic/components';
 import styled from '@emotion/styled';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import i18n from 'i18n-calypso';
 import accept from 'calypso/lib/accept';
 import { SSHKeyData } from './use-ssh-key-query';
 
@@ -20,7 +22,13 @@ const SSHPublicKey = styled.code( {
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap',
-	marginRight: '1rem',
+} );
+
+const SSHKeyAddedDate = styled.span( {
+	display: 'block',
+	fontStyle: 'italic',
+	fontSize: '0.875rem',
+	color: 'var( --color-text-subtle )',
 } );
 
 const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
@@ -35,7 +43,21 @@ const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 
 	return (
 		<SSHKeyItemCard>
-			<SSHPublicKey>{ sshKey.sha256 }</SSHPublicKey>
+			<div style={ { marginRight: '1rem' } }>
+				<SSHPublicKey>{ sshKey.sha256 }</SSHPublicKey>
+				<SSHKeyAddedDate>
+					{ sprintf(
+						// translators: addedOn is when the SSH key was added.
+						__( 'Added on %(addedOn)s' ),
+						{
+							addedOn: new Intl.DateTimeFormat( i18n.getLocaleSlug() ?? 'en', {
+								dateStyle: 'long',
+								timeStyle: 'medium',
+							} ).format( new Date( sshKey.created_at ) ),
+						}
+					) }
+				</SSHKeyAddedDate>
+			</div>
 			<Button
 				busy={ keyBeingDeleted === sshKey.name }
 				disabled={ !! keyBeingDeleted }

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -100,15 +100,10 @@ export const SecuritySSHKey = () => {
 			<DocumentHead title={ __( 'SSH Key' ) } />
 
 			<CompactCard>
-				<p>
-					{ __(
-						'Add a SSH key to connect to our servers and manage your plugin-enabled WordPress.com website via command-line tools.'
-					) }
-				</p>
 				<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
 					{ createInterpolateElement(
 						__(
-							'Site-level Business plan is required to connect with SSH keys. <a>Read more.</a>'
+							'Add a SSH key to manage your SSH-enabled WordPress.com website via command-line tools. Site-level Business plan is required to connect with SSH keys. <a>Read more.</a>'
 						),
 						{
 							a: (

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -39,7 +39,7 @@ export const SecuritySSHKey = () => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
 
-	const addSSHKey = useAddSSHKeyMutation( {
+	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
 			dispatch( recordTracksEvent( 'calypso_ssh_key_add_request' ) );
 		},
@@ -125,7 +125,10 @@ export const SecuritySSHKey = () => {
 				{ isLoading ? (
 					<Placeholders />
 				) : ! hasKeys ? (
-					<AddSSHKeyForm addSSHKey={ ( { name, key } ) => addSSHKey( { name, key } ) } />
+					<AddSSHKeyForm
+						addSSHKey={ ( { name, key } ) => addSSHKey( { name, key } ) }
+						isAdding={ isAdding }
+					/>
 				) : null }
 			</CompactCard>
 			{ hasKeys && (

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -9,6 +9,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { AddSSHKeyForm } from './add-ssh-key-form';
 import { ManageSSHKeys } from './manage-ssh-keys';
@@ -38,10 +39,19 @@ export const SecuritySSHKey = () => {
 	const { __ } = useI18n();
 
 	const addSSHKey = useAddSSHKeyMutation( {
+		onMutate: () => {
+			dispatch( recordTracksEvent( 'calypso_ssh_key_add_request' ) );
+		},
 		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_ssh_key_add_success' ) );
 			dispatch( successNotice( __( 'SSH key has been successfully added!' ) ) );
 		},
-		onError: () => {
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_ssh_key_add_failure', {
+					code: error.code,
+				} )
+			);
 			dispatch(
 				errorNotice( __( 'Sorry, we had a problem saving that SSH key. Please try again.' ) )
 			);
@@ -49,10 +59,19 @@ export const SecuritySSHKey = () => {
 	} );
 
 	const deleteSSHKey = useDeleteSSHKeyMutation( {
+		onMutate: () => {
+			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_request' ) );
+		},
 		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_success' ) );
 			dispatch( successNotice( __( 'SSH key has been successfully removed!' ) ) );
 		},
-		onError: () => {
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_ssh_key_delete_failure', {
+					code: error.code,
+				} )
+			);
 			dispatch(
 				errorNotice( __( 'Sorry, we had a problem deleting that SSH key. Please try again.' ) )
 			);

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable no-nested-ternary */
+import { CompactCard, LoadingPlaceholder } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDispatch } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { AddSSHKeyForm } from './add-ssh-key-form';
+import { ManageSSHKeys } from './manage-ssh-keys';
+import { useAddSSHKeyMutation } from './use-add-ssh-key-mutation';
+import { useDeleteSSHKeyMutation } from './use-delete-ssh-key-mutation';
+import { useSSHKeyQuery } from './use-ssh-key-query';
+
+const SSHKeyLoadingPlaceholder = styled( LoadingPlaceholder )( {
+	':not(:last-child)': {
+		marginBlockEnd: '0.5rem',
+	},
+} );
+
+const Placeholders = () => (
+	<>
+		{ Array( 5 )
+			.fill( null )
+			.map( ( _, i ) => (
+				<SSHKeyLoadingPlaceholder key={ i } />
+			) ) }
+	</>
+);
+
+export const SecuritySSHKey = () => {
+	const { data, isLoading } = useSSHKeyQuery();
+	const dispatch = useDispatch();
+	const { __ } = useI18n();
+
+	const addSSHKey = useAddSSHKeyMutation( {
+		onSuccess: () => {
+			dispatch( successNotice( __( 'SSH key has been successfully added!' ) ) );
+		},
+		onError: () => {
+			dispatch(
+				errorNotice( __( 'Sorry, we had a problem saving that SSH key. Please try again.' ) )
+			);
+		},
+	} );
+
+	const deleteSSHKey = useDeleteSSHKeyMutation( {
+		onSuccess: () => {
+			dispatch( successNotice( __( 'SSH key has been successfully removed!' ) ) );
+		},
+		onError: () => {
+			dispatch(
+				errorNotice( __( 'Sorry, we had a problem deleting that SSH key. Please try again.' ) )
+			);
+		},
+	} );
+
+	const hasKeys = data && data.length > 0;
+
+	return (
+		<Main wideLayout className="security">
+			<PageViewTracker path="/me/security/ssh-key" title="Me > SSH Key" />
+
+			<FormattedHeader brandFont headerText={ __( 'Security' ) } align="left" />
+
+			<HeaderCake backText={ __( 'Back' ) } backHref="/me/security">
+				{ __( 'SSH Key' ) }
+			</HeaderCake>
+
+			<DocumentHead title={ __( 'SSH Key' ) } />
+
+			<CompactCard>
+				<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
+					{ __(
+						'Add a SSH key to connect to our servers and manage your plugin-enabled WordPress.com website via command-line tools.'
+					) }
+				</p>
+
+				{ isLoading ? (
+					<Placeholders />
+				) : ! hasKeys ? (
+					<AddSSHKeyForm addSSHKey={ ( { name, key } ) => addSSHKey( { name, key } ) } />
+				) : null }
+			</CompactCard>
+			{ hasKeys && (
+				<ManageSSHKeys
+					sshKeys={ data }
+					onDelete={ ( sshKeyName ) => deleteSSHKey( { sshKeyName } ) }
+				/>
+			) }
+		</Main>
+	);
+};

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -11,7 +11,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { AddSSHKeyForm } from './add-ssh-key-form';
 import { ManageSSHKeys } from './manage-ssh-keys';
 import { useAddSSHKeyMutation } from './use-add-ssh-key-mutation';
@@ -34,6 +34,12 @@ const Placeholders = () => (
 	</>
 );
 
+const noticeOptions = {
+	duration: 3000,
+};
+
+const sshKeySaveFailureNoticeId = 'ssh-key-save-failure';
+
 export const SecuritySSHKey = () => {
 	const { data, isLoading } = useSSHKeyQuery();
 	const dispatch = useDispatch();
@@ -42,10 +48,11 @@ export const SecuritySSHKey = () => {
 	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
 			dispatch( recordTracksEvent( 'calypso_ssh_key_add_request' ) );
+			dispatch( removeNotice( sshKeySaveFailureNoticeId ) );
 		},
 		onSuccess: () => {
 			dispatch( recordTracksEvent( 'calypso_ssh_key_add_success' ) );
-			dispatch( successNotice( __( 'SSH key has been successfully added!' ) ) );
+			dispatch( successNotice( __( 'SSH key has been successfully added!' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(
@@ -56,7 +63,11 @@ export const SecuritySSHKey = () => {
 			dispatch(
 				errorNotice(
 					// translators: "reason" is why adding the ssh key failed.
-					sprintf( __( 'Saving SSH key failed: %(reason)s' ), { reason: error.message } )
+					sprintf( __( 'Saving SSH key failed: %(reason)s' ), { reason: error.message } ),
+					{
+						...noticeOptions,
+						id: sshKeySaveFailureNoticeId,
+					}
 				)
 			);
 		},
@@ -68,7 +79,7 @@ export const SecuritySSHKey = () => {
 		},
 		onSuccess: () => {
 			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_success' ) );
-			dispatch( successNotice( __( 'SSH key has been successfully removed!' ) ) );
+			dispatch( successNotice( __( 'SSH key has been successfully removed!' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(
@@ -79,7 +90,8 @@ export const SecuritySSHKey = () => {
 			dispatch(
 				errorNotice(
 					// translators: "reason" is why deleting the ssh key failed.
-					sprintf( __( 'Deleting SSH key failed: %(reason)s' ), { reason: error.message } )
+					sprintf( __( 'Deleting SSH key failed: %(reason)s' ), { reason: error.message } ),
+					noticeOptions
 				)
 			);
 		},

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -47,7 +47,6 @@ export const SecuritySSHKey = () => {
 
 	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
-			dispatch( recordTracksEvent( 'calypso_ssh_key_add_request' ) );
 			dispatch( removeNotice( sshKeySaveFailureNoticeId ) );
 		},
 		onSuccess: () => {
@@ -74,9 +73,6 @@ export const SecuritySSHKey = () => {
 	} );
 
 	const { deleteSSHKey, keyBeingDeleted } = useDeleteSSHKeyMutation( {
-		onMutate: () => {
-			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_request' ) );
-		},
 		onSuccess: () => {
 			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_success' ) );
 			dispatch( successNotice( __( 'SSH key has been successfully removed!' ), noticeOptions ) );

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -2,6 +2,7 @@
 import { CompactCard, LoadingPlaceholder } from '@automattic/components';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -53,7 +54,10 @@ export const SecuritySSHKey = () => {
 				} )
 			);
 			dispatch(
-				errorNotice( __( 'Sorry, we had a problem saving that SSH key. Please try again.' ) )
+				errorNotice(
+					// translators: "reason" is why adding the ssh key failed.
+					sprintf( __( 'Saving SSH key failed: %(reason)s' ), { reason: error.message } )
+				)
 			);
 		},
 	} );
@@ -73,7 +77,10 @@ export const SecuritySSHKey = () => {
 				} )
 			);
 			dispatch(
-				errorNotice( __( 'Sorry, we had a problem deleting that SSH key. Please try again.' ) )
+				errorNotice(
+					// translators: "reason" is why deleting the ssh key failed.
+					sprintf( __( 'Deleting SSH key failed: %(reason)s' ), { reason: error.message } )
+				)
 			);
 		},
 	} );

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -62,7 +62,7 @@ export const SecuritySSHKey = () => {
 		},
 	} );
 
-	const deleteSSHKey = useDeleteSSHKeyMutation( {
+	const { deleteSSHKey, keyBeingDeleted } = useDeleteSSHKeyMutation( {
 		onMutate: () => {
 			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_request' ) );
 		},
@@ -135,6 +135,7 @@ export const SecuritySSHKey = () => {
 				<ManageSSHKeys
 					sshKeys={ data }
 					onDelete={ ( sshKeyName ) => deleteSSHKey( { sshKeyName } ) }
+					keyBeingDeleted={ keyBeingDeleted }
 				/>
 			) }
 		</Main>

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import { CompactCard, LoadingPlaceholder } from '@automattic/components';
 import styled from '@emotion/styled';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -73,9 +74,25 @@ export const SecuritySSHKey = () => {
 			<DocumentHead title={ __( 'SSH Key' ) } />
 
 			<CompactCard>
-				<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
+				<p>
 					{ __(
 						'Add a SSH key to connect to our servers and manage your plugin-enabled WordPress.com website via command-line tools.'
+					) }
+				</p>
+				<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
+					{ createInterpolateElement(
+						__(
+							'Site-level Business plan is required to connect with SSH keys. <a>Read more.</a>'
+						),
+						{
+							a: (
+								<a
+									href="https://wordpress.com/support/connect-to-ssh-on-wordpress-com/"
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						}
 					) }
 				</p>
 

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -50,12 +50,12 @@ export const SecuritySSHKey = () => {
 			dispatch( removeNotice( sshKeySaveFailureNoticeId ) );
 		},
 		onSuccess: () => {
-			dispatch( recordTracksEvent( 'calypso_ssh_key_add_success' ) );
+			dispatch( recordTracksEvent( 'calypso_security_ssh_key_add_success' ) );
 			dispatch( successNotice( __( 'SSH key has been successfully added!' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(
-				recordTracksEvent( 'calypso_ssh_key_add_failure', {
+				recordTracksEvent( 'calypso_security_ssh_key_add_failure', {
 					code: error.code,
 				} )
 			);
@@ -74,12 +74,12 @@ export const SecuritySSHKey = () => {
 
 	const { deleteSSHKey, keyBeingDeleted } = useDeleteSSHKeyMutation( {
 		onSuccess: () => {
-			dispatch( recordTracksEvent( 'calypso_ssh_key_delete_success' ) );
+			dispatch( recordTracksEvent( 'calypso_security_ssh_key_delete_success' ) );
 			dispatch( successNotice( __( 'SSH key has been successfully removed!' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(
-				recordTracksEvent( 'calypso_ssh_key_delete_failure', {
+				recordTracksEvent( 'calypso_security_ssh_key_delete_failure', {
 					code: error.code,
 				} )
 			);

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -14,6 +14,7 @@ interface MutationResponse {
 
 interface MutationError {
 	code: string;
+	message: string;
 }
 
 export const useAddSSHKeyMutation = (
@@ -21,21 +22,14 @@ export const useAddSSHKeyMutation = (
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
-		async ( { name, key }: MutationVariables ) => {
-			const response = await wp.req.post(
+		async ( { name, key }: MutationVariables ) =>
+			wp.req.post(
 				{ path: '/me/ssh-keys', apiNamespace: 'wpcom/v2' },
 				{
 					name,
 					key,
 				}
-			);
-
-			if ( ! response.success ) {
-				throw new Error( 'Adding SSH key was unsuccessful', response );
-			}
-
-			return response;
-		},
+			),
 		{
 			...options,
 			onSuccess( ...args ) {

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -39,9 +39,9 @@ export const useAddSSHKeyMutation = (
 		}
 	);
 
-	const { mutate } = mutation;
+	const { mutate, isLoading } = mutation;
 
-	const deleteSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
+	const addSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return deleteSSHKey;
+	return { addSSHKey, isLoading };
 };

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -32,8 +32,8 @@ export const useAddSSHKeyMutation = (
 			),
 		{
 			...options,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			onSuccess: async ( ...args ) => {
+				await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
 				options.onSuccess?.( ...args );
 			},
 		}

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -8,8 +8,12 @@ interface MutationVariables {
 	key: string;
 }
 
+interface MutationError {
+	code: string;
+}
+
 export const useAddSSHKeyMutation = (
-	options: UseMutationOptions< unknown, unknown, MutationVariables > = {}
+	options: UseMutationOptions< unknown, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -8,12 +8,16 @@ interface MutationVariables {
 	key: string;
 }
 
+interface MutationResponse {
+	message: string;
+}
+
 interface MutationError {
 	code: string;
 }
 
 export const useAddSSHKeyMutation = (
-	options: UseMutationOptions< unknown, MutationError, MutationVariables > = {}
+	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+import wp from 'calypso/lib/wp';
+import { SSH_KEY_QUERY_KEY } from './use-ssh-key-query';
+
+interface MutationVariables {
+	name: string;
+	key: string;
+}
+
+export const useAddSSHKeyMutation = (
+	options: UseMutationOptions< unknown, unknown, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		async ( { name, key }: MutationVariables ) => {
+			const response = await wp.req.post(
+				{ path: '/me/ssh-keys', apiNamespace: 'wpcom/v2' },
+				{
+					name,
+					key,
+				}
+			);
+
+			if ( ! response.success ) {
+				throw new Error( 'Adding SSH key was unsuccessful', response );
+			}
+
+			return response;
+		},
+		{
+			...options,
+			onSuccess( ...args ) {
+				queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+				options.onSuccess?.( ...args );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const deleteSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
+
+	return deleteSSHKey;
+};

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -7,8 +7,12 @@ interface MutationVariables {
 	sshKeyName: string;
 }
 
+interface MutationError {
+	code: string;
+}
+
 export const useDeleteSSHKeyMutation = (
-	options: UseMutationOptions< unknown, unknown, MutationVariables > = {}
+	options: UseMutationOptions< unknown, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -40,5 +40,9 @@ export const useDeleteSSHKeyMutation = (
 
 	const deleteSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return deleteSSHKey;
+	return {
+		deleteSSHKey,
+		keyBeingDeleted:
+			mutation.isLoading && mutation.variables ? mutation.variables.sshKeyName : null,
+	};
 };

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -29,8 +29,8 @@ export const useDeleteSSHKeyMutation = (
 			} ),
 		{
 			...options,
-			onSuccess( ...args ) {
-				queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			onSuccess: async ( ...args ) => {
+				await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
 				options.onSuccess?.( ...args );
 			},
 		}

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -7,12 +7,16 @@ interface MutationVariables {
 	sshKeyName: string;
 }
 
+interface MutationResponse {
+	message: string;
+}
+
 interface MutationError {
 	code: string;
 }
 
 export const useDeleteSSHKeyMutation = (
-	options: UseMutationOptions< unknown, MutationError, MutationVariables > = {}
+	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -13,6 +13,7 @@ interface MutationResponse {
 
 interface MutationError {
 	code: string;
+	message: string;
 }
 
 export const useDeleteSSHKeyMutation = (
@@ -20,19 +21,12 @@ export const useDeleteSSHKeyMutation = (
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
-		async ( { sshKeyName }: MutationVariables ) => {
-			const response = await wp.req.get( {
+		async ( { sshKeyName }: MutationVariables ) =>
+			wp.req.get( {
 				path: `/me/ssh-keys/${ sshKeyName }`,
 				apiNamespace: 'wpcom/v2',
 				method: 'DELETE',
-			} );
-
-			if ( ! response.success ) {
-				throw new Error( 'Deleting SSH key was unsuccessful', response );
-			}
-
-			return response;
-		},
+			} ),
 		{
 			...options,
 			onSuccess( ...args ) {

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+import wp from 'calypso/lib/wp';
+import { SSH_KEY_QUERY_KEY } from './use-ssh-key-query';
+
+interface MutationVariables {
+	sshKeyName: string;
+}
+
+export const useDeleteSSHKeyMutation = (
+	options: UseMutationOptions< unknown, unknown, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		async ( { sshKeyName }: MutationVariables ) => {
+			const response = await wp.req.get( {
+				path: `/me/ssh-keys/${ sshKeyName }`,
+				apiNamespace: 'wpcom/v2',
+				method: 'DELETE',
+			} );
+
+			if ( ! response.success ) {
+				throw new Error( 'Deleting SSH key was unsuccessful', response );
+			}
+
+			return response;
+		},
+		{
+			...options,
+			onSuccess( ...args ) {
+				queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+				options.onSuccess?.( ...args );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const deleteSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
+
+	return deleteSSHKey;
+};

--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -4,9 +4,7 @@ import wp from 'calypso/lib/wp';
 export const SSH_KEY_FORMATS = [
 	'ssh-rsa',
 	'ssh-ed25519',
-	'ssh-dss',
 	'ecdsa-sha2-nistp256',
-	'ecdsa-sha2-nistp384',
 	'ecdsa-sha2-nistp521',
 ] as const;
 

--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -1,9 +1,20 @@
 import { useQuery } from 'react-query';
 import wp from 'calypso/lib/wp';
 
+export const SSH_KEY_FORMATS = [
+	'ssh-rsa',
+	'ssh-ed25519',
+	'ssh-dss',
+	'ecdsa-sha2-nistp256',
+	'ecdsa-sha2-nistp384',
+	'ecdsa-sha2-nistp521',
+] as const;
+
 export interface SSHKeyData {
 	name: string;
 	key: string;
+	type: typeof SSH_KEY_FORMATS[ number ];
+	sha256: string;
 }
 
 export const SSH_KEY_QUERY_KEY = [ 'me', 'ssh-keys' ];

--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -1,0 +1,16 @@
+import { useQuery } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+export interface SSHKeyData {
+	name: string;
+	key: string;
+}
+
+export const SSH_KEY_QUERY_KEY = [ 'me', 'ssh-keys' ];
+
+export const useSSHKeyQuery = () =>
+	useQuery( SSH_KEY_QUERY_KEY, (): SSHKeyData[] =>
+		wp.req.get( '/me/ssh-keys', {
+			apiNamespace: 'wpcom/v2',
+		} )
+	);

--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -13,6 +13,7 @@ export interface SSHKeyData {
 	key: string;
 	type: typeof SSH_KEY_FORMATS[ number ];
 	sha256: string;
+	created_at: string;
 }
 
 export const SSH_KEY_QUERY_KEY = [ 'me', 'ssh-keys' ];

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -6,6 +6,7 @@ import ConnectedAppsComponent from 'calypso/me/connected-applications';
 import SecurityAccountEmail from 'calypso/me/security-account-email';
 import AccountRecoveryComponent from 'calypso/me/security-account-recovery';
 import SecurityCheckupComponent from 'calypso/me/security-checkup';
+import { SecuritySSHKey } from 'calypso/me/security-ssh-key/security-ssh-key';
 import PasswordComponent from 'calypso/me/security/main';
 import SocialLoginComponent from 'calypso/me/social-login';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -82,5 +83,10 @@ export function socialLogin( context, next ) {
 		socialService,
 		socialServiceResponse,
 	} );
+	next();
+}
+
+export function sshKey( context, next ) {
+	context.primary = <SecuritySSHKey />;
 	next();
 }

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -9,6 +9,7 @@ import {
 	securityAccountEmail,
 	securityCheckup,
 	socialLogin,
+	sshKey,
 	twoStep,
 } from './controller';
 
@@ -33,4 +34,6 @@ export default function () {
 	);
 
 	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
+
+	page( '/me/security/ssh-key', sidebar, sshKey, makeLayout, clientRender );
 }

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -35,5 +35,7 @@ export default function () {
 
 	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
 
-	page( '/me/security/ssh-key', sidebar, sshKey, makeLayout, clientRender );
+	if ( isEnabled( 'hosting/ssh-keys' ) ) {
+		page( '/me/security/ssh-key', sidebar, sshKey, makeLayout, clientRender );
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,
+		"hosting/ssh-keys": true,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,6 +42,7 @@
 		"happychat": false,
 		"help": true,
 		"home/layout-dev": true,
+		"hosting/ssh-keys": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"inline-help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,6 +44,7 @@
 		"google-my-business": true,
 		"happychat": true,
 		"help": true,
+		"hosting/ssh-keys": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"inline-help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -42,6 +42,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"happychat": true,
+		"hosting/ssh-keys": false,
 		"help": true,
 		"i18n/empathy-mode": true,
 		"inline-help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,6 +50,7 @@
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,
+		"hosting/ssh-keys": true,
 		"i18n/translation-scanner": true,
 		"importers/substack": true,
 		"inline-help": true,


### PR DESCRIPTION
#### Proposed Changes

Closes https://github.com/Automattic/wp-calypso/issues/68201 and gates the SSH CRUD behind the `hosting/ssh-keys` feature flag.

It misses an icon to the left of the key, the date it's been added, and event validation (@danielbachhuber, @vindl). 

Do we really care about the icon and the added date, or is it OK to add them on a follow-up?

#### Testing Instructions

1. Patch your sandbox with D88901-code and make sure you're proxied;
2. Open your profile settings and check that there is a new item in the "Security Checklist" section:

![image](https://user-images.githubusercontent.com/26530524/193914716-167c2deb-cfaa-4922-b6ca-7285449609d1.png)

3. Click on that item, fill the public key text area, and press "Save SSH key":

![image](https://user-images.githubusercontent.com/26530524/193914967-5c6e7610-9a17-42fb-89a2-f61bf06f0502.png)

4. Check the SSH key was added:

![image](https://user-images.githubusercontent.com/26530524/193915040-f508c6b2-93ad-4f40-bd09-420d5933f3ec.png)

5. Click "Remove SSH key" and check that there's confirmation preceding the action:

![image](https://user-images.githubusercontent.com/26530524/193915234-c1f53711-bdac-4a9c-9211-c30603a9b91d.png)

6. After confirming, the SSH key is gone:

![image](https://user-images.githubusercontent.com/26530524/193915334-844c2b4d-728d-4423-a555-ff766b8d81f7.png)

7. Check that the Tracks events were properly dispatched in the success scenarios;
8. Check that the _failure_ Tracks events are also dispatched, including the error code. One quick way to test is to enable the form regardless if there are stored keys (right now, only the "default" one is allowed).