### PR TITLE
Fix reader share popup styling issues

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -88,8 +88,7 @@
 		fill: var( --color-facebook );
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		.gridicon,
 		.reader-twitter,
 		.reader-facebook {

--- a/client/reader/components/reader-popover/style.scss
+++ b/client/reader/components/reader-popover/style.scss
@@ -56,7 +56,6 @@
 .reader-popover__wrapper {
 	display: flex;
 	flex-direction: column;
-	min-width: 300px;
 }
 
 .reader-popover__header {


### PR DESCRIPTION
There are a couple of issues with the reader share popup;

- [x] For smaller dimensions (iphone 11) the inner divs render outside the container div
<img width="313" alt="Screenshot 2022-10-06 at 13 09 56" src="https://user-images.githubusercontent.com/5560595/194329505-302dd3ef-9cbf-460e-a68d-4920acad2a5f.png">

- [x] The facebook icon disappears when popup first shows
<img width="226" alt="Screenshot 2022-10-06 at 13 08 08" src="https://user-images.githubusercontent.com/5560595/194329611-41f78341-3751-43bf-848e-6a6c2058c329.png">

Ref - https://github.com/Automattic/wp-calypso/issues/68604