### PR TITLE
HelpCenterContactForm: fix invalid html

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -311,7 +311,7 @@ export const HelpCenterContactForm = () => {
 		const [ isOpen, setOpen ] = useState( false );
 
 		return (
-			<div>
+			<>
 				<button
 					className="help-center-contact-form__site-picker-forum-privacy-info"
 					ref={ ref }
@@ -334,7 +334,7 @@ export const HelpCenterContactForm = () => {
 						) }
 					</span>
 				</Popover>
-			</div>
+			</>
 		);
 	};
 


### PR DESCRIPTION
| Before  | After |
|  ------------- | ------------- |
| <img width="699" alt="Screenshot 2022-10-06 at 18 27 42" src="https://user-images.githubusercontent.com/7000684/194368663-83fad428-ed71-4362-b82d-8a5633157d5f.png"> |  <img width="1398" alt="Screenshot 2022-10-06 at 18 33 22" src="https://user-images.githubusercontent.com/7000684/194368979-682ffacd-f786-4c67-a020-66d301bf286b.png"> |

#### Proposed Changes

* The `InfoTip` component was returning a `div` container which was put into a `p` element. This PR modifies it to return a fragment. 

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Login with a free user
- Open the help center's contact form
- Ensure that there is no html validation error in the console and that `Don’t display my site’s URL publicly` checkbox retains the same functionality and look.

Related to #68723
