### PR TITLE
Videomaker Onboarding: Add theme selection step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -35,6 +35,7 @@ export { default as difmStartingPoint } from './difm-starting-point';
 export { default as letsGetStarted } from './lets-get-started';
 export { default as intro } from './intro';
 export { default as linkInBioSetup } from './link-in-bio-setup';
+export { default as videomakerSetup } from './videomaker-setup';
 export { default as completingPurchase } from './completing-purchase';
 export { default as chooseADomain } from './choose-a-domain';
 export { default as chooseAPlan } from './choose-a-plan';
@@ -89,4 +90,5 @@ export type StepPath =
 	| 'subscribers'
 	| 'promote'
 	| 'getCurrentThemeSoftwareSets'
-	| 'chooseAPlan';
+	| 'chooseAPlan'
+	| 'videomakerSetup';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import React, { FormEvent } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ONBOARD_STORE } from '../../../../stores';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+
+	const handleSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+
+		// Set some flow meta here?
+
+		submit?.();
+	};
+
+	const lightClasses = classNames( 'videomaker-setup__light-button', {
+		selected: 'premium/videomaker-white' === selectedDesign?.theme,
+	} );
+
+	const darkClasses = classNames( 'videomaker-setup__dark-button', {
+		selected: 'premium/videomaker' === selectedDesign?.theme,
+	} );
+
+	const stepContent = (
+		<div className="videomaker-setup__step-content">
+			<div className="videomaker-setup__theme-picker">
+				<button
+					className={ darkClasses }
+					onClick={ () =>
+						setSelectedDesign( {
+							slug: 'videomaker',
+							theme: 'premium/videomaker',
+							is_premium: true,
+							title: 'Videomaker',
+							categories: [],
+							features: [],
+							template: '',
+						} )
+					}
+				>
+					<img
+						src="https://videopress2.files.wordpress.com/2022/10/videomaker-theme-dark.jpg"
+						alt={ __( 'Videomaker dark' ) }
+					/>
+				</button>
+				<button
+					className={ lightClasses }
+					onClick={ () =>
+						setSelectedDesign( {
+							slug: 'videomaker',
+							theme: 'premium/videomaker-white',
+							is_premium: true,
+							title: 'Videomaker',
+							categories: [],
+							features: [],
+							template: '',
+						} )
+					}
+				>
+					<img
+						src="https://videopress2.files.wordpress.com/2022/10/videomaker-theme-light.jpg"
+						alt={ __( 'Videomaker white' ) }
+					/>
+				</button>
+			</div>
+			<form className="videomaker-setup__form" onSubmit={ handleSubmit }>
+				<Button className="videomaker-setup-form__submit" primary type="submit">
+					{ __( 'Continue' ) }
+				</Button>
+			</form>
+		</div>
+	);
+
+	return (
+		<StepContainer
+			stepName={ 'videomaker-setup' }
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName={ 'videopress' }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'videomaker-setup-header' }
+					headerText={ __( 'Choose a design' ) }
+					subHeaderText={ __(
+						'This is what your homepage will look like. You’ll be able to customize it further at any time.'
+					) }
+					align={ 'center' }
+				/>
+			}
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+			showVideoPressPowered
+		/>
+	);
+};
+
+export default VideomakerSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -22,8 +22,6 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 
-		// Set some flow meta here?
-
 		submit?.();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import classNames from 'classnames';
