### PR TITLE
Reader: Restore search input styles to share tools and search

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -47,6 +47,25 @@
 		width: 152px;
 		padding-right: 2px;
 	}
+	.search {
+		border-radius: 6px;
+		.search__icon-navigation {
+			border-bottom-left-radius: 6px;
+			border-top-left-radius: 6px;
+		}
+		.search__input.form-text-input[type="search"],
+		.search__close-icon {
+			border-bottom-right-radius: 6px;
+			border-top-right-radius: 6px;
+			padding: 6px 0;
+		}
+		&.is-open.has-focus {
+			box-shadow: none;
+			&:hover {
+				box-shadow: none;
+			}
+		}
+	}
 }
 
 .reader-share__popover-item {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -10,6 +10,23 @@
 
 .search-stream .search {
 	margin-bottom: 0;
+	border-radius: 6px;
+	.search__icon-navigation {
+		border-bottom-left-radius: 6px;
+		border-top-left-radius: 6px;
+	}
+	.search__input.form-text-input[type="search"],
+	.search__close-icon {
+		border-bottom-right-radius: 6px;
+		border-top-right-radius: 6px;
+		padding: 6px 0;
+	}
+	&.is-open.has-focus {
+		box-shadow: none;
+		&:hover {
+			box-shadow: none;
+		}
+	}
 }
 
 .is-reader-page .search-stream__fixed-area {


### PR DESCRIPTION
## Proposed Changes

Re-restores changes reverted in https://github.com/Automattic/wp-calypso/pull/68826#issuecomment-1273714472

Previously #68850, which was reverted in #68888

See p1665430054068019-slack-C03NLNTPZ2T

### Before

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/36432/195069081-ca22132d-e7e3-41c5-9c50-963ec839a794.png">

<img width="264" alt="image" src="https://user-images.githubusercontent.com/36432/195069021-616e5beb-d5cc-4252-b53c-67680c65ad50.png">

### After

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/36432/195068186-bc4ef4e1-a7ba-47b2-9eb8-a2d86c7570d3.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/36432/195068217-f3c491d6-0568-4249-aefa-4dff63d0c286.png">

## Testing Instructions

1. Verify everything looks as expected in the Reader.