### PR TITLE
Marketplace: Top header Refinements - Search term removal + box size change

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -148,7 +148,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			<JetpackDisconnectedNotice />
 			<SearchBoxHeader
 				searchRef={ searchRef }
-				popularSearchesRef={ searchHeaderRef }
+				stickySearchBoxRef={ searchHeaderRef }
 				isSticky={ isAboveElement }
 				searchTerm={ search }
 				isSearching={ isFetchingPluginsBySearchTerm }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -2,9 +2,8 @@ import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useCurrentRoute } from 'calypso/components/route';
 import { setQueryArgs } from 'calypso/lib/query-args';
-import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
 function pageToSearch( s ) {
@@ -36,72 +35,10 @@ const SearchBox = ( { isMobile, searchTerm, searchBoxRef, isSearching } ) => {
 	);
 };
 
-const SearchLink = ( { searchTerm, currentTerm, onSelect } ) => {
-	const classes = [ 'search-box-header__recommended-searches-list-item' ];
-	const route = useCurrentRoute();
-
-	if ( searchTerm === currentTerm ) {
-		classes.push( 'search-box-header__recommended-searches-list-item-selected' );
-
-		return <span className={ classes.join( ' ' ) }>{ searchTerm }</span>;
-	}
-
-	return (
-		<a
-			href={ `${ route.currentRoute }?s=${ searchTerm }` }
-			className={ classes.join( ' ' ) }
-			onClick={ onSelect }
-			onKeyPress={ onSelect }
-		>
-			{ searchTerm }
-		</a>
-	);
-};
-
-const PopularSearches = ( props ) => {
-	const { searchTerms, searchedTerm, searchBoxRef, popularSearchesRef } = props;
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const clickHandler = ( searchTerm ) => ( event ) => {
-		event.preventDefault();
-
-		dispatch(
-			recordTracksEvent( 'calypso_plugins_popular_searches_click', {
-				search_term: searchTerm,
-			} )
-		);
-
-		// When loading a search via click instead of interacting with the search
-		// box input directly we need to set the search term separately.
-		searchBoxRef?.current?.setKeyword( searchTerm );
-		pageToSearch( searchTerm );
-	};
-
-	return (
-		<div className="search-box-header__recommended-searches" ref={ popularSearchesRef }>
-			<div className="search-box-header__recommended-searches-title">
-				{ translate( 'Most popular searches' ) }
-			</div>
-
-			<div className="search-box-header__recommended-searches-list">
-				{ searchTerms.map( ( searchTerm, n ) => (
-					<SearchLink
-						key={ 'search-box-item' + n }
-						onSelect={ clickHandler( searchTerm ) }
-						searchTerm={ searchTerm }
-						currentTerm={ searchedTerm }
-					/>
-				) ) }
-			</div>
-		</div>
-	);
-};
-
 const SearchBoxHeader = ( props ) => {
 	const {
 		searchTerm,
 		title,
-		searchTerms,
 		isSticky,
 		popularSearchesRef,
 		isSearching,
@@ -130,12 +67,7 @@ const SearchBoxHeader = ( props ) => {
 					isSearching={ isSearching }
 				/>
 			</div>
-			<PopularSearches
-				searchBoxRef={ searchRef }
-				searchedTerm={ searchTerm }
-				searchTerms={ searchTerms }
-				popularSearchesRef={ popularSearchesRef }
-			/>
+			<div className="search-box-header__sticky-ref" ref={ popularSearchesRef }></div>
 		</div>
 	);
 };

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -40,7 +40,7 @@ const SearchBoxHeader = ( props ) => {
 		searchTerm,
 		title,
 		isSticky,
-		popularSearchesRef,
+		stickySearchBoxRef,
 		isSearching,
 		searchRef,
 		renderTitleInH1,
@@ -67,7 +67,7 @@ const SearchBoxHeader = ( props ) => {
 					isSearching={ isSearching }
 				/>
 			</div>
-			<div className="search-box-header__sticky-ref" ref={ popularSearchesRef }></div>
+			<div className="search-box-header__sticky-ref" ref={ stickySearchBoxRef }></div>
 		</div>
 	);
 };

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -22,6 +22,9 @@
 			.search-component {
 				height: 52px;
 				z-index: 0;
+				max-width: 400px;
+				margin: 0 auto;
+
 				&.is-expanded-to-container {
 					height: 100%;
 				}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -24,12 +24,13 @@
 				z-index: 0;
 				max-width: 400px;
 				margin: 0 auto;
+				border-radius: 4px;
 
 				&.is-expanded-to-container {
 					height: 100%;
 				}
 
-				box-shadow: 0 0 0 1px var(--studio-gray-10);
+				box-shadow: 0 0 0 1px var(--studio-gray-5);
 
 				.search-component__icon-navigation:focus {
 					box-shadow: none;
@@ -37,7 +38,7 @@
 
 				.search-component__open-icon,
 				.search-component__close-icon {
-					color: var(--studio-black);
+					color: var(--studio-gray-5);
 				}
 
 				&.is-searching {
@@ -47,6 +48,18 @@
 					}
 				}
 
+				.search-component__input-fade {
+					right: 3px;
+				}
+				.search-component__icon-navigation:first-of-type {
+					margin-left: 3px;
+				}
+				.search-component__icon-navigation:not(:first-of-type) {
+					margin-right: 3px;
+					.search-component__close-icon {
+						color: #757575;
+					}
+				}
 			}
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -311,6 +311,7 @@ body.is-section-plugins #primary {
 			&.is-pressed {
 				&::before {
 					background: var(--studio-blue-90);
+					border-radius: 4px;
 				}
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

Remove `popular search` and change the box size following the [design](https://github.com/Automattic/wp-calypso/issues/67285#issuecomment-1263572934)

#### Testing Instructions
1. Go to /plugins
2. `Popular search` should not show
3. Check box size should be 400px

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68574
