### PR TITLE
Jetpack Pricing: Fix missing description and features translations

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/features.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/features.tsx
@@ -4,7 +4,7 @@ import {
 	PLAN_JETPACK_COMPLETE_MONTHLY,
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 } from '@automattic/calypso-products';
-import { translate, TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import GrowthIcon from 'calypso/assets/images/jetpack/jetpack-icon-growth.svg';
 import LockIcon from 'calypso/assets/images/jetpack/jetpack-icon-lock.svg';
 import PerformanceIcon from 'calypso/assets/images/jetpack/jetpack-icon-performance.svg';
@@ -17,91 +17,97 @@ type FeaturesGroup = {
 	title: string;
 };
 
-const SECURITY_BUNDLE_FEATURES: Array< FeaturesGroup > = [
-	{
-		icon: LockIcon,
-		included: true,
-		slug: 'security',
-		title: translate( 'Security' ),
-		features: [
-			translate( 'Real-time backups as you edit' ),
-			translate( '10GB of cloud storage' ),
-			translate( '30-day activity log archive' ),
-			translate( 'Unlimited one-click restores from the last 30 days' ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (10k API calls/mo)' ),
-		],
-	},
-	{
-		icon: PerformanceIcon,
-		included: false,
-		slug: 'performance',
-		title: translate( 'Performance' ),
-		features: [ translate( 'Site Search' ), translate( 'VideoPress' ), translate( 'Boost' ) ],
-	},
-	{
-		icon: GrowthIcon,
-		included: false,
-		slug: 'growth',
-		title: translate( 'Growth' ),
-		features: [ translate( 'CRM: with 30 extensions' ) ],
-	},
-];
+export function useBundleFeaturesList( planSlug: string ) {
+	const translate = useTranslate();
 
-const COMPLETE_BUNDLE_FEATURES: Array< FeaturesGroup > = [
-	{
-		icon: LockIcon,
-		included: true,
-		slug: 'security',
-		title: translate( 'Security' ),
-		features: [
-			translate( 'Real-time backups as you edit' ),
-			translate( '{{b}}1TB (1,000GB){{/b}} of cloud storage', {
-				components: {
-					b: <b />,
-				},
-			} ),
-			translate( '{{b}}1-year{{/b}} activity log archive', {
-				components: {
-					b: <b />,
-				},
-			} ),
-			translate( 'Unlimited one-click restores from the last {{b}}one year{{/b}}', {
-				components: {
-					b: <b />,
-				},
-			} ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection ({{b}}60k API calls/mo{{/b}})', {
-				components: {
-					b: <b />,
-				},
-			} ),
-		],
-	},
-	{
-		icon: PerformanceIcon,
-		included: true,
-		slug: 'performance',
-		title: translate( 'Performance' ),
-		features: [
-			<b>{ translate( 'Site Search: 100k records' ) }</b>,
-			<b>{ translate( 'VideoPress: 1TB ad-free video hosting' ) }</b>,
-			<b>{ translate( 'Boost: Automatic CSS Generation' ) }</b>,
-		],
-	},
-	{
-		icon: GrowthIcon,
-		included: true,
-		slug: 'growth',
-		title: translate( 'Growth' ),
-		features: [ <b>{ translate( 'CRM: Entrepreneur with 30 extensions' ) }</b> ],
-	},
-];
+	const securityBundleFeatures: Array< FeaturesGroup > = [
+		{
+			icon: LockIcon,
+			included: true,
+			slug: 'security',
+			title: translate( 'Security' ),
+			features: [
+				translate( 'Real-time backups as you edit' ),
+				translate( '10GB of cloud storage' ),
+				translate( '30-day activity log archive' ),
+				translate( 'Unlimited one-click restores from the last 30 days' ),
+				translate( 'Real-time malware scanning and one-click fixes' ),
+				translate( 'Comment and form spam protection (10k API calls/mo)' ),
+			],
+		},
+		{
+			icon: PerformanceIcon,
+			included: false,
+			slug: 'performance',
+			title: translate( 'Performance' ),
+			features: [ translate( 'Site Search' ), translate( 'VideoPress' ), translate( 'Boost' ) ],
+		},
+		{
+			icon: GrowthIcon,
+			included: false,
+			slug: 'growth',
+			title: translate( 'Growth' ),
+			features: [ translate( 'CRM: with 30 extensions' ) ],
+		},
+	];
 
-export const BUNDLE_FEATURES_LIST: Record< string, Array< FeaturesGroup > > = {
-	[ PLAN_JETPACK_SECURITY_T1_YEARLY ]: SECURITY_BUNDLE_FEATURES,
-	[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: SECURITY_BUNDLE_FEATURES,
-	[ PLAN_JETPACK_COMPLETE ]: COMPLETE_BUNDLE_FEATURES,
-	[ PLAN_JETPACK_COMPLETE_MONTHLY ]: COMPLETE_BUNDLE_FEATURES,
-};
+	const completeBundleFeatures: Array< FeaturesGroup > = [
+		{
+			icon: LockIcon,
+			included: true,
+			slug: 'security',
+			title: translate( 'Security' ),
+			features: [
+				translate( 'Real-time backups as you edit' ),
+				translate( '{{b}}1TB (1,000GB){{/b}} of cloud storage', {
+					components: {
+						b: <b />,
+					},
+				} ),
+				translate( '{{b}}1-year{{/b}} activity log archive', {
+					components: {
+						b: <b />,
+					},
+				} ),
+				translate( 'Unlimited one-click restores from the last {{b}}one year{{/b}}', {
+					components: {
+						b: <b />,
+					},
+				} ),
+				translate( 'Real-time malware scanning and one-click fixes' ),
+				translate( 'Comment and form spam protection ({{b}}60k API calls/mo{{/b}})', {
+					components: {
+						b: <b />,
+					},
+				} ),
+			],
+		},
+		{
+			icon: PerformanceIcon,
+			included: true,
+			slug: 'performance',
+			title: translate( 'Performance' ),
+			features: [
+				<b>{ translate( 'Site Search: 100k records' ) }</b>,
+				<b>{ translate( 'VideoPress: 1TB ad-free video hosting' ) }</b>,
+				<b>{ translate( 'Boost: Automatic CSS Generation' ) }</b>,
+			],
+		},
+		{
+			icon: GrowthIcon,
+			included: true,
+			slug: 'growth',
+			title: translate( 'Growth' ),
+			features: [ <b>{ translate( 'CRM: Entrepreneur with 30 extensions' ) }</b> ],
+		},
+	];
+
+	const bundleFeaturesList: Record< string, Array< FeaturesGroup > > = {
+		[ PLAN_JETPACK_SECURITY_T1_YEARLY ]: securityBundleFeatures,
+		[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: securityBundleFeatures,
+		[ PLAN_JETPACK_COMPLETE ]: completeBundleFeatures,
+		[ PLAN_JETPACK_COMPLETE_MONTHLY ]: completeBundleFeatures,
+	};
+
+	return bundleFeaturesList[ planSlug ];
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
@@ -3,13 +3,13 @@ import { useTranslate } from 'i18n-calypso';
 import GreenCheckmark from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
 import RedCross from 'calypso/assets/images/jetpack/jetpack-red-cross.svg';
 import FoldableCard from 'calypso/components/foldable-card';
-import { BUNDLE_FEATURES_LIST } from './features';
+import { useBundleFeaturesList } from './features';
 import type { FeaturesListProps } from '../types';
 
 import './style.scss';
 
 export const FeaturesList: React.FC< FeaturesListProps > = ( { item } ) => {
-	const featuresList = BUNDLE_FEATURES_LIST[ item.productSlug ];
+	const featuresList = useBundleFeaturesList( item.productSlug );
 
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-bundles-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-bundles-to-display.ts
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getSitePlan } from 'calypso/state/sites/selectors';
@@ -7,6 +8,7 @@ import { ItemToDisplayProps } from '../types';
 import { isolatePopularItems } from '../utils/isolate-popular-items';
 
 export const useBundlesToDisplay = ( { siteId, duration }: ItemToDisplayProps ) => {
+	const translate = useTranslate();
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 
 	const currentPlanSlug = currentPlan?.product_slug || null;
@@ -15,5 +17,12 @@ export const useBundlesToDisplay = ( { siteId, duration }: ItemToDisplayProps ) 
 		const allItems = getPlansToDisplay( { duration, currentPlanSlug } );
 
 		return isolatePopularItems( allItems, MOST_POPULAR_BUNDLES );
-	}, [ duration, currentPlanSlug ] );
+
+		// The plans object returned by `getPlansToDisplay` is using translate calls internally,
+		// which in this case requires adding `translate` to the memoization dependancies list,
+		// so that the object gets recomputed with the updated strings from the `translate` calls
+		// when i18n data changes (i.e. after async translations are being loaded).
+		//
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ duration, currentPlanSlug, translate ] );
 };


### PR DESCRIPTION
This PR fixes the missing translations on the Jetpack Pricing page for the most popular bundles description and features.

#### Proposed Changes

* Replace product store features constant with a custom hook using `useTranslate` so that the features object gets recomputed when i18n data changes.
* Update `useBundlesToDisplay` to include `translate` to the memoization dependencies list, so that the returned objects gets recomputed  when i18n data changes.

#### Testing Instructions

* Use calypso.live Jetpack Cloud build or checkout the branch locally and start with `CALYPSO_ENV=jetpack-cloud-development yarn start`
* Go to `/{locale_slug}/pricing?view=bundles`, where `{locale_slug}` is any of the Mag-16 locales' slug, e.g. `/de/pricing?view=bundles`.
* Confirm all strings on the page are translated as expected.

**Before:**
![CleanShot 2022-10-11 at 15 19 13](https://user-images.githubusercontent.com/2722412/195091510-376c749a-60f9-49c3-b436-ef029d3c7829.png)

**After:**
![CleanShot 2022-10-11 at 15 18 01](https://user-images.githubusercontent.com/2722412/195091536-fdcbd1e5-54a0-4bbd-a75a-2702f2fe5936.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 523-gh-Automattic/i18n-issues
