### PR TITLE
Gating Global Styles: Add more Tracks events

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -243,7 +243,7 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 	$custom_controls[] = array(
 		'desktop_message'    => __( 'Styles hidden', 'full-site-editing' ),
 		'mobile_message'     => __( 'Styles', 'full-site-editing' ),
-		'track_button_name'  => 'wpcom_gs_notice',
+		'track_button_name'  => 'wpcom_global_styles_gating_notice',
 		'tooltip'            => __( 'You need to be on a paid plan for your style changes to be made public.', 'full-site-editing' ),
 		'tooltip_link_title' => __( 'Upgrade your plan', 'full-site-editing' ),
 		'tooltip_link_url'   => $upgrade_url,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -1,5 +1,6 @@
 /* global wpcomGlobalStyles */
 
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useEffect } from '@wordpress/element';
@@ -37,11 +38,20 @@ const GlobalStylesNotice = () => {
 			return;
 		}
 
+		recordTracksEvent( 'calypso_core_global_styles_gating_notice_reset_click', {
+			context: 'site-editor',
+		} );
+
 		editEntityRecord( 'root', 'globalStyles', globalStylesId, {
 			styles: {},
 			settings: {},
 		} );
 	};
+
+	const trackGlobalStylesNoticeUpgrade = () =>
+		recordTracksEvent( 'calypso_core_global_styles_gating_notice_upgrade_click', {
+			context: 'site-editor',
+		} );
 
 	// Closes the sidebar if there are no more changes to be saved.
 	useEffect( () => {
@@ -74,7 +84,14 @@ const GlobalStylesNotice = () => {
 					'full-site-editing'
 				),
 				{
-					a: <Button variant="link" href={ wpcomGlobalStyles.upgradeUrl } target="_top" />,
+					a: (
+						<Button
+							href={ wpcomGlobalStyles.upgradeUrl }
+							onClick={ trackGlobalStylesNoticeUpgrade }
+							target="_top"
+							variant="link"
+						/>
+					),
 				}
 			) }
 			&nbsp;


### PR DESCRIPTION
#### Proposed Changes

* Add two new Tracks events to the Global Styles gating notice in the editor:
  * `calypso_core_global_styles_gating_notice_upgrade_click`
  * `calypso_core_global_styles_gating_notice_reset_click`
* Both new events have a `context` property (valued here as `site-editor`) which should make it easier to use the same events in notices displayed elsewhere.
* Also renamed the `wpcom_launchbar_button_click` Launchbar event's `button` property to `wpcom_global_styles_gating_notice`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In your sandbox run: `install-plugin.sh editing-toolkit add/global-styles-gating-notice-events`
- Open the Site Editor on a free site, change some Global Styles, and click "Save".
- In the GS gating notice, click both links.
- Make sure the `calypso_core_global_styles_gating_notice_upgrade_click` and `calypso_core_global_styles_gating_notice_reset_click` are recorded correctly and with the `context: 'site-editor'` custom property.
- Save the changes and open the front end.
- Click on the "Styles hidden" button in the Launchbar.
- Wait a bit, and make sure a `wpcom_launchbar_button_click` event with `button: 'wpcom_global_styles_gating_notice'` custom property is recorded.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
