### PR TITLE
reader: Remove redundant follow buttons, add border to single images

### DIFF
--- a/client/blocks/reader-post-card/featured-images.jsx
+++ b/client/blocks/reader-post-card/featured-images.jsx
@@ -2,10 +2,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import { getImagesFromPostToDisplay } from 'calypso/state/reader/posts/normalization-rules';
-import {
-	READER_CONTENT_WIDTH,
-	READER_FEATURED_MAX_IMAGE_HEIGHT,
-} from 'calypso/state/reader/posts/sizes';
+import { READER_FEATURED_MAX_IMAGE_HEIGHT } from 'calypso/state/reader/posts/sizes';
 
 const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia } ) => {
 	let classNames = 'reader-post-card__featured-images';
@@ -21,8 +18,10 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia } ) => {
 	}
 
 	const listItems = imagesToDisplay.map( ( image, index, [ imageWidth, imageHeight ] ) => {
-		imageWidth = READER_CONTENT_WIDTH;
+		imageWidth = null;
 		imageHeight = READER_FEATURED_MAX_IMAGE_HEIGHT;
+
+		let width = '50%';
 
 		if ( imagesToDisplay.length === 4 ) {
 			imageWidth = imageWidth / 2;
@@ -36,6 +35,7 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia } ) => {
 		} else if ( imagesToDisplay.length === 2 ) {
 			classNames = classnames( 'reader-post-card__featured-images', 'two-images' );
 		} else {
+			width = '100%';
 			classNames = classnames( 'reader-post-card__featured-images', 'one-image' );
 		}
 
@@ -46,6 +46,7 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia } ) => {
 				fetched={ image.fetched }
 				imageWidth={ imageWidth }
 				imageHeight={ imageHeight }
+				children={ <div style={ { width: width } } /> }
 			/>
 		);
 

--- a/client/blocks/reader-post-card/featured-images.jsx
+++ b/client/blocks/reader-post-card/featured-images.jsx
@@ -29,7 +29,8 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia } ) => {
 			classNames = classnames( 'reader-post-card__featured-images', 'four-images' );
 		} else if ( imagesToDisplay.length === 3 ) {
 			if ( index !== 0 ) {
-				imageHeight = imageHeight / 2;
+				// leave space for a 2px gap, always round down to an integer
+				imageHeight = Math.floor( imageHeight / 2 ) - 1;
 			}
 			classNames = classnames( 'reader-post-card__featured-images', 'three-images' );
 		} else if ( imagesToDisplay.length === 2 ) {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -830,6 +830,25 @@
 			}
 		}
 	}
+	&.one-image {
+		.reader-post-card__featured-images-item {
+			width: 100%;
+			.reader-featured-image {
+				position: relative;
+				&::after {
+					content: "";
+					position: absolute;
+					pointer-events: none;
+					top: 0;
+					left: 0;
+					bottom: 0;
+					right: 0;
+					box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
+					border-radius: 6px;
+				}
+			}
+		}
+	}
 }
 
 .reader-post-card__featured-images-item {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -272,6 +272,18 @@
 		}
 	}
 
+	&::after {
+		content: "";
+		position: absolute;
+		pointer-events: none;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
+		border-radius: 6px;
+	}
+
 	&::before {
 		content: "";
 		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.37) 65%, rgba(0, 0, 0, 1) 110%);
@@ -281,6 +293,7 @@
 		bottom: 0;
 		left: 0;
 		width: 100%;
+		border-radius: 0 0 6px 6px;
 	}
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -280,7 +280,7 @@
 		left: 0;
 		bottom: 0;
 		right: 0;
-		box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 		border-radius: 4px;
 	}
 
@@ -857,7 +857,7 @@
 					left: 0;
 					bottom: 0;
 					right: 0;
-					box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
+					box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 					border-radius: 4px;
 				}
 			}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -281,7 +281,7 @@
 		bottom: 0;
 		right: 0;
 		box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
-		border-radius: 6px;
+		border-radius: 4px;
 	}
 
 	&::before {
@@ -293,7 +293,7 @@
 		bottom: 0;
 		left: 0;
 		width: 100%;
-		border-radius: 0 0 6px 6px;
+		border-radius: 0 0 4px 4px;
 	}
 }
 
@@ -754,6 +754,7 @@
 		}
 		/* First image */
 		.reader-post-card__featured-images-item:first-child {
+			border-top-left-radius: 4px;
 			border-bottom-left-radius: 4px;
 			max-height: 302px;
 			overflow: hidden;
@@ -857,7 +858,7 @@
 					bottom: 0;
 					right: 0;
 					box-shadow: inset 0 0 0 1px rgba(0,0,0,.1);
-					border-radius: 6px;
+					border-radius: 4px;
 				}
 			}
 		}

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -75,7 +75,7 @@ const exported = {
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				showBack={ false }
-				showPrimaryFollowButtonOnCards={ true }
+				showPrimaryFollowButtonOnCards={ false }
 				autoFocusInput={ autoFocusInput }
 				onQueryChange={ reportQueryChange }
 				onSortChange={ reportSortChange }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -75,7 +75,7 @@ class ReaderStream extends Component {
 		onUpdatesShown: noop,
 		className: '',
 		showDefaultEmptyContentIfMissing: true,
-		showPrimaryFollowButtonOnCards: true,
+		showPrimaryFollowButtonOnCards: false,
 		isDiscoverStream: false,
 		isMain: true,
 		useCompactCards: false,

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -46,7 +46,7 @@ export const tagListing = ( context, next ) => {
 			startDate={ startDate }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
 			showBack={ !! context.lastRoute }
-			showPrimaryFollowButtonOnCards={ true }
+			showPrimaryFollowButtonOnCards={ false }
 			followSource={ TAG_PAGE }
 		/>
 	);

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -59,7 +59,7 @@ export function imageWithCorrectRatio( image ) {
 export function getImagesFromPostToDisplay( post, numberOfImagesToDisplay ) {
 	const images = ( post.images && [ ...post.images ] ) || [];
 
-	//Remove duplicates, small images and images that are outside ideal aspect ratio
+	// Remove duplicates, small images and images that are outside ideal aspect ratio
 	return images
 		.filter(
 			( element, index ) => index === images.findIndex( ( elem ) => elem.src === element.src )


### PR DESCRIPTION
#### Proposed Changes

Fixes two bugs reported here p1665441293827979-slack-C03NLNTPZ2T
<img width="953" alt="Screen Shot 2022-10-11 at 8 33 12 am" src="https://user-images.githubusercontent.com/22446385/195041331-a9aec63a-7139-41b1-adef-0699316294dd.png">

Duplicate follow buttons have been removed from the search results, liked posts, and tags pages.

It appears that the `showPrimaryFollowButtonOnCards` prop is no longer used (now always false) and so we can remove associated code.

Also adds a border to single image cards which was missing and makes their width consistently 100% of the card

#### Testing Instructions

* Ensure no cards need "primary" follow buttons but don't have them, across all of reader as I've changed the default `showPrimaryFollowButtonOnCards` to `false` 
* Ensure that one, two, three and four image layouts have their borders as expected
* ensure that single images in cards are not stretched now that I've set width:100% on the container
