### PR TITLE
Tailored flows: change intro CTA to Get started

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -11,7 +11,6 @@ interface Props {
 interface IntroContent {
 	[ key: string ]: {
 		title: WPElement;
-		buttonText: string;
 	};
 }
 
@@ -24,14 +23,12 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				__( 'You’re 3 minutes away from<br />a launch-ready Newsletter. ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Set up your Newsletter' ),
 		},
 		'link-in-bio': {
 			title: createInterpolateElement(
 				__( 'You’re 3 minutes away from<br />a stand-out Link in Bio site.<br />Ready? ' ),
 				{ br: <br /> }
 			),
-			buttonText: __( 'Set up your Link in Bio' ),
 		},
 	};
 
@@ -41,7 +38,7 @@ const Intro: React.FC< Props > = ( { onSubmit, flowName } ) => {
 				<span>{ introContent[ flowName ].title }</span>
 			</h1>
 			<Button className="intro__button" primary onClick={ onSubmit }>
-				{ introContent[ flowName ].buttonText }
+				{ __( 'Get started' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
#### Testing Instructions

1. Go to the live link below and visit both flows (/setup?flow=newsletter, /setup?flow=link-in-bio). 
2. The CTA should be "Get started".

Once we get a response here: pbAok1-3nH-p2#comment-5614. We can merge.