### PR TITLE
Add scrollbar to reader tables

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -155,6 +155,10 @@
 	color: var(--color-neutral-70);
 	font-size: rem(17px);
 	line-height: 28px;
+
+	figure.wp-block-table {
+		overflow: auto;
+	}
 }
 
 .reader-full-post__story-content img {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -155,7 +155,6 @@
 	color: var(--color-neutral-70);
 	font-size: rem(17px);
 	line-height: 28px;
-
 	figure.wp-block-table {
 		overflow: auto;
 	}


### PR DESCRIPTION
This updates the tables in reader to add scrollbar if width of table exceeds the content width.

Related to https://github.com/Automattic/wp-calypso/issues/68604

Example can be found here - http://calypso.localhost:3000/read/feeds/45339984/posts/4283753749

Before;
<img width="1515" alt="Screen Shot 2022-10-04 at 3 09 34 PM" src="https://user-images.githubusercontent.com/5560595/193918855-14a94686-d5ea-490f-9c8b-c235272a1058.png">

After;
<img width="851" alt="Screenshot 2022-10-05 at 13 04 28" src="https://user-images.githubusercontent.com/5560595/194056312-0e38538d-0161-44d6-8c45-c49cd49527ba.png">
