### PR TITLE
Jetpack pricing: remove redundant alternative texts

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -68,14 +68,7 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 				{ ( discountPercentage > 0 || isLoading ) && (
 					<div className="intro-pricing-banner__content">
 						<div className="intro-pricing-banner__item">
-							<img
-								className="intro-pricing-banner__item-icon"
-								src={ rocket }
-								alt={ translate( 'Rocket representing %(percent)d%% sale', {
-									args: { percent: discountPercentage },
-									textOnly: true,
-								} ) }
-							/>
+							<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
 							<span className="intro-pricing-banner__item-label">
 								{ preventWidows(
 									translate( 'Get up to %(percent)d%% off your first year.', {

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
@@ -23,7 +23,7 @@ export const FeaturesList: React.FC< FeaturesListProps > = ( { item } ) => {
 			{ featuresList.map( ( { features, icon, included, slug, title } ) => (
 				<div key={ slug } className="features-list__group">
 					<div className="features-list__group--title">
-						<img className="features-list__group--icon" alt={ title } src={ icon } />
+						<img className="features-list__group--icon" alt="" src={ icon } />
 						{ title }
 					</div>
 					<ul className="features-list__group--features">


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the [Jetpack pricing page](https://cloud.jetpack.com/pricing), some non-text content has a text alternative that's redundant with the surrounding text. It makes the reading by screen readers unnecessary longer (see videos below).

### Implementation notes

See the [text alternatives guideline](https://www.w3.org/TR/WCAG21/#non-text-content) from the W3C if you'd like to learn more about it.

### Testing instructions

- Spin up the pricing page by running this branch locally, or using the live link below.
- If you're familiar with a screen reader (e.g. VoiceOver on Mac), check that it ignores the rocket and category icons (see videos below).
- Otherwise, check in the code that the `alt` attribute is empty for these icons.

### Videos

_Turn the sound on._

https://user-images.githubusercontent.com/1620183/194337593-31f99c13-f09f-4e4c-a0aa-996161e6d029.mov

Unlike the other icons, the rocket icon has an alternative text that's redundant with the following text.

https://user-images.githubusercontent.com/1620183/194337620-cea3c87b-e10b-4a2a-b444-664915b3c55f.mov

Category icons have an alternative text that mention the category, making screen readers say the category twice.

