### PR TITLE
Prevent Global Styles tracking from changing actual entities

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -3,7 +3,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import debugFactory from 'debug';
-import { find, isEqual } from 'lodash';
+import { find, isEqual, cloneDeep } from 'lodash';
 import delegateEventTracking, {
 	registerSubscriber as registerDelegateEventSubscriber,
 } from './tracking/delegate-event-tracking';
@@ -610,8 +610,14 @@ const trackEditEntityRecord = ( kind, type, id, updates ) => {
 
 	if ( kind === 'root' && type === 'globalStyles' ) {
 		const editedEntity = select( 'core' ).getEditedEntityRecord( kind, type, id );
-		const entityContent = { settings: editedEntity.settings, styles: editedEntity.styles };
-		const updatedContent = { settings: updates.settings, styles: updates.styles };
+		const entityContent = {
+			settings: cloneDeep( editedEntity.settings ),
+			styles: cloneDeep( editedEntity.styles ),
+		};
+		const updatedContent = {
+			settings: cloneDeep( updates.settings ),
+			styles: cloneDeep( updates.styles ),
+		};
 
 		// Sometimes a second update is triggered corresponding to no changes since the last update.
 		// Therefore we must check if there is a change to avoid debouncing a valid update to a changeless update.
@@ -654,8 +660,14 @@ const trackSaveEditedEntityRecord = ( kind, type, id ) => {
 	} );
 
 	if ( kind === 'root' && type === 'globalStyles' ) {
-		const entityContent = { settings: savedEntity.settings, styles: savedEntity.styles };
-		const updatedContent = { settings: editedEntity.settings, styles: editedEntity.styles };
+		const entityContent = {
+			settings: cloneDeep( savedEntity.settings ),
+			styles: cloneDeep( savedEntity.styles ),
+		};
+		const updatedContent = {
+			settings: cloneDeep( editedEntity.settings ),
+			styles: cloneDeep( editedEntity.styles ),
+		};
 
 		buildGlobalStylesContentEvents(
 			updatedContent,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68512

#### Proposed Changes

Ensures that the tracked Global Styles entities don't affect the actual entities used by Gutenberg. Looks like the previous tracking logic added in https://github.com/Automattic/wp-calypso/pull/57957 was inadvertently changing some properties of these entities because they were passed by reference. To prevent that, we now deeply clone the entities into full new object so they are isolated.

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh wpcom-block-editor fix/global-styles-clearing-each-other`
- Sandbox `widgets.wp.com`
- Go to https://wordpress.com/
- Switch to a Simple or Atomic site
- Make sure the site uses a block theme such as Twenty Twenty Two.
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Select a non-default style variation
- Select the default style variation.
- Close the sidebar
- Open the GS sidebar again, and open the style variations.
- Make sure the styles of every variation are previewed correctly

