### PR TITLE
Revert "Reader: Re-apply search input styling to Share Tools"

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -47,25 +47,6 @@
 		width: 152px;
 		padding-right: 2px;
 	}
-	.search {
-		border-radius: 4px;
-		.search__icon-navigation {
-			border-bottom-left-radius: 4px;
-			border-top-left-radius: 4px;
-		}
-		.search__input.form-text-input[type="search"],
-		.search__close-icon {
-			border-bottom-right-radius: 4px;
-			border-top-right-radius: 4px;
-			padding: 4px 0;
-		}
-		&.is-open.has-focus {
-			box-shadow: none;
-			&:hover {
-				box-shadow: none;
-			}
-		}
-	}
 }
 
 .reader-share__popover-item {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#68850

Nothing major, just found that the highlight was incorrectly affecting the search field!

<img width="1053" alt="Screen Shot 2022-10-11 at 5 44 56 pm" src="https://user-images.githubusercontent.com/22446385/195027834-a136137a-5257-4afb-be4a-e9a3c6a1065d.png">
