### PR TITLE
Encapsulate all promote post assets on the main wrapper

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post/components/campaign-item/style.scss
@@ -1,104 +1,109 @@
-.campaign-item__foldable-card {
-	margin-bottom: 0;
+.promote-post {
 
-	.campaign-item__header {
-		display: flex;
-		justify-content: space-between;
-		width: 100%;
-		align-items: center;
+	.campaign-item__foldable-card {
+		margin-bottom: 0;
 
-		.campaign-item__header-image {
-			height: 60px;
-			width: 80px;
-			margin-right: 20px;
+		.campaign-item__header {
+			display: flex;
+			justify-content: space-between;
+			width: 100%;
+			align-items: center;
 
-			img {
-				object-fit: cover;
+			.campaign-item__header-image {
 				height: 60px;
 				width: 80px;
-			}
-		}
+				margin-right: 20px;
 
-		.campaign-item__header-content {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			justify-content: space-around;
-
-			.campaign-item__display-name {
-				color: var(--color-neutral-50);
-				font-size: 0.75rem;
+				img {
+					object-fit: cover;
+					height: 60px;
+					width: 80px;
+				}
 			}
 
-			.campaign-item__header-title {
-				font-weight: 500;
-				font-size: 1.25rem;
-				margin: 4px 0;
-			}
-
-			.campaign-item__header-status .badge {
-				font-size: 0.75rem;
-			}
-		}
-	}
-
-	.campaign-item__notice {
-		margin-left: 0;
-
-		.campaign-item__notice-icon {
-			margin-right: 16px;
-			margin-left: 8px;
-			vertical-align: middle;
-			padding-bottom: 3px;
-		}
-
-		a {
-			color: var(--color-text-subtle);
-			text-decoration: underline;
-		}
-	}
-
-	.campaign-item__section {
-		border-bottom: #dcdcde thin solid;
-
-		.campaign-item__row {
-			display: flex;
-			flex-flow: row wrap;
-			width: 100%;
-			margin-top: 20px;
-			margin-bottom: 20px;
-
-			.campaign-item__column {
+			.campaign-item__header-content {
+				flex: 1;
 				display: flex;
 				flex-direction: column;
-				flex: 1;
+				justify-content: space-around;
 
-				.campaign-item__block_label {
+				.campaign-item__display-name {
+					color: var(--color-neutral-50);
 					font-size: 0.75rem;
 				}
 
-				.campaign-item__block_value {
-					font-size: 1rem;
+				.campaign-item__header-title {
+					font-weight: 500;
+					font-size: 1.25rem;
+					margin: 4px 0;
 				}
 
-				.campaign-item__reach-value,
-				.campaign-item__clicks-value {
-					font-size: 1.5rem;
-					font-weight: 600;
+				.campaign-item__header-status .badge {
+					font-size: 0.75rem;
 				}
 			}
 		}
+
+		.campaign-item__notice {
+			margin-left: 0;
+
+			.campaign-item__notice-icon {
+				margin-right: 16px;
+				margin-left: 8px;
+				vertical-align: middle;
+				padding-bottom: 3px;
+			}
+
+			a {
+				color: var(--color-text-subtle);
+				text-decoration: underline;
+			}
+		}
+
+		.campaign-item__section {
+			border-bottom: #dcdcde thin solid;
+
+			.campaign-item__row {
+				display: flex;
+				flex-flow: row wrap;
+				width: 100%;
+				margin-top: 20px;
+				margin-bottom: 20px;
+
+				.campaign-item__column {
+					display: flex;
+					flex-direction: column;
+					flex: 1;
+
+					.campaign-item__block_label {
+						font-size: 0.75rem;
+					}
+
+					.campaign-item__block_value {
+						font-size: 1rem;
+					}
+
+					.campaign-item__reach-value,
+					.campaign-item__clicks-value {
+						font-size: 1.5rem;
+						font-weight: 600;
+					}
+				}
+			}
+		}
+
+		.campaign-item__payment-and-action {
+			display: flex;
+			flex-direction: row-reverse;
+			margin-top: 20px;
+			margin-bottom: 10px;
+		}
+
+		.campaign-item__target-value a {
+			word-break: break-all;
+			color: var(--color-text);
+		}
 	}
 
-	.campaign-item__payment-and-action {
-		display: flex;
-		flex-direction: row-reverse;
-		margin-top: 20px;
-		margin-bottom: 10px;
-	}
 
-	.campaign-item__target-value a {
-		word-break: break-all;
-		color: var(--color-text);
-	}
 }

--- a/client/my-sites/promote-post/components/campaigns-empty/style.scss
+++ b/client/my-sites/promote-post/components/campaigns-empty/style.scss
@@ -1,8 +1,10 @@
-.campaigns-empty__container {
-	background: white;
-	padding: 50px;
+.promote-post {
+	.campaigns-empty__container {
+		background: #fff;
+		padding: 50px;
 
-	.empty-content__action {
-		margin-left: 15px;
+		.empty-content__action {
+			margin-left: 15px;
+		}
 	}
 }

--- a/client/my-sites/promote-post/components/campaigns-list/style.scss
+++ b/client/my-sites/promote-post/components/campaigns-list/style.scss
@@ -1,4 +1,7 @@
-.posts-list__loading-container {
-	display: flex;
-	justify-content: center;
+.promote-post {
+	.posts-list__loading-container {
+		display: flex;
+		justify-content: center;
+	}
+
 }

--- a/client/my-sites/promote-post/components/empty-promotion-list/style.scss
+++ b/client/my-sites/promote-post/components/empty-promotion-list/style.scss
@@ -1,10 +1,13 @@
+.promote-post {
 
-.empty-promotion-list__container {
-	text-align: center;
-	margin-top: 80px;
-	.empty-promotion-list__title {
-		font-weight: 700;
-		font-size: $font-title-small;
-		margin-bottom: 20px;
+	.empty-promotion-list__container {
+		text-align: center;
+		margin-top: 80px;
+		.empty-promotion-list__title {
+			font-weight: 700;
+			font-size: $font-title-small;
+			margin-bottom: 20px;
+		}
 	}
+
 }

--- a/client/my-sites/promote-post/components/post-item/style.scss
+++ b/client/my-sites/promote-post/components/post-item/style.scss
@@ -1,96 +1,99 @@
 $post-item-background-color: var(--color-surface);
 
-.post-item__panel {
-	box-sizing: border-box;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 0 16px;
-	background: $post-item-background-color;
-}
-
-.post-item__detail {
-	position: relative;
-	width: calc(100% - 50px);
-	margin-right: auto;
-	word-break: break-word;
-	word-wrap: break-word;
-	padding: 16px 0;
-}
-
-.card.is-compact {
-	padding: 0 16px;
-}
-
-.post-item__title {
-	margin: 0;
-	padding: 0 0 2px;
-	font-weight: 600;
-	font-size: $font-title-small;
-	line-height: 1.2;
-}
-
-.post-item__meta,
-.post-item__post-type {
-	font-size: $font-body-extra-small;
-	color: var(--color-text-subtle);
-}
-
-.post-item__meta-time-status {
-	display: inline-block;
-	margin-right: 16px;
-}
-
-.post-item__post-type {
-	margin-right: 16px;
-}
-
-/* Force all items in the meta section to be middle-aligned */
-.post-item__meta a,
-.post-item__meta div,
-.post-item__meta li,
-.post-item__meta span,
-.post-item__meta ul {
-	display: inline-block;
-	vertical-align: bottom;
-}
-
-a.post-item__title-link,
-a.post-item__title-link:visited {
-	color: var(--color-neutral-70);
-	display: block;
-	padding-bottom: 2px;
-	padding-right: 8px;
-
-	&:hover {
-		color: var(--color-neutral-50);
+.promote-post {
+	.post-item__detail {
+		position: relative;
+		width: calc(100% - 50px);
+		margin-right: auto;
+		word-break: break-word;
+		word-wrap: break-word;
+		padding: 16px 0;
 	}
 
-	.post-item__panel.is-untitled & {
+
+	.post-item__title {
+		margin: 0;
+		padding: 0 0 2px;
+		font-weight: 600;
+		font-size: $font-title-small;
+		line-height: 1.2;
+	}
+
+	.post-item__meta,
+	.post-item__post-type {
+		font-size: $font-body-extra-small;
 		color: var(--color-text-subtle);
-		font-style: italic;
 	}
-}
 
-.post-item__post-thumbnail-wrapper {
-	display: block;
-	position: relative;
-	width: 80px;
-	align-self: stretch;
-	overflow: hidden;
-	margin: 8px 0;
-}
+	.post-item__meta-time-status {
+		display: inline-block;
+		margin-right: 16px;
+	}
 
-.post-item__post-thumbnail {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	height: 100%;
-	max-height: 80px;
-	max-width: none;
-}
+	.post-item__post-type {
+		margin-right: 16px;
+	}
 
-.post-item__promote-link {
-	margin-left: 32px;
+	/* Force all items in the meta section to be middle-aligned */
+	.post-item__meta a,
+	.post-item__meta div,
+	.post-item__meta li,
+	.post-item__meta span,
+	.post-item__meta ul {
+		display: inline-block;
+		vertical-align: bottom;
+	}
+
+	a.post-item__title-link,
+	a.post-item__title-link:visited {
+		color: var(--color-neutral-70);
+		display: block;
+		padding-bottom: 2px;
+		padding-right: 8px;
+
+		&:hover {
+			color: var(--color-neutral-50);
+		}
+
+		.post-item__panel.is-untitled & {
+			color: var(--color-text-subtle);
+			font-style: italic;
+		}
+	}
+
+	.post-item__panel {
+		box-sizing: border-box;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0 16px;
+		background: $post-item-background-color;
+		&.card.is-compact {
+			padding: 0 16px;
+		}
+	}
+
+	.post-item__post-thumbnail-wrapper {
+		display: block;
+		position: relative;
+		width: 80px;
+		align-self: stretch;
+		overflow: hidden;
+		margin: 8px 0;
+	}
+
+	.post-item__post-thumbnail {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		height: 100%;
+		max-height: 80px;
+		max-width: none;
+	}
+
+	.post-item__promote-link {
+		margin-left: 32px;
+	}
+
 }

--- a/client/my-sites/promote-post/components/posts-list-banner/style.scss
+++ b/client/my-sites/promote-post/components/posts-list-banner/style.scss
@@ -1,26 +1,29 @@
-.posts-list-banner__container {
-	padding: 30px;
-	display: flex;
-	align-items: center;
-	margin-bottom: 17px;
-	border: 1px solid var(--color-border-subtle);
-	border-radius: 2px;
-	background-color: var(--color-surface);
-	color: var(--color-text);
-
-	.posts-list-banner__img {
-		margin-right: 40px;
-	}
-
-	.posts-list-banner__title {
-		font-size: 2rem;
-		font-weight: bold;
-		margin-bottom: 14px;
-	}
-
-	.posts-list-banner__footer {
+.promote-post {
+	.posts-list-banner__container {
+		padding: 30px;
 		display: flex;
 		align-items: center;
-		margin-top: 20px;
+		margin-bottom: 17px;
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 2px;
+		background-color: var(--color-surface);
+		color: var(--color-text);
+
+		.posts-list-banner__img {
+			margin-right: 40px;
+		}
+
+		.posts-list-banner__title {
+			font-size: 2rem;
+			font-weight: bold;
+			margin-bottom: 14px;
+		}
+
+		.posts-list-banner__footer {
+			display: flex;
+			align-items: center;
+			margin-top: 20px;
+		}
 	}
+
 }

--- a/client/my-sites/promote-post/components/posts-list/style.scss
+++ b/client/my-sites/promote-post/components/posts-list/style.scss
@@ -1,5 +1,8 @@
-.campaigns-list__loading-container {
-	display: flex;
-	justify-content: center;
-}
+.promote-post {
+	.campaigns-list__loading-container {
+		display: flex;
+		justify-content: center;
+	}
 
+
+}


### PR DESCRIPTION
#### Proposed Changes

* Encapsulate all CSS styles in promote post in the .promote-post wrapper to avoid leakage

#### Testing Instructions

- Visit https://wordpress.com/advertising section with cleared cache  (open page, press shift+refresh)
- Go to Settings -> Performance, or pages list, or anything with .cards.
- Note how card components just looks good, with no padding issues.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
