### PR TITLE
Update border around gallery images

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -660,7 +660,6 @@
 }
 
 .reader-post-card__gallery-item {
-	border: 1px solid var(--color-neutral-0);
 	cursor: pointer;
 	flex: 1;
 	height: auto;
@@ -687,7 +686,7 @@
 
 .reader-post-card__gallery-image {
 	border-radius: 6px;
-	box-shadow: 0 0 0 1px rgba(0,0,0,.1);
+	box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
 	height: 300px;
 }
 


### PR DESCRIPTION
## Description

@ollierozdarz reported that the border around gallery images was a bit jacked. Should be updated now with this PR.

## Before

![CleanShot 2022-10-05 at 16 25 22@2x](https://user-images.githubusercontent.com/5634774/194156691-97fcabd1-2690-4819-9cf8-1c38abf139f6.png)

## After

<img width="565" alt="image" src="https://user-images.githubusercontent.com/5634774/194156899-16475de6-49a7-4489-9037-5cd90471cac1.png">

## Related

- #68647
- #68604
