### PR TITLE
Try to fix window.AppBoot is not a function

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -212,9 +212,15 @@ class Document extends Component {
 					{ chunkFiles.js.map( ( chunk ) => (
 						<script key={ chunk } src={ chunk } />
 					) ) }
-					<script nonce={ inlineScriptNonce } type="text/javascript">
+					<script
+						nonce={ inlineScriptNonce }
+						type="text/javascript"
+						dangerouslySetInnerHTML={ {
+							__html: `
 						window.AppBoot();
-					</script>
+						`,
+						} }
+					/>
 					<script
 						nonce={ inlineScriptNonce }
 						dangerouslySetInnerHTML={ {


### PR DESCRIPTION
#### Proposed Changes

* This PR tries to fix the error of `Uncaught TypeError: window.AppBoot is not a function` and looks like `dangerouslySetInnerHTML` is the simplest way to resolve it. I tested it several times and it seems to work! However, I'm not really sure whether it fixes the issue or not.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/`
* Modify the `window.AppBoot` function in [client/boot/app.js](https://github.com/Automattic/wp-calypso/blob/f2c91ec4c3c05e50399a7e1eb4b7ed30750372b7/client/boot/app.js#L8)
* Refresh the page and you won't see the error
* Go to `/setup?siteSlug=<your_site>`
* Modify the `window.AppBoot` function in [client/landing/stepper/index.tsx](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/index.tsx#L102)
* Refresh the page again and you won't see the error either!

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
