### PR TITLE
Sites Management Page: Show "Coming soon" tile for sites that have not launched yet. 

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -14,6 +14,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'jetpack',
 	'is_wpcom_atomic',
 	'user_interactions',
+	'lang',
 ] as const;
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -6,7 +6,7 @@ type Props = {
 	siteName?: string;
 	className?: string;
 	style?: CSSProperties;
-	lang: string;
+	lang?: string;
 };
 
 const Root = styled.div( {

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -49,7 +49,7 @@ const getTranslation = ( lang?: string ) => {
 	return text;
 };
 
-export const SiteComingSoon = ( { siteName = '', lang = '', style }: Props ) => {
+export const SiteComingSoon = ( { siteName = '', lang, style }: Props ) => {
 	const comingSoon = getTranslation( lang );
 	return (
 		<Root style={ style }>

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { CSSProperties } from 'react';
+
+type Props = {
+	siteName?: string;
+	className?: string;
+	style?: CSSProperties;
+	lang: string;
+};
+
+const Root = styled.div( {
+	display: 'flex',
+	alignItems: 'center',
+	backgroundColor: '#117ac9',
+	borderRadius: 4,
+	boxSizing: 'border-box',
+} );
+
+export const SiteComingSoon = ( { siteName = '', lang = '', className, style }: Props ) => {
+	return (
+		<Root className={ className } style={ style } data-testid="site-coming-soon">
+			<svg width="100%" viewBox="0 0 375 272" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<text
+					fill="white"
+					fontFamily="Recoleta, Georgia, 'Times New Roman', Times, serif"
+					fontSize="30"
+				>
+					<tspan x="31" y="153.016">
+						{ /** todo: translate to site language */ }
+						{ `Coming soon ( ${ lang } )` }
+					</tspan>
+				</text>
+				<text
+					fill="white"
+					fontFamily='-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif'
+					fontSize="14"
+				>
+					<tspan x="31" y="120.102">
+						{ siteName }
+					</tspan>
+				</text>
+			</svg>
+		</Root>
+	);
+};

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
 import { CSSProperties } from 'react';
 
 type Props = {
@@ -38,7 +39,7 @@ const comingSoonTranslations: Record< string, string > = {
 };
 
 const getTranslation = ( lang?: string ) => {
-	let text = 'Coming soon';
+	let text = __( 'Coming Soon' );
 	if ( lang ) {
 		lang = lang.split( '-' )[ 0 ];
 		if ( comingSoonTranslations[ lang ] ) {
@@ -48,10 +49,10 @@ const getTranslation = ( lang?: string ) => {
 	return text;
 };
 
-export const SiteComingSoon = ( { siteName = '', lang = '', className, style }: Props ) => {
+export const SiteComingSoon = ( { siteName = '', lang = '', style }: Props ) => {
 	const comingSoon = getTranslation( lang );
 	return (
-		<Root className={ className } style={ style } data-testid="site-coming-soon">
+		<Root style={ style }>
 			<svg width="100%" viewBox="0 0 375 272" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<title>{ comingSoon }</title>
 				<text

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -16,18 +16,51 @@ const Root = styled.div( {
 	boxSizing: 'border-box',
 } );
 
+const comingSoonTranslations: Record< string, string > = {
+	ar: 'قريبًا',
+	de: 'Demnächst verfügbar',
+	es: 'Próximamente',
+	fr: 'Bientôt disponible',
+	he: 'בקרוב',
+	id: 'Segera hadir',
+	it: 'Presto disponibile',
+	ja: '近日公開',
+	ko: '공개 예정',
+	nb: 'Kommer snart',
+	nl: 'Komt binnenkort',
+	pt: 'Em breve',
+	ro: 'În curând',
+	ru: 'Скоро будет',
+	skr: 'جلدی آندا پئے',
+	sv: 'Kommer snart',
+	tr: 'Pek yakında',
+	zh: '即将推出',
+};
+
+const getTranslation = ( lang?: string ) => {
+	let text = 'Coming soon';
+	if ( lang ) {
+		lang = lang.split( '-' )[ 0 ];
+		if ( comingSoonTranslations[ lang ] ) {
+			text = comingSoonTranslations[ lang ];
+		}
+	}
+	return text;
+};
+
 export const SiteComingSoon = ( { siteName = '', lang = '', className, style }: Props ) => {
+	const comingSoon = getTranslation( lang );
 	return (
 		<Root className={ className } style={ style } data-testid="site-coming-soon">
 			<svg width="100%" viewBox="0 0 375 272" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<title>{ comingSoon }</title>
 				<text
 					fill="white"
 					fontFamily="Recoleta, Georgia, 'Times New Roman', Times, serif"
 					fontSize="30"
 				>
 					<tspan x="31" y="153.016">
-						{ /** todo: translate to site language */ }
-						{ `Coming soon ( ${ lang } )` }
+						{ comingSoon }
 					</tspan>
 				</text>
 				<text

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -1,10 +1,11 @@
-import { SiteThumbnail } from '@automattic/components';
+import { SiteThumbnail, DEFAULT_THUMBNAIL_SIZE } from '@automattic/components';
 import { getSiteLaunchStatus } from '@automattic/sites';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentProps } from 'react';
 import Image from 'calypso/components/image';
+import { SiteComingSoon } from './sites-site-coming-soon';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const NoIcon = styled.div( {
@@ -36,6 +37,14 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 			preview: true,
 			hide_banners: true,
 		} );
+	}
+
+	if ( site.is_coming_soon ) {
+		const style = {
+			width: props.width || DEFAULT_THUMBNAIL_SIZE.width,
+			height: props.height || DEFAULT_THUMBNAIL_SIZE.height,
+		};
+		return <SiteComingSoon siteName={ site.name } style={ style } lang={ site.lang } />;
 	}
 
 	return (

--- a/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import { SiteItemThumbnail } from '../sites-site-item-thumbnail';
 
-function makeTestSite( { title = 'test' } = {} ) {
+function makeTestSite( { title = 'test', is_coming_soon = false } = {} ) {
 	return {
 		ID: 1,
 		title,
@@ -13,6 +13,8 @@ function makeTestSite( { title = 'test' } = {} ) {
 		launch_status: 'launched',
 		options: {},
 		jetpack: false,
+		is_coming_soon,
+		lang: 'en',
 	};
 }
 
@@ -84,5 +86,10 @@ function defineCommonSiteInitialTests() {
 
 		render( <SiteItemThumbnail site={ testSite } /> );
 		expect( screen.getByLabelText( 'Site Icon' ) ).toBeEmptyDOMElement();
+	} );
+
+	test( 'shows "Coming soon" tile if site has not launched', () => {
+		render( <SiteItemThumbnail site={ makeTestSite( { title: '', is_coming_soon: true } ) } /> );
+		expect( screen.getByTestId( 'site-coming-soon' ) ).toBeInTheDocument();
 	} );
 }

--- a/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
@@ -90,7 +90,7 @@ function defineCommonSiteInitialTests() {
 
 	test( 'shows "Coming soon" tile if site has not launched', () => {
 		render( <SiteItemThumbnail site={ makeTestSite( { title: '', is_coming_soon: true } ) } /> );
-		expect( screen.getByTestId( 'site-coming-soon' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'Coming Soon' ) ).toBeInTheDocument();
 	} );
 
 	test( 'shows "Coming soon" translated to site language', () => {
@@ -106,6 +106,6 @@ function defineCommonSiteInitialTests() {
 		render(
 			<SiteItemThumbnail site={ makeTestSite( { title: '', is_coming_soon: true, lang: 'zz' } ) } />
 		);
-		expect( screen.getByTitle( 'Coming soon' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'Coming Soon' ) ).toBeInTheDocument();
 	} );
 }

--- a/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import { SiteItemThumbnail } from '../sites-site-item-thumbnail';
 
-function makeTestSite( { title = 'test', is_coming_soon = false } = {} ) {
+function makeTestSite( { title = 'test', is_coming_soon = false, lang = 'en' } = {} ) {
 	return {
 		ID: 1,
 		title,
@@ -14,7 +14,7 @@ function makeTestSite( { title = 'test', is_coming_soon = false } = {} ) {
 		options: {},
 		jetpack: false,
 		is_coming_soon,
-		lang: 'en',
+		lang,
 	};
 }
 
@@ -91,5 +91,21 @@ function defineCommonSiteInitialTests() {
 	test( 'shows "Coming soon" tile if site has not launched', () => {
 		render( <SiteItemThumbnail site={ makeTestSite( { title: '', is_coming_soon: true } ) } /> );
 		expect( screen.getByTestId( 'site-coming-soon' ) ).toBeInTheDocument();
+	} );
+
+	test( 'shows "Coming soon" translated to site language', () => {
+		render(
+			<SiteItemThumbnail
+				site={ makeTestSite( { title: '', is_coming_soon: true, lang: 'de-DE' } ) }
+			/>
+		);
+		expect( screen.getByTitle( 'Demnächst verfügbar' ) ).toBeInTheDocument();
+	} );
+
+	test( 'shows "Coming soon" in English when site language is not translated', () => {
+		render(
+			<SiteItemThumbnail site={ makeTestSite( { title: '', is_coming_soon: true, lang: 'zz' } ) } />
+		);
+		expect( screen.getByTitle( 'Coming soon' ) ).toBeInTheDocument();
 	} );
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -13,7 +13,7 @@ export { default as Ribbon } from './ribbon';
 export { default as RootChild } from './root-child';
 export { default as ScreenReaderText } from './screen-reader-text';
 export { useScrollToTop } from './scroll-to-top/use-scroll-to-top';
-export { SiteThumbnail } from './site-thumbnail';
+export { SiteThumbnail, DEFAULT_THUMBNAIL_SIZE } from './site-thumbnail';
 export { default as Suggestions } from './suggestions';
 export { default as PaginationControl } from './pagination-control';
 export { Gravatar } from './gravatar';

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -7,9 +7,9 @@ import { getTextColorFromBackground } from './utils';
 
 export type SizeCss = { width: number; height: number };
 
-const DEFAULT_SIZE = { width: 106, height: 76.55 };
+export const DEFAULT_THUMBNAIL_SIZE = { width: 106, height: 76.55 };
 
-const DEFAULT_CLASSNAME = css( DEFAULT_SIZE );
+const DEFAULT_CLASSNAME = css( DEFAULT_THUMBNAIL_SIZE );
 
 const VIEWPORT_BASE = 1200;
 
@@ -35,8 +35,8 @@ export const SiteThumbnail = ( {
 	alt,
 	mShotsUrl = '',
 	bgColorImgUrl,
-	width = DEFAULT_SIZE.width,
-	height = DEFAULT_SIZE.height,
+	width = DEFAULT_THUMBNAIL_SIZE.width,
+	height = DEFAULT_THUMBNAIL_SIZE.height,
 	dimensionsSrcset = [],
 	sizesAttr = '',
 	viewport = VIEWPORT_BASE,
@@ -65,7 +65,7 @@ export const SiteThumbnail = ( {
 	const showLoader = mShotsUrl && ! isError;
 	const mshotIsFullyLoaded = imgProps.src && ! isError && ! isLoading;
 
-	const blurSize = width > DEFAULT_SIZE.width ? 'medium' : 'small';
+	const blurSize = width > DEFAULT_THUMBNAIL_SIZE.width ? 'medium' : 'small';
 
 	return (
 		<div className={ classes } style={ { backgroundColor, color } }>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68859

I still need to translate the "Coming soon" text but not sure how to do that. 

#### Proposed Changes

* If a site has not launched yet, show a "Coming Soon" tile like we do when accessing the site's homepage. 

- [x] Coming soon sites have a site thumbnail that looks similar to the coming soon frontend
- [ ] Thumbnail translated into the _site's_ language (this is the language used by the frontend, not the admin UI language)
- [x] Thumbnail switches to mShots when site is launched
- [x] Thumbnail switches to SVG when site is set to coming soon

![image](https://user-images.githubusercontent.com/6851384/195023611-7f4381dc-41ab-4cce-98fc-e1c73e8f197d.png)

![image](https://user-images.githubusercontent.com/6851384/195023631-9a7b16a1-997f-47eb-87bd-210e83640229.png)

![image](https://user-images.githubusercontent.com/6851384/195233349-7b3c5e69-cda4-4181-ac80-f5a3f55a8469.png)

![image](https://user-images.githubusercontent.com/6851384/195233373-2643a13a-c2a8-42b4-80d0-16f7aff27bab.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` with at least one that has not launched yet `site.is_coming_soon = true`. 
* Make sure you see a blue "Coming soon" tile for that site, whether in grid or table view
* Launch the site
* Go back to `/sites` and confirm you see an mShots thumbnail
* Make the site privacy setting "Coming soon" again and confirm that you see a blue tile 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
