### PR TITLE
Jetpack Licensing Portal: Allow selling Jetpack Boost to agencies

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -20,7 +20,6 @@ function queryProducts(): Promise< APIProductFamily[] > {
 				'jetpack-backup-daily',
 				'jetpack-backup-realtime',
 				'jetpack-backup-t0',
-				'jetpack-boost',
 				'jetpack-security-daily',
 				'jetpack-security-realtime',
 			];

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -133,17 +133,6 @@ describe( 'useProductsQuery', () => {
 					},
 				],
 			},
-			{
-				name: 'Jetpack Boost',
-				slug: 'jetpack-boost',
-				products: [
-					{
-						name: 'Jetpack Boost',
-						product_id: 2401,
-						slug: 'jetpack-boost',
-					},
-				],
-			},
 		];
 		const expected = [
 			{


### PR DESCRIPTION
#### Proposed Changes

* Removes Jetpack Boost from the list of blocked products in the Jetpack Licensing Portal.

#### Testing Instructions

* Create two new test sites and connect Jetpack on both.
* Load this branch in local dev, head to the licensing portal, issue a license for Jetpack Boost (it should now appear in the list of licensable products.
* Copy the license key into the Jetpack dashboard of your first site. It should activate normally.
* Issue a second license for Jetpack Boost, and attempt to automatically attach it via the Licensing Portal. It should attach and activate normally.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
