### PR TITLE
Plugins: Make upsell nudge margins specific

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -14,6 +14,14 @@
 		padding-top: 60px;
 	}
 
+	.upsell-nudge {
+		margin-top: 16px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin: 16px;
+		}
+	}
+
 	.upsell-nudge.is-jetpack {
 		margin-top: 51px;
 		margin-bottom: -20px;
@@ -32,14 +40,6 @@ body.is-section-plugins.theme-default.color-scheme {
 .plugin__installed-on,
 .plugin-details__installed-on {
 	margin-bottom: 16px;
-}
-
-.upsell-nudge {
-	margin-top: 16px;
-
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 16px;
-	}
 }
 
 .plugin__installed-on {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -13,6 +13,16 @@
 	@media ( max-width: 660px ) {
 		padding-top: 60px;
 	}
+
+	.upsell-nudge.is-jetpack {
+		margin-top: 51px;
+		margin-bottom: -20px;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin-top: 86px;
+			margin-bottom: -50px;
+		}
+	}
 }
 
 body.is-section-plugins.theme-default.color-scheme {
@@ -22,16 +32,6 @@ body.is-section-plugins.theme-default.color-scheme {
 .plugin__installed-on,
 .plugin-details__installed-on {
 	margin-bottom: 16px;
-}
-
-.upsell-nudge.is-jetpack {
-	margin-top: 51px;
-	margin-bottom: -20px;
-
-	@include breakpoint-deprecated( "<660px" ) {
-		margin-top: 86px;
-		margin-bottom: -50px;
-	}
 }
 
 .upsell-nudge {


### PR DESCRIPTION
#### Proposed Changes

When we introduced some additional specific spacing for the Jetpack upsell banners in #61765, we broke upsell banners on pages that we render after we render the plugins page.

This PR improves the specificity so the margin changes apply only to the plugins page.

#### Testing Instructions

* Visit `/plugins/:site` for a site on a business plan.
* Navigate to `/settings/peformance/:site` from the Settings menu.
* Verify banner spacing is now correct.
* Verify #61765 testing instructions still work well, especially the spacing on the plugins page.

#### Preview

Before:
<img width="774" alt="Screenshot 2022-10-07 at 10 35 15" src="https://user-images.githubusercontent.com/8436925/194510765-f2a83411-a019-48ef-8819-301d22647a12.png">

After:
<img width="764" alt="Screenshot 2022-10-07 at 10 35 32" src="https://user-images.githubusercontent.com/8436925/194510760-f424a9d8-3548-40f2-b2e3-2fd21fddbb70.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1665074605761439-slack-C02FMH4G8