### PR TITLE
Jetpack New Pricing Page - Show scroll for overflowing lightbox

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -42,6 +42,8 @@
 
 	&.ReactModal__Overlay--after-open {
 		background-color: rgb(0 0 0 / 70%);
+		max-height: 100vh;
+		overflow-y: auto;
 	}
 }
 
@@ -70,6 +72,8 @@
 	height: 100%;
 	width: 60%;
 	overflow-y: auto;
+	background-color: #f6f7f7;
+	border-radius: 8px 0 0 8px; /* stylelint-disable-line scales/radii */
 
 	hr {
 		margin: 0.75rem 0;


### PR DESCRIPTION
#### Proposed Changes

* Show scroll when the lightbox overflows more than the height of the viewport
* Fix the border radius and background-color for lightbox content section

#### Testing Instructions

* click on Jetpack Cloud live link below
    * Goto `/pricing?flags=jetpack/pricing-page-rework-v1`
* or boot up this PR 
    * Run `git fetch && git checkout fix/lightbox-scroll`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/pricing-page-rework-v1
* Reduce the window size to anywhere between `770px-930px` and also reduce the height of the window to less than `700px`
* Open the lightbox by clicking **More about** link in any product card (For Ex: **More about Backup**)
* Make sure the scroll is shown and the lightbox is scrollable (Refer to the video for more info)
* Add also make sure border-radius is applied to the left top and left bottom of the lightbox
  
#### Screecast 

##### Before
[before-fix-scroll.webm](https://user-images.githubusercontent.com/2027003/194462477-00433e9a-dc1f-4bc9-bf41-a9e76966a482.webm)


##### After
[after-fix-scroll.webm](https://user-images.githubusercontent.com/2027003/194462481-1f06c920-6db4-450d-a74b-6e3ac2ae8728.webm)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202858161751496-as-1203102145883188/f