### PR TITLE
Connect `featured_image_email_enabled` option with its setting toggle

### DIFF
--- a/client/my-sites/site-settings/featured-image-toggle.jsx
+++ b/client/my-sites/site-settings/featured-image-toggle.jsx
@@ -3,8 +3,9 @@ import { ToggleControl } from '@wordpress/components';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 
 const FeaturedImageTemplateToggle = ( props ) => {
-	const { isRequestingSettings, isSavingSettings } = props;
+	const { isRequestingSettings, isSavingSettings, fields, handleAutosavingToggle } = props;
 	const isDisabled = isRequestingSettings || isSavingSettings;
+	const settingName = 'featured_image_email_enabled';
 
 	return (
 		<div className="featured-image-template-toggle-settings">
@@ -14,9 +15,9 @@ const FeaturedImageTemplateToggle = ( props ) => {
 			/>
 			<Card className="featured-image-template-toggle-card">
 				<ToggleControl /* TODO: Update props as needed. Currently the toggle does nothing */
-					checked={ false }
+					checked={ !! fields[ settingName ] }
 					disabled={ isDisabled }
-					onChange={ null }
+					onChange={ handleAutosavingToggle( settingName ) }
 					label="Enable Featured image in the New Post email template" /* TODO: this will need to be translated */
 				/>
 			</Card>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -103,6 +103,7 @@ class SiteSettingsFormWriting extends Component {
 					<FeaturedImageTemplateToggle
 						isSavingSettings={ isSavingSettings }
 						isRequestingSettings={ isRequestingSettings }
+						handleAutosavingToggle={ handleAutosavingToggle }
 						fields={ fields }
 					/>
 				) }
@@ -212,6 +213,7 @@ const getFormSettings = ( settings ) => {
 		'timezone_string',
 		'podcasting_category_id',
 		'wpcom_publish_posts_with_markdown',
+		'featured_image_email_enabled',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values


### PR DESCRIPTION
#### Proposed Changes

The proposed changes connect the newly-created site option `featured_image_email_enabled` with its user-facing toggle on the _Settings → Writing_ page:
![Markup on 2022-10-18 at 11:12:44](https://user-images.githubusercontent.com/25105483/196389009-0594d528-7fd0-4361-b978-55cf87e67cc6.png)

Please note:
- strings are not being translated on purpose - as the setting design is just temporary, waiting for the design to be ready
- the feature is available in the development environment only

TODOs:
- [x] site option needs to be exposed first: https://github.com/Automattic/jetpack/pull/26696
- [x] test with Simple, Atomic snd self-hosted

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the PR branch.
2. Navigate to the _Settings → Writing_ page.
3. Take a look at the Featured image toggle. It should be **disabled** by default.
4. Switch the toggle. It should save the new setting automatically.
5. Review that the setting is being correctly saved with the help of the [Developer Console](https://developer.wordpress.com/docs/api/console/). Example:
![Markup on 2022-10-18 at 11:31:33](https://user-images.githubusercontent.com/25105483/196393655-fdb70705-2a57-4a70-ae85-d5ae2049211f.png)

request format: `/sites/<SITE-ID>/settings`

Please note the setting may be "hidden" initially:
![Markup on 2022-10-18 at 11:32:25](https://user-images.githubusercontent.com/25105483/196394173-b7a5c806-3c81-4075-b974-a925eb1c4d96.png)

The above steps will work "right-of-the-box" for Simple sites. In order to test with Atomic or Jetpack site, the current Jetpack trunk build needs to be used. The reason for this is that while the related required PR (https://github.com/Automattic/jetpack/pull/26696) is already merged, it hasn't been released to production yet.

Jetpack build sync instructions that can help us: pdWQjU-77-p2.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68747