### PR TITLE
Fix calypso masterbar menu items tracking.

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -125,7 +125,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 
 	const onLinkClick = useCallback( ( e ) => {
 		recordTracksEvent( 'calypso_jetpack_nav_item_click', {
-			nav_item: e.currentTarget.getAttribute( 'href' )?.replace( JETPACK_COM_BASE_URL, '' ),
+			nav_item: e.currentTarget
+				.getAttribute( 'href' )
+				// Remove the hostname https://jetpack.com/ from the href
+				// (including other languages, ie. es.jetpack.com, fr.jetpack.com, etc.)
+				?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
 		} );
 	}, [] );
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the tracking event for the Masterbar nav item click which was reporting erroneous values when viewing the Jetpack Cloud pricing page in other languages. (see testing instructions for further explanation)

Completes task: 1202858161751496-as-1203084998113442/f

#### Testing Instructions

**First to view (and understand) the issue:**
- Go to Jetpack Cloud pricing page in a different language from English, **ie.-** https://cloud.jetpack.com/es/pricing
- In the the browser dev console, enter `localStorage.debug = 'calypso:analytics*';`, press enter, and reload the page. (You should now see `calypso:analytics` debug messages in the console when the page loads).
- In the console settings, make sure you have `Preserve log:` checked. (and `Selected context only:` **Not** checked).
- In the top Masterbar nav menu, click "Products" --> Then "Backup".
- In the console, observe the `calypso_jetpack_nav_item_click` event. Notice the `nav_item` property value is: `https://es.jetpack.com/upgrade/backup/`. This is the bug/issue.  The `nav_item` value is supposed to be the url **path** only (with the hostname removed), such as `/upgrade/backup/`. This bug is causing erroneous data to be recorded in Tracks.

**Now test this PR:**
- - Do any one of these:
    - Click on Jetpack Cloud Live link below , then go to `/es/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout  fix/masterbar-menu-tracking`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/es/pricing](http://jetpack.cloud.localhost:3000/es/pricing)
- Open the browser dev console, enter `localStorage.debug = 'calypso:analytics*';`, press enter, and reload the page.
- In the top Masterbar nav menu, click "Products" --> Then "Backup".
- In the console, observe the `calypso_jetpack_nav_item_click` event.
- Verify that the `nav_item` property value is: `/upgrade/backup/`. (Not `https://es.jetpack.com/upgrade/backup/`)
- You can also test other links in the menu. Verify the `nav_item` property value is the href **path** only (the hostname is removed). (Except for the CRM product. The CRM product records the full url. This is ok.)
- You can try loading the pricing page in other languages too, such as http://jetpack.cloud.localhost:3000/fr/pricing OR http://jetpack.cloud.localhost:3000/ro/pricing. Click the menu links, and verify the `nav_item` property value is the href **path** only (hostname is removed).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
