### PR TITLE
Better match script tags without matching script contents

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -50,10 +50,25 @@ function head_error_handler() {
  * @param {string} $tag string containing the def of a script tag.
  */
 function add_crossorigin_to_script_els( $tag ) {
+	$end_of_tag = strpos( $tag, ">" );
+	if ( $end_of_tag === false ) {
+		return $tag;
+	}
+
+	// Get JUST the <script ...> tag, not anything else. $tag can include the content of the script as well.
+	// Assumes that $tag begins with <script..., which does seem to be the case in our testing.
+	$script_tag = substr( $tag, 0, $end_of_tag + 1 );
+
+	// If the src of that script tag points to an internal domain, set crossorigin=anonymous.
 	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
-	if ( preg_match( '/<script\s.*src=.*(s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com).*>/', $tag ) ) {
-		return str_replace( ' src=', ' crossorigin="anonymous" src=', $tag );
+	if ( preg_match( '/<script.*src=.*(s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com).*>/', $script_tag ) ) {
+		// Update the src of the <script...> tag
+		$new_tag = str_replace( ' src=', " crossorigin='anonymous' src=", $script_tag );
+		// Then, find the original script_tag within the ENTIRE $tag, and replace
+		// it with the updated version. Now the script includes crossorigin=anonymous.
+		return str_replace( $script_tag, $new_tag, $tag);
 	};
+
 	return $tag;
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -50,8 +50,8 @@ function head_error_handler() {
  * @param {string} $tag string containing the def of a script tag.
  */
 function add_crossorigin_to_script_els( $tag ) {
-	$end_of_tag = strpos( $tag, ">" );
-	if ( $end_of_tag === false ) {
+	$end_of_tag = strpos( $tag, '>' );
+	if ( false === $end_of_tag ) {
 		return $tag;
 	}
 
@@ -62,11 +62,11 @@ function add_crossorigin_to_script_els( $tag ) {
 	// If the src of that script tag points to an internal domain, set crossorigin=anonymous.
 	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	if ( preg_match( '/<script.*src=.*(s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com).*>/', $script_tag ) ) {
-		// Update the src of the <script...> tag
+		// Update the src of the <script...> tag.
 		$new_tag = str_replace( ' src=', " crossorigin='anonymous' src=", $script_tag );
 		// Then, find the original script_tag within the ENTIRE $tag, and replace
 		// it with the updated version. Now the script includes crossorigin=anonymous.
-		return str_replace( $script_tag, $new_tag, $tag);
+		return str_replace( $script_tag, $new_tag, $tag );
 	};
 
 	return $tag;


### PR DESCRIPTION
### Proposed Changes

We have a filter which updates internal scripts to include crossorogin=anonymous, which helps with error reporting. The regex we used to update the script tag didn't account for the fact that the `$tag` parameter to that filter can also include the script content, if the script is an inline script.

For example, there is an inline script initializing the editor which includes a huge amount of JSON data, including various image blocks contained in block templates. These image blocks have `<img src="s0.wp.com">`. In other words, given content like this:

```
<script id="foo">
  doSomething({ block: "<img src=\"s0.wp.com\">" })
</script>
```

The regex can match `src=s0.wp.com` inside the image element inside the block inside the JSON inside the inline script. Then, it updates that so that crossorigin-anonymous is set on the `img` element. And since that update doesn't think it will occur inside a string, the result is `<img crossorigin=""anonymous"" src=s0.wp.com>`, which results in a syntax error.

This causes a WSOD in the editor.

Another fun fact is that this ONLY happens when `jsconcat` is disabled for the editor. We do not know why.

But this fixes the WSOD in that circumstance and allows us to disable jsconcat. The fix just makes sure we execute the regex and string replace on the `<script...>` portion at the beginning of the string, without being greedy and matching any `>` much later in the string.

#### Testing Instructions
0. Sync this PR to the sandbox
1. Make sure that `crossorigin=anonymous` is still set on script we expect. 
3. See D89124-code to add back JSconcat disabling for the dotcom P2
4. Sandbox the dotcom P2 and s0.wp.com
5. Test that /wp-admin/post-new.php loads for the dotcom P2
