### PR TITLE
Fix tracks name typo for real-time backups banner

### DIFF
--- a/client/my-sites/backup/backups-made-realtime-banner.tsx
+++ b/client/my-sites/backup/backups-made-realtime-banner.tsx
@@ -26,7 +26,7 @@ const BackupsMadeRealtimeBanner: FunctionComponent = () => {
 			title={ translate( 'Every change you make will be backed up' ) }
 			tracksClickName="calypso_backups_made_realtime_banner_click"
 			tracksDismissName="calypso_backups_made_realtime_banner_dismiss"
-			tracksImpressionName="ccalypso_backups_made_realtime_banner_view"
+			tracksImpressionName="calypso_backups_made_realtime_banner_view"
 			horizontal
 			disableCircle
 		/>


### PR DESCRIPTION
Currently, when working on dev environment, if you visit the Backup page on Jetpack Cloud for a site with credentials, a Backup Real-time Banner is visible on top of the page and an error is thrown on console:
```Tracks: Event `ccalypso_backups_made_realtime_banner_view` will be ignored because it does not match /^calypso(?:_[a-z0-9]+){2,}$/ and is not a listed exception. Please use a compliant event name.```

![image](https://user-images.githubusercontent.com/1488641/194590627-be384e16-ebf8-47db-8573-1191f6097bac.png)


#### Proposed Changes

* Fix typo on real-time backups banner, replace `ccalypso` with `calypso`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the backup page on Jetpack Cloud using a site with credentials stored. You should see the backup real-time banner visible on top of the page and the error ```Tracks: Event `ccalypso_backups_made_realtime_banner_view` will be ignored because...``` is now gone.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65445
