### PR TITLE
Use toLocaleString to add commas to search totals

### DIFF
--- a/client/my-sites/plugins/plugins-category-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-category-results-page/index.jsx
@@ -22,7 +22,7 @@ const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
 			count: pagination.results,
 			textOnly: true,
 			args: {
-				total: pagination.results,
+				total: pagination.results.toLocaleString(),
 			},
 		} );
 	}

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -87,7 +87,7 @@ const PluginsSearchResultPage = ( {
 					count: pluginsPagination.results,
 					textOnly: true,
 					args: {
-						total: pluginsPagination.results,
+						total: pluginsPagination.results.toLocaleString(),
 						searchTerm,
 					},
 				}
@@ -101,7 +101,7 @@ const PluginsSearchResultPage = ( {
 						count: pluginsPagination.results,
 						textOnly: true,
 						args: {
-							total: pluginsPagination.results,
+							total: pluginsPagination.results.toLocaleString(),
 							searchTerm,
 							categoryName,
 						},


### PR DESCRIPTION
#### Proposed Changes

* Use toLocaleString to add commas to plugin search totals.

Before | After
--|--
![before](https://user-images.githubusercontent.com/140841/194198432-5b139dc7-40ae-44a6-9b9c-0b1b30b4d567.png) | ![after](https://user-images.githubusercontent.com/140841/194198459-b4e369a1-c54c-44b8-886c-78a62bf6fc58.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Check the search total at the top of the categories page. Example: http://calypso.localhost:3000/plugins/browse/ecommerce/example.wordpress.com
* Check the search total at the top of the search results page. Example: http://calypso.localhost:3000/plugins/example.wordpress.com?s=seo

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68683
