### PR TITLE
WPCOM SSH: Copy tweaks

### DIFF
--- a/client/me/security-checkup/ssh-key.tsx
+++ b/client/me/security-checkup/ssh-key.tsx
@@ -20,7 +20,7 @@ export const SecurityCheckupSSHKey = () => {
 			text={ __( 'SSH Key' ) }
 			description={
 				hasSSHKey
-					? __( 'You have added a SSH key to your account.' )
+					? __( 'You have a SSH key added to your account.' )
 					: __( 'You do not have a SSH key added to your account.' )
 			}
 		/>

--- a/client/me/security-ssh-key/add-ssh-key-form.tsx
+++ b/client/me/security-ssh-key/add-ssh-key-form.tsx
@@ -58,7 +58,7 @@ export const AddSSHKeyForm = ( { addSSHKey, isAdding }: AddSSHKeyFormProps ) => 
 			} }
 		>
 			<FormFieldset>
-				<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'Public SSH key' ) }</FormLabel>
+				<FormLabel htmlFor={ PUBLIC_SSH_KEY_INPUT_ID }>{ __( 'SSH Public Key' ) }</FormLabel>
 				<TextareaAutosize
 					required
 					id={ PUBLIC_SSH_KEY_INPUT_ID }
@@ -67,7 +67,7 @@ export const AddSSHKeyForm = ( { addSSHKey, isAdding }: AddSSHKeyFormProps ) => 
 					isError={ showSSHKeyError }
 					placeholder={ sprintf(
 						// translators: "formats" is a list of SSH-key formats.
-						__( 'Paste the public key here. It should begin with %(formats)s…' ),
+						__( 'Paste your SSH public key here. It should begin with %(formats)s…' ),
 						{
 							formats,
 						}
@@ -81,7 +81,7 @@ export const AddSSHKeyForm = ( { addSSHKey, isAdding }: AddSSHKeyFormProps ) => 
 						isError
 						text={ sprintf(
 							// translators: "formats" is a list of SSH-key formats.
-							__( 'Invalid public key. It should begin with %(formats)s.' ),
+							__( 'Invalid SSH public key. It should begin with %(formats)s.' ),
 							{
 								formats,
 							}

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import { CompactCard, LoadingPlaceholder } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -51,7 +52,7 @@ export const SecuritySSHKey = () => {
 		},
 		onSuccess: () => {
 			dispatch( recordTracksEvent( 'calypso_security_ssh_key_add_success' ) );
-			dispatch( successNotice( __( 'SSH key has been successfully added!' ), noticeOptions ) );
+			dispatch( successNotice( __( 'SSH key added to account.' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(
@@ -62,7 +63,7 @@ export const SecuritySSHKey = () => {
 			dispatch(
 				errorNotice(
 					// translators: "reason" is why adding the ssh key failed.
-					sprintf( __( 'Saving SSH key failed: %(reason)s' ), { reason: error.message } ),
+					sprintf( __( 'Failed to save SSH key: %(reason)s' ), { reason: error.message } ),
 					{
 						...noticeOptions,
 						id: sshKeySaveFailureNoticeId,
@@ -75,7 +76,7 @@ export const SecuritySSHKey = () => {
 	const { deleteSSHKey, keyBeingDeleted } = useDeleteSSHKeyMutation( {
 		onSuccess: () => {
 			dispatch( recordTracksEvent( 'calypso_security_ssh_key_delete_success' ) );
-			dispatch( successNotice( __( 'SSH key has been successfully removed!' ), noticeOptions ) );
+			dispatch( successNotice( __( 'SSH key removed from account.' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(
@@ -86,7 +87,7 @@ export const SecuritySSHKey = () => {
 			dispatch(
 				errorNotice(
 					// translators: "reason" is why deleting the ssh key failed.
-					sprintf( __( 'Deleting SSH key failed: %(reason)s' ), { reason: error.message } ),
+					sprintf( __( 'Failed to delete SSH key: %(reason)s' ), { reason: error.message } ),
 					noticeOptions
 				)
 			);
@@ -108,22 +109,32 @@ export const SecuritySSHKey = () => {
 			<DocumentHead title={ __( 'SSH Key' ) } />
 
 			<CompactCard>
-				<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
-					{ createInterpolateElement(
-						__(
-							'Add a SSH key to manage your SSH-enabled WordPress.com website via command-line tools. Site-level Business plan is required to connect with SSH keys. <a>Read more.</a>'
-						),
-						{
-							a: (
-								<a
-									href="https://wordpress.com/support/connect-to-ssh-on-wordpress-com/"
-									target="_blank"
-									rel="noreferrer"
-								/>
+				<div>
+					<p>
+						{ __(
+							'Add a SSH key to your WordPress.com account to use it for authentication on sites with a Business or eCommerce plan.'
+						) }
+					</p>
+					<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
+						{ createInterpolateElement(
+							__(
+								'Once added, the SSH key will need to be attached to each site as well. <a>Read more.</a>'
 							),
-						}
-					) }
-				</p>
+							{
+								br: <br />,
+								a: (
+									<a
+										href={ localizeUrl(
+											'https://wordpress.com/support/connect-to-ssh-on-wordpress-com/'
+										) }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+							}
+						) }
+					</p>
+				</div>
 
 				{ isLoading ? (
 					<Placeholders />

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -112,13 +112,13 @@ export const SecuritySSHKey = () => {
 				<div>
 					<p>
 						{ __(
-							'Add a SSH key to your WordPress.com account to use it for authentication on sites with a Business or eCommerce plan.'
+							'Add a SSH key to your WordPress.com account to make it available for SFTP and SSH authentication.'
 						) }
 					</p>
 					<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
 						{ createInterpolateElement(
 							__(
-								'Once added, the SSH key will need to be attached to each site as well. <a>Read more.</a>'
+								'Once added, attach the SSH key to a site with a Business or eCommerce plan to enable SSH key authentication for that site. <a>Read more.</a>'
 							),
 							{
 								br: <br />,


### PR DESCRIPTION
## Proposed Changes

Tweaks to copy associated with `/me/security/ssh-key`:

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/36432/194931881-82800806-6f1b-4832-b103-d912a2fdcd5c.png">

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/36432/194932662-505d98ae-bd92-4e39-a7e1-6d43ebd302f0.png">

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/36432/194932730-17ba358e-c992-4049-af16-f0d28822ec1d.png">

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/36432/194932800-520bd7b6-62d3-45af-8ca5-cc8d0f58cc5c.png">

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/36432/194932859-bcc553e0-0fec-4823-9015-5076835adaae.png">

## Testing Instructions

1. Navigate to `/me/security/ssh-key`.
2. Verify it's possible to successfully add a SSH key.