### PR TITLE
Themes: adds is_logged_in prop to calypso_page_view event.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -660,6 +660,7 @@ class ThemeSheet extends Component {
 			translate,
 			canUserUploadThemes,
 			isWPForTeamsSite,
+			isLoggedIn,
 		} = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
@@ -785,7 +786,11 @@ class ThemeSheet extends Component {
 				}
 				<QuerySitePlans siteId={ siteId } />
 				<DocumentHead title={ title } meta={ metas } />
-				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
+				<PageViewTracker
+					path={ analyticsPath }
+					title={ analyticsPageTitle }
+					properties={ { is_logged_in: isLoggedIn } }
+				/>
 				{ this.renderBar() }
 				<QueryActiveTheme siteId={ siteId } />
 				<ThanksModal source={ 'details' } />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -384,6 +384,7 @@ class ThemeShowcase extends Component {
 				<PageViewTracker
 					path={ this.props.analyticsPath }
 					title={ this.props.analyticsPageTitle }
+					properties={ { is_logged_in: isLoggedIn } }
 				/>
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />


### PR DESCRIPTION
#### Proposed Changes

* adds `is_logged_in` prop to `calypso_page_view` event for `/themes` and `/theme/:theme` components.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load `wordpress.com/themes` or ``wordpress.com/themes/[any theme]` as logged out user
* Make sure that `calypso_page_view` includes `is_logged_in : false`
* Repeat as logged in user and inspect for `is_logged_in : true`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to Bespin Data Watch – September 2022