### PR TITLE
Domains: remove dotblog_subdomain_not_available string

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -39,7 +39,6 @@ const SITE_TAKEN_ERROR_CODES = [
 	'blog_name_exists',
 	'blog_name_reserved',
 	'blog_name_reserved_but_may_be_available',
-	'dotblog_subdomain_not_available',
 ];
 
 const WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS = [ 'p2', 'team', 'work' ];

--- a/client/signup/steps/videopress-site/index.jsx
+++ b/client/signup/steps/videopress-site/index.jsx
@@ -43,7 +43,6 @@ const SITE_TAKEN_ERROR_CODES = [
 	'blog_name_exists',
 	'blog_name_reserved',
 	'blog_name_reserved_but_may_be_available',
-	'dotblog_subdomain_not_available',
 ];
 
 const WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS = [ 'video' ];


### PR DESCRIPTION
#### Proposed Changes

* This removes the error code `dotblog_subdomain_not_available` from Calypso as it creates an unnecessary dependency between the backend and the frontend.
* When creating a new site, the error message that we show to the end-user in cases when the free dot blog subdomain already exists would be changed from `Sorry, that site already exists! Please, try a different one` to `This address is already taken. Please choose another one.`
* Currently it looks like there are no flows that would actually show this message since we don't allow the users to manually enter a custom address for their free dot blog subdomains.

#### Testing Instructions

* Currently the available flows do not allow selecting a free dot blog subdomain, only a free `.wordpress.com` one.
* Please make sure the flows to create a new [VideoPress](https://wordpress.com/start/videopress/videopress-site) and [P2](https://wordpress.com/start/p2/p2-site) sites are working correctly. This is the only place (to my knowledge) currently allowing manual entry for free subdomains and might be affected by that change.

#### Related to
* 1146722293412575-as-1202931472225336
* D89185