### PR TITLE
Reader: Re-apply search input styling to Share Tools

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -47,6 +47,25 @@
 		width: 152px;
 		padding-right: 2px;
 	}
+	.search {
+		border-radius: 4px;
+		.search__icon-navigation {
+			border-bottom-left-radius: 4px;
+			border-top-left-radius: 4px;
+		}
+		.search__input.form-text-input[type="search"],
+		.search__close-icon {
+			border-bottom-right-radius: 4px;
+			border-top-right-radius: 4px;
+			padding: 4px 0;
+		}
+		&.is-open.has-focus {
+			box-shadow: none;
+			&:hover {
+				box-shadow: none;
+			}
+		}
+	}
 }
 
 .reader-share__popover-item {


### PR DESCRIPTION
## Proposed Changes

#68692 and #66650 unexpectedly broke search input styling in the Site Switcher. I reverted the changes (https://github.com/Automattic/wp-calypso/pull/68826#issuecomment-1273714472), and then this PR re-applies them to the Share Tools.

Notably:
* The original styles used `6px` but VS Code is automatically changing this to `4px` for me. I guess there's a rule being enforced?
* Are there other Reader components needing these style changes too?

<img width="418" alt="image" src="https://user-images.githubusercontent.com/36432/194938598-81ea7ceb-a5a3-4b78-a517-94f95ae53bf6.png">

## Testing Instructions

1. Verify everything looks as expected in the Reader.