### PR TITLE
Marketplace: Selected category on dropdown is not seen

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -305,7 +305,7 @@ body.is-section-plugins #primary {
 
 	.categories__menu {
 		.components-button {
-			&:not(.is-pressed) {
+			&:not(.is-pressed):not(.is-selected) {
 				color: var(--studio-blue-90);
 			}
 			&.is-pressed {


### PR DESCRIPTION
#### Proposed Changes

Fix categories dropdown color for selected items.

#### Screenshot
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/194886497-0c7c9140-bcba-433f-b295-3a6223ddba89.png) | ![image](https://user-images.githubusercontent.com/402286/194885886-ad5bb0f2-fcd7-422b-bfea-a680e234115e.png) |

#### Testing Instructions

1. Go to `/plugins`
2. Select a Category from the dropdown
3. Check the color of the selected category.
4. 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes #68832