### PR TITLE
Launchpad: Update site detail option types

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
@@ -141,7 +141,9 @@ export const defaultSiteDetails: SiteDetails = {
 		site_intent: 'link-in-bio',
 		site_vertical_id: null,
 		launchpad_screen: 'full',
-		launchpad_checklist_tasks_statuses: [],
+		launchpad_checklist_tasks_statuses: {
+			links_edited: false,
+		},
 	},
 	plan: {
 		product_id: 1,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -221,7 +221,7 @@ export interface SiteDetailsOptions {
 	woocommerce_is_active?: boolean;
 	wordads?: boolean;
 	launchpad_screen?: false | 'off' | 'full' | 'minimized';
-	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses | [];
+	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -152,7 +152,7 @@ export interface SiteDetailsOptions {
 	admin_url?: string;
 	advanced_seo_front_page_description?: string;
 	advanced_seo_title_formats?: string[];
-	ak_vp_bundle_enabled?: boolean;
+	ak_vp_bundle_enabled?: boolean | null;
 	allowed_file_types?: string[];
 	anchor_podcast?: boolean;
 	background_color?: boolean;
@@ -164,8 +164,8 @@ export interface SiteDetailsOptions {
 	default_ping_status?: boolean;
 	default_post_format?: string;
 	default_sharing_status?: boolean;
-	design_type?: string;
-	difm_lite_site_options?: DifmLiteSiteOptions;
+	design_type?: string | null;
+	difm_lite_site_options?: DifmLiteSiteOptions | Record< string, never >;
 	editing_toolkit_is_active?: boolean;
 	featured_images_enabled?: boolean;
 	frame_nonce?: string;
@@ -181,7 +181,7 @@ export interface SiteDetailsOptions {
 	image_thumbnail_crop?: number;
 	image_thumbnail_height?: number;
 	image_thumbnail_width?: number;
-	import_engine?: string;
+	import_engine?: string | null;
 	is_automated_transfer?: boolean;
 	is_cloud_eligible?: boolean;
 	is_difm_lite_in_progress?: boolean;
@@ -196,32 +196,32 @@ export interface SiteDetailsOptions {
 	jetpack_frame_nonce?: string;
 	jetpack_version?: string | undefined;
 	login_url?: string;
-	p2_hub_blog_id?: number;
+	p2_hub_blog_id?: number | null;
 	page_for_posts?: number;
 	page_on_front?: number;
 	permalink_structure?: string;
-	podcasting_archive?: boolean;
+	podcasting_archive?: boolean | null;
 	post_formats?: string[];
 	publicize_permanently_disabled?: boolean;
 	selected_features?: FeatureId[];
 	show_on_front?: string;
 	site_intent?: string;
-	site_segment?: string;
-	site_vertical_id?: string;
+	site_segment?: string | null;
+	site_vertical_id?: string | null;
 	software_version?: string;
 	theme_slug?: string;
 	timezone?: string;
 	unmapped_url?: string;
 	updated_at?: string;
 	upgraded_filetypes_enabled?: boolean;
-	verification_services_codes?: string;
+	verification_services_codes?: string | null;
 	videopress_enabled?: boolean;
 	videopress_storage_used?: number;
 	was_created_with_blank_canvas_design?: boolean;
 	woocommerce_is_active?: boolean;
 	wordads?: boolean;
 	launchpad_screen?: false | 'off' | 'full' | 'minimized';
-	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
+	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses | [];
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];


### PR DESCRIPTION
#### Proposed Changes

* Updates site detail option types

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that all unit tests are still passing with `yarn test-client launchpad`
* Verify that all circle CI builds are passing

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
