### PR TITLE
Add Tracks event for design render in Design Picker

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -303,7 +303,7 @@ const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerPr
 	const divTrackingRef = useTrackDesignView( {
 		category: `__generated_vertical_${ verticalId }`,
 		design,
-		isPremiumThemeAvailable: true,
+		isPremiumThemeAvailable: false,
 	} );
 
 	return (

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -300,7 +300,7 @@ const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerPr
 		use_screenshot_overrides: true,
 	} );
 
-	const divTrackingRef = useTrackDesignView( {
+	const trackingDivRef = useTrackDesignView( {
 		category: `__generated_vertical_${ verticalId }`,
 		design,
 		isPremiumThemeAvailable: false,
@@ -311,7 +311,7 @@ const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerPr
 			className={ classnames( 'design-button-container', 'design-button-container--is-generated', {
 				'design-button-container--is-generated--is-showing': isShowing,
 			} ) }
-			ref={ divTrackingRef }
+			ref={ trackingDivRef }
 		>
 			<div className="design-picker__design-option">
 				<button className="generated-design-thumbnail" onClick={ () => onPreview( design ) }>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -65,6 +65,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 
 interface TrackDesignViewProps {
 	category?: string | null;
+	className: string;
 	design: Design;
 	isPremiumThemeAvailable?: boolean;
 }
@@ -72,6 +73,7 @@ interface TrackDesignViewProps {
 const TrackDesignView: React.FC< TrackDesignViewProps > = ( {
 	category,
 	children,
+	className,
 	design,
 	isPremiumThemeAvailable,
 } ) => {
@@ -132,7 +134,7 @@ const TrackDesignView: React.FC< TrackDesignViewProps > = ( {
 	);
 
 	return (
-		<div className="track-design-view" ref={ wrapperDivRefCallback }>
+		<div className={ className } ref={ wrapperDivRefCallback }>
 			{ children }
 		</div>
 	);
@@ -256,23 +258,18 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	onSelect,
 	...props
 } ) => {
-	const isBlankCanvas = isBlankCanvasDesign( props.design );
-
-	const designButtonContents = isBlankCanvas ? (
-		<PatternAssemblerCta onButtonClick={ () => onSelect( props.design ) } />
-	) : (
-		<div className="design-button-container">
-			<DesignButton { ...props } />
-		</div>
-	);
+	if ( isBlankCanvasDesign( props.design ) ) {
+		return <PatternAssemblerCta onButtonClick={ () => onSelect( props.design ) } />;
+	}
 
 	return (
 		<TrackDesignView
+			className="design-button-container"
 			category={ category }
 			design={ props.design }
 			isPremiumThemeAvailable={ props.isPremiumThemeAvailable }
 		>
-			{ designButtonContents }
+			<DesignButton { ...props } />
 		</TrackDesignView>
 	);
 };
@@ -302,11 +299,13 @@ const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerPr
 	} );
 
 	return (
-		<div
-			key={ `generated-design__${ design.slug }` }
+		<TrackDesignView
+			category={ `__generated_vertical_${ verticalId }` }
 			className={ classnames( 'design-button-container', 'design-button-container--is-generated', {
 				'design-button-container--is-generated--is-showing': isShowing,
 			} ) }
+			design={ design }
+			isPremiumThemeAvailable={ true }
 		>
 			<div className="design-picker__design-option">
 				<button className="generated-design-thumbnail" onClick={ () => onPreview( design ) }>
@@ -319,7 +318,7 @@ const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerPr
 					</span>
 				</button>
 			</div>
-		</div>
+		</TrackDesignView>
 	);
 };
 
@@ -338,16 +337,14 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 } ) => (
 	<div className="design-picker__grid">
 		{ designs.map( ( design ) => (
-			<TrackDesignView category="__generated" design={ design }>
-				<GeneratedDesignButtonContainer
-					key={ `generated-design__${ design.slug }` }
-					design={ design }
-					locale={ locale }
-					verticalId={ verticalId }
-					isShowing
-					onPreview={ onPreview }
-				/>
-			</TrackDesignView>
+			<GeneratedDesignButtonContainer
+				key={ `generated-design__${ design.slug }` }
+				design={ design }
+				locale={ locale }
+				verticalId={ verticalId }
+				isShowing
+				onPreview={ onPreview }
+			/>
 		) ) }
 	</div>
 );
