### PR TITLE
Fix styles for ellipse menu in reader

### DIFF
--- a/client/blocks/conversation-follow-button/style.scss
+++ b/client/blocks/conversation-follow-button/style.scss
@@ -83,13 +83,28 @@ button.conversation-follow-button {
 			}
 		}
 
-		&.popover__menu-item:hover {
-			.conversation-follow-button__label {
+		&.popover__menu-item {
+			&:hover,
+			&:focus {
 				color: white;
-			}
 
-			.gridicon, .reader-follow-conversation, .reader-following-conversation {
-				fill: var( --color-text-inverted );
+				.gridicon, .reader-follow-conversation, .reader-following-conversation {
+					color: var( --color-text-inverted );
+				}
+
+				svg.reader-external path {
+					fill: var( --color-text-inverted );
+				}
+
+				svg.reader-follow-conversation path, svg.reader-following-conversation path {
+					fill: none;
+					stroke: var( --color-text-inverted );
+
+					&.status {
+						fill: var( --color-primary );
+						stroke: none;
+					}
+				}
 			}
 		}
 	}

--- a/client/components/popover-menu/style.scss
+++ b/client/components/popover-menu/style.scss
@@ -33,7 +33,7 @@
 	&.is-selected,
 	&:hover,
 	&:focus {
-		background-color: var(--color-primary);
+		background-color: var( --color-primary );
 		border: 0;
 		box-shadow: none;
 		color: white;

--- a/client/components/popover-menu/style.scss
+++ b/client/components/popover-menu/style.scss
@@ -31,7 +31,8 @@
 	}
 
 	&.is-selected,
-	&:hover {
+	&:hover,
+	&:focus {
 		background-color: var(--color-primary);
 		border: 0;
 		box-shadow: none;


### PR DESCRIPTION
The follow conversation label looks hidden when the ellipse menu is first opened. Once the menu is hovered over it is corrected. I think some regression here slipped in. This PR updates the style for the ellipse menu and the conversation button to be consistent, in particular how we use the focus state.

BEFORE:
<img width="198" alt="Screenshot 2022-10-06 at 18 03 10" src="https://user-images.githubusercontent.com/5560595/194529462-ee6e9002-e657-40f2-acc5-73953a24a9f3.png">

AFTER:
<img width="238" alt="Screenshot 2022-10-07 at 11 07 48" src="https://user-images.githubusercontent.com/5560595/194529605-22778566-bf2e-405c-8ca0-8afe7f8f9933.png">

Ref - https://github.com/Automattic/wp-calypso/issues/68604
