### PR TITLE
Launchpad: Redirect pre-existing non-launchpad sites to MyHome

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -30,7 +30,7 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 		if ( launchpadScreenOption !== undefined ) {
 			// The screen option returns false for sites that have never set the option
 			if ( launchpadScreenOption === false || launchpadScreenOption === 'off' ) {
-				window.location.replace( `/home/${ siteSlug }/?forceLoadLaunchpadData=true` );
+				window.location.replace( `/home/${ siteSlug }` );
 				recordTracksEvent( 'calypso_launchpad_redirect_to_home', { flow: flow } );
 			} else {
 				recordTracksEvent( 'calypso_launchpad_loaded', { flow: flow } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -27,8 +27,9 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 	useEffect( () => {
 		// launchpadScreenOption changes from undefined to either 'off' or 'full'
 		// we need to check if it's defined to avoid recording the same action twice
-		if ( launchpadScreenOption ) {
-			if ( launchpadScreenOption === 'off' ) {
+		if ( launchpadScreenOption !== undefined ) {
+			// The screen option returns false for sites with no option set
+			if ( launchpadScreenOption === false || launchpadScreenOption === 'off' ) {
 				window.location.replace( `/home/${ siteSlug }/?forceLoadLaunchpadData=true` );
 				recordTracksEvent( 'calypso_launchpad_redirect_to_home', { flow: flow } );
 			} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -28,7 +28,7 @@ const Launchpad: Step = ( { navigation }: LaunchpadProps ) => {
 		// launchpadScreenOption changes from undefined to either 'off' or 'full'
 		// we need to check if it's defined to avoid recording the same action twice
 		if ( launchpadScreenOption !== undefined ) {
-			// The screen option returns false for sites with no option set
+			// The screen option returns false for sites that have never set the option
 			if ( launchpadScreenOption === false || launchpadScreenOption === 'off' ) {
 				window.location.replace( `/home/${ siteSlug }/?forceLoadLaunchpadData=true` );
 				recordTracksEvent( 'calypso_launchpad_redirect_to_home', { flow: flow } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { Site } from '@automattic/data-stores';
+import { render } from '@testing-library/react';
+import { useDispatch } from '@wordpress/data';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { createReduxStore } from 'calypso/state';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+import Launchpad from '../index';
+import { buildSiteDetails, defaultSiteDetails } from './lib/fixtures';
+
+jest.mock( '../launchpad-site-preview', () => () => {
+	return <div></div>;
+} );
+
+// JSDOM doesn't support browser navigation, so we temporarily mock the
+// window.location object
+const replaceMock = jest.fn();
+const savedWindow = window;
+global.window = Object.create( window );
+Object.defineProperty( window, 'location', {
+	value: { replace: replaceMock },
+} );
+
+const siteSlug = `testlinkinbio.wordpress.com`;
+const user = {
+	ID: 1234,
+	username: 'testUser',
+	email: 'testEmail@gmail.com',
+};
+
+function renderLaunchpad( props = {}, siteDetails = defaultSiteDetails ): void {
+	function TestLaunchpad( props ) {
+		const initialState = getInitialState( initialReducer, user.ID );
+		const reduxStore = createReduxStore( initialState, initialReducer );
+		setStore( reduxStore, getStateFromCache( user.ID ) );
+
+		const SITE_STORE = Site.register( {
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_id' ),
+		} );
+
+		const { receiveSite } = useDispatch( SITE_STORE );
+
+		receiveSite( siteDetails.ID, siteDetails );
+
+		return (
+			<Provider store={ reduxStore }>
+				<MemoryRouter
+					initialEntries={ [ `/setup/launchpad?flow=link-in-bio&siteSlug=${ siteSlug }` ] }
+				>
+					<Launchpad { ...props } />
+				</MemoryRouter>
+			</Provider>
+		);
+	}
+
+	render( <TestLaunchpad { ...props } /> );
+}
+
+describe( 'Launchpad', () => {
+	const props = {
+		siteSlug,
+		/* eslint-disable @typescript-eslint/no-empty-function */
+		navigation: {
+			submit: () => {},
+			goNext: () => {},
+			goToStep: () => {},
+		},
+		/* eslint-enable @typescript-eslint/no-empty-function */
+	};
+
+	afterAll( () => {
+		global.window = savedWindow;
+	} );
+
+	describe( 'when loading the Launchpad view', () => {
+		describe( 'and the site is launchpad enabled', () => {
+			it( 'does not redirect', () => {
+				renderLaunchpad( props );
+				expect( replaceMock ).not.toBeCalled();
+			} );
+		} );
+
+		describe( 'and the site is not launchpad enabled', () => {
+			it( 'redirects to Calypso My Home', () => {
+				renderLaunchpad(
+					props,
+					buildSiteDetails( {
+						options: {
+							...defaultSiteDetails.options,
+							launchpad_screen: 'off',
+						},
+					} )
+				);
+
+				expect( replaceMock ).toBeCalledTimes( 1 );
+				expect( replaceMock ).toBeCalledWith( `/home/${ siteSlug }` );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* If the launchpad screen option is `false`, it means that the site did not go through one of the tailored onboarding flows, which means launchpad was never enabled
* Upon visiting the launchpad, we check said option to determine whether or not we redirect the site to MyHome

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site through the standard onboarding flow https://wordpress.com/start/domains?ref=calypso-selector
* Visit http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug={YOUR_SITE_SLUG}
* Verify that we can see and interact with the launchpad, even though the site never stepped through tailored onboarding
* Check out this branch
* Visit http://calypso.localhost:3000/setup/launchpad?flow=link-in-bio&siteSlug={YOUR_SITE_SLUG}
* Verify that we are redirected to MyHome

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68665
