### PR TITLE
Issue 932: Fix menu casing

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
@@ -38,7 +38,7 @@ function PostActionsEllipsisMenuPromote( { globalId, postId, bumpStatKey, status
 
 	return (
 		<PopoverMenuItem onClick={ showDSPWidget } icon={ 'speaker' }>
-			{ type === 'post' ? translate( 'Promote Post' ) : translate( 'Promote Page' ) }
+			{ type === 'post' ? translate( 'Promote post' ) : translate( 'Promote page' ) }
 		</PopoverMenuItem>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

Minor changes in relation to this ticket [932](https://github.tumblr.net/Tumblr/wordads-picard/issues/932) to change case of items in menu (for the promote post item) 



#### Testing Instructions

Before version 
![Screenshot 2022-10-05 at 17 24 00](https://user-images.githubusercontent.com/1416426/194085004-f3c0c5ed-06ed-44b6-a870-9428a41705da.png)

after version 

![Screenshot 2022-10-05 at 17 23 33](https://user-images.githubusercontent.com/1416426/194085020-ee8dc5ab-e553-4cd7-9a6d-f41ad9d7aa2d.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
