### PR TITLE
Reader: Fix missing excerpt

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -40,7 +40,7 @@ const ReaderExcerpt = ( { post } ) => {
 	}
 
 	if ( excerpt === undefined ) {
-		excerpt = post.content_no_html;
+		excerpt = post.content_no_html || '';
 	}
 
 	return (

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -6,34 +6,42 @@ import './style.scss';
 const ReaderExcerpt = ( { post } ) => {
 	let excerpt = post.better_excerpt || post.excerpt;
 
-	// Excerpt is set to use webkit-line-clamp to limit number of lines of text to show inside container
-	// If we use an excerpt with no html, then text that contains <br> will appear on the same line with incorrect spacing.
-	// If we use an excerpt with html, we need to remove the paragraph tags to avoid multiple containers that are subject to webkit-line-clamp
-	const paragraphs = excerpt.split( '<p>' );
-	const lines = [];
+	if ( excerpt !== undefined ) {
+		// Excerpt is set to use webkit-line-clamp to limit number of lines of text to show inside container
+		// If we use an excerpt with no html, then text that contains <br> will appear on the same line with incorrect spacing.
+		// If we use an excerpt with html, we need to remove the paragraph tags to avoid multiple containers that are subject to webkit-line-clamp
+		const paragraphs = excerpt.split( '<p>' );
+		const lines = [];
 
-	// Split html text into paragraphs
-	paragraphs.forEach( ( paragraph ) => {
-		if ( paragraph.length !== 0 ) {
-			// Remove paragraph closing tag
-			let p = paragraph.replaceAll( '</p>', '' );
-			// Clean up any newline chars
-			p = p.replaceAll( '\n', '' );
-			// Replace <br> tags with proper break tag
-			p = p.replaceAll( '<br>', '<br />' );
+		if ( paragraphs.length > 0 ) {
+			// Split html text into paragraphs
+			paragraphs.forEach( ( paragraph ) => {
+				if ( paragraph.length !== 0 ) {
+					// Remove paragraph closing tag
+					let p = paragraph.replaceAll( '</p>', '' );
+					// Clean up any newline chars
+					p = p.replaceAll( '\n', '' );
+					// Replace <br> tags with proper break tag
+					p = p.replaceAll( '<br>', '<br />' );
 
-			// Now split this text into lines based on break tags
-			const breaks = p.split( '<br />' );
+					// Now split this text into lines based on break tags
+					const breaks = p.split( '<br />' );
 
-			// Append lines to array
-			breaks.map( ( line ) => {
-				lines.push( line );
+					// Append lines to array
+					breaks.map( ( line ) => {
+						lines.push( line );
+					} );
+				}
 			} );
-		}
-	} );
 
-	// Re-join the lines into a html string with breaks
-	excerpt = lines.join( '<br />' );
+			// Re-join the lines into a html string with breaks
+			excerpt = lines.join( '<br />' );
+		}
+	}
+
+	if ( excerpt === undefined ) {
+		excerpt = post.content_no_html;
+	}
 
 	return (
 		<AutoDirection>


### PR DESCRIPTION
If a post has no `better_excerpt` or `excerpt` defined, the Reader search will crash, i.e. https://wordpress.com/read/search?q=houseofthedragon

This hardens the code that displays the excerpt in the reader feed to fall back to the post `content_no_html` where no excerpt is found.