### PR TITLE
Fix reader keyboard shortcuts

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -85,7 +85,7 @@ const ReaderAvatar = ( {
 	} );
 
 	const defaultIconElement = ! hasSiteIcon && ! hasAvatar && ! showPlaceholder && (
-		<Gridicon icon="globe" size={ siteIconSize } />
+		<Gridicon key="globe-icon" icon="globe" size={ siteIconSize } />
 	);
 	const siteIconElement = hasSiteIcon && (
 		<SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />

--- a/client/reader/components/icons/following-feed-icon.jsx
+++ b/client/reader/components/icons/following-feed-icon.jsx
@@ -10,13 +10,18 @@ export default function ReaderFollowingFeedIcon( { iconSize } ) {
 			xmlns="http://www.w3.org/2000/svg"
 		>
 			<path
-				class="following-icon-background"
-				fill-rule="evenodd"
-				clip-rule="evenodd"
+				className="following-icon-background"
+				fillRule="evenodd"
+				clipRule="evenodd"
 				d="M16 4.5H4V15C4 15.2761 4.22386 15.5 4.5 15.5H11.5V17H4.5C3.39543 17 2.5 16.1046 2.5 15V4.5V3H4H16H17.5V4.5V12.5H16V4.5ZM5.5 6.5H14.5V8H5.5V6.5ZM5.5 9.5H9.5V11H5.5V9.5ZM12 11H13V12H12V11ZM10.5 9.5H12H13H14.5V11V12V13.5H13H12H10.5V12V11V9.5ZM5.5 12H9.5V13.5H5.5V12Z"
 				fill="#606A73"
 			/>
-			<path class="following-icon-tick" d="M13.5 16L15.5 18L19 14.5" stroke="#008A20" stroke-width="1.5" />
+			<path
+				className="following-icon-tick"
+				d="M13.5 16L15.5 18L19 14.5"
+				stroke="#008A20"
+				strokeWidth="1.5"
+			/>
 		</svg>
 	);
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -111,8 +111,8 @@ class ReaderStream extends Component {
 	};
 
 	scrollToSelectedPost( animate ) {
-		const HEADER_OFFSET = -80; // a fixed position header means we can't just scroll the element into view.
-		const selectedNode = ReactDom.findDOMNode( this ).querySelector( '.is-selected' );
+		const HEADER_OFFSET = -32; // a fixed position header means we can't just scroll the element into view.
+		const selectedNode = ReactDom.findDOMNode( this ).querySelector( '.card.is-selected' );
 		if ( selectedNode ) {
 			const documentElement = document.documentElement;
 			selectedNode.focus();


### PR DESCRIPTION
The keyboard shortcuts aren't working properly. I suspect this is due to errors in console.

Related to https://github.com/Automattic/wp-calypso/issues/68604#issuecomment-1267703081

### Test

Check the the `j` and `k` keyboard shortcuts work as expected

