### PR TITLE
Pattern Assembler - Add all header and footer patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -57,6 +57,10 @@ const footerPatterns: Pattern[] = [
 		name: 'Centered footer with social links',
 	},
 	{
+		id: 1622,
+		name: 'Contact',
+	},
+	{
 		id: 5880,
 		name: 'Footer with background color and three columns',
 	},
@@ -67,6 +71,14 @@ const footerPatterns: Pattern[] = [
 	{
 		id: 5888,
 		name: 'Footer with navigation and credit line',
+	},
+	{
+		id: 5873,
+		name: 'Simple centered footer',
+	},
+	{
+		id: 5886,
+		name: 'Footer with large font size',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -2,8 +2,24 @@ import type { Pattern } from './types';
 
 const headerPatterns: Pattern[] = [
 	{
+		id: 5588,
+		name: 'Simple Header',
+	},
+	{
+		id: 5601,
+		name: 'Simple Header With Tagline',
+	},
+	{
+		id: 5582,
+		name: 'Simple Header With Large Font Size',
+	},
+	{
 		id: 5603,
 		name: 'Header with Site Title and Menu Button',
+	},
+	{
+		id: 5605,
+		name: 'Header with Site Title and Vertical Navigation',
 	},
 	{
 		id: 5608,
@@ -12,14 +28,6 @@ const headerPatterns: Pattern[] = [
 	{
 		id: 5579,
 		name: 'Centered header',
-	},
-	{
-		id: 5605,
-		name: 'Header with Site Title and Vertical Navigation',
-	},
-	{
-		id: 5601,
-		name: 'Simple Header With Tagline',
 	},
 	{
 		id: 5590,
@@ -33,25 +41,9 @@ const headerPatterns: Pattern[] = [
 		id: 5593,
 		name: 'Simple Header With Dark background',
 	},
-	{
-		id: 5588,
-		name: 'Simple Header',
-	},
-	{
-		id: 5582,
-		name: 'Simple Header With Large Font Size',
-	},
 ];
 
 const footerPatterns: Pattern[] = [
-	{
-		id: 5316,
-		name: 'Footer with Social Icons, Address, E-mail, and Telephone Number',
-	},
-	{
-		id: 5047,
-		name: 'Footer with Navigation, Contact Details, Social Links, and Subscription Form',
-	},
 	{
 		id: 5877,
 		name: 'Centered footer with social links',
@@ -61,8 +53,20 @@ const footerPatterns: Pattern[] = [
 		name: 'Contact',
 	},
 	{
+		id: 5316,
+		name: 'Footer with Social Icons, Address, E-mail, and Telephone Number',
+	},
+	{
+		id: 5047,
+		name: 'Footer with Navigation, Contact Details, Social Links, and Subscription Form',
+	},
+	{
 		id: 5880,
 		name: 'Footer with background color and three columns',
+	},
+	{
+		id: 5886,
+		name: 'Footer with large font size',
 	},
 	{
 		id: 5883,
@@ -75,10 +79,6 @@ const footerPatterns: Pattern[] = [
 	{
 		id: 5873,
 		name: 'Simple centered footer',
-	},
-	{
-		id: 5886,
-		name: 'Footer with large font size',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -2,6 +2,18 @@ import type { Pattern } from './types';
 
 const headerPatterns: Pattern[] = [
 	{
+		id: 5603,
+		name: 'Header with Site Title and Menu Button',
+	},
+	{
+		id: 5608,
+		name: 'Centred Header with Logo and Navigation',
+	},
+	{
+		id: 5579,
+		name: 'Centered header',
+	},
+	{
 		id: 5605,
 		name: 'Header with Site Title and Vertical Navigation',
 	},


### PR DESCRIPTION
#### Proposed Changes

* Add new header patterns
* Add new footer patterns
* Updated the order

**Knowing issues**

There are some patterns that are not displayed correctly in the previews. It seems not related to Blank canvas because it can be reproduced with all themes @Automattic/ganon any idea of why? I'll create a separated issue.

The header Centred Header with Logo and Navigation shows the logo placeholder in the [source](https://dotcompatterns.wordpress.com/2022/08/29/centred-header-with-logo-and-navigation/) site but not in the [preview](https://mc.a8c.com/patterns-toolkit/block-patterns/index.php?site=dotcompatterns.wordpress.com&categories%5B0%5D=footer&theme=zoologist&pattern=5608).

These footer patterns don't show the navigation in the preview:

- Footer with credit line and navigation 
  - [Preview](https://mc.a8c.com/patterns-toolkit/block-patterns/index.php?site=dotcompatterns.wordpress.com&categories%5B0%5D=footer&theme=zoologist&pattern=5883)
  - [Source](https://dotcompatterns.wordpress.com/2022/08/26/footer-with-credit-line-and-navigation/)

- Footer with navigation and credit line
  - [Preview](https://mc.a8c.com/patterns-toolkit/block-patterns/index.php?site=dotcompatterns.wordpress.com&categories%5B0%5D=footer&theme=zoologist&pattern=5883)
  - [Source](https://dotcompatterns.wordpress.com/2022/08/26/footer-with-navigation-and-credit-line/)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the patterns previews are displayed correctly in the pattern assembler
* See the previews in the MC Pattern toolkit
  * [Footer](https://mc.a8c.com/patterns-toolkit/block-patterns/index.php?site=dotcompatterns.wordpress.com&categories%5B0%5D=footer&theme=zoologist)
  * [Header](https://mc.a8c.com/patterns-toolkit/block-patterns/index.php?site=dotcompatterns.wordpress.com&categories%5B0%5D=header&theme=zoologist)
* And in the source site
  * [Footer](https://dotcompatterns.wordpress.com/category/footer/)
  * [Header](https://dotcompatterns.wordpress.com/category/header/) 


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/66789
