### PR TITLE
Sites Management Page: P2 thumbnails show sidebar content

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -10,6 +10,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'icon',
 	'name',
 	'options',
+	'p2_thumbnail_elements',
 	'plan',
 	'jetpack',
 	'is_wpcom_atomic',

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -1,8 +1,5 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useInView } from 'react-intersection-observer';
-import { useQuery } from 'react-query';
-import wpcom from 'calypso/lib/wp';
 import type { SitesDisplayMode } from './sites-display-mode-switcher';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -91,22 +88,22 @@ interface P2ThumbnailProps {
 
 export function P2Thumbnail( { site, displayMode }: P2ThumbnailProps ) {
 	const { __ } = useI18n();
-	const { ref, inView } = useInView( { triggerOnce: true } );
-	const { data, isLoading } = useP2ThumbnailElementsQuery( site.ID, { enabled: inView } );
+
+	if ( ! site.p2_thumbnail_elements ) {
+		return null;
+	}
+
+	const { color_link, color_sidebar_background, header_image } = site.p2_thumbnail_elements;
 
 	function renderContents() {
-		if ( isLoading || ! data ) {
-			return null;
-		}
-
 		const isSmall = displayMode === 'list';
 
 		return (
 			<>
-				{ data.header_image ? (
-					<HeaderImage src={ data.header_image } alt="" />
+				{ header_image ? (
+					<HeaderImage src={ header_image } alt="" />
 				) : (
-					<ColorGradient style={ { backgroundColor: data.color_link } } />
+					<ColorGradient style={ { backgroundColor: color_link } } />
 				) }
 				{ site.icon && (
 					<SiteIconContainer isSmall={ isSmall }>
@@ -119,32 +116,11 @@ export function P2Thumbnail( { site, displayMode }: P2ThumbnailProps ) {
 
 	return (
 		<Container
-			ref={ ref }
 			role={ 'img' }
 			aria-label={ __( 'Site Icon' ) }
-			style={ { backgroundColor: data?.color_sidebar_background } }
+			style={ { backgroundColor: color_sidebar_background } }
 		>
 			{ renderContents() }
 		</Container>
-	);
-}
-
-interface P2ThumbnailElements {
-	color_link: string;
-	color_sidebar_background: string;
-	header_image: string | null;
-}
-
-function useP2ThumbnailElementsQuery( siteId: number, { enabled = true } ) {
-	return useQuery(
-		[ 'p2-thumbnail-elements', siteId ],
-		(): Promise< P2ThumbnailElements > =>
-			wpcom.req.get( {
-				path: `/sites/${ siteId }/p2-thumbnail-elements`,
-				apiNamespace: 'wpcom/v2',
-			} ),
-		{
-			enabled,
-		}
 	);
 }

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import { useInView } from 'react-intersection-observer';
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+const Container = styled.div( {
+	userSelect: 'none',
+	position: 'relative',
+	top: 0,
+	left: 0,
+	width: '100%',
+	height: '100%',
+	backgroundSize: 'contain',
+	backgroundRepeat: 'no-repeat',
+	backgroundPosition: 'top center',
+} );
+
+const SiteIcon = styled.img( {
+	background: '#fff',
+	padding: '3px',
+	borderRadius: '3px',
+	position: 'absolute',
+	bottom: '16px',
+	left: '16px',
+} );
+
+interface P2ThumbnailProps {
+	site: SiteExcerptData;
+}
+
+export function P2Thumbnail( { site }: P2ThumbnailProps ) {
+	const { __ } = useI18n();
+	const { ref, inView } = useInView( { triggerOnce: true } );
+	const { data, isLoading } = useP2ThumbnailElementsQuery( site.ID, { enabled: inView } );
+
+	const inlineStyles =
+		isLoading || ! data
+			? {}
+			: {
+					backgroundColor: data.color_sidebar_background,
+					backgroundImage: data.header_image ? `url("${ data.header_image }")` : undefined,
+			  };
+
+	const siteIcon =
+		isLoading || ! data || ! site.icon ? null : (
+			<SiteIcon src={ site.icon.img } alt="" width="64" height="64" />
+		);
+
+	return (
+		<Container ref={ ref } role={ 'img' } aria-label={ __( 'Site Icon' ) } style={ inlineStyles }>
+			{ siteIcon }
+		</Container>
+	);
+}
+
+interface P2ThumbnailElements {
+	color_sidebar_background: string;
+	header_image: string | null;
+}
+
+function useP2ThumbnailElementsQuery( siteId: number, { enabled = true } ) {
+	return useQuery(
+		[ 'p2-thumbnail-elements', siteId ],
+		(): Promise< P2ThumbnailElements > =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/p2-thumbnail-elements`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			enabled,
+		}
+	);
+}

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -33,13 +33,18 @@ const ColorGradient = styled.div( {
 	},
 } );
 
-const SiteIcon = styled.img( {
+const SiteIconContainer = styled.div( {
 	background: '#fff',
 	padding: '3px',
-	borderRadius: '3px',
+	borderRadius: '4px',
 	position: 'absolute',
-	bottom: '16px',
-	left: '16px',
+	left: '32px',
+	top: '109px',
+} );
+
+const SiteIcon = styled.img( {
+	borderRadius: '2px',
+	display: 'block',
 } );
 
 interface P2ThumbnailProps {
@@ -63,7 +68,11 @@ export function P2Thumbnail( { site }: P2ThumbnailProps ) {
 				) : (
 					<ColorGradient style={ { backgroundColor: data.color_link } } />
 				) }
-				{ site.icon && <SiteIcon src={ site.icon.img } alt="" width="64" height="64" /> }
+				{ site.icon && (
+					<SiteIconContainer>
+						<SiteIcon src={ site.icon.img } alt="" width="64" height="64" />
+					</SiteIconContainer>
+				) }
 			</>
 		);
 	}

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -17,6 +17,8 @@ const Container = styled.div( {
 
 const HeaderImage = styled.img( {
 	width: '100%',
+	height: '144px',
+	objectFit: 'cover',
 } );
 
 const ColorGradient = styled.div( {

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -114,7 +114,7 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 
 	return (
 		<Container
-			role={ 'img' }
+			role="img"
 			aria-label={ alt }
 			style={ { backgroundColor: color_sidebar_background } }
 		>

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -115,18 +115,24 @@ export function P2Thumbnail( { site, displayMode, alt, sizesAttr }: P2ThumbnailP
 }
 
 function getHeaderImgProps( isSmall: boolean, imgSrc: string ) {
+	const param = getWidthParam( imgSrc );
+
+	if ( ! param ) {
+		return { src: imgSrc };
+	}
+
 	if ( isSmall ) {
 		return {
-			src: addQueryArgs( imgSrc, { w: DEFAULT_THUMBNAIL_SIZE.width } ),
-			srcSet: addQueryArgs( imgSrc, { w: 2 * DEFAULT_THUMBNAIL_SIZE.width } ) + ' 2x',
+			src: addQueryArgs( imgSrc, { [ param ]: DEFAULT_THUMBNAIL_SIZE.width } ),
+			srcSet: addQueryArgs( imgSrc, { [ param ]: 2 * DEFAULT_THUMBNAIL_SIZE.width } ) + ' 2x',
 		};
 	}
 
 	return {
 		src: imgSrc,
 		srcSet: [
-			addQueryArgs( imgSrc, { w: 360 } ) + ' 360w',
-			addQueryArgs( imgSrc, { w: 720 } ) + ' 720w', // 720px is the recommended header width in the P2 customizer
+			addQueryArgs( imgSrc, { [ param ]: 360 } ) + ' 360w',
+			addQueryArgs( imgSrc, { [ param ]: 720 } ) + ' 720w', // 720px is the recommended header width in the P2 customizer
 		].join( ',' ),
 	};
 }
@@ -134,10 +140,31 @@ function getHeaderImgProps( isSmall: boolean, imgSrc: string ) {
 function getIconImgProps( isSmall: boolean, imgSrc: string ) {
 	const width = isSmall ? SMALL_ICON_PX : LARGE_ICON_PX;
 
+	const param = getWidthParam( imgSrc );
+
+	if ( ! param ) {
+		return {
+			src: imgSrc,
+			width: `${ width }px`,
+			height: `${ width }px`,
+		};
+	}
+
 	return {
-		src: addQueryArgs( imgSrc, { s: width } ),
-		srcSet: addQueryArgs( imgSrc, { s: 2 * width } ) + ' 2x',
+		src: addQueryArgs( imgSrc, { [ param ]: width } ),
+		srcSet: addQueryArgs( imgSrc, { [ param ]: 2 * width } ) + ' 2x',
 		width: `${ width }px`,
 		height: `${ width }px`,
 	};
+}
+
+function getWidthParam( imgSrc: string ) {
+	const { hostname } = new URL( imgSrc, 'http://example.com' );
+	if ( hostname.endsWith( 'gravatar.com' ) ) {
+		return 's';
+	}
+	if ( hostname.endsWith( 'files.wordpress.com' ) ) {
+		return 'w';
+	}
+	return null;
 }

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -88,7 +88,7 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 		return (
 			<>
 				{ header_image ? (
-					<HeaderImage src={ header_image } alt="" />
+					<HeaderImage { ...getHeaderImgProps( isSmall, header_image ) } />
 				) : (
 					<ColorGradient style={ { backgroundColor: color_link } } />
 				) }
@@ -110,6 +110,30 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 			{ renderContents() }
 		</Container>
 	);
+}
+
+function getHeaderImgProps( isSmall: boolean, imgSrc: string ) {
+	if ( isSmall ) {
+		return {
+			src: addQueryArgs( imgSrc, { w: 106 } ),
+			srcSet: addQueryArgs( imgSrc, { w: 2 * 106 } ) + ' 2x',
+		};
+	}
+
+	return {
+		src: imgSrc,
+		srcSet: [
+			addQueryArgs( imgSrc, { w: 360 } ) + ' 360w',
+			addQueryArgs( imgSrc, { w: 720 } ) + ' 720w',
+		].join( ',' ),
+		sizes: [
+			'(min-width: 1345px) 405px',
+			'(min-width: 960px) calc( ( 100vw - 128px ) / 3 )',
+			'(min-width: 780px) calc( ( 100vw - 96px ) / 2 )',
+			'(min-width: 660px) calc( ( 100vw - 64px ) / 2 )',
+			'calc( 100vw - 32px )',
+		].join( ',' ),
+	};
 }
 
 function getIconImgProps( isSmall: boolean, imgSrc: string ) {

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -3,7 +3,18 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useInView } from 'react-intersection-observer';
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
+import type { SitesDisplayMode } from './sites-display-mode-switcher';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+const LARGE_ICON_PX = 64;
+const SMALL_ICON_PX = 32;
+const ICON_BORDER_PX = 3;
+
+const headerImageSize = {
+	width: '100%',
+	height: 'auto',
+	aspectRatio: '5/2',
+};
 
 const Container = styled.div( {
 	userSelect: 'none',
@@ -13,16 +24,20 @@ const Container = styled.div( {
 	width: '100%',
 	height: '100%',
 	overflow: 'hidden',
+
+	// Using flex to remove an unexplained gap between the header image and site icon
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'start',
 } );
 
 const HeaderImage = styled.img( {
-	width: '100%',
-	height: '144px',
+	...headerImageSize,
 	objectFit: 'cover',
 } );
 
 const ColorGradient = styled.div( {
-	height: '144px',
+	...headerImageSize,
 
 	'::before': {
 		content: '""',
@@ -33,25 +48,48 @@ const ColorGradient = styled.div( {
 	},
 } );
 
-const SiteIconContainer = styled.div( {
-	background: '#fff',
-	padding: '3px',
-	borderRadius: '4px',
-	position: 'absolute',
-	left: '32px',
-	top: '109px',
-} );
+const SiteIconContainer = styled.div< { isSmall: boolean } >(
+	{
+		background: '#fff',
+		padding: ICON_BORDER_PX,
+		borderRadius: '4px',
+		position: 'relative',
+	},
+	( { isSmall } ) =>
+		isSmall
+			? {
+					left: '8px',
+					top: `${ -SMALL_ICON_PX / 2 - ICON_BORDER_PX }px`,
+			  }
+			: {
+					left: '32px',
+					top: `${ -LARGE_ICON_PX / 2 - ICON_BORDER_PX }px`,
+			  }
+);
 
-const SiteIcon = styled.img( {
-	borderRadius: '2px',
-	display: 'block',
-} );
+const SiteIcon = styled.img< { isSmall: boolean } >(
+	{
+		borderRadius: '2px',
+		display: 'block',
+	},
+	( { isSmall } ) =>
+		isSmall
+			? {
+					width: SMALL_ICON_PX,
+					height: SMALL_ICON_PX,
+			  }
+			: {
+					width: LARGE_ICON_PX,
+					height: LARGE_ICON_PX,
+			  }
+);
 
 interface P2ThumbnailProps {
 	site: SiteExcerptData;
+	displayMode: SitesDisplayMode;
 }
 
-export function P2Thumbnail( { site }: P2ThumbnailProps ) {
+export function P2Thumbnail( { site, displayMode }: P2ThumbnailProps ) {
 	const { __ } = useI18n();
 	const { ref, inView } = useInView( { triggerOnce: true } );
 	const { data, isLoading } = useP2ThumbnailElementsQuery( site.ID, { enabled: inView } );
@@ -61,6 +99,8 @@ export function P2Thumbnail( { site }: P2ThumbnailProps ) {
 			return null;
 		}
 
+		const isSmall = displayMode === 'list';
+
 		return (
 			<>
 				{ data.header_image ? (
@@ -69,8 +109,8 @@ export function P2Thumbnail( { site }: P2ThumbnailProps ) {
 					<ColorGradient style={ { backgroundColor: data.color_link } } />
 				) }
 				{ site.icon && (
-					<SiteIconContainer>
-						<SiteIcon src={ site.icon.img } alt="" width="64" height="64" />
+					<SiteIconContainer isSmall={ isSmall }>
+						<SiteIcon src={ site.icon.img } alt="" isSmall={ isSmall } />
 					</SiteIconContainer>
 				) }
 			</>

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_THUMBNAIL_SIZE } from '@automattic/components';
 import styled from '@emotion/styled';
 import { addQueryArgs } from '@wordpress/url';
 import type { SitesDisplayMode } from './sites-display-mode-switcher';
@@ -73,9 +74,10 @@ interface P2ThumbnailProps {
 	site: SiteExcerptData;
 	displayMode: SitesDisplayMode;
 	alt: string;
+	sizesAttr?: string;
 }
 
-export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
+export function P2Thumbnail( { site, displayMode, alt, sizesAttr }: P2ThumbnailProps ) {
 	if ( ! site.p2_thumbnail_elements ) {
 		return null;
 	}
@@ -88,7 +90,7 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 		return (
 			<>
 				{ header_image ? (
-					<HeaderImage { ...getHeaderImgProps( isSmall, header_image ) } />
+					<HeaderImage { ...getHeaderImgProps( isSmall, header_image ) } sizes={ sizesAttr } />
 				) : (
 					<ColorGradient style={ { backgroundColor: color_link } } />
 				) }
@@ -115,8 +117,8 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 function getHeaderImgProps( isSmall: boolean, imgSrc: string ) {
 	if ( isSmall ) {
 		return {
-			src: addQueryArgs( imgSrc, { w: 106 } ),
-			srcSet: addQueryArgs( imgSrc, { w: 2 * 106 } ) + ' 2x',
+			src: addQueryArgs( imgSrc, { w: DEFAULT_THUMBNAIL_SIZE.width } ),
+			srcSet: addQueryArgs( imgSrc, { w: 2 * DEFAULT_THUMBNAIL_SIZE.width } ) + ' 2x',
 		};
 	}
 
@@ -124,14 +126,7 @@ function getHeaderImgProps( isSmall: boolean, imgSrc: string ) {
 		src: imgSrc,
 		srcSet: [
 			addQueryArgs( imgSrc, { w: 360 } ) + ' 360w',
-			addQueryArgs( imgSrc, { w: 720 } ) + ' 720w',
-		].join( ',' ),
-		sizes: [
-			'(min-width: 1345px) 405px',
-			'(min-width: 960px) calc( ( 100vw - 128px ) / 3 )',
-			'(min-width: 780px) calc( ( 100vw - 96px ) / 2 )',
-			'(min-width: 660px) calc( ( 100vw - 64px ) / 2 )',
-			'calc( 100vw - 32px )',
+			addQueryArgs( imgSrc, { w: 720 } ) + ' 720w', // 720px is the recommended header width in the P2 customizer
 		].join( ',' ),
 	};
 }

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -12,9 +12,23 @@ const Container = styled.div( {
 	left: 0,
 	width: '100%',
 	height: '100%',
-	backgroundSize: 'contain',
-	backgroundRepeat: 'no-repeat',
-	backgroundPosition: 'top center',
+	overflow: 'hidden',
+} );
+
+const HeaderImage = styled.img( {
+	width: '100%',
+} );
+
+const ColorGradient = styled.div( {
+	height: '144px',
+
+	'::before': {
+		content: '""',
+		display: 'block',
+		width: '100%',
+		height: '100%',
+		background: 'linear-gradient( 80.15deg, rgba( 0, 0, 0, .3 ) 0%, rgba( 0, 0, 0, 0 ) 100% )',
+	},
 } );
 
 const SiteIcon = styled.img( {
@@ -35,27 +49,37 @@ export function P2Thumbnail( { site }: P2ThumbnailProps ) {
 	const { ref, inView } = useInView( { triggerOnce: true } );
 	const { data, isLoading } = useP2ThumbnailElementsQuery( site.ID, { enabled: inView } );
 
-	const inlineStyles =
-		isLoading || ! data
-			? {}
-			: {
-					backgroundColor: data.color_sidebar_background,
-					backgroundImage: data.header_image ? `url("${ data.header_image }")` : undefined,
-			  };
+	function renderContents() {
+		if ( isLoading || ! data ) {
+			return null;
+		}
 
-	const siteIcon =
-		isLoading || ! data || ! site.icon ? null : (
-			<SiteIcon src={ site.icon.img } alt="" width="64" height="64" />
+		return (
+			<>
+				{ data.header_image ? (
+					<HeaderImage src={ data.header_image } alt="" />
+				) : (
+					<ColorGradient style={ { backgroundColor: data.color_link } } />
+				) }
+				{ site.icon && <SiteIcon src={ site.icon.img } alt="" width="64" height="64" /> }
+			</>
 		);
+	}
 
 	return (
-		<Container ref={ ref } role={ 'img' } aria-label={ __( 'Site Icon' ) } style={ inlineStyles }>
-			{ siteIcon }
+		<Container
+			ref={ ref }
+			role={ 'img' }
+			aria-label={ __( 'Site Icon' ) }
+			style={ { backgroundColor: data?.color_sidebar_background } }
+		>
+			{ renderContents() }
 		</Container>
 	);
 }
 
 interface P2ThumbnailElements {
+	color_link: string;
 	color_sidebar_background: string;
 	header_image: string | null;
 }

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { addQueryArgs } from '@wordpress/url';
 import type { SitesDisplayMode } from './sites-display-mode-switcher';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -63,22 +64,10 @@ const SiteIconContainer = styled.div< { isSmall: boolean } >(
 			  }
 );
 
-const SiteIcon = styled.img< { isSmall: boolean } >(
-	{
-		borderRadius: '2px',
-		display: 'block',
-	},
-	( { isSmall } ) =>
-		isSmall
-			? {
-					width: SMALL_ICON_PX,
-					height: SMALL_ICON_PX,
-			  }
-			: {
-					width: LARGE_ICON_PX,
-					height: LARGE_ICON_PX,
-			  }
-);
+const SiteIcon = styled.img( {
+	borderRadius: '2px',
+	display: 'block',
+} );
 
 interface P2ThumbnailProps {
 	site: SiteExcerptData;
@@ -105,7 +94,7 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 				) }
 				{ site.icon && (
 					<SiteIconContainer isSmall={ isSmall }>
-						<SiteIcon src={ site.icon.img } alt="" isSmall={ isSmall } />
+						<SiteIcon { ...getIconImgProps( isSmall, site.icon.img ) } />
 					</SiteIconContainer>
 				) }
 			</>
@@ -121,4 +110,15 @@ export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 			{ renderContents() }
 		</Container>
 	);
+}
+
+function getIconImgProps( isSmall: boolean, imgSrc: string ) {
+	const width = isSmall ? SMALL_ICON_PX : LARGE_ICON_PX;
+
+	return {
+		src: addQueryArgs( imgSrc, { s: width } ),
+		srcSet: addQueryArgs( imgSrc, { s: 2 * width } ) + ' 2x',
+		width: `${ width }px`,
+		height: `${ width }px`,
+	};
 }

--- a/client/sites-dashboard/components/p2-thumbnail.tsx
+++ b/client/sites-dashboard/components/p2-thumbnail.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useI18n } from '@wordpress/react-i18n';
 import type { SitesDisplayMode } from './sites-display-mode-switcher';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -84,11 +83,10 @@ const SiteIcon = styled.img< { isSmall: boolean } >(
 interface P2ThumbnailProps {
 	site: SiteExcerptData;
 	displayMode: SitesDisplayMode;
+	alt: string;
 }
 
-export function P2Thumbnail( { site, displayMode }: P2ThumbnailProps ) {
-	const { __ } = useI18n();
-
+export function P2Thumbnail( { site, displayMode, alt }: P2ThumbnailProps ) {
 	if ( ! site.p2_thumbnail_elements ) {
 		return null;
 	}
@@ -117,7 +115,7 @@ export function P2Thumbnail( { site, displayMode }: P2ThumbnailProps ) {
 	return (
 		<Container
 			role={ 'img' }
-			aria-label={ __( 'Site Icon' ) }
+			aria-label={ alt }
 			style={ { backgroundColor: color_sidebar_background } }
 		>
 			{ renderContents() }

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -11,7 +11,7 @@ const container = css( {
 	gap: '10px',
 } );
 
-type SitesDisplayMode = 'tile' | 'list';
+export type SitesDisplayMode = 'tile' | 'list';
 
 export const useSitesDisplayMode = () => {
 	const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -85,6 +85,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 			leading={
 				<ThumbnailLink { ...siteDashboardUrlProps }>
 					<SiteItemThumbnail
+						displayMode="tile"
 						className={ siteThumbnail }
 						site={ site }
 						width={ THUMBNAIL_DIMENSION.width }

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -16,9 +16,10 @@ import { SiteUrl, Truncated } from './sites-site-url';
 import { ThumbnailLink } from './thumbnail-link';
 
 const SIZES_ATTR = [
-	'(min-width: 1400px) 401px',
-	'(min-width: 960px) calc(33vw - 48px)',
-	'(min-width: 660px) calc(50vw - 48px)',
+	'(min-width: 1345px) calc((1280px - 64px) / 3)',
+	'(min-width: 960px) calc((100vw - 128px) / 3)',
+	'(min-width: 780px) calc((100vw - 96px) / 2)',
+	'(min-width: 660px) calc((100vw - 64px) / 2)',
 	'calc(100vw - 32px)',
 ].join( ', ' );
 

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentProps } from 'react';
 import Image from 'calypso/components/image';
+import { P2Thumbnail } from './p2-thumbnail';
 import { SiteComingSoon } from './sites-site-coming-soon';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -55,6 +56,28 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 		);
 	}
 
+	function renderFallback() {
+		if ( site.options.is_wpforteams_site && getSiteLaunchStatus( site ) !== 'public' ) {
+			return <P2Thumbnail site={ site } />;
+		}
+
+		if ( site.icon ) {
+			return (
+				<Image
+					src={ site.icon.img }
+					alt={ __( 'Site Icon' ) }
+					style={ { height: '50px', width: '50px' } }
+				/>
+			);
+		}
+
+		return (
+			<NoIcon role="img" aria-label={ __( 'Site Icon' ) }>
+				{ getFirstGrapheme( site.title ?? '' ) }
+			</NoIcon>
+		);
+	}
+
 	return (
 		<SiteThumbnail
 			{ ...props }
@@ -62,17 +85,7 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 			alt={ site.title || __( 'Site thumbnail' ) }
 			bgColorImgUrl={ site.icon?.img }
 		>
-			{ site.icon ? (
-				<Image
-					src={ site.icon.img }
-					alt={ __( 'Site Icon' ) }
-					style={ { height: '50px', width: '50px' } }
-				/>
-			) : (
-				<NoIcon role="img" aria-label={ __( 'Site Icon' ) }>
-					{ getFirstGrapheme( site.title ?? '' ) }
-				</NoIcon>
-			) }
+			{ renderFallback() }
 		</SiteThumbnail>
 	);
 };

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -59,12 +59,8 @@ export const SiteItemThumbnail = ( { displayMode, site, ...props }: SiteItemThum
 	}
 
 	function renderFallback() {
-		if (
-			displayMode === 'tile' &&
-			site.options.is_wpforteams_site &&
-			getSiteLaunchStatus( site ) !== 'public'
-		) {
-			return <P2Thumbnail site={ site } />;
+		if ( site.options.is_wpforteams_site && getSiteLaunchStatus( site ) !== 'public' ) {
+			return <P2Thumbnail site={ site } displayMode={ displayMode } />;
 		}
 
 		if ( site.icon ) {

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -64,7 +64,13 @@ export const SiteItemThumbnail = ( { displayMode, site, ...props }: SiteItemThum
 			site.options.is_wpforteams_site &&
 			getSiteLaunchStatus( site ) !== 'public'
 		) {
-			return <P2Thumbnail site={ site } displayMode={ displayMode } />;
+			return (
+				<P2Thumbnail
+					site={ site }
+					displayMode={ displayMode }
+					alt={ site.title || __( 'Site thumbnail' ) }
+				/>
+			);
 		}
 
 		if ( site.icon ) {

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -7,6 +7,7 @@ import { ComponentProps } from 'react';
 import Image from 'calypso/components/image';
 import { P2Thumbnail } from './p2-thumbnail';
 import { SiteComingSoon } from './sites-site-coming-soon';
+import type { SitesDisplayMode } from './sites-display-mode-switcher';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const NoIcon = styled.div( {
@@ -16,11 +17,12 @@ const NoIcon = styled.div( {
 } );
 
 interface SiteItemThumbnailProps extends Omit< ComponentProps< typeof SiteThumbnail >, 'alt' > {
+	displayMode: SitesDisplayMode;
 	site: SiteExcerptData;
 	alt?: string;
 }
 
-export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) => {
+export const SiteItemThumbnail = ( { displayMode, site, ...props }: SiteItemThumbnailProps ) => {
 	const { __ } = useI18n();
 
 	const shouldUseScreenshot = getSiteLaunchStatus( site ) === 'public';
@@ -57,7 +59,11 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 	}
 
 	function renderFallback() {
-		if ( site.options.is_wpforteams_site && getSiteLaunchStatus( site ) !== 'public' ) {
+		if (
+			displayMode === 'tile' &&
+			site.options.is_wpforteams_site &&
+			getSiteLaunchStatus( site ) !== 'public'
+		) {
 			return <P2Thumbnail site={ site } />;
 		}
 

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -59,7 +59,11 @@ export const SiteItemThumbnail = ( { displayMode, site, ...props }: SiteItemThum
 	}
 
 	function renderFallback() {
-		if ( site.options.is_wpforteams_site && getSiteLaunchStatus( site ) !== 'public' ) {
+		if (
+			site.p2_thumbnail_elements &&
+			site.options.is_wpforteams_site &&
+			getSiteLaunchStatus( site ) !== 'public'
+		) {
 			return <P2Thumbnail site={ site } displayMode={ displayMode } />;
 		}
 

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -69,6 +69,7 @@ export const SiteItemThumbnail = ( { displayMode, site, ...props }: SiteItemThum
 					site={ site }
 					displayMode={ displayMode }
 					alt={ site.title || __( 'Site thumbnail' ) }
+					sizesAttr={ props.sizesAttr }
 				/>
 			);
 		}

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -102,7 +102,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							href={ getDashboardUrl( site.slug ) }
 							title={ __( 'Visit Dashboard' ) }
 						>
-							<SiteItemThumbnail site={ site } />
+							<SiteItemThumbnail displayMode="list" site={ site } />
 						</ListTileLeading>
 					}
 					title={

--- a/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/test/sites-site-item-thumbnail.tsx
@@ -30,6 +30,7 @@ describe( '<SiteItemThumbnail>', () => {
 			test( 'site title can be multi-codepoint emoji', () => {
 				render(
 					<SiteItemThumbnail
+						displayMode="tile"
 						site={ makeTestSite( { title: '👩‍👩‍👦‍👦 family: woman, woman, boy, boy' } ) }
 					/>
 				);
@@ -54,6 +55,7 @@ describe( '<SiteItemThumbnail>', () => {
 				// Without the Segmenter API we fall back to returning the first codepoint
 				render(
 					<SiteItemThumbnail
+						displayMode="tile"
 						site={ makeTestSite( { title: '👩‍👩‍👦‍👦 family: woman, woman, boy, boy' } ) }
 					/>
 				);
@@ -65,17 +67,17 @@ describe( '<SiteItemThumbnail>', () => {
 
 function defineCommonSiteInitialTests() {
 	test( 'an English site title', () => {
-		render( <SiteItemThumbnail site={ makeTestSite( { title: 'hello' } ) } /> );
+		render( <SiteItemThumbnail displayMode="tile" site={ makeTestSite( { title: 'hello' } ) } /> );
 		expect( screen.getByLabelText( 'Site Icon' ) ).toHaveTextContent( /^h$/ );
 	} );
 
 	test( 'diacritic mark on first letter', () => {
-		render( <SiteItemThumbnail site={ makeTestSite( { title: 'öwl' } ) } /> );
+		render( <SiteItemThumbnail displayMode="tile" site={ makeTestSite( { title: 'öwl' } ) } /> );
 		expect( screen.getByLabelText( 'Site Icon' ) ).toHaveTextContent( /^ö$/ );
 	} );
 
 	test( 'empty site title renders no initial', () => {
-		render( <SiteItemThumbnail site={ makeTestSite( { title: '' } ) } /> );
+		render( <SiteItemThumbnail displayMode="tile" site={ makeTestSite( { title: '' } ) } /> );
 		expect( screen.getByLabelText( 'Site Icon' ) ).toBeEmptyDOMElement();
 	} );
 
@@ -84,7 +86,7 @@ function defineCommonSiteInitialTests() {
 		// @ts-expect-error Let's artificially remove the title so it tries to render an empty string
 		testSite.title = undefined;
 
-		render( <SiteItemThumbnail site={ testSite } /> );
+		render( <SiteItemThumbnail displayMode="tile" site={ testSite } /> );
 		expect( screen.getByLabelText( 'Site Icon' ) ).toBeEmptyDOMElement();
 	} );
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -72,6 +72,12 @@ export interface CreateSiteParams {
 	};
 }
 
+export interface P2ThumbnailElements {
+	color_link: string;
+	color_sidebar_background: string;
+	header_image: string | null;
+}
+
 export interface SiteDetailsPlan {
 	product_id: number;
 	product_slug: string;
@@ -113,6 +119,7 @@ export interface SiteDetails {
 	logo: { id: string; sizes: string[]; url: string };
 	name: string | undefined;
 	options: SiteDetailsOptions;
+	p2_thumbnail_elements?: P2ThumbnailElements | null;
 	plan?: SiteDetailsPlan;
 	products?: SiteDetailsPlan[];
 	single_user_site?: boolean;


### PR DESCRIPTION
#### Proposed Changes

Show P2 specific content in place of the regular fallback thumbnail for private sites. This can help with navigation.
Header images won't necessarily look good shrunk down too much, so the P2 specific fallback only happens in tile mode. The regular private site fallback thumbnail looks best in list mode (the blurred site icon effect looks best at the small size IMO) so I think this is fine.

The goal is for the thumbnail to be reminiscent of the P2 sidebar, but not an exact reproduction. Many P2s use custom CSS to make adjustments to the header image, but we can't reproduce those.

It makes a separate request for the P2 design elements so that it doesn't put even more content into the initial payload.

**No image or site icon**
<img width="455" alt="CleanShot 2022-10-12 at 16 18 14@2x" src="https://user-images.githubusercontent.com/1500769/195241982-335e3552-ca2c-4695-9398-7216ffa2920a.png">

**Custom "sidebar" and "link" colours**
<img width="440" alt="CleanShot 2022-10-12 at 16 21 17@2x" src="https://user-images.githubusercontent.com/1500769/195242294-24c3251a-1a55-4f51-af56-244e1326cf51.png">

**Custom header image, site icon, and sidebar colour**
<img width="432" alt="CleanShot 2022-10-12 at 16 52 21@2x" src="https://user-images.githubusercontent.com/1500769/195246069-a2b507c7-9ea7-4760-97fa-585d38bc9b8c.png">

**List mode**
<img width="131" alt="CleanShot 2022-10-13 at 18 43 03@2x" src="https://user-images.githubusercontent.com/1500769/195511442-35b033d4-2757-4efe-ad62-84d6aee6927d.png">

**A public P2**
<img width="439" alt="CleanShot 2022-10-12 at 16 19 38@2x" src="https://user-images.githubusercontent.com/1500769/195242078-914338f6-5ea2-464a-9087-900e3e7ee6c5.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D89929-code to sandbox
* Navigate to `/sites` and check out those a8c P2s

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68866