### PR TITLE
Limit Global Styles: Track events

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -243,7 +243,7 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 	$custom_controls[] = array(
 		'desktop_message'    => __( 'Styles hidden', 'full-site-editing' ),
 		'mobile_message'     => __( 'Styles', 'full-site-editing' ),
-		'track_button_name'  => 'wpcom_gs_notice',
+		'track_button_name'  => 'wpcom_global_styles_gating_notice',
 		'tooltip'            => __( 'You need to be on a paid plan for your style changes to be made public.', 'full-site-editing' ),
 		'tooltip_link_title' => __( 'Upgrade your plan', 'full-site-editing' ),
 		'tooltip_link_url'   => $upgrade_url,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -1,5 +1,6 @@
 /* global wpcomGlobalStyles */
 
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -22,6 +23,17 @@ const GlobalStylesModal = () => {
 		setPreference( 'core/edit-site', 'welcomeGuideStyles', false );
 	}, [ setPreference ] );
 
+	useEffect( () => {
+		if ( isVisible ) {
+			recordTracksEvent( 'calypso_global_styles_paid_feature_modal_show' );
+		}
+	}, [ isVisible ] );
+
+	const closeModal = () => {
+		dismissModal();
+		recordTracksEvent( 'calypso_global_styles_paid_feature_modal_dismiss' );
+	};
+
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -29,7 +41,7 @@ const GlobalStylesModal = () => {
 	return (
 		<Modal
 			className="wpcom-global-styles-modal"
-			onRequestClose={ dismissModal }
+			onRequestClose={ closeModal }
 			// set to false so that 1Password's autofill doesn't automatically close the modal
 			shouldCloseOnClickOutside={ false }
 		>
@@ -44,10 +56,17 @@ const GlobalStylesModal = () => {
 					) }
 				</p>
 				<div className="wpcom-global-styles-modal__actions">
-					<Button variant="secondary" onClick={ dismissModal }>
+					<Button variant="secondary" onClick={ closeModal }>
 						{ __( 'Try it out', 'full-site-editing' ) }
 					</Button>
-					<Button variant="primary" href={ wpcomGlobalStyles.upgradeUrl } target="_top">
+					<Button
+						variant="primary"
+						href={ wpcomGlobalStyles.upgradeUrl }
+						target="_top"
+						onClick={ () =>
+							recordTracksEvent( 'calypso_global_styles_paid_feature_modal_upgrade_click' )
+						}
+					>
 						{ __( 'Upgrade plan', 'full-site-editing' ) }
 					</Button>
 				</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -25,13 +25,17 @@ const GlobalStylesModal = () => {
 
 	useEffect( () => {
 		if ( isVisible ) {
-			recordTracksEvent( 'calypso_global_styles_paid_feature_modal_show' );
+			recordTracksEvent( 'calypso_global_styles_paid_feature_modal_show', {
+				context: 'site-editor',
+			} );
 		}
 	}, [ isVisible ] );
 
 	const closeModal = () => {
 		dismissModal();
-		recordTracksEvent( 'calypso_global_styles_paid_feature_modal_dismiss' );
+		recordTracksEvent( 'calypso_global_styles_paid_feature_modal_dismiss', {
+			context: 'site-editor',
+		} );
 	};
 
 	if ( ! isVisible ) {
@@ -64,7 +68,9 @@ const GlobalStylesModal = () => {
 						href={ wpcomGlobalStyles.upgradeUrl }
 						target="_top"
 						onClick={ () =>
-							recordTracksEvent( 'calypso_global_styles_paid_feature_modal_upgrade_click' )
+							recordTracksEvent( 'calypso_global_styles_paid_feature_modal_upgrade_click', {
+								context: 'site-editor',
+							} )
 						}
 					>
 						{ __( 'Upgrade plan', 'full-site-editing' ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -25,7 +25,7 @@ const GlobalStylesModal = () => {
 
 	useEffect( () => {
 		if ( isVisible ) {
-			recordTracksEvent( 'calypso_global_styles_paid_feature_modal_show', {
+			recordTracksEvent( 'calypso_global_styles_gating_modal_show', {
 				context: 'site-editor',
 			} );
 		}
@@ -33,7 +33,7 @@ const GlobalStylesModal = () => {
 
 	const closeModal = () => {
 		dismissModal();
-		recordTracksEvent( 'calypso_global_styles_paid_feature_modal_dismiss', {
+		recordTracksEvent( 'calypso_global_styles_gating_modal_dismiss', {
 			context: 'site-editor',
 		} );
 	};
@@ -68,7 +68,7 @@ const GlobalStylesModal = () => {
 						href={ wpcomGlobalStyles.upgradeUrl }
 						target="_top"
 						onClick={ () =>
-							recordTracksEvent( 'calypso_global_styles_paid_feature_modal_upgrade_click', {
+							recordTracksEvent( 'calypso_global_styles_gating_modal_upgrade_click', {
 								context: 'site-editor',
 							} )
 						}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -43,7 +43,9 @@ const GlobalStylesNotice = () => {
 			settings: {},
 		} );
 
-		recordTracksEvent( 'calypso_global_styles_paid_feature_notice_reset_click' );
+		recordTracksEvent( 'calypso_global_styles_paid_feature_notice_reset_click', {
+			context: 'site-editor',
+		} );
 	};
 	// Do not show the notice if the use is trying to save the default styles.
 	const isVisible =
@@ -67,7 +69,9 @@ const GlobalStylesNotice = () => {
 
 	useEffect( () => {
 		if ( isVisible ) {
-			recordTracksEvent( 'calypso_global_styles_paid_feature_notice_show' );
+			recordTracksEvent( 'calypso_global_styles_paid_feature_notice_show', {
+				context: 'site-editor',
+			} );
 		}
 	}, [ isVisible ] );
 
@@ -89,7 +93,9 @@ const GlobalStylesNotice = () => {
 							href={ wpcomGlobalStyles.upgradeUrl }
 							target="_top"
 							onClick={ () =>
-								recordTracksEvent( 'calypso_global_styles_paid_feature_notice_upgrade_click' )
+								recordTracksEvent( 'calypso_global_styles_paid_feature_notice_upgrade_click', {
+									context: 'site-editor',
+								} )
 							}
 						/>
 					),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -43,7 +43,7 @@ const GlobalStylesNotice = () => {
 			settings: {},
 		} );
 
-		recordTracksEvent( 'calypso_global_styles_paid_feature_notice_reset_click', {
+		recordTracksEvent( 'calypso_global_styles_gating_notice_reset_click', {
 			context: 'site-editor',
 		} );
 	};
@@ -69,7 +69,7 @@ const GlobalStylesNotice = () => {
 
 	useEffect( () => {
 		if ( isVisible ) {
-			recordTracksEvent( 'calypso_global_styles_paid_feature_notice_show', {
+			recordTracksEvent( 'calypso_global_styles_gating_notice_show', {
 				context: 'site-editor',
 			} );
 		}
@@ -93,7 +93,7 @@ const GlobalStylesNotice = () => {
 							href={ wpcomGlobalStyles.upgradeUrl }
 							target="_top"
 							onClick={ () =>
-								recordTracksEvent( 'calypso_global_styles_paid_feature_notice_upgrade_click', {
+								recordTracksEvent( 'calypso_global_styles_gating_notice_upgrade_click', {
 									context: 'site-editor',
 								} )
 							}


### PR DESCRIPTION
#### Proposed Changes

- Tracks multiple events in the site editor when the Global Styles feature is limited:
  - `calypso_global_styles_gating_modal_show`: When the modal shows up
  - `calypso_global_styles_gating_modal_upgrade_click`: When a user clicks on the modal's upgrade button
  - `calypso_global_styles_gating_modal_dismiss`: When a user dismisses the modal
  - `calypso_global_styles_gating_notice_show`: When the pre-save notice shows up
  - `calypso_global_styles_gating_notice_upgrade_click`: When a user clicks on the pre-save notices' upgrade button
  - `calypso_global_styles_gating_notice_reset_click`: When a user resets the styles via the pre-save notice
- All events have a `context` property (valued here as `site-editor`) which should make it easier to use the same events in notices displayed elsewhere (props @Copons).
- Also renamed the `wpcom_launchbar_button_click` Launchbar event's `button` property to `wpcom_global_styles_gating_notice` (props @Copons).

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit update/limit-global-styles-track-upgrade-clicks`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Verify that the site-editor events listed above are tracked correctly and with the `context: 'site-editor'` custom property by inspecting the network requests:

<img width="471" alt="Screen Shot 2022-10-07 at 15 40 35" src="https://user-images.githubusercontent.com/1233880/194568953-4f36f241-d334-4868-ad7c-947d203122e8.png">

- Add some Global Styles changes and save them.
- Open the frontend.
- Click on the "Styles hidden" button in the Launchbar.
- Wait a bit, and make sure a `wpcom_launchbar_button_click` event with `button: 'wpcom_global_styles_gating_notice'` custom property is recorded.
