### PR TITLE
Vertical Step: Randomize the featured verticals by site id

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -14,6 +14,8 @@ import type { SiteVerticalsResponse } from 'calypso/data/site-verticals';
 interface Props {
 	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
+	/** Use to randomize the featured verticals */
+	seed?: string;
 	onInputChange?: ( searchTerm: string ) => void;
 	onSelect?: ( vertical: Vertical ) => void;
 }
@@ -21,6 +23,7 @@ interface Props {
 const SelectVertical: React.FC< Props > = ( {
 	defaultVertical,
 	isSkipSynonyms,
+	seed,
 	onInputChange,
 	onSelect,
 } ) => {
@@ -39,7 +42,7 @@ const SelectVertical: React.FC< Props > = ( {
 		skip_synonyms: isSkipSynonyms,
 	} );
 
-	const { data: featured } = useSiteVerticalsFeatured();
+	const { data: featured } = useSiteVerticalsFeatured( seed );
 
 	const mapOneSiteVerticalsResponseToVertical = ( vertical: SiteVerticalsResponse ): Vertical => ( {
 		value: vertical.id,

--- a/client/data/site-verticals/use-site-verticals-featured.ts
+++ b/client/data/site-verticals/use-site-verticals-featured.ts
@@ -2,23 +2,26 @@ import { useQuery, UseQueryResult, QueryKey } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 import type { SiteVerticalsResponse } from './types';
 
-const useSiteVerticalsFeatured = (): UseQueryResult< SiteVerticalsResponse[] > => {
-	return useQuery( getCacheKey(), () => fetchSiteVerticalsFeatured(), {
+const useSiteVerticalsFeatured = ( seed?: string ): UseQueryResult< SiteVerticalsResponse[] > => {
+	return useQuery( getCacheKey( seed ), () => fetchSiteVerticalsFeatured( seed ), {
 		enabled: true,
 		staleTime: Infinity,
 		refetchInterval: false,
 	} );
 };
 
-export function fetchSiteVerticalsFeatured(): Promise< SiteVerticalsResponse[] > {
-	return wpcom.req.get( {
-		apiNamespace: 'wpcom/v2',
-		path: '/site-verticals/featured',
-	} );
+export function fetchSiteVerticalsFeatured( seed?: string ): Promise< SiteVerticalsResponse[] > {
+	return wpcom.req.get(
+		{
+			apiNamespace: 'wpcom/v2',
+			path: '/site-verticals/featured',
+		},
+		{ seed }
+	);
 }
 
-export function getCacheKey(): QueryKey {
-	return [ 'site-verticals', 'featured' ];
+export function getCacheKey( seed?: string ): QueryKey {
+	return [ 'site-verticals', 'featured', seed ];
 }
 
 export default useSiteVerticalsFeatured;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -13,6 +13,7 @@ interface Props {
 	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
 	isBusy?: boolean;
+	siteID: number;
 	onSelect?: ( vertical: Vertical ) => void;
 	onSubmit?: ( event: React.FormEvent, userInput: string ) => void;
 }
@@ -21,6 +22,7 @@ const SiteVerticalForm: React.FC< Props > = ( {
 	defaultVertical,
 	isSkipSynonyms,
 	isBusy,
+	siteID,
 	onSelect,
 	onSubmit,
 } ) => {
@@ -48,6 +50,7 @@ const SiteVerticalForm: React.FC< Props > = ( {
 				<SelectVertical
 					defaultVertical={ defaultVertical }
 					isSkipSynonyms={ isSkipSynonyms }
+					seed={ siteID }
 					onInputChange={ handleInputChange }
 					onSelect={ onSelect }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -86,6 +86,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 						defaultVertical={ siteVertical }
 						isSkipSynonyms={ Boolean( isSkipSynonyms ) }
 						isBusy={ isBusy }
+						siteID={ site?.ID }
 						onSelect={ handleSiteVerticalSelect }
 						onSubmit={ handleSubmit }
 					/>

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -3,7 +3,13 @@ import { SITE_STORE } from '../stores';
 import { useSiteIdParam } from './use-site-id-param';
 import { useSiteSlugParam } from './use-site-slug-param';
 
-export function useSite() {
+export interface Site {
+	ID: number;
+	name: string;
+	URL: string;
+}
+
+export function useSite(): Site | null {
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
 	const siteId = useSelect(

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -2,14 +2,9 @@ import { useSelect } from '@wordpress/data';
 import { SITE_STORE } from '../stores';
 import { useSiteIdParam } from './use-site-id-param';
 import { useSiteSlugParam } from './use-site-slug-param';
+import type { SiteDetails } from '@automattic/data-stores';
 
-export interface Site {
-	ID: number;
-	name: string;
-	URL: string;
-}
-
-export function useSite(): Site | null {
+export function useSite(): SiteDetails | null {
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
 	const siteId = useSelect(


### PR DESCRIPTION
#### Proposed Changes

* As title, use site id to get the featured verticals list to eliminate the influence of the order 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D89106-code to your sandbox
* Head to the vertical question screen: `/setup/vertical?siteSlug=<your_site>`
* Ensure that the list of featured verticals is fetched from the API with seed.
* Head to the vertical question screen with another site
* Check the order of the featured verticals list is different

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67854