### PR TITLE
ETK: Move endpoint attributes out of Constructor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials-endpoint.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials-endpoint.php
@@ -11,13 +11,25 @@
 class WPCom_Tutorials_Endpoint extends WP_REST_Controller {
 
 	/**
-	 * Constructor
+	 * Namespace.
+	 *
+	 * @var string
 	 */
-	public function __construct() {
-		$this->namespace                       = 'wpcom/v2';
-		$this->rest_base                       = 'tutorials';
-		$this->wpcom_is_site_specific_endpoint = false;
-	}
+	public $namespace = 'wpcom/v2';
+
+	/**
+	 * Rest base.
+	 *
+	 * @var string
+	 */
+	public $rest_base = 'tutorials';
+
+	/**
+	 * Whether this is a site-specific endpoint.
+	 *
+	 * @var bool
+	 */
+	public $wpcom_is_site_specific_endpoint = false;
 
 	/**
 	 * Callback for registering our REST routes


### PR DESCRIPTION
Allows for better documentation of class attributes.

It's also a low-impact way of testing ETK deploys.

#### Proposed Changes

* Move endpoint attributes into documented class properties.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api
* Apply this diff to your sandbox: `install-plugin.sh editing-toolkit update/ETK-tutorials-endpoint`
* Using the API console, query `/wpcom/v2/tutorials` and make sure it doesn't throw errors and returns an empty result.

<img width="424" alt="image" src="https://user-images.githubusercontent.com/1398304/194393469-f941749e-4d54-4428-865a-77d33b95a5bc.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
