### PR TITLE
SMP: Add max width to stats to avoid overlapping columns

### DIFF
--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -26,12 +26,13 @@ const SparklineChart = ( {
 		<div
 			className={ classnames( 'stats-sparkline', className ) }
 			title={ title }
-			style={ { height: chartHeight + 'px', width: chartWidth + 'px' } }
+			style={ { height: chartHeight + 'px', width: chartWidth + 'px', maxWidth: '100%' } }
 		>
 			<svg
 				width={ chartWidth }
 				height={ chartHeight }
 				viewBox={ `0 0 ${ chartWidth } ${ chartHeight }` }
+				style={ { maxWidth: '100%' } }
 			>
 				{ hourlyViews.map( ( value, i ) => {
 					// for zero value, we show a baseline bar with 1px height


### PR DESCRIPTION
#### Proposed Changes

* Add a width limit to the `StatsSparkline` Chart.

In SMP `/sites` this chart is overlapping in some viewports. This PR fixes that issue.

#### Screenshots

**Stats in the SMP**
![68731-add-max-width](https://user-images.githubusercontent.com/779993/194837779-131ccf09-e3a8-405c-bc72-148bbc50d833.gif)

**Stats in the Sidebar**
<img width="276" alt="Screenshot 2022-10-10 at 10 43 41" src="https://user-images.githubusercontent.com/779993/194838773-a9660bbb-4d98-4865-902c-01d72c30f50b.png">

#### Testing Instructions

* Open `/sites`
* Reduce the viewport to 990px or similar.
* Observe the stats chart and the three dots button don't overlap with each other.
* Click on the stats
* Observe the stats on the left sidebar are still looking good.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68626
