### PR TITLE
Fix Jetpack Social discounted price by hard-coding it

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -1,6 +1,6 @@
 import {
-	PRODUCT_JETPACK_CRM,
-	PRODUCT_JETPACK_CRM_MONTHLY,
+	JETPACK_CRM_PRODUCTS,
+	JETPACK_SOCIAL_PRODUCTS,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import { useMemo } from 'react';
@@ -163,6 +163,15 @@ const useItemPrice = (
 			discountedPrice = introductoryOfferPrices.introOfferCost
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;
+
+			// Override Jetpack Social price by hard-coding it for now
+			if (
+				JETPACK_SOCIAL_PRODUCTS.includes(
+					item?.productSlug as typeof JETPACK_SOCIAL_PRODUCTS[ number ]
+				)
+			) {
+				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;
+			}
 		}
 	}
 
@@ -171,7 +180,10 @@ const useItemPrice = (
 	}
 
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
-	if ( item && [ PRODUCT_JETPACK_CRM, PRODUCT_JETPACK_CRM_MONTHLY ].includes( item.productSlug ) ) {
+	if (
+		item &&
+		JETPACK_CRM_PRODUCTS.includes( item.productSlug as typeof JETPACK_CRM_PRODUCTS[ number ] )
+	) {
 		discountedPrice = item.displayPrice || -1;
 		originalPrice = item.displayPrice || -1;
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the Jetpack Social discounted price which was considered to be a yearly discount. It hard-codes it to be a monthly discount.

#### Testing Instructions


- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
    - or boot up this PR 
        - Run `git fetch && git checkout fix/jetpack-social-price`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Confirm that the price for Jetpack Social is **$1 <s>$10</s>** instead of **$0.08 <s>$10</s>**

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1664891686656539-slack-C03RCHNVC0H

<img width="595" alt="Screenshot 2022-10-05 at 11 48 01 AM" src="https://user-images.githubusercontent.com/18226415/194018770-11d8fe34-f319-4d90-94e9-191a01894810.png">
