### PR TITLE
Marketplace: Update Educational Article Section Colors and Padding

### DIFF
--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -6,50 +6,48 @@ import './style.scss';
 
 interface LinkCardContainerProps {
 	background?: string;
+	backgroundColor?: string;
 }
-
-interface LinkCardElementsProps {
-	dark?: boolean;
-}
-
 interface LinkCardProps {
 	label?: ReactChild;
 	title: ReactChild;
 	cta?: ReactChild;
 	background?: string;
+	backgroundColor?: string;
 	url: string;
 	external?: boolean;
-	dark?: boolean;
 	onClick?: () => void;
 }
 
 const LinkCardContainer = styled.div< LinkCardContainerProps >`
 	:hover {
-		filter: brightness( 120% );
+		filter: brightness( 102% );
 	}
 
 	border-radius: 5px;
 	padding: 24px;
-	background: var( --${ ( props ) => props.background || 'studio-white' } );
+	background: ${ ( props ) => {
+		if ( props.backgroundColor ) {
+			return props.backgroundColor;
+		}
+		return 'var( --' + props.background || 'studio-white' + ');';
+	} };
 `;
 
-const LinkCardLabel = styled.div< LinkCardElementsProps >`
+const LinkCardLabel = styled.div`
 	margin-bottom: 8px;
 	font-size: var( --scss-font-body-extra-small );
