### PR TITLE
Enable feature flag for login/react-lost-password-screen in staging a…

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -69,7 +69,7 @@
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,
-		"login/react-lost-password-screen": false,
+		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
 		"marketplace-jetpack-plugin-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -67,7 +67,7 @@
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,
-		"login/react-lost-password-screen": false,
+		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": true,


### PR DESCRIPTION
#### Proposed Changes

Enable feature flag for login/react-lost-password-screen in staging and production environments

#### Testing Instructions

Checking code changes should be sufficient

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
