### PR TITLE
Checkout: Hide variant picker behind Edit button for each item

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
-import { useGetProductVariants } from '../../hooks/product-variants';
 import { ItemVariantPrice } from './variant-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -91,12 +90,10 @@ const OptionList = styled.ul`
 export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps > = ( {
 	isDisabled,
 	onChangeItemVariant,
-	productSlug,
 	selectedItem,
-	siteId,
+	variants,
 } ) => {
 	const translate = useTranslate();
-	const variants = useGetProductVariants( siteId, productSlug );
 
 	const [ open, setOpen ] = useState( false );
 	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -16,9 +16,8 @@ export type ItemVariationPickerProps = {
 	selectedItem: ResponseCartProduct;
 	onChangeItemVariant: OnChangeItemVariant;
 	isDisabled: boolean;
-	siteId: number | undefined;
-	productSlug: string;
 	isLoading?: boolean;
+	variants: WPCOMProductVariant[];
 };
 
 export type OnChangeItemVariant = (

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -90,6 +90,7 @@ export function WPOrderReviewLineItems( {
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
+					key={ product.product_slug }
 					product={ product }
 					siteId={ siteId }
 					isSummary={ isSummary }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -211,7 +211,11 @@ const EditTerm = styled( Button )< { theme?: Theme } >`
 function TermVariantEditButton( { onClick }: { onClick: () => void } ) {
 	const translate = useTranslate();
 	return (
-		<EditTerm buttonType="text-button" onClick={ onClick }>
+		<EditTerm
+			buttonType="text-button"
+			onClick={ onClick }
+			aria-label={ translate( 'Change the billing term for this product' ) }
+		>
 			{ translate( 'Edit' ) }
 		</EditTerm>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -15,6 +15,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
+import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
@@ -165,6 +166,8 @@ function LineItemWrapper( {
 		! isPremiumPlanWithDIFMInTheCart( product, responseCart ) &&
 		! hasPartnerCoupon;
 	const [ isEditingTerm, setEditingTerm ] = useState( false );
+	const variants = useGetProductVariants( siteId, product.product_slug );
+	const areThereVariants = variants.length > 1;
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
@@ -180,16 +183,15 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ shouldShowVariantSelector && ! isEditingTerm && (
+				{ areThereVariants && shouldShowVariantSelector && ! isEditingTerm && (
 					<TermVariantEditButton onClick={ () => setEditingTerm( true ) } />
 				) }
-				{ shouldShowVariantSelector && isEditingTerm && (
+				{ areThereVariants && shouldShowVariantSelector && isEditingTerm && (
 					<ItemVariationPicker
 						selectedItem={ product }
 						onChangeItemVariant={ onChangePlanLength }
 						isDisabled={ isDisabled }
-						siteId={ siteId }
-						productSlug={ product.product_slug }
+						variants={ variants }
 					/>
 				) }
 			</LineItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
-import { isAtomicSite } from 'calypso/state/selectors/is-site-automated-transfer';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -14,8 +14,11 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
+import { isAtomicSite } from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
@@ -170,6 +173,10 @@ function LineItemWrapper( {
 	const variants = useGetProductVariants( siteId, product.product_slug );
 	const areThereVariants = variants.length > 1;
 
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isJetpackSelfHosted = isJetpack && ! isAtomic;
+
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
 			<LineItem
@@ -184,17 +191,20 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ areThereVariants && shouldShowVariantSelector && ! isEditingTerm && (
-					<TermVariantEditButton onClick={ () => setEditingTerm( true ) } />
-				) }
-				{ areThereVariants && shouldShowVariantSelector && isEditingTerm && (
-					<ItemVariationPicker
-						selectedItem={ product }
-						onChangeItemVariant={ onChangePlanLength }
-						isDisabled={ isDisabled }
-						variants={ variants }
-					/>
-				) }
+				{ ! isJetpackSelfHosted &&
+					areThereVariants &&
+					shouldShowVariantSelector &&
+					! isEditingTerm && <TermVariantEditButton onClick={ () => setEditingTerm( true ) } /> }
+				{ areThereVariants &&
+					shouldShowVariantSelector &&
+					( isJetpackSelfHosted || isEditingTerm ) && (
+						<ItemVariationPicker
+							selectedItem={ product }
+							onChangeItemVariant={ onChangePlanLength }
+							isDisabled={ isDisabled }
+							variants={ variants }
+						/>
+					) }
 			</LineItem>
 		</WPOrderReviewListItem>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,4 +1,4 @@
-import { isPremium } from '@automattic/calypso-products';
+import { isJetpackPurchasableItem, isPremium } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
 import {
 	canItemBeRemovedFromCart,
@@ -14,11 +14,8 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
@@ -173,9 +170,9 @@ function LineItemWrapper( {
 	const variants = useGetProductVariants( siteId, product.product_slug );
 	const areThereVariants = variants.length > 1;
 
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const isJetpackSelfHosted = isJetpack && ! isAtomic;
+	const isJetpack = responseCart.products.some( ( product ) =>
+		isJetpackPurchasableItem( product.product_slug )
+	);
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
@@ -191,20 +188,17 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ ! isJetpackSelfHosted &&
-					areThereVariants &&
-					shouldShowVariantSelector &&
-					! isEditingTerm && <TermVariantEditButton onClick={ () => setEditingTerm( true ) } /> }
-				{ areThereVariants &&
-					shouldShowVariantSelector &&
-					( isJetpackSelfHosted || isEditingTerm ) && (
-						<ItemVariationPicker
-							selectedItem={ product }
-							onChangeItemVariant={ onChangePlanLength }
-							isDisabled={ isDisabled }
-							variants={ variants }
-						/>
-					) }
+				{ ! isJetpack && areThereVariants && shouldShowVariantSelector && ! isEditingTerm && (
+					<TermVariantEditButton onClick={ () => setEditingTerm( true ) } />
+				) }
+				{ areThereVariants && shouldShowVariantSelector && ( isJetpack || isEditingTerm ) && (
+					<ItemVariationPicker
+						selectedItem={ product }
+						onChangeItemVariant={ onChangePlanLength }
+						isDisabled={ isDisabled }
+						variants={ variants }
+					/>
+				) }
 			</LineItem>
 		</WPOrderReviewListItem>
 	);

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -153,6 +153,10 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
+			const editLineItem = await screen.findByLabelText(
+				'Change the billing term for this product'
+			);
+			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -175,6 +179,10 @@ describe( 'CheckoutMain with a variant picker', () => {
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
+			const editLineItem = await screen.findByLabelText(
+				'Change the billing term for this product'
+			);
+			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -196,7 +204,9 @@ describe( 'CheckoutMain with a variant picker', () => {
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
+			await expect(
+				screen.findByLabelText( 'Change the billing term for this product' )
+			).toNeverAppear();
 		}
 	);
 
@@ -210,6 +220,10 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
+			const editLineItem = await screen.findByLabelText(
+				'Change the billing term for this product'
+			);
+			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -251,6 +265,10 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
+			const editLineItem = await screen.findByLabelText(
+				'Change the billing term for this product'
+			);
+			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -266,7 +284,9 @@ describe( 'CheckoutMain with a variant picker', () => {
 		const cartChanges = { products: [ domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
-		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
+		await expect(
+			screen.findByLabelText( 'Change the billing term for this product' )
+		).toNeverAppear();
 	} );
 
 	it.each( [
@@ -281,7 +301,9 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getPersonalPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
+			await expect(
+				screen.findByLabelText( 'Change the billing term for this product' )
+			).toNeverAppear();
 		}
 	);
 
@@ -290,6 +312,8 @@ describe( 'CheckoutMain with a variant picker', () => {
 		const cartChanges = { products: [ currentPlanRenewal ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
-		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
+		await expect(
+			screen.findByLabelText( 'Change the billing term for this product' )
+		).toNeverAppear();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/65374 we modified the wpcom checkout product term variant picker to use a drop-down list in the same manner as the Jetpack product variant picker. Mostly this was so that the variant picker itself was no longer hidden behind the first step's "Edit" button, which could easily be overlooked. However, there's some concern that the variant picker is now being used too often.

This PR restores hiding the variant picker behind a toggle, but does so with a new "Edit" button _just for the line item_ instead of the whole step.

> **Warning**
> This affects both Jetpack and WPCom line items! We should get sign-off from both organizations before merging!

#### Screenshots

Before:

<img width="565" alt="Screen Shot 2022-10-04 at 6 13 16 PM" src="https://user-images.githubusercontent.com/2036909/193941407-45fef35b-f2ee-4420-8d22-2cac5830549f.png">

After:

<img width="568" alt="Screen Shot 2022-10-04 at 6 13 06 PM" src="https://user-images.githubusercontent.com/2036909/193941427-909dd728-e747-4802-bf4f-ef3b3e09f8d3.png">

And after clicking the "Edit" button...

<img width="573" alt="Screen Shot 2022-10-04 at 6 13 26 PM" src="https://user-images.githubusercontent.com/2036909/193941437-8b4b0c84-8e5e-43a8-ab65-04920d52b7c6.png">


(Note: this was extracted from https://github.com/Automattic/wp-calypso/pull/66027)

#### Testing Instructions

- Add a product to the cart which has term variants (eg: any legacy plan like Personal or Premium or Business).
- Visit checkout and verify that you do not see the variant picker displayed, but that there is an "Edit" button on each line item.
- Click the "Edit" button on the product and verify that the variant picker appears for that product.
- Click to change the currently selected term variant and verify that the price changes as expected.