### PR TITLE
Purchases page: Fix Pressable purchases saying payment method is missing.

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -334,16 +334,16 @@ class ManagePurchase extends Component {
 	};
 
 	getUpgradeUrl() {
-		const { purchase, siteId } = this.props;
+		const { purchase, siteSlug } = this.props;
 
 		const isUpgradeableBackupProduct = JETPACK_BACKUP_T1_PRODUCTS.includes( purchase.productSlug );
 		const isUpgradeableSecurityPlan = JETPACK_SECURITY_T1_PLANS.includes( purchase.productSlug );
 
 		if ( isUpgradeableBackupProduct || isUpgradeableSecurityPlan ) {
-			return `/plans/storage/${ siteId }`;
+			return `/plans/storage/${ siteSlug }`;
 		}
 
-		return `/plans/${ siteId }`;
+		return `/plans/${ siteSlug }`;
 	}
 
 	renderUpgradeNavItem() {
@@ -409,7 +409,7 @@ class ManagePurchase extends Component {
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate, siteSlug, getChangePaymentMethodUrlFor } = this.props;
 
-		if ( ! this.props.site ) {
+		if ( isPartnerPurchase( purchase ) || ! this.props.site ) {
 			return null;
 		}
 
@@ -870,11 +870,12 @@ class ManagePurchase extends Component {
 						</div>
 					) }
 				</Card>
-				<PurchasePlanDetails
-					purchaseId={ this.props.purchaseId }
-					isProductOwner={ isProductOwner }
-				/>
-
+				{ ! isPartnerPurchase( purchase ) && (
+					<PurchasePlanDetails
+						purchaseId={ this.props.purchaseId }
+						isProductOwner={ isProductOwner }
+					/>
+				) }
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
 						{ preventRenewal && this.renderSelectNewNavItem() }

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -409,7 +409,11 @@ class PurchaseItem extends Component {
 	getPaymentMethod() {
 		const { purchase, translate } = this.props;
 
-		if ( purchase.isAutoRenewEnabled && ! hasPaymentMethod( purchase ) ) {
+		if (
+			purchase.isAutoRenewEnabled &&
+			! hasPaymentMethod( purchase ) &&
+			! isPartnerPurchase( purchase )
+		) {
 			return (
 				<div className={ 'purchase-item__no-payment-method' }>
 					<Icon icon={ warningIcon } />


### PR DESCRIPTION
### Proposed Changes

This PR fixes an issue where purchases that are managed by another hosting partner (such as Pressable) were incorrectly showing a message that, "You don't have a payment method to renew this subscription".   (See image below, and See the "Reported issue")

![pressable-purchase](https://user-images.githubusercontent.com/11078128/194171289-e999fbf6-ecac-47a2-8ca3-20fad687cee9.png)


Reported issue: pbFq2u-pD-p2
Completes task: 1202858161751496-as-1203109873684265/f

### Testing Instructions

#### Prerequisites:
- You'll need a "Pressable" site. If you don't already have a Pressable hosted site, follow these instructions to create a free Pressable site: PCYsg-9TF-p2
- Note: Pressable sites come with a free Jetpack Security subscription (When asked to share hosting credentials, choose yes/accept).
- Visit your site wp-admin dashboard and "Connect" Jetpack.

#### Test this PR:

- First to see the issue, go to `https://cloud.jetpack.com/purchases/subscriptions/[:site-slug]`, where `[:site-slug]` is the site URL of your Pressable site.
- Notice that the Free Jetpack Security plan that come with the Pressable site is stating that, "You don't have a payment method to renew this subscription". This is incorrect. Payment methods are managed at the hosting partner, so this message should not be showing here.  (See image below)

![Markup 2022-10-05 at 18 30 37](https://user-images.githubusercontent.com/11078128/194175944-73ddc9e1-8d89-4ac6-8817-4746ed5cd94d.png)

- Click into the Jetpack Security Daily product (managed by Pressable), which will open the Purchase item page.
- Notice that there are a couple UI elements that are not needed here (the empty plan details box, and the "Add Payment method" button.)  See image below:

![Markup 2022-10-06 at 16 29 49](https://user-images.githubusercontent.com/11078128/194412958-32bf2d03-02f1-4fc1-96ae-bb5fc146abc5.png)


Calypso Green (Jetpack Cloud):

- Next, do one of these:
    - Spin up this PR in Jetpack Cloud env
        - Run `git fetch && git checkout  fix/purchases-pressable-payment-method`
        - Run `yarn start-jetpack-cloud`
        - Goto `http://jetpack.cloud.localhost:3000/purchases/subscriptions/[:site-slug]`, where `[:site-slug]` is the site URL of your Pressable site.
    - OR click on _Jetpack Cloud Live_ link below , then go to `/purchases/subscriptions/[:site-slug]`    
- Verify you **no longer** see the message that your payment method is missing:

![Markup 2022-10-05 at 18 32 22](https://user-images.githubusercontent.com/11078128/194176075-60d16d89-c505-439d-bcfa-0ee1bb1f633c.png)

- Click into the Jetpack Security Daily product (managed by Pressable), which will open the Purchase item page.
- Verify that the unnecessary UI elements are no longer showing (the empty plan details box, and the "Add Payment method" button. You can compare with the image above and compare with cloud.jetpack.com)  See image below:

![Markup 2022-10-06 at 16 32 36](https://user-images.githubusercontent.com/11078128/194413675-b4e2e948-e497-4f48-921e-d146df33bf6d.png)


Calypso Blue (WordPress.com)

- Do one of these:
    - Spin up this PR in wordpress.com env
        - Run `yarn start` (First make sure you quit (Ctrl+c) your previous build above)
        - Go to http://calypso.localhost:3000/me/purchases
    - OR click on the _Calypso Live_ link below , then go to `/me/purchases`
- Locate the purchase for Jetpack Security for your Pressable hosted site.
- Verify it is **not** showing the message that your payment method is missing.
- Click into the Jetpack Security Daily product (managed by Pressable), which will open the Purchase item page.
- Verify that the unnecessary UI elements are no longer showing (the empty plan details box, and the "Add Payment method" button. You can compare with the image above and compare with wordpress.com)
- For completeness, view other purchases you may own on other sites. Verify they all look the same as they do on wordpress.com production. 😉

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
