### PR TITLE
Sites Management Page: Refactor launch nag to use `inViewOnce`

### DIFF
--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { getDashboardUrl, getLaunchpadUrl } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -76,15 +76,13 @@ const SiteLaunchDonut = () => {
 
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const { __ } = useI18n();
-	const { ref, inView } = useInView();
-	const hasRecordedInView = useRef( false );
+	const { ref, inView: inViewOnce } = useInView( { triggerOnce: true } );
 
 	useEffect( () => {
-		if ( inView && ! hasRecordedInView.current ) {
+		if ( inViewOnce ) {
 			recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_inview' );
-			hasRecordedInView.current = true;
 		}
-	}, [ inView ] );
+	}, [ inViewOnce ] );
 
 	// Don't show nag to all Coming Soon sites, only those that are "unlaunched"
 	// That's because sites that have been previously launched before going back to


### PR DESCRIPTION
## Proposed Changes

Refactors `<SiteLaunchNag />` to use the `triggerOnce: true` option. It cleans the code up a bit.

## Testing Instructions

1. Navigate to `/sites`.
2. Enable Calypso debug `localStorage.setItem( 'debug', 'calypso:analytics*' );`.
3. Verify the `calypso_sites_dashboard_site_launch_nag_inview` event fires when you scroll past it.

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/36432/194957285-0d6c9d88-950c-4501-a8f3-8de59b24d215.png">
