### PR TITLE
For email subscription non-owners, return early from `resolveEmailPlanStatus`

### DIFF
--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -137,6 +137,10 @@ export function resolveEmailPlanStatus(
 	};
 
 	if ( hasGSuiteWithUs( domain ) ) {
+		if ( ! canCurrentUserAddEmail( domain ) ) {
+			return cannotManageStatus;
+		}
+
 		// Check for pending TOS acceptance warnings at the account level
 		if (
 			isPendingGSuiteTOSAcceptance( domain ) ||
@@ -160,14 +164,14 @@ export function resolveEmailPlanStatus(
 			};
 		}
 
-		if ( ! canCurrentUserAddEmail( domain ) ) {
-			return cannotManageStatus;
-		}
-
 		return activeStatus;
 	}
 
 	if ( hasTitanMailWithUs( domain ) ) {
+		if ( ! canCurrentUserAddEmail( domain ) ) {
+			return cannotManageStatus;
+		}
+
 		// Check for expired subscription
 		const titanExpiryDateString = getTitanExpiryDate( domain );
 
@@ -193,10 +197,6 @@ export function resolveEmailPlanStatus(
 			getMaxTitanMailboxCount( domain ) > getConfiguredTitanMailboxCount( domain )
 		) {
 			return errorStatus;
-		}
-
-		if ( ! canCurrentUserAddEmail( domain ) ) {
-			return cannotManageStatus;
 		}
 
 		return activeStatus;


### PR DESCRIPTION
#### Proposed Changes

This PR relates to #68435 and #68601. 

When a user cannot manage an email subscription, we display a warning about that on the `EmailPlan` page. But currently, things can get a little confused when the email subscription also has an unconfigured mailbox. In those cases, `resolveEmailPlanStatus` will return info related to that unconfigured mailbox rather than info about the fact that the current user cannot manage the email subscription. This PR changes that.

This screenshot is what the non-owner user sees:

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/1101677/194900242-049083ca-d743-418e-85f1-7eb615c0700d.png) | ![after](https://user-images.githubusercontent.com/1101677/194900228-2cc36df4-ce2c-48a6-8a9d-4353f5ff7b24.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with multiple domains where at least one of those has an email subscription
2. Add a second admin user to that site
3. Log in with that admin user
4. Navigate to `/email/:domain/manage/:site_slug`
5. Ensure that what you see matches the **After** screenshot above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
