### PR TITLE
Plugin Management: handle error scenarios for plugins API

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -32,6 +32,7 @@ import {
 	getPlugins,
 	isRequestingForSites,
 	isRequestingForAllSites,
+	requestPluginsError,
 } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
@@ -359,7 +360,7 @@ export class PluginsMain extends Component {
 		const showInstalledPluginList =
 			isJetpackCloud || ! isEmpty( currentPlugins ) || this.isFetchingPlugins();
 
-		if ( ! showInstalledPluginList && ! search ) {
+		if ( ! showInstalledPluginList && ! search && ! this.props.requestPluginsError ) {
 			const emptyContentData = this.getEmptyContentData();
 			if ( emptyContentData ) {
 				return (
@@ -381,6 +382,7 @@ export class PluginsMain extends Component {
 				isLoading={ this.props.requestingPluginsForSites }
 				isJetpackCloud={ this.props.isJetpackCloud }
 				searchTerm={ search }
+				requestPluginsError={ this.props.requestPluginsError }
 			/>
 		);
 
@@ -443,7 +445,7 @@ export class PluginsMain extends Component {
 			return <NavItem { ...attr }>{ filterItem.title }</NavItem>;
 		} );
 
-		const { isJetpackCloud, selectedSite, currentPlugins } = this.props;
+		const { isJetpackCloud, selectedSite } = this.props;
 
 		const pageTitle = isJetpackCloud
 			? this.props.translate( 'Plugins', { textOnly: true } )
@@ -457,6 +459,8 @@ export class PluginsMain extends Component {
 				{ count ? <Count count={ count } compact={ true } /> : null }
 			</span>
 		);
+
+		const currentPlugins = this.getCurrentPlugins();
 
 		return (
 			<>
@@ -516,18 +520,20 @@ export class PluginsMain extends Component {
 				</div>
 				<div className="plugins__main-content">
 					<div className="plugins__content-wrapper">
-						<div className="plugins__search">
-							<Search
-								hideFocus
-								isOpen
-								onSearch={ this.props.doSearch }
-								initialValue={ this.props.search }
-								hideClose={ ! this.props.search }
-								ref={ `url-search` }
-								analyticsGroup="Plugins"
-								placeholder={ this.props.translate( 'Search plugins' ) }
-							/>
-						</div>
+						{ currentPlugins?.length > 1 && (
+							<div className="plugins__search">
+								<Search
+									hideFocus
+									isOpen
+									onSearch={ this.props.doSearch }
+									initialValue={ this.props.search }
+									hideClose={ ! this.props.search }
+									ref={ `url-search` }
+									analyticsGroup="Plugins"
+									placeholder={ this.props.translate( 'Search plugins' ) }
+								/>
+							</div>
+						) }
 						{ this.renderPluginsContent() }
 					</div>
 				</div>
@@ -588,6 +594,7 @@ export default flow(
 				hasInstallPurchasedPlugins: hasInstallPurchasedPlugins,
 				isJetpackCloud,
 				breadcrumbs,
+				requestPluginsError: requestPluginsError( state ),
 			};
 		},
 		{

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -16,6 +16,7 @@ import './style.scss';
 interface Props {
 	plugins: Array< Plugin >;
 	isLoading: boolean;
+	requestError: boolean;
 	selectedSite: SiteDetails;
 	searchTerm: string;
 	isBulkManagementActive: boolean;
@@ -34,7 +35,8 @@ export default function PluginManagementV2( {
 	removePluginNotice,
 	updatePlugin,
 	isJetpackCloud,
-}: Props ): ReactElement {
+	requestError,
+}: Props ): ReactElement | null {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -107,6 +109,9 @@ export default function PluginManagementV2( {
 	];
 
 	if ( ! plugins.length && ! isLoading ) {
+		if ( requestError ) {
+			return null;
+		}
 		let emptyStateMessage = translate( 'No plugins found' );
 		if ( searchTerm ) {
 			emptyStateMessage = translate( 'No results found. Please try refining your search.' );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -577,6 +577,7 @@ export class PluginsList extends Component {
 					removePluginNotice={ this.removePluginDialog }
 					updatePlugin={ this.updatePlugin }
 					isJetpackCloud={ this.props.isJetpackCloud }
+					requestError={ this.props.requestPluginsError }
 				/>
 			</div>
 		);

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import {
 	ACTIVATE_PLUGIN,
 	DEACTIVATE_PLUGIN,
@@ -39,6 +40,7 @@ import {
 	PLUGIN_REMOVE_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getNetworkSites from 'calypso/state/selectors/get-network-sites';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
@@ -590,6 +592,7 @@ export function fetchAllPlugins() {
 
 		const receivePluginsDispatchFail = ( error ) => {
 			dispatch( { type: PLUGINS_ALL_REQUEST_FAILURE, error } );
+			dispatch( errorNotice( translate( 'Failed to retrieve plugins. Please try again later.' ) ) );
 		};
 
 		return wpcom.req

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -42,6 +42,27 @@ export function isRequestingAll( state = false, action ) {
 	}
 }
 
+/**
+ * Returns the updated requesting error state after an action has been dispatched.
+ * requestingError state tracks whether a network request is failed for all
+ * plugins on all sites.
+ *
+ * @param  {object} state  Current state
+ * @param  {object} action Action object
+ * @returns {object}        Updated state
+ */
+export function requestError( state = false, action ) {
+	switch ( action.type ) {
+		case PLUGINS_ALL_REQUEST:
+		case PLUGINS_ALL_REQUEST_SUCCESS:
+			return false;
+		case PLUGINS_ALL_REQUEST_FAILURE:
+			return true;
+		default:
+			return state;
+	}
+}
+
 /*
  * Tracks the requesting state for installed plugins on a per-site index.
  */
@@ -144,6 +165,7 @@ function plugin( state, action ) {
 export default combineReducers( {
 	isRequesting,
 	isRequestingAll,
+	requestError,
 	plugins,
 	status,
 } );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -56,6 +56,10 @@ export function isRequestingForAllSites( state ) {
 	return state.plugins.installed.isRequestingAll;
 }
 
+export function requestPluginsError( state ) {
+	return state.plugins.installed.requestError;
+}
+
 export function getPlugins( state, siteIds, pluginFilter ) {
 	let pluginList = reduce(
 		siteIds,


### PR DESCRIPTION
#### Proposed Changes

This PR changes how error scenarios are handled in the plugins' view. It now throws an error when the API fails and displays the cached data if available. 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/error-handling-for-plugins-api` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Plugins** in the side nav -> Open the network tab -> Block the plugins API as shown below

<img width="340" alt="Screenshot 2022-10-07 at 10 45 33 AM" src="https://user-images.githubusercontent.com/10586875/194472878-4806e74b-9ed5-412d-a8fa-b81234b2c696.png">

4. Refresh the page and verify it throws an error, and cached data is shown as below

<img width="1649" alt="Screenshot 2022-10-06 at 4 23 41 PM" src="https://user-images.githubusercontent.com/10586875/194472086-61851798-6ba2-4f64-b0a1-21929b78f82b.png">

5. Right-click on the refresh icon and click on `Empty cache and hard load` as shown below(you might have to do it a couple of times)

<img width="383" alt="Screenshot 2022-10-07 at 10 47 01 AM" src="https://user-images.githubusercontent.com/10586875/194473344-6b50e297-35d0-43bc-8d7f-ef6f13ef7874.png">

6. Verify it throws an error as shown below

<img width="1649" alt="Screenshot 2022-10-06 at 4 22 40 PM" src="https://user-images.githubusercontent.com/10586875/194472068-7e372df4-6daf-465f-9380-8bb58e380033.png">

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? 
- [X] ~~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [X] Have you checked for TypeScript, React or other console errors?
- [X] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [X] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Related to 1202619025189113-as-1202789398406899