### PR TITLE
Marketplace: Top header Refinements - Margin/Padding review

### DIFF
--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -1,5 +1,5 @@
 .search-box-header {
-	margin: 32px 0;
+	margin: 40px 0 48px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -4,14 +4,14 @@
 @import "./woocommerce-box.scss";
 
 .is-section-plugins .main {
-	padding-top: 35px; // Compensate for the fixed header.
+	padding-top: 24px; // Compensate for the fixed header.
 
 	@media ( max-width: 782px ) {
-		padding-top: 50px;
+		padding-top: 45px;
 	}
 
 	@media ( max-width: 660px ) {
-		padding-top: 70px;
+		padding-top: 60px;
 	}
 }
 
@@ -324,6 +324,7 @@ body.is-section-plugins #primary {
 		.plugin-sections {
 			margin-top: 20px;
 		}
+
 		.section-nav-tabs__list {
 			box-shadow: none;
 		}


### PR DESCRIPTION
#### Proposed Changes

Review all the  Top header padding specs following the [design](https://github.com/Automattic/wp-calypso/issues/67285#issuecomment-1263572934)

#### Testing Instructions
1. Go to /plugins
2. Check margin/paddings to follow the screenshot comments

#### Screenshot
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/97929097/193278552-a581f3ea-9679-4c88-8413-2203689f042f.jpg">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68573
