### PR TITLE
Manage Following: Show a placeholder state when reader follows are loading

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -31,6 +31,7 @@ import {
 import {
 	getReaderAliasedFollowFeedUrl,
 	getReaderFollowsCount,
+	isReaderFollowsLoading,
 } from 'calypso/state/reader/follows/selectors';
 import {
 	getReaderRecommendedSites,
@@ -41,6 +42,7 @@ import { getDismissedSites } from 'calypso/state/reader/site-dismissals/selector
 import FollowingManageEmptyContent from './empty';
 import FollowingManageSearchFeedsResults from './feed-search-results';
 import FollowingManageSubscriptions from './subscriptions';
+import FollowingManageSubscriptionsPlaceholder from './subscriptions-placeholder';
 import './style.scss';
 
 const PAGE_SIZE = 4;
@@ -183,6 +185,7 @@ class FollowingManage extends Component {
 			blockedSites,
 			dismissedSites,
 			followsCount,
+			isFollowsLoading,
 			readerAliasedFollowFeedUrl,
 		} = this.props;
 		const searchPlaceholderText = translate( 'Search or enter URL to follow…' );
@@ -277,7 +280,8 @@ class FollowingManage extends Component {
 							windowScrollerRef={ this.handleWindowScrollerMounted }
 						/>
 					) }
-					{ ! hasFollows && <FollowingManageEmptyContent /> }
+					{ ! hasFollows && isFollowsLoading && <FollowingManageSubscriptionsPlaceholder /> }
+					{ ! hasFollows && ! isFollowsLoading && <FollowingManageEmptyContent /> }
 				</ReaderMain>
 			</Fragment>
 		);
@@ -306,6 +310,7 @@ export default connect(
 		dismissedSites: getDismissedSites( state ),
 		readerAliasedFollowFeedUrl: sitesQuery && getReaderAliasedFollowFeedUrl( state, sitesQuery ),
 		followsCount: getReaderFollowsCount( state ),
+		isFollowsLoading: isReaderFollowsLoading( state ),
 	} ),
 	{ recordReaderTracksEvent }
 )( localize( FollowingManage ) );

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -20,6 +20,10 @@
 	padding-top: 10px;
 }
 
+.following-manage__subscriptions-placeholder > div {
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+
 // Load more results
 .following-manage__show-more {
 	border-top: 1px solid var(--color-neutral-10);

--- a/client/reader/following-manage/subscriptions-placeholder.jsx
+++ b/client/reader/following-manage/subscriptions-placeholder.jsx
@@ -1,0 +1,18 @@
+import { Component } from 'react';
+import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
+
+class FollowingManageSubscriptionsPlaceholder extends Component {
+	render() {
+		return (
+			<div className="following-manage__subscriptions-placeholder">
+				{ Array( 3 )
+					.fill( null )
+					.map( () => (
+						<ReaderSubscriptionListItemPlaceholder />
+					) ) }
+			</div>
+		);
+	}
+}
+
+export default FollowingManageSubscriptionsPlaceholder;

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -303,8 +303,20 @@ export const lastSyncTime = ( state = null, action ) => {
 	return state;
 };
 
+export const loading = ( state = null, action ) => {
+	switch ( action.type ) {
+		case READER_FOLLOWS_SYNC_START:
+			return true;
+		case READER_FOLLOWS_SYNC_COMPLETE:
+			return false;
+	}
+
+	return state;
+};
+
 export default combineReducers( {
 	items,
 	itemsCount,
 	lastSyncTime,
+	loading,
 } );

--- a/client/state/reader/follows/selectors/index.js
+++ b/client/state/reader/follows/selectors/index.js
@@ -5,4 +5,5 @@ export { default as getReaderFollowsCount } from './get-reader-follows-count';
 export { default as getReaderFollowsLastSyncTime } from './get-reader-follows-last-sync-time';
 export { default as getReaderFollows } from './get-reader-follows';
 export { default as isFollowing } from './is-following';
+export { default as isReaderFollowsLoading } from './is-reader-follows-loading';
 export { default as hasReaderFollowOrganization } from './has-reader-follows-organization';

--- a/client/state/reader/follows/selectors/is-reader-follows-loading.js
+++ b/client/state/reader/follows/selectors/is-reader-follows-loading.js
@@ -1,0 +1,11 @@
+import 'calypso/state/reader/init';
+
+/*
+ * Whether or not the reader follows are loading
+ *
+ * @param  {object}  state  Global state tree
+ * @returns {boolean} Follow count
+ */
+const isReaderFollowsLoading = ( state ) => state.reader.follows.loading;
+
+export default isReaderFollowsLoading;


### PR DESCRIPTION
## Proposed Changes

Tracks `state.reader.follows.loading` so we can show a placeholder state when reader follows are loading. Previously, "You haven't followed any sites yet" would erroneously display.

### Before

https://user-images.githubusercontent.com/36432/194887795-6df5d78a-cde8-429b-86c8-f503bb73306b.mp4

### After

https://user-images.githubusercontent.com/36432/194887117-4a408d00-7184-4a06-a7c1-0004e835c5b9.mp4

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/following/manage
2. Force refresh and view the placeholder state in all its glory.