### PR TITLE
Style selection: Surface themes with style variations to top of the theme grid

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -35,7 +35,7 @@ import DesignPickerDesignTitle from './design-picker-design-title';
 import PreviewToolbar from './preview-toolbar';
 import UpgradeModal from './upgrade-modal';
 import getThemeIdFromDesign from './utils/get-theme-id-from-design';
-import { removeLegacyDesignVariations } from './utils/style-variations';
+import { removeLegacyDesignVariations, promoteDesignVariations } from './utils/style-variations';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
 import type { StarterDesigns } from '@automattic/data-stores';
@@ -83,6 +83,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
 		if ( isEnabled( 'signup/design-picker-style-selection' ) ) {
 			allDesigns.static.designs = removeLegacyDesignVariations( allDesigns?.static?.designs || [] );
+			allDesigns.static.designs = promoteDesignVariations( allDesigns.static.designs );
 		}
 
 		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
@@ -1,4 +1,3 @@
-import { shuffle } from '@automattic/js-utils';
 import { Design } from 'calypso/../packages/design-picker/src/types';
 
 /**
@@ -20,13 +19,15 @@ export function removeLegacyDesignVariations( designs: Design[] ) {
  * Promote designs with style variations by having them at the beginning of the list.
  */
 export function promoteDesignVariations( designs: Design[] ) {
-	const designsWithVariations = designs.filter(
-		( design ) => design.style_variations && design.style_variations.length > 0
-	);
+	return designs.sort( ( a, b ) => {
+		if ( ! a.style_variations || a.style_variations.length === 0 ) {
+			return 1;
+		}
 
-	const designsWithoutVariations = designs.filter(
-		( design ) => design.style_variations && design.style_variations.length === 0
-	);
+		if ( ! b.style_variations || b.style_variations.length === 0 ) {
+			return -1;
+		}
 
-	return shuffle( designsWithVariations ).concat( shuffle( designsWithoutVariations ) );
+		return 0;
+	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
@@ -20,14 +20,20 @@ export function removeLegacyDesignVariations( designs: Design[] ) {
  */
 export function promoteDesignVariations( designs: Design[] ) {
 	return designs.sort( ( a, b ) => {
-		if ( ! a.style_variations || a.style_variations.length === 0 ) {
-			return 1;
+		const a_style_variations = a.style_variations || [];
+		const b_style_variations = b.style_variations || [];
+
+		// Keep original order if:
+		// (1) neither a or b have style variations or
+		// (2) both a and b have style variations
+		if (
+			( a_style_variations.length === 0 && b_style_variations.length === 0 ) ||
+			( a_style_variations.length > 0 && b_style_variations.length > 0 )
+		) {
+			return 0;
 		}
 
-		if ( ! b.style_variations || b.style_variations.length === 0 ) {
-			return -1;
-		}
-
-		return 0;
+		// Sort b before a if it has style variations.
+		return b_style_variations.length > a_style_variations.length ? 1 : -1;
 	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
@@ -1,3 +1,4 @@
+import { shuffle } from '@automattic/js-utils';
 import { Design } from 'calypso/../packages/design-picker/src/types';
 
 /**
@@ -13,4 +14,19 @@ export function removeLegacyDesignVariations( designs: Design[] ) {
 			design.slug.startsWith( designWithVariations.slug + '-' )
 		);
 	return designs.filter( ( design ) => ! isVariationOfAnotherDesign( design ) );
+}
+
+/**
+ * Promote designs with style variations by having them at the beginning of the list.
+ */
+export function promoteDesignVariations( designs: Design[] ) {
+	const designsWithVariations = designs.filter(
+		( design ) => design.style_variations && design.style_variations.length > 0
+	);
+
+	const designsWithoutVariations = designs.filter(
+		( design ) => design.style_variations && design.style_variations.length === 0
+	);
+
+	return shuffle( designsWithVariations ).concat( shuffle( designsWithoutVariations ) );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/utils/style-variations.ts
@@ -20,20 +20,16 @@ export function removeLegacyDesignVariations( designs: Design[] ) {
  */
 export function promoteDesignVariations( designs: Design[] ) {
 	return designs.sort( ( a, b ) => {
-		const a_style_variations = a.style_variations || [];
-		const b_style_variations = b.style_variations || [];
+		const a_has_variations = ( a.style_variations || [] ).length > 0;
+		const b_has_variations = ( b.style_variations || [] ).length > 0;
 
 		// Keep original order if:
 		// (1) neither a or b have style variations or
 		// (2) both a and b have style variations
-		if (
-			( a_style_variations.length === 0 && b_style_variations.length === 0 ) ||
-			( a_style_variations.length > 0 && b_style_variations.length > 0 )
-		) {
+		if ( a_has_variations === b_has_variations ) {
 			return 0;
 		}
 
-		// Sort b before a if it has style variations.
-		return b_style_variations.length > a_style_variations.length ? 1 : -1;
+		return a_has_variations ? -1 : 1;
 	} );
 }


### PR DESCRIPTION
#### Proposed Changes

This PR adds the function `promoteDesignVariations` which takes a list of themes, and returns a new list of themes where the ones with style variations are placed at the beginning. In simpler words, the new list looks like:
```
[ ...[ shuffled list of themes with variations ], ...[ shuffled list of themes without variations] ]
```

The purpose of this function is to surface themes with style variations to the top of the theme grid.
See screenshot for reference:
![Screen Shot 2022-10-05 at 2 08 58 PM](https://user-images.githubusercontent.com/797888/193992674-14c55100-b3a7-47d3-8c29-76b53e46c502.png)

Note that for analytics purposes, we are aiming to deploy this change no sooner than October 12th, 2022.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Ensure that themes with style variations are all at the beginning of the theme grid.
* Ensure that this behavior also persists across theme filters.
* Ensure that all themes are still present in the theme grid.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68183
