### PR TITLE
Sites Management Page: Launch nag icon should be bolder

### DIFF
--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -24,13 +24,14 @@ const SiteLaunchDonutProgress = styled( SiteLaunchDonutBase )( {
 
 const SiteLaunchDonutContainer = styled.div( {
 	position: 'relative',
-	width: '13px',
-	marginTop: '3px',
-	marginRight: '4px',
+	height: '25px',
 } );
 
 const SiteLaunchNagLink = styled.a( {
 	display: 'flex',
+	alignItems: 'center',
+	gap: '25px',
+	marginLeft: '-5px',
 	fontSize: '12px',
 	lineHeight: '20px',
 	whiteSpace: 'nowrap',
@@ -42,17 +43,32 @@ const SiteLaunchNagLink = styled.a( {
 const SiteLaunchDonut = () => {
 	return (
 		<SiteLaunchDonutContainer>
-			<SiteLaunchDonutProgress viewBox="0 0 26 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M0 13.5C0 20.6797 5.8203 26.5 13 26.5C20.1797 26.5 26 20.6797 26 13.5C26 6.3203 20.1797 0.5 13 0.5V2.5C19.0751 2.5 24 7.42487 24 13.5C24 19.5751 19.0751 24.5 13 24.5C6.92487 24.5 2 19.5751 2 13.5H0Z"
-					fill="currentColor"
-				/>
+			<SiteLaunchDonutProgress
+				width="25"
+				height="25"
+				viewBox="0 0 27 27"
+				version="1.1"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<circle
+					r="7"
+					cx="13.5"
+					cy="13.5"
+					fill="transparent"
+					stroke="#DCDCDE"
+					strokeWidth="3"
+				></circle>
+				<circle
+					r="7"
+					cx="13.5"
+					cy="13.5"
+					fill="transparent"
+					strokeDashoffset="-32.9823"
+					strokeDasharray="43.9823 11"
+					stroke="currentColor"
+					strokeWidth="3"
+				></circle>
 			</SiteLaunchDonutProgress>
-			<SiteLaunchDonutBase viewBox="0 0 26 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<circle cx="13" cy="13.5" r="12" stroke="#DCDCDE" strokeWidth="2" />
-			</SiteLaunchDonutBase>
 		</SiteLaunchDonutContainer>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68623

#### Proposed Changes

* Increase donut `stroke-width` by `1px` so it is now `3px`. This increases the overall size so I have reduced the `size` by `2px`. I wasn't sure how to modify the existing path so I switched to a pair of `circle` elements and used `strokeDasharray` and `strokeDashoffset` on the progress layer.  

![image](https://user-images.githubusercontent.com/6851384/194524691-c75d6943-0dcc-459a-a90c-4f6f9c1113e7.png)
![image](https://user-images.githubusercontent.com/6851384/194524710-9d6db42a-87a8-42f4-83ed-cff7794f9b77.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or load the Calypso Live link and see what you think. Try it on as many monitors are possible. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
