### PR TITLE
Revert "Revert "Jetpack pricing: add Social to nav""

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -95,6 +95,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 						href: `${ JETPACK_COM_BASE_URL }/features/growth/`,
 						items: [
 							{
+								label: translate( 'Social' ),
+								tagline: translate( 'Write once, post everywhere' ),
+								href: `${ JETPACK_COM_BASE_URL }/social/`,
+							},
+							{
 								label: translate( 'CRM' ),
 								tagline: translate( 'Connect with your people' ),
 								href: 'https://jetpackcrm.com/?utm_medium=automattic_referred&utm_source=jpcom_header',


### PR DESCRIPTION
Reverts Automattic/wp-calypso#68774

Initial PR: https://github.com/Automattic/wp-calypso/pull/68729