### PR TITLE
Add strikethrough for Launchpad completed tasks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -237,6 +237,7 @@
 	.launchpad__checklist-item-text {
 		color: var(--studio-gray-50);
 		font-weight: 400;
+		text-decoration: line-through;
 	}
 
 	.launchpad__checklist-item-chevron,


### PR DESCRIPTION
#### Proposed Changes

* Adds strikethrough to LaunchPad completed tasks (CSS:`text-decoration: line-through`).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and run yarn start.
- Use an existing launchpad enabled site or create a new newsletter/link-in-bio site: https://wordpress.com/hp-2022-tailored-flows/
- If you created a new site, go through the site creation flow until you reach the Launchpad screen. Switch to calypso.localhost:3000/setup/launchpad?flow={flow}&siteSlug={siteSlug}
- Verify that all the completed task texts include a strike-through.

<img width="455" alt="image" src="https://user-images.githubusercontent.com/10482592/194549317-a154fa8e-b506-4113-84bc-5b94a28945ef.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68711
