### PR TITLE
WIP Launchpad: Find the best domain to use for iFrame and for domain preview

### DIFF
--- a/client/data/domains/use-get-domains-query.ts
+++ b/client/data/domains/use-get-domains-query.ts
@@ -1,11 +1,14 @@
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
-import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { UseQueryOptions } from 'react-query';
 
 export const getCacheKey = ( siteId: number | null ) => [ 'sites', siteId, 'domains' ];
 
-type UseGetDomainsQueryData = ResponseDomain[];
+export type Domain = {
+	domain: string;
+	registration_date: string;
+};
+type UseGetDomainsQueryData = Domain[];
 
 export const useGetDomainsQuery = (
 	siteId: number | null,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useState } from 'react';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ResponseDomain } from 'calypso/lib/domains/types';
 import LaunchpadSitePreview from './launchpad-site-preview';
 import Sidebar from './sidebar';
 
@@ -9,11 +13,62 @@ type StepContentProps = {
 	goToStep?: NavigationControls[ 'goToStep' ];
 };
 
-const StepContent = ( { siteSlug, submit, goNext, goToStep }: StepContentProps ) => (
-	<div className="launchpad__content">
-		<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } goToStep={ goToStep } />
-		<LaunchpadSitePreview siteSlug={ siteSlug } />
-	</div>
-);
+const StepContent = ( { siteSlug, submit, goNext, goToStep }: StepContentProps ) => {
+	// We can also pass the siteId from the parent component when we figure out the rest of the logic
+	const site = useSite();
+
+	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
+
+	const [ freeDomainObject, setFreeDomainObject ] = useState< ResponseDomain >();
+	const [ customDomainObject, setCustomDomainObject ] = useState< ResponseDomain >();
+
+	useEffect( () => {
+		if ( allDomains ) {
+			// console.log( { allDomains } );
+			// Filter for custom domains
+			let customDomainObjects = allDomains.filter( ( domainObject ) => {
+				if ( domainObject.domain.endsWith( '.wordpress.com' ) ) {
+					setFreeDomainObject( domainObject );
+				}
+				return ! domainObject.domain.endsWith( '.wordpress.com' );
+			} );
+
+			// Sort by "latest" custom domain
+			customDomainObjects =
+				customDomainObjects &&
+				customDomainObjects.sort( ( firstCustomDomainObject, secondCustomDomainObject ) => {
+					const firstCustomDomainDate = new Date( firstCustomDomainObject.registration_date );
+					const secondCustomDomainDate = new Date( secondCustomDomainObject.registration_date );
+					if ( firstCustomDomainDate > secondCustomDomainDate ) {
+						return -1;
+					}
+					if ( firstCustomDomainDate < secondCustomDomainDate ) {
+						return 1;
+					}
+					return 0;
+				} );
+
+			if ( customDomainObjects && customDomainObjects.length > 0 ) {
+				setCustomDomainObject( customDomainObjects[ 0 ] );
+			}
+
+			// console.log( 'sorted', customDomainObjects );
+		}
+	}, [ allDomains ] );
+
+	// 'freeDomainObject' will be used for sidebar URL box
+	console.log( { freeDomainObject } );
+	// 'customDomainObject' will be used for site preview based on additional conditionals (ssl_status && points_to_wpcom)
+	console.log( { customDomainObject } );
+
+	return (
+		<div className="launchpad__content">
+			<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } goToStep={ goToStep } />
+			<LaunchpadSitePreview siteSlug={ siteSlug } />
+		</div>
+	);
+};
 
 export default StepContent;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { ResponseDomain } from 'calypso/lib/domains/types';
 import LaunchpadSitePreview from './launchpad-site-preview';
 import Sidebar from './sidebar';
 
@@ -14,59 +13,29 @@ type StepContentProps = {
 };
 
 const StepContent = ( { siteSlug, submit, goNext, goToStep }: StepContentProps ) => {
-	// We can also pass the siteId from the parent component when we figure out the rest of the logic
 	const site = useSite();
 
 	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
 		retry: false,
 	} );
 