@@ -419,16 +416,14 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					/>
 				) ) }
 				{ generatedDesigns.map( ( design ) => (
-					<TrackDesignView design={ design }>
-						<GeneratedDesignButtonContainer
-							key={ `generated-design__${ design.slug }` }
-							design={ design }
-							locale={ locale }
-							verticalId={ verticalId }
-							isShowing={ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG }
-							onPreview={ onPreview }
-						/>
-					</TrackDesignView>
+					<GeneratedDesignButtonContainer
+						key={ `generated-design__${ design.slug }` }
+						design={ design }
+						locale={ locale }
+						verticalId={ verticalId }
+						isShowing={ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG }
+						onPreview={ onPreview }
+					/>
 				) ) }
 			</div>
 		</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -64,19 +64,19 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 };
 
 interface TrackDesignViewProps {
-	categorization?: string | null;
+	category?: string | null;
 	design: Design;
 	isPremiumThemeAvailable?: boolean;
 }
 
 const TrackDesignView: React.FC< TrackDesignViewProps > = ( {
-	categorization,
+	category,
 	design,
 	isPremiumThemeAvailable,
 } ) => {
 	useEffect( () => {
 		recordTracksEvent( 'calypso_design_picker_design_display', {
-			category: categorization,
+			category,
 			design_type: design.design_type,
 			is_premium: design.is_premium,
 			is_premium_available: isPremiumThemeAvailable,
@@ -218,7 +218,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	return (
 		<>
 			<TrackDesignView
-				categorization={ categorization }
+				category={ categorization }
 				design={ props.design }
 				isPremiumThemeAvailable={ props.isPremiumThemeAvailable }
 			/>


### PR DESCRIPTION
#### Proposed Changes

* This PR explores adding a new `calypso_design_picker_design_display` Tracks event when each design option is rendered in the Design Picker, as it makes it easier to see what options a user actually saw in the design picker
* The proposed event includes the following properties:
  - `category` - the design picker category at the time of the render (which is empty for the "Show All" listing)
  - `design_type` - the type of the design (pulled from the `design` object being rendered)
  - `is_premium` - whether the design is a premium design
  - `is_premium_available` - whether the premium design is available to the user already (i.e. they have the necessary plan)
  - `slug` - the theme slug

The main reason for this new event is to support analysis around the following items:
 - How often are users seeing premium themes?
 - How often are specific premium themes being shown?
 - How often are users able to use premium themes without a plan upgrade?
 - How often do they actually pick a premium theme? (This will be broken down by when they're able to use the theme immediately or not.)
 - How often do users pick themes from a more specific category or vs the all themes listing?

At present, we only fire the event if more than 60% of the theme preview is visible.

#### Testing Instructions

* Set up your browser so you can easily see Tracks events -- I would strongly recommend the [Tracks Vigilante Chrome extension](https://github.com/Automattic/tracks-chrome-extension)
* Open the Calypso live branch for this PR (or via your local Calypso environment)
* Navigate to the Design Picker for a site with a supported vertical specified on the vertical step (e.g. Travel and Transportation) -- you can navigate directly there via `/setup/site-setup/designSetup?siteSlug=[your-site-slug]`
* Inspect the Tracks events logged for the page view and confirm you see a number of `calypso_design_picker_design_display` events for the themes that are mostly visible at the top of the page. Also verify that the events have valid properties
* Scroll down the page, as you see most of each row, verify that you see valid additional Tracks events for each of the themes on that row
* Scroll back up the page, and verify that you don't re-trigger events for any themes
* Switch the category to limit the list
* Verify that events are sent with appropriate values for the smaller list of themes that are initially visible - the main change should be that the `category` field is specified
* Scroll down and up and verify that you only get events when themes first become visible
* Switch to another new category again and verify that you get events for the visible themes

_Note:_ There are some cases where we don't log events, primarily when switching back to a previously viewed category where the same components are re-rendered. This is OK, as we will already have logged the necessary events, but it complicates the testing instructions!

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
