### PR TITLE
Change style in Promote Post rejection dialog

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -175,7 +175,7 @@ export default function CampaignItem( { campaign }: Props ) {
 					<Notice isDismissible={ false } className="campaign-item__notice" status="warning">
 						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />
 						{ translate(
-							'Your ad was not approved, please review our {{wpcomTos}}WordPress.com Terms{{/wpcomTos}} and {{advertisingTos}}Advertising Guidelines{{/advertisingTos}}.',
+							'Your ad was not approved, please review our {{wpcomTos}}WordPress.com Terms{{/wpcomTos}} and {{advertisingTos}}Advertising Policy{{/advertisingTos}}.',
 							{
 								components: {
 									wpcomTos: (

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -1,13 +1,13 @@
 import './style.scss';
 import { safeImageUrl } from '@automattic/calypso-url';
-import { Dialog } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Dialog, Gridicon } from '@automattic/components';
+import { Button, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import FoldableCard from 'calypso/components/foldable-card';
-import Notice from 'calypso/components/notice';
 import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-post-cancel-campaign-mutation';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
@@ -34,6 +34,7 @@ export default function CampaignItem( { campaign }: Props ) {
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ showErrorDialog, setShowErrorDialog ] = useState( false );
 	const siteId = useSelector( getSelectedSiteId );
+	const translate = useTranslate();
 
 	const { cancelCampaign } = useCancelCampaignMutation( () => setShowErrorDialog( true ) );
 
@@ -73,9 +74,7 @@ export default function CampaignItem( { campaign }: Props ) {
 		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
 		[ budget_cents, spent_budget_cents ]
 	);
-	const totalBudgetLeftString = totalBudgetLeft
-		? `($${ formatCents( totalBudgetLeft ) } ${ __( 'left' ) })`
-		: '';
+	const totalBudgetLeftString = `($${ formatCents( totalBudgetLeft || 0 ) } ${ __( 'left' ) })`;
 
 	const estimatedImpressions = useMemo(
 		() => getCampaignEstimatedImpressions( display_delivery_estimate ),
@@ -173,8 +172,29 @@ export default function CampaignItem( { campaign }: Props ) {
 
 			<FoldableCard header={ header } hideSummary={ true } className="campaign-item__foldable-card">
 				{ campaignStatus === 'rejected' && moderation_reason && (
-					<Notice status="is-warning" showDismiss={ false }>
-						{ __( 'Your ad is rejected: ' ) } { moderation_reason }
+					<Notice isDismissible={ false } className="campaign-item__notice" status="warning">
+						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />
+						{ translate(
+							'Your ad was not approved, please review our {{wpcomTos}}WordPress.com Terms{{/wpcomTos}} and {{advertisingTos}}Advertising Guidelines{{/advertisingTos}}.',
+							{
+								components: {
+									wpcomTos: (
+										<a
+											href="https://wordpress.com/tos/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									advertisingTos: (
+										<a
+											href="https://automattic.com/advertising-policy/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
 					</Notice>
 				) }
 

--- a/client/my-sites/promote-post/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post/components/campaign-item/style.scss
@@ -42,6 +42,22 @@
 		}
 	}
 
+	.campaign-item__notice {
+		margin-left: 0;
+
+		.campaign-item__notice-icon {
+			margin-right: 16px;
+			margin-left: 8px;
+			vertical-align: middle;
+			padding-bottom: 3px;
+		}
+
+		a {
+			color: var(--color-text-subtle);
+			text-decoration: underline;
+		}
+	}
+
 	.campaign-item__section {
 		border-bottom: #dcdcde thin solid;
 

--- a/client/my-sites/promote-post/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post/components/campaigns-list/index.tsx
@@ -1,22 +1,46 @@
+import { translate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import ListEnd from 'calypso/components/list-end';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import Notice from 'calypso/components/notice';
 import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import CampaignItem from 'calypso/my-sites/promote-post/components/campaign-item';
 import './style.scss';
 import CampaignsEmpty from 'calypso/my-sites/promote-post/components/campaigns-empty';
 import EmptyPromotionList from '../empty-promotion-list';
 
+const noCampaignListMessage = translate(
+	'There was a problem obtaining the campaign list' +
+		'Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
+	{
+		components: {
+			contactSupportLink: <a href={ CALYPSO_CONTACT } />,
+		},
+		comment: 'Validation error when filling out domain checkout contact details form',
+	}
+);
+
 export default function CampaignsList( {
 	isLoading,
+	isError,
 	campaigns,
 }: {
 	isLoading: boolean;
+	isError: boolean;
 	campaigns: Campaign[];
 } ) {
 	const memoCampaigns = useMemo< Campaign[] >( () => campaigns || [], [ campaigns ] );
 
 	const isEmpty = ! memoCampaigns.length;
+
+	if ( isError ) {
+		return (
+			<Notice status="is-error" icon="mention">
+				{ noCampaignListMessage }
+			</Notice>
+		);
+	}
 
 	if ( isLoading ) {
 		return (
@@ -32,8 +56,8 @@ export default function CampaignsList( {
 
 	return (
 		<>
-			{ isEmpty && <CampaignsEmpty /> }
-			{ ! isEmpty && (
+			{ isEmpty && ! isError && <CampaignsEmpty /> }
+			{ ! isEmpty && ! isError && (
 				<>
 					{ memoCampaigns.map( function ( campaign ) {
 						return <CampaignItem key={ campaign.campaign_id } campaign={ campaign } />;

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -28,9 +28,8 @@ interface Props {
 export default function PromotedPosts( { tab }: Props ) {
 	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const { isLoading: campaignsIsLoading, data: campaignsData } = useCampaignsQuery(
-		selectedSiteId ?? 0
-	);
+	const test = useCampaignsQuery( selectedSiteId ?? 0 );
+	const { isLoading: campaignsIsLoading, data: campaignsData, isError } = test;
 
 	const tabs: TabOption[] = [
 		{ id: 'posts', name: translate( 'Ready to promote' ) },
@@ -75,8 +74,12 @@ export default function PromotedPosts( { tab }: Props ) {
 			<SitePreview />
 			{ ! campaignsData?.length && ! campaignsIsLoading && <PostsListBanner /> }
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
-			{ selectedTab === 'campaigns' && campaignsData && (
-				<CampaignsList isLoading={ campaignsIsLoading } campaigns={ campaignsData } />
+			{ selectedTab === 'campaigns' && (
+				<CampaignsList
+					isError={ isError }
+					isLoading={ campaignsIsLoading }
+					campaigns={ campaignsData || [] }
+				/>
 			) }
 			{ selectedTab === 'posts' && <PostsList /> }
 


### PR DESCRIPTION
- Changes the style of the rejection notice in Promoted Post campaign list
- Adds better error handling when cannot get Promoted Post campaign list

#### Testing Instructions
- Open a campaign that is rejected: You should see a dialog similar to this:
![image](https://user-images.githubusercontent.com/43957544/194020920-83137296-8104-45cc-ab77-f44c7a7ddcb0.png)

#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
