### PR TITLE
Tailored Flows: Update intro step CTA text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -24,14 +24,14 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				__( 'You’re 3 minutes away from<br />a launch-ready Newsletter. ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Set up your Newsletter' ),
+			buttonText: __( 'Get started' ),
 		},
 		'link-in-bio': {
 			title: createInterpolateElement(
 				__( 'You’re 3 minutes away from<br />a stand-out Link in Bio site.<br />Ready? ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Set up your Link in Bio' ),
+			buttonText: __( 'Get started' ),
 		},
 	};
 


### PR DESCRIPTION
## Proposed Changes

Change Intro step Call to action button text.

## Testing Instructions

- Run this branch and navigate to `/setup/intro?flow=link-in-bio` and `/setup/intro?flow=newsletter`
- The button text should be "Get Started" 

<img width="624" alt="image" src="https://user-images.githubusercontent.com/2653810/194519651-caac1f45-f71c-460a-a51c-99ce43dda960.png">


Related to #68751
Fixes #68751
