### PR TITLE
Jetpack Backup: Prevent restores with invalid credentials

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import ActivityCard from 'calypso/components/activity-card';
+import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack-credentials-status';
 import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
@@ -321,6 +322,7 @@ class ActivityCardList extends Component {
 				<QueryRewindPolicies siteId={ siteId } />
 				<QueryRewindCapabilities siteId={ siteId } />
 				<QueryRewindState siteId={ siteId } />
+				<QueryJetpackCredentialsStatus siteId={ siteId } role="main" />
 
 				{ ( ! logs || requestingRewindPolicies ) && this.renderLoading() }
 				{ logs && this.renderData() }

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -11,7 +11,7 @@ import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id'
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSiteSlug, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
@@ -46,14 +46,14 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 		getDoesRewindNeedCredentials( state, siteId )
 	);
 
-	const areJetpackCredentialsInvalid = useSelector( ( state ) =>
-		getAreJetpackCredentialsInvalid( state, siteId, 'main' )
+	const areCredentialsInvalid = useSelector( ( state ) =>
+		areJetpackCredentialsInvalid( state, siteId, 'main' )
 	);
 
 	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
 	const isRestoreDisabled =
-		doesRewindNeedCredentials || isRestoreInProgress || areJetpackCredentialsInvalid;
+		doesRewindNeedCredentials || isRestoreInProgress || areCredentialsInvalid;
 
 	return (
 		<>
@@ -80,7 +80,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 				>
 					{ translate( 'Restore to this point' ) }
 				</Button>
-				{ ( doesRewindNeedCredentials || areJetpackCredentialsInvalid ) && (
+				{ ( doesRewindNeedCredentials || areCredentialsInvalid ) && (
 					<div className="toolbar__credentials-warning">
 						<img src={ missingCredentialsIcon } alt="" role="presentation" />
 						<div className="toolbar__credentials-warning-text">

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -80,7 +80,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 				>
 					{ translate( 'Restore to this point' ) }
 				</Button>
-				{ doesRewindNeedCredentials && (
+				{ ( doesRewindNeedCredentials || areJetpackCredentialsInvalid ) && (
 					<div className="toolbar__credentials-warning">
 						<img src={ missingCredentialsIcon } alt="" role="presentation" />
 						<div className="toolbar__credentials-warning-text">

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -11,7 +11,7 @@ import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id'
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
+import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSiteSlug, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -11,6 +11,7 @@ import { getActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id'
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSiteSlug, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
@@ -45,9 +46,14 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 		getDoesRewindNeedCredentials( state, siteId )
 	);
 
+	const areJetpackCredentialsInvalid = useSelector( ( state ) =>
+		getAreJetpackCredentialsInvalid( state, siteId, 'main' )
+	);
+
 	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
-	const isRestoreDisabled = doesRewindNeedCredentials || isRestoreInProgress;
+	const isRestoreDisabled =
+		doesRewindNeedCredentials || isRestoreInProgress || areJetpackCredentialsInvalid;
 
 	return (
 		<>

--- a/client/components/data/query-jetpack-credentials-status/README.md
+++ b/client/components/data/query-jetpack-credentials-status/README.md
@@ -1,0 +1,37 @@
+# Query Jetpack Credentials Status
+
+`<QueryJetpackCredentialsStatus />` is a React component which dispatches actions for testing Jetpack Credentials to determinate if they are still valid or not.
+## Usage
+
+Render the component, passing `siteId` and `role`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack-credentials-status';
+
+export default function MyComponent( { siteId, role } ) {
+	return (
+		<>
+			<QueryJetpackCredentialsStatus siteId={ siteId } role={ role } />
+		</>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which Jetpack Credentials status should be requested.
+
+### `role`
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The credentials role we want to test. For example: "main", "alternate".

--- a/client/components/data/query-jetpack-credentials-status/README.md
+++ b/client/components/data/query-jetpack-credentials-status/README.md
@@ -1,6 +1,6 @@
 # Query Jetpack Credentials Status
 
-`<QueryJetpackCredentialsStatus />` is a React component which dispatches actions for testing Jetpack Credentials to determinate if they are still valid or not.
+`<QueryJetpackCredentialsStatus />` is a React component that dispatches actions for testing Jetpack Credentials to determine whether they are still valid.
 ## Usage
 
 Render the component, passing `siteId` and `role`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.

--- a/client/components/data/query-jetpack-credentials-status/index.jsx
+++ b/client/components/data/query-jetpack-credentials-status/index.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { testCredentials } from 'calypso/state/jetpack/credentials/actions';
+import { isRequestingJetpackCredentialsTest } from 'calypso/state/jetpack/credentials/selectors';
+
+const request = ( siteId, role ) => ( dispatch, getState ) => {
+	if ( ! isRequestingJetpackCredentialsTest( getState(), siteId, role ) ) {
+		dispatch( testCredentials( siteId, role ) );
+	}
+};
+
+function QueryJetpackCredentialsStatus( { siteId, role } ) {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		dispatch( request( siteId, role ) );
+	}, [ dispatch, siteId, role ] );
+
+	return null;
+}
+
+QueryJetpackCredentialsStatus.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	role: PropTypes.string.isRequired,
+};
+
+export default QueryJetpackCredentialsStatus;

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -43,14 +43,14 @@ const RestoreButton = ( { disabled, rewindId, primary } ) => {
 		getDoesRewindNeedCredentials( state, siteId )
 	);
 
-	const areJetpackCredentialsInvalid = useSelector( ( state ) =>
-		getAreJetpackCredentialsInvalid( state, siteId, 'main' )
+	const areCredentialsInvalid = useSelector( ( state ) =>
+		areJetpackCredentialsInvalid( state, siteId, 'main' )
 	);
 
 	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
 	const isRestoreDisabled =
-		disabled || needsCredentials || isRestoreInProgress || areJetpackCredentialsInvalid;
+		disabled || needsCredentials || isRestoreInProgress || areCredentialsInvalid;
 	const href = ! isRestoreDisabled ? backupRestorePath( siteSlug, rewindId ) : undefined;
 	const onRestore = () =>
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore', { rewind_id: rewindId } ) );

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
+import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -41,9 +42,15 @@ const RestoreButton = ( { disabled, rewindId, primary } ) => {
 	const needsCredentials = useSelector( ( state ) =>
 		getDoesRewindNeedCredentials( state, siteId )
 	);
+
+	const areJetpackCredentialsInvalid = useSelector( ( state ) =>
+		getAreJetpackCredentialsInvalid( state, siteId, 'main' )
+	);
+
 	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
-	const isRestoreDisabled = disabled || needsCredentials || isRestoreInProgress;
+	const isRestoreDisabled =
+		disabled || needsCredentials || isRestoreInProgress || areJetpackCredentialsInvalid;
 	const href = ! isRestoreDisabled ? backupRestorePath( siteSlug, rewindId ) : undefined;
 	const onRestore = () =>
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore', { rewind_id: rewindId } ) );

--- a/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
@@ -5,6 +5,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as record from 'calypso/state/analytics/actions/record';
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { renderWithProvider as render } from 'calypso/test-helpers/testing-library';
@@ -12,6 +13,7 @@ import ActionButtons from '../action-buttons';
 
 jest.mock( 'calypso/state/ui/selectors' );
 jest.mock( 'calypso/state/selectors/get-does-rewind-need-credentials' );
+jest.mock( 'calypso/state/jetpack/credentials/selectors' );
 
 const recordTracksEvent = jest.spyOn( record, 'recordTracksEvent' );
 
@@ -57,6 +59,7 @@ describe( 'ActionButtons', () => {
 
 	test( 'enables the restore button when credentials are not needed', () => {
 		getDoesRewindNeedCredentials.mockImplementation( () => false );
+		areJetpackCredentialsInvalid.mockImplementation( () => false );
 		const rewindId = 'test';
 
 		render( <ActionButtons rewindId={ rewindId } /> );
@@ -71,6 +74,7 @@ describe( 'ActionButtons', () => {
 
 	test( 'disables the restore button when credentials are needed', () => {
 		getDoesRewindNeedCredentials.mockImplementation( () => true );
+		areJetpackCredentialsInvalid.mockImplementation( () => true );
 
 		render( <ActionButtons rewindId="test" /> );
 		const restoreButton = screen.getByRole( 'button', { name: /restore/i } );
@@ -94,6 +98,7 @@ describe( 'ActionButtons', () => {
 	test( 'emits a Tracks event when the restore button is enabled and clicked', async () => {
 		const user = userEvent.setup();
 		getDoesRewindNeedCredentials.mockImplementation( () => false );
+		areJetpackCredentialsInvalid.mockImplementation( () => false );
 		const rewindId = 'test';
 		render( <ActionButtons rewindId={ rewindId } /> );
 

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -44,7 +44,7 @@ import {
 	withAnalytics,
 } from 'calypso/state/analytics/actions';
 import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
-import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-rewind-policies-request-status';
@@ -430,13 +430,13 @@ class ActivityLog extends Component {
 			isJetpack,
 			isIntroDismissed,
 			isMultisite,
-			areJetpackCredentialsInvalid,
+			areCredentialsInvalid,
 		} = this.props;
 
 		const disableRestore =
 			! enableRewind ||
 			[ 'queued', 'running' ].includes( get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
-			areJetpackCredentialsInvalid ||
+			areCredentialsInvalid ||
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
@@ -692,7 +692,7 @@ export default connect(
 			hasFullActivityLog: siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG ),
 			isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
 			isMultisite: isJetpackSiteMultiSite( state, siteId ),
-			areJetpackCredentialsInvalid: getAreJetpackCredentialsInvalid( state, siteId, 'main' ),
+			areCredentialsInvalid: areJetpackCredentialsInvalid( state, siteId, 'main' ),
 		};
 	},
 	{

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -10,6 +10,7 @@ import { connect, useSelector } from 'react-redux';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import VisibleDaysLimitUpsell from 'calypso/components/activity-card-list/visible-days-limit-upsell';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack-credentials-status';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryRewindBackupStatus from 'calypso/components/data/query-rewind-backup-status';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
@@ -43,6 +44,7 @@ import {
 	withAnalytics,
 } from 'calypso/state/analytics/actions';
 import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-rewind-policies-request-status';
@@ -428,11 +430,13 @@ class ActivityLog extends Component {
 			isJetpack,
 			isIntroDismissed,
 			isMultisite,
+			areJetpackCredentialsInvalid,
 		} = this.props;
 
 		const disableRestore =
 			! enableRewind ||
 			[ 'queued', 'running' ].includes( get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
+			areJetpackCredentialsInvalid ||
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
@@ -472,6 +476,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<QueryRewindBackups siteId={ siteId } />
+				<QueryJetpackCredentialsStatus siteId={ siteId } role="main" />
 
 				{ isJetpackCloud() && <SidebarNavigation /> }
 
@@ -687,6 +692,7 @@ export default connect(
 			hasFullActivityLog: siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG ),
 			isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
 			isMultisite: isJetpackSiteMultiSite( state, siteId ),
+			areJetpackCredentialsInvalid: getAreJetpackCredentialsInvalid( state, siteId, 'main' ),
 		};
 	},
 	{

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import BackupStorageSpace from 'calypso/components/backup-storage-space';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack-credentials-status';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
@@ -145,6 +146,7 @@ function AdminContent( { selectedDate } ) {
 				siteId={ siteId } /* The policies inform the max visible limit for backups */
 			/>
 			<QueryRewindState siteId={ siteId } />
+			<QueryJetpackCredentialsStatus siteId={ siteId } role="main" />
 
 			{ isFiltering && <SearchResults /> }
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -23,7 +23,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import isRewindPoliciesInitialized from 'calypso/state/rewind/selectors/is-rewind-policies-initialized';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -127,8 +127,8 @@ function AdminContent( { selectedDate } ) {
 	const activityLogFilter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const isFiltering = ! isFilterEmpty( activityLogFilter );
 
-	const areJetpackCredentialsInvalid = useSelector( ( state ) =>
-		getAreJetpackCredentialsInvalid( state, siteId, 'main' )
+	const areCredentialsInvalid = useSelector( ( state ) =>
+		areJetpackCredentialsInvalid( state, siteId, 'main' )
 	);
 
 	const needCredentials = useSelector( ( state ) => getDoesRewindNeedCredentials( state, siteId ) );
@@ -159,7 +159,7 @@ function AdminContent( { selectedDate } ) {
 						onDateChange={ onDateChange }
 						selectedDate={ selectedDate }
 						needCredentials={ needCredentials }
-						areJetpackCredentialsInvalid={ areJetpackCredentialsInvalid }
+						areCredentialsInvalid={ areCredentialsInvalid }
 					/>
 				</>
 			) }
@@ -167,12 +167,7 @@ function AdminContent( { selectedDate } ) {
 	);
 }
 
-function BackupStatus( {
-	selectedDate,
-	needCredentials,
-	onDateChange,
-	areJetpackCredentialsInvalid,
-} ) {
+function BackupStatus( { selectedDate, needCredentials, onDateChange, areCredentialsInvalid } ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 
@@ -188,8 +183,8 @@ function BackupStatus( {
 	return (
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
-				{ ( needCredentials || areJetpackCredentialsInvalid ) && <EnableRestoresBanner /> }
-				{ ! needCredentials && ! areJetpackCredentialsInvalid && hasRealtimeBackups && (
+				{ ( needCredentials || areCredentialsInvalid ) && <EnableRestoresBanner /> }
+				{ ! needCredentials && ! areCredentialsInvalid && hasRealtimeBackups && (
 					<BackupsMadeRealtimeBanner />
 				) }
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -22,6 +22,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
 import isRewindPoliciesInitialized from 'calypso/state/rewind/selectors/is-rewind-policies-initialized';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -125,6 +126,10 @@ function AdminContent( { selectedDate } ) {
 	const activityLogFilter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const isFiltering = ! isFilterEmpty( activityLogFilter );
 
+	const areJetpackCredentialsInvalid = useSelector( ( state ) =>
+		getAreJetpackCredentialsInvalid( state, siteId, 'main' )
+	);
+
 	const needCredentials = useSelector( ( state ) => getDoesRewindNeedCredentials( state, siteId ) );
 
 	const onDateChange = useCallback(
@@ -152,6 +157,7 @@ function AdminContent( { selectedDate } ) {
 						onDateChange={ onDateChange }
 						selectedDate={ selectedDate }
 						needCredentials={ needCredentials }
+						areJetpackCredentialsInvalid={ areJetpackCredentialsInvalid }
 					/>
 				</>
 			) }
@@ -159,7 +165,12 @@ function AdminContent( { selectedDate } ) {
 	);
 }
 
-function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
+function BackupStatus( {
+	selectedDate,
+	needCredentials,
+	onDateChange,
+	areJetpackCredentialsInvalid,
+} ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 
@@ -175,8 +186,10 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 	return (
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
-				{ needCredentials && <EnableRestoresBanner /> }
-				{ ! needCredentials && hasRealtimeBackups && <BackupsMadeRealtimeBanner /> }
+				{ ( needCredentials || areJetpackCredentialsInvalid ) && <EnableRestoresBanner /> }
+				{ ! needCredentials && ! areJetpackCredentialsInvalid && hasRealtimeBackups && (
+					<BackupsMadeRealtimeBanner />
+				) }
 
 				<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
 				<BackupStorageSpace />

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -22,7 +22,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
+import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import isRewindPoliciesInitialized from 'calypso/state/rewind/selectors/is-rewind-policies-initialized';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';

--- a/client/state/jetpack/credentials/reducer.js
+++ b/client/state/jetpack/credentials/reducer.js
@@ -71,8 +71,25 @@ export const testRequestStatus = keyedReducer( 'siteId', ( state, { type, role }
 		case JETPACK_CREDENTIALS_TEST:
 			return {
 				...state,
-				[ role ]: 'pending',
+				[ role ]: true,
 			};
+
+		case JETPACK_CREDENTIALS_TEST_VALID:
+		case JETPACK_CREDENTIALS_TEST_INVALID:
+			return {
+				...state,
+				[ role ]: false,
+			};
+	}
+
+	return state;
+} );
+
+export const testStatus = keyedReducer( 'siteId', ( state, { type, role } ) => {
+	switch ( type ) {
+		// Do not affect current state if executing a new test
+		case JETPACK_CREDENTIALS_TEST:
+			return state;
 
 		case JETPACK_CREDENTIALS_TEST_VALID:
 			return {
@@ -130,4 +147,5 @@ export const reducer = combineReducers( {
 	errors,
 	progressUpdates,
 	testRequestStatus,
+	testStatus,
 } );

--- a/client/state/jetpack/credentials/reducer.js
+++ b/client/state/jetpack/credentials/reducer.js
@@ -87,10 +87,6 @@ export const testRequestStatus = keyedReducer( 'siteId', ( state, { type, role }
 
 export const testStatus = keyedReducer( 'siteId', ( state, { type, role } ) => {
 	switch ( type ) {
-		// Do not affect current state if executing a new test
-		case JETPACK_CREDENTIALS_TEST:
-			return state;
-
 		case JETPACK_CREDENTIALS_TEST_VALID:
 			return {
 				...state,

--- a/client/state/jetpack/credentials/selectors.js
+++ b/client/state/jetpack/credentials/selectors.js
@@ -5,5 +5,5 @@ export function getAreJetpackCredentialsInvalid( state, siteId, role ) {
 }
 
 export function isRequestingJetpackCredentialsTest( state, siteId, role ) {
-	return state.jetpack.credentials.testRequestStatus?.[ siteId ]?.[ role ];
+	return state.jetpack.credentials.testRequestStatus?.[ siteId ]?.[ role ] || false;
 }

--- a/client/state/jetpack/credentials/selectors.js
+++ b/client/state/jetpack/credentials/selectors.js
@@ -1,5 +1,5 @@
 import 'calypso/state/jetpack/init';
 
-export default function getAreJetpackCredentialsInvalid( state, siteId, role ) {
+export function getAreJetpackCredentialsInvalid( state, siteId, role ) {
 	return 'invalid' === state.jetpack.credentials.testRequestStatus[ siteId ]?.[ role ];
 }

--- a/client/state/jetpack/credentials/selectors.js
+++ b/client/state/jetpack/credentials/selectors.js
@@ -1,9 +1,9 @@
 import 'calypso/state/jetpack/init';
 
 export function getAreJetpackCredentialsInvalid( state, siteId, role ) {
-	return 'invalid' === state.jetpack.credentials.testStatus?.[ siteId ]?.[ role ];
+	return 'invalid' === state.jetpack?.credentials?.testStatus?.[ siteId ]?.[ role ];
 }
 
 export function isRequestingJetpackCredentialsTest( state, siteId, role ) {
-	return state.jetpack.credentials.testRequestStatus?.[ siteId ]?.[ role ] || false;
+	return state.jetpack?.credentials?.testRequestStatus?.[ siteId ]?.[ role ] || false;
 }

--- a/client/state/jetpack/credentials/selectors.js
+++ b/client/state/jetpack/credentials/selectors.js
@@ -1,5 +1,9 @@
 import 'calypso/state/jetpack/init';
 
 export function getAreJetpackCredentialsInvalid( state, siteId, role ) {
-	return 'invalid' === state.jetpack.credentials.testRequestStatus[ siteId ]?.[ role ];
+	return 'invalid' === state.jetpack.credentials.testStatus?.[ siteId ]?.[ role ];
+}
+
+export function isRequestingJetpackCredentialsTest( state, siteId, role ) {
+	return state.jetpack.credentials.testRequestStatus?.[ siteId ]?.[ role ];
 }

--- a/client/state/jetpack/credentials/selectors.js
+++ b/client/state/jetpack/credentials/selectors.js
@@ -1,0 +1,5 @@
+import 'calypso/state/jetpack/init';
+
+export default function getAreJetpackCredentialsInvalid( state, siteId, role ) {
+	return 'invalid' === state.jetpack.credentials.testRequestStatus[ siteId ]?.[ role ];
+}

--- a/client/state/jetpack/credentials/selectors.js
+++ b/client/state/jetpack/credentials/selectors.js
@@ -1,9 +1,9 @@
 import 'calypso/state/jetpack/init';
 
-export function getAreJetpackCredentialsInvalid( state, siteId, role ) {
-	return 'invalid' === state.jetpack?.credentials?.testStatus?.[ siteId ]?.[ role ];
+export function areJetpackCredentialsInvalid( state, siteId, role ) {
+	return 'invalid' === state.jetpack.credentials.testStatus[ siteId ]?.[ role ];
 }
 
 export function isRequestingJetpackCredentialsTest( state, siteId, role ) {
-	return state.jetpack?.credentials?.testRequestStatus?.[ siteId ]?.[ role ] || false;
+	return state.jetpack.credentials.testRequestStatus[ siteId ]?.[ role ] || false;
 }

--- a/client/state/jetpack/credentials/test/reducer.js
+++ b/client/state/jetpack/credentials/test/reducer.js
@@ -75,6 +75,33 @@ describe( 'reducer', () => {
 				},
 			} );
 		} );
+
+		test( 'should keep existing sites data after requesting a credentials test for a new site', () => {
+			const stateIn = {
+				123456: {
+					main: false,
+					alternate: false,
+				},
+				987654: {
+					main: false,
+				},
+			};
+			const action = testCredentials( 999000, 'main' );
+			const stateOut = testRequestStatus( stateIn, action );
+
+			expect( stateOut ).toEqual( {
+				123456: {
+					main: false,
+					alternate: false,
+				},
+				987654: {
+					main: false,
+				},
+				999000: {
+					main: true,
+				},
+			} );
+		} );
 	} );
 
 	describe( 'testStatus', () => {
@@ -152,6 +179,66 @@ describe( 'reducer', () => {
 				678000: {
 					main: 'valid',
 					alternate: 'invalid',
+				},
+			} );
+		} );
+
+		test( 'should keep existing sites data after marking a role for a new site as valid', () => {
+			const stateIn = {
+				123000: {
+					main: 'valid',
+				},
+				456000: {
+					main: 'invalid',
+					alternate: 'valid',
+				},
+				999000: {
+					main: 'pending',
+				},
+			};
+			const action = markCredentialsAsValid( 999000, 'main' );
+
+			const stateOut = testStatus( stateIn, action );
+			expect( stateOut ).toEqual( {
+				123000: {
+					main: 'valid',
+				},
+				456000: {
+					main: 'invalid',
+					alternate: 'valid',
+				},
+				999000: {
+					main: 'valid',
+				},
+			} );
+		} );
+
+		test( 'should keep existing sites data after marking a role for a new site as invalid', () => {
+			const stateIn = {
+				123000: {
+					main: 'valid',
+				},
+				456000: {
+					main: 'invalid',
+					alternate: 'valid',
+				},
+				999000: {
+					main: 'pending',
+				},
+			};
+			const action = markCredentialsAsInvalid( 999000, 'main' );
+
+			const stateOut = testStatus( stateIn, action );
+			expect( stateOut ).toEqual( {
+				123000: {
+					main: 'valid',
+				},
+				456000: {
+					main: 'invalid',
+					alternate: 'valid',
+				},
+				999000: {
+					main: 'invalid',
 				},
 			} );
 		} );

--- a/client/state/jetpack/credentials/test/selectors.js
+++ b/client/state/jetpack/credentials/test/selectors.js
@@ -1,68 +1,106 @@
-import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import {
+	getAreJetpackCredentialsInvalid,
+	isRequestingJetpackCredentialsTest,
+} from 'calypso/state/jetpack/credentials/selectors';
 import { sites as SITES_CREDENTIALS_FIXTURE } from 'calypso/state/selectors/test/fixtures/jetpack-credentials-test-status';
 
-describe( 'getAreJetpackCredentialsInvalid()', () => {
-	test( 'should return false when when siteId not exists in state', () => {
-		const stateIn = {
-			jetpack: {
-				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+describe( 'selectors', () => {
+	describe( 'getAreJetpackCredentialsInvalid()', () => {
+		test( 'should return false when when siteId not exists in state', () => {
+			const stateIn = {
+				jetpack: {
+					credentials: {
+						testStatus: SITES_CREDENTIALS_FIXTURE,
+					},
 				},
-			},
-		};
+			};
 
-		const siteId = 9990000;
-		const role = 'main';
+			const siteId = 9990000;
+			const role = 'main';
 
-		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
-		expect( output ).toEqual( false );
+			const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+			expect( output ).toEqual( false );
+		} );
+
+		test( 'should return false when test status is valid', () => {
+			const stateIn = {
+				jetpack: {
+					credentials: {
+						testStatus: SITES_CREDENTIALS_FIXTURE,
+					},
+				},
+			};
+
+			const siteId = 2340000;
+			const role = 'main';
+
+			const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+			expect( output ).toEqual( false );
+		} );
+
+		test( 'should return true when test status is invalid', () => {
+			const stateIn = {
+				jetpack: {
+					credentials: {
+						testStatus: SITES_CREDENTIALS_FIXTURE,
+					},
+				},
+			};
+
+			const siteId = 3450000;
+			const role = 'main';
+
+			const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+			expect( output ).toEqual( true );
+		} );
 	} );
 
-	test( 'should return false when test status is pending', () => {
-		const stateIn = {
-			jetpack: {
-				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+	describe( 'isRequestingJetpackCredentialsTest()', () => {
+		test( 'should return false when we have no credentials test request for a siteId and role', () => {
+			const stateIn = {
+				jetpack: {
+					credentials: {
+						testRequestStatus: {},
+					},
 				},
-			},
-		};
+			};
 
-		const siteId = 1230000;
-		const role = 'main';
+			const output = isRequestingJetpackCredentialsTest( stateIn, 123000, 'main' );
+			expect( output ).toEqual( false );
+		} );
 
-		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
-		expect( output ).toEqual( false );
-	} );
-
-	test( 'should return false when test status is valid', () => {
-		const stateIn = {
-			jetpack: {
-				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+		test( 'should return false when we have a false value for a siteId and role', () => {
+			const stateIn = {
+				jetpack: {
+					credentials: {
+						testRequestStatus: {
+							123000: {
+								main: false,
+							},
+						},
+					},
 				},
-			},
-		};
+			};
 
-		const siteId = 2340000;
-		const role = 'main';
+			const output = isRequestingJetpackCredentialsTest( stateIn, 123000, 'main' );
+			expect( output ).toEqual( false );
+		} );
 
-		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
-		expect( output ).toEqual( false );
-	} );
-
-	test( 'should return true when test status is invalid', () => {
-		const stateIn = {
-			jetpack: {
-				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+		test( 'should return true when we have a true value for a siteId and role', () => {
+			const stateIn = {
+				jetpack: {
+					credentials: {
+						testRequestStatus: {
+							123000: {
+								main: true,
+							},
+						},
+					},
 				},
-			},
-		};
+			};
 
-		const siteId = 3450000;
-		const role = 'main';
-
-		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
-		expect( output ).toEqual( true );
+			const output = isRequestingJetpackCredentialsTest( stateIn, 123000, 'main' );
+			expect( output ).toEqual( true );
+		} );
 	} );
 } );

--- a/client/state/jetpack/credentials/test/selectors.js
+++ b/client/state/jetpack/credentials/test/selectors.js
@@ -1,11 +1,11 @@
 import {
-	getAreJetpackCredentialsInvalid,
+	areJetpackCredentialsInvalid,
 	isRequestingJetpackCredentialsTest,
 } from 'calypso/state/jetpack/credentials/selectors';
 import { sites as SITES_CREDENTIALS_FIXTURE } from 'calypso/state/selectors/test/fixtures/jetpack-credentials-test-status';
 
 describe( 'selectors', () => {
-	describe( 'getAreJetpackCredentialsInvalid()', () => {
+	describe( 'areJetpackCredentialsInvalid()', () => {
 		test( 'should return false when when siteId not exists in state', () => {
 			const stateIn = {
 				jetpack: {
@@ -18,7 +18,7 @@ describe( 'selectors', () => {
 			const siteId = 9990000;
 			const role = 'main';
 
-			const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+			const output = areJetpackCredentialsInvalid( stateIn, siteId, role );
 			expect( output ).toEqual( false );
 		} );
 
@@ -34,7 +34,7 @@ describe( 'selectors', () => {
 			const siteId = 2340000;
 			const role = 'main';
 
-			const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+			const output = areJetpackCredentialsInvalid( stateIn, siteId, role );
 			expect( output ).toEqual( false );
 		} );
 
@@ -50,7 +50,7 @@ describe( 'selectors', () => {
 			const siteId = 3450000;
 			const role = 'main';
 
-			const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+			const output = areJetpackCredentialsInvalid( stateIn, siteId, role );
 			expect( output ).toEqual( true );
 		} );
 	} );

--- a/client/state/jetpack/credentials/test/selectors.js
+++ b/client/state/jetpack/credentials/test/selectors.js
@@ -14,7 +14,6 @@ describe( 'getAreJetpackCredentialsInvalid()', () => {
 		const siteId = 9990000;
 		const role = 'main';
 
-		expect( true ).toBe( true );
 		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
 		expect( output ).toEqual( false );
 	} );
@@ -31,7 +30,6 @@ describe( 'getAreJetpackCredentialsInvalid()', () => {
 		const siteId = 1230000;
 		const role = 'main';
 
-		expect( true ).toBe( true );
 		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
 		expect( output ).toEqual( false );
 	} );
@@ -48,7 +46,6 @@ describe( 'getAreJetpackCredentialsInvalid()', () => {
 		const siteId = 2340000;
 		const role = 'main';
 
-		expect( true ).toBe( true );
 		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
 		expect( output ).toEqual( false );
 	} );
@@ -65,7 +62,6 @@ describe( 'getAreJetpackCredentialsInvalid()', () => {
 		const siteId = 3450000;
 		const role = 'main';
 
-		expect( true ).toBe( true );
 		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
 		expect( output ).toEqual( true );
 	} );

--- a/client/state/jetpack/credentials/test/selectors.js
+++ b/client/state/jetpack/credentials/test/selectors.js
@@ -1,0 +1,72 @@
+import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
+import { sites as SITES_CREDENTIALS_FIXTURE } from 'calypso/state/selectors/test/fixtures/jetpack-credentials-test-status';
+
+describe( 'getAreJetpackCredentialsInvalid()', () => {
+	test( 'should return false when when siteId not exists in state', () => {
+		const stateIn = {
+			jetpack: {
+				credentials: {
+					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+				},
+			},
+		};
+
+		const siteId = 9990000;
+		const role = 'main';
+
+		expect( true ).toBe( true );
+		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+		expect( output ).toEqual( false );
+	} );
+
+	test( 'should return false when test status is pending', () => {
+		const stateIn = {
+			jetpack: {
+				credentials: {
+					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+				},
+			},
+		};
+
+		const siteId = 1230000;
+		const role = 'main';
+
+		expect( true ).toBe( true );
+		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+		expect( output ).toEqual( false );
+	} );
+
+	test( 'should return false when test status is valid', () => {
+		const stateIn = {
+			jetpack: {
+				credentials: {
+					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+				},
+			},
+		};
+
+		const siteId = 2340000;
+		const role = 'main';
+
+		expect( true ).toBe( true );
+		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+		expect( output ).toEqual( false );
+	} );
+
+	test( 'should return true when test status is invalid', () => {
+		const stateIn = {
+			jetpack: {
+				credentials: {
+					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+				},
+			},
+		};
+
+		const siteId = 3450000;
+		const role = 'main';
+
+		expect( true ).toBe( true );
+		const output = getAreJetpackCredentialsInvalid( stateIn, siteId, role );
+		expect( output ).toEqual( true );
+	} );
+} );

--- a/client/state/jetpack/credentials/test/selectors.js
+++ b/client/state/jetpack/credentials/test/selectors.js
@@ -1,4 +1,4 @@
-import getAreJetpackCredentialsInvalid from 'calypso/state/jetpack/credentials/selectors';
+import { getAreJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import { sites as SITES_CREDENTIALS_FIXTURE } from 'calypso/state/selectors/test/fixtures/jetpack-credentials-test-status';
 
 describe( 'getAreJetpackCredentialsInvalid()', () => {

--- a/client/state/selectors/get-jetpack-credentials-test-status.js
+++ b/client/state/selectors/get-jetpack-credentials-test-status.js
@@ -1,5 +1,5 @@
 import 'calypso/state/jetpack/init';
 
 export default function getJetpackCredentialsTestStatus( state, siteId, role ) {
-	return state.jetpack.credentials.testRequestStatus[ siteId ]?.[ role ] || 'pending';
+	return state.jetpack.credentials.testStatus[ siteId ]?.[ role ] || 'pending';
 }

--- a/client/state/selectors/test/get-jetpack-credentials-test-status.js
+++ b/client/state/selectors/test/get-jetpack-credentials-test-status.js
@@ -6,7 +6,7 @@ describe( 'getJetpackCredentialsTestStatus()', () => {
 		const stateIn = {
 			jetpack: {
 				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+					testStatus: SITES_CREDENTIALS_FIXTURE,
 				},
 			},
 		};
@@ -21,7 +21,7 @@ describe( 'getJetpackCredentialsTestStatus()', () => {
 		const stateIn = {
 			jetpack: {
 				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+					testStatus: SITES_CREDENTIALS_FIXTURE,
 				},
 			},
 		};
@@ -36,7 +36,7 @@ describe( 'getJetpackCredentialsTestStatus()', () => {
 		const stateIn = {
 			jetpack: {
 				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+					testStatus: SITES_CREDENTIALS_FIXTURE,
 				},
 			},
 		};
@@ -51,7 +51,7 @@ describe( 'getJetpackCredentialsTestStatus()', () => {
 		const stateIn = {
 			jetpack: {
 				credentials: {
-					testRequestStatus: SITES_CREDENTIALS_FIXTURE,
+					testStatus: SITES_CREDENTIALS_FIXTURE,
 				},
 			},
 		};


### PR DESCRIPTION
**Original PR:** #68552

We require to prevent site restores if Jetpack Credentials are no longer valid.
We implemented a way to validate credentials in #66468 and #67589 on Calypso Blue and Calypso Green settings page. The idea is to reuse it and disable restore buttons as soon as we detect they are invalid.

#### Proposed changes
- [x] Disable `Restore to this point` button in actions toolbar on Activity Log when credentials are invalid
- [x] Disable `Restore to this point` button in main backups page when credentials are invalid
- [x] Show banner requesting credentials if credentials are invalid
- [x] Introduce new `QueryJetpackCredentialsStatus` data component that will trigger actions for testing Jetpack Credentials to determinate whether they are still valid or not.
- [x] Trigger credentials test validation in backup page
- [x] Trigger credentials test validation in Activity List component

#### Reducer changes
- [x] Jetpack Credentials `testRequestStatus` reducer is now used for handling the test credentials request status, so we can use it to validate is there is an ongoing request to avoid unnecessary API calls.
- [x] Jetpack Credentials `testStatus` reducer is now used for handling the status of the credentials. It will handle `pending`, `valid` and `invalid` statuses.
- [x] Refactored `getJetpackCredentialsTestStatus` and unit tests to consider the changes in reducers.

#### Screenshots

We are reusing the same messages and behaviors that we have when the customer has no credentials.

Component | Valid credentials | Invalid credentials
--- | --- | ---
Backup page (Banner and Daily Backup) | ![image](https://user-images.githubusercontent.com/1488641/194476053-90efa5eb-d2eb-4e4c-8586-9c141945abc0.png) | ![image](https://user-images.githubusercontent.com/1488641/194476175-4e1914b3-7839-47ca-8a4c-93a5602ebd28.png)
Actions toolbar in Activity Log item (Backup and Activity Log pages) | ![image](https://user-images.githubusercontent.com/1488641/194476263-e8f0a6a8-fd81-47d9-89d4-4588c4c57e57.png) |  ![image](https://user-images.githubusercontent.com/1488641/194476326-e06ae093-c02d-4500-b418-74fb58afde4b.png)

#### Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
“Before / After” screenshots can also be very helpful when the change is visual.
-->

* **Jetpack Cloud / Calypso Green**
  * Grab a site with a Jetpack Backup plan. Preferable, a site you can modify the SSH/SFTP password.
  * Ensure you have working SSH/SFTP credentials on `Settings` page.
  * Navigate to `Activity Log` and `Backup` sections and ensure you can see the `Restore to this point` buttons in green color (that means they are enabled).
    * Also you should see the banner with the message _“Every change you make will be backed up”_ on top of Backup page.
  * Modify the SSH/SFTP password on your site server (not on Jetpack Cloud settings).
  * Navigate again to `Activity Log` or `Backup` page and validate the same buttons are now disabled. It may take a couple of seconds as it is trying to test credentials using an API.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the “[Status] String Freeze” label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the “fixes” keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### References
* peaFOp-7G-p2
* 1202895132770065-as-1202906937479000