### PR TITLE
Help Center: move the Help Center router state to the store and use the Help Center in /help/contact

### DIFF
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { isMobile } from '@automattic/viewport';
 import { withDispatch } from '@wordpress/data';
 import classnames from 'classnames';
@@ -8,6 +9,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { initConnection } from 'calypso/state/happychat/connection/actions';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import hasUnreadMessages from 'calypso/state/happychat/selectors/has-unread-messages';
@@ -37,6 +39,7 @@ export class HappychatButton extends Component {
 		openChat: PropTypes.func,
 		translate: PropTypes.func,
 		openHelpCenter: PropTypes.bool,
+		userId: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -56,7 +59,7 @@ export class HappychatButton extends Component {
 	};
 
 	onClick = ( event ) => {
-		if ( this.props.openHelpCenter ) {
+		if ( this.props.openHelpCenter || shouldShowHelpCenterToUser( this.props.userId ) ) {
 			this.props.setHelpCenterVisible( true );
 		} else if ( this.props.allowMobileRedirect && isMobile() ) {
 			// For mobile clients, happychat will always use the
@@ -121,6 +124,7 @@ export default withDispatch( ( dataStoresDispatch ) => {
 			hasUnread: hasUnreadMessages( state ),
 			getAuth: getHappychatAuth( state ),
 			isChatAvailable: isHappychatAvailable( state ),
+			userId: getCurrentUserId( state ),
 			isChatActive: hasActiveHappychatSession( state ),
 			isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
 			setHelpCenterVisible: ownProps.dataStoresDispatch( HELP_CENTER_STORE ).setShowHelpCenter,

--- a/client/components/happychat/test/button.jsx
+++ b/client/components/happychat/test/button.jsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { HappychatButton } from '../button';
 
 describe( 'Button', () => {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -243,8 +243,8 @@ class Layout extends Component {
 		};
 
 		const loadHelpCenter =
-			// we want to show only the Help center in my home
-			( this.props.sectionName === 'home' ||
+			// we want to show only the Help center in my home and the help section (but not the FAB)
+			( [ 'home', 'help' ].includes( this.props.sectionName ) ||
 				shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute ) ) &&
 			this.props.userAllowedToHelpCenter;
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -12,7 +12,7 @@ import {
 	SUPPORT_UPWORK_TICKET,
 } from '@automattic/help-center';
 import { isDefaultLocale, localizeUrl } from '@automattic/i18n-utils';
-import { dispatch } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -128,7 +128,7 @@ class HelpContact extends Component {
 		this.recordSubmitWithActiveTickets( 'chat' );
 
 		if ( this.props.shouldShowHelpCenterToUser ) {
-			dispatch( HELP_CENTER_STORE ).startHelpCenterChat( site, message );
+			this.props.startHelpCenterChat( site, message );
 		} else {
 			this.props.openHappychat();
 
@@ -726,39 +726,44 @@ class HelpContact extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
-		const selectedSite = getHelpSelectedSite( state );
-		const isChatEligible = isHappychatUserEligible( state );
-		return {
-			selectedSite,
-			currentUserLocale: getCurrentUserLocale( state ),
-			currentUser: getCurrentUser( state ),
-			getUserInfo: getHappychatUserInfo( state ),
-			hasHappychatLocalizedSupport: hasHappychatLocalizedSupport( state ),
-			hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
-			isDirectlyFailed: isDirectlyFailed( state ),
-			isDirectlyReady: isDirectlyReady( state ),
-			isDirectlyUninitialized: isDirectlyUninitialized( state ),
-			isEmailVerified: isCurrentUserEmailVerified( state ),
-			isHappychatUserEligible: isChatEligible,
-			localizedLanguageNames: getLocalizedLanguageNames( state ),
-			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
-			ticketSupportRequestError: getTicketSupportRequestError( state ),
-			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
-			shouldStartHappychatConnection: ! isRequestingSites( state ) && isChatEligible,
-			isRequestingSites: isRequestingSites( state ),
-			supportVariation: getInlineHelpSupportVariation( state ),
-			shouldShowHelpCenterToUser: shouldShowHelpCenterToUser( getCurrentUserId( state ) ),
-		};
-	},
-	{
-		askDirectlyQuestion,
-		errorNotice,
-		initializeDirectly,
-		openHappychat,
-		recordTracksEventAction,
-		sendHappychatMessage,
-		sendUserInfo,
-	}
-)( localize( withActiveSupportTickets( HelpContact ) ) );
+export default withDispatch( ( dataStoresDispatch ) => {
+	return { dataStoresDispatch };
+} )(
+	connect(
+		( state, ownProps ) => {
+			const selectedSite = getHelpSelectedSite( state );
+			const isChatEligible = isHappychatUserEligible( state );
+			return {
+				selectedSite,
+				currentUserLocale: getCurrentUserLocale( state ),
+				currentUser: getCurrentUser( state ),
+				getUserInfo: getHappychatUserInfo( state ),
+				hasHappychatLocalizedSupport: hasHappychatLocalizedSupport( state ),
+				hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
+				isDirectlyFailed: isDirectlyFailed( state ),
+				isDirectlyReady: isDirectlyReady( state ),
+				isDirectlyUninitialized: isDirectlyUninitialized( state ),
+				isEmailVerified: isCurrentUserEmailVerified( state ),
+				isHappychatUserEligible: isChatEligible,
+				localizedLanguageNames: getLocalizedLanguageNames( state ),
+				ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
+				ticketSupportRequestError: getTicketSupportRequestError( state ),
+				hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
+				shouldStartHappychatConnection: ! isRequestingSites( state ) && isChatEligible,
+				isRequestingSites: isRequestingSites( state ),
+				supportVariation: getInlineHelpSupportVariation( state ),
+				shouldShowHelpCenterToUser: shouldShowHelpCenterToUser( getCurrentUserId( state ) ),
+				startHelpCenterChat: ownProps.dataStoresDispatch( HELP_CENTER_STORE ).startHelpCenterChat,
+			};
+		},
+		{
+			askDirectlyQuestion,
+			errorNotice,
+			initializeDirectly,
+			openHappychat,
+			recordTracksEventAction,
+			sendHappychatMessage,
+			sendUserInfo,
+		}
+	)( localize( withActiveSupportTickets( HelpContact ) ) )
+);

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -12,6 +12,20 @@ export const setDirectlyData = ( data: { isLoaded: boolean; hasSession: boolean 
 		data,
 	} as const );
 
+export const setRouterState = ( history: Location[], index: number ) =>
+	( {
+		type: 'HELP_CENTER_SET_ROUTER_STATE',
+		history,
+		index,
+	} as const );
+
+export const resetRouterState = () =>
+	( {
+		type: 'HELP_CENTER_SET_ROUTER_STATE',
+		history: undefined,
+		index: undefined,
+	} as const );
+
 export const setSite = ( site: SiteDetails | undefined ) =>
 	( {
 		type: 'HELP_CENTER_SET_SITE',
@@ -75,6 +89,8 @@ export type HelpCenterAction = ReturnType<
 	| typeof setDirectlyData
 	| typeof setSite
 	| typeof setSubject
+	| typeof setRouterState
+	| typeof resetRouterState
 	| typeof resetStore
 	| typeof setMessage
 	| typeof setUserDeclaredSite

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,4 +1,5 @@
 import { SiteDetails } from '../site';
+import { Location } from './types';
 
 export const setShowHelpCenter = ( show: boolean ) =>
 	( {
@@ -78,6 +79,13 @@ export const setUserDeclaredSite = ( site: SiteDetails | undefined ) =>
 		type: 'HELP_CENTER_SET_USER_DECLARED_SITE',
 		site,
 	} as const );
+
+export const startHelpCenterChat = function* ( site: SiteDetails, message: string ) {
+	yield setRouterState( [ { pathname: '/inline-chat' } ], 0 );
+	yield setSite( site );
+	yield setMessage( message );
+	yield setShowHelpCenter( true );
+};
 
 export const resetStore = () =>
 	( {

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
+import type { Location } from './types';
 import type { Reducer } from 'redux';
 
 const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state, action ) => {
@@ -99,6 +100,17 @@ const iframe: Reducer< HTMLIFrameElement | undefined | null, HelpCenterAction > 
 	return state;
 };
 
+const routerState: Reducer< { history: Location[] | undefined; index: number | undefined } > = (
+	state = { history: undefined, index: undefined },
+	action
+) => {
+	switch ( action.type ) {
+		case 'HELP_CENTER_SET_ROUTER_STATE':
+			return { history: action.history, index: action.index };
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	directlyData,
 	showHelpCenter,
@@ -110,6 +122,7 @@ const reducer = combineReducers( {
 	isMinimized,
 	unreadCount,
 	iframe,
+	routerState,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -10,3 +10,4 @@ export const getDirectly = ( state: State ) => state.directlyData;
 export const getUserDeclaredSite = ( state: State ) => state.userDeclaredSite;
 export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
+export const getRouterState = ( state: State ) => state.routerState;

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -1,0 +1,7 @@
+export type Location = {
+	pathname: string;
+	search: string;
+	hash: string;
+	state: unknown;
+	key: string;
+};

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -1,7 +1,7 @@
 export type Location = {
 	pathname: string;
-	search: string;
-	hash: string;
-	state: unknown;
-	key: string;
+	search?: string;
+	hash?: string;
+	state?: unknown;
+	key?: string;
 };

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -19,6 +19,7 @@ import { Container } from '../types';
 import HelpCenterContent from './help-center-content';
 import HelpCenterFooter from './help-center-footer';
 import HelpCenterHeader from './help-center-header';
+import { HistoryRecorder } from './history-recorder';
 
 interface OptionalDraggableProps extends Partial< DraggableProps > {
 	draggable: boolean;
@@ -46,6 +47,10 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 	} );
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
 	const { data } = useHappychatAvailable( Boolean( supportAvailability?.is_user_eligible ) );
+	const { history, index } = useSelect( ( select ) =>
+		select( HELP_CENTER_STORE ).getRouterState()
+	);
+	const { resetRouterState } = useDispatch( HELP_CENTER_STORE );
 
 	const onDismiss = () => {
 		setIsVisible( false );
@@ -56,6 +61,8 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 			handleClose();
 			// after calling handleClose, reset the visibility state to default
 			setIsVisible( true );
+			// reset nav history when the help center is closed by the user
+			resetRouterState();
 		}
 	};
 
@@ -74,8 +81,9 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 	}
 
 	return (
-		<MemoryRouter>
+		<MemoryRouter initialEntries={ history } initialIndex={ index }>
 			{ data?.status === 'assigned' && <Redirect to="/inline-chat?session=continued" /> }
+			<HistoryRecorder />
 			<FeatureFlagProvider>
 				<OptionalDraggable
 					draggable={ ! isMobile }

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -50,7 +50,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 	const { history, index } = useSelect( ( select ) =>
 		select( HELP_CENTER_STORE ).getRouterState()
 	);
-	const { resetRouterState } = useDispatch( HELP_CENTER_STORE );
 
 	const onDismiss = () => {
 		setIsVisible( false );
@@ -61,8 +60,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 			handleClose();
 			// after calling handleClose, reset the visibility state to default
 			setIsVisible( true );
-			// reset nav history when the help center is closed by the user
-			resetRouterState();
 		}
 	};
 

--- a/packages/help-center/src/components/history-recorder.tsx
+++ b/packages/help-center/src/components/history-recorder.tsx
@@ -1,0 +1,11 @@
+import { useDispatch } from '@wordpress/data';
+import { useHistory } from 'react-router-dom';
+import { HELP_CENTER_STORE } from '../stores';
+
+export function HistoryRecorder() {
+	const history = useHistory();
+	const { setRouterState } = useDispatch( HELP_CENTER_STORE );
+	setRouterState( history.entries, history.index );
+
+	return null;
+}

--- a/packages/help-center/src/components/history-recorder.tsx
+++ b/packages/help-center/src/components/history-recorder.tsx
@@ -1,11 +1,15 @@
 import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { HELP_CENTER_STORE } from '../stores';
 
 export function HistoryRecorder() {
 	const history = useHistory();
 	const { setRouterState } = useDispatch( HELP_CENTER_STORE );
-	setRouterState( history.entries, history.index );
+
+	useEffect( () => {
+		setRouterState( history.entries, history.index );
+	}, [ history, setRouterState ] );
 
 	return null;
 }


### PR DESCRIPTION
#### Proposed Changes

For users who have access to the Help Center, we made a false assumption that they will never need HappyChat socket connection in Calypso. This turns out to be false because this page (https://wordpress.com/help/contact) requires an alive connection even when users are eligible for the Help Center.

Our first solution was to enable the connection when accessing this page. But this creates a sticky connection, and we'd have two instances of HappyChat connected to the same session:

![image](https://user-images.githubusercontent.com/17054134/194079072-8078d964-d1af-4081-a50b-c4de82da3d74.png)


#### How to fix that?

1. Develop the ability to open the Help Center and decide at which page of its pages the user should land. This was easy since the Help Center uses `MemoryRouter` and we just needed to configure the initial path name.
2. When the user is in `/help/contact`, we enable the Calypso HappyChat connection. Yes, sadly, when the user lands in this page, there will be two socket connections (Calypso's and the Help Center's). The good thing is that the Help Center's connection lasts for 1 second only. But if the user starts a chat, we'd have two prolonged connections. We can theoretically merge the two connections, but that would be pretty complicated to achieve, and it's probably not worth the effort for this transitional stage.
3. With the two points above, we have two powers:
	- knowing if we chat is available to enable the chat variation in the form
	- starting a chat in the Help Center when people submit the form (by opening the Help Center at the chat page). 
4. Regarding the tiny button here ![image](https://user-images.githubusercontent.com/17054134/194078716-362ff13f-d387-419b-9701-0bbc8a7aa07b.png), clicking it now reopens the Help Center ✨ .
 

#### Testing Instructions

If you're using local Calypso, you don't need a special user. The env will be `development` and this makes you eligible for the Help Center.

1. Start calypso from this branch.
2. Login to HUD here https://hud-staging.happychat.io/
3. Go to http://calypso.localhost:3000/help/contact
4. Wait a couple of seconds (for some reason, Happychat staging is pretty slow today).
5. The form's submit button should be "Chat with us". 
6. Fill the form and click "Chat with is". 
7. This should open the Help Center in chat mode directly.
8. The HUD chat should get the correct chat infromation.

**Testing the small button**
 
1. While having an active session, go to http://calypso.localhost:3000/help/contact.
2. The Help center should popup automatically if you have a session. 
3. Close the Help Center. 
4. Click the tiny conversation button on the bottom right corner.
5. It should re-open the Help Center in chat mode.
6. Yes, we could remove this button in this case, but that would complicate reverting things a lot. This change is pretty minimal and delivers a good result.


#### Demo

https://user-images.githubusercontent.com/17054134/194084581-a6f994ef-a384-4b36-8ec8-2c1c853aafbc.mov

