### PR TITLE
HappyChat: remove extra scrollbar

### DIFF
--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="no-scroll">
 	<head>
 		<meta charset="utf-8" />
 		<meta http-equiv="X-UA-Compatible" content="IE=9" />


### PR DESCRIPTION
#### Proposed Changes
| Before  | After |
| ------------- | ------------- |
|  <img width="264" alt="Screenshot 2022-10-06 at 13 47 23" src="https://user-images.githubusercontent.com/7000684/194304867-1a790103-5638-4d85-bb23-22d409091acd.png">  |  <img width="440" alt="Screenshot 2022-10-06 at 13 45 45" src="https://user-images.githubusercontent.com/7000684/194304919-6ddfe541-c600-40dc-8b3b-0cbc24d7cfec.png">  |

* By default our styles add overflow visible to `html`. This causes 2 scrollbars to appear in happy chat if there are lots of messages exchanged. To fix this the utility class 'no-scroll' is set to the html

#### Testing Instructions
- Checkout this branch
- sandbox [widgets.wp.com](http://widgets.wp.com/)
- cd into apps/happychat
- run yarn dev --sync
- Login to https://hud-staging.happychat.io/
- Its very painful to test this on browser stack and we can't use the sandbox there, so to test go to you mac Settings -> General. And for "Show scrollbars" choose always.
- Open the help center
- Initiate a chat to staging
- Write lots of messages to make it scrollable
- Check if there is only one scrollbar

Related to #68277