-	const [ freeDomainObject, setFreeDomainObject ] = useState< ResponseDomain >();
-	const [ customDomainObject, setCustomDomainObject ] = useState< ResponseDomain >();
+	const [ freeDomain, setFreeDomain ] = useState< string | null >( null );
 
 	useEffect( () => {
 		if ( allDomains ) {
-			// console.log( { allDomains } );
-			// Filter for custom domains
-			let customDomainObjects = allDomains.filter( ( domainObject ) => {
+			allDomains.forEach( ( domainObject ) => {
+				// find the free .wordpress.com domain which will always be secure (will have SSL certificate)
 				if ( domainObject.domain.endsWith( '.wordpress.com' ) ) {
-					setFreeDomainObject( domainObject );
+					setFreeDomain( domainObject.domain );
 				}
-				return ! domainObject.domain.endsWith( '.wordpress.com' );
 			} );
-
-			// Sort by "latest" custom domain
-			customDomainObjects =
-				customDomainObjects &&
-				customDomainObjects.sort( ( firstCustomDomainObject, secondCustomDomainObject ) => {
-					const firstCustomDomainDate = new Date( firstCustomDomainObject.registration_date );
-					const secondCustomDomainDate = new Date( secondCustomDomainObject.registration_date );
-					if ( firstCustomDomainDate > secondCustomDomainDate ) {
-						return -1;
-					}
-					if ( firstCustomDomainDate < secondCustomDomainDate ) {
-						return 1;
-					}
-					return 0;
-				} );
-
-			if ( customDomainObjects && customDomainObjects.length > 0 ) {
-				setCustomDomainObject( customDomainObjects[ 0 ] );
-			}
-
-			// console.log( 'sorted', customDomainObjects );
 		}
 	}, [ allDomains ] );
-
-	// 'freeDomainObject' will be used for sidebar URL box
-	console.log( { freeDomainObject } );
-	// 'customDomainObject' will be used for site preview based on additional conditionals (ssl_status && points_to_wpcom)
-	console.log( { customDomainObject } );
 
 	return (
 		<div className="launchpad__content">
 			<Sidebar siteSlug={ siteSlug } submit={ submit } goNext={ goNext } goToStep={ goToStep } />
-			<LaunchpadSitePreview siteSlug={ siteSlug } />
+			<LaunchpadSitePreview siteSlug={ freeDomain } />
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -34,18 +34,16 @@ function findBestDomain( domains: Domain[], useFor: UseFor ) {
 			if ( currentDomainObject.domain.endsWith( '.wordpress.com' ) ) {
 				return currentDomainObject.domain;
 			}
-		} else if ( useFor === UseFor.PreviewDomain ) {
-			// if trying to find the best domain for the domain preview (find the most recently registered one)
-			const currentDomainRegisteredTimestamp = new Date(
-				currentDomainObject.registration_date
-			).getTime();
+		}
 
-			if (
-				currentDomainRegisteredTimestamp > ( mostRecentlyRegisteredDomain.timestamp as number )
-			) {
-				mostRecentlyRegisteredDomain.domain = currentDomainObject.domain;
-				mostRecentlyRegisteredDomain.timestamp = currentDomainRegisteredTimestamp;
-			}
+		// continue with finding the most recently registered domain
+		const currentDomainRegisteredTimestamp = new Date(
+			currentDomainObject.registration_date
+		).getTime();
+
+		if ( currentDomainRegisteredTimestamp > ( mostRecentlyRegisteredDomain.timestamp as number ) ) {
+			mostRecentlyRegisteredDomain.domain = currentDomainObject.domain;
+			mostRecentlyRegisteredDomain.timestamp = currentDomainRegisteredTimestamp;
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes
We want to find the best domain to use for the iFrame and for the domain container preview.

For the iFrame the best domain will always be the `.wordpress.com` because it will have a SSL certificate at all times so it won't cause an error when trying to load the iFrame with an insecure domain. If the `.wordpress.com` domain doesn't exist for some reason, as a safety fallback we are choosing the most recently registered domain name for that site.

For the iFrame preview container the best domain will always be the most recently registered domain name for that site (the custom domain when the user has chosen a custom domain) because that will be the domain that the user would expect to see.

#### Testing Instructions
1. Start a new newsletter flow or link-in-bio flow and create a site with a custom domain
2. Once you arrive at the Launchpad screen you should see that in the domain preview container we see the custom domain (even though you may have the `.wordpress.com` domain in the `siteSlug` param)
3. The iFrame should load correctly because it will use the `.wordpress.com` domain instead of custom domain (which will most likely be laking a SSL cert at this point)

![image](https://user-images.githubusercontent.com/20927667/194523454-b8456802-fd0c-4703-9ee9-6ea7cb782b19.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68519
