### PR TITLE
Plugin details: fixes spacing and typo. Cleans up.

### DIFF
--- a/client/my-sites/plugins/plugin-details-body/index.tsx
+++ b/client/my-sites/plugins/plugin-details-body/index.tsx
@@ -13,12 +13,7 @@ export default function PluginDetailsBody( { fullPlugin, isMarketplaceProduct, i
 		<div className="plugin-details__layout plugin-details__body">
 			<div className="plugin-details__layout-col-left">
 				{ fullPlugin.wporg || isMarketplaceProduct ? (
-					<PluginSections
-						className="plugin-details__plugins-sections"
-						plugin={ fullPlugin }
-						isWpcom={ isWpcom }
-						addBanner
-					/>
+					<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } addBanner />
 				) : (
 					<PluginSectionsCustom plugin={ fullPlugin } />
 				) }

--- a/client/my-sites/plugins/plugin-details-body/index.tsx
+++ b/client/my-sites/plugins/plugin-details-body/index.tsx
@@ -18,7 +18,6 @@ export default function PluginDetailsBody( { fullPlugin, isMarketplaceProduct, i
 						plugin={ fullPlugin }
 						isWpcom={ isWpcom }
 						addBanner
-						removeReadMore
 					/>
 				) : (
 					<PluginSectionsCustom plugin={ fullPlugin } />

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -309,12 +309,7 @@ function PluginDetails( props ) {
 								) }
 
 								{ fullPlugin.wporg || isMarketplaceProduct ? (
-									<PluginSections
-										className="plugin-details__plugins-sections"
-										plugin={ fullPlugin }
-										isWpcom={ isWpcom }
-										addBanner
-									/>
+									<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } addBanner />
 								) : (
 									<PluginSectionsCustom plugin={ fullPlugin } />
 								) }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -314,7 +314,6 @@ function PluginDetails( props ) {
 										plugin={ fullPlugin }
 										isWpcom={ isWpcom }
 										addBanner
-										removeReadMore
 									/>
 								) : (
 									<PluginSectionsCustom plugin={ fullPlugin } />

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -68,10 +68,6 @@
 			box-shadow: none;
 		}
 
-		.plugin-details__plugins-sections .card {
-			padding-top: 24px;
-		}
-
 		.plugin-details__layout-col-left {
 			padding-block-start: 12px;
 

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -266,7 +266,7 @@ class PluginSections extends Component {
 			availableSections.find( ( section ) => section.key === 'description' );
 
 		return (
-			<div className={ classNames( 'plugin-sections', this.props.className ) }>
+			<div className="plugin-sections">
 				{ ! hasOnlyDescriptionSection && (
 					<div className="plugin-sections__header">
 						<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,4 +1,3 @@
-import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { filter, find } from 'lodash';
@@ -24,7 +23,6 @@ class PluginSections extends Component {
 
 	state = {
 		selectedSection: false,
-		readMore: false,
 		descriptionHeight: 0,
 	};
 
@@ -185,7 +183,6 @@ class PluginSections extends Component {
 
 	setSelectedSection = ( section, event ) => {
 		this.setState( {
-			readMore: false !== this.state.readMore || this.getSelected() !== section,
 			selectedSection: section,
 		} );
 		if ( event ) {
@@ -193,41 +190,8 @@ class PluginSections extends Component {
 		}
 	};
 
-	toggleReadMore = () => {
-		this.setState( { readMore: ! this.state.readMore } );
-	};
-
-	renderReadMore = () => {
-		if (
-			this.props.removeReadMore ||
-			this.props.isWpcom ||
-			this.state.descriptionHeight < this._COLLAPSED_DESCRIPTION_HEIGHT
-		) {
-			return null;
-		}
-		const button = (
-			<button className="plugin-sections__read-more-link" onClick={ this.toggleReadMore }>
-				<span className="plugin-sections__read-more-text">
-					{ this.props.translate( 'Read More' ) }
-				</span>
-				<Gridicon icon="chevron-down" size={ 18 } />
-			</button>
-		);
-		return (
-			<div className="plugin-sections__read-more">
-				{
-					// We remove the link but leave the plugin-sections__read-more container
-					// in order to minimize jump on small sections.
-					this.state.readMore ? null : button
-				}
-			</div>
-		);
-	};
-
 	renderSelectedSection() {
-		const contentClasses = classNames( 'plugin-sections__content', {
-			trimmed: ! this.props.removeReadMore && ! this.props.isWpcom && ! this.state.readMore,
-		} );
+		const contentClasses = classNames( 'plugin-sections__content' );
 		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
 		const videoUrl = this.props.plugin?.banner_video_src;
 
@@ -322,11 +286,8 @@ class PluginSections extends Component {
 						</SectionNav>
 					</div>
 				) }
-				<Card className={ classNames( { 'no-header': hasOnlyDescriptionSection } ) }>
-					{ 'faq' === this.getSelected() && this.props.isWpcom && this.getWpcomSupportContent() }
-					{ this.renderSelectedSection() }
-					{ this.renderReadMore() }
-				</Card>
+				{ 'faq' === this.getSelected() && this.props.isWpcom && this.getWpcomSupportContent() }
+				{ this.renderSelectedSection() }
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -50,6 +50,7 @@
 
 	img {
 		margin: 32px 0;
+		display: block;
 	}
 
 	position: relative;

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -60,6 +60,7 @@
 	line-height: 21px;
 	word-wrap: break-word;
 	hyphens: auto;
+	margin: 32px 0;
 }
 
 .plugin-sections__support {

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -5,9 +5,9 @@
 	h4,
 	h5,
 	h6 {
-		font-size: $font-body-small;
 		font-weight: 600;
-		margin-bottom: 16px;
+		margin: 32px 0;
+		font-size: $font-body-large;
 	}
 	h1 {
 		font-size: $font-title-large;
@@ -33,7 +33,7 @@
 		}
 	}
 	code {
-		font-size: $font-body-small;
+		font-size: $font-body;
 		padding: 1px 4px;
 		border-radius: 2px;
 		background: var(--color-neutral-0);
@@ -48,18 +48,17 @@
 		margin-bottom: 20px;
 	}
 
+	img {
+		margin: 32px 0;
+	}
+
 	position: relative;
 	font-family: $sans;
-	font-size: $font-body-small;
+	font-size: $font-body;
 	font-weight: 400;
 	line-height: 21px;
 	word-wrap: break-word;
 	hyphens: auto;
-}
-
-.plugin-sections__content.trimmed {
-	overflow: hidden;
-	max-height: 150px;
 }
 
 .plugin-sections__support {
@@ -74,66 +73,10 @@
 	}
 }
 
-.plugin-sections__read-more {
-	text-align: center;
-}
-
-.plugin-sections__read-more-link {
-	display: block;
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	width: 100%;
-	padding-top: 12px;
-	padding-bottom: 2px;
-	background: var(--color-surface);
-	color: var(--color-neutral-light);
-	cursor: pointer;
-	font-size: $font-body-extra-small;
-	text-transform: uppercase;
-
-	&:focus {
-		.plugin-sections__read-more-text {
-			color: var(--color-primary);
-			outline: solid var(--color-neutral-light) 1px;
-		}
-	}
-	&::after {
-		position: absolute;
-		left: 0;
-		bottom: 100%;
-		content: "";
-		width: 100%;
-		height: 44px;
-		background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
-	}
-}
-
-.plugin-sections__read-more-link .gridicon {
-	display: block;
-	margin: 0 auto;
-}
-
-.plugin-sections__read-more-text {
-	padding: 8px 8px 0;
-}
-
-.plugin-sections__header .card,
 .plugin-sections__header > div {
 	margin-bottom: 0;
 }
 
-.plugin-details__plugins-sections {
-	.card {
-		padding-top: 32px;
-
-		&.no-header {
-			padding-top: 20px;
-		}
-	}
-
-	.plugin-sections__banner {
-		padding-bottom: 50px;
-	}
+.plugin-sections__banner {
+	margin-bottom: 0;
 }

--- a/client/my-sites/plugins/woocommerce-box.scss
+++ b/client/my-sites/plugins/woocommerce-box.scss
@@ -163,21 +163,4 @@ $c-gray-100: #101517 !default;
 		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin: 10px 0 10px 70px;
 	}
-
-	&.post-theme-info {
-		margin: 0 0 20px;
-		padding: 0;
-
-		.fl {
-			float: none;
-			padding: 15px 0 5px;
-			text-align: center;
-		}
-
-		.fr {
-			float: none;
-			padding: 5px 0 15px;
-			text-align: center;
-		}
-	}
 }


### PR DESCRIPTION
#### Proposed Changes

- adjust spacing and padding
- removes read more, card components and css (not used anymore
- removes plugin-details__plugins-sections class

|Before | After|
|-------|------|
|![CleanShot 2022-10-10 at 12 34 04@2x](https://user-images.githubusercontent.com/12430020/194837179-1f0e082f-dbef-4734-947e-2c30d5f93b6d.png)|<img width="1070" alt="CleanShot 2022-10-10 at 12 34 52@2x" src="https://user-images.githubusercontent.com/12430020/194837229-5a32d4e1-2c2f-44fd-9d6d-a7c87430657b.png">|

|Before | After|
|-------|------|
|![CleanShot 2022-10-10 at 12 35 24@2x](https://user-images.githubusercontent.com/12430020/194837344-7e797b2d-68b8-44aa-8b5f-664204b68f9f.png)|<img width="733" alt="CleanShot 2022-10-10 at 12 35 50@2x" src="https://user-images.githubusercontent.com/12430020/194837395-1e29c3ff-7323-4807-a8c3-805841cdab03.png">|

|Before | After|
|-------|------|
|![CleanShot 2022-10-10 at 12 36 32@2x](https://user-images.githubusercontent.com/12430020/194837523-b125c24b-001b-4e87-b400-7da6637a528b.png)|<img width="1103" alt="CleanShot 2022-10-10 at 12 36 49@2x" src="https://user-images.githubusercontent.com/12430020/194837574-6e3d6c6f-758c-46da-a179-0e373e19501d.png">|

|Before | After removes wc specific rule that was breaking css and avoid floating images|
|-------|------|
|![CleanShot 2022-10-10 at 12 37 37@2x](https://user-images.githubusercontent.com/12430020/194837757-5af05063-952d-4aa9-8527-1ba19af0cd0c.png)|<img width="1087" alt="CleanShot 2022-10-10 at 12 38 11@2x" src="https://user-images.githubusercontent.com/12430020/194837809-90cd616b-495d-4b91-930f-8c108e132964.png">|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Inspect free and premium plugin pages

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
