### PR TITLE
Marketplace: Top header Refinements - Color changes

### DIFF
--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -47,13 +47,13 @@
 	&::before {
 		box-sizing: border-box;
 		content: "";
-		background-color: #fdfdfd;
+		background-color: #fff;
 		position: absolute;
 		height: 100%;
 		width: 200vw;
 		left: -100vw;
 		z-index: -1;
-		border-top: 1px solid #eee;
+		border-top: 1px solid #f6f7f7;
 	}
 }
 

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -55,7 +55,7 @@
 		font-size: $font-title-large;
 		font-weight: 400;
 		line-height: 40px;
-
+		color: var(--studio-blue-90);
 	}
 
 	.search-box-header__recommended-searches {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -291,12 +291,80 @@ body.is-section-plugins header .select-dropdown__item {
 	padding: 0 0 0 16px !important;
 }
 
+body.is-section-plugins #primary {
+	&::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #fdfdfd;
+		position: absolute;
+		height: 100%;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+	}
+
+	.categories__menu {
+		.components-button {
+			&:not(.is-pressed) {
+				color: var(--studio-blue-90);
+			}
+			&.is-pressed {
+				&::before {
+					background: var(--studio-blue-90);
+				}
+			}
+		}
+	}
+}
+
 .legacy {
 	.plugin-details__body {
 		border-top: 1px solid var(--studio-gray-5);
 
 		.plugin-sections {
 			margin-top: 20px;
+		}
+		.section-nav-tabs__list {
+			box-shadow: none;
+		}
+
+		.section-nav-tab {
+			border-bottom: 2px solid transparent;
+
+			&.is-selected,
+			&:hover:not(.is-selected) {
+				border-bottom-color: transparent;
+			}
+
+			&:first-child .section-nav-tab__link {
+				padding-left: 0;
+			}
+
+			.section-nav-tab__link {
+				font-size: $font-body-small;
+				color: var(--color-primary);
+				padding: 16px 16px 14px;
+
+				&:hover {
+					background-color: transparent;
+					color: var(--color-primary);
+				}
+
+				.section-nav-tab__text {
+					padding-bottom: 0;
+					border-bottom: none;
+				}
+			}
+
+			&.is-selected .section-nav-tab__link {
+				font-weight: bold;
+				border-bottom: none;
+				color: var(--color-neutral-70);
+
+				&:hover {
+					color: var(--color-neutral-70);
+				}
+			}
 		}
 	}
 
@@ -433,53 +501,6 @@ body.is-section-plugins header .select-dropdown__item {
 	}
 }
 
-.legacy {
-	.plugin-details__body {
-		.section-nav-tabs__list {
-			box-shadow: none;
-		}
-
-		.section-nav-tab {
-			border-bottom: 2px solid transparent;
-
-			&.is-selected,
-			&:hover:not(.is-selected) {
-				border-bottom-color: transparent;
-			}
-
-			&:first-child .section-nav-tab__link {
-				padding-left: 0;
-			}
-
-			.section-nav-tab__link {
-				font-size: $font-body-small;
-				color: var(--color-primary);
-				padding: 16px 16px 14px;
-
-				&:hover {
-					background-color: transparent;
-					color: var(--color-primary);
-				}
-
-				.section-nav-tab__text {
-					padding-bottom: 0;
-					border-bottom: none;
-				}
-			}
-
-			&.is-selected .section-nav-tab__link {
-				font-weight: bold;
-				border-bottom: none;
-				color: var(--color-neutral-70);
-
-				&:hover {
-					color: var(--color-neutral-70);
-				}
-			}
-		}
-	}
-}
-
 .plugins__confirmation-modal {
 	.plugins__confirmation-modal-heading {
 		font-size: 1rem;
@@ -528,3 +549,4 @@ body.is-section-plugins header .select-dropdown__item {
 		}
 	}
 }
+


### PR DESCRIPTION
#### Proposed Changes

Change colors of Top header following the [design](https://github.com/Automattic/wp-calypso/issues/67285#issuecomment-1263572934)

#### Testing Instructions

1. Go to `/plugins`
2. Check for the header to follow the tasks and the screenshot

#### Tasks
- [x] Add a Light Grey background #fdfdfd to the top header
- [x] Add/change the below-header background color to white. This applies to all pages (#fff)
- [x] Change the color of the main title (Flex your site's features with plugins), the activated category button, and the category names to Blue90 (#01283D).
- [x] The line (stroke) right below the main top header should be 1px #F6F7F7

#### Screenshot
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/402286/193964232-37361b32-37e6-400d-87cb-c3e6a3cc8fec.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68572
