### PR TITLE
E2E (Atomic): Fix published post meta validation

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -123,7 +123,7 @@ export class PublishedPostPage {
 	 * @param {string} category Category to validate on page.
 	 */
 	async validateCategory( category: string ): Promise< void > {
-		await this.page.waitForSelector( `.cat-links :text("${ category }")` );
+		await this.page.waitForSelector( `a:text-is("${ category }")` );
 	}
 
 	/**
@@ -132,6 +132,6 @@ export class PublishedPostPage {
 	 * @param {string} tag Tag to validate on page.
 	 */
 	async validateTags( tag: string ): Promise< void > {
-		await this.page.waitForSelector( `.tags-links :text("${ tag }")` );
+		await this.page.waitForSelector( `a:text-is("${ tag }")` );
 	}
 }


### PR DESCRIPTION
Tracking issue: #65906


### Proposed Changes

Make the following test compatible with the Atomic environment:

> **Post metadata is found in published post**
> specs/editor/editor__post-basic-flow.ts: Editor: Basic Post Flow: Publish


### Why was it failing?

A parent element classname for the meta links was incompatible as it seemed to be theme-based. Removing the theme from the equation fixed the issue.


### Testing instruction

The fixed tests should pass for both Simple and Atomic sites (production).