### PR TITLE
Subscriber form: Update "learn more" support link

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -274,7 +274,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 							Button: createElement( Button, {
 								isLink: true,
 								target: '__blank',
-								href: localizeUrl( 'https://wordpress.com/support/user-roles/' ),
+								href: localizeUrl(
+									'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
+								),
 							} ),
 						}
 					) }


### PR DESCRIPTION
Closes #68708

#### Proposed Changes

* Update support link to: https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/

#### Testing Instructions

<img width="408" alt="Screenshot 2022-10-06 at 13 24 21" src="https://user-images.githubusercontent.com/1241413/194300875-4636b982-6bf2-43be-b798-551e54978147.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
