### PR TITLE
Checkout: Replace lodash snake/camel conversions with local versions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -1,4 +1,4 @@
-import { snakeCase } from 'lodash';
+import { camelToSnakeCase } from '@automattic/js-utils';
 import type { CheckoutPaymentMethodSlug, WPCOMPaymentMethod } from '@automattic/wpcom-checkout';
 
 /**
@@ -172,7 +172,7 @@ export function translateCheckoutPaymentMethodToTracksPaymentMethod(
 		case 'google-pay':
 			return 'web_payment';
 	}
-	return snakeCase( paymentMethodSlug );
+	return camelToSnakeCase( paymentMethodSlug );
 }
 
 export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): boolean {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
@@ -1,11 +1,11 @@
 import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { snakeToCamelCase } from '@automattic/js-utils';
 import { Field } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { camelCase } from 'lodash';
 import { Fragment } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { maskField } from 'calypso/lib/checkout';
@@ -241,7 +241,10 @@ function NetBankingPayButton( {
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
 	const massagedFields: typeof fields = Object.entries( fields ).reduce(
-		( accum, [ key, managedValue ] ) => ( { ...accum, [ camelCase( key ) ]: managedValue.value } ),
+		( accum, [ key, managedValue ] ) => ( {
+			...accum,
+			[ snakeToCamelCase( key ) ]: managedValue.value,
+		} ),
 		{}
 	);
 	const contactCountryCode = 'IN'; // If this payment method is available and the country is not India, we have other problems


### PR DESCRIPTION
#### Proposed Changes

This replaces lodash's `snakeCase()` and `camelCase()` in checkout with `camelToSnakeCase()` and `snakeToCamelCase()`, respectively, from `@automattic/js-utils`. This helps with the movement to remove lodash from calypso and should be more lightweight since, unlike lodash, the custom versions of these functions have no dependencies.

#### Testing Instructions

Both of the changed files are TypeScript so if the tests pass then there should be no testing needed.

In addition, `translateCheckoutPaymentMethodToTracksPaymentMethod()` is [only used for analytics](https://github.com/Automattic/wp-calypso/blob/b6d6b391472a7d68923ba300014dd3b4fde4341f/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx#L620).

