### PR TITLE
Design Picker: Add test cases for UDP

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/designs.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/designs.ts
@@ -1,0 +1,14 @@
+export const generateMockedStarterDesigns = () => {
+	return {
+		generated: {
+			designs: [],
+		},
+		static: {
+			designs: [],
+		},
+	};
+};
+
+export const generateMockedStarterDesignDetails = () => {
+	return {};
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/index.ts
@@ -1,0 +1,2 @@
+export * from './designs';
+export * from './site';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/site.ts
@@ -1,0 +1,1 @@
+export const MOCKED_SITE = { ID: 1 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomXhrRequest from 'wpcom-xhr-request';
+import {
+	MOCKED_SITE,
+	generateMockedStarterDesignDetails,
+	generateMockedStarterDesigns,
+} from '../mocks';
+import UnifiedDesignPickerStep from '../unified-design-picker';
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn( () => false ),
+} ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/designSetup',
+		search: '?siteSlug=test.wordpress.com',
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+jest.mock( 'wpcom-proxy-request', () => jest.requireActual( 'wpcom-proxy-request' ) );
+
+jest.mock( '../../../../../hooks/use-site', () => ( {
+	useSite: () => MOCKED_SITE,
+} ) );
+
+/**
+ * Mock wpcom-proxy-request so that we could use wpcom-xhr-request to call the endpoint
+ * and get the response from nock
+ */
+jest
+	.spyOn( wpcomProxyRequest, 'default' )
+	.mockImplementation(
+		( ...args ) =>
+			new Promise( ( resolve, reject ) =>
+				wpcomXhrRequest( ...args, ( err, res ) => ( err ? reject( err ) : resolve( res ) ) )
+			)
+	);
+
+const middlewares = [ thunk ];
+
+const mockStore = configureStore( middlewares );
+
+const renderComponent = ( component, initialState = {} ) => {
+	const queryClient = new QueryClient();
+	const store = mockStore( {
+		purchases: {},
+		...initialState,
+	} );
+
+	return render(
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ component }</QueryClientProvider>
+		</Provider>
+	);
+};
+
+describe( 'UnifiedDesignPickerStep', () => {
+	let originalScrollTo;
+	const user = userEvent.setup();
+
+	const navigation = {
+		goBack: jest.fn(),
+		goNext: jest.fn(),
+		submit: jest.fn(),
+	};
+
+	beforeAll( () => {
+		originalScrollTo = window.scrollTo;
+		window.scrollTo = jest.fn();
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/wpcom/v2/starter-designs' )
+			.query( true )
+			.reply( 200, generateMockedStarterDesigns );
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( /\/wpcom\/v2\/starter-designs\/\w+/ )
+			.query( true )
+			.reply( 200, generateMockedStarterDesignDetails );
+	} );
+
+	afterAll( () => {
+		window.scrollTo = originalScrollTo;
+
+		nock.cleanAll();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Basics', () => {
+		it( 'should render successfully', async () => {
+			const { container } = renderComponent(
+				<UnifiedDesignPickerStep flow="site-setup" navigation={ navigation } />
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Pick a design' ) ).toBeInTheDocument();
+				expect(
+					container.getElementsByClassName( 'unified-design-picker__standard-designs' )
+				).toHaveLength( 1 );
+			} );
+		} );
+	} );
+
+	describe( 'Skip for now', () => {
+		it( 'should call submit successfully', async () => {
+			renderComponent( <UnifiedDesignPickerStep flow="site-setup" navigation={ navigation } /> );
+
+			await waitFor( () => screen.getByText( 'Pick a design' ) );
+			await user.click( screen.getByText( 'Skip for now' ) );
+
+			expect( navigation.submit ).toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Add test cases for UDP
  * Add the test case to ensure it's rendered successfully
  * Add the test case to ensure the “Skip for now” works as expected

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn run test-client:watch` 
* Type `p` to filter the test
* Type `unified-design-picker` to run the new test cases

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1664807460227249-slack-CRNF6A9DX