### PR TITLE
Fix reader image dimension ratio

### DIFF
--- a/client/reader/components/icons/comment-icon.jsx
+++ b/client/reader/components/icons/comment-icon.jsx
@@ -8,6 +8,7 @@ export default function ReaderCommentIcon( { iconSize } ) {
 
 	return (
 		<svg
+			key="comment"
 			fill="none"
 			viewBox="0 0 20 20"
 			width={ iconSize }

--- a/client/reader/components/icons/external-icon.jsx
+++ b/client/reader/components/icons/external-icon.jsx
@@ -1,6 +1,7 @@
 export default function ReaderExternalIcon( { iconSize } ) {
 	return (
 		<svg
+			key="external"
 			fill="none"
 			className="reader-external"
 			viewBox="0 0 20 20"

--- a/client/reader/components/icons/facebook-icon.jsx
+++ b/client/reader/components/icons/facebook-icon.jsx
@@ -1,6 +1,7 @@
 export default function ReaderFacebookIcon( { iconSize } ) {
 	return (
 		<svg
+			key="facebook"
 			fill="none"
 			className="reader-facebook"
 			viewBox="0 0 24 24"

--- a/client/reader/components/icons/follow-conversation-icon.jsx
+++ b/client/reader/components/icons/follow-conversation-icon.jsx
@@ -1,6 +1,7 @@
 export default function ReaderFollowConversationIcon( { iconSize } ) {
 	return (
 		<svg
+			key="follow-conversation"
 			fill="none"
 			viewBox="0 0 20 20"
 			width={ iconSize }

--- a/client/reader/components/icons/following-conversation-icon.jsx
+++ b/client/reader/components/icons/following-conversation-icon.jsx
@@ -1,6 +1,7 @@
 export default function ReaderFollowingConversationIcon( { iconSize } ) {
 	return (
 		<svg
+			key="following-conversation"
 			fill="none"
 			viewBox="0 0 20 20"
 			width={ iconSize }

--- a/client/reader/components/icons/like-icon.jsx
+++ b/client/reader/components/icons/like-icon.jsx
@@ -11,6 +11,7 @@ export default function ReaderLikeIcon( { liked, iconSize } ) {
 	return (
 		<span className="like-button__like-icons">
 			<svg
+				key="like"
 				fill="none"
 				height={ iconSize }
 				className={ className }

--- a/client/reader/components/icons/share-icon.jsx
+++ b/client/reader/components/icons/share-icon.jsx
@@ -1,6 +1,7 @@
 export default function ReaderShareIcon( { iconSize } ) {
 	return (
 		<svg
+			key="share"
 			fill="none"
 			className="reader-share"
 			viewBox="0 0 20 20"

--- a/client/reader/components/icons/twitter-icon.jsx
+++ b/client/reader/components/icons/twitter-icon.jsx
@@ -1,6 +1,7 @@
 export default function ReaderTwitterIcon( { iconSize } ) {
 	return (
 		<svg
+			key="twitter"
 			fill="none"
 			className="reader-twitter"
 			viewBox="0 0 24 24"

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -51,8 +51,8 @@ export function imageIsBigEnoughForGallery( image ) {
 
 export function imageWithCorrectRatio( image ) {
 	const imageRatio = image.height / image.width;
-	const minRatio = 9 / 17;
-	const maxRatio = 17 / 9;
+	const minRatio = 1 / 3;
+	const maxRatio = 3;
 	return imageRatio >= minRatio && imageRatio <= maxRatio;
 }
 


### PR DESCRIPTION
Fixing issue in reader where images are being filtered as they are deemed outside ideal dimension ratio's.

The ratio in place was 9x17 min and 17x9 max (wxh). This was fairly arbitary based on testing but it looks like we need to allow up to 1x3 min and 3x1 max.

Example of image that is currently being omitted (1800x600) - https://disperser.files.wordpress.com/2022/03/1800x600-copy-studio.jpg

This PR also includes a minor fix for some error consoles complaining new icon svgs are missing key attributes.

REF - https://github.com/Automattic/wp-calypso/issues/68604