### PR TITLE
Jetpack Cloud: Update Jetpack Social Pricing

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -32,10 +32,7 @@ import {
 	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
-	PRODUCT_JETPACK_SOCIAL_BASIC,
-	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
-	SOCIAL_SHARES_1000,
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
 	JETPACK_BACKUP_PRODUCTS,
@@ -143,46 +140,12 @@ export const EXTERNAL_PRODUCT_CRM_MONTHLY = (): SelectorProduct => ( {
 	costProductSlug: PRODUCT_JETPACK_CRM_MONTHLY,
 } );
 
-export const EXTERNAL_PRODUCT_SOCIAL_BASIC = (): SelectorProduct => ( {
-	// This is a virtual, non-purchasable product for Jetpack Social that
-	// points to an external landing page.
-	productSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
-	term: TERM_ANNUALLY,
-	type: ITEM_TYPE_PRODUCT,
-	costProductSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
-	monthlyProductSlug: PRODUCT_JETPACK_SOCIAL_BASIC,
-	iconSlug: 'jetpack_crm',
-	displayName: translate( 'Social' ),
-	shortName: translate( 'Social' ),
-	tagline: translate( 'Easily share your website content on your social media channels' ),
-	description: translate(
-		'Easily share your website content on your social media channels from one place.'
-	),
-	shortDescription: translate( 'Write once, post everywhere.' ),
-	buttonLabel: translate( 'Get Social' ),
-	features: {
-		items: buildCardFeaturesFromItem( [ SOCIAL_SHARES_1000 ] ),
-	},
-	hidePrice: true,
-	externalUrl: 'https://jetpack.com/social/',
-} );
-
-export const EXTERNAL_PRODUCT_SOCIAL_BASIC_MONTHLY = (): SelectorProduct => ( {
-	...EXTERNAL_PRODUCT_SOCIAL_BASIC(),
-	productSlug: PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
-	term: TERM_MONTHLY,
-	displayTerm: TERM_ANNUALLY,
-	costProductSlug: PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
-} );
-
 // List of products showcased in the Plans grid but not sold through Calypso
 export const EXTERNAL_PRODUCTS_LIST = [
 	PRODUCT_JETPACK_CRM_FREE,
 	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	PRODUCT_JETPACK_CRM,
 	PRODUCT_JETPACK_CRM_MONTHLY,
-	PRODUCT_JETPACK_SOCIAL_BASIC,
-	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
 ];
 
 // External Product slugs to SelectorProduct.
@@ -191,8 +154,6 @@ export const EXTERNAL_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct >
 	[ PRODUCT_JETPACK_CRM_FREE_MONTHLY ]: EXTERNAL_PRODUCT_CRM_FREE_MONTHLY,
 	[ PRODUCT_JETPACK_CRM ]: EXTERNAL_PRODUCT_CRM,
 	[ PRODUCT_JETPACK_CRM_MONTHLY ]: EXTERNAL_PRODUCT_CRM_MONTHLY,
-	[ PRODUCT_JETPACK_SOCIAL_BASIC ]: EXTERNAL_PRODUCT_SOCIAL_BASIC,
-	[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: EXTERNAL_PRODUCT_SOCIAL_BASIC_MONTHLY,
 };
 
 /**

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -21,7 +22,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 	const translate = useTranslate();
 	const { containerRef, isCompact } = useItemPriceCompact();
 
-	const { originalPrice, discountedPrice, isFetching } = useItemPrice(
+	const { originalPrice, discountedPrice, discountedPriceDuration, isFetching } = useItemPrice(
 		siteId,
 		product,
 		product?.monthlyProductSlug || ''
@@ -36,6 +37,21 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 	);
 
 	const billingTerm = product.displayTerm || product.term;
+
+	const getDiscountedLabel = useCallback( () => {
+		if ( ! discountedPrice ) {
+			return;
+		}
+		const translateArgs = {
+			args: {
+				percentOff: Math.floor( ( ( originalPrice - discountedPrice ) / originalPrice ) * 100 ),
+			},
+			comment: '"%%" is the literal percent symbol escaped using the other one.',
+		};
+		return 1 === discountedPriceDuration
+			? translate( '%(percentOff)d%% off the first month', translateArgs )
+			: translate( '%(percentOff)d%% off the first year', translateArgs );
+	}, [ discountedPriceDuration, originalPrice, discountedPrice, translate ] );
 
 	return (
 		<div className="product-lightbox__variants-plan">
@@ -65,14 +81,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 								<span className="product-lightbox__variants-plan-card-old-price">
 									<PlanPrice original rawPrice={ originalPrice } currencyCode={ currencyCode } />
 								</span>
-								{ translate( '%(percentOff)d%% off the first year', {
-									args: {
-										percentOff: Math.floor(
-											( ( originalPrice - discountedPrice ) / originalPrice ) * 100
-										),
-									},
-									comment: '"%%" is the literal percent symbol escaped using the other one.',
-								} ) }
+								{ getDiscountedLabel() }
 							</div>
 						) }
 					</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -3,7 +3,6 @@ import {
 	JetpackPurchasableItemSlug,
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_SCAN_PRODUCTS,
-	JETPACK_SOCIAL_PRODUCTS,
 	planHasFeature,
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -192,24 +191,6 @@ export const useStoreItemInfo = ( {
 		]
 	);
 
-	/**
-	 * This is a temporary custom label for Jetpack Social product only.
-	 * TODO: Remove 'getCustomLabel' in the near future when Social is ready for purchase.
-	 */
-	const getCustomLabel = useCallback(
-		( item: SelectorProduct ) => {
-			if (
-				! getIsOwned( item ) &&
-				getIsExternal( item ) &&
-				( [ ...JETPACK_SOCIAL_PRODUCTS ] as ReadonlyArray< string > ).includes( item.productSlug )
-			) {
-				return translate( 'Coming soon!' );
-			}
-			return null;
-		},
-		[ getIsOwned, translate ]
-	);
-
 	return useMemo(
 		() => ( {
 			getCheckoutURL,
@@ -227,7 +208,6 @@ export const useStoreItemInfo = ( {
 			getOnClickPurchase,
 			getPurchase,
 			isMultisite,
-			getCustomLabel,
 		} ),
 		[
 			getCheckoutURL,
@@ -242,7 +222,6 @@ export const useStoreItemInfo = ( {
 			getOnClickPurchase,
 			getPurchase,
 			isMultisite,
-			getCustomLabel,
 		]
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -29,7 +29,6 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		getIsUserPurchaseOwner,
 		getOnClickPurchase,
 		isMultisite,
-		getCustomLabel,
 	} = useStoreItemInfoContext();
 
 	const wrapperClassName = classNames( 'jetpack-product-store__all-items', className );
@@ -53,7 +52,6 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 						( ( isOwned || isIncludedInPlan ) && ! getIsUserPurchaseOwner( item ) );
 
 					const ctaLabel = getCtaLabel( item );
-					const customLabel = getCustomLabel( item );
 
 					const hideMoreInfoLink = isDeprecated || isOwned || isIncludedInPlanOrSuperseded;
 
@@ -95,7 +93,6 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 							onClickCta={ getOnClickPurchase( item ) }
 							price={ price }
 							title={ item.displayName }
-							customLabel={ customLabel }
 						/>
 					);
 				} ) }

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/index.tsx
@@ -14,7 +14,6 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 	onClickCta,
 	price,
 	title,
-	customLabel,
 } ) => {
 	return (
 		<div className="simple-item-card">
@@ -22,14 +21,7 @@ export const SimpleItemCard: React.FC< SimpleItemCardProps > = ( {
 			<div className="simple-item-card__body">
 				<div className="simple-item-card__header">
 					<div>
-						<h3 className="simple-item-card__title">
-							{ title }
-							{ customLabel && (
-								<div className="simple-item-card__custom-label">
-									<span>{ customLabel }</span>
-								</div>
-							) }
-						</h3>
+						<h3 className="simple-item-card__title">{ title }</h3>
 						<div className="simple-item-card__price">{ price }</div>
 					</div>
 					<Button

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -100,7 +100,6 @@ export type FeaturedItemCardProps = {
 	onClickCta?: VoidFunction;
 	price: React.ReactNode;
 	title: React.ReactNode;
-	customLabel?: React.ReactNode;
 };
 
 export type SimpleItemCardProps = Omit< FeaturedItemCardProps, 'hero' > & {

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
@@ -14,11 +14,11 @@ const setProductsInPosition = ( slugs: ReadonlyArray< string >, position: number
 	slugs.reduce( ( map, slug ) => ( { ...map, [ slug ]: position } ), {} );
 
 const DISPLAYABLE_PRODUCT_POSITION_MAP: Record< string, number > = {
-	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 1 ),
-	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 2 ),
-	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 3 ),
-	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 4 ),
-	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 5 ),
+	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 1 ),
+	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 2 ),
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 3 ),
+	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 4 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 5 ),
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 6 ),
 	// Featured products at the end
 	...setProductsInPosition( JETPACK_BACKUP_PRODUCTS, 7 ),


### PR DESCRIPTION
#### Proposed Changes

Now that the Jetpack Social plan has launched, this removes the placeholder plan from the pricing page, along with the custom 'Coming soon!' label.

#### Testing Instructions

- Using the live branch or local version of Jetpack Cloud
- go to `/pricing`
- Check that the Social product doesn't display 'Coming soon!' and that the Get link takes you to the checkout for the plan.
- Also check that the 'More about Social' link opens the modal with the product information

**Before**

<img width="624" alt="image" src="https://user-images.githubusercontent.com/96462/195065824-aee60257-b3a2-465b-aa64-4a5593ca1dc9.png">

**After**

<img width="624" alt="image" src="https://user-images.githubusercontent.com/96462/195065902-66b596a5-56e0-4a96-a0a5-7fbe949ae185.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
