### PR TITLE
[WIP] Use new endpoint to get site screenshots

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -211,7 +211,7 @@ export function SitesDashboard( {
 					grouping={ { status, showHidden: true } }
 				>
 					{ ( { sites, statuses } ) => {
-						const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );
+						const paginatedSites = sites.slice( 0, 3 );
 
 						const selectedStatus =
 							statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -23,20 +23,9 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 
 	const shouldUseScreenshot = getSiteLaunchStatus( site ) === 'public';
 
-	let siteUrl = site.URL;
-	if ( site.options?.updated_at ) {
-		const updatedAt = new Date( site.options.updated_at );
-		updatedAt.setMinutes( 0 );
-		updatedAt.setSeconds( 0 );
-		siteUrl = addQueryArgs( siteUrl, {
-			v: updatedAt.getTime() / 1000,
-
-			// This combination of flags stops free site headers and cookie banners from appearing.
-			iframe: true,
-			preview: true,
-			hide_banners: true,
-		} );
-	}
+	const siteUrl = addQueryArgs( `https://public-api.wordpress.com/wpcom/v2/screenshots`, {
+		site_url: site.URL,
+	} );
 
 	return (
 		<SiteThumbnail

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -21,8 +21,6 @@ interface SiteItemThumbnailProps extends Omit< ComponentProps< typeof SiteThumbn
 export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) => {
 	const { __ } = useI18n();
 
-	const shouldUseScreenshot = getSiteLaunchStatus( site ) === 'public';
-
 	const siteUrl = addQueryArgs( `https://public-api.wordpress.com/wpcom/v2/screenshots`, {
 		site_url: site.URL,
 	} );
@@ -30,7 +28,7 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 	return (
 		<SiteThumbnail
 			{ ...props }
-			mShotsUrl={ shouldUseScreenshot ? siteUrl : undefined }
+			mShotsUrl={ siteUrl }
 			alt={ site.title || __( 'Site thumbnail' ) }
 			bgColorImgUrl={ site.icon?.img }
 		>

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -69,27 +69,12 @@ export const SiteThumbnail = ( {
 
 	return (
 		<div className={ classes } style={ { backgroundColor, color } }>
-			{ !! bgColorImgUrl && ! mshotIsFullyLoaded && (
-				<div
-					className={ `site-thumbnail__image-bg site-thumbnail__image-blur-${ blurSize }` }
-					style={ { backgroundImage: `url(${ bgColorImgUrl })` } }
-				></div>
-			) }
-			{ isLoading && (
-				<div
-					className={ classnames( { 'site-thumbnail-loader': showLoader }, 'site-thumbnail-icon' ) }
-				>
-					{ children }
-				</div>
-			) }
-			{ imgProps.src && ! isLoading && (
-				<img
-					className="site-thumbnail__image"
-					alt={ alt }
-					sizes={ sizesAttr || `${ width }px` }
-					{ ...imgProps }
-				/>
-			) }
+			<img
+				className="site-thumbnail__image"
+				alt={ alt }
+				sizes={ sizesAttr || `${ width }px` }
+				src={ mShotsUrl }
+			/>
 		</div>
 	);
 };

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -69,12 +69,27 @@ export const SiteThumbnail = ( {
 
 	return (
 		<div className={ classes } style={ { backgroundColor, color } }>
-			<img
-				className="site-thumbnail__image"
-				alt={ alt }
-				sizes={ sizesAttr || `${ width }px` }
-				src={ mShotsUrl }
-			/>
+			{ !! bgColorImgUrl && ! mshotIsFullyLoaded && (
+				<div
+					className={ `site-thumbnail__image-bg site-thumbnail__image-blur-${ blurSize }` }
+					style={ { backgroundImage: `url(${ bgColorImgUrl })` } }
+				></div>
+			) }
+			{ isLoading && (
+				<div
+					className={ classnames( { 'site-thumbnail-loader': showLoader }, 'site-thumbnail-icon' ) }
+				>
+					{ children }
+				</div>
+			) }
+			{ imgProps.src && ! isLoading && (
+				<img
+					className="site-thumbnail__image"
+					alt={ alt }
+					sizes={ sizesAttr || `${ width }px` }
+					{ ...imgProps }
+				/>
+			) }
 		</div>
 	);
 };

--- a/packages/components/src/site-thumbnail/style.scss
+++ b/packages/components/src/site-thumbnail/style.scss
@@ -14,6 +14,8 @@
 .site-thumbnail__image {
 	align-self: start;
 	width: 100%;
+	height: 100%;
+    object-fit: cover;
 }
 
 .site-thumbnail__image-bg {

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -35,79 +35,29 @@ export const useMshotsImg = (
 	isError: boolean;
 	imgProps: Partial< React.ImgHTMLAttributes< HTMLImageElement > >;
 } => {
-	const [ previousSrc, setPreviousSrc ] = useState( src );
-	const srcHasChanged = src !== previousSrc;
-
-	const [ retryCount, setRetryCount ] = useState( 0 );
-	const { mshotUrl, srcSet } = useMemo( () => {
-		// If the src has changed, the retry count will be reset
-		// and we want to avoid caching the mshot loading the image
-		const count = srcHasChanged ? -1 : retryCount;
-		const mshotUrl = mshotsUrl( src, options, count );
-
-		// Add retina sizes 2x and 3x.
-		const srcSet = [ ...sizes, getRetinaSize( 2, options ), getRetinaSize( 3, options ) ]
-			.map( ( { width, height } ) => {
-				const resizedUrl = mshotsUrl( src, { ...options, w: width, h: height }, count );
-				return `${ resizedUrl } ${ width }w`;
-			} )
-			.join( ', ' );
-		return { mshotUrl, srcSet };
-	}, [ srcHasChanged, retryCount, src, options, sizes ] );
-
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isError, setIsError ] = useState( false );
 
-	const timeout = useRef< ReturnType< typeof setTimeout > >();
-
-	const onError = useCallback( () => {
-		setIsError( true );
-	}, [] );
-
 	useEffect( () => {
-		if ( ! src ) {
-			return;
-		}
+		const img = document.createElement( 'img' ) as HTMLImageElement;
 
-		async function checkRedirectImage() {
-			const isRedirect = await fetchIsRedirect( mshotUrl );
-			// 307 is the status code for a temporary redirect used by mshots.
-			// If we `follow` the redirect, the `response.url` will be 'https://s0.wp.com/mshots/v1/default'
-			// and the `response.headers.get('content-type)` will be 'image/gif'
-			if ( ! isRedirect ) {
-				setIsLoading( false );
-			}
-		}
-
-		if ( isLoading && retryCount < MAXTRIES ) {
-			// Only refresh 10 times
-			timeout.current = setTimeout( () => {
-				setRetryCount( ( retryCount ) => retryCount + 1 );
-				checkRedirectImage();
-			}, retryCount * 600 );
-		}
-
-		return () => {
-			clearTimeout( timeout.current );
+		img.onload = () => {
+			setIsLoading( false );
 		};
-	}, [ isLoading, mshotUrl, retryCount, src ] );
 
-	useEffect( () => {
-		// Reset state when the image src changes. e.g. When the site is updated
-		if ( srcHasChanged ) {
-			setIsLoading( true );
-			setRetryCount( 0 );
-			setPreviousSrc( src );
-		}
-	}, [ src, srcHasChanged ] );
+		img.onerror = () => {
+			setIsError( true );
+			setIsLoading( false );
+		};
+
+		img.src = src;
+	}, [ src ] );
 
 	return {
 		isLoading,
 		isError,
 		imgProps: {
-			onError,
-			srcSet,
-			src: mshotUrl,
+			src,
 			loading: 'lazy',
 		},
 	};

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -3,15 +3,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { fetchIsRedirect } from './fetch-is-redirect';
 
 export function mshotsUrl( targetUrl: string, options: MShotsOptions, countToRefresh = 0 ): string {
-	if ( ! targetUrl ) {
-		return '';
-	}
-	const mshotsUrl = 'https://s0.wp.com/mshots/v1/';
-	const mshotsRequest = addQueryArgs( mshotsUrl + encodeURIComponent( targetUrl ), {
-		...options,
-		countToRefresh,
-	} );
-	return mshotsRequest;
+	return targetUrl;
 }
 const MAXTRIES = 10;
 


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
