### PR TITLE
Updated CSS for plans step in signup

### DIFF
--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -75,10 +75,6 @@ $plan-features-sidebar-width: 272px;
 	text-align: center;
 }
 
-.plans-features-main__group.is-wpcom {
-	padding-top: 19px;
-}
-
 .plans-wrapper {
 	margin: 0 auto;
 	padding: 20px 0 10px;
@@ -95,6 +91,10 @@ $plan-features-sidebar-width: 272px;
 		@include breakpoint-deprecated( ">660px" ) {
 			max-width: 1100px;
 		}
+	}
+
+	.signup__steps .plans-features-main__group.is-scrollable & {
+		max-width: 100%;
 	}
 
 	.plan-features-comparison__table {
@@ -334,28 +334,8 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plans-features-main__group.is-scrollable {
-	position: relative;
-
-	.is-section-signup & {
-		width: 100vw;
-		margin-left: calc(50% - 50vw);
-
-		@media ( min-width: 1600px ) {
-			max-width: 1600px;
-			margin-left: -280px;
-		}
-
-		@include breakpoint-deprecated( "<1040px" ) {
-			padding-top: 12px;
-		}
-	}
-
-	.signup__steps & .plan-features--signup {
-		max-width: 100%;
-	}
-
-	.plan-features-comparison__content {
+.plan-features-comparison__content {
+	.plans-features-main__group.is-scrollable & {
 		margin: -16px 0 0;
 		padding-top: $plan-features-header-banner-height;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -121,6 +121,11 @@ $plan-features-sidebar-width: 272px;
 .plan-features__content {
 	margin: -16px -16px 0;
 	padding-top: $plan-features-header-banner-height;
+
+	.plans-features-main__group.is-scrollable & {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .is-section-plans .plan-features__mobile {
@@ -675,10 +680,6 @@ $plan-features-sidebar-width: 272px;
 /*= Plans in Signup
 ========================================*/
 
-.plans-features-main__group.is-wpcom {
-	padding-top: 19px;
-}
-
 // This is the customer type buttons that let
 // you toggle the visible plans in signup.
 // The #primary id is included to increase specificity
@@ -746,6 +747,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		@include breakpoint-deprecated( ">660px" ) {
 			max-width: 1100px;
 		}
+	}
+
+	.signup__steps .plans-features-main__group.is-scrollable & {
+		max-width: 100%;
 	}
 
 	.plan-features__table {
@@ -866,49 +871,6 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__header-price-group-prices {
 		display: inline-block;
-	}
-}
-
-.plans-features-main__group.is-scrollable {
-	position: relative;
-
-	.is-section-signup & {
-		width: 100vw;
-		margin-left: calc(50% - 50vw);
-
-		@media ( min-width: 1600px ) {
-			max-width: 1600px;
-			margin-left: -280px;
-		}
-
-		@include breakpoint-deprecated( "<1040px" ) {
-			padding-top: 12px;
-		}
-	}
-
-	.is-section-plans & {
-		overflow: hidden;
-		width: calc(100vw - 278px);
-		margin-left: calc(50% - 50vw + 138px);
-
-		@include breakpoint-deprecated( "<660px" ) {
-			margin-left: 0;
-			width: 100%;
-		}
-
-		@media ( min-width: 1800px ) {
-			max-width: 1520px;
-			margin-left: -240px;
-		}
-	}
-
-	.signup__steps & .plan-features--signup {
-		max-width: 100%;
-	}
-
-	.plan-features__content {
-		margin-left: 0;
-		margin-right: 0;
 	}
 }
 
@@ -1224,6 +1186,7 @@ button.plan-features__scroll-button {
 	}
 }
 
+/* stylelint-disable-next-line no-duplicate-selectors */
 .plans-wrapper {
 	.plan-features__item-annual-plan {
 		font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -12,6 +12,47 @@
 	}
 }
 
+
+.plans-features-main__group.is-scrollable {
+	position: relative;
+
+	.is-section-signup & {
+		--approximate-viewport-scrollbar-width: 20px;
+
+		width: calc(100vw - var(--approximate-viewport-scrollbar-width));
+		margin-left: calc(50% - 50vw + var(--approximate-viewport-scrollbar-width) / 2);
+
+		@media ( min-width: 1600px ) {
+			max-width: 1600px;
+			margin-left: -280px;
+		}
+
+		@include breakpoint-deprecated( "<1040px" ) {
+			padding-top: 12px;
+		}
+	}
+
+	.is-section-plans & {
+		overflow: hidden;
+		width: calc(100vw - 278px);
+		margin-left: calc(50% - 50vw + 138px);
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin-left: 0;
+			width: 100%;
+		}
+
+		@media ( min-width: 1800px ) {
+			max-width: 1520px;
+			margin-left: -240px;
+		}
+	}
+}
+
+.plans-features-main__group.is-wpcom {
+	padding-top: 19px;
+}
+
 // Required additional specificity
 .plans-features-main .plans-features-main__happychat-button {
 	color: var(--color-primary);


### PR DESCRIPTION
#### Proposed Changes

ℹ️ This is a follow-up to #67220, which was closed in favor of #67665. However, that PR was later reverted (#68074), so this PR is a second attempt at fixing the underlying problem.

This PR fixes a CSS issue in the `PlansStep` component in the signup flow where a horizontal scrollbar would appear in the viewport (if the browser isn't using macOS overlay scrollbars). See screenshot below for clarification.

I have tried to untangle some CSS that was previously spread between `PlansFeaturesMain`, `PlanFeatures` and `PlanFeaturesComparison`. The problem with how the CSS was structured was both interdependence between the components and duplication of CSS rules.

| macOS (non-overlay scrollbars) | Windows (always) |
| - | - |
| ![macOS](https://user-images.githubusercontent.com/1101677/187712659-3e2a48f7-8053-4227-b09e-81631f5438e5.png) | ![bs_win11_Edge_105 0](https://user-images.githubusercontent.com/1101677/190115314-3ce09fdb-9a07-4939-b29b-4f33a86c901c.jpg) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/start`
2. Proceed to the plans step
3. Resize viewport to 1440x900px (e.g. with "responsive mode" in the browser devtools). If you are on macOS, open System Settings > General, set "Show scroll bars" to "Always". 
4. Ensure that no horizontal scrollbar is visible in the viewport
5. Navigate to `/plans/:site_slug`
6. Ensure that this screen renders identical with this PR as it does on wordpress.com

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
