### PR TITLE
E2E (Atomic): Fix the block pattern count

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -82,22 +82,31 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		const frame = await editorPage.getEditorHandle();
 		const actualBlockPatternCount = await frame.evaluate(
 			() =>
+				/* eslint-disable @typescript-eslint/ban-ts-comment */
 				new Promise( ( resolve ) => {
+					let hasTimedOut = false;
+
+					// This needs to be done in a loop until patterns request
+					// returns anything as initially the data is not there yet,
+					// and it returns an empty array, making this case a false
+					// positive.
 					const wait = setInterval( () => {
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore
 						const patterns = window.wp.data.select( 'core' ).getBlockPatterns();
-						if ( patterns.length > 0 ) {
+						if ( patterns.length > 0 || hasTimedOut ) {
 							clearInterval( wait );
-							// This needs to be done in a loop until patterns
-							// request returns anything as initially it returns
-							// an empty array, making this case a false positive.
 							resolve( patterns.length );
 						}
 					}, 100 );
-				} )
-		);
 
+					// Timeout after 10 seconds. No need to wait for the full
+					// jest (2 minutes) timeout.
+					setTimeout( () => {
+						hasTimedOut = true;
+					}, 10000 );
+				} )
+			/* eslint-enable @typescript-eslint/ban-ts-comment */
+		);
 		expect( actualBlockPatternCount ).toBeGreaterThanOrEqual( expectedBlockPatternCount );
 	} );
 } );

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -81,7 +81,21 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		const expectedBlockPatternCount = 50;
 		const frame = await editorPage.getEditorHandle();
 		const actualBlockPatternCount = await frame.evaluate(
-			`window.wp.data.select( 'core' ).getBlockPatterns().length`
+			() =>
+				new Promise( ( resolve ) => {
+					const wait = setInterval( () => {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						const patterns = window.wp.data.select( 'core' ).getBlockPatterns();
+						if ( patterns.length > 0 ) {
+							clearInterval( wait );
+							// This needs to be done in a loop until patterns
+							// request returns anything as initially it returns
+							// an empty array, making this case a false positive.
+							resolve( patterns.length );
+						}
+					}, 100 );
+				} )
 		);
 
 		expect( actualBlockPatternCount ).toBeGreaterThanOrEqual( expectedBlockPatternCount );


### PR DESCRIPTION
Tracking issue: #65906


### Proposed Changes

Make the following test compatible with the Atomic environment:

> **Block pattern count should be greater than default**
> specs/infrastructure/infrastructure__experimental-gutenberg.ts: Gutenberg: Experimental Features


### Why was it failing?

The `wp.data.select('core').getBlockPatterns()` request returns an empty array initially (at least on an Atomic site). If we put it in a loop and wait to return anything, we're fixing this test and making it more stable.

### Testing instruction

The fixed tests should pass for both Simple and Atomic sites (production).