### PR TITLE
Fix: Pro plan links in Upsell Nudges in Settings > Performance

### DIFF
--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -9,21 +9,19 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const Cloudflare = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const showCloudflare = config.isEnabled( 'cloudflare' );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 	const hasCloudflareCDN = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_CLOUDFLARE_CDN )
 	);
 	const hasJetpackCDN = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_CDN )
 	);
-	const upgradeLink = `/checkout/${ siteSlug }/pro`;
 
 	const recordClick = () => {
 		dispatch(
@@ -62,7 +60,7 @@ const Cloudflare = () => {
 					{ ! hasJetpackCDN && (
 						<UpsellNudge
 							title={ translate( 'Available on Business plan or higher' ) }
-							href={ upgradeLink }
+							feature={ WPCOM_FEATURES_CDN }
 							event={ 'calypso_settings_cloudflare_cdn_upsell_nudge_click' }
 							showIcon={ true }
 							forceDisplay
@@ -101,7 +99,7 @@ const Cloudflare = () => {
 							description={ translate(
 								'A CDN (Content Delivery Network) optimizes your content to provide users with the fastest experience.'
 							) }
-							href={ upgradeLink }
+							feature={ WPCOM_FEATURES_CLOUDFLARE_CDN }
 							event={ 'calypso_settings_cloudflare_cdn_upsell_nudge_click' }
 							showIcon={ true }
 							forceDisplay


### PR DESCRIPTION
There were some hardcoded links to the Pro plan in settings > performance (Cloudflare and Jetpack CDN links). 

Reported here: p1665075284832259-slack-C02FMH4G8

I've changed these so they go to the plans page, and also send the feature as a URL parameter. This is consistent with other upsell nudges in Calypso.

An alternative is to link them directly to the checkout with the respective plan in the cart.

#### Testing Instructions

* Use a Free site
* Head over to /settings/performance/:site_slug either via the Live link below or by checking out this branch locally.
* Verify that you're taken to the plans page for your selected site, and not to the checkout (with a Pro plan in the cart) like the current behavior in prod.
* You can also test different plans as a sanity check, e.g. Business, Premium, Personal, etc. and verify the following behaviors:
    * Business -> No upsell nudges shown (just for JP search)
    * Premium -> Upsell for JP CDN (Business), no CF upsell
    * Personal -> All upsells showing
    * Ecommerce -> Same as Business 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #