### PR TITLE
`WpcomLoginForm`: Fix getFormAction logic

### DIFF
--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { useEffect, useRef } from 'react';
 
 function getFormAction( redirectTo ) {
-	const subdomainRegExp = /^https?:\/\/(?!public-api)([a-z0-9-]+)\.wordpress\.com(?:$|\/)/;
+	const subdomainRegExp = /^https?:\/\/([a-z0-9-]+)\.wordpress\.com(?:$|\/)/;
 	const hostname = config( 'hostname' );
 	let subdomain = '';
 
@@ -11,7 +11,10 @@ function getFormAction( redirectTo ) {
 		hostname !== 'wpcalypso.wordpress.com' &&
 		hostname !== 'horizon.wordpress.com'
 	) {
-		subdomain = redirectTo.match( subdomainRegExp )[ 1 ] + '.';
+		const subdomainMatch = redirectTo.match( subdomainRegExp );
+		if ( subdomainMatch && subdomainMatch[ 1 ] !== 'public-api' ) {
+			subdomain = subdomainMatch[ 1 ] + '.';
+		}
 	}
 
 	return `https://${ subdomain }wordpress.com/wp-login.php`;

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { useEffect, useRef } from 'react';
 
 function getFormAction( redirectTo ) {
-	const subdomainRegExp = /^https?:\/\/([a-z0-9-]+)\.wordpress\.com(?:$|\/)/;
+	const subdomainRegExp = /^https?:\/\/(?!public-api)([a-z0-9-]+)\.wordpress\.com(?:$|\/)/;
 	const hostname = config( 'hostname' );
 	let subdomain = '';
 

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -109,4 +109,15 @@ describe( 'WpcomLoginForm', () => {
 			'https://wordpress.com/wp-login.php'
 		);
 	} );
+
+	test( 'its action should has no subdomain when `redirectTo` prop contains public-api.wordpress.com', () => {
+		const { container } = render(
+			<WpcomLoginForm { ...props } redirectTo="https://public-api.wordpress.com/" />
+		);
+
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
+			'https://wordpress.com/wp-login.php'
+		);
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR fixes a woo SSO signup error caused by https://github.com/Automattic/wp-calypso/pull/68099. 

68099 fixed a regular expression bug such that when the redirect prop is like `https://<pattern>.wordpress.com/`,  the form action URL will be `https://<pattern>wordpress.com/wp-login.php`. However, the `https://public-api.wordpress.com/wp-login.php` is a 404 page.

This PR updates the regular expression to not match the redirect prop containing `https://public-api.wordpress.com`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Comment or remove [this line](https://github.com/Automattic/wp-calypso/blob/9332b75599908cc6ef44b8747a86b5dfc6e051d0/client/signup/wpcom-login-form/index.jsx#L12) to test this locally
2. Set up a wpcalypso.wordpress.com environment
3. Log out WordPress.com or use incognito mode
4. Go to https://woocommerce.com/start/?nuxentrysource=signup_menu
5. Replace the URL https://wordpress.com/ with https://wpcalypso.wordpress.com/
6. Sign up via Google or Apple
7. Confirm that you can complete the signup flow without errors.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