-import React, { FormEvent } from 'react';
+import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -17,38 +15,27 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
-	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
-	const handleSubmit = async ( event: FormEvent ) => {
-		event.preventDefault();
+	const onSelectTheme = ( slug: string ) => {
+		setSelectedDesign( {
+			slug: 'videomaker',
+			theme: slug,
+			is_premium: true,
+			title: 'Videomaker',
+			categories: [],
+			features: [],
+			template: '',
+		} );
 
 		submit?.();
 	};
-
-	const lightClasses = classNames( 'videomaker-setup__light-button', {
-		selected: 'premium/videomaker-white' === selectedDesign?.theme,
-	} );
-
-	const darkClasses = classNames( 'videomaker-setup__dark-button', {
-		selected: 'premium/videomaker' === selectedDesign?.theme,
-	} );
 
 	const stepContent = (
 		<div className="videomaker-setup__step-content">
 			<div className="videomaker-setup__theme-picker">
 				<button
-					className={ darkClasses }
-					onClick={ () =>
-						setSelectedDesign( {
-							slug: 'videomaker',
-							theme: 'premium/videomaker',
-							is_premium: true,
-							title: 'Videomaker',
-							categories: [],
-							features: [],
-							template: '',
-						} )
-					}
+					className="videomaker-setup__dark-button"
+					onClick={ () => onSelectTheme( 'premium/videomaker' ) }
 				>
 					<img
 						src="https://videopress2.files.wordpress.com/2022/10/videomaker-theme-dark.jpg"
@@ -56,18 +43,8 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 					/>
 				</button>
 				<button
-					className={ lightClasses }
-					onClick={ () =>
-						setSelectedDesign( {
-							slug: 'videomaker',
-							theme: 'premium/videomaker-white',
-							is_premium: true,
-							title: 'Videomaker',
-							categories: [],
-							features: [],
-							template: '',
-						} )
-					}
+					className="videomaker-setup__light-button"
+					onClick={ () => onSelectTheme( 'premium/videomaker-white' ) }
 				>
 					<img
 						src="https://videopress2.files.wordpress.com/2022/10/videomaker-theme-light.jpg"
@@ -75,11 +52,6 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 					/>
 				</button>
 			</div>
-			<form className="videomaker-setup__form" onSubmit={ handleSubmit }>
-				<Button className="videomaker-setup-form__submit" primary type="submit">
-					{ __( 'Continue' ) }
-				</Button>
-			</form>
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -7,9 +7,9 @@ import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import React, { FormEvent } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { ONBOARD_STORE } from '../../../../stores';
-import type { Step } from '../../types';
+import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
 import './styles.scss';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
@@ -15,8 +15,9 @@ $font-family: 'SF Pro Text', $sans;
 
 	.videomaker-setup__theme-picker {
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 		margin-block-end: 36px;
+		align-items: center;
 
 		.videomaker-setup__light-button img {
 			background-color: #FFFFFF;
@@ -36,10 +37,11 @@ $font-family: 'SF Pro Text', $sans;
 			transform: scale( 1.0 );
 			z-index: 0;
 			cursor: pointer;
+			max-width: 76%;
 
 			img {
 				display: block;
-				max-width: 400px;
+				width: 100%;
 				height: auto;
 				border-radius: 6px;
 				flex-grow: 1;
@@ -47,7 +49,7 @@ $font-family: 'SF Pro Text', $sans;
 			}
 
 			&:first-of-type {
-				margin-inline-end: 30px;
+				margin-bottom: 30px;
 			}
 
 			&:hover, &.selected {
@@ -55,6 +57,23 @@ $font-family: 'SF Pro Text', $sans;
 				z-index: 1;
 				background-color: $videopress-theme-yellow;
 				border: 8px solid $videopress-theme-yellow;
+			}
+		}
+
+		@include break-medium {
+			flex-direction: row;
+			padding: 0 16px;
+
+			button {
+
+				&:first-of-type {
+					margin-bottom: 0px;
+					margin-inline-end: 30px;
+				}
+			}
+
+			img {
+				max-width: 400px;
 			}
 		}
 	}
@@ -68,6 +87,7 @@ $font-family: 'SF Pro Text', $sans;
 	.step-container__header {
 		margin-top: 100px;
 		margin-bottom: 36px;
+		padding: 0 24px;
 
 		h1.formatted-header__title {
 			font-size: $font-title-medium;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
@@ -52,7 +52,7 @@ $font-family: 'SF Pro Text', $sans;
 				margin-bottom: 30px;
 			}
 
-			&:hover, &.selected {
+			&:hover {
 				transform: scale( 1.05 );
 				z-index: 1;
 				background-color: $videopress-theme-yellow;
@@ -75,6 +75,12 @@ $font-family: 'SF Pro Text', $sans;
 
 			img {
 				max-width: 400px;
+			}
+		}
+
+		@include break-large {
+			img {
+				max-width: 500px;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
@@ -63,6 +63,7 @@ $font-family: 'SF Pro Text', $sans;
 		@include break-medium {
 			flex-direction: row;
 			padding: 0 16px;
+			min-height: 312px;
 
 			button {
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
@@ -1,0 +1,85 @@
+@import '../../videopress.scss';
+
+$font-family: 'SF Pro Text', $sans;
+
+.videomaker-setup {
+	form {
+		padding: 0 20px;
+	}
+
+	.videomaker-setup__step-content {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.videomaker-setup__theme-picker {
+		display: flex;
+		flex-direction: row;
+		margin-block-end: 36px;
+
+		.videomaker-setup__light-button img {
+			background-color: #FFFFFF;
+		}
+
+		.videomaker-setup__dark-button img {
+			background-color: #000000;
+		}
+
+		button {
+			background-color: $videopress-theme-border-color;
+			border: 10px solid $videopress-theme-border-color;
+			border-radius: 8px;
+			padding: 0;
+			margin: 0;
+			transition: all 0.2s ease-in-out;
+			transform: scale( 1.0 );
+			z-index: 0;
+			cursor: pointer;
+
+			img {
+				display: block;
+				max-width: 400px;
+				height: auto;
+				border-radius: 6px;
+				flex-grow: 1;
+				object-fit: cover;
+			}
+
+			&:first-of-type {
+				margin-inline-end: 30px;
+			}
+
+			&:hover, &.selected {
+				transform: scale( 1.05 );
+				z-index: 1;
+				background-color: $videopress-theme-yellow;
+				border: 8px solid $videopress-theme-yellow;
+			}
+		}
+	}
+
+	.step-container__content {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 30px;
+	}
+
+	.step-container__header {
+		margin-top: 100px;
+		margin-bottom: 36px;
+
+		h1.formatted-header__title {
+			font-size: $font-title-medium;
+
+			@include break-medium {
+				font-size: $font-headline-medium;
+			}
+		}
+	}
+
+	.videomaker-setup-form__submit {
+		border: none;
+		min-width: 240px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -3,6 +3,7 @@
 $videopress-theme-base-text-color: #fff;
 $videopress-theme-yellow: #ffe61c;
 $videopress-theme-header-subtitle-text-color: #a7aaad;
+$videopress-theme-border-color: #252726;
 
 body.is-videopress-stepper {
 	background-color: #010101;

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -48,7 +48,7 @@ export const videopress: Flow = {
 		}
 
 		const name = this.name;
-		const { setDomain, setSiteDescription, setSiteTitle, setStepProgress } =
+		const { setDomain, setSelectedDesign, setSiteDescription, setSiteTitle, setStepProgress } =
 			useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
 		setStepProgress( flowProgress );
@@ -60,6 +60,7 @@ export const videopress: Flow = {
 			setSiteTitle( '' );
 			setSiteDescription( '' );
 			setDomain( undefined );
+			setSelectedDesign( undefined );
 		};
 
 		const stepValidateUserIsLoggedIn = () => {

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -20,6 +20,7 @@ export const videopress: Flow = {
 		return [
 			'intro',
 			'options',
+			'videomakerSetup',
 			'chooseADomain',
 			'chooseAPlan',
 			'completingPurchase',
@@ -110,18 +111,24 @@ export const videopress: Flow = {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
 					setSiteDescription( tagline as string );
+					return navigate( 'videomakerSetup' );
+				}
+
+				case 'videomakerSetup': {
 					return navigate( 'chooseADomain' );
 				}
 
-				case 'chooseADomain':
+				case 'chooseADomain': {
 					return navigate( 'chooseAPlan' );
+				}
 
 				case 'chooseAPlan': {
 					return navigate( 'processing' );
 				}
 
-				case 'completingPurchase':
+				case 'completingPurchase': {
 					return navigate( 'launchpad' );
+				}
 
 				case 'launchpad': {
 					clearOnboardingSiteOptions();

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -55,6 +55,7 @@ export function* createVideoPressSite( {
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
 	const defaultTheme = selectedDesign?.theme || 'premium/videomaker';
+	const siteVertical = 'premium/videomaker' === defaultTheme ? 'videomaker' : 'videomaker-white';
 	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 
 	const params: CreateSiteParams = {
@@ -76,6 +77,7 @@ export function* createVideoPressSite( {
 				font_headings: selectedFonts.headings,
 			} ),
 			use_patterns: true,
+			site_vertical_name: siteVertical,
 			selected_features: selectedFeatures,
 			wpcom_public_coming_soon: 1,
 			...( selectedDesign && { is_blank_canvas: isBlankCanvasDesign( selectedDesign ) } ),

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -54,7 +54,7 @@ export function* createVideoPressSite( {
 
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-	const defaultTheme = 'premium/videomaker';
+	const defaultTheme = selectedDesign?.theme || 'premium/videomaker';
 	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 
 	const params: CreateSiteParams = {

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -26,10 +26,11 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		intro: 0,
 		user: 1,
 		options: 2,
-		chooseADomain: 3,
-		chooseAPlan: 4,
-		processing: 5,
-		launchpad: 6,
+		videomakerSetup: 3,
+		chooseADomain: 4,
+		chooseAPlan: 5,
+		processing: 6,
+		launchpad: 7,
 	},
 };
 


### PR DESCRIPTION
#### Proposed Changes

* Adds a new step to the onboarding flow so that a user can choose between the Videomaker dark or light theme:

<img width="933" alt="Screen Shot 2022-10-06 at 9 26 54 AM" src="https://user-images.githubusercontent.com/789137/194354287-fd3656a0-2f5e-4c4b-95e3-846267be3c15.png">

#### Testing Instructions
* ~Apply D87583-code to your sandbox.~ Deployed
* Create a new site via http://calypso.localhost:3000/setup/intro?flow=videopress
* You should arrive at the theme selection choice.
* Choose a theme and click `continue`. (If you don't click anything it will default to `dark` theme)
* Finish the checkout and launch the site.
* The site should be using the theme you selected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
