### PR TITLE
Fixed issue where long lines were being cut off incorrectly

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -63,10 +63,6 @@
 		top: auto;
 	}
 
-	@include breakpoint-deprecated( "<960px" ) {
-		max-height: 16px * 5.9;
-	}
-
 	a {
 		text-align: center;
 	}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -63,6 +63,7 @@
 		top: auto;
 	}
 
+	// Center title
 	a {
 		text-align: center;
 	}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -40,14 +40,14 @@
 }
 
 .reader-feed-header__site .reader-feed-header__site-title {
-	align-items: center;
+	align-items: flex-start;
 	display: flex;
 	font-family: $serif;
 	font-size: $font-title-large;
 	font-weight: 600;
+	line-height: 2.5rem;
 	justify-content: center;
-	max-height: 16px * 4;
-	margin-bottom: 6px;
+	margin-bottom: 19px;
 	overflow: hidden;
 	position: relative;
 	white-space: normal;
@@ -67,9 +67,13 @@
 		max-height: 16px * 5.9;
 	}
 
+	a {
+		text-align: center;
+	}
+
 	.blog-stickers {
 		position: relative;
-		top: 2px;
+		top: 11px;
 	}
 }
 


### PR DESCRIPTION
## Description

@shaunandrews reported:

> There's some overflow issues with site titles.

## Before

![image](https://user-images.githubusercontent.com/5634774/194081655-87220cc5-e697-404d-a4c4-6469b7b6a3b2.png)

## After

<img width="697" alt="CleanShot 2022-10-05 at 10 05 46@2x" src="https://user-images.githubusercontent.com/5634774/194081617-51b9e1de-ebc8-4a27-b34a-5682c6f3f8c5.png">

## Related to

#68647
#68604
