### PR TITLE
`SftpCard`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -39,7 +39,6 @@ import './style.scss';
 const FILEZILLA_URL = 'https://filezilla-project.org/';
 const SFTP_URL = 'sftp.wp.com';
 const SFTP_PORT = 22;
-const noop = () => {};
 
 export const SftpCard = ( {
 	translate,
@@ -140,7 +139,12 @@ export const SftpCard = ( {
 			return (
 				<>
 					<div className="sftp-card__copy-field sftp-card__password-field">
-						<FormTextInput className="sftp-card__copy-input" value={ password } onChange={ noop } />
+						<FormTextInput
+							id="password"
+							className="sftp-card__copy-input"
+							value={ password }
+							readOnly
+						/>
 						<ClipboardButton
 							className="sftp-card__copy-button"
 							text={ password }
@@ -205,11 +209,7 @@ export const SftpCard = ( {
 				/>
 				{ isSshAccessEnabled && (
 					<div className="sftp-card__copy-field">
-						<FormTextInput
-							className="sftp-card__copy-input"
-							value={ sshConnectString }
-							onChange={ noop }
-						/>
+						<FormTextInput className="sftp-card__copy-input" value={ sshConnectString } readOnly />
 						<ClipboardButton
 							className="sftp-card__copy-button"
 							text={ sshConnectString }
@@ -328,9 +328,9 @@ export const SftpCard = ( {
 			) }
 			{ username && (
 				<FormFieldset className="sftp-card__info-field">
-					<FormLabel>{ translate( 'URL' ) }</FormLabel>
+					<FormLabel htmlFor="url">{ translate( 'URL' ) }</FormLabel>
 					<div className="sftp-card__copy-field">
-						<FormTextInput className="sftp-card__copy-input" value={ SFTP_URL } onChange={ noop } />
+						<FormTextInput id="url" className="sftp-card__copy-input" value={ SFTP_URL } readOnly />
 						<ClipboardButton
 							className="sftp-card__copy-button"
 							text={ SFTP_URL }
@@ -341,12 +341,13 @@ export const SftpCard = ( {
 							{ isCopied.url ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
 						</ClipboardButton>
 					</div>
-					<FormLabel>{ translate( 'Port' ) }</FormLabel>
+					<FormLabel htmlFor="port">{ translate( 'Port' ) }</FormLabel>
 					<div className="sftp-card__copy-field">
 						<FormTextInput
+							id="port"
 							className="sftp-card__copy-input"
 							value={ SFTP_PORT }
-							onChange={ noop }
+							readOnly
 						/>
 						<ClipboardButton
 							className="sftp-card__copy-button"
@@ -358,9 +359,14 @@ export const SftpCard = ( {
 							{ isCopied.port ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
 						</ClipboardButton>
 					</div>
-					<FormLabel>{ translate( 'Username' ) }</FormLabel>
+					<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
 					<div className="sftp-card__copy-field">
-						<FormTextInput className="sftp-card__copy-input" value={ username } onChange={ noop } />
+						<FormTextInput
+							id="username"
+							className="sftp-card__copy-input"
+							value={ username }
+							readOnly
+						/>
 						<ClipboardButton
 							className="sftp-card__copy-button"
 							text={ username }
@@ -373,7 +379,7 @@ export const SftpCard = ( {
 								: translate( 'Copy', { context: 'verb' } ) }
 						</ClipboardButton>
 					</div>
-					<FormLabel>{ translate( 'Password' ) }</FormLabel>
+					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					{ renderPasswordField() }
 					{ siteHasSshFeature && (
 						<FormLabel className="sftp-card__ssh-label">{ translate( 'SSH Access' ) }</FormLabel>

--- a/client/my-sites/hosting/sftp-card/test/index.js
+++ b/client/my-sites/hosting/sftp-card/test/index.js
@@ -2,11 +2,23 @@
  * @jest-environment jsdom
  */
 
-import { shallow, mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { SftpCard } from '..';
+
+jest.mock( '@automattic/components/src/spinner', () => ( {
+	__esModule: true,
+	Spinner: () => <div data-testid="spinner" />,
+} ) );
 
 const translate = ( x ) => x;
 const requestSftpUsers = ( x ) => x;
+const removePasswordFromState = ( x ) => x;
+
+const props = {
+	translate,
+	requestSftpUsers,
+	removePasswordFromState,
+};
 
 describe( 'SftpCard', () => {
 	beforeAll( () => {
@@ -27,86 +39,92 @@ describe( 'SftpCard', () => {
 	} );
 
 	describe( 'Sftp Questions', () => {
-		it( 'should display sftp questions if no sftp username', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } /> );
+		it( 'should display sftp questions if no sftp username', async () => {
+			render( <SftpCard { ...props } username={ null } /> );
 
-			expect( wrapper.find( '.sftp-card__questions' ) ).toHaveLength( 1 );
+			expect( screen.getByText( 'What is SFTP?' ) ).toBeVisible();
+			expect( screen.getByText( 'What is SSH?' ) ).toBeVisible();
 		} );
+
 		it( 'should not display sftp questions if sftp username is set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+			render( <SftpCard { ...props } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__questions' ) ).toHaveLength( 0 );
+			expect( screen.queryByText( 'What is SFTP?' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'What is SSH?' ) ).not.toBeInTheDocument();
 		} );
-		it( 'should not display sftp questions if loading', () => {
-			// need to use a mount rather than shallow for tests that require useEffects to run
-			const wrapper = mount(
-				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } />
-			);
 
-			expect( wrapper.find( '.sftp-card__questions' ) ).toHaveLength( 0 );
+		it( 'should not display sftp questions if loading', () => {
+			render( <SftpCard { ...props } /> );
+
+			expect( screen.queryByText( 'What is SFTP?' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'What is SSH?' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Loading', () => {
 		it( 'should display spinner if username not set and not disabled', () => {
-			const wrapper = mount(
-				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } />
-			);
+			render( <SftpCard { ...props } /> );
 
-			expect( wrapper.find( 'Spinner' ) ).toHaveLength( 1 );
+			expect( screen.getByTestId( 'spinner' ) ).toBeVisible();
 		} );
-		it( 'should not display spinner if disabled', () => {
-			const wrapper = mount(
-				<SftpCard translate={ translate } requestSftpUsers={ requestSftpUsers } disabled={ true } />
-			);
 
-			expect( wrapper.find( 'Spinner' ) ).toHaveLength( 0 );
+		it( 'should not display spinner if disabled', () => {
+			render( <SftpCard { ...props } disabled={ true } /> );
+
+			expect( screen.queryByTestId( 'spinner' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Create SFTP credentials', () => {
+		const btnName = 'Create credentials';
 		it( 'should display create SFTP credentials if username not set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } /> );
+			render( <SftpCard { ...props } username={ null } /> );
 
-			expect( wrapper.find( '.sftp-card__create-credentials-button' ) ).toHaveLength( 1 );
+			expect( screen.getByRole( 'button', { name: btnName } ) ).toBeVisible();
 		} );
-		it( 'should not display create SFTP credentials if username set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__create-credentials-button' ) ).toHaveLength( 0 );
+		it( 'should not display create SFTP credentials if username set', () => {
+			render( <SftpCard { ...props } username="testuser" /> );
+
+			expect( screen.queryByRole( 'button', { name: btnName } ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'User info fields', () => {
 		it( 'should display user info fields if username set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+			render( <SftpCard { ...props } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__info-field' ) ).toHaveLength( 1 );
+			expect( screen.getByLabelText( 'URL' ) ).toHaveValue( 'sftp.wp.com' );
+			expect( screen.getByLabelText( 'Port' ) ).toHaveValue( '22' );
+			expect( screen.getByLabelText( 'Username' ) ).toHaveValue( 'testuser' );
 		} );
-		it( 'should not display user info fields if username not set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } /> );
 
-			expect( wrapper.find( '.sftp-card__info-field' ) ).toHaveLength( 0 );
+		it( 'should not display user info fields if username not set', () => {
+			render( <SftpCard { ...props } /> );
+
+			expect( screen.queryByLabelText( 'URL' ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( 'Port' ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( 'Username' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Password', () => {
 		it( 'should display password field if password set', () => {
-			const wrapper = shallow(
-				<SftpCard translate={ translate } username="testuser" password="secret" />
-			);
+			render( <SftpCard { ...props } username="testuser" password="secret" /> );
 
-			expect( wrapper.find( '.sftp-card__password-field' ) ).toHaveLength( 1 );
+			expect( screen.getByLabelText( 'Password' ) ).toBeVisible();
 		} );
+
 		it( 'should not display password field if password not set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
+			render( <SftpCard { ...props } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__password-field' ) ).toHaveLength( 0 );
+			expect( screen.queryByLabelText( 'Password' ) ).not.toBeInTheDocument();
 		} );
-		it( 'should display password reset button if password not set', () => {
-			const wrapper = shallow( <SftpCard translate={ translate } username="testuser" /> );
 
-			expect( wrapper.find( '.sftp-card__password-reset-button' ) ).toHaveLength( 1 );
+		it( 'should display password reset button if password not set', () => {
+			render( <SftpCard { ...props } username="testuser" /> );
+
+			expect( screen.getByRole( 'button', { name: 'Reset password' } ) ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `SftpCard`: refactor tests to `@testing-library/react`
* Improve used input components, e.g.
  * associate input fields with labels
  * use `readOnly` instead of adding a `noop` to `onChange`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 
