### PR TITLE
Launchpad: Refactor test fixtures

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -4,55 +4,42 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import ChecklistItem from '../checklist-item';
-import { Task } from '../types';
-
-function getTask( taskData = {} ) {
-	const task: Task = {
-		id: 'foo_task',
-		isCompleted: false,
-		actionUrl: '#',
-		taskType: 'blog',
-		displayBadge: false,
-		title: 'Foo Task',
-	};
-
-	return { ...task, ...taskData };
-}
+import { buildTask } from './lib/fixtures';
 
 describe( 'ChecklistItem', () => {
 	describe( 'when the task requires a badge', () => {
 		it( 'displays a badge', () => {
 			const badgeText = 'Badge Text';
-			render( <ChecklistItem task={ getTask( { displayBadge: true, badgeText } ) } /> );
+			render( <ChecklistItem task={ buildTask( { displayBadge: true, badgeText } ) } /> );
 			expect( screen.getByText( badgeText ) ).toBeTruthy();
 		} );
 	} );
 
 	describe( 'when the task is complete', () => {
 		it( 'shows the task complete icon', () => {
-			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			render( <ChecklistItem task={ buildTask( { isCompleted: true } ) } /> );
 			const taskCompleteIcon = screen.queryByLabelText( 'Task complete' );
 			expect( taskCompleteIcon ).toBeTruthy();
 		} );
 		it( 'hides the task enabled icon', () => {
-			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			render( <ChecklistItem task={ buildTask( { isCompleted: true } ) } /> );
 			const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
 			expect( taskEnabledIcon ).toBeFalsy();
 		} );
 		it( 'disables the task', () => {
-			render( <ChecklistItem task={ getTask( { isCompleted: true } ) } /> );
+			render( <ChecklistItem task={ buildTask( { isCompleted: true } ) } /> );
 			const taskButton = screen.queryByRole( 'link' );
 			expect( taskButton ).toHaveAttribute( 'disabled' );
 		} );
 
 		describe( 'and the task is kept active', () => {
 			it( 'hides the task enabled icon', () => {
-				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
+				render( <ChecklistItem task={ buildTask( { isCompleted: true, keepActive: true } ) } /> );
 				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
 				expect( taskEnabledIcon ).toBeFalsy();
 			} );
 			it( 'enables the task', () => {
-				render( <ChecklistItem task={ getTask( { isCompleted: true, keepActive: true } ) } /> );
+				render( <ChecklistItem task={ buildTask( { isCompleted: true, keepActive: true } ) } /> );
 				const taskButton = screen.queryByRole( 'link' );
 				expect( taskButton ).not.toHaveAttribute( 'disabled' );
 			} );
@@ -61,7 +48,7 @@ describe( 'ChecklistItem', () => {
 
 	describe( 'when a task is incomplete', () => {
 		it( 'hides the task complete icon', () => {
-			render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+			render( <ChecklistItem task={ buildTask( { isCompleted: false } ) } /> );
 			const taskCompleteIcon = screen.queryByLabelText( 'Task complete' );
 			expect( taskCompleteIcon ).toBeFalsy();
 		} );
@@ -71,7 +58,7 @@ describe( 'ChecklistItem', () => {
 				const otherTaskCompleted = false;
 				render(
 					<ChecklistItem
-						task={ getTask( { isCompleted: false, dependencies: [ otherTaskCompleted ] } ) }
+						task={ buildTask( { isCompleted: false, dependencies: [ otherTaskCompleted ] } ) }
 					/>
 				);
 				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
@@ -81,7 +68,7 @@ describe( 'ChecklistItem', () => {
 				const otherTaskCompleted = false;
 				render(
 					<ChecklistItem
-						task={ getTask( { isCompleted: false, dependencies: [ otherTaskCompleted ] } ) }
+						task={ buildTask( { isCompleted: false, dependencies: [ otherTaskCompleted ] } ) }
 					/>
 				);
 				const taskButton = screen.queryByRole( 'link' );
@@ -91,12 +78,12 @@ describe( 'ChecklistItem', () => {
 
 		describe( 'and the task does not depend on the completion of other tasks', () => {
 			it( 'shows the task enabled icon', () => {
-				render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+				render( <ChecklistItem task={ buildTask( { isCompleted: false } ) } /> );
 				const taskEnabledIcon = screen.queryByLabelText( 'Task enabled' );
 				expect( taskEnabledIcon ).toBeTruthy();
 			} );
 			it( 'enables the task', () => {
-				render( <ChecklistItem task={ getTask( { isCompleted: false } ) } /> );
+				render( <ChecklistItem task={ buildTask( { isCompleted: false } ) } /> );
 				const taskButton = screen.queryByRole( 'link' );
 				expect( taskButton ).not.toHaveAttribute( 'disabled' );
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist.tsx
@@ -4,19 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Checklist from '../checklist';
-import { Task } from '../types';
-
-function getTask( taskData = {} ) {
-	const task: Task = {
-		id: 'foo_task',
-		isCompleted: false,
-		actionUrl: '#',
-		taskType: 'blog',
-		displayBadge: false,
-	};
-
-	return { ...task, ...taskData };
-}
+import { buildTask } from './lib/fixtures';
 
 describe( 'Checklist', () => {
 	describe( 'when provided no tasks', () => {
@@ -29,7 +17,9 @@ describe( 'Checklist', () => {
 
 	describe( 'when a number of tasks are provided', () => {
 		it( 'then the same number of tasks are rendered', () => {
-			render( <Checklist tasks={ [ getTask( { id: 'task1' } ), getTask( { id: 'task2' } ) ] } /> );
+			render(
+				<Checklist tasks={ [ buildTask( { id: 'task1' } ), buildTask( { id: 'task2' } ) ] } />
+			);
 			const checklistItems = screen.getAllByRole( 'listitem' );
 			expect( checklistItems.length ).toBe( 2 );
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
@@ -1,4 +1,5 @@
 import { SiteDetails } from '@automattic/data-stores/src/site';
+import { Task } from '../../types';
 
 export const defaultSiteDetails: SiteDetails = {
 	ID: 211078228,
@@ -184,9 +185,25 @@ export const defaultSiteDetails: SiteDetails = {
 	user_interactions: [ '2022-10-01' ],
 };
 
-export function generateSiteDetails( details ) {
+export const defaultTask: Task = {
+	id: 'foo_task',
+	isCompleted: false,
+	actionUrl: '#',
+	taskType: 'blog',
+	displayBadge: false,
+	title: 'Foo Task',
+};
+
+export function buildSiteDetails( details ) {
 	return {
 		...defaultSiteDetails,
 		...details,
+	};
+}
+
+export function buildTask( overrides ) {
+	return {
+		...defaultTask,
+		...overrides,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -8,7 +8,7 @@ import { useDispatch } from '@wordpress/data';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import Sidebar from '../sidebar';
-import { defaultSiteDetails, generateSiteDetails } from './lib/fixtures';
+import { defaultSiteDetails, buildSiteDetails } from './lib/fixtures';
 
 const siteName = 'testlinkinbio';
 const secondAndTopLevelDomain = 'wordpress.com';
@@ -76,7 +76,7 @@ describe( 'Sidebar', () => {
 	describe( 'when the tailored flow includes a task to launch the site', () => {
 		describe( 'and all tasks except the launch site task are complete', () => {
 			it( 'shows a launch title', () => {
-				const siteDetails = generateSiteDetails( {
+				const siteDetails = buildSiteDetails( {
 					options: {
 						...defaultSiteDetails.options,
 						launchpad_checklist_tasks_statuses: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -3,28 +3,16 @@
  */
 import { getArrayOfFilteredTasks, getEnhancedTasks, isTaskDisabled } from '../task-helper';
 import { tasks, launchpadFlowTasks } from '../tasks';
-import { Task } from '../types';
-
-function getTask( taskData = {} ) {
-	const task: Task = {
-		id: 'foo_task',
-		isCompleted: false,
-		actionUrl: '#',
-		taskType: 'blog',
-		displayBadge: false,
-	};
-
-	return { ...task, ...taskData };
-}
+import { buildTask } from './lib/fixtures';
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
 		describe( 'when a task should not be enhanced', () => {
 			it( 'then it is not enhanced', () => {
 				const fakeTasks = [
-					getTask( { id: 'fake-task-1' } ),
-					getTask( { id: 'fake-task-2' } ),
-					getTask( { id: 'fake-task-3' } ),
+					buildTask( { id: 'fake-task-1' } ),
+					buildTask( { id: 'fake-task-2' } ),
+					buildTask( { id: 'fake-task-3' } ),
 				];
 				// eslint-disable-next-line @typescript-eslint/no-empty-function
 				expect( getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {} ) ).toEqual(
@@ -34,7 +22,7 @@ describe( 'Task Helpers', () => {
 		} );
 		describe( 'when it is link_in_bio_launched task', () => {
 			it( 'then it receives launchtask property = true', () => {
-				const fakeTasks = [ getTask( { id: 'link_in_bio_launched' } ) ];
+				const fakeTasks = [ buildTask( { id: 'link_in_bio_launched' } ) ];
 				// eslint-disable-next-line @typescript-eslint/no-empty-function
 				const enhancedTasks = getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {} );
 				expect( enhancedTasks[ 0 ].isLaunchTask ).toEqual( true );
@@ -68,7 +56,7 @@ describe( 'Task Helpers', () => {
 			describe( 'and the other tasks are incomplete', () => {
 				it( 'then the given task is disabled', () => {
 					const dependencies = [ true, false ];
-					const task = getTask( { dependencies, isCompleted: false } );
+					const task = buildTask( { dependencies, isCompleted: false } );
 					expect( isTaskDisabled( task ) ).toBe( true );
 				} );
 			} );
@@ -76,19 +64,19 @@ describe( 'Task Helpers', () => {
 				const dependencies = [ true, true ];
 				describe( 'and the task can be revisited', () => {
 					it( 'then the task is enabled', () => {
-						const task = getTask( { dependencies, keepActive: true, isCompleted: false } );
+						const task = buildTask( { dependencies, keepActive: true, isCompleted: false } );
 						expect( isTaskDisabled( task ) ).toBe( false );
 					} );
 				} );
 				describe( 'and the given task complete', () => {
 					it( 'then the task is disabled', () => {
-						const task = getTask( { dependencies, keepActive: false, isCompleted: true } );
+						const task = buildTask( { dependencies, keepActive: false, isCompleted: true } );
 						expect( isTaskDisabled( task ) ).toBe( true );
 					} );
 				} );
 				describe( 'and the given task is incomplete', () => {
 					it( 'then the given task is enabled', () => {
-						const task = getTask( { dependencies, keepActive: false, isCompleted: false } );
+						const task = buildTask( { dependencies, keepActive: false, isCompleted: false } );
 						expect( isTaskDisabled( task ) ).toBe( false );
 					} );
 				} );


### PR DESCRIPTION
#### Proposed Changes

* Creates a shared task test fixture
* Creates a task test object generator function

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn test-client launchpad` and verify that all tests are still passing

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
