### PR TITLE
Sites Management Page: Add explicit width/height to avoid layout shift

### DIFF
--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -173,6 +173,8 @@ export const NoSitesMessage = ( { status, statusSiteCount }: SitesContainerProps
 			action={ __( 'Create your first site' ) }
 			actionURL={ '/start?source=sites-dashboard&ref=calypso-nosites' }
 			illustration={ '/calypso/images/illustrations/illustration-empty-sites.svg' }
+			illustrationWidth={ 124 }
+			illustrationHeight={ 101 }
 		/>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

Adds explicit `width=` and `height=` attributes to avoid layout shift (inspired by #68825)

<img width="785" alt="image" src="https://user-images.githubusercontent.com/36432/194916568-1156c144-3e8f-47ca-9cec-b9c1c0b1cca5.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Apply patch below.
3. Verify the message loads without a layout shift.

```diff
diff --git a/client/sites-dashboard/components/sites-dashboard.tsx b/client/sites-dashboard/components/sites-dashboard.tsx
index 8d9acf4e8a..3e947f993a 100644
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -140,7 +140,9 @@ export function SitesDashboard( {
 	queryParams: { page = 1, perPage = 96, search, status = 'all' },
 }: SitesDashboardProps ) {
 	const { __, _n } = useI18n();
-	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
+	// const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
+	const allSites = [];
+	const isLoading = false;
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 	const userPreferencesLoaded = hasSitesSortingPreferenceLoaded && 'none' !== displayMode;

```