### PR TITLE
i18n: Fix RTL chevron in block editor sidebar home button

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -9,8 +9,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { forwardRef, useLayoutEffect, useRef, useEffect } from '@wordpress/element';
 import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
-import { chevronLeft } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -216,7 +216,7 @@ function WpcomBlockEditorNavSidebar() {
 					aria-description={ __( 'Returns to the dashboard', 'full-site-editing' ) }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
-					icon={ chevronLeft }
+					icon={ isRTL() ? chevronRight : chevronLeft }
 					onClick={ handleClose }
 				>
 					{ closeLabel }


### PR DESCRIPTION
#### Proposed Changes

This fixes the chevron direction for RTL languages in the "All posts" button of the block editor's sidebar. It will now point to the right instead of to the left.

||Before|After|
|-|-|-|
|RTL|![image](https://user-images.githubusercontent.com/75777864/195074776-b925631d-91ca-4dde-ae41-e374ae20ab60.png)|![image](https://user-images.githubusercontent.com/75777864/195074815-33ba515c-82f4-4d55-8e1c-f2a4a80e854f.png)|
|LTR (unchanged)|![image](https://user-images.githubusercontent.com/75777864/195074903-0c53ff57-edc1-4f7b-b4dd-4e66bc757194.png)|![image](https://user-images.githubusercontent.com/75777864/195074930-64a2dd9b-1407-4da2-b450-0f93a6619971.png)|

**NOTE:** For RTL languages, the button itself should also be right-aligned. A fix for this has been proposed in Gutenberg: https://github.com/WordPress/gutenberg/pull/44787

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh etk fix/wpcom-block-editor-nav-sidebar-rtl` on your sandbox.
* Sandbox a Simple site, the public API, and `s0`.
* On the sandboxed site, switch to an RTL language and edit or create a new post.
* Open the sidebar and verify that the chevron is pointing to the right (as per the screenshots).
* Switch to an LTR language and verify that the chevron is still pointing to the left.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **N/A**
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? **There's a styling issue with the button on RTL Atomic sites. Created an issue at 524-gh-Automattic/i18n-issues.**
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) **N/A**
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **N/A**

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 519-gh-Automattic/i18n-issues, 524-gh-Automattic/i18n-issues, https://github.com/WordPress/gutenberg/pull/44787.
