### PR TITLE
Help Center: add Help Center tag to ZD tickets

### DIFF
--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -25,7 +25,11 @@ function InlineHelpContactViewLoaded() {
 		);
 	}, [ dispatch, supportVariation, sectionName ] );
 
-	return supportVariation === SUPPORT_FORUM ? <InlineHelpForumView /> : <HelpContact compact />;
+	return supportVariation === SUPPORT_FORUM ? (
+		<InlineHelpForumView />
+	) : (
+		<HelpContact compact source="inline-help" />
+	);
 }
 
 export default function InlineHelpContactView() {

--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -25,11 +25,7 @@ function InlineHelpContactViewLoaded() {
 		);
 	}, [ dispatch, supportVariation, sectionName ] );
 
-	return supportVariation === SUPPORT_FORUM ? (
-		<InlineHelpForumView />
-	) : (
-		<HelpContact compact source="inline-help" />
-	);
+	return supportVariation === SUPPORT_FORUM ? <InlineHelpForumView /> : <HelpContact compact />;
 }
 
 export default function InlineHelpContactView() {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -162,7 +162,7 @@ class HelpContact extends Component {
 			locale: currentUserLocale,
 			client: config( 'client_slug' ),
 			is_chat_overflow: supportVariation === SUPPORT_CHAT_OVERFLOW,
-			source: 'inline-form',
+			source: 'inline-help',
 		};
 		if ( site ) {
 			payload.blog_url = site.URL;

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -162,6 +162,7 @@ class HelpContact extends Component {
 			locale: currentUserLocale,
 			client: config( 'client_slug' ),
 			is_chat_overflow: supportVariation === SUPPORT_CHAT_OVERFLOW,
+			source: 'inline-form',
 		};
 		if ( site ) {
 			payload.blog_url = site.URL;

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -7,6 +7,7 @@ type Ticket = {
 	locale: string;
 	client: string;
 	is_chat_overflow: boolean;
+	is_help_center: boolean;
 	blog_url: string;
 };
 

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -7,7 +7,7 @@ type Ticket = {
 	locale: string;
 	client: string;
 	is_chat_overflow: boolean;
-	is_help_center: boolean;
+	source: string;
 	blog_url: string;
 };
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -280,7 +280,7 @@ export const HelpCenterContactForm = () => {
 						locale,
 						client: 'browser:help-center',
 						is_chat_overflow: overflow,
-						is_help_center: true,
+						source: 'help-center',
 						blog_url: supportSite.URL,
 					} )
 						.then( () => {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -280,6 +280,7 @@ export const HelpCenterContactForm = () => {
 						locale,
 						client: 'browser:help-center',
 						is_chat_overflow: overflow,
+						is_help_center: true,
 						blog_url: supportSite.URL,
 					} )
 						.then( () => {


### PR DESCRIPTION
#### Proposed Changes

* This adds `help-center` param to ZD tickets that come from the Help Center.
* It also adds `inline-help` tag to tickets that come from Calypso.
* Test alongside D89566-code

#### Testing Instructions

1. Send a ticket from the Help Center.
2. It should have the `help-center` tag.
