### PR TITLE
WPCOM SSH: Add nistp384 key type to list of allowed types

### DIFF
--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -5,6 +5,7 @@ export const SSH_KEY_FORMATS = [
 	'ssh-rsa',
 	'ssh-ed25519',
 	'ecdsa-sha2-nistp256',
+	'ecdsa-sha2-nistp384',
 	'ecdsa-sha2-nistp521',
 ] as const;
 


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to add the nistp384 SSH key type to the list of allowed types. This key type is supported now (1023-gh-Automattic/dotcom-forge) , was added under D89319-code.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open My Profile -> Security -> SSH Key
2. Confirm that both placeholder message and invalid key type validation message include a list of all allowed key types:
- ssh-rsa
- ssh-ed25519
- ecdsa-sha2-nistp256
- ecdsa-sha2-nistp384
- ecdsa-sha2-nistp521

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1035-gh-Automattic/dotcom-forge