### PR TITLE
Site Selector: move height style from component to layout

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -15,7 +15,6 @@
 	z-index: z-index("root", ".site-selector");
 	display: flex;
 	flex-direction: column;
-	height: calc(100vh - var(--masterbar-height));
 
 	&.is-large .search {
 		display: flex;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -163,6 +163,7 @@ body.is-focus-sites {
 		left: 0;
 		pointer-events: none;
 		transform: translateX(calc(-1 * var(--sidebar-width-max)));
+		height: calc(100vh - var(--masterbar-height));
 
 		&.is-large .site-selector__sites {
 			border-color: var(--color-sidebar-border);


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/68257. The height style, `height: calc(100vh - var(--masterbar-height));`, in the component file, was not appropriate for all instances of the Site Picker. @ebinnion  reported a bug [here](p1665335853271669-slack-C0347E545HR). 

#### Testing Instructions

You can check the locations where the Site Picker is used:

`/read` then `Share`
`/domains/add` via `domains/manage/:site-with-domain` after `Options > Add a domain to different site`
`/home` then `Switch site`
`/help/contact`
`/dashboard` (Jetpack Agency dashboard - not sure how to test this but it looks ok in the Jetpack Cloud link)

 * To test, reproduce the issue at `/help/contact` on `trunk` and also visit the other locations above. 
 * Next, check out this branch and repeat the above checks. Verify that the Site Picker`/help/contact` no longer has an issue and that no other regressions were introduced. 
 * Test it with the Calypso C and Jetpack Cloud links
 * Test it with different screen sizes. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #