### PR TITLE
DIFM: Add descriptions and badges on Page Picker step

### DIFF
--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import {
 	HOME_PAGE,
 	BLOG_PAGE,
@@ -27,72 +26,66 @@ import type { TranslateResult } from 'i18n-calypso';
  */
 export function useTranslatedPageTitles() {
 	const translate = useTranslate();
-	const pages: Record< string, TranslateResult > = useMemo(
-		() => ( {
-			[ HOME_PAGE ]: translate( 'Home' ),
-			[ BLOG_PAGE ]: translate( 'Blog' ),
-			[ CONTACT_PAGE ]: translate( 'Contact' ),
-			[ ABOUT_PAGE ]: translate( 'About' ),
-			[ PHOTO_GALLERY_PAGE ]: translate( 'Photo Gallery' ),
-			[ VIDEO_GALLERY_PAGE ]: translate( 'Video Gallery' ),
-			[ PODCAST_PAGE ]: translate( 'Podcast' ),
-			[ PORTFOLIO_PAGE ]: translate( 'Portfolio' ),
-			[ FAQ_PAGE ]: translate( 'FAQ' ),
-			[ SITEMAP_PAGE ]: translate( 'Sitemap' ),
-			[ PROFILE_PAGE ]: translate( 'Profile' ),
-			[ MENU_PAGE ]: translate( 'Menu' ),
-			[ SERVICES_PAGE ]: translate( 'Services' ),
-			[ TESTIMONIALS_PAGE ]: translate( 'Testimonials' ),
-			[ PRICING_PAGE ]: translate( 'Pricing' ),
-			[ TEAM_PAGE ]: translate( 'Team' ),
-		} ),
-		[ translate ]
-	);
+	const pages: Record< string, TranslateResult > = {
+		[ HOME_PAGE ]: translate( 'Home' ),
+		[ BLOG_PAGE ]: translate( 'Blog' ),
+		[ CONTACT_PAGE ]: translate( 'Contact' ),
+		[ ABOUT_PAGE ]: translate( 'About' ),
+		[ PHOTO_GALLERY_PAGE ]: translate( 'Photo Gallery' ),
+		[ VIDEO_GALLERY_PAGE ]: translate( 'Video Gallery' ),
+		[ PODCAST_PAGE ]: translate( 'Podcast' ),
+		[ PORTFOLIO_PAGE ]: translate( 'Portfolio' ),
+		[ FAQ_PAGE ]: translate( 'FAQ' ),
+		[ SITEMAP_PAGE ]: translate( 'Sitemap' ),
+		[ PROFILE_PAGE ]: translate( 'Profile' ),
+		[ MENU_PAGE ]: translate( 'Menu' ),
+		[ SERVICES_PAGE ]: translate( 'Services' ),
+		[ TESTIMONIALS_PAGE ]: translate( 'Testimonials' ),
+		[ PRICING_PAGE ]: translate( 'Pricing' ),
+		[ TEAM_PAGE ]: translate( 'Team' ),
+	};
 	return pages;
 }
 
 export function useTranslatedPageDescriptions() {
 	const translate = useTranslate();
-	const descriptions: Record< string, TranslateResult > = useMemo(
-		() => ( {
-			[ HOME_PAGE ]: translate(
-				'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site?'
-			),
-			[ ABOUT_PAGE ]: translate(
-				'Provide background information about you or the business. Why did you start this website? What is your personal story?'
-			),
-			[ CONTACT_PAGE ]: translate(
-				'Visitors want to get in touch with you. How can they reach you?'
-			),
-			[ BLOG_PAGE ]: translate(
-				'How would you introduce your journal entries/news articles/chapters? Describe what readers can expect from your regularly published content!'
-			),
-			[ PHOTO_GALLERY_PAGE ]: translate(
-				'A visual space to share pictures with your website visitors. Add a text summary to describe the gallery to your visitors.'
-			),
-			[ SERVICES_PAGE ]: translate(
-				'Describe what services you offer to the website visitor. Imagine if the visitor is unfamiliar with your field of expertise: how would you explain what you offer?'
-			),
-			[ VIDEO_GALLERY_PAGE ]: translate(
-				'A perfect place to showcase videos of you or your business. Add a text summary to describe the gallery to your visitors.'
-			),
-			[ PRICING_PAGE ]: translate(
-				"What's for sale? This can be food on the menu, hair styling costs, books, services, consulting, etc. You can list the prices of anything you're selling!"
-			),
-			[ PORTFOLIO_PAGE ]: translate(
-				'A space to showcase your work. What is the common theme with your work? What do you do best?'
-			),
-			[ FAQ_PAGE ]: translate(
-				'Do customers/readers tend to ask similar questions? List the most common questions with the answers to help people find information.'
-			),
-			[ TESTIMONIALS_PAGE ]: translate(
-				'Use this page to build credibility. Share reviews or quotes about you and/or your business.'
-			),
-			[ TEAM_PAGE ]: translate(
-				'Showcase a mini profile of each member of your business, with an image, name, and role description.'
-			),
-		} ),
-		[ translate ]
-	);
+	const descriptions: Record< string, TranslateResult > = {
+		[ HOME_PAGE ]: translate(
+			'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site?'
+		),
+		[ ABOUT_PAGE ]: translate(
+			'Provide background information about you or the business. Why did you start this website? What is your personal story?'
+		),
+		[ CONTACT_PAGE ]: translate(
+			'Visitors want to get in touch with you. How can they reach you?'
+		),
+		[ BLOG_PAGE ]: translate(
+			'How would you introduce your journal entries/news articles/chapters? Describe what readers can expect from your regularly published content!'
+		),
+		[ PHOTO_GALLERY_PAGE ]: translate(
+			'A visual space to share pictures with your website visitors. Add a text summary to describe the gallery to your visitors.'
+		),
+		[ SERVICES_PAGE ]: translate(
+			'Describe what services you offer to the website visitor. Imagine if the visitor is unfamiliar with your field of expertise: how would you explain what you offer?'
+		),
+		[ VIDEO_GALLERY_PAGE ]: translate(
+			'A perfect place to showcase videos of you or your business. Add a text summary to describe the gallery to your visitors.'
+		),
+		[ PRICING_PAGE ]: translate(
+			"What's for sale? This can be food on the menu, hair styling costs, books, services, consulting, etc. You can list the prices of anything you're selling!"
+		),
+		[ PORTFOLIO_PAGE ]: translate(
+			'A space to showcase your work. What is the common theme with your work? What do you do best?'
+		),
+		[ FAQ_PAGE ]: translate(
+			'Do customers/readers tend to ask similar questions? List the most common questions with the answers to help people find information.'
+		),
+		[ TESTIMONIALS_PAGE ]: translate(
+			'Use this page to build credibility. Share reviews or quotes about you and/or your business.'
+		),
+		[ TEAM_PAGE ]: translate(
+			'Showcase a mini profile of each member of your business, with an image, name, and role description.'
+		),
+	};
 	return descriptions;
 }

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -56,40 +56,40 @@ export function useTranslatedPageDescriptions() {
 	const descriptions: Record< string, TranslateResult > = useMemo(
 		() => ( {
 			[ HOME_PAGE ]: translate(
-				'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site? '
+				'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site?'
 			),
 			[ ABOUT_PAGE ]: translate(
-				'A great place to provide background information about you or the business. Why did you start this website? What is your personal story?'
+				'Provide background information about you or the business. Why did you start this website? What is your personal story?'
 			),
 			[ CONTACT_PAGE ]: translate(
-				'Visitors want to get in touch with you. Do you have a message for them to say hello, and that it’s okay to get in touch? How can they reach you?'
+				'Visitors want to get in touch with you. How can they reach you?'
 			),
 			[ BLOG_PAGE ]: translate(
-				'How would you introduce your journal entries/news-articles/chapters? Describe what readers can expect from your regularly published content!'
+				'How would you introduce your journal entries/news articles/chapters? Describe what readers can expect from your regularly published content!'
 			),
 			[ PHOTO_GALLERY_PAGE ]: translate(
-				'A visual space to share pictures with your website visitors. How would you introduce your group of photos? What should visitors know about these pictures?'
+				'A visual space to share pictures with your website visitors. Add a text summary to describe the gallery to your visitors.'
 			),
 			[ SERVICES_PAGE ]: translate(
 				'Describe what services you offer to the website visitor. Imagine if the visitor is unfamiliar with your field of expertise: how would you explain what you offer?'
 			),
 			[ VIDEO_GALLERY_PAGE ]: translate(
-				'If you have videos to showcase, what are your videos about? How can you describe what to expect before the visitor begins clicking play on each video?'
+				'A perfect place to showcase videos of you or your business. Add a text summary to describe the gallery to your visitors.'
 			),
 			[ PRICING_PAGE ]: translate(
 				"What's for sale? This can be food on the menu, hair styling costs, books, services, consulting, etc. You can list the prices of anything you're selling!"
 			),
 			[ PORTFOLIO_PAGE ]: translate(
-				'A space to showcase your work. Feel free to promote yourself with your words. What is the common theme with your work? What do you do best? '
+				'A space to showcase your work. What is the common theme with your work? What do you do best?'
 			),
 			[ FAQ_PAGE ]: translate(
-				'Do customers/readers tend to ask similar questions? You can list the most common questions with the answers to help people find info before contacting you.'
+				'Do customers/readers tend to ask similar questions? List the most common questions with the answers to help people find information.'
 			),
 			[ TESTIMONIALS_PAGE ]: translate(
-				'This page is used to build credibility. You can share reviews or quotes about you and/or your business. Do you have words from a fan praising your work?'
+				'Use this page to build credibility. Share reviews or quotes about you and/or your business.'
 			),
 			[ TEAM_PAGE ]: translate(
-				'Let the site visitors meet your team! This is a good space to show a mini profile of each member of your business, with an image, name, and role description.'
+				'Showcase a mini profile of each member of your business, with an image, name, and role description.'
 			),
 		} ),
 		[ translate ]

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -60,7 +60,7 @@ export function useTranslatedPageDescriptions() {
 			'Visitors want to get in touch with you. How can they reach you?'
 		),
 		[ BLOG_PAGE ]: translate(
-			'How would you introduce your journal entries/news articles/chapters? Describe what readers can expect from your regularly published content!'
+			'Blog posts can be news stories, journal entries, or even recipes! We will set up the blog page and explain how you can add posts to your new site.'
 		),
 		[ PHOTO_GALLERY_PAGE ]: translate(
 			'A visual space to share pictures with your website visitors. Add a text summary to describe the gallery to your visitors.'
@@ -75,7 +75,7 @@ export function useTranslatedPageDescriptions() {
 			"What's for sale? This can be food on the menu, hair styling costs, books, services, consulting, etc. You can list the prices of anything you're selling!"
 		),
 		[ PORTFOLIO_PAGE ]: translate(
-			'A space to showcase your work. What is the common theme with your work? What do you do best?'
+			'A space to showcase your work, including examples of completed projects, photography, artwork, or even books or articles you’ve written.'
 		),
 		[ FAQ_PAGE ]: translate(
 			'Do customers/readers tend to ask similar questions? List the most common questions with the answers to help people find information.'

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -50,3 +50,49 @@ export function useTranslatedPageTitles() {
 	);
 	return pages;
 }
+
+export function useTranslatedPageDescriptions() {
+	const translate = useTranslate();
+	const descriptions: Record< string, TranslateResult > = useMemo(
+		() => ( {
+			[ HOME_PAGE ]: translate(
+				'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site? '
+			),
+			[ ABOUT_PAGE ]: translate(
+				'A great place to provide background information about you or the business. Why did you start this website? What is your personal story?'
+			),
+			[ CONTACT_PAGE ]: translate(
+				'Visitors want to get in touch with you. Do you have a message for them to say hello, and that it’s okay to get in touch? How can they reach you?'
+			),
+			[ BLOG_PAGE ]: translate(
+				'How would you introduce your journal entries/news-articles/chapters? Describe what readers can expect from your regularly published content!'
+			),
+			[ PHOTO_GALLERY_PAGE ]: translate(
+				'A visual space to share pictures with your website visitors. How would you introduce your group of photos? What should visitors know about these pictures?'
+			),
+			[ SERVICES_PAGE ]: translate(
+				'Describe what services you offer to the website visitor. Imagine if the visitor is unfamiliar with your field of expertise: how would you explain what you offer?'
+			),
+			[ VIDEO_GALLERY_PAGE ]: translate(
+				'If you have videos to showcase, what are your videos about? How can you describe what to expect before the visitor begins clicking play on each video?'
+			),
+			[ PRICING_PAGE ]: translate(
+				"What's for sale? This can be food on the menu, hair styling costs, books, services, consulting, etc. You can list the prices of anything you're selling!"
+			),
+			[ PORTFOLIO_PAGE ]: translate(
+				'A space to showcase your work. Feel free to promote yourself with your words. What is the common theme with your work? What do you do best? '
+			),
+			[ FAQ_PAGE ]: translate(
+				'Do customers/readers tend to ask similar questions? You can list the most common questions with the answers to help people find info before contacting you.'
+			),
+			[ TESTIMONIALS_PAGE ]: translate(
+				'This page is used to build credibility. You can share reviews or quotes about you and/or your business. Do you have words from a fan praising your work?'
+			),
+			[ TEAM_PAGE ]: translate(
+				'Let the site visitors meet your team! This is a good space to show a mini profile of each member of your business, with an image, name, and role description.'
+			),
+		} ),
+		[ translate ]
+	);
+	return descriptions;
+}

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import InfoPopover from 'calypso/components/info-popover';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { BrowserView } from 'calypso/signup/difm/components/BrowserView';
 import {
@@ -24,7 +25,10 @@ import {
 	PRICING_PAGE,
 	TEAM_PAGE,
 } from 'calypso/signup/difm/constants';
-import { useTranslatedPageTitles } from 'calypso/signup/difm/translation-hooks';
+import {
+	useTranslatedPageDescriptions,
+	useTranslatedPageTitles,
+} from 'calypso/signup/difm/translation-hooks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -86,6 +90,10 @@ const CellLabelContainer = styled.div`
 	@media ( min-width: 960px ) {
 		justify-content: left;
 	}
+
+	.info-popover {
+		margin-inline-start: auto;
+	}
 `;
 
 const PageCellBadge = styled.div`
@@ -117,6 +125,7 @@ function PageCell( { pageId, popular, required, selectedPages, onClick }: PageCe
 	const isDisabled =
 		! config.isEnabled( 'difm/allow-extra-pages' ) && PAGE_LIMIT <= totalSelections;
 	const title = useTranslatedPageTitles()[ pageId ];
+	const description = useTranslatedPageDescriptions()[ pageId ];
 
 	return (
 		<GridCellContainer isSelected={ isSelected } isClickDisabled={ isDisabled }>
@@ -131,6 +140,9 @@ function PageCell( { pageId, popular, required, selectedPages, onClick }: PageCe
 				<div>{ title }</div>
 				{ popular ? <PageCellBadge>{ translate( 'Popular' ) }</PageCellBadge> : null }
 				{ required ? <PageCellBadge>{ translate( 'Required' ) }</PageCellBadge> : null }
+				<InfoPopover showOnHover={ true } position="top">
+					{ description }
+				</InfoPopover>
 			</CellLabelContainer>
 		</GridCellContainer>
 	);

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -3,6 +3,7 @@ import { getDIFMTieredPriceDetails, WPCOM_DIFM_LITE } from '@automattic/calypso-
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -140,7 +141,7 @@ function PageCell( { pageId, popular, required, selectedPages, onClick }: PageCe
 				<div>{ title }</div>
 				{ popular ? <PageCellBadge>{ translate( 'Popular' ) }</PageCellBadge> : null }
 				{ required ? <PageCellBadge>{ translate( 'Required' ) }</PageCellBadge> : null }
-				<InfoPopover showOnHover={ true } position="top">
+				<InfoPopover showOnHover={ true } position={ isMobile() ? 'left' : 'top' }>
 					{ description }
 				</InfoPopover>
 			</CellLabelContainer>

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -205,15 +205,30 @@ function PageSelector( {
 				selectedPages={ selectedPages }
 				onClick={ onPageClick }
 			/>
-			<PageCell pageId={ SERVICES_PAGE } selectedPages={ selectedPages } onClick={ onPageClick } />
+			<PageCell
+				popular
+				pageId={ SERVICES_PAGE }
+				selectedPages={ selectedPages }
+				onClick={ onPageClick }
+			/>
 			<PageCell
 				pageId={ VIDEO_GALLERY_PAGE }
 				selectedPages={ selectedPages }
 				onClick={ onPageClick }
 			/>
-			<PageCell pageId={ PRICING_PAGE } selectedPages={ selectedPages } onClick={ onPageClick } />
+			<PageCell
+				popular
+				pageId={ PRICING_PAGE }
+				selectedPages={ selectedPages }
+				onClick={ onPageClick }
+			/>
 			<PageCell pageId={ PORTFOLIO_PAGE } selectedPages={ selectedPages } onClick={ onPageClick } />
-			<PageCell pageId={ FAQ_PAGE } selectedPages={ selectedPages } onClick={ onPageClick } />
+			<PageCell
+				popular
+				pageId={ FAQ_PAGE }
+				selectedPages={ selectedPages }
+				onClick={ onPageClick }
+			/>
 			<PageCell
 				pageId={ TESTIMONIALS_PAGE }
 				selectedPages={ selectedPages }

--- a/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
@@ -6,7 +6,7 @@ import useCartForDIFM, { CartItem } from './use-cart-for-difm';
 const CartContainer = styled.div`
 	position: relative;
 	@media ( max-width: 600px ) {
-		z-index: 177;
+		z-index: 1100;
 		margin-bottom: 61px;
 		position: fixed;
 		background: white;
@@ -23,7 +23,7 @@ const CartContainer = styled.div`
 const LoadingContainer = styled.div`
 	position: relative;
 	@media ( max-width: 600px ) {
-		z-index: 177;
+		z-index: 1100;
 		margin-bottom: 61px;
 		position: fixed;
 		background: white;


### PR DESCRIPTION
#### Proposed Changes

Ref: pdh1Xd-1sI-p2

* Adds page descriptions as tooltips on the page picker step in the DIFM flow.

https://user-images.githubusercontent.com/5436027/195095073-999915e3-db2a-41ad-befd-faac8fe0a683.mp4

* Adds the Popular badge to the Services, Pricing and FAQ pages.

<img width="772" alt="image" src="https://user-images.githubusercontent.com/5436027/195361777-5de6c1a4-6915-432b-bf6e-386662f50593.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and go through the flow steps.
* On the page picker step, hover over the info icon for each page and confirm that the page description is displayed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1124
Fixes Automattic/martech#1142