### PR TITLE
Fix unnecessary "Upgrade to Business" warning during plugin "Upgrade and activate" installation

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -1,4 +1,4 @@
-import { planHasFeature, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
@@ -36,6 +36,7 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { initiateThemeTransfer as initiateTransfer } from 'calypso/state/themes/actions';
 import {
@@ -123,11 +124,13 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 	);
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 
+	const hasAtomicFeature = useSelector( ( state ) =>
+		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
+	);
 	const supportsAtomicUpgrade = useRef< boolean >();
 	useEffect( () => {
-		supportsAtomicUpgrade.current =
-			selectedSite?.plan && planHasFeature( selectedSite.plan.product_slug, WPCOM_FEATURES_ATOMIC );
-	}, [ selectedSite ] );
+		supportsAtomicUpgrade.current = hasAtomicFeature;
+	}, [ hasAtomicFeature ] );
 
 	// retrieve plugin data if not available
 	useEffect( () => {
@@ -186,7 +189,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 				dispatch( installPlugin( siteId, wporgPlugin, false ) );
 
 				triggerInstallFlow();
-			} else if ( supportsAtomicUpgrade.current ) {
+			} else if ( hasAtomicFeature ) {
 				// initialize atomic flow
 				setAtomicFlow( true );
 				dispatch( initiateTransfer( siteId, null, productSlug ) );
@@ -204,6 +207,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 		wporgPlugin,
 		productSlug,
 		dispatch,
+		hasAtomicFeature,
 	] );
 
 	// Validate completion of atomic transfer flow


### PR DESCRIPTION
#### Proposed Changes

* This PR prevents the "Upgrade to Business" warning from showing up during the installation of a plugin during the "Upgrade and activate" installation flow.
* The fix is we useEffect to update the list of site features when the site changes, so when a site goes from free to Business during upgrade, the features are updated, and the check for the `WPCOM_FEATURES_ATOMIC` feature passes, preventing the "Upgrade to Business" warning.

#### Testing Instructions

First check that this does not introduce a regression by visiting the plugin installation page on a sub-business plan. http://calypso.localhost:3000/marketplace/wordpress-seo/install/[free_site] You should see the "Upgrade to Business Plan" warning after 2 seconds.

<img src="https://user-images.githubusercontent.com/140841/194658804-e21e9b69-d438-485e-960d-55daeb44b918.png" width="400" />

Next check that we fixed the "Upgrade and activate" installation flow

1. On a free site "Upgrade and activate" a free plugin
2. After checkout the installation progress screen starts
3. You should **_NOT_** see a screen to "Upgrade to Business Plan" <img src="https://user-images.githubusercontent.com/140841/194639601-e5448688-5b55-42cb-af75-20c92152f0b1.png" width="400" />
4. The installation progress bar screen should eventually give way to the "All ready to go!" installation complete screen.



Please test around this issue and make sure plugin installation is behaving on simple, Atomic, and Jetpack sites.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/68788
