### PR TITLE
Jetpack Connect: Refactor `JetpackConnectNotices` tests to `@testing-library/react`

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -1,30 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JetpackConnectNotices Should not render terminal notice if callback supplied 1`] = `""`;
-
 exports[`JetpackConnectNotices Should render non-terminal notice if callback supplied 1`] = `
-<div
-  className="jetpack-connect__notices-container"
->
-  <Localized(Notice)
-    icon="notice"
-    showDismiss={false}
-    status="is-warning"
-    text="In some cases, authorization can take a few attempts. Please try again."
-    userCanRetry={true}
-  />
+<div>
+  <div
+    class="jetpack-connect__notices-container"
+  >
+    <div
+      aria-label="Notice"
+      class="notice is-warning"
+      role="status"
+    >
+      <span
+        class="notice__icon-wrapper"
+      >
+        <span
+          class="notice__icon-wrapper-drop"
+        />
+        <svg
+          class="gridicon gridicons-notice notice__icon"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-notice"
+          />
+        </svg>
+      </span>
+      <span
+        class="notice__content"
+      >
+        <span
+          class="notice__text"
+        >
+          In some cases, authorization can take a few attempts. Please try again.
+        </span>
+      </span>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`JetpackConnectNotices Should render notice 1`] = `
-<div
-  className="jetpack-connect__notices-container"
->
-  <Localized(Notice)
-    icon="notice"
-    showDismiss={false}
-    status="is-error"
-    text="This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}."
-  />
+<div>
+  <div
+    class="jetpack-connect__notices-container"
+  >
+    <div
+      aria-label="Notice"
+      class="notice is-error"
+      role="status"
+    >
+      <span
+        class="notice__icon-wrapper"
+      >
+        <span
+          class="notice__icon-wrapper-drop"
+        />
+        <svg
+          class="gridicon gridicons-notice notice__icon"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-notice"
+          />
+        </svg>
+      </span>
+      <span
+        class="notice__content"
+      >
+        <span
+          class="notice__text"
+        >
+          This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.
+        </span>
+      </span>
+    </div>
+  </div>
 </div>
 `;

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { JetpackConnectNotices } from '../jetpack-connect-notices';
 
 const terminalErrorNoticeType = 'siteBlocked';
@@ -11,29 +10,27 @@ const requiredProps = { translate: ( string ) => string };
 
 describe( 'JetpackConnectNotices', () => {
 	test( 'Should render notice', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<JetpackConnectNotices { ...requiredProps } noticeType={ terminalErrorNoticeType } />
 		);
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.isEmptyRender() ).toBe( false );
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'Should not render terminal notice if callback supplied', () => {
 		const onTerminalError = jest.fn();
-		const wrapper = shallow(
+		const { container } = render(
 			<JetpackConnectNotices
 				{ ...requiredProps }
 				noticeType={ terminalErrorNoticeType }
 				onTerminalError={ onTerminalError }
 			/>
 		);
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.isEmptyRender() ).toBe( true );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'Should call callback on terminal error', () => {
 		const onTerminalError = jest.fn();
-		shallow(
+		render(
 			<JetpackConnectNotices
 				{ ...requiredProps }
 				noticeType={ terminalErrorNoticeType }
@@ -45,7 +42,7 @@ describe( 'JetpackConnectNotices', () => {
 
 	test( 'Should render non-terminal notice if callback supplied', () => {
 		const onTerminalError = jest.fn();
-		const wrapper = shallow(
+		const { container } = render(
 			<JetpackConnectNotices
 				{ ...requiredProps }
 				noticeType={ nonTerminalErrorNoticeType }
@@ -53,7 +50,6 @@ describe( 'JetpackConnectNotices', () => {
 			/>
 		);
 		expect( onTerminalError ).not.toHaveBeenCalled();
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.isEmptyRender() ).toBe( false );
+		expect( container ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `JetpackConnectNotices` tests to use `@testing-library/react`

#### Testing Instructions

Verify tests still pass: `yarn run test-client client/jetpack-connect/test/jetpack-connect-notices.js`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
