### PR TITLE
Jetpack pricing: add Social to nav

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -95,6 +95,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 						href: `${ JETPACK_COM_BASE_URL }/features/growth/`,
 						items: [
 							{
+								label: translate( 'Social' ),
+								tagline: translate( 'Write once, post everywhere' ),
+								href: `${ JETPACK_COM_BASE_URL }/social/`,
+							},
+							{
 								label: translate( 'CRM' ),
 								tagline: translate( 'Connect with your people' ),
 								href: 'https://jetpackcrm.com/?utm_medium=automattic_referred&utm_source=jpcom_header',


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds Social to the pricing page navigation, to match the [Jetpack.com ](https://jetpack.com/)navigation.

### Testing instructions

- Spin up the pricing page in Cloud, by running this branch locally, or with the live link below.
- Check that the Products menu contains Social, and that the copy matches the one in Jetpack.com.
- Check that the link is correct.

### Screenshots

_Before_
<img width="1088" alt="Screen Shot 2022-10-06 at 3 31 21 PM" src="https://user-images.githubusercontent.com/1620183/194402633-6c10add4-864b-4523-9b8d-fb0cff5f82cc.png">


_After_
<img width="1130" alt="Screen Shot 2022-10-06 at 3 31 54 PM" src="https://user-images.githubusercontent.com/1620183/194402652-c2203c83-7a1d-4a72-afa0-2184a3962cb8.png">

