### PR TITLE
BBE: Experiment for BBE goal copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -4,20 +4,21 @@ import { useTranslate } from 'i18n-calypso';
 import { useExperiment } from 'calypso/lib/explat';
 import type { Goal } from './types';
 
+export const CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME = 'calypso_difm_goal_change_prototype';
+
 const SiteGoal = Onboard.SiteGoal;
 const HIDE_GOALS = [ SiteGoal.DIFM, SiteGoal.Import ];
-
 const shouldDisplayGoal = ( { key }: Goal ) => ! HIDE_GOALS.includes( key );
 
 export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
-	const [ , experimentAssignment ] = useExperiment( 'calypso_difm_goal_change_prototype' );
+	const [ , experimentAssignment ] = useExperiment( CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME );
 	const showTreatmentDifmGoal = experimentAssignment?.variationName === 'treatment';
 
 	let difmGoalDisplayText = translate( 'Hire a professional to design my website' );
 	if ( showTreatmentDifmGoal ) {
-		difmGoalDisplayText = translate( '[Treatment] Hire a professional' );
+		difmGoalDisplayText = translate( 'Hire an expert' );
 	}
 
 	const goals = [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -20,10 +20,9 @@ export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const [ , experimentAssignment ] = useExperiment(
 		CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME
 	);
-	let variationName = experimentAssignment?.variationName;
+	const variationName = experimentAssignment?.variationName;
 
 	let builtByExpressGoalDisplayText;
-	variationName = VARIATION_GET;
 	switch ( variationName ) {
 		case VARIATION_BUY:
 			builtByExpressGoalDisplayText = translate( 'Buy a website' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -4,10 +4,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useExperiment } from 'calypso/lib/explat';
 import type { Goal } from './types';
 
-export const CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME = 'calypso_difm_goal_change_prototype';
+export const CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME =
+	'calypso_builtbyexpress_goal_copy_change_202210';
 export const VARIATION_CONTROL = 'control';
 export const VARIATION_BUY = 'variation_buy';
-export const VARIOATION_GET = 'variation_get';
+export const VARIATION_GET = 'variation_get';
 
 const SiteGoal = Onboard.SiteGoal;
 const HIDE_GOALS = [ SiteGoal.DIFM, SiteGoal.Import ];
@@ -16,21 +17,23 @@ const shouldDisplayGoal = ( { key }: Goal ) => ! HIDE_GOALS.includes( key );
 export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
-	const [ , experimentAssignment ] = useExperiment( CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME );
+	const [ , experimentAssignment ] = useExperiment(
+		CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME
+	);
 	let variationName = experimentAssignment?.variationName;
 
-	let difmGoalDisplayText;
-	variationName = VARIOATION_GET;
+	let builtByExpressGoalDisplayText;
+	variationName = VARIATION_GET;
 	switch ( variationName ) {
 		case VARIATION_BUY:
-			difmGoalDisplayText = translate( 'Buy a website' );
+			builtByExpressGoalDisplayText = translate( 'Buy a website' );
 			break;
-		case VARIOATION_GET:
-			difmGoalDisplayText = translate( 'Get a website quickly' );
+		case VARIATION_GET:
+			builtByExpressGoalDisplayText = translate( 'Get a website quickly' );
 			break;
 		case VARIATION_CONTROL:
 		default:
-			difmGoalDisplayText = translate( 'Hire a professional to design my website' );
+			builtByExpressGoalDisplayText = translate( 'Hire a professional to design my website' );
 	}
 
 	const goals = [
@@ -48,7 +51,7 @@ export const useGoals = ( displayAllGoals = false ): Goal[] => {
 		},
 		{
 			key: SiteGoal.DIFM,
-			title: difmGoalDisplayText,
+			title: builtByExpressGoalDisplayText,
 			isPremium: true,
 		},
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,6 +1,7 @@
 import { Onboard } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import { useExperiment } from 'calypso/lib/explat';
 import type { Goal } from './types';
 
 const SiteGoal = Onboard.SiteGoal;
@@ -11,6 +12,13 @@ const shouldDisplayGoal = ( { key }: Goal ) => ! HIDE_GOALS.includes( key );
 export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
+	const [ , experimentAssignment ] = useExperiment( 'calypso_difm_goal_change_prototype' );
+	const showTreatmentDifmGoal = experimentAssignment?.variationName === 'treatment';
+
+	let difmGoalDisplayText = translate( 'Hire a professional to design my website' );
+	if ( showTreatmentDifmGoal ) {
+		difmGoalDisplayText = translate( '[Treatment] Hire a professional' );
+	}
 
 	const goals = [
 		{
@@ -27,7 +35,7 @@ export const useGoals = ( displayAllGoals = false ): Goal[] => {
 		},
 		{
 			key: SiteGoal.DIFM,
-			title: translate( 'Hire a professional to design my website' ),
+			title: difmGoalDisplayText,
 			isPremium: true,
 		},
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -5,6 +5,9 @@ import { useExperiment } from 'calypso/lib/explat';
 import type { Goal } from './types';
 
 export const CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME = 'calypso_difm_goal_change_prototype';
+export const VARIATION_CONTROL = 'control';
+export const VARIATION_BUY = 'variation_buy';
+export const VARIOATION_GET = 'variation_get';
 
 const SiteGoal = Onboard.SiteGoal;
 const HIDE_GOALS = [ SiteGoal.DIFM, SiteGoal.Import ];
@@ -14,11 +17,20 @@ export const useGoals = ( displayAllGoals = false ): Goal[] => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const [ , experimentAssignment ] = useExperiment( CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME );
-	const showTreatmentDifmGoal = experimentAssignment?.variationName === 'treatment';
+	let variationName = experimentAssignment?.variationName;
 
-	let difmGoalDisplayText = translate( 'Hire a professional to design my website' );
-	if ( showTreatmentDifmGoal ) {
-		difmGoalDisplayText = translate( 'Hire an expert' );
+	let difmGoalDisplayText;
+	variationName = VARIOATION_GET;
+	switch ( variationName ) {
+		case VARIATION_BUY:
+			difmGoalDisplayText = translate( 'Buy a website' );
+			break;
+		case VARIOATION_GET:
+			difmGoalDisplayText = translate( 'Get a website quickly' );
+			break;
+		case VARIATION_CONTROL:
+		default:
+			difmGoalDisplayText = translate( 'Hire a professional to design my website' );
 	}
 
 	const goals = [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -79,7 +79,7 @@ export const SelectGoals = ( {
 		const selectedGoalsWithDIFM = addGoal( SiteGoal.DIFM );
 		onSubmit( selectedGoalsWithDIFM );
 	};
-
+	const hasBuiltByExpressGoal = goalOptions.some( ( g ) => g.key === SiteGoal.DIFM );
 	return (
 		<>
 			{ displayAllGoals && (
@@ -87,7 +87,8 @@ export const SelectGoals = ( {
 			) }
 
 			<div className="select-goals__cards-container">
-				{ isBuiltByExpressExperimentLoading
+				{ /* We only need to show the goal loader only if the BBE goal will be displayed */ }
+				{ hasBuiltByExpressGoal && isBuiltByExpressExperimentLoading
 					? goalOptions.map( ( { key } ) => (
 							<div
 								className="select-card__container"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useExperiment } from 'calypso/lib/explat';
 import DIFMLink from './difm-link';
-import { useGoals } from './goals';
+import { CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME, useGoals } from './goals';
 import ImportLink from './import-link';
 import SelectCard from './select-card';
 
@@ -45,7 +45,7 @@ export const SelectGoals = ( {
 }: SelectGoalsProps ) => {
 	const translate = useTranslate();
 	const goalOptions = useGoals( displayAllGoals );
-	const [ isDIFMxperimentsLoading ] = useExperiment( 'calypso_difm_goal_change_prototype' );
+	const [ isDIFMxperimentsLoading ] = useExperiment( CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME );
 
 	const addGoal = ( goal: Onboard.SiteGoal ) => {
 		const goalSet = new Set( selectedGoals );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useExperiment } from 'calypso/lib/explat';
 import DIFMLink from './difm-link';
 import { useGoals } from './goals';
 import ImportLink from './import-link';
@@ -13,6 +15,26 @@ type SelectGoalsProps = {
 	selectedGoals: Onboard.SiteGoal[];
 };
 
+const Placeholder = styled.div`
+	padding: 0 60px;
+	animation: loading-fade 800ms ease-in-out infinite;
+	background-color: var( --color-neutral-10 );
+	color: transparent;
+	min-height: 20px;
+	width: 100%;
+	@keyframes loading-fade {
+		0% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0.5;
+		}
+	}
+`;
+
 const SiteGoal = Onboard.SiteGoal;
 
 export const SelectGoals = ( {
@@ -23,6 +45,7 @@ export const SelectGoals = ( {
 }: SelectGoalsProps ) => {
 	const translate = useTranslate();
 	const goalOptions = useGoals( displayAllGoals );
+	const [ isDIFMxperimentsLoading ] = useExperiment( 'calypso_difm_goal_change_prototype' );
 
 	const addGoal = ( goal: Onboard.SiteGoal ) => {
 		const goalSet = new Set( selectedGoals );
@@ -62,19 +85,30 @@ export const SelectGoals = ( {
 			) }
 
 			<div className="select-goals__cards-container">
-				{ goalOptions.map( ( { key, title, isPremium } ) => (
-					<SelectCard
-						key={ key }
-						onChange={ handleChange }
-						selected={ selectedGoals.includes( key ) }
-						value={ key }
-					>
-						<span className="select-goals__goal-title">{ title }</span>
-						{ isPremium && (
-							<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
-						) }
-					</SelectCard>
-				) ) }
+				{ isDIFMxperimentsLoading
+					? goalOptions.map( ( { key } ) => (
+							<div
+								className="select-card__container"
+								role="progressbar"
+								key={ `goal-${ key }-placeholder` }
+								style={ { cursor: 'default' } }
+							>
+								<Placeholder />
+							</div>
+					  ) )
+					: goalOptions.map( ( { key, title, isPremium } ) => (
+							<SelectCard
+								key={ key }
+								onChange={ handleChange }
+								selected={ selectedGoals.includes( key ) }
+								value={ key }
+							>
+								<span className="select-goals__goal-title">{ title }</span>
+								{ isPremium && (
+									<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
+								) }
+							</SelectCard>
+					  ) ) }
 			</div>
 
 			<div className="select-goals__actions-container">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useExperiment } from 'calypso/lib/explat';
 import DIFMLink from './difm-link';
-import { CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME, useGoals } from './goals';
+import { CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME, useGoals } from './goals';
 import ImportLink from './import-link';
 import SelectCard from './select-card';
 
@@ -45,7 +45,9 @@ export const SelectGoals = ( {
 }: SelectGoalsProps ) => {
 	const translate = useTranslate();
 	const goalOptions = useGoals( displayAllGoals );
-	const [ isDIFMxperimentsLoading ] = useExperiment( CALYPSO_DIFM_GOAL_TEXT_EXPERIMENT_NAME );
+	const [ isBuiltByExpressExperimentLoading ] = useExperiment(
+		CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME
+	);
 
 	const addGoal = ( goal: Onboard.SiteGoal ) => {
 		const goalSet = new Set( selectedGoals );
@@ -85,7 +87,7 @@ export const SelectGoals = ( {
 			) }
 
 			<div className="select-goals__cards-container">
-				{ isDIFMxperimentsLoading
+				{ isBuiltByExpressExperimentLoading
 					? goalOptions.map( ( { key } ) => (
 							<div
 								className="select-card__container"

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -875,7 +875,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		client_secret: config( 'wpcom_signup_key' ),
 	};
 
-	// Pre Load Experiment relevent to the post site creation goal screen
+	// Pre Load Experiment relevant to the post site creation goal screen
 	loadExperimentAssignment( CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME );
 
 	wpcom.req.post( '/sites/new', data, function ( errors, response ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -8,6 +8,7 @@ import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils
 import { setupSiteAfterCreation, isTailoredSignupFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
+import { CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/goals/goals';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -15,6 +16,7 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'calypso/lib/cart-values/cart-items';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
@@ -266,6 +268,8 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	}
 
 	const locale = getLocaleSlug();
+	// Pre Load Experiment relevent to the post site creation goal screen
+	loadExperimentAssignment( CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME );
 
 	wpcom.req.post(
 		'/sites/new',
@@ -870,6 +874,9 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
 	};
+
+	// Pre Load Experiment relevent to the post site creation goal screen
+	loadExperimentAssignment( CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME );
 
 	wpcom.req.post( '/sites/new', data, function ( errors, response ) {
 		let providedDependencies;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -268,7 +268,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	}
 
 	const locale = getLocaleSlug();
-	// Pre Load Experiment relevent to the post site creation goal screen
+	// Pre Load Experiment relevant to the post site creation goal screen
 	loadExperimentAssignment( CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME );
 
 	wpcom.req.post(


### PR DESCRIPTION
#### Proposed Changes
- Adds a loading animation for when the experiment is loading
- Adds a different goals text for DIFM when the experiment treatment is active
- We also preload the experiment when site is created to try and eliminate the loader in most cases.
- The loader would be hidden for non EN users (when the BBE goal does not exist for display)

![goalsexp](https://user-images.githubusercontent.com/3422709/194855440-85ef2624-a97a-4712-b452-7d294e87733d.gif)


#### Testing Instructions
- Create a site
- Land on the post site creation goal step and make sure the normal UI is visible
- Go to the experiment 20855-explat-experiment and activate the treatment cookie
- Now refresh the goal step from above and make sure the treatment is visible

- Loader Dynamics
- When creating the site make sure that a loader is not visible when the experiment loads.
- Refresh the page after 1 minute (TTL) and make sure a loader is visible
- Change language to NON En and make sure the loader is never visible.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

