### PR TITLE
Marketplace: Fix error on incognito navigation avoiding /me/sites/plugins call at /plugins

### DIFF
--- a/client/components/data/query-plugins/index.tsx
+++ b/client/components/data/query-plugins/index.tsx
@@ -6,6 +6,7 @@ import QueryJetpackPlugins from '../query-jetpack-plugins';
 export default function QueryPlugins( { siteId }: { siteId?: number } ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
+	// Sites plugins can only be retrieved by logged in users
 	if ( isLoggedIn === false ) {
 		return false;
 	}

--- a/client/components/data/query-plugins/index.tsx
+++ b/client/components/data/query-plugins/index.tsx
@@ -5,7 +5,10 @@ import QueryJetpackPlugins from '../query-jetpack-plugins';
 
 export default function QueryPlugins( { siteId }: { siteId?: number } ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	if ( isLoggedIn === false ) return false;
+
+	if ( isLoggedIn === false ) {
+		return false;
+	}
 
 	return siteId ? <QueryJetpackPlugins siteIds={ [ siteId ] } /> : <QueryAllJetpackSitesPlugins />;
 }

--- a/client/components/data/query-plugins/index.tsx
+++ b/client/components/data/query-plugins/index.tsx
@@ -1,6 +1,11 @@
+import { useSelector } from 'react-redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import QueryAllJetpackSitesPlugins from '../query-all-jetpack-sites-plugins';
 import QueryJetpackPlugins from '../query-jetpack-plugins';
 
 export default function QueryPlugins( { siteId }: { siteId?: number } ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	if ( isLoggedIn === false ) return false;
+
 	return siteId ? <QueryJetpackPlugins siteIds={ [ siteId ] } /> : <QueryAllJetpackSitesPlugins />;
 }


### PR DESCRIPTION
fix #68828

### Proposed Changes

* Fix error on incognito navigation avoiding /me/sites/plugins call at /plugins

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**At logged-in navigation**:
* Make sure we still have the /me/sites/plugins call at /plugins page

**At incognito navigation**:

* Open the http://calypso.localhost:3000/plugins page
* Open plugin details
* Make a plugin search

In all the above scenarios, make sure you don't see the error anymore:

![image](https://user-images.githubusercontent.com/1044309/194888878-b0909549-3731-4cfe-84ba-44ed449b9239.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
