### PR TITLE
Help Center: don't load in unwanted places

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,6 +386,11 @@ function load_help_center() {
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
+	// disable help center in P2s.
+	if ( ! defined( 'IS_ATOMIC' ) && \WPForTeams\is_wpforteams_site( get_current_blog_id() ) ) {
+		return false;
+	}
+
 	$current_segment = 10; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,6 +386,11 @@ function load_help_center() {
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
+	// disable help center in P2s.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && \WPForTeams\is_wpforteams_site( get_current_blog_id() ) ) {
+		return false;
+	}
+
 	$current_segment = 10; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,11 +386,6 @@ function load_help_center() {
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
-	// disable help center in P2s.
-	if ( ! defined( 'IS_ATOMIC' ) && \WPForTeams\is_wpforteams_site( get_current_blog_id() ) ) {
-		return false;
-	}
-
 	$current_segment = 10; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -148,9 +148,11 @@ class Help_Center {
 		global $wp_admin_bar, $current_screen;
 
 		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
-		if ( ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
+		if ( ! is_admin() || ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
 			return;
 		}
+
+		l( is_admin() );
 
 		wp_localize_script(
 			'help-center-script',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -148,7 +148,7 @@ class Help_Center {
 		global $wp_admin_bar, $current_screen;
 
 		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
-		if ( ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
+		if ( ! is_admin() || ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
 			return;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -148,11 +148,9 @@ class Help_Center {
 		global $wp_admin_bar, $current_screen;
 
 		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
-		if ( ! is_admin() || ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
+		if ( ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
 			return;
 		}
-
-		l( is_admin() );
 
 		wp_localize_script(
 			'help-center-script',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -1,3 +1,5 @@
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+
 .help-center.entry-point-button {
 	&.is-active {
 		background: #1e1e1e;
@@ -28,12 +30,16 @@
 /**
  * WP-ADMIN Masterbar Styling
  */
-.wp-toolbar {
+#wpadminbar #wp-toolbar {
 	#wp-admin-bar-help-center {
 		position: relative;
 		padding: 0;
 		width: 36px;
 		right: 5px;
+		display: none;
+		@include breakpoint-deprecated( ">960px" ) {
+			display: block;
+		}
 
 		svg {
 			position: absolute;


### PR DESCRIPTION
## Proposed Changes

Removes Help Center from...

* Non-admin pages - to prevent it being applied to masterbar while logged in at wpcom
* wp-admin mobile pages - this only hides the icon until we sort out where it should go in the list
* P2's - this is not something that should be seeing WordPress.com help I believe?

## Testing Instructions

1. Pull branch and run ` cd apps/editing-toolkit/ && yarn dev --sync`
2. Sandbox your test site AND a P2 like dDR7T-p2
3. Test both those sites. The Help Center should not load outside of `wp-admin` pages AND should not appear in P2's at all.