### PR TITLE
Marketplace: Plugins header background color fix on plugins details

### DIFF
--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -1,5 +1,4 @@
 .search-box-header {
-	padding: 40px 0 48px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -72,6 +71,10 @@
 		font-weight: 400;
 		line-height: 40px;
 		color: var(--studio-blue-90);
+		padding-top: 40px;
+	}
+	.search-box-header__sticky-ref {
+		padding-bottom: 48px;
 	}
 
 	.search-box-header__recommended-searches {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -292,7 +292,7 @@ body.is-section-plugins header .select-dropdown__item {
 }
 
 body.is-section-plugins #primary {
-	&::before {
+	.search-box-header::before {
 		box-sizing: border-box;
 		content: "";
 		background-color: #fdfdfd;


### PR DESCRIPTION
#### Proposed Changes

Plugins header background color is affecting plugins details ([commented here](https://github.com/Automattic/wp-calypso/pull/68614#discussion_r989077244))
Added background color to the `search-box` element instead of the `primary` element 

#### Testing Instructions

1. Go to `/plugins`
2. Check for the background color of the header (it should be #fdfdfd).
3. Click on a plugin and check background should not be like the previews header.

#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes #68572
