### PR TITLE
Jetpack Connect: Refactor `JetpackConnectMainWrapper` tests to RTL

### DIFF
--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -2,68 +2,61 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'calypso/components/data/document-head', () => 'DocumentHead' );
-
-import { shallow } from 'enzyme';
-import Main from 'calypso/components/main';
+import { render, within } from '@testing-library/react';
 import { JetpackConnectMainWrapper } from '../main-wrapper';
+
+jest.mock( 'calypso/components/data/document-head', () => () => 'DocumentHead' );
 
 describe( 'JetpackConnectMainWrapper', () => {
 	const translate = ( string ) => string;
 
-	test( 'should render a <Main> instance', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
-
-		expect( wrapper.find( Main ) ).toHaveLength( 1 );
-	} );
-
 	test( 'should render the passed children as children of the component', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<JetpackConnectMainWrapper translate={ translate }>
-				<span className="test__child" />
+				<span data-testid="test__child" />
 			</JetpackConnectMainWrapper>
-		).render();
+		);
 
-		expect( wrapper.find( '.test__child' ) ).toHaveLength( 1 );
+		expect( within( container.firstChild ).getByTestId( 'test__child' ) ).toBeVisible();
 	} );
 
 	test( 'should always specify the jetpack-connect__main class', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
+		const { container } = render( <JetpackConnectMainWrapper translate={ translate } /> );
 
-		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).toBe( true );
+		expect( container.firstChild ).toHaveClass( 'jetpack-connect__main' );
 	} );
 
 	test( 'should allow more classes to be added', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<JetpackConnectMainWrapper className="test__class" translate={ translate } />
 		);
 
-		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).toBe( true );
-		expect( wrapper.hasClass( 'test__class' ) ).toBe( true );
+		expect( container.firstChild ).toHaveClass( 'jetpack-connect__main' );
+		expect( container.firstChild ).toHaveClass( 'test__class' );
 	} );
 
 	test( 'should not contain the is-wide modifier class by default', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
+		const { container } = render( <JetpackConnectMainWrapper translate={ translate } /> );
 
-		expect( wrapper.hasClass( 'is-wide' ) ).toBe( false );
+		expect( container.firstChild ).not.toHaveClass( 'is-wide' );
 	} );
 
 	test( 'should contain the is-wide modifier class if prop is specified', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ translate } /> );
+		const { container } = render( <JetpackConnectMainWrapper isWide translate={ translate } /> );
 
-		expect( wrapper.hasClass( 'is-wide' ) ).toBe( true );
+		expect( container.firstChild ).toHaveClass( 'is-wide' );
 	} );
 
 	test( 'should not contain the is-mobile-app-flow modifier class by default', () => {
-		const wrapper = shallow( <JetpackConnectMainWrapper translate={ translate } /> );
+		const { container } = render( <JetpackConnectMainWrapper translate={ translate } /> );
 
-		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).toBe( false );
+		expect( container.firstChild ).not.toHaveClass( 'is-mobile-app-flow' );
 	} );
 
 	test( 'should contain the is-mobile-app-flow modifier if cookie is set', () => {
 		document.cookie = 'jetpack_connect_mobile_redirect=some url';
-		const wrapper = shallow( <JetpackConnectMainWrapper isWide translate={ translate } /> );
+		const { container } = render( <JetpackConnectMainWrapper isWide translate={ translate } /> );
 
-		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).toBe( true );
+		expect( container.firstChild ).toHaveClass( 'is-mobile-app-flow' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `JetpackConnectMainWrapper` tests to use `@testing-library/react`

#### Testing Instructions

Verify tests still pass: `yarn run test-client client/jetpack-connect/test/main-wrapper.jsx`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
