### PR TITLE
HelpCenter: track availability of email and chat in the contact form

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,6 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Spinner } from '@automattic/components';
+import { useEffect } from '@wordpress/element';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -40,6 +41,17 @@ export const HelpCenterContactPage: React.FC = () => {
 	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
 		staleTime: 30 * 60 * 1000,
 	} );
+
+	useEffect( () => {
+		if ( renderChat.isLoading || isLoadingTickets ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_helpcenter_contact_options_impression', {
+			location: 'help-center',
+			chat_available: renderChat.state === 'AVAILABLE',
+			email_available: renderEmail,
+		} );
+	}, [ isLoadingTickets, renderChat.isLoading, renderChat.state, renderEmail ] );
 
 	if ( renderChat.isLoading || isLoadingTickets ) {
 		return (

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -41,9 +41,10 @@ export const HelpCenterContactPage: React.FC = () => {
 	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
 		staleTime: 30 * 60 * 1000,
 	} );
+	const isLoading = renderChat.isLoading || isLoadingTickets;
 
 	useEffect( () => {
-		if ( renderChat.isLoading || isLoadingTickets ) {
+		if ( isLoading ) {
 			return;
 		}
 		recordTracksEvent( 'calypso_helpcenter_contact_options_impression', {
@@ -51,9 +52,9 @@ export const HelpCenterContactPage: React.FC = () => {
 			chat_available: renderChat.state === 'AVAILABLE',
 			email_available: renderEmail,
 		} );
-	}, [ isLoadingTickets, renderChat.isLoading, renderChat.state, renderEmail ] );
+	}, [ isLoading, renderChat.state, renderEmail ] );
 
-	if ( renderChat.isLoading || isLoadingTickets ) {
+	if ( isLoading ) {
 		return (
 			<div className="help-center-contact-page__loading">
 				<Spinner baseClassName="" />

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -41,7 +41,7 @@ export const HelpCenterContactPage: React.FC = () => {
 	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
 		staleTime: 30 * 60 * 1000,
 	} );
-	const isLoading = renderChat.isLoading || isLoadingTickets;
+	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTickets;
 
 	useEffect( () => {
 		if ( isLoading ) {
@@ -50,9 +50,9 @@ export const HelpCenterContactPage: React.FC = () => {
 		recordTracksEvent( 'calypso_helpcenter_contact_options_impression', {
 			location: 'help-center',
 			chat_available: renderChat.state === 'AVAILABLE',
-			email_available: renderEmail,
+			email_available: renderEmail.render,
 		} );
-	}, [ isLoading, renderChat.state, renderEmail ] );
+	}, [ isLoading, renderChat.state, renderEmail.render ] );
 
 	if ( isLoading ) {
 		return (
@@ -100,7 +100,7 @@ export const HelpCenterContactPage: React.FC = () => {
 						</ConditionalLink>
 					) }
 
-					{ renderEmail && (
+					{ renderEmail.render && (
 						<Link
 							// set overflow flag when chat is not available nor closed, and the user is eligible to chat, but still sends a support ticket
 							to={ `/contact-form?mode=EMAIL&overflow=${ (

--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -1,12 +1,13 @@
 import { useSupportAvailability } from '@automattic/data-stores';
 
 export function useShouldRenderEmailOption() {
-	const { data: supportAvailability } = useSupportAvailability( 'OTHER' );
-	if (
-		supportAvailability?.is_user_eligible_for_tickets ||
-		supportAvailability?.is_user_eligible_for_upwork
-	) {
-		return true;
-	}
-	return false;
+	const { data: supportAvailability, isFetching } = useSupportAvailability( 'OTHER' );
+
+	return {
+		isLoading: isFetching,
+		render:
+			( supportAvailability?.is_user_eligible_for_tickets ||
+				supportAvailability?.is_user_eligible_for_upwork ) ??
+			false,
+	};
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR adds tracking for the help center contact form. An event is send `calypso_helpcenter_contact_options_impression` which in its data contains information on whether or not the chat and email options are available.

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- In chrome devtools inspect the network requests
- Open the help center and open the contact form
- Run this filter for network requests `t.gif?location=help-center&chat_available`
- Ensure that the request is only sent once with the correct payload

Related to #68578
