### PR TITLE
Style selection: Fix issue where style variation won't be reset when the user clicks on the browser back button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -290,6 +290,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlugOrId && _selectedDesign ) {
+			// Ensure that the selected design actually has the selected style variation.
+			const styleVariation =
+				_selectedDesign.style_variations && selectedStyleVariation
+					? _selectedDesign.style_variations.find(
+							( variation ) => variation.slug === selectedStyleVariation.slug
+					  )
+					: null;
+
 			let positionIndex = generatedDesigns.findIndex(
 				( design ) => design.slug === _selectedDesign.slug
 			);
@@ -298,9 +306,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					( design ) => design.slug === _selectedDesign.slug
 				);
 			}
+
 			setPendingAction( () =>
 				setDesignOnSite( siteSlugOrId, _selectedDesign, {
-					styleVariation: selectedStyleVariation,
+					styleVariation,
 					verticalId: siteVerticalId,
 				} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -153,6 +153,12 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	);
 	const { setSelectedStyleVariation } = useDispatch( ONBOARD_STORE );
 
+	// Unset the selected design, thus restarting the design picking experience.
+	useEffect( () => {
+		setSelectedDesign( undefined );
+		setSelectedStyleVariation( undefined );
+	}, [] );
+
 	function getEventPropsByDesign( design: Design, variation?: StyleVariation ) {
 		const variationSlugSuffix =
 			variation && variation.slug !== 'default' ? `-${ variation.slug }` : '';
@@ -290,14 +296,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlugOrId && _selectedDesign ) {
-			// Ensure that the selected design actually has the selected style variation.
-			const styleVariation =
-				_selectedDesign.style_variations && selectedStyleVariation
-					? _selectedDesign.style_variations.find(
-							( variation ) => variation.slug === selectedStyleVariation.slug
-					  )
-					: null;
-
 			let positionIndex = generatedDesigns.findIndex(
 				( design ) => design.slug === _selectedDesign.slug
 			);
@@ -306,10 +304,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					( design ) => design.slug === _selectedDesign.slug
 				);
 			}
-
 			setPendingAction( () =>
 				setDesignOnSite( siteSlugOrId, _selectedDesign, {
-					styleVariation,
+					styleVariation: selectedStyleVariation,
 					verticalId: siteVerticalId,
 				} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 			);


### PR DESCRIPTION
#### Proposed Changes

This PR updates the unified design picker component so that the previously selected design and style variation is unset upon mount. This approach takes into consideration that the unified design picker starts the design picking experience from scratch each time users land on the screen, so there is no really a need for the selected design and style variation to persist beyond the design picker screen.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}
* Run through the steps as describe in #68628 and ensure that the error is no longer reproducible.
* Also test the in-app back button and ensure that it works as it used to.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68628
