### PR TITLE
Limit Global Styles: Add notice to newsletter onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -1,18 +1,17 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { isEnabled } from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { hasMinContrast, RGB } from '@automattic/onboarding';
-import { ColorPicker, Tooltip } from '@wordpress/components';
-import { Icon, starFilled } from '@wordpress/icons';
+import { ColorPicker } from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { Dispatch, SetStateAction, useState, useRef } from 'react';
-import Badge from 'calypso/components/badge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { tip } from 'calypso/signup/icons';
+import GlobalStylesPremiumBadge from '../global-styles-premium-badge';
 
 import './style.scss';
 
@@ -81,20 +80,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					{ hasTranslation( 'Favorite color' ) || locale === 'en'
 						? __( 'Favorite color' )
 						: __( 'Accent color' ) }
-					{ isEnabled( 'limit-global-styles' ) && (
-						<Tooltip
-							text={ __(
-								'Upgrade to a paid plan for color changes to take affect and to unlock all premium design tools'
-							) }
-						>
-							<span className="accent-color-control__premium-label">
-								<Badge type="info">
-									<Icon icon={ starFilled } size={ 18 } />
-									<span>{ __( 'Premium' ) }</span>
-								</Badge>
-							</span>
-						</Tooltip>
-					) }
+					<GlobalStylesPremiumBadge />
 				</FormLabel>
 				<FormInput
 					inputRef={ accentColorRef }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { isEnabled } from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { hasMinContrast, RGB } from '@automattic/onboarding';
-import { ColorPicker } from '@wordpress/components';
+import { ColorPicker, Tooltip } from '@wordpress/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
@@ -80,10 +81,20 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					{ hasTranslation( 'Favorite color' ) || locale === 'en'
 						? __( 'Favorite color' )
 						: __( 'Accent color' ) }
-					<Badge type="info">
-						<Icon icon={ starFilled } />
-						<span>{ __( 'Premium' ) }</span>
-					</Badge>
+					{ isEnabled( 'limit-global-styles' ) && (
+						<Tooltip
+							text={ __(
+								'Upgrade to a paid plan for color changes to take affect and to unlock all premium design tools'
+							) }
+						>
+							<span className="accent-color-control__premium-label">
+								<Badge type="info">
+									<Icon icon={ starFilled } size={ 18 } />
+									<span>{ __( 'Premium' ) }</span>
+								</Badge>
+							</span>
+						</Tooltip>
+					) }
 				</FormLabel>
 				<FormInput
 					inputRef={ accentColorRef }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -3,10 +3,11 @@ import { Popover } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { hasMinContrast, RGB } from '@automattic/onboarding';
 import { ColorPicker } from '@wordpress/components';
-import { Icon } from '@wordpress/icons';
+import { Icon, starFilled } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { Dispatch, SetStateAction, useState, useRef } from 'react';
+import Badge from 'calypso/components/badge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
@@ -79,6 +80,10 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					{ hasTranslation( 'Favorite color' ) || locale === 'en'
 						? __( 'Favorite color' )
 						: __( 'Accent color' ) }
+					<Badge type="info">
+						<Icon icon={ starFilled } />
+						<span>{ __( 'Premium' ) }</span>
+					</Badge>
 				</FormLabel>
 				<FormInput
 					inputRef={ accentColorRef }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -52,20 +52,3 @@
 		width: unset !important;
 	}
 }
-
-.accent-color-control__premium-label {
-	position: relative;
-
-	.badge {
-		background-color: var(--color-neutral-80);
-		color: var(--color-neutral-0);
-		font-size: 0.75rem;
-		margin-left: 8px;
-		padding-left: 6px;
-	}
-
-	svg {
-		fill: var(--color-neutral-0);
-		vertical-align: top;
-	}
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -52,3 +52,20 @@
 		width: unset !important;
 	}
 }
