### PR TITLE
Added logic for free domain and custom domain info (DO NOT MERGE)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useState } from 'react';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ResponseDomain } from 'calypso/lib/domains/types';
 import LaunchpadSitePreview from './launchpad-site-preview';
 import Sidebar from './sidebar';
 
@@ -9,11 +13,62 @@ type StepContentProps = {
 	goToStep?: NavigationControls[ 'goToStep' ];
 };
 
-const StepContent = ( { siteSlug, submit, goNext, goToStep }: StepContentProps ) => (
-	<div className="launchpad__content">
-		<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } goToStep={ goToStep } />
-		<LaunchpadSitePreview siteSlug={ siteSlug } />
-	</div>
-);
+const StepContent = ( { siteSlug, submit, goNext, goToStep }: StepContentProps ) => {
+	// We can also pass the siteId from the parent component when we figure out the rest of the logic
+	const site = useSite();
+
+	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
+
+	const [ freeDomainObject, setFreeDomainObject ] = useState< ResponseDomain >();
+	const [ customDomainObject, setCustomDomainObject ] = useState< ResponseDomain >();
+
+	useEffect( () => {
+		if ( allDomains ) {
+			// console.log( { allDomains } );
+			// Filter for custom domains
+			let customDomainObjects = allDomains.filter( ( domainObject ) => {
+				if ( domainObject.domain.endsWith( '.wordpress.com' ) ) {
+					setFreeDomainObject( domainObject );
+				}
+				return ! domainObject.domain.endsWith( '.wordpress.com' );
+			} );
+
+			// Sort by "latest" custom domain
+			customDomainObjects =
+				customDomainObjects &&
+				customDomainObjects.sort( ( firstCustomDomainObject, secondCustomDomainObject ) => {
+					const firstCustomDomainDate = new Date( firstCustomDomainObject.registration_date );
+					const secondCustomDomainDate = new Date( secondCustomDomainObject.registration_date );
+					if ( firstCustomDomainDate > secondCustomDomainDate ) {
+						return -1;
+					}
+					if ( firstCustomDomainDate < secondCustomDomainDate ) {
+						return 1;
+					}
+					return 0;
+				} );
+
+			if ( customDomainObjects && customDomainObjects.length > 0 ) {
+				setCustomDomainObject( customDomainObjects[ 0 ] );
+			}
+
+			// console.log( 'sorted', customDomainObjects );
+		}
+	}, [ allDomains ] );
+
+	// 'freeDomainObject' will be used for sidebar URL box
+	console.log( { freeDomainObject } );
+	// 'customDomainObject' will be used for site preview based on additional conditionals (ssl_status && points_to_wpcom)
+	console.log( { customDomainObject } );
+
+	return (
+		<div className="launchpad__content">
+			<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } goToStep={ goToStep } />
+			<LaunchpadSitePreview siteSlug={ siteSlug } />
+		</div>
+	);
+};
 
 export default StepContent;


### PR DESCRIPTION
#### Proposed Changes

* Test changes for fixing custom domain and free domain logic.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
