### PR TITLE
Limit Global Styles: Hide notice when saving default styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -2,22 +2,31 @@
 
 import { Button, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import './notice.scss';
 
 const GlobalStylesNotice = () => {
-	const { globalStylesId, otherDirtyEntityRecords } = useSelect( ( select ) => {
-		const { __experimentalGetCurrentGlobalStylesId, __experimentalGetDirtyEntityRecords } =
-			select( 'core' );
+	const { globalStylesConfig, globalStylesId, siteChanges } = useSelect( ( select ) => {
+		const {
+			getEditedEntityRecord,
+			__experimentalGetCurrentGlobalStylesId,
+			__experimentalGetDirtyEntityRecords,
+		} = select( 'core' );
+
+		const _globalStylesId = __experimentalGetCurrentGlobalStylesId
+			? __experimentalGetCurrentGlobalStylesId()
+			: null;
+		const globalStylesRecord = getEditedEntityRecord( 'root', 'globalStyles', _globalStylesId );
+
 		return {
-			globalStylesId: __experimentalGetCurrentGlobalStylesId
-				? __experimentalGetCurrentGlobalStylesId()
-				: null,
-			otherDirtyEntityRecords: __experimentalGetDirtyEntityRecords
-				? __experimentalGetDirtyEntityRecords().filter( ( { name } ) => name !== 'globalStyles' )
-				: [],
+			globalStylesConfig: {
+				styles: globalStylesRecord?.styles ?? {},
+				settings: globalStylesRecord?.settings ?? {},
+			},
+			globalStylesId: _globalStylesId,
+			siteChanges: __experimentalGetDirtyEntityRecords ? __experimentalGetDirtyEntityRecords() : [],
 		};
 	}, [] );
 
@@ -32,11 +41,12 @@ const GlobalStylesNotice = () => {
 			styles: {},
 			settings: {},
 		} );
+	};
 
-		if ( ! otherDirtyEntityRecords.length ) {
+	// Closes the sidebar if there are no more changes to be saved.
+	useEffect( () => {
+		if ( ! siteChanges.length ) {
 			/*
-			 * Closes the sidebar if there are no more changes to be saved.
-			 *
 			 * This uses a fragile CSS selector to target the cancel button which might be broken on
 			 * future releases of Gutenberg. Unfortunately, Gutenberg doesn't provide any mechanism
 			 * for closing the sidebar – everything is handled using an internal state that it is not
@@ -44,12 +54,17 @@ const GlobalStylesNotice = () => {
 			 *
 			 * See https://github.com/WordPress/gutenberg/blob/0b30a4cb34d39c9627b6a3795a18aee21019ce25/packages/edit-site/src/components/editor/index.js#L137-L138.
 			 */
-			const closeSidebarButton = document.querySelector(
-				'.entities-saved-states__panel-header button:last-child'
-			);
-			closeSidebarButton?.click();
+			document.querySelector( '.entities-saved-states__panel-header button:last-child' )?.click();
 		}
-	};
+	}, [ siteChanges ] );
+
+	// Do not show the notice if the use is trying to save the default styles.
+	if (
+		Object.keys( globalStylesConfig.styles ).length === 0 &&
+		Object.keys( globalStylesConfig.settings ).length === 0
+	) {
+		return null;
+	}
 
 	return (
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
@@ -64,7 +79,7 @@ const GlobalStylesNotice = () => {
 			) }
 			&nbsp;
 			{ canRevertGlobalStyles &&
-				createInterpolateElement( __( 'You can <a>revert your styles</a>.', 'full-site-editing' ), {
+				createInterpolateElement( __( 'You can <a>reset your styles</a>.', 'full-site-editing' ), {
 					a: <Button variant="link" onClick={ revertGlobalStyles } />,
 				} ) }
 		</Notice>


### PR DESCRIPTION
#### Proposed Changes

Prevents the global styles notice from showing up if the user is trying to save the default styles (which are always available for free).

It also changes the copy to better align with the wording used by Gutenberg to reset the styles.

<img width="150" alt="Screen Shot 2022-10-06 at 10 03 31" src="https://user-images.githubusercontent.com/1233880/194254804-03ac8afa-ba5c-41d0-9fac-443a1676ac2f.png">

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit update/limit-global-styles-hide-notice-with-defaults-styles`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Click on the "Browse styles" button
- Select a non-default variation
- Click on the "Save" button
- Make sure the notice shows up
- Save the changes
- Open the Global Styles sidebar again
- Click on the "Browse styles" button
- Select the default variation
- Click on the "Save" button
- Make sure the notice doesn't show up

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

