### PR TITLE
Support: Remove Kayako mentions

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -197,9 +197,8 @@ class HelpContact extends Component {
 			payload.blog_url = site.URL;
 		}
 
-		// Endpoint url has 'kayako', but actually submits to Zendesk.
 		wpcom.req
-			.post( '/help/tickets/kayako/new', payload )
+			.post( '/help/tickets/zendesk/new', payload )
 			.then( () => {
 				this.setState( {
 					isSubmitting: false,

--- a/client/state/help/ticket/actions.js
+++ b/client/state/help/ticket/actions.js
@@ -29,7 +29,7 @@ export const ticketSupportConfigurationRequest = () => ( dispatch ) => {
 	dispatch( requestAction );
 
 	return wpcom.req
-		.get( '/help/tickets/kayako/mine' )
+		.get( '/help/tickets/zendesk/mine' )
 		.then( ( configuration ) => {
 			dispatch( ticketSupportConfigurationRequestSuccess( configuration ) );
 		} )

--- a/client/state/help/ticket/test/actions.js
+++ b/client/state/help/ticket/test/actions.js
@@ -35,7 +35,7 @@ describe( 'ticket-support/configuration actions', () => {
 	} );
 
 	const apiUrl = 'https://public-api.wordpress.com:443';
-	const endpoint = '/rest/v1.1/help/tickets/kayako/mine';
+	const endpoint = '/rest/v1.1/help/tickets/zendesk/mine';
 
 	describe( '#ticketSupportConfigurationRequest success', () => {
 		const spy = jest.fn();

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -13,7 +13,7 @@ type Ticket = {
 export function useSubmitTicketMutation() {
 	return useMutation( ( newTicket: Ticket ) =>
 		wpcomRequest( {
-			path: '/help/tickets/kayako/new',
+			path: '/help/tickets/zendesk/new',
 			apiVersion: '1.1',
 			method: 'POST',
 			body: newTicket,

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -277,11 +277,11 @@ export const HelpCenterContactForm = () => {
 
 					const ticketMeta = [ 'Site I need help with: ' + supportSite.URL, 'Plan: ' + planName ];
 
-					const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
+					const emailMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
 
 					submitTicket( {
 						subject: subject ?? '',
-						message: kayakoMessage,
+						message: emailMessage,
 						locale,
 						client: 'browser:help-center',
 						is_chat_overflow: overflow,
@@ -289,7 +289,7 @@ export const HelpCenterContactForm = () => {
 					} )
 						.then( () => {
 							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
-								support_variation: 'kayako',
+								support_variation: 'ticket',
 								location: 'help-center',
 								section: sectionName,
 							} );


### PR DESCRIPTION
It's an old ticketing system - we don't use it anymore and its mentions are confusing. The endpoints have been modified to support old and new paths, so we can deploy with backwards compatibility (cached Calypso, etc.)

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
