### PR TITLE
HelpCenterContactForm: fix formTitles translations and add hasTranslation check for new strings

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -381,24 +381,28 @@ export const HelpCenterContactForm = () => {
 		if ( ! showingSibylResults && sibylArticles && sibylArticles.length > 0 ) {
 			return __( 'Continue', __i18n_text_domain__ );
 		}
-		switch ( mode ) {
-			case 'CHAT':
-				if (
-					showingSibylResults &&
-					( hasTranslation( 'Still chat with us' ) || locale === 'en' )
-				) {
-					return __( 'Still chat with us', __i18n_text_domain__ );
-				}
-			case 'EMAIL':
-				if ( showingSibylResults && ( hasTranslation( 'Still email us' ) || locale === 'en' ) ) {
-					return __( 'Still email us', __i18n_text_domain__ );
-				}
-			case 'FORUM':
-				if ( ownershipStatusLoading ) {
-					return formTitles.buttonLoadingLabel;
-				}
-				return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
+
+		if (
+			mode === 'CHAT' &&
+			showingSibylResults &&
+			( hasTranslation( 'Still chat with us' ) || locale === 'en' )
+		) {
+			return __( 'Still chat with us', __i18n_text_domain__ );
 		}
+
+		if (
+			mode === 'EMAIL' &&
+			showingSibylResults &&
+			( hasTranslation( 'Still email us' ) || locale === 'en' )
+		) {
+			return __( 'Still email us', __i18n_text_domain__ );
+		}
+
+		if ( ownershipStatusLoading ) {
+			return formTitles.buttonLoadingLabel;
+		}
+
+		return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
 	};
 
 	return showingSibylResults ? (

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -19,6 +19,7 @@ import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
@@ -83,40 +84,40 @@ const HelpCenterSitePicker: React.FC< SitePicker > = ( {
 	);
 };
 
-const titles: {
-	[ key: string ]: {
-		formTitle: string;
-		formSubtitle?: string;
-		trayText?: string;
-		formDisclaimer?: string;
-		buttonLabel: string;
-		buttonSubmittingLabel: string;
-		buttonLoadingLabel?: string;
-	};
-} = {
-	CHAT: {
-		formTitle: __( 'Start live chat', __i18n_text_domain__ ),
-		trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
-		buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
-		buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
-	},
-	EMAIL: {
-		formTitle: __( 'Send us an email', __i18n_text_domain__ ),
-		trayText: __( 'Our WordPress experts will get back to you soon', __i18n_text_domain__ ),
-		buttonLabel: __( 'Email us', __i18n_text_domain__ ),
-		buttonSubmittingLabel: __( 'Sending email', __i18n_text_domain__ ),
-	},
-	FORUM: {
-		formTitle: __( 'Ask in our community forums', __i18n_text_domain__ ),
-		formDisclaimer: __(
-			'Please do not provide financial or contact information when submitting this form.',
-			__i18n_text_domain__
-		),
-		buttonLabel: __( 'Ask in the forums', __i18n_text_domain__ ),
-		buttonSubmittingLabel: __( 'Posting in the forums', __i18n_text_domain__ ),
-		buttonLoadingLabel: __( 'Analyzing site…', __i18n_text_domain__ ),
-	},
-};
+function useFormTitles( mode: Mode ): {
+	formTitle: string;
+	formSubtitle?: string;
+	trayText?: string;
+	formDisclaimer?: string;
+	buttonLabel: string;
+	buttonSubmittingLabel: string;
+	buttonLoadingLabel?: string;
+} {
+	return {
+		CHAT: {
+			formTitle: __( 'Start live chat', __i18n_text_domain__ ),
+			trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
+			buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
+			buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
+		},
+		EMAIL: {
+			formTitle: __( 'Send us an email', __i18n_text_domain__ ),
+			trayText: __( 'Our WordPress experts will get back to you soon', __i18n_text_domain__ ),
+			buttonLabel: __( 'Email us', __i18n_text_domain__ ),
+			buttonSubmittingLabel: __( 'Sending email', __i18n_text_domain__ ),
+		},
+		FORUM: {
+			formTitle: __( 'Ask in our community forums', __i18n_text_domain__ ),
+			formDisclaimer: __(
+				'Please do not provide financial or contact information when submitting this form.',
+				__i18n_text_domain__
+			),
+			buttonLabel: __( 'Ask in the forums', __i18n_text_domain__ ),
+			buttonSubmittingLabel: __( 'Posting in the forums', __i18n_text_domain__ ),
+			buttonLoadingLabel: __( 'Analyzing site…', __i18n_text_domain__ ),
+		},
+	}[ mode ];
+}
 
 type Mode = 'CHAT' | 'EMAIL' | 'FORUM';
 
@@ -137,7 +138,7 @@ export const HelpCenterContactForm = () => {
 	const userWithNoSites = userSites?.sites.length === 0;
 	const queryClient = useQueryClient();
 	const email = useSelector( getCurrentUserEmail );
-
+	const { hasTranslation } = useI18n();
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
@@ -174,7 +175,7 @@ export const HelpCenterContactForm = () => {
 		}
 	}, [ userWithNoSites ] );
 
-	const formTitles = titles[ mode ];
+	const formTitles = useFormTitles( mode );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const currentSite = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
@@ -382,19 +383,21 @@ export const HelpCenterContactForm = () => {
 		}
 		switch ( mode ) {
 			case 'CHAT':
-				if ( showingSibylResults ) {
+				if (
+					showingSibylResults &&
+					( hasTranslation( 'Still chat with us' ) || locale === 'en' )
+				) {
 					return __( 'Still chat with us', __i18n_text_domain__ );
 				}
 			case 'EMAIL':
-				if ( showingSibylResults ) {
+				if ( showingSibylResults && ( hasTranslation( 'Still email us' ) || locale === 'en' ) ) {
 					return __( 'Still email us', __i18n_text_domain__ );
 				}
-			case 'FORUM': {
+			case 'FORUM':
 				if ( ownershipStatusLoading ) {
 					return formTitles.buttonLoadingLabel;
 				}
 				return isSubmitting ? formTitles.buttonSubmittingLabel : formTitles.buttonLabel;
-			}
 		}
 	};
 
@@ -402,7 +405,11 @@ export const HelpCenterContactForm = () => {
 		<div className="help-center__sibyl-articles-page">
 			<BackButton />
 			<SibylArticles
-				title={ __( 'These are some helpful articles', __i18n_text_domain__ ) }
+				title={
+					hasTranslation( 'These are some helpful articles' ) || locale === 'en'
+						? __( 'These are some helpful articles', __i18n_text_domain__ )
+						: ''
+				}
 				supportSite={ supportSite }
 				message={ message }
 				articleCanNavigateBack


### PR DESCRIPTION
#### Proposed Changes
| Before  | After |
| ------------- | ------------- |
|  <img width="537" alt="Screenshot 2022-10-10 at 10 41 16" src="https://user-images.githubusercontent.com/7000684/194828334-6324df36-6ed6-4117-8a91-b97517d2ccb2.png"> | <img width="436" alt="Screenshot 2022-10-10 at 10 41 45" src="https://user-images.githubusercontent.com/7000684/194829291-20e2478d-5938-47c5-8d4d-58b72527aa5c.png"> |
| <img width="432" alt="Screenshot 2022-10-10 at 10 46 02" src="https://user-images.githubusercontent.com/7000684/194829048-ae873f99-541b-47e2-a0b1-868be8421b51.png"> | <img width="437" alt="Screenshot 2022-10-10 at 10 45 07" src="https://user-images.githubusercontent.com/7000684/194828972-033afd04-05d6-475d-9b63-b8acb482599b.png"> |

* The way we were loading formTitle translations was causing an issue. The translations defaulted to english. This PR changes how we load them to give time for the locale to be properly set in js and avoid a race condition.
* This PR adds hasTranslation checks for the new strings that were added to show sibyl results before contacting support

#### Testing Instructions
- According to this https://translate.wordpress.com/deliverables/overview/7569430/ the translations are still not done for Italian language.
- Checkout this branch
- Run `yarn start`
- Login with the 10 percent user and set the locale to italian
- Open the help center contact page and test contact via email
- Check the form title translations
- Write a title and a description 'how do I add paypal'
- Click the submit button
- Check the form title translations and the header of the articles
- Perform the same check for "Chat with us"
