### PR TITLE
Jetpack License Portal: add the "Issue New License" button to the billing page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -1,4 +1,6 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -6,10 +8,17 @@ import BillingDetails from 'calypso/jetpack-cloud/sections/partner-portal/billin
 import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
 import './style.scss';
 
 export default function BillingDashboard() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onIssueNewLicenseClick = () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
+	};
 
 	return (
 		<Main wideLayout className="billing-dashboard">
@@ -20,6 +29,10 @@ export default function BillingDashboard() {
 				<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>
 
 				<SelectPartnerKeyDropdown />
+
+				<Button primary href="/partner-portal/issue-license" onClick={ onIssueNewLicenseClick }>
+					{ translate( 'Issue New License' ) }
+				</Button>
 			</div>
 
 			<BillingSummary />

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/style.scss
@@ -1,13 +1,24 @@
-.billing-dashboard {
-	&__header {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
+.billing-dashboard__header {
+	display: flex;
+	align-items: center;
 
-		@include breakpoint-deprecated( ">960px" ) {
-			> * + * {
-				margin-left: 24px;
-			}
+	> * + * {
+		margin-left: 24px;
+	}
+
+	a.button {
+		margin-left: auto;
+	}
+
+	@include breakpoint-deprecated( "<960px" ) {
+		flex-wrap: wrap;
+		> * {
+			width: 100%;
+			margin-bottom: 16px;
+		}
+
+		> * + * {
+			margin-left: 0;
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR adds the "Issue New License" button to the billing page.

#### Testing Instructions

**Prerequisites**

Make sure to have a partner account.

**Instructions**

1. Run `git checkout add/issue-new-license-button-in-billing-page` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/ -> Click on **Licensing** on top nav -> Click on **Billing** on left nav.
3. Keep the network tab open and apply the search filter as `calypso_partner_portal_issue_license_click_billing_page`
4. Verify that the `Issue New License` button is as shown below, and clicking on that takes you to the issue license page. 
5. Verify that we are recording the click event with the key `calypso_partner_portal_issue_license_click_billing_page`.

**Large Screen**

<img width="1104" alt="Screenshot 2022-10-05 at 12 34 22 PM" src="https://user-images.githubusercontent.com/10586875/194007339-25a2cd5e-0feb-4268-9270-350c1f27fa49.png">

**Small Screen**

<img width="356" alt="Screenshot 2022-10-05 at 12 34 14 PM" src="https://user-images.githubusercontent.com/10586875/194007314-d15a1ff6-d316-4b87-a7d0-6aaf13ca40eb.png">

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? 
- [x] ~~Have you tested the feature in [Simple](P9HQHe-k8-p2-p2), [Atomic](P9HQHe-jW-p2-p2), and [self-hosted Jetpack sites](PCYsg-g6b-p2-p2)?~~
- [x] Have you checked for TypeScript, React, or other console errors?
- [x] Are we memoizing when appropriate (for expensive computations)? More info in [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) and [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)
- [x] Have we sent any new strings [for translation](PCYsg-1vr-p2-p2) ASAP?

Related to 1202619025189113-as-1202835755236987