### PR TITLE
Jetpack Connect: Refactor `AuthFormHeader` tests to `@testing-library/react`

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
@@ -2,33 +2,29 @@
 
 exports[`AuthFormHeader renders as expected 1`] = `
 <div>
-  <FormattedHeader
-    align="center"
-    brandFont={false}
-    className=""
-    compactOnMobile={false}
-    headerText="Create an account to set up Jetpack"
-    id=""
-    isSecondary={false}
-    subHeaderText="You are moments away from a better WordPress."
-    tooltipText=""
-  />
-  <CompactCard
-    className="jetpack-connect__site"
-  >
-    <Connect(Localized(Site))
-      site={
-        Object {
-          "ID": null,
-          "admin_url": "http://an.example.site/wp-admin",
-          "domain": "an.example.site",
-          "icon": false,
-          "is_vip": false,
-          "title": "Example Blog",
-          "url": "http://an.example.site",
-        }
-      }
-    />
-  </CompactCard>
+  <div>
+    <header
+      class="formatted-header"
+      id=""
+    >
+      <h1
+        class="formatted-header__title"
+      >
+        Create an account to set up Jetpack
+         
+        
+      </h1>
+      <p
+        class="formatted-header__subtitle"
+      >
+        You are moments away from a better WordPress.
+      </p>
+    </header>
+    <div
+      class="card jetpack-connect__site is-compact"
+    >
+      Site
+    </div>
+  </div>
 </div>
 `;

--- a/client/jetpack-connect/test/auth-form-header.js
+++ b/client/jetpack-connect/test/auth-form-header.js
@@ -1,11 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-
-import { shallow } from 'enzyme';
-import FormattedHeader from 'calypso/components/formatted-header';
+import { render, screen } from '@testing-library/react';
 import { AuthFormHeader } from '../auth-form-header';
 import wooDnaConfig from '../woo-dna-config';
+
+jest.mock( 'calypso/blocks/site', () => () => 'Site' );
 
 const CLIENT_ID = 98765;
 const SITE_SLUG = 'an.example.site';
@@ -33,9 +33,9 @@ const DEFAULT_PROPS = {
 
 describe( 'AuthFormHeader', () => {
 	test( 'renders as expected', () => {
-		const wrapper = shallow( <AuthFormHeader { ...DEFAULT_PROPS } /> );
+		const { container } = render( <AuthFormHeader { ...DEFAULT_PROPS } /> );
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render WC Payments specific sub header copy', () => {
@@ -53,11 +53,11 @@ describe( 'AuthFormHeader', () => {
 		// Notice we have \xa0. This is needed when we compare translated text.
 		// Please refer to https://stackoverflow.com/questions/54242039/intl-numberformat-space-character-does-not-match
 		const expectedText =
-			'Approve your connection. Your account will enable you to start using the features and benefits offered by WooCommerce\xa0Payments';
-		const wrapper = shallow( <AuthFormHeader { ...props } /> )
-			.find( FormattedHeader )
-			.render();
+			'Approve your connection. Your account will enable you to start using the features and benefits offered by WooCommerce Payments';
 
-		expect( wrapper.find( '.formatted-header__subtitle' ).text() ).toEqual( expectedText );
+		render( <AuthFormHeader { ...props } /> );
+
+		expect( screen.getByText( expectedText ) ).toBeVisible();
+		expect( screen.getByText( expectedText ) ).toHaveClass( 'formatted-header__subtitle' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `AuthFormHeader` tests to use `@testing-library/react`

#### Testing Instructions

Verify tests still pass: `yarn run test-client client/jetpack-connect/test/auth-form-header.js`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
