### PR TITLE
Stats: Fix padding for tabs underneath the graph

### DIFF
--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -46,9 +46,6 @@ $stats-tab-outer-padding: 10px;
 
 			a,
 			.no-link {
-				display: block;
-				min-height: 35px;
-				padding-top: $stats-tab-outer-padding;
 				padding-bottom: 0; // needed to avoid double bottom spacing (because of min-height)
 			}
 

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -1,6 +1,8 @@
 // Module Tabs
 // (currently only used for the bar chart module at the top)
 
+$stats-tab-outer-padding: 10px;
+
 .stats-tabs {
 	@include clear-fix;
 	background: var(--color-surface);
@@ -46,8 +48,8 @@
 			.no-link {
 				display: block;
 				min-height: 35px;
-				padding-top: 10px;
-				padding-bottom: 0;
+				padding-top: $stats-tab-outer-padding;
+				padding-bottom: 0; // needed to avoid double bottom spacing (because of min-height)
 			}
 
 			.label {
@@ -95,11 +97,12 @@
 		.no-link {
 			display: block;
 			min-height: 35px;
-			padding-top: 10px;
+			padding-top: $stats-tab-outer-padding;
 
 			@include breakpoint-deprecated( ">480px" ) {
 				@include mobile-link-element;
 				@include clear-fix;
+				padding-bottom: $stats-tab-outer-padding;
 				-webkit-touch-callout: none;
 			}
 		}
@@ -229,6 +232,7 @@
 	}
 
 	// If there's only one tab (used on the Post/Video Details page)
+	// forced "mobile view" that takes the whole width (e.g. visible for stats for a specific blog page)
 	li:only-child {
 		width: auto;
 		float: none;
@@ -236,7 +240,11 @@
 
 		a {
 			line-height: 24px;
-			padding-top: 10px;
+			padding-top: $stats-tab-outer-padding;
+		}
+
+		.no-link {
+			padding-bottom: 0; // reset bottom padding until min-width is removed
 		}
 
 		.label {


### PR DESCRIPTION
#### Proposed Changes

* add bottom padding to the tabs under the chart on the stats page
* replace padding values with a variable
* remove redundant CSS properties from the compact tab version. They are already inherited from the main tab styles. 
* keep additional bottom padding for stats summary after navigating to `all my sites`

#### Testing Instructions
* checkout `update/stats-tabs-padding` branch and run locally
* navigate to any page and select `Stats` from the left menu

Tabs before:
![Screenshot 2022-10-05 at 5 25 59 PM](https://user-images.githubusercontent.com/112354940/193981226-a6b62aaf-dab4-4630-88b2-a372d4713cd1.png)

Tabs after:
![Screenshot 2022-10-05 at 5 26 14 PM](https://user-images.githubusercontent.com/112354940/193981256-249f5597-ba87-4ded-ab0c-1e4dfe007df2.png)

* reduce the screen size and verify that the mobile version of the tabs looks the same

When viewing stats for multiple pages, the chart is not visible but the tabs are. I propose keeping additional 10px padding at the bottom of the tab until the tabs are refactored from using `float` to `flexbox`. With that future refactoring, I'll propose extending the tabs with an additional version that is already used on the `site overview` page instead of coupling tabs and site overview styles.

After the changes:
![Screenshot 2022-10-05 at 5 03 16 PM](https://user-images.githubusercontent.com/112354940/193981887-4dbbae3e-9570-4d89-84c2-dd10fdb2c15a.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68669 
