### PR TITLE
Checkout: Replace lodash get/isEmpty in checkout controller

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,7 +1,6 @@
 import { isJetpackLegacyItem } from '@automattic/calypso-products';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { get, isEmpty } from 'lodash';
 import page from 'page';
 import DocumentHead from 'calypso/components/data/document-head';
 import { setSectionMiddleware } from 'calypso/controller';
@@ -251,7 +250,7 @@ export function checkoutThankYou( context, next ) {
 
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-	const displayMode = get( context, 'query.d' );
+	const displayMode = context.query?.d;
 
 	setSectionMiddleware( { name: 'checkout-thank-you' } )( context );
 
@@ -266,7 +265,7 @@ export function checkoutThankYou( context, next ) {
 
 			<CheckoutThankYouComponent
 				displayMode={ displayMode }
-				domainOnlySiteFlow={ isEmpty( context.params.site ) }
+				domainOnlySiteFlow={ ! context.params.site }
 				email={ context.query.email }
 				gsuiteReceiptId={ gsuiteReceiptId }
 				receiptId={ receiptId }


### PR DESCRIPTION
#### Proposed Changes

This removes lodash's `get()` and `isEmpty()` from the checkout controller file. They can easily be replaced with native JS functionality.

#### Testing Instructions

These are only used by the `CheckoutThankYouComponent` component in the routes `/checkout/thank-you/:siteSlug/:receiptId`, `/checkout/thank-you/features/:feature/:site/:receiptId?`, and `/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId`. 

A visual inspection should be sufficient. The `get()` replacement is fairly straightforward, and the `isEmpty()` replacement should work because `context.params.site` is a string (see routes above) or nothing.