### PR TITLE
Help Center: add Calypso live to Help Center testing envs

### DIFF
--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-restricted-imports */
-import config from '@automattic/calypso-config';
+import config, { isCalypsoLive } from '@automattic/calypso-config';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 
 // function that tells us if we want to show the Help Center to the user, given that we're showing it to
 // only a certain percentage of users.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function shouldShowHelpCenterToUser( userId: number ) {
-	const isNonProdEnv = [ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) );
+	const isNonProdEnv =
+		[ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) ) || isCalypsoLive();
 
 	const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;


### PR DESCRIPTION
#### Proposed Changes

* This allows us to test the Help Center in Calypso using Calypso live links. Would make reviewing many PRs easier.
* Please keep testing the Help Center in ETK as we're used to. But if the change is clearly unrelated to the environment (like fixing a query caching config, changing a color, etc..) testing on Calypso live should suffice.

#### Testing Instructions

1. Open the live link below.
2. The Help Center should be there.