### PR TITLE
Marketplace: Top header Refinements - Browse all link text change

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,4 +1,4 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { times } from 'lodash';
@@ -96,8 +96,7 @@ const PluginsBrowserList = ( {
 					<div className="plugins-browser-list__actions">
 						{ expandedListLink && (
 							<a className="plugins-browser-list__browse-all" href={ expandedListLink }>
-								{ __( 'Browse All' ) }
-								<Gridicon icon="arrow-right" size="18" />
+								{ __( 'Browse all' ) }
 							</a>
 						) }
 					</div>


### PR DESCRIPTION
#### Proposed Changes

On `Browse All`, we need to remove the arrow and lowercase `All`

#### Testing Instructions
1. Go to /plugins
2. Check margin/paddings to follow the screenshot comments

#### Tasks
- [x] Remove arrow from `Browse All`
- [x] Lowercase `All` on `Browse All`

#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes #68575
