### PR TITLE
Help Center: dont send empty Sibyl queries

### DIFF
--- a/packages/data-stores/src/support-queries/use-sibyl-query.ts
+++ b/packages/data-stores/src/support-queries/use-sibyl-query.ts
@@ -26,6 +26,7 @@ export function useSibylQuery( query: string, isJetpackSite: boolean, isAtomic: 
 		{
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,
+			enabled: !! query,
 		}
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

* We're querying the qanda endpoint with no query string for no reason. This makes sure this doesn't happen.
* Context: pdDR7T-l0-p2#comment-271

#### Testing Instructions

1. Open the Help Center.
2. Go to DevTools > Network. Filter by "qanda".
3. Make sure there is no request to the endpoint unless you go to the contact form and search for something.