### PR TITLE
Pricing page: Display first month discount message in Jetpack Social price.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -16,6 +16,7 @@ type OwnProps = {
 	belowPriceText?: TranslateResult;
 	billingTerm: Duration;
 	currencyCode?: string | null;
+	discountDurationInMonths?: number;
 	discountedPrice?: number;
 	discountedPriceFirst?: boolean;
 	displayFrom?: boolean;
@@ -36,6 +37,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	belowPriceText,
 	billingTerm,
 	currencyCode,
+	discountDurationInMonths,
 	discountedPrice,
 	discountedPriceFirst,
 	displayFrom,
@@ -75,6 +77,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 
 	return (
 		<Paid
+			discountDurationInMonths={ discountDurationInMonths }
 			discountedPrice={ discountedPrice }
 			discountedPriceFirst={ discountedPriceFirst }
 			originalPrice={ originalPrice }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -16,8 +16,8 @@ type OwnProps = {
 	belowPriceText?: TranslateResult;
 	billingTerm: Duration;
 	currencyCode?: string | null;
-	discountDurationInMonths?: number;
 	discountedPrice?: number;
+	discountedPriceDuration?: number;
 	discountedPriceFirst?: boolean;
 	displayFrom?: boolean;
 	expiryDate?: Moment;
@@ -37,8 +37,8 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	belowPriceText,
 	billingTerm,
 	currencyCode,
-	discountDurationInMonths,
 	discountedPrice,
+	discountedPriceDuration,
 	discountedPriceFirst,
 	displayFrom,
 	expiryDate,
@@ -77,7 +77,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 
 	return (
 		<Paid
-			discountDurationInMonths={ discountDurationInMonths }
+			discountedPriceDuration={ discountedPriceDuration }
 			discountedPrice={ discountedPrice }
 			discountedPriceFirst={ discountedPriceFirst }
 			originalPrice={ originalPrice }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -7,6 +7,7 @@ import type { Moment } from 'moment';
 import type { ReactNode } from 'react';
 
 type OwnProps = {
+	discountDurationInMonths?: number;
 	discountedPrice?: number;
 	discountedPriceFirst?: boolean;
 	originalPrice?: number;
@@ -19,6 +20,7 @@ type OwnProps = {
 };
 
 const Paid: React.FC< OwnProps > = ( {
+	discountDurationInMonths,
 	discountedPrice,
 	discountedPriceFirst,
 	originalPrice,
@@ -43,7 +45,11 @@ const Paid: React.FC< OwnProps > = ( {
 				/>
 				{ /* Remove this secondary <PlanPrice/> placeholder if we're not showing discounted prices */ }
 				<PlanPrice discounted rawPrice={ 0.01 } currencyCode={ '$' } />
-				<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+				<TimeFrame
+					expiryDate={ expiryDate }
+					billingTerm={ billingTerm }
+					discountDurationInMonths={ discountDurationInMonths }
+				/>
 			</>
 		);
 	}
@@ -88,7 +94,11 @@ const Paid: React.FC< OwnProps > = ( {
 					{ tooltipText }
 				</InfoPopover>
 			) }
-			<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+			<TimeFrame
+				expiryDate={ expiryDate }
+				billingTerm={ billingTerm }
+				discountDurationInMonths={ discountDurationInMonths }
+			/>
 		</>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -7,8 +7,8 @@ import type { Moment } from 'moment';
 import type { ReactNode } from 'react';
 
 type OwnProps = {
-	discountDurationInMonths?: number;
 	discountedPrice?: number;
+	discountedPriceDuration?: number;
 	discountedPriceFirst?: boolean;
 	originalPrice?: number;
 	pricesAreFetching?: boolean | null;
@@ -20,8 +20,8 @@ type OwnProps = {
 };
 
 const Paid: React.FC< OwnProps > = ( {
-	discountDurationInMonths,
 	discountedPrice,
+	discountedPriceDuration,
 	discountedPriceFirst,
 	originalPrice,
 	pricesAreFetching,
@@ -45,11 +45,7 @@ const Paid: React.FC< OwnProps > = ( {
 				/>
 				{ /* Remove this secondary <PlanPrice/> placeholder if we're not showing discounted prices */ }
 				<PlanPrice discounted rawPrice={ 0.01 } currencyCode={ '$' } />
-				<TimeFrame
-					expiryDate={ expiryDate }
-					billingTerm={ billingTerm }
-					discountDurationInMonths={ discountDurationInMonths }
-				/>
+				<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
 			</>
 		);
 	}
@@ -97,7 +93,7 @@ const Paid: React.FC< OwnProps > = ( {
 			<TimeFrame
 				expiryDate={ expiryDate }
 				billingTerm={ billingTerm }
-				discountDurationInMonths={ discountDurationInMonths }
+				discountedPriceDuration={ discountedPriceDuration }
 			/>
 		</>
 	);

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -24,7 +24,7 @@ interface PartialDiscountTimeFrameProps {
 	discountedPriceDuration: number;
 }
 
-const RegularTimeFrame = ( { billingTerm }: RegularTimeFrameProps ) => {
+const RegularTimeFrame: React.FC< RegularTimeFrameProps > = ( { billingTerm } ) => {
 	const translate = useTranslate();
 
 	const billingTermText = useMemo( () => {
@@ -53,7 +53,7 @@ const RegularTimeFrame = ( { billingTerm }: RegularTimeFrameProps ) => {
 	);
 };
 
-const ExpiringDateTimeFrame = ( { productExpiryDate }: ExpiringDateTimeFrameProps ) => {
+const ExpiringDateTimeFrame: React.FC< ExpiringDateTimeFrameProps > = ( { productExpiryDate } ) => {
 	const translate = useTranslate();
 	return (
 		<time
@@ -69,10 +69,10 @@ const ExpiringDateTimeFrame = ( { productExpiryDate }: ExpiringDateTimeFrameProp
 	);
 };
 
-const PartialDiscountTimeFrame = ( {
+const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps > = ( {
 	billingTerm,
 	discountedPriceDuration,
-}: PartialDiscountTimeFrameProps ) => {
+} ) => {
 	const translate = useTranslate();
 
 	const BillingTermText = useMemo( () => {

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -8,7 +8,7 @@ import type { Moment } from 'moment';
 interface TimeFrameProps {
 	expiryDate?: Moment;
 	billingTerm: Duration;
-	discountDurationInMonths?: number;
+	discountedPriceDuration?: number;
 }
 
 interface RegularTimeFrameProps {
@@ -19,9 +19,9 @@ interface ExpiringDateTimeFrameProps {
 	productExpiryDate: Moment;
 }
 
-interface IntroDiscountTimeFrameProps {
+interface PartialDiscountTimeFrameProps {
 	billingTerm: Duration;
-	discountDurationInMonths: number;
+	discountedPriceDuration: number;
 }
 
 const RegularTimeFrame = ( { billingTerm }: RegularTimeFrameProps ) => {
@@ -69,27 +69,27 @@ const ExpiringDateTimeFrame = ( { productExpiryDate }: ExpiringDateTimeFrameProp
 	);
 };
 
-const IntroDiscountTimeFrame = ( {
+const PartialDiscountTimeFrame = ( {
 	billingTerm,
-	discountDurationInMonths,
-}: IntroDiscountTimeFrameProps ) => {
+	discountedPriceDuration,
+}: PartialDiscountTimeFrameProps ) => {
 	const translate = useTranslate();
 
 	const BillingTermText = useMemo( () => {
 		if ( billingTerm === TERM_MONTHLY ) {
-			return discountDurationInMonths > 1
+			return discountedPriceDuration > 1
 				? translate( 'for the first %(months)d months, billed monthly', {
-						args: { months: discountDurationInMonths },
+						args: { months: discountedPriceDuration },
 				  } )
 				: translate( 'for the first month, billed monthly' );
 		}
 
-		return discountDurationInMonths > 1
+		return discountedPriceDuration > 1
 			? translate( 'for the first %(months)d months, billed yearly', {
-					args: { months: discountDurationInMonths },
+					args: { months: discountedPriceDuration },
 			  } )
 			: translate( 'for the first month, billed yearly' );
-	}, [ discountDurationInMonths, billingTerm, translate ] );
+	}, [ discountedPriceDuration, billingTerm, translate ] );
 
 	return <span className="display-price__billing-time-frame">{ BillingTermText }</span>;
 };
@@ -97,7 +97,7 @@ const IntroDiscountTimeFrame = ( {
 const TimeFrame: React.FC< TimeFrameProps > = ( {
 	expiryDate,
 	billingTerm,
-	discountDurationInMonths,
+	discountedPriceDuration,
 } ) => {
 	const moment = useLocalizedMoment();
 	const productExpiryDate =
@@ -107,11 +107,11 @@ const TimeFrame: React.FC< TimeFrameProps > = ( {
 		return <ExpiringDateTimeFrame productExpiryDate={ productExpiryDate } />;
 	}
 
-	if ( discountDurationInMonths ) {
+	if ( discountedPriceDuration ) {
 		return (
-			<IntroDiscountTimeFrame
+			<PartialDiscountTimeFrame
 				billingTerm={ billingTerm }
-				discountDurationInMonths={ discountDurationInMonths }
+				discountedPriceDuration={ discountedPriceDuration }
 			/>
 		);
 	}

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -16,7 +16,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	siteId,
 	isMultiSiteIncompatible,
 } ) => {
-	const { originalPrice, discountedPrice, isFetching } = useItemPrice(
+	const { originalPrice, discountedPrice, discountDurationInMonths, isFetching } = useItemPrice(
 		siteId,
 		item,
 		item?.monthlyProductSlug || ''
@@ -40,6 +40,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 			<DisplayPrice
 				isFree={ item.isFree }
 				isOwned={ isOwned }
+				discountDurationInMonths={ discountDurationInMonths }
 				discountedPrice={ discountedPrice }
 				discountedPriceFirst
 				currencyCode={ item.displayCurrency || currencyCode }

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -16,7 +16,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	siteId,
 	isMultiSiteIncompatible,
 } ) => {
-	const { originalPrice, discountedPrice, discountDurationInMonths, isFetching } = useItemPrice(
+	const { originalPrice, discountedPrice, discountedPriceDuration, isFetching } = useItemPrice(
 		siteId,
 		item,
 		item?.monthlyProductSlug || ''
@@ -40,7 +40,7 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 			<DisplayPrice
 				isFree={ item.isFree }
 				isOwned={ isOwned }
-				discountDurationInMonths={ discountDurationInMonths }
+				discountedPriceDuration={ discountedPriceDuration }
 				discountedPrice={ discountedPrice }
 				discountedPriceFirst
 				currencyCode={ item.displayCurrency || currencyCode }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
@@ -22,14 +22,16 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 			<div className="simple-item-card__body">
 				<div className="simple-item-card__header">
 					<div>
-						<h3 className="simple-item-card__title">{ title }</h3>
+						<h3 className="simple-item-card__title">
+							{ title }
+							{ customLabel && (
+								<div className="simple-item-card__custom-label">
+									<span>{ customLabel }</span>
+								</div>
+							) }
+						</h3>
 						<div className="simple-item-card__price">{ price }</div>
 					</div>
-					{ customLabel && (
-						<div className="simple-item-card__custom-label">
-							<span>{ customLabel }</span>
-						</div>
-					) }
 					<Button
 						className="simple-item-card__cta"
 						onClick={ onClickCta }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -49,6 +49,10 @@
 	line-height: rem(29px);
 	margin-bottom: 0 !important;
 	color: var(--studio-gray-100);
+	display: flex;
+	flex-direction: row;
+	gap: 0.5rem;
+	align-items: center;
 }
 
 .simple-item-card__cta {
@@ -67,10 +71,9 @@
 }
 
 .simple-item-card__custom-label {
+	display: inline-block;
 	span {
-		display: inline-block;
 		padding: 0.125rem 0.5rem;
-		margin: 0.4rem 1rem 0 0;
 		background-color: var(--studio-yellow-10);
 		border-radius: 4px;
 		font-size: 0.875rem;

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -25,7 +25,7 @@ interface ItemPrices {
 	isFetching: boolean | null;
 	originalPrice: number;
 	discountedPrice?: number;
-	discountDurationInMonths?: number;
+	discountedPriceDuration?: number;
 	priceTierList: PriceTierEntry[];
 }
 
@@ -156,7 +156,7 @@ const useItemPrice = (
 
 	let originalPrice = 0;
 	let discountedPrice = undefined;
-	let discountDurationInMonths = undefined;
+	let discountedPriceDuration = undefined;
 
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
@@ -173,7 +173,7 @@ const useItemPrice = (
 				)
 			) {
 				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;
-				discountDurationInMonths = 1;
+				discountedPriceDuration = 1;
 			}
 		}
 	}
@@ -195,7 +195,7 @@ const useItemPrice = (
 		isFetching,
 		originalPrice,
 		discountedPrice,
-		discountDurationInMonths,
+		discountedPriceDuration,
 		priceTierList,
 	};
 };

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -25,6 +25,7 @@ interface ItemPrices {
 	isFetching: boolean | null;
 	originalPrice: number;
 	discountedPrice?: number;
+	discountDurationInMonths?: number;
 	priceTierList: PriceTierEntry[];
 }
 
@@ -155,6 +156,7 @@ const useItemPrice = (
 
 	let originalPrice = 0;
 	let discountedPrice = undefined;
+	let discountDurationInMonths = undefined;
 
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
@@ -171,6 +173,7 @@ const useItemPrice = (
 				)
 			) {
 				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;
+				discountDurationInMonths = 1;
 			}
 		}
 	}
@@ -192,6 +195,7 @@ const useItemPrice = (
 		isFetching,
 		originalPrice,
 		discountedPrice,
+		discountDurationInMonths,
 		priceTierList,
 	};
 };


### PR DESCRIPTION
### Description
This PR will fix the display price for Jetpack Social in the pricing page highlighting that the discount is only applied for the first month.

#### Proposed Changes

* Updated the `DisplayPrice` component to add display support for partial annual discount such as the Jetpack Social.
* Move 'Coming Soon' custom label next to the title in the simple card component to prevent text from wrapping in smaller screens. 

#### Testing Instructions

1. * Run `git fetch && git checkout add/display-price-partial-discount-support`
    * Run `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing or use the jetpack cloud live link and goto `/pricing`.
3. Confirm that the Jetpack Social display price message `for the first month, billed yearly`.

Before:

<img width="633" alt="Screen Shot 2022-10-07 at 8 49 50 PM" src="https://user-images.githubusercontent.com/56598660/194557820-a5db9036-0adb-46ca-b589-ff3a150b0dd8.png">


After:
<img width="626" alt="Screen Shot 2022-10-07 at 8 51 13 PM" src="https://user-images.githubusercontent.com/56598660/194558285-4a803751-a84c-49a5-ab05-f6940d3a2aea.png">




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1664891686656539-slack-C03RCHNVC0H