### PR TITLE
Tools: CLI script to search for feature flags

### DIFF
--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -12,14 +12,8 @@ async function getConfigFeatures( config ) {
 }
 
 function calcLongestConfig( result ) {
-	let longestConfig = '';
-	for ( const item of result ) {
-		if ( item.config.length > longestConfig.length ) {
-			longestConfig = item.config;
-		}
-	}
-
-	return longestConfig.length;
+	const configLengths = result.map( ( item ) => item.config.length );
+	return Math.max( ...configLengths );
 }
 
 function getPadding( count ) {

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -106,6 +106,7 @@ ${ chalk.bgBlue( '\tyarn feature-search plugin' ) }
 
 ${ chalk.cyan( 'Example: Searching by regex' ) }
 ${ chalk.bgBlue( `\tyarn feature-search 'bundl(e|ing)'` ) }
+${ chalk.cyan.italic( 'Note: Regular expression searches should be surrounded by quotes.' ) }
 	`;
 
 	console.log( helpText );

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -127,18 +127,16 @@ const main = async () => {
 	for ( const key in results ) {
 		const keys = [];
 
-		for ( const item of results[ key ] ) {
-			keys.push( item.config );
-		}
+		const knownConfigs = results[ key ].map( ( item ) => item.config );
 
-		for ( const config of configs ) {
-			if ( ! keys.includes( config ) ) {
-				results[ key ].push( {
-					config,
-					set: 'NA',
-				} );
-			}
-		}
+		const missingConfigs = configs.filter( ( config ) => ! knownConfigs.includes( config ) );
+
+		missingConfigs.forEach( ( missingConfig ) => {
+			results[ key ].push( {
+				config,
+				set: null, // or 'NA'
+			} );
+		} );
 	}
 
 	outputResults( results );

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -63,6 +63,8 @@ function outputResults( results ) {
 				setStr = chalk.green( set );
 			} else if ( set === false ) {
 				setStr = chalk.red( set );
+			} else if ( set === null ) {
+				setStr = chalk.yellow( '(not set)' );
 			} else {
 				setStr = chalk.yellow( set );
 			}

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -111,7 +111,8 @@ try {
 	console.log( chalk.red( `Error processing search term '${ process.argv[ 2 ] }'` ) );
 	console.log(
 		chalk.red(
-			'\nPlease make sure your search is a valid regular expression or does not contain any special characters (for simple string searches).'
+			'\nPlease make sure your search is a valid regular expression or does not contain any special characters (for simple string searches).',
+			'\n[' + e.name + '] ' + e.message;
 		)
 	);
 	process.exit( 1 );

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -104,7 +104,18 @@ ${ chalk.bgBlue( `\tyarn feature-search 'bundl(e|ing)'` ) }
 	process.exit( 1 );
 }
 
-const searchRe = new RegExp( process.argv[ 2 ], 'g' );
+let searchRe = null;
+try {
+	searchRe = new RegExp( process.argv[ 2 ], 'g' );
+} catch ( e ) {
+	console.log( chalk.red( `Error processing search term '${ process.argv[ 2 ] }'` ) );
+	console.log(
+		chalk.red(
+			'\nPlease make sure your search is a valid regular expression or does not contain any special characters (for simple string searches).'
+		)
+	);
+	process.exit( 1 );
+}
 
 const main = async () => {
 	const results = {};

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -119,10 +119,11 @@ try {
 } catch ( e ) {
 	console.log( chalk.red( `Error processing search term '${ process.argv[ 2 ] }'` ) );
 	console.log(
-		chalk.red(
-			'\nPlease make sure your search is a valid regular expression or does not contain any special characters (for simple string searches).',
-			'\n[' + e.name + '] ' + e.message;
-		)
+		chalk.red( `
+Please make sure your search is a valid regular expression or does not contain any special characters (for simple string searches).
+
+[${ e.name }] ${ e.message }
+		` )
 	);
 	process.exit( 1 );
 }

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -39,6 +39,22 @@ function sortResult( result ) {
 	} );
 }
 
+function getFormattedFeatureString( set ) {
+	if ( set === true ) {
+		return chalk.green( set );
+	}
+
+	if ( set === false ) {
+		return chalk.red( set );
+	}
+
+	if ( set === null ) {
+		return chalk.yellow( '(not set)' );
+	}
+
+	return chalk.yellow( set );
+}
+
 function outputResults( results ) {
 	const resultKeys = Object.keys( results ).sort();
 
@@ -57,17 +73,7 @@ function outputResults( results ) {
 		for ( const item of result ) {
 			const { config, set } = item;
 			const configStr = chalk.cyan( `\t${ config }:` );
-
-			let setStr = '';
-			if ( set === true ) {
-				setStr = chalk.green( set );
-			} else if ( set === false ) {
-				setStr = chalk.red( set );
-			} else if ( set === null ) {
-				setStr = chalk.yellow( '(not set)' );
-			} else {
-				setStr = chalk.yellow( set );
-			}
+			const setStr = getFormattedFeatureString( set );
 
 			console.log( `${ configStr }${ getPadding( maxLength - config.length + 5 ) }${ setStr }` );
 		}

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -31,7 +31,7 @@ function sortResult( result ) {
 			return -1;
 		}
 
-		if ( a.config > b ) {
+		if ( a.config > b.config ) {
 			return 1;
 		}
 

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -88,16 +88,16 @@ const configs = [
 
 if ( process.argv.length !== 3 ) {
 	const helpText = `
-${ chalk.yellow.bold( 'Usage: node bin/config-check.js {flag-search}' ) }
+${ chalk.yellow.bold( 'Usage: yarn feature-search {flag-search}' ) }
 ${ chalk.cyan(
-	'\nThis script makes it easy to search for particular feature flags across config environments. The value of {flag-search} can be a simple string or a regular expression.'
+	'\nThis script makes it easy to search for particular feature flags across config environments. The value of {flag-search} can be a simple string (letters and numbers, no special characters) or a valid regular expression.'
 ) }
 
 ${ chalk.cyan( 'Example: Searching by simple string' ) }
-${ chalk.bgBlue( '\tnode bin/feature-search.js plugin' ) }
+${ chalk.bgBlue( '\tyarn feature-search plugin' ) }
 
 ${ chalk.cyan( 'Example: Searching by regex' ) }
-${ chalk.bgBlue( `\tnode bin/feature-search.js 'bundl(e|ing)'` ) }
+${ chalk.bgBlue( `\tyarn feature-search 'bundl(e|ing)'` ) }
 	`;
 
 	console.log( helpText );

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -1,0 +1,153 @@
+#! /usr/env/bin node
+
+const fs = require( 'fs' );
+const chalk = require( 'chalk' );
+
+async function getConfigFeatures( config ) {
+	const file = `${ __dirname }/../config/${ config }.json`;
+	const json = await fs.readFileSync( file, 'utf8' );
+	const data = JSON.parse( json );
+
+	return data.features;
+}
+
+function calcLongestConfig( result ) {
+	let longestConfig = '';
+	for ( const item of result ) {
+		if ( item.config.length > longestConfig.length ) {
+			longestConfig = item.config;
+		}
+	}
+
+	return longestConfig.length;
+}
+
+function getPadding( count ) {
+	let padding = '';
+	for ( let i = 0; i < count; i++ ) {
+		padding += ' ';
+	}
+
+	return padding;
+}
+
+function sortResult( result ) {
+	result.sort( ( a, b ) => {
+		if ( a.config < b.config ) {
+			return -1;
+		}
+
+		if ( a.config > b ) {
+			return 1;
+		}
+
+		return 0;
+	} );
+}
+
+function outputResults( results ) {
+	const resultKeys = Object.keys( results ).sort();
+
+	for ( const key of resultKeys ) {
+		const result = results[ key ];
+		const maxLength = calcLongestConfig( result );
+
+		sortResult( result );
+
+		console.log( chalk.white.bgBlue.bold( key ) );
+		for ( const item of result ) {
+			const { config, set } = item;
+			const configStr = chalk.cyan( `\t${ config }:` );
+
+			let setStr = '';
+			if ( set === true ) {
+				setStr = chalk.green( set );
+			} else if ( set === false ) {
+				setStr = chalk.red( set );
+			} else {
+				setStr = chalk.yellow( set );
+			}
+
+			console.log( `${ configStr }${ getPadding( maxLength - config.length + 5 ) }${ setStr }` );
+		}
+		console.log( '' );
+	}
+}
+
+const configs = [
+	'development',
+	'jetpack-cloud-development',
+	'jetpack-cloud-horizon',
+	'jetpack-cloud-production',
+	'jetpack-cloud-stage',
+	'horizon',
+	'production',
+	'stage',
+	'test',
+	'wpcalypso',
+];
+
+if ( process.argv.length !== 3 ) {
+	const helpText = `
+${ chalk.yellow.bold( 'Usage: node bin/config-check.js {flag-search}' ) }
+${ chalk.cyan(
+	'\nThis script makes it easy to search for particular feature flags across config environments. The value of {flag-search} can be a simple string or a regular expression.'
+) }
+
+${ chalk.cyan( 'Example: Searching by simple string' ) }
+${ chalk.bgBlue( '\tnode bin/feature-search.js plugin' ) }
+
+${ chalk.cyan( 'Example: Searching by regex' ) }
+${ chalk.bgBlue( `\tnode bin/feature-search.js 'bundl(e|ing)'` ) }
+	`;
+
+	console.log( helpText );
+	process.exit( 1 );
+}
+
+const searchRe = new RegExp( process.argv[ 2 ], 'g' );
+
+const main = async () => {
+	const results = {};
+
+	// Find all of the matching flags in each config file.
+	for ( const config of configs ) {
+		const features = await getConfigFeatures( config );
+
+		for ( const flag in features ) {
+			if ( flag.match( searchRe ) ) {
+				if ( ! results.hasOwnProperty( flag ) ) {
+					results[ flag ] = [];
+				}
+
+				results[ flag ].push( {
+					config,
+					set: features[ flag ],
+				} );
+			}
+		}
+	}
+
+	// Add any configs that aren't part of the result set because they didn't have a flag match.
+	// This ensures that our output is the same for each flag.
+	for ( const key in results ) {
+		const keys = [];
+
+		for ( const item of results[ key ] ) {
+			keys.push( item.config );
+		}
+
+		for ( const config of configs ) {
+			if ( ! keys.includes( config ) ) {
+				results[ key ].push( {
+					config,
+					set: 'NA',
+				} );
+			}
+		}
+	}
+
+	outputResults( results );
+};
+
+main();

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -42,6 +42,11 @@ function sortResult( result ) {
 function outputResults( results ) {
 	const resultKeys = Object.keys( results ).sort();
 
+	if ( resultKeys.length === 0 ) {
+		console.log( 'No matching features found.' );
+		return;
+	}
+
 	for ( const key of resultKeys ) {
 		const result = results[ key ];
 		const maxLength = calcLongestConfig( result );

--- a/bin/feature-search.js
+++ b/bin/feature-search.js
@@ -12,7 +12,7 @@ async function getConfigFeatures( config ) {
 }
 
 function calcLongestConfig( result ) {
-	const configLengths = result.map( ( item ) => item.config.length );
+	const configLengths = result.map( ( item ) => ( item.config ? item.config.length : 0 ) );
 	return Math.max( ...configLengths );
 }
 
@@ -130,16 +130,14 @@ const main = async () => {
 	// Add any configs that aren't part of the result set because they didn't have a flag match.
 	// This ensures that our output is the same for each flag.
 	for ( const key in results ) {
-		const keys = [];
-
 		const knownConfigs = results[ key ].map( ( item ) => item.config );
 
 		const missingConfigs = configs.filter( ( config ) => ! knownConfigs.includes( config ) );
 
 		missingConfigs.forEach( ( missingConfig ) => {
 			results[ key ].push( {
-				config,
-				set: null, // or 'NA'
+				config: missingConfig,
+				set: null,
 			} );
 		} );
 	}

--- a/config/README.md
+++ b/config/README.md
@@ -27,7 +27,7 @@ Please make sure to add new feature flags alphabetically so they are easy to fin
 
 You can search for feature flags by partial string or regular expression with the [bin/feature-search.js](bin/feature-search.js) tool.
 
-Run `node bin/feature-search.js` from the root calypso directory to see example searches.
+Run `yarn feature-search [search]` from the root calypso directory to see example searches.
 
 ### Progression of Environments
 

--- a/config/README.md
+++ b/config/README.md
@@ -25,6 +25,10 @@ The config files contain a features object that can be used to determine whether
 
 Please make sure to add new feature flags alphabetically so they are easy to find and add any new feature flags in all config files (client.json, development.json, production.json, horizon.json, stage.json, test.json, wpcalypso.json).
 
+You can search for feature flags by partial string or regular expression with the [bin/feature-search.js](bin/feature-search.js) too.
+
+Run `node bin/feature-search.js` from the root calypso directory to see example searches.
+
 ### Progression of Environments
 
 When working with feature flags, there is a progression of environments that should be considered.

--- a/config/README.md
+++ b/config/README.md
@@ -25,7 +25,7 @@ The config files contain a features object that can be used to determine whether
 
 Please make sure to add new feature flags alphabetically so they are easy to find and add any new feature flags in all config files (client.json, development.json, production.json, horizon.json, stage.json, test.json, wpcalypso.json).
 
-You can search for feature flags by partial string or regular expression with the [bin/feature-search.js](bin/feature-search.js) too.
+You can search for feature flags by partial string or regular expression with the [bin/feature-search.js](bin/feature-search.js) tool.
 
 Run `node bin/feature-search.js` from the root calypso directory to see example searches.
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"eslint-branch": "node bin/eslint-branch.js",
+		"feature-search": "node bin/feature-search.js",
 		"install-if-no-packages": "node bin/install-if-no-packages.js",
 		"lint": "run-s -s 'lint:*'",
 		"lint:config-defaults": "node bin/validate-config-keys.js",


### PR DESCRIPTION
#### Proposed Changes

This adds a new script (`bin/feature-search.js`) which lets you search for flags by string or regex. We then show all matching flags and how they're set in each config environment.


#### Testing Instructions

**Basic string search**
Run the command `node bin/feature-search.js plugin ` from the root of the calypso project. You should see output similar to the following (there will be more flags in the output than pictured here):

<img width="524" alt="image" src="https://user-images.githubusercontent.com/917632/194545229-61a65664-242a-4d23-84ec-715fe260a7d8.png">

**Regex search**
Run the command `node bin/feature-search.js 'bundl(e|ing)' `. You should see the following output:

<img width="579" alt="image" src="https://user-images.githubusercontent.com/917632/194545648-24300384-3782-46e9-b0af-13cbee75db2a.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
