### PR TITLE
Help Center: No draggable when minimized and click maximizes it

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -78,7 +78,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 			{ data?.status === 'assigned' && <Redirect to="/inline-chat?session=continued" /> }
 			<FeatureFlagProvider>
 				<OptionalDraggable
-					draggable={ ! isMobile }
+					draggable={ ! isMobile && ! isMinimized }
 					nodeRef={ nodeRef }
 					handle=".help-center__container-header"
 					bounds="body"

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -3,7 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { closeSmall, chevronUp, lineSolid, commentContent, page, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { HELP_CENTER_STORE } from '../stores';
 import type { Header } from '../types';
@@ -47,34 +47,30 @@ const SupportModeTitle = () => {
 };
 
 const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDismiss }: Header ) => {
-	const headerRef = useRef< HTMLDivElement >( null );
 	const unreadCount = useSelect( ( select ) => select( HELP_CENTER_STORE ).getUnreadCount() );
 	const classNames = classnames( 'help-center__container-header' );
 	const { __ } = useI18n();
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
 
-	const handleMouseup = useCallback(
+	const handleClick = useCallback(
 		( event ) => {
-			if ( isMinimized && ! [ 'BUTTON', 'svg' ].includes( event.target.parentNode.tagName ) ) {
+			if ( isMinimized && event.target === event.currentTarget ) {
 				onMaximize?.();
 			}
 		},
 		[ isMinimized, onMaximize ]
 	);
 
-	useEffect( () => {
-		const elementRef = headerRef.current;
-		elementRef?.addEventListener( 'mouseup', handleMouseup );
-
-		return () => {
-			elementRef?.removeEventListener( 'mouseup', handleMouseup );
-		};
-	}, [ handleMouseup ] );
-
 	return (
-		<CardHeader className={ classNames } ref={ headerRef }>
-			<Flex>
-				<p id="header-text" className="help-center-header__text">
+		<CardHeader className={ classNames }>
+			<Flex onClick={ handleClick }>
+				<p
+					id="header-text"
+					className="help-center-header__text"
+					onClick={ handleClick }
+					onKeyUp={ handleClick }
+					role="presentation"
+				>
 					{ isMinimized ? (
 						<Switch>
 							<Route path="/" exact>

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { closeSmall, chevronUp, lineSolid, commentContent, page, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { useCallback, useEffect, useRef } from 'react';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { HELP_CENTER_STORE } from '../stores';
 import type { Header } from '../types';
@@ -44,18 +45,34 @@ const SupportModeTitle = () => {
 		}
 	}
 };
+
 const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDismiss }: Header ) => {
+	const headerRef = useRef< HTMLDivElement >( null );
 	const unreadCount = useSelect( ( select ) => select( HELP_CENTER_STORE ).getUnreadCount() );
 	const classNames = classnames( 'help-center__container-header' );
 	const { __ } = useI18n();
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
 
-	const handleClose = () => {
-		onDismiss();
-	};
+	const handleMouseup = useCallback(
+		( event ) => {
+			if ( isMinimized && ! [ 'BUTTON', 'svg' ].includes( event.target.parentNode.tagName ) ) {
+				onMaximize?.();
+			}
+		},
+		[ isMinimized, onMaximize ]
+	);
+
+	useEffect( () => {
+		const elementRef = headerRef.current;
+		elementRef?.addEventListener( 'mouseup', handleMouseup );
+
+		return () => {
+			elementRef?.removeEventListener( 'mouseup', handleMouseup );
+		};
+	}, [ handleMouseup ] );
 
 	return (
-		<CardHeader className={ classNames }>
+		<CardHeader className={ classNames } ref={ headerRef }>
 			<Flex>
 				<p id="header-text" className="help-center-header__text">
 					{ isMinimized ? (
@@ -101,7 +118,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 						label={ __( 'Close Help Center', __i18n_text_domain__ ) }
 						tooltipPosition="top left"
 						icon={ closeSmall }
-						onClick={ handleClose }
+						onClick={ onDismiss }
 					/>
 				</div>
 			</Flex>

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -98,6 +98,12 @@ $head-foot-height: 50px;
 
 			&.is-minimized {
 				min-height: $head-foot-height;
+				top: unset;
+				bottom: calc(#{$header-height} + 16px);
+
+				.help-center__container-header {
+					cursor: pointer;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Help Center should always be on the bottom right when minimized
* Make the whole bar a maximize button when minimized

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch / Live Link
* Open Help Center
* Verify that minimizing it makes the Help Center show in the bottom right corner
* Check that the Help Center is not draggable when minimized, and no drag icon is showed
* Check that clicking on the help center maximizes it, but now if you click on the buttons

![image](https://user-images.githubusercontent.com/52076348/194584642-f039f15d-0d5b-4eb8-9bf1-1fa75ee2836a.png)

Fixes #68589
Fixes #68279
