### PR TITLE
Prototyping screenshots using getDisplayMedia

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/frontend-screenshots/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/frontend-screenshots/index.php
@@ -2,12 +2,18 @@
 
 namespace A8C\FSE\Frontend_Screenshots;
 
-function enqueue() {
-	wp_enqueue_script(
-		'frontend-screenshots-script',
-		plugins_url( 'dist/frontend-screenshots.min.js', __FILE__ ),
-		$asset_file['dependencies'],
-		$asset_file['version'],
-		true
-	);
+function enqueue_screenshot_script() {
+		wp_enqueue_script(
+			'frontend-screenshots-script',
+			plugins_url( 'dist/frontend-screenshots.min.js', __FILE__ ),
+			$asset_file['dependencies'],
+			$asset_file['version'],
+			true
+		);
 }
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_screenshot_script' );
+
+function add_screenshot_headers() {
+	header( 'Feature-Policy: display-capture' );
+}
+add_action( 'send_headers', __NAMESPACE__ . '\add_screenshot_headers' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/frontend-screenshots/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/frontend-screenshots/index.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace A8C\FSE\Frontend_Screenshots;
+
+function enqueue() {
+	wp_enqueue_script(
+		'frontend-screenshots-script',
+		plugins_url( 'dist/frontend-screenshots.min.js', __FILE__ ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
+		true
+	);
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/frontend-screenshots/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/frontend-screenshots/index.ts
@@ -1,0 +1,43 @@
+export {};
+
+const capture = async () => {
+	const canvas = document.createElement( 'canvas' );
+	canvas.width = window.innerWidth / 2;
+	canvas.height = window.innerHeight / 2;
+	const context = canvas.getContext( '2d' );
+	const video = document.createElement( 'video' );
+
+	const captureStream = await navigator.mediaDevices.getDisplayMedia();
+	video.srcObject = captureStream;
+	return new Promise( ( resolve ) => {
+		video.addEventListener( 'loadedmetadata', () => {
+			video.play();
+			context?.drawImage( video, 0, 0, canvas.width, canvas.height );
+			const frame = canvas.toDataURL( 'image/png' );
+			setTimeout( () => {
+				captureStream.getTracks().forEach( ( track ) => track.stop() );
+				resolve( frame );
+			}, 200 );
+		} );
+	} );
+};
+
+window.logDataUrl = async function () {
+	try {
+		const url = await capture();
+		console.log( url );
+	} catch ( e ) {
+		console.log( e );
+	}
+};
+
+window.addEventListener( 'message', async ( e ) => {
+	switch ( e.data?.type ) {
+		case 'CAPTURE_SCREEN':
+			e.source?.postMessage( {
+				type: 'RETURN_SCREEN',
+				dataUrl: await capture(),
+			} );
+			break;
+	}
+} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -434,3 +434,14 @@ function load_wpcom_global_styles() {
 	require_once __DIR__ . '/wpcom-global-styles/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );
+
+/**
+ * Load support for taking screenshots of front end
+ */
+function load_frontend_screenshots() {
+	if ( isset( $_GET['enable-frontend-screenshots'] ) ) {
+		require_once __DIR__ . '/frontend-screenshots/index.php';
+		\A8C\FSE\Frontend_Screenshots\enqueue();
+	}
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\load_frontend_screenshots' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -441,7 +441,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );
 function load_frontend_screenshots() {
 	if ( isset( $_GET['enable-frontend-screenshots'] ) ) {
 		require_once __DIR__ . '/frontend-screenshots/index.php';
-		\A8C\FSE\Frontend_Screenshots\enqueue();
 	}
 }
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\load_frontend_screenshots' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_frontend_screenshots' );

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -19,6 +19,7 @@
 		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url'",
 		"build:error-reporting": "calypso-build --env source='error-reporting'",
 		"build:event-countdown-block": "calypso-build --env source='event-countdown-block'",
+		"build:frontend-screenshots": "calypso-build --env source='frontend-screenshots'",
 		"build:global-styles": "calypso-build --env source='global-styles'",
 		"build:global-styles-customizer-fonts": "calypso-build --env source='global-styles/customizer-fonts'",
 		"build:help-center": "calypso-build --env source='help-center'",

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -126,6 +126,35 @@ const WpAdminItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	);
 };
 
+const Screenshot = ( { site }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<MenuItemLink onClick={ () => takeScreenshot( site.URL ) }>{ __( 'Screenshot' ) }</MenuItemLink>
+	);
+};
+
+function takeScreenshot( url: string ) {
+	const iframe = document.createElement( 'iframe' );
+	iframe.width = '1366';
+	iframe.height = '768';
+	iframe.src = url + '?enable-frontend-screenshots';
+	document.body.appendChild( iframe );
+	setTimeout( () => {
+		iframe.contentWindow?.postMessage( {
+			type: 'CAPTURE_SCREEN',
+		} );
+	}, 9000 );
+	window.addEventListener( 'message', ( e ) => {
+		switch ( e.data?.type ) {
+			case 'RETURN_SCREEN':
+				console.log( e.data?.dataUrl );
+				iframe.remove();
+				break;
+		}
+	} );
+}
+
 const SiteMenuGroup = styled( MenuGroup )( {
 	'> div[role="group"]': {
 		display: 'flex',
@@ -172,6 +201,7 @@ export const SitesEllipsisMenu = ( {
 					<ManagePluginsItem { ...props } />
 					{ ! isNotAtomicJetpack( site ) && <HostingConfigItem { ...props } /> }
 					<WpAdminItem { ...props } />
+					<Screenshot { ...props } />
 				</SiteMenuGroup>
 			) }
 		</SiteDropdownMenu>


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
