### PR TITLE
Help Center: fix wp-admin errors

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -69,7 +69,7 @@ class Help_Center {
 	}
 
 	/**
-	 * Enqueue block editor assets.
+	 * Enqueue Help Center assets.
 	 */
 	public function enqueue_script() {
 		$script_dependencies = $this->asset_file['dependencies'];

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -19,16 +19,29 @@ class Help_Center {
 	private static $instance = null;
 
 	/**
+	 * Asset file.
+	 *
+	 * @var asset_file
+	 */
+	private $asset_file;
+
+	/**
+	 * Version number of the plugin.
+	 *
+	 * @var version
+	 */
+	private $version;
+
+	/**
 	 * Help_Center constructor.
 	 */
 	public function __construct() {
+		$this->asset_file = include plugin_dir_path( __FILE__ ) . 'dist/help-center.asset.php';
+		$this->version    = $this->asset_file['version'];
+
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
-		// Crazy high number inorder to prevent Jetpack removing it
-		// https://github.com/Automattic/jetpack/blob/30213ee594cd06ca27199f73b2658236fda24622/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php#L196.
-		add_action( 'wp_before_admin_bar_render', array( $this, 'admin_bar_menu' ), 100000 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_script' ), 100 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_wp_components_styles' ), 100 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_wp_admin_scripts' ), 100 );
 	}
 
 	/**
@@ -56,35 +69,16 @@ class Help_Center {
 	}
 
 	/**
-	 * Enqueue wp-component styles because they're not enqueued in wp-admin outside of the editor
-	 */
-	public function enqueue_wp_components_styles() {
-		$asset_file = include plugin_dir_path( __FILE__ ) . 'dist/help-center.asset.php';
-		$version    = $asset_file['version'];
-
-		if ( function_exists( 'gutenberg_url' ) ) {
-			wp_enqueue_style(
-				'wp-components',
-				gutenberg_url( 'build/components/style' . ( is_rtl() ? '.rtl.css' : '.css' ) ),
-				array( 'dashicons' ),
-				$version
-			);
-		}
-	}
-
-	/**
 	 * Enqueue block editor assets.
 	 */
 	public function enqueue_script() {
-		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/help-center.asset.php';
-		$script_dependencies = $asset_file['dependencies'];
-		$version             = $asset_file['version'];
+		$script_dependencies = $this->asset_file['dependencies'];
 
 		wp_enqueue_script(
 			'help-center-script',
 			plugins_url( 'dist/help-center.min.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
-			$version,
+			$this->version,
 			true
 		);
 
@@ -92,7 +86,7 @@ class Help_Center {
 			'help-center-style',
 			plugins_url( 'dist/help-center' . ( is_rtl() ? '.rtl.css' : '.css' ), __FILE__ ),
 			array(),
-			$version
+			$this->version
 		);
 
 		wp_localize_script(
@@ -141,36 +135,59 @@ class Help_Center {
 	}
 
 	/**
-	 * Add icon to WP-ADMIN admin bar
+	 * Add icon to WP-ADMIN admin bar.
 	 */
-	public function admin_bar_menu() {
+	public function enqueue_wp_admin_scripts() {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		global $wp_admin_bar, $current_screen;
 
 		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
+
 		if ( ! is_admin() || ! is_object( $wp_admin_bar ) || $is_site_editor || $current_screen->is_block_editor ) {
 			return;
 		}
 
-		wp_localize_script(
-			'help-center-script',
-			'helpCenterAdminBar',
-			array(
-				'isLoaded' => true,
-			)
+		// Enqueue wp-component styles because they're not enqueued in wp-admin outside of the editor.
+		if ( function_exists( 'gutenberg_url' ) ) {
+			wp_enqueue_style(
+				'wp-components',
+				gutenberg_url( 'build/components/style' . ( is_rtl() ? '.rtl.css' : '.css' ) ),
+				array( 'dashicons' ),
+				$this->version
+			);
+		}
+
+		// Crazy high number inorder to prevent Jetpack removing it
+		// https://github.com/Automattic/jetpack/blob/30213ee594cd06ca27199f73b2658236fda24622/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php#L196.
+		add_action(
+			'wp_before_admin_bar_render',
+			function () {
+				global $wp_admin_bar;
+
+				wp_localize_script(
+					'help-center-script',
+					'helpCenterAdminBar',
+					array(
+						'isLoaded' => true,
+					)
+				);
+
+				$wp_admin_bar->add_menu(
+					array(
+						'id'     => 'help-center',
+						'title'  => file_get_contents( plugin_dir_path( __FILE__ ) . 'src/help-icon.svg', true ),
+						'parent' => 'top-secondary',
+						'meta'   => array(
+							'html'  => '<div id="help-center-masterbar" />',
+							'class' => 'menupop',
+						),
+					)
+				);
+			},
+			100000
 		);
 
-		$wp_admin_bar->add_menu(
-			array(
-				'id'     => 'help-center',
-				'title'  => file_get_contents( plugin_dir_path( __FILE__ ) . 'src/help-icon.svg', true ),
-				'parent' => 'top-secondary',
-				'meta'   => array(
-					'html'  => '<div id="help-center-masterbar" />',
-					'class' => 'menupop',
-				),
-			)
-		);
+		$this->enqueue_script();
 	}
 }
 add_action( 'init', array( __NAMESPACE__ . '\Help_Center', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/index.js
@@ -2,9 +2,6 @@ import './src/config';
 import { HelpCenter } from '@automattic/data-stores';
 import './src/help-center';
 import './src/help-center.scss';
-
-if ( window.helpCenterAdminBar?.isLoaded ) {
-	import( './src/admin-bar' );
-}
+import './src/admin-bar';
 
 HelpCenter.register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -40,11 +40,13 @@ function AdminHelpCenterContent() {
 	return <HelpCenter handleClose={ () => setShowHelpCenter( false ) } />;
 }
 
-ReactDOM.render(
-	<QueryClientProvider client={ whatsNewQueryClient }>
-		<CalypsoStateProvider>
-			<AdminHelpCenterContent />
-		</CalypsoStateProvider>
-	</QueryClientProvider>,
-	document.getElementById( 'help-center-masterbar' )
-);
+if ( window.helpCenterAdminBar?.isLoaded ) {
+	ReactDOM.render(
+		<QueryClientProvider client={ whatsNewQueryClient }>
+			<CalypsoStateProvider>
+				<AdminHelpCenterContent />
+			</CalypsoStateProvider>
+		</QueryClientProvider>,
+		document.getElementById( 'help-center-masterbar' )
+	);
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -24,12 +24,12 @@ function AdminHelpCenterContent() {
 		if ( show ) {
 			recordTracksEvent( 'calypso_inlinehelp_close', {
 				location: 'help-center',
-				sectionName: 'wp-admin',
+				section: 'wp-admin',
 			} );
 		} else {
 			recordTracksEvent( 'calypso_inlinehelp_show', {
 				location: 'help-center',
-				sectionName: 'wp-admin',
+				section: 'wp-admin',
 			} );
 		}
 		setShowHelpCenter( ! show );
@@ -40,7 +40,7 @@ function AdminHelpCenterContent() {
 	return <HelpCenter handleClose={ () => setShowHelpCenter( false ) } />;
 }
 
-if ( window.helpCenterAdminBar?.isLoaded ) {
+if ( window?.helpCenterAdminBar?.isLoaded ) {
 	ReactDOM.render(
 		<QueryClientProvider client={ whatsNewQueryClient }>
 			<CalypsoStateProvider>


### PR DESCRIPTION
## Proposed Changes

This addresses the webpack chunk errors in WP-ADMIN by moving the logic to the `admin-bar.js` file and importing it as normal.

As well I refactored how we are importing the assets in admin. There were some duplications that caused an error in console.

Also there was an error with the track event that is resolved.

## Testing Instructions

1. Pull branch and sandbox your IP for a test site
2. `cd apps/editing-toolkit/ && yarn dev --sync`
3. Go to `[ your-test-site ]`/wp-admin and check for errors in console or regressions.
4. Take a look at your editor and make sure it is also working.
