### PR TITLE
We now check if global styles are not in use and bail out

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -209,6 +209,10 @@ add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
 function wpcom_global_styles_in_use() {
 	$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
 
+	if ( ! isset( $user_cpt['post_content'] ) ) {
+		return false;
+	}
+
 	$global_style_keys = array_keys( json_decode( $user_cpt['post_content'], true ) ?? array() );
 
 	return count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -202,6 +202,19 @@ function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
 
 /**
+ * Checks if the current blog has custom styles in use.
+ *
+ * @return bool Returns true if custom styles are in use.
+ */
+function wpcom_global_styles_in_use() {
+	$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
+
+	$global_style_keys = array_keys( json_decode( $user_cpt['post_content'], true ) ?? array() );
+
+	return count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;
+}
+
+/**
  * Adds the global style notice banner to the custom launch bar controls.
  *
  * @param array $custom_controls List of custom controls.
@@ -210,7 +223,7 @@ add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
  */
 function wpcom_display_global_styles_banner( $custom_controls ) {
 	// Do not show the banner if the user can use global styles.
-	if ( ! wpcom_should_limit_global_styles() ) {
+	if ( ! wpcom_should_limit_global_styles() || ! wpcom_global_styles_in_use() ) {
 		return;
 	}
 


### PR DESCRIPTION
#### Proposed Changes
Fixes: https://github.com/Automattic/wp-calypso/issues/68643
* We now check if the site is currently using Global Styles before showing the notice on the launchbar.

#### Testing Instructions

1. Run `install-plugin.sh editing-toolkit add/launchbar-should-only-show-notice-when-gs-are-used` on your sandbox.
2. You need to be logged in and open the site.
3. Make sure your site isn't launched.
4. You should see all the normal icons + the GS notice.
5. Launch your site, you should only see the GS notice.
6. Upgrade your plan, you should not see the GS notice and/or the launch bar.
7. You should only see the notice when you've saved Global Style changes, otherwise, the notice shouldn't be shown.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #