### PR TITLE
Marketplace: Add CollectionListView

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -1,7 +1,10 @@
 @use "../variables";
 @import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .plugins-browser-item {
+	width: 100%;
 	background-color: $studio-white;
 	box-sizing: border-box;
 	cursor: pointer;
@@ -59,24 +62,22 @@
 		.plugins-browser-item__description {
 			font-size: $font-body-extra-small;
 			margin: 5px 0 0 0;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
-		@include breakpoint-deprecated(">960px") {
+		@include break-medium {
+			width: calc(50% - 10px); // 2 column grid with 20px gutter
+		}
+
+		@include break-wide {
 			width: calc(33% - 10px); // 3 column grid with 20px gutter
-		}
-
-		@include breakpoint-deprecated("<960px") {
-			width: 100%;
 		}
 	}
 
 	&.extended {
-		@include breakpoint-deprecated(">960px") {
+		@include break-large {
 			width: calc(50% - 10px); // 2 column grid with 20px gutter
-		}
-
-		@include breakpoint-deprecated("<960px") {
-			width: 100%;
 		}
 	}
 

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -41,17 +41,36 @@
 	}
 
 	&.compact {
+		.plugins-browser-item__link {
+			padding: 16px;
+		}
+
+		.plugins-browser-item__title {
+			font-size: $font-body-small;
+		}
+
 		.plugins-browser-item__description {
+			font-size: $font-body-extra-small;
 			margin: 5px 0 0 calc(60px + 16px); // icon width + margin
+		}
+
+		@include breakpoint-deprecated(">960px") {
+			width: calc(33% - 10px); // 3 column grid with 20px gutter
+		}
+
+		@include breakpoint-deprecated("<960px") {
+			width: 100%;
 		}
 	}
 
-	@include breakpoint-deprecated(">960px") {
-		width: calc(50% - 10px); // 2 column grid with 20px gutter
-	}
+	&.extended {
+		@include breakpoint-deprecated(">960px") {
+			width: calc(50% - 10px); // 2 column grid with 20px gutter
+		}
 
-	@include breakpoint-deprecated("<960px") {
-		width: 100%;
+		@include breakpoint-deprecated("<960px") {
+			width: 100%;
+		}
 	}
 
 	&.incompatible {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -41,17 +41,24 @@
 	}
 
 	&.compact {
+		.plugin-icon {
+			width: 40px;
+			height: 40px;
+			margin-right: 16px;
+		}
+
 		.plugins-browser-item__link {
 			padding: 16px;
 		}
 
 		.plugins-browser-item__title {
 			font-size: $font-body-small;
+			margin-left: 0;
 		}
 
 		.plugins-browser-item__description {
 			font-size: $font-body-extra-small;
-			margin: 5px 0 0 calc(60px + 16px); // icon width + margin
+			margin: 5px 0 0 0;
 		}
 
 		@include breakpoint-deprecated(">960px") {

--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -1,0 +1,151 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement } from 'react';
+import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
+import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+
+export type Plugin = {
+	slug: string;
+	name: string;
+	short_description: string;
+	icon: string;
+};
+
+export type Collection = {
+	name: string;
+	slug: 'monetization' | 'business' | 'ecommerce';
+	description?: string;
+	plugins: Plugin[];
+	separator?: boolean;
+};
+
+export function useCollections(): Record< string, Collection > {
+	const { __ } = useI18n();
+	return {
+		monetization: {
+			name: __( 'Supercharging and monetizing your blog' ),
+			slug: 'monetization',
+			description: __(
+				'Building a money-making blog doesn’t have to be as hard as you might think'
+			),
+			plugins: [
+				{
+					slug: 'wordpress-seo-premium',
+					name: __( 'Yoast SEO Premium' ),
+					icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png',
+					short_description: __( 'Optimize your site for search engines' ),
+				},
+				{
+					slug: 'give',
+					name: __( 'GiveWP' ),
+					icon: 'https://ps.w.org/give/assets/icon-256x256.jpg?rev=2659032',
+					short_description: __( 'Create donation pages and collect more' ),
+				},
+				{
+					slug: 'woothemes-sensei',
+					name: __( 'Sensei Pro' ),
+					icon: 'https://wordpress.com/wp-content/lib/marketplace-images/sensei-pro.svg',
+					short_description: __( 'Manage and sell digital courses' ),
+				},
+			],
+		},
+		business: {
+			name: __( 'Setting up your local business' ),
+			slug: 'business',
+			description: __( 'These plugins are here to keep your business on track' ),
+			plugins: [
+				{
+					slug: 'wordpress-seo-premium',
+					name: __( 'Yoast SEO Premium' ),
+					icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png',
+					short_description: __( 'Optimize your site for search engines' ),
+				},
+				{
+					slug: 'woocommerce-bookings',
+					name: __( 'WooCommerce Bookings ' ),
+					icon: 'https://wordpress.com/wp-content/lib/marketplace-images/woocommerce-bookings.png',
+					short_description: __( 'Allow customers to book appointments' ),
+				},
+				{
+					slug: 'mailpoet',
+					name: __( 'MailPoet' ),
+					icon: 'https://ps.w.org/mailpoet/assets/icon-256x256.png?rev=2784430',
+					short_description: __( 'Send emails and create loyal customers' ),
+				},
+			],
+		},
+		ecommerce: {
+			name: __( 'Powering your online store' ),
+			slug: 'ecommerce',
+			description: __( 'Tools that will set you up to optimize your online business' ),
+			plugins: [
+				{
+					slug: 'woocommerce-subscriptions',
+					name: __( 'WooCommerce Subscriptions' ),
+					icon: 'https://wordpress.com/wp-content/lib/marketplace-images/woocommerce-subscriptions.png',
+					short_description: __( 'Let customers subscribe to your service' ),
+				},
+				{
+					slug: 'woocommerce-xero',
+					name: __( 'Xero' ),
+					icon: 'https://woocommerce.com/wp-content/uploads/2012/08/xero2.png',
+					short_description: __( 'Sync your site with your Xero account' ),
+				},
+				{
+					slug: 'automatewoo',
+					name: __( 'AutomateWoo' ),
+					icon: 'https://wordpress.com/wp-content/lib/marketplace-images/automatewoo.png',
+					short_description: __( 'Create a range of automated workflows' ),
+				},
+				{
+					slug: 'woocommerce-shipment-tracking',
+					name: __( 'Shipment tracking' ),
+					icon: 'https://wordpress.com/wp-content/lib/marketplace-images/woocommerce-shipment-tracking.png',
+					short_description: __( 'Provide shipment tracking information' ),
+				},
+				{
+					slug: 'woocommerce-shipping-usps',
+					name: __( 'WooCommerce USPS Shipping' ),
+					icon: 'https://wordpress.com/wp-content/lib/marketplace-images/woocommerce.svg',
+					short_description: __( 'Get shipping rates from the USPS API' ),
+				},
+				{
+					slug: 'optinmonster',
+					name: __( 'OptinMonster' ),
+					icon: 'https://ps.w.org/optinmonster/assets/icon-256x256.png?rev=1145864',
+					short_description: __( 'Monetize your website traffic' ),
+				},
+			],
+		},
+	};
+}
+
+export default function CollectionListView( {
+	collection,
+	siteSlug,
+	sites,
+}: {
+	collection: 'monetization' | 'business' | 'ecommerce';
+	siteSlug: string;
+	sites: any;
+} ): ReactElement | null {
+	const collections = useCollections();
+
+	const plugins = collections[ collection ].plugins.slice( 0, 6 );
+
+	return (
+		<PluginsBrowserList
+			listName={ 'collection-' + collection }
+			plugins={ plugins }
+			size={ plugins.length }
+			title={ collections[ collection ].name }
+			subtitle={ collections[ collection ].description }
+			site={ siteSlug }
+			currentSites={ sites }
+			variant={ PluginsBrowserListVariant.Fixed }
+			showPlaceholders={ false }
+			expandedListLink={ false }
+			search={ '' }
+			extended={ false }
+		/>
+	);
+}

--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -143,7 +143,8 @@ export default function CollectionListView( {
 			currentSites={ sites }
 			variant={ PluginsBrowserListVariant.Fixed }
 			showPlaceholders={ false }
-			expandedListLink={ false }
+			browseAllLink={ false }
+			resultCount={ false }
 			search={ '' }
 			extended={ false }
 		/>

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -11,7 +11,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Module variables
  */
-const SHORT_LIST_LENGTH = 6;
+export const SHORT_LIST_LENGTH = 4;
 
 const PLUGIN_SLUGS_BLOCKLIST = [];
 

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -1,5 +1,6 @@
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
-import SingleListView from '../plugins-browser/single-list-view';
+import CollectionListView from '../plugins-browser/collection-list-view';
+import SingleListView, { SHORT_LIST_LENGTH } from '../plugins-browser/single-list-view';
 import usePlugins from '../use-plugins';
 import './style.scss';
 import UpgradeNudge from './upgrade-nudge';
@@ -7,7 +8,6 @@ import UpgradeNudge from './upgrade-nudge';
 /**
  * Module variables
  */
-const SHORT_LIST_LENGTH = 6;
 
 function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	const displayedFeaturedSlugsMap = new Map(
@@ -85,13 +85,16 @@ const PluginsDiscoveryPage = ( props ) => {
 		<>
 			<UpgradeNudge { ...props } paidPlugins={ true } />
 			<PaidPluginsSection { ...props } />
+			<CollectionListView collection="monetization" { ...props } />
 			<UpgradeNudge { ...props } />
 			<FeaturedPluginsSection
 				{ ...props }
 				pluginsByCategoryFeatured={ pluginsByCategoryFeatured }
 				isFetchingPluginsByCategoryFeatured={ isFetchingPluginsByCategoryFeatured }
 			/>
+			<CollectionListView collection="business" { ...props } />
 			<PopularPluginsSection { ...props } pluginsByCategoryFeatured={ pluginsByCategoryFeatured } />
+			<CollectionListView collection="ecommerce" { ...props } />
 		</>
 	);
 };

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -69,8 +69,8 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			'Yoast SEO',
 			'MailPoet – emails and newsletters in WordPress',
 			'Jetpack CRM – Clients, Invoices, Leads, & Billing for WordPress',
-			'Contact Form 7',
-			'Site Kit by Google – Analytics, Search Console, AdSense, Speed',
+			// 'Contact Form 7',
+			// 'Site Kit by Google – Analytics, Search Console, AdSense, Speed',
 		] )( 'Featured Plugins section should show the %s plugin', async function ( plugin: string ) {
 			await pluginsPage.validateHasPluginOnSection( PluginsPage.featuredSection, plugin );
 		} );

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -69,8 +69,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			'Yoast SEO',
 			'MailPoet – emails and newsletters in WordPress',
 			'Jetpack CRM – Clients, Invoices, Leads, & Billing for WordPress',
-			// 'Contact Form 7',
-			// 'Site Kit by Google – Analytics, Search Console, AdSense, Speed',
 		] )( 'Featured Plugins section should show the %s plugin', async function ( plugin: string ) {
 			await pluginsPage.validateHasPluginOnSection( PluginsPage.featuredSection, plugin );
 		} );


### PR DESCRIPTION
#### Proposed Changes

* Adds collection list view component #68800 #67987
* Adds some hard coded collections #67925 #67980 #67982 - Note missing some per [this comment](https://github.com/Automattic/wp-calypso/issues/67987#issuecomment-1274118347). We can add more later.
* Shrinks the compact plugin list view to 3 columns based on figma f84fqtCG4pCnCh2Hq0But5-fi-3620%3A32644 #67979
* Drops the short list constant to 4 from 6 to match figma #68877

#### Testing Instructions

* Plugins screen should render the new collections sections
* Old sections should be shrunk to 4 from 6

Fixes #68800
Fixes #67979
Fixes #67925
Fixes #67980
Fixes #67982
Fixes #68877

Related to #67987

Before 
![Screenshot 2022-10-11 at 17-09-50 Plugins ‹ Bussiness Simple — WordPress com](https://user-images.githubusercontent.com/811776/195009890-bde6bc51-f72e-4e12-b5e3-3fce6278ee3d.png)

After
![Screenshot 2022-10-11 at 15-29-10 Plugins ‹ Simple 123 — WordPress com](https://user-images.githubusercontent.com/140841/195192211-bbf88362-0e39-447d-9a99-97a8c8f4759f.png)
