### PR TITLE
HelpCenter: fix maximize on mobile

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -108,11 +108,10 @@ $head-foot-height: 50px;
 		}
 
 		&.is-mobile {
-			top: 45px;
 			bottom: 0;
 			left: 0;
 			right: 0;
-			max-height: 100%;
+			max-height: calc(100% - 45px);
 
 			.help-center__container-content {
 				flex: auto;


### PR DESCRIPTION
#### Proposed Changes

* Before
https://d.pr/i/yQVet4
* After
https://d.pr/v/tTWKIB

#### Testing Instructions
- Checkout this branch
- Run `yarn start`
- Open the help center with mobile device
- Minimize and maximize the help center
- The maximization should start from the bottom to the top and not the other way around

Related to #68823
