### PR TITLE
Launchpad: Add Newsletter Post-Setup Screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -57,6 +57,7 @@ button {
 .import-focused,
 .plugin-bundle,
 .newsletter-setup,
+.newsletter-post-setup,
 .patterns,
 .link-in-bio-setup,
 .link-in-bio-post-setup,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -31,6 +31,7 @@ export { default as wooConfirm } from './woo-confirm';
 export { default as wooVerifyEmail } from './woo-verify-email';
 export { default as editEmail } from './edit-email';
 export { default as newsletterSetup } from './newsletter-setup';
+export { default as newsletterPostSetup } from './newsletter-post-setup';
 export { default as difmStartingPoint } from './difm-starting-point';
 export { default as letsGetStarted } from './lets-get-started';
 export { default as intro } from './intro';
@@ -82,6 +83,7 @@ export type StepPath =
 	| 'linkInBioSetup'
 	| 'linkInBioPostSetup'
 	| 'newsletterSetup'
+	| 'newsletterPostSetup'
 	| 'intro'
 	| 'launchpad'
 	| 'subscribers'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -5,10 +5,12 @@ import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
+	const clearCache = useQuery().get( 'clearCache' );
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const flow = useFlowParam();
 	const devicesToShow: Device[] = [ DEVICE_TYPE.COMPUTER, DEVICE_TYPE.PHONE ];
@@ -27,6 +29,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 			// hide cookies popup
 			preview: true,
 			do_preview_no_interactions: true,
+			clearmemcache: clearCache ? 'brisket' : '',
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -10,7 +10,7 @@ import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
-	const clearCache = useQuery().get( 'clearCache' );
+	const color = useQuery().get( 'color' );
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const flow = useFlowParam();
 	const devicesToShow: Device[] = [ DEVICE_TYPE.COMPUTER, DEVICE_TYPE.PHONE ];
@@ -29,7 +29,7 @@ const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 			// hide cookies popup
 			preview: true,
 			do_preview_no_interactions: true,
-			clearmemcache: clearCache ? 'brisket' : '',
+			...( color && { preview_accent_color: color } ),
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -34,6 +34,8 @@ export function getEnhancedTasks(
 				case 'setup_newsletter':
 					taskData = {
 						title: translate( 'Personalize Newsletter' ),
+						keepActive: true,
+						actionUrl: `/setup/newsletterPostSetup?flow=newsletter-post-setup&siteSlug=${ siteSlug }`,
 					};
 					break;
 				case 'plan_selected':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -35,7 +35,12 @@ export function getEnhancedTasks(
 					taskData = {
 						title: translate( 'Personalize Newsletter' ),
 						keepActive: true,
-						actionUrl: `/setup/newsletterPostSetup?flow=newsletter-post-setup&siteSlug=${ siteSlug }`,
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.isCompleted, task.id );
+							window.location.replace(
+								`/setup/newsletterPostSetup?flow=newsletter-post-setup&siteSlug=${ siteSlug }`
+							);
+						},
 					};
 					break;
 				case 'plan_selected':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -10,6 +10,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import useAccentColor from 'calypso/landing/stepper/hooks/use-accent-color';
+import useSaveAccentColor from 'calypso/landing/stepper/hooks/use-save-accent-color';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
@@ -25,6 +26,7 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 	const { __ } = useI18n();
 	const site = useSite();
 	const fetchedAccentColor = useAccentColor();
+	const saveAccentColor = useSaveAccentColor();
 	const newsletterFormText = {
 		titlePlaceholder: __( 'My newsletter' ),
 		titleMissing: __( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
@@ -77,6 +79,9 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 					blogname: siteTitle,
 					blogdescription: tagline,
 				} );
+				if ( accentColor.hex !== fetchedAccentColor ) {
+					await saveAccentColor( site.ID, accentColor.hex );
+				}
 				if ( base64Image ) {
 					await uploadAndSetSiteLogo(
 						site.ID,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -99,17 +99,17 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 
 	return (
 		<StepContainer
-			stepName={ 'newsletter-setup' }
+			stepName="newsletter-setup"
 			isWideLayout={ true }
 			hideBack={ true }
-			flowName={ 'newsletter' }
+			flowName="newsletter"
 			formattedHeader={
 				<FormattedHeader
-					id={ 'newsletter-setup-header' }
+					id="newsletter-setup-header"
 					headerText={ createInterpolateElement( __( 'Personalize your<br />Newsletter' ), {
 						br: <br />,
 					} ) }
-					align={ 'center' }
+					align="center"
 				/>
 			}
 			stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -1,0 +1,120 @@
+import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import { FormEvent, useEffect, useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../../../../hooks/use-site';
+import AccentColorControl, { AccentColor } from '../components/accent-color-control';
+import SetupForm from '../components/setup-form';
+import { defaultAccentColor } from '../newsletter-setup';
+import type { Step } from '../../types';
+
+import '../newsletter-setup/style.scss';
+
+const NewsletterPostSetup: Step = ( { navigation } ) => {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const site = useSite();
+
+	const newsletterFormText = {
+		titlePlaceholder: __( 'My newsletter' ),
+		titleMissing: __( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
+		taglinePlaceholder: __( 'Describe your Newsletter in a line or two' ),
+		iconPlaceholder: __( 'Add a site icon' ),
+	};
+
+	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
+	const [ siteTitle, setComponentSiteTitle ] = useState( '' );
+	const [ tagline, setTagline ] = useState( '' );
+	const [ accentColor, setAccentColor ] = useState< AccentColor >( defaultAccentColor );
+	const [ base64Image, setBase64Image ] = useState< string | null >();
+	const [ selectedFile, setSelectedFile ] = useState< File | undefined >();
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isSubmitError, setIsSubmitError ] = useState( false );
+
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
+	useEffect( () => {
+		setComponentSiteTitle( site?.name || '' );
+		setTagline( site?.description || '' );
+	}, [ site ] );
+
+	useEffect( () => {
+		setIsSubmitError( false );
+	}, [ siteTitle, tagline, selectedFile, base64Image ] );
+
+	const handleSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+
+		if ( ! siteTitle.trim().length ) {
+			setInvalidSiteTitle( true );
+			return;
+		}
+
+		try {
+			if ( site ) {
+				setIsLoading( true );
+				await saveSiteSettings( site.ID, {
+					blogname: siteTitle,
+					blogdescription: tagline,
+				} );
+				if ( base64Image ) {
+					await uploadAndSetSiteLogo(
+						site.ID,
+						new File( [ base64ImageToBlob( base64Image ) ], 'site-logo.png' )
+					);
+				}
+				setIsLoading( false );
+				submit?.();
+			}
+		} catch {
+			setIsSubmitError( true );
+			setIsLoading( false );
+		}
+	};
+
+	return (
+		<StepContainer
+			stepName={ 'newsletter-setup' }
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName={ 'newsletter' }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'newsletter-setup-header' }
+					headerText={ createInterpolateElement( __( 'Personalize your<br />Newsletter' ), {
+						br: <br />,
+					} ) }
+					align={ 'center' }
+				/>
+			}
+			stepContent={
+				<SetupForm
+					site={ site }
+					siteTitle={ siteTitle }
+					setComponentSiteTitle={ setComponentSiteTitle }
+					invalidSiteTitle={ invalidSiteTitle }
+					setInvalidSiteTitle={ setInvalidSiteTitle }
+					tagline={ tagline }
+					setTagline={ setTagline }
+					selectedFile={ selectedFile }
+					setSelectedFile={ setSelectedFile }
+					setBase64Image={ setBase64Image }
+					handleSubmit={ handleSubmit }
+					translatedText={ newsletterFormText }
+					isLoading={ isLoading }
+					isSubmitError={ isSubmitError }
+				>
+					<AccentColorControl accentColor={ accentColor } setAccentColor={ setAccentColor } />
+				</SetupForm>
+			}
+			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
+		/>
+	);
+};
+
+export default NewsletterPostSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -1,9 +1,15 @@
-import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
+import {
+	StepContainer,
+	base64ImageToBlob,
+	uploadAndSetSiteLogo,
+	hexToRgb,
+} from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import useAccentColor from 'calypso/landing/stepper/hooks/use-accent-color';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
@@ -18,7 +24,7 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const site = useSite();
-
+	const fetchedAccentColor = useAccentColor();
 	const newsletterFormText = {
 		titlePlaceholder: __( 'My newsletter' ),
 		titleMissing: __( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
@@ -41,6 +47,16 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 		setComponentSiteTitle( site?.name || '' );
 		setTagline( site?.description || '' );
 	}, [ site ] );
+
+	useEffect( () => {
+		if ( fetchedAccentColor ) {
+			setAccentColor( {
+				hex: fetchedAccentColor,
+				rgb: hexToRgb( fetchedAccentColor ),
+				default: false,
+			} );
+		}
+	}, [ fetchedAccentColor ] );
 
 	useEffect( () => {
 		setIsSubmitError( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -89,7 +89,7 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 					);
 				}
 				setIsLoading( false );
-				submit?.();
+				submit?.( { color: accentColor.hex.replace( '#', '' ) } );
 			}
 		} catch {
 			setIsSubmitError( true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -13,7 +13,7 @@ import SetupForm from '../components/setup-form';
 import type { Step } from '../../types';
 import './style.scss';
 
-const defaultAccentColor = {
+export const defaultAccentColor = {
 	hex: '#1D39EB',
 	rgb: { r: 29, g: 57, b: 235 },
 	default: true,

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -22,7 +22,7 @@ export const newsletterPostSetup: Flow = {
 			switch ( currentStep ) {
 				case 'newsletterPostSetup':
 					return window.location.assign(
-						`/setup/launchpad?flow=newsletter&siteSlug=${ siteSlug }&clearCache=true`
+						`/setup/launchpad?flow=newsletter&siteSlug=${ siteSlug }&color=${ providedDependencies.color }`
 					);
 			}
 		}

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -1,0 +1,44 @@
+import { NEWSLETTER_POST_SETUP_FLOW } from '@automattic/onboarding';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { ProvidedDependencies } from './internals/types';
+import type { StepPath } from './internals/steps-repository';
+import type { Flow } from './internals/types';
+
+export const newsletterPostSetup: Flow = {
+	name: NEWSLETTER_POST_SETUP_FLOW,
+	title: 'Newsletter',
+	useSteps() {
+		return [ 'newsletterPostSetup' ] as StepPath[];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const siteSlug = useSiteSlug();
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'newsletter-post-setup', flowName, currentStep );
+
+			switch ( currentStep ) {
+				case 'newsletterPostSetup':
+					return window.location.assign(
+						`/setup/launchpad?flow=newsletter&siteSlug=${ siteSlug }`
+					);
+			}
+		}
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			return;
+		};
+
+		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -22,7 +22,7 @@ export const newsletterPostSetup: Flow = {
 			switch ( currentStep ) {
 				case 'newsletterPostSetup':
 					return window.location.assign(
-						`/setup/launchpad?flow=newsletter&siteSlug=${ siteSlug }`
+						`/setup/launchpad?flow=newsletter&siteSlug=${ siteSlug }&clearCache=true`
 					);
 			}
 		}

--- a/client/landing/stepper/hooks/use-accent-color.ts
+++ b/client/landing/stepper/hooks/use-accent-color.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { useSite } from './use-site';
+
+const useAccentColor = () => {
+	const ID = useSite()?.ID;
+	const [ color, setColor ] = useState( '' );
+
+	useEffect( () => {
+		if ( ID ) {
+			wpcom.req
+				.get( {
+					path: `/sites/${ ID }/global-styles-variation/site-accent-color`,
+					apiNamespace: 'wpcom/v2',
+				} )
+				.then( ( color: string ) => {
+					setColor( color );
+				} );
+		}
+	}, [ ID ] );
+
+	return color;
+};
+
+export default useAccentColor;

--- a/client/landing/stepper/hooks/use-accent-color.ts
+++ b/client/landing/stepper/hooks/use-accent-color.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useSite } from './use-site';
 
@@ -6,18 +6,16 @@ const useAccentColor = () => {
 	const ID = useSite()?.ID;
 	const [ color, setColor ] = useState( '' );
 
-	useEffect( () => {
-		if ( ID ) {
-			wpcom.req
-				.get( {
-					path: `/sites/${ ID }/global-styles-variation/site-accent-color`,
-					apiNamespace: 'wpcom/v2',
-				} )
-				.then( ( color: string ) => {
-					setColor( color );
-				} );
-		}
-	}, [ ID ] );
+	if ( ID ) {
+		wpcom.req
+			.get( {
+				path: `/sites/${ ID }/global-styles-variation/site-accent-color`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( ( color: string ) => {
+				setColor( color );
+			} );
+	}
 
 	return color;
 };

--- a/client/landing/stepper/hooks/use-save-accent-color.ts
+++ b/client/landing/stepper/hooks/use-save-accent-color.ts
@@ -1,0 +1,16 @@
+import wpcom from 'calypso/lib/wp';
+
+const useSaveAccentColor = () => {
+	const saveAccentColor = async ( siteID: number, color: string ) => {
+		return wpcom.req.post( {
+			path: `/sites/${ siteID }/global-styles-variation/site-accent-color`,
+			apiNamespace: 'wpcom/v2',
+			body: {
+				color,
+			},
+		} );
+	};
+	return saveAccentColor;
+};
+
+export default useSaveAccentColor;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -34,6 +34,7 @@ import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
 import { linkInBioPostSetup } from './declarative-flow/link-in-bio-post-setup';
 import { newsletter } from './declarative-flow/newsletter';
+import { newsletterPostSetup } from './declarative-flow/newsletter-post-setup';
 import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
@@ -69,6 +70,7 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
 	{ flowName: 'link-in-bio-post-setup', pathToFlow: linkInBioPostSetup },
+	{ flowName: 'newsletter-post-setup', pathToFlow: newsletterPostSetup },
 	config.isEnabled( 'themes/plugin-bundling' )
 		? { flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow }
 		: null,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -1,4 +1,5 @@
 export const NEWSLETTER_FLOW = 'newsletter';
+export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
 export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
@@ -7,7 +8,12 @@ export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
 		flowName &&
-			[ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_POST_SETUP_FLOW ].includes( flowName )
+			[
+				NEWSLETTER_FLOW,
+				NEWSLETTER_POST_SETUP_FLOW,
+				LINK_IN_BIO_FLOW,
+				LINK_IN_BIO_POST_SETUP_FLOW,
+			].includes( flowName )
 	);
 };
 


### PR DESCRIPTION
### Proposed Changes

**Addresses this issue:** https://github.com/Automattic/wp-calypso/issues/67974

**Requires this backend code:** D88664-code

We want to allow users in the Newsletter tailored flow to return from Launchpad the Newsletter Setup screen. In line with past conversations, rather than send users back to the original Setup screen, we are creating a new, Newsletter Post Setup stepper flow and screen. Users can navigate between Launchpad and the Post Setup screen, and changes made on new screen should be reflected on their site, including the Launchpad website preview. 

Specific changes include: 
* Create Newsletter Post Setup stepper flow
* Create Newsletter Post Setup step/screen within the new flow
* Ensure Newsletter Post Setup screen pre-populates site title/tagline/icon/color from the Redux SITE_STORE or API.
* Ensure changes to site title/tagline/icon/color are updated when saving/continuing on from screen.
* Add link to new flow/screen from Launchpad. 
* In separate backend PR (link above): Updated global-styles-variation to get/set site accent color 

### Testing Instructions

1. Checkout this branch, and run yarn and yarn start if needed.
2. Apply D88664-code to your sandbox. 
2. Start a new Newsletter site from https://wordpress.com/hp-2022-tailored-flows/
3. Proceed through flow until you arrive at Launchpad. 
4. When you arrive at Launchpad, replace `https://worpdress.com` with `http://calypso.localhost:3000/` to ensure you are seeing local branch.
5. TEST: From Launchpad, confirm the 'Personalize Newsletter' task is active/clickable. 
6. TEST: Click the 'Personalize Newsletter' task. You should arrive at a screen that looks exactly like the original setup screen, but the url should be `http://calypso.localhost:3000/setup/newsletterPostSetup?flow=newsletter-post-setup&siteSlug=[YOUR_SITE_SLUG]`
7. TEST: Confirm you can edit the site title, tagline, icon, and color. 
8. TEST: Click 'Continue' and confirm you return to Launchpad. 
9. TEST: Confirm the Launchpad web preview shows your updated site title, tagline, icon, and color.

### Screenshots

For potential translations and for reference during testing, the new Newsletter Post Setup screen looks like this.

<img width="1487" alt="newsletter-post-setup" src="https://user-images.githubusercontent.com/21228350/194174510-16942e40-3e57-471e-83bc-24ebb891193a.png">