### PR TITLE
update: Remove border radius from search input

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -10,7 +10,7 @@
 }
 
 .search {
-	border-radius: 6px;
+	border-radius: 2px;
 	display: flex;
 	flex: 1 1 auto;
 	margin-bottom: 24px;
@@ -56,7 +56,11 @@
 	}
 
 	&.is-open.has-focus {
-		border-color: var( --color-primary );
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 1px var(--color-primary), 0 0 0 4px var(--color-primary-10);
+		&:hover {
+			box-shadow: 0 0 0 1px var(--color-primary), 0 0 0 4px var(--color-primary-20);
+		}
 	}
 
 	&.is-compact {

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -26,8 +26,6 @@
 		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
-		border-bottom-left-radius: 6px;
-    border-top-left-radius: 6px;
 		background-color: var(--color-surface);
 		height: 100%;
 
@@ -150,10 +148,7 @@
 
 	.search__input,
 	.search__close-icon {
-		border-bottom-right-radius: 6px;
-    border-top-right-radius: 6px;
 		opacity: 1;
-		padding: 6px 0;
 	}
 
 	.search__input {


### PR DESCRIPTION
#### Proposed Changes

Due to some recent changes, the search input field styling on the site switcher is now broken:

![before1](https://user-images.githubusercontent.com/497103/194891195-83285acf-c1d4-4a5d-9c77-0fb7bea9bdee.png)

This pr updates this input field to its previous state.

![before2](https://user-images.githubusercontent.com/497103/194893365-5a726a19-8b78-49fb-8c69-ff601f0c3c9b.png)


#### Testing Instructions

##### Before

- Visit `wordpress.com/home/<your-site>`
- On the top left of the sidebar, click on "Switch Site"
- Write anything in the input field that appears.
- Confirm that the input field is now appearing as shown in the following screenshot:

![before-test](https://user-images.githubusercontent.com/497103/194893922-c5eedd85-d57a-484c-bfb1-394bb9760b4d.png)


##### After

- Locally, visit `/home/<your-site>`
- On the top left of the sidebar, click on "Switch Site"
- Write anything in the input field that appears.
- Confirm that the input field is now appearing as shown in the following screenshot:

![after-test](https://user-images.githubusercontent.com/497103/194894096-86b5edf2-771b-47db-b7df-3ba29f0c9d54.png)

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #68842 