### PR TITLE
Manage Following: Set `illustrationHeight` to avoid layout shift on load

### DIFF
--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -12,6 +12,7 @@ class EmptyContent extends Component {
 		title: PropTypes.node,
 		illustration: PropTypes.string,
 		illustrationWidth: PropTypes.number,
+		illustrationHeight: PropTypes.number,
 		line: PropTypes.node,
 		action: PropTypes.node,
 		actionURL: PropTypes.string,
@@ -91,6 +92,7 @@ class EmptyContent extends Component {
 				src={ this.props.illustration }
 				alt=""
 				width={ this.props.illustrationWidth }
+				height={ this.props.illustrationHeight }
 				className="empty-content__illustration"
 			/>
 		);

--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -38,6 +38,7 @@ class FollowingManageEmptyContent extends Component {
 				line={ this.props.translate( 'Search for a site above or explore Discover.' ) }
 				illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 				illustrationWidth={ 400 }
+				illustrationHeight={ 250 }
 			/>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
## Proposed Changes

Sets `illustrationHeight` on the illustration to avoid a layout shift on load. Because `height` isn't set unless the prop is passed, this change shouldn't have an impact on other use of `<EmptyContent />`

### Before

Notice the brief layout shift as the illustration is loaded:

https://user-images.githubusercontent.com/36432/194874654-d70f7f68-4d77-4bab-bc13-894f3b6fa844.mp4

### After

https://user-images.githubusercontent.com/36432/194873430-c85cfb20-da27-402a-a066-ddc400b17fe5.mp4

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/following/manage?s=testing.wordpress.com
2. Force refresh the page and notice there isn't a layout shift with the illustration.