### PR TITLE
Pattern Assembler - Show a placeholder logo in the patterns preview as in the editor

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,4 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const STYLE_SHEET = 'pub/blank-canvas-blocks';
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
+export const SITE_LOGO_URL = 'https://dotcompatterns.files.wordpress.com/2020/04/site-logo.png';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -11,6 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
 import { ONBOARD_STORE } from '../../../../stores';
 import PreviewToolbar from '../design-setup/preview-toolbar';
+import { SITE_LOGO_URL } from './constants';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
 import type { Design } from '@automattic/design-picker';
@@ -79,6 +80,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 						? getDesignPreviewUrl( mergedDesign, {
 								language: locale,
 								disable_viewport_height: true,
+								site_logo_url: SITE_LOGO_URL,
 						  } )
 						: 'about:blank'
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,5 +1,10 @@
 import { addQueryArgs } from '@wordpress/url';
-import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL, STYLE_SHEET } from './constants';
+import {
+	PATTERN_SOURCE_SITE_ID,
+	PREVIEW_PATTERN_URL,
+	STYLE_SHEET,
+	SITE_LOGO_URL,
+} from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
@@ -9,6 +14,7 @@ export const getPatternPreviewUrl = ( id: number, language: string ) => {
 		stylesheet: STYLE_SHEET,
 		pattern_id: encodePatternId( id ),
 		language,
+		site_logo_url: SITE_LOGO_URL,
 	} );
 };
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -126,6 +126,7 @@ export interface DesignPreviewOptions {
 	viewport_height?: number;
 	use_screenshot_overrides?: boolean;
 	disable_viewport_height?: boolean;
+	site_logo_url?: string;
 }
 
 /** @deprecated used for Gutenboarding (/new flow) */

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -34,6 +34,7 @@ export const getDesignPreviewUrl = (
 			: undefined,
 		source_site: 'patternboilerplates.wordpress.com',
 		use_screenshot_overrides: options.use_screenshot_overrides,
+		site_logo_url: options.site_logo_url,
 	} );
 
 	// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped


### PR DESCRIPTION
#### Proposed Changes

* Add param `site_logo_url` to show a logo placeholder in the preview of patterns with the API `/blocks-preview`.
* The placeholder logo is the same as in the editor 

We preview patterns in the pattern assembler project using the APIs `/blocks-preview/site` and `/blocks-preview/pattern`. The sites that use the pattern assembler don't have a site logo because they are newly created sites. The preview must show a logo placeholder with the same look as in the editor. 

The feature to choose a logo for the preview already exists in the API `/blocks-preview` but it doesn't work because the Site Logo block renders nothing when there is no custom logo set in the site. We are fixing that issue in the diff D89629-code.

#### Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Must be tested with the diff D89629-code that fixes the feature to choose a logo for the preview.
* Access the URL `wordpress.com/setup?siteSlug=[YOUR SITE]&flags=signup/design-picker-pattern-assembler`
* Don't choose any goal or vertical
* On the design picker, click on the blank canvas CTA
* Click to choose a header
* Check that the headers in the list have a logo as in the following screenshot
<img width="309" alt="Screen Shot 2565-10-11 at 15 50 27" src="https://user-images.githubusercontent.com/1881481/195044276-0ad9e6bf-f201-47ab-b776-3a3fd95ff970.png">
* Choose a header and check that the logo also appears in the site preview
<img width="812" alt="Screen Shot 2565-10-11 at 15 52 43" src="https://user-images.githubusercontent.com/1881481/195044822-369f09a1-60b2-4cac-94b3-8a244243319c.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68695