-	color: rgba(
-		var( --${ ( props ) => ( props.dark ? 'studio-celadon-60-rgb' : 'studio-purple-5-rgb' ) } ),
-		0.75
-	);
+	color: rgba( var( --studio-blue-50 ), 0.75 );
 	line-height: 1.25rem;
 `;
 
-const LinkCardTitle = styled.div< LinkCardElementsProps >`
+const LinkCardTitle = styled.div`
 	@media ( max-width: 1090px ) {
 		-webkit-line-clamp: 4; // trunk text to 4 lines then ellipsis
 		line-clamp: 4;
 	}
 
-	color: var( --${ ( props ) => ( props.dark ? 'studio-celadon-60' : 'studio-purple-5' ) } );
+	color: var( --studio-blue-50 );
 	margin-bottom: 32px;
 	font-size: var( --scss-font-title-small );
 	text-overflow: ellipsis;
@@ -62,26 +60,23 @@ const LinkCardTitle = styled.div< LinkCardElementsProps >`
 	line-height: 1.5rem;
 `;
 
-const LinkCardCta = styled.div< LinkCardElementsProps >`
+const LinkCardCta = styled.div`
 	font-size: var( --scss-font-body-small );
-	color: rgba(
-		var( --${ ( props ) => ( props.dark ? 'studio-celadon-60-rgb' : 'studio-purple-5-rgb' ) } ),
-		0.75
-	);
+	color: rgba( var( --studio-blue-50 ), 0.75 );
 	line-height: 1.25rem;
 `;
 
 const LinkCard = ( props: LinkCardProps ) => {
-	const { label, title, cta, background, url, external, dark, onClick } = props;
+	const { label, title, cta, background, backgroundColor, url, external, onClick } = props;
 
 	const Link = external ? ExternalLink : 'a';
 
 	return (
 		<Link href={ url } onClick={ onClick }>
-			<LinkCardContainer background={ background }>
-				<LinkCardLabel dark={ dark }>{ label }</LinkCardLabel>
-				<LinkCardTitle dark={ dark }>{ title }</LinkCardTitle>
-				<LinkCardCta dark={ dark }>{ cta }</LinkCardCta>
+			<LinkCardContainer background={ background } backgroundColor={ backgroundColor }>
+				<LinkCardLabel>{ label }</LinkCardLabel>
+				<LinkCardTitle>{ title }</LinkCardTitle>
+				<LinkCardCta>{ cta }</LinkCardCta>
 			</LinkCardContainer>
 		</Link>
 	);

--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -6,14 +6,12 @@ import './style.scss';
 
 interface LinkCardContainerProps {
 	background?: string;
-	backgroundColor?: string;
 }
 interface LinkCardProps {
 	label?: ReactChild;
 	title: ReactChild;
 	cta?: ReactChild;
 	background?: string;
-	backgroundColor?: string;
 	url: string;
 	external?: boolean;
 	onClick?: () => void;
@@ -26,12 +24,7 @@ const LinkCardContainer = styled.div< LinkCardContainerProps >`
 
 	border-radius: 5px;
 	padding: 24px;
-	background: ${ ( props ) => {
-		if ( props.backgroundColor ) {
-			return props.backgroundColor;
-		}
-		return 'var( --' + props.background || 'studio-white' + ');';
-	} };
+	background: ${ ( props ) => props.background || 'var(--studio-white)' };
 `;
 
 const LinkCardLabel = styled.div`
@@ -67,13 +60,13 @@ const LinkCardCta = styled.div`
 `;
 
 const LinkCard = ( props: LinkCardProps ) => {
-	const { label, title, cta, background, backgroundColor, url, external, onClick } = props;
+	const { label, title, cta, background, url, external, onClick } = props;
 
 	const Link = external ? ExternalLink : 'a';
 
 	return (
 		<Link href={ url } onClick={ onClick }>
-			<LinkCardContainer background={ background } backgroundColor={ backgroundColor }>
+			<LinkCardContainer background={ background }>
 				<LinkCardLabel>{ label }</LinkCardLabel>
 				<LinkCardTitle>{ title }</LinkCardTitle>
 				<LinkCardCta>{ cta }</LinkCardCta>

--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -8,6 +8,10 @@ interface LinkCardContainerProps {
 	background?: string;
 }
 
+interface LinkCardElementsProps {
+	dark?: boolean;
+}
+
 interface LinkCardProps {
 	label?: ReactChild;
 	title: ReactChild;
@@ -15,6 +19,7 @@ interface LinkCardProps {
 	background?: string;
 	url: string;
 	external?: boolean;
+	dark?: boolean;
 	onClick?: () => void;
 }
 
@@ -28,20 +33,23 @@ const LinkCardContainer = styled.div< LinkCardContainerProps >`
 	background: var( --${ ( props ) => props.background || 'studio-white' } );
 `;
 
-const LinkCardLabel = styled.div`
+const LinkCardLabel = styled.div< LinkCardElementsProps >`
 	margin-bottom: 8px;
 	font-size: var( --scss-font-body-extra-small );
-	color: rgba( var( --studio-white-rgb ), 0.75 );
+	color: rgba(
+		var( --${ ( props ) => ( props.dark ? 'studio-celadon-60-rgb' : 'studio-purple-5-rgb' ) } ),
+		0.75
+	);
 	line-height: 1.25rem;
 `;
 
-const LinkCardTitle = styled.div`
+const LinkCardTitle = styled.div< LinkCardElementsProps >`
 	@media ( max-width: 1090px ) {
 		-webkit-line-clamp: 4; // trunk text to 4 lines then ellipsis
 		line-clamp: 4;
 	}
 
-	color: var( --color-text-inverted );
+	color: var( --${ ( props ) => ( props.dark ? 'studio-celadon-60' : 'studio-purple-5' ) } );
 	margin-bottom: 32px;
 	font-size: var( --scss-font-title-small );
 	text-overflow: ellipsis;
@@ -54,23 +62,26 @@ const LinkCardTitle = styled.div`
 	line-height: 1.5rem;
 `;
 
-const LinkCardCta = styled.div`
+const LinkCardCta = styled.div< LinkCardElementsProps >`
 	font-size: var( --scss-font-body-small );
-	color: rgba( var( --studio-white-rgb ), 0.75 );
+	color: rgba(
+		var( --${ ( props ) => ( props.dark ? 'studio-celadon-60-rgb' : 'studio-purple-5-rgb' ) } ),
+		0.75
+	);
 	line-height: 1.25rem;
 `;
 
 const LinkCard = ( props: LinkCardProps ) => {
-	const { label, title, cta, background, url, external, onClick } = props;
+	const { label, title, cta, background, url, external, dark, onClick } = props;
 
 	const Link = external ? ExternalLink : 'a';
 
 	return (
 		<Link href={ url } onClick={ onClick }>
 			<LinkCardContainer background={ background }>
-				<LinkCardLabel>{ label }</LinkCardLabel>
-				<LinkCardTitle>{ title }</LinkCardTitle>
-				<LinkCardCta>{ cta }</LinkCardCta>
+				<LinkCardLabel dark={ dark }>{ label }</LinkCardLabel>
+				<LinkCardTitle dark={ dark }>{ title }</LinkCardTitle>
+				<LinkCardCta dark={ dark }>{ cta }</LinkCardCta>
 			</LinkCardContainer>
 		</Link>
 	);

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -8,12 +8,10 @@ interface SectionProps {
 	subheader?: ReactChild;
 	children: ReactChild | ReactChild[];
 	dark?: boolean;
-	whiteBackground?: boolean;
 }
 
 interface SectionContainerProps {
 	dark?: boolean;
-	whiteBackground?: boolean;
 }
 
 interface SectionHeaderProps {
@@ -24,12 +22,8 @@ const SectionContainer = styled.div< SectionContainerProps >`
 	::before {
 		box-sizing: border-box;
 		content: '';
-		background-color: ${ ( props ) => {
-			if ( props.whiteBackground ) {
-				return 'var( --studio-white )';
-			}
-			return props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-gray-0 )';
-		} };
+		background-color: ${ ( props ) =>
+			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
 		position: absolute;
 		height: 100%;
 		width: 200vw;
@@ -68,10 +62,10 @@ const SectionHeaderContainer = styled.div< SectionHeaderProps >`
 const SectionContent = styled.div``;
 
 const Section = ( props: SectionProps ) => {
-	const { children, header, subheader, dark, whiteBackground } = props;
+	const { children, header, subheader, dark } = props;
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<SectionContainer dark={ dark } whiteBackground={ whiteBackground }>
+		<SectionContainer dark={ dark }>
 			<SectionHeaderContainer>
 				<SectionHeader dark={ dark } className="wp-brand-font">
 					{ header }

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -8,10 +8,12 @@ interface SectionProps {
 	subheader?: ReactChild;
 	children: ReactChild | ReactChild[];
 	dark?: boolean;
+	whiteBackground?: boolean;
 }
 
 interface SectionContainerProps {
 	dark?: boolean;
+	whiteBackground?: boolean;
 }
 
 interface SectionHeaderProps {
@@ -22,8 +24,12 @@ const SectionContainer = styled.div< SectionContainerProps >`
 	::before {
 		box-sizing: border-box;
 		content: '';
-		background-color: ${ ( props ) =>
-			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-gray-0 )' };
+		background-color: ${ ( props ) => {
+			if ( props.whiteBackground ) {
+				return 'var( --studio-white )';
+			}
+			return props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-gray-0 )';
+		} };
 		position: absolute;
 		height: 100%;
 		width: 200vw;
@@ -62,10 +68,10 @@ const SectionHeaderContainer = styled.div< SectionHeaderProps >`
 const SectionContent = styled.div``;
 
 const Section = ( props: SectionProps ) => {
-	const { children, header, subheader, dark } = props;
+	const { children, header, subheader, dark, whiteBackground } = props;
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<SectionContainer dark={ dark }>
+		<SectionContainer dark={ dark } whiteBackground={ whiteBackground }>
 			<SectionHeaderContainer>
 				<SectionHeader dark={ dark } className="wp-brand-font">
 					{ header }

--- a/client/components/section/style.scss
+++ b/client/components/section/style.scss
@@ -1,3 +1,4 @@
 :root {
 	--scss-font-title-large: #{$font-title-large};
+	--scss-font-title-medium: #{$font-title-medium};
 }

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -89,7 +89,6 @@ const EducationFooter = () => {
 			<Section
 				header={ __( 'Get started with plugins' ) }
 				subheader={ __( 'Our favorite how-to guides to get you started with plugins' ) }
-				whiteBackground
 			>
 				<ThreeColumnContainer>
 					<LinkCard

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -99,7 +99,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/website-building/what-are-wordpress-plugins-and-themes-a-beginners-guide/'
 						) }
-						backgroundColor="#e5f3f0"
+						background="#e5f3f0"
 						onClick={ () => onClickLinkCard( 'website_building' ) }
 					/>
 					<LinkCard
@@ -110,7 +110,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/customization/how-to-choose-wordpress-plugins-for-your-website-7-tips/'
 						) }
-						backgroundColor="#f9f0f6"
+						background="#f9f0f6"
 						onClick={ () => onClickLinkCard( 'customization' ) }
 					/>
 					<LinkCard
@@ -121,7 +121,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/tips/do-you-need-to-use-seo-plugins-on-your-wordpress-com-site/'
 						) }
-						backgroundColor="#e5f4ff"
+						background="#e5f4ff"
 						onClick={ () => onClickLinkCard( 'seo' ) }
 					/>
 				</ThreeColumnContainer>

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -100,7 +100,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/website-building/what-are-wordpress-plugins-and-themes-a-beginners-guide/'
 						) }
-						background="studio-celadon-50"
+						backgroundColor="#e5f3f0"
 						onClick={ () => onClickLinkCard( 'website_building' ) }
 					/>
 					<LinkCard
@@ -111,7 +111,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/customization/how-to-choose-wordpress-plugins-for-your-website-7-tips/'
 						) }
-						background="studio-blue-50"
+						backgroundColor="#f9f0f6"
 						onClick={ () => onClickLinkCard( 'customization' ) }
 					/>
 					<LinkCard
@@ -122,8 +122,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/tips/do-you-need-to-use-seo-plugins-on-your-wordpress-com-site/'
 						) }
-						background="studio-blue-10"
-						dark
+						backgroundColor="#e5f4ff"
 						onClick={ () => onClickLinkCard( 'seo' ) }
 					/>
 				</ThreeColumnContainer>

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -25,7 +25,20 @@ const ThreeColumnContainer = styled.div`
 `;
 
 const EducationFooterContainer = styled.div`
-	margin-top: 48px;
+	margin-top: 40px;
+
+	> div:first-child {
+		padding: 0;
+		margin-bottom: 60px;
+
+		.wp-brand-font {
+			font-size: var( --scss-font-title-medium );
+		}
+
+		> div:first-child {
+			margin-bottom: 24px;
+		}
+	}
 `;
 
 export const MarketplaceFooter = () => {
@@ -76,6 +89,7 @@ const EducationFooter = () => {
 			<Section
 				header={ __( 'Get started with plugins' ) }
 				subheader={ __( 'Our favorite how-to guides to get you started with plugins' ) }
+				whiteBackground
 			>
 				<ThreeColumnContainer>
 					<LinkCard
@@ -86,7 +100,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/website-building/what-are-wordpress-plugins-and-themes-a-beginners-guide/'
 						) }
-						background="studio-celadon-60"
+						background="studio-celadon-50"
 						onClick={ () => onClickLinkCard( 'website_building' ) }
 					/>
 					<LinkCard
@@ -97,7 +111,7 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/customization/how-to-choose-wordpress-plugins-for-your-website-7-tips/'
 						) }
-						background="studio-purple-80"
+						background="studio-blue-50"
 						onClick={ () => onClickLinkCard( 'customization' ) }
 					/>
 					<LinkCard
@@ -108,7 +122,8 @@ const EducationFooter = () => {
 						url={ localizeUrl(
 							'https://wordpress.com/go/tips/do-you-need-to-use-seo-plugins-on-your-wordpress-com-site/'
 						) }
-						background="studio-wordpress-blue-80"
+						background="studio-blue-10"
+						dark
 						onClick={ () => onClickLinkCard( 'seo' ) }
 					/>
 				</ThreeColumnContainer>


### PR DESCRIPTION
#### Proposed Changes

Update Educational articles section following the Figma design

Figma: f84fqtCG4pCnCh2Hq0But5-fi-3760%3A33351

#### Testing Instructions
1. Go to /plugins
2. Check colors/paddings are the correct following Figma and [latest update](https://github.com/Automattic/woocommerce.com/issues/14351#issuecomment-1268469385)

#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes https://github.com/Automattic/woocommerce.com/issues/14351