### PR TITLE
Marketplace: Eligibility warning modal shows title on non business plans only

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -147,23 +147,23 @@ export const EligibilityWarnings = ( {
 					/>
 				</CompactCard>
 			) }
-			{ ! isPlaceholder && context === 'plugin-details' && (
-				<CompactCard>
-					<div className="eligibility-warnings__header">
-						<div className="eligibility-warnings__title">
-							{ translate( 'Upgrade your plan to install plugins' ) }
+			{ ! isPlaceholder &&
+				context === 'plugin-details' &&
+				listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1 && (
+					<CompactCard>
+						<div className="eligibility-warnings__header">
+							<div className="eligibility-warnings__title">
+								{ translate( 'Upgrade your plan to install plugins' ) }
+							</div>
+							<div className="eligibility-warnings__primary-text">
+								{ translate(
+									'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for %(monthlyCost)s/month.',
+									{ args: { monthlyCost } }
+								) }
+							</div>
 						</div>
-						<div className="eligibility-warnings__primary-text">
-							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
-								? translate(
-										'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for %(monthlyCost)s/month.',
-										{ args: { monthlyCost } }
-								  )
-								: '' }
-						</div>
-					</div>
-				</CompactCard>
-			) }
+					</CompactCard>
+				) }
 
 			{ ( isPlaceholder || filteredHolds.length > 0 ) && (
 				<CompactCard>


### PR DESCRIPTION
#### Proposed Changes

Remove `Upgrade your plan to install plugins` when the domain is on `Business` plan.

#### Testing Instructions

1. Go to `/plugins` with a domain with `Business` plan and `.wordpress.com` (not yet migrated)
2. Try to install any plugin (including Free). It should show a modal with the domain change message but with no title.

#### Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/194190814-aba4a801-86a9-4ab3-bfd4-266330134443.png) | ![image](https://user-images.githubusercontent.com/402286/194190861-346573db-e625-4144-923b-fddecb52f766.png) |

#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes #68689
