### PR TITLE
Upsell Nudge: remove duplicated logic

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -19,7 +19,6 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -157,7 +156,6 @@ export default connect( ( state, ownProps ) => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isVip: isVipSite( state, siteId ),
-		currentPlan: getCurrentPlan( state, siteId ),
 		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),
 	};
 } )( UpsellNudge );

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -1,15 +1,4 @@
-import {
-	planMatches,
-	isBloggerPlan,
-	isPersonalPlan,
-	isPremiumPlan,
-	isBusinessPlan,
-	isEcommercePlan,
-	GROUP_JETPACK,
-	GROUP_WPCOM,
-	WPCOM_FEATURES_NO_ADVERTS,
-	isFreePlanProduct,
-} from '@automattic/calypso-products';
+import { WPCOM_FEATURES_NO_ADVERTS, isFreePlanProduct } from '@automattic/calypso-products';
 import classnames from 'classnames';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
@@ -87,17 +76,7 @@ export const UpsellNudge = ( {
 		return null;
 	}
 
-	const classes = classnames(
-		'upsell-nudge',
-		className,
-		{ 'is-upgrade-blogger': plan && isBloggerPlan( plan ) },
-		{ 'is-upgrade-personal': plan && isPersonalPlan( plan ) },
-		{ 'is-upgrade-premium': plan && isPremiumPlan( plan ) },
-		{ 'is-upgrade-business': plan && isBusinessPlan( plan ) },
-		{ 'is-upgrade-ecommerce': plan && isEcommercePlan( plan ) },
-		{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
-		{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) }
-	);
+	const classes = classnames( 'upsell-nudge', className );
 
 	if ( dismissPreferenceName && forceHref && href ) {
 		debug(

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -52,7 +52,7 @@ export const UpsellNudge = ( {
 	onDismissClick,
 	plan,
 	price,
-	primaryButton,
+	primaryButton = true,
 	selectedSiteHasFeature,
 	showIcon = false,
 	icon = 'star',
@@ -140,10 +140,6 @@ export const UpsellNudge = ( {
 			tracksImpressionProperties={ tracksImpressionProperties }
 		/>
 	);
-};
-
-UpsellNudge.defaultProps = {
-	primaryButton: true,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -14,7 +14,6 @@ import classnames from 'classnames';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import Banner from 'calypso/components/banner';
-import { addQueryArgs } from 'calypso/lib/url';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -22,7 +21,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -31,7 +30,6 @@ const debug = debugFactory( 'calypso:upsell-nudge' );
 export const UpsellNudge = ( {
 	callToAction,
 	canManageSite,
-	canUserUpgrade,
 	className,
 	compact,
 	customerType,
@@ -60,7 +58,6 @@ export const UpsellNudge = ( {
 	showIcon = false,
 	icon = 'star',
 	site,
-	siteSlug,
 	target,
 	title,
 	tracksClickName,
@@ -91,13 +88,6 @@ export const UpsellNudge = ( {
 		return null;
 	}
 
-	if ( ! href && siteSlug && canUserUpgrade ) {
-		href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );
-		if ( customerType ) {
-			href = `/plans/${ siteSlug }?customerType=${ customerType }`;
-		}
-	}
-
 	const classes = classnames(
 		'upsell-nudge',
 		className,
@@ -121,6 +111,7 @@ export const UpsellNudge = ( {
 			callToAction={ callToAction }
 			className={ classes }
 			compact={ compact }
+			customerType={ customerType }
 			description={ description }
 			disableHref={ disableHref }
 			dismissPreferenceName={ dismissPreferenceName }
@@ -167,8 +158,6 @@ export default connect( ( state, ownProps ) => {
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		currentPlan: getCurrentPlan( state, siteId ),
-		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
-		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),
 	};
 } )( UpsellNudge );


### PR DESCRIPTION
The `UpsellNudge` component effectively acts as a case-specific early return for the `Banner` component, but over time has duplicated a good bit of logic that `Banner` handles itself. This has lead to some inconsistencies in the way different upgrade flows are handled. See: https://github.com/Automattic/dotcom-forge/issues/1032

This PR removes the duplicated logic between `UpsellNudge` and `Banner`.

**To test:**
- visit a page with an upsell nudge in both localhost and production (e.g. /themes - a list of them can be found on this post: p58i-dhn-p2)
- verify that they visually match and have the same call to action/link
- repeat for other nudges