+
+.accent-color-control__premium-label {
+	position: relative;
+
+	.badge {
+		background-color: var(--color-neutral-80);
+		color: var(--color-neutral-0);
+		font-size: 0.75rem;
+		margin-left: 8px;
+		padding-left: 6px;
+	}
+
+	svg {
+		fill: var(--color-neutral-0);
+		vertical-align: top;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/index.js
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/index.js
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Popover } from '@wordpress/components';
+import { Popover } from '@automattic/components';
 import { useState } from '@wordpress/element';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -49,22 +49,16 @@ const GlobalStylesPremiumBadge = () => {
 					<span>{ __( 'Premium' ) }</span>
 				</Badge>
 			</button>
-			{ isPopoverVisible && (
-				<Popover
-					anchor={ popoverAnchor }
-					animate={ false }
-					className="global-styles-premium-badge__popover"
-					focusOnMount={ false }
-					offset={ 8 }
-					placement="bottom"
-				>
-					<span>
-						{ __(
-							'Upgrade to a paid plan for color changes to take affect and to unlock all premium design tools'
-						) }
-					</span>
-				</Popover>
-			) }
+			<Popover
+				className="global-styles-premium-badge__popover"
+				context={ popoverAnchor }
+				isVisible={ isPopoverVisible }
+				onClose={ () => setIsPopoverVisible( false ) }
+			>
+				{ __(
+					'Upgrade to a paid plan for color changes to take effect and to unlock the advanced design customization'
+				) }
+			</Popover>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/index.js
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/index.js
@@ -1,31 +1,71 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Tooltip } from '@wordpress/components';
+import { Popover } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import Badge from 'calypso/components/badge';
+import { hasTouch } from 'calypso/lib/touch-detect';
 
 import './style.scss';
 
 const GlobalStylesPremiumBadge = () => {
 	const { __ } = useI18n();
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 
 	if ( ! isEnabled( 'limit-global-styles' ) ) {
 		return null;
 	}
 
+	const isTouch = hasTouch();
+
 	return (
-		<Tooltip
-			text={ __(
-				'Upgrade to a paid plan for color changes to take affect and to unlock all premium design tools'
-			) }
-		>
-			<span className="global-styles-premium-badge">
+		<>
+			<button
+				ref={ setPopoverAnchor }
+				className="global-styles-premium-badge"
+				onClick={ () => {
+					if ( ! isTouch ) {
+						return;
+					}
+					setIsPopoverVisible( ( state ) => ! state );
+				} }
+				onMouseEnter={ () => {
+					if ( isTouch ) {
+						return;
+					}
+					setIsPopoverVisible( true );
+				} }
+				onMouseLeave={ () => {
+					if ( isTouch ) {
+						return;
+					}
+					setIsPopoverVisible( false );
+				} }
+				type="button"
+			>
 				<Badge type="info">
 					<Icon icon={ starFilled } size={ 18 } />
 					<span>{ __( 'Premium' ) }</span>
 				</Badge>
-			</span>
-		</Tooltip>
+			</button>
+			{ isPopoverVisible && (
+				<Popover
+					anchor={ popoverAnchor }
+					animate={ false }
+					className="global-styles-premium-badge__popover"
+					focusOnMount={ false }
+					offset={ 8 }
+					placement="bottom"
+				>
+					<span>
+						{ __(
+							'Upgrade to a paid plan for color changes to take affect and to unlock all premium design tools'
+						) }
+					</span>
+				</Popover>
+			) }
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/index.js
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/index.js
@@ -1,0 +1,32 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Tooltip } from '@wordpress/components';
+import { Icon, starFilled } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import Badge from 'calypso/components/badge';
+
+import './style.scss';
+
+const GlobalStylesPremiumBadge = () => {
+	const { __ } = useI18n();
+
+	if ( ! isEnabled( 'limit-global-styles' ) ) {
+		return null;
+	}
+
+	return (
+		<Tooltip
+			text={ __(
+				'Upgrade to a paid plan for color changes to take affect and to unlock all premium design tools'
+			) }
+		>
+			<span className="global-styles-premium-badge">
+				<Badge type="info">
+					<Icon icon={ starFilled } size={ 18 } />
+					<span>{ __( 'Premium' ) }</span>
+				</Badge>
+			</span>
+		</Tooltip>
+	);
+};
+
+export default GlobalStylesPremiumBadge;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
@@ -1,0 +1,14 @@
+.global-styles-premium-badge {
+	.badge {
+		background-color: var(--color-neutral-80);
+		color: var(--color-neutral-0);
+		font-size: 0.75rem;
+		margin-left: 8px;
+		padding-left: 6px;
+	}
+
+	svg {
+		fill: var(--color-neutral-0);
+		vertical-align: top;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
@@ -20,18 +20,25 @@
 }
 
 .global-styles-premium-badge__popover {
-	margin-left: -35px;
+	margin-left: 4px;
+	outline: none;
 
-	.components-popover__content {
-		width: min(300px, 100vw);
+	.popover__inner {
 		background-color: var(--color-neutral-80);
 		color: var(--color-neutral-0);
+		max-width: 320px;
 		text-align: center;
-		font-size: 0.75rem;
 		padding: 8px;
-		line-height: 1.4;
-		border-width: 0;
-		outline: none;
+		border: none;
 		box-shadow: none;
+	}
+
+	&.is-top .popover__arrow {
+		border-top-color: var(--color-neutral-80);
+		bottom: 4px;
+
+		&::before {
+			display: none;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
@@ -1,4 +1,10 @@
 .global-styles-premium-badge {
+	padding: 0;
+	margin: 0;
+	background: none;
+	border: none;
+	position: relative;
+
 	.badge {
 		background-color: var(--color-neutral-80);
 		color: var(--color-neutral-0);
@@ -11,9 +17,21 @@
 		fill: var(--color-neutral-0);
 		vertical-align: top;
 	}
+}
 
-	.components-tooltip .components-popover__content {
+.global-styles-premium-badge__popover {
+	margin-left: -35px;
+
+	.components-popover__content {
 		width: min(300px, 100vw);
-		white-space: normal;
+		background-color: var(--color-neutral-80);
+		color: var(--color-neutral-0);
+		text-align: center;
+		font-size: 0.75rem;
+		padding: 8px;
+		line-height: 1.4;
+		border-width: 0;
+		outline: none;
+		box-shadow: none;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/global-styles-premium-badge/style.scss
@@ -11,4 +11,9 @@
 		fill: var(--color-neutral-0);
 		vertical-align: top;
 	}
+
+	.components-tooltip .components-popover__content {
+		width: min(300px, 100vw);
+		white-space: normal;
+	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -73,6 +73,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"limit-global-styles": true,
 		"login/magic-login": true,
 		"logmein": true,
 		"mailchimp": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/894

#### Proposed Changes

<img width="300" alt="Screen Shot 2022-10-13 at 13 56 42" src="https://user-images.githubusercontent.com/1233880/195591698-a2e7b2c7-0d5e-4783-9d9b-9bb2a58f851f.png">

- Add a notice to the newsletter onboarding to highlight that a color change during onboarding is a paid feature and requires upgrading for those changes to be made public.
- Also add the `limit-global-styles` feature flag to the wpcalyps.json config file so it's easier to test in that environment.

Further reading: paYJgx-2p8-p2

#### Testing Instructions

- Use the Calypso live link below
- Go to `/setup/newsletterSetup?flow=newsletter`
- Make sure the favorite color input displays a premium badge
- Hover the badge
- Make sure a notice shows up
- Add a `?flags=-limit-global-styles` param to the URL to disable the feature flag
- Make sure the premium badge doesn't show up