### PR TITLE
Update descriptions for Domain Connect templates

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-description.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-description.jsx
@@ -4,9 +4,10 @@ import { Component } from 'react';
 
 class DomainConnectAuthorizeDescription extends Component {
 	static propTypes = {
+		dnsTemplateError: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		providerId: PropTypes.string.isRequired,
-		dnsTemplateError: PropTypes.bool,
+		serviceId: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -24,57 +25,46 @@ class DomainConnectAuthorizeDescription extends Component {
 	};
 
 	render() {
-		const { dnsTemplateError, isPlaceholder, providerId, translate } = this.props;
+		const { dnsTemplateError, isPlaceholder, providerId, serviceId, translate } = this.props;
 
 		if ( isPlaceholder ) {
 			return this.placeholder();
 		}
 
-		// Note: these are only examples. The exact templates that we will use haven't yet been determined.
-		const templateDescription = {
-			'g-suite': translate(
-				'Howdy! It looks like you want to make your domain work with ' +
-					"{{strong}}Google's G Suite email service{{/strong}}.",
-				{
-					components: {
-						strong: <strong />,
-					},
-				}
-			),
+		if ( providerId === 'google.com' && serviceId === 'gmail-setup' ) {
+			return (
+				<p>
+					{ translate(
+						'Howdy! It looks like you want to make your domain work with the ' +
+							'{{strong}}Google Workspace email service{{/strong}}.',
+						{ components: { strong: <strong /> } }
+					) }
+				</p>
+			);
+		}
 
-			'microsoft-office365': translate(
-				'Howdy! It looks like you want to set up your domain to ' +
-					'work with the {{strong}}Microsoft Office 365 service{{/strong}}.',
-				{
-					components: {
-						strong: <strong />,
-					},
-				}
-			),
-
-			'zoho-mail': translate(
-				'Howdy! It looks like you want to set up ' +
-					'{{strong}}Zoho Mail service{{/strong}} to work with your domain.',
-				{
-					components: {
-						strong: <strong />,
-					},
-				}
-			),
-
-			'template-error': translate(
-				'There seems to be a problem with the information we received ' +
-					"about the service you're trying to set up. Contact your service providers support and " +
-					'let them know about this error message.'
-			),
-		};
-
-		if ( templateDescription[ providerId ] ) {
-			return <p>{ templateDescription[ providerId ] }</p>;
+		if ( providerId === 'microsoft.com' && serviceId === 'O365' ) {
+			return (
+				<p>
+					{ translate(
+						'Howdy! It looks like you want to set up your domain to ' +
+							'work with the {{strong}}Microsoft Office 365 service{{/strong}}.',
+						{ components: { strong: <strong /> } }
+					) }
+				</p>
+			);
 		}
 
 		if ( dnsTemplateError ) {
-			return <p>{ templateDescription[ 'template-error' ] }</p>;
+			return (
+				<p>
+					{ translate(
+						'There seems to be a problem with the information we received ' +
+							"about the service you're trying to set up. Contact your service providers support and " +
+							'let them know about this error message.'
+					) }
+				</p>
+			);
 		}
 
 		return null;

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -145,6 +145,7 @@ class DomainConnectAuthorize extends Component {
 					<DomainConnectAuthorizeDescription
 						isPlaceholder={ ! this.state.dnsTemplateRecordsRetrieved }
 						providerId={ this.props.providerId }
+						serviceId={ this.props.serviceId }
 						dnsTemplateError={ this.state.dnsTemplateError }
 					/>
 					<DomainConnectAuthorizeRecords

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -143,10 +143,10 @@ class DomainConnectAuthorize extends Component {
 						} ) }
 					</h2>
 					<DomainConnectAuthorizeDescription
+						dnsTemplateError={ this.state.dnsTemplateError }
 						isPlaceholder={ ! this.state.dnsTemplateRecordsRetrieved }
 						providerId={ this.props.providerId }
 						serviceId={ this.props.serviceId }
-						dnsTemplateError={ this.state.dnsTemplateError }
 					/>
 					<DomainConnectAuthorizeRecords
 						domain={ domain }


### PR DESCRIPTION
#### Proposed Changes

Letero is always on the lookout for stale `G Suite` strings, and just recently, we found one in the Domain Connect templates in Calypso 🧐 

This PR changes the strings in `DomainConnectAuthorizeDescription` to actually match the templates that we support.

I don't know what kind of usage the Domain Connect feature sees, and this is definitely nothing more than a paper cut at most (since the page works perfectly well even without the `DomainConnectAuthorizeDescription`), but it still seemed like a nice thing to fix.

Here's what the Domain Connect screen looks like when attempting to apply the Google Workspace template with this PR.

![domain-connect](https://user-images.githubusercontent.com/1101677/194551896-3a0a6d91-64a1-4b73-8b3a-0287c442345f.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with a custom domain
2. Navigate to `/domain-connect/authorize/v2/domainTemplates/providers/google.com/services/gmail-setup/apply?domain={domain}&spfrule=test` (replace `{domain}` with your real domain name)
3. Ensure that the first paragraph reads `Howdy! It looks like you want to make your domain work with the Google Workspace email service.`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
