### PR TITLE
Plugins help: update article for managing plugins.

### DIFF
--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -794,7 +794,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 		},
 		{
 			get link() {
-				return localizeUrl( 'https://wordpress.com/support/plugins/#managing-plugins' );
+				return localizeUrl( 'https://wordpress.com/support/plugins/use-your-plugins/' );
 			},
 			post_id: 206930,
 			get title() {

--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -796,13 +796,13 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			get link() {
 				return localizeUrl( 'https://wordpress.com/support/plugins/#managing-plugins' );
 			},
-			post_id: 134818,
+			post_id: 206930,
 			get title() {
 				return __( 'Managing plugins', __i18n_text_domain__ );
 			},
 			get description() {
 				return __(
-					'After you install a plugin, it will appear in a list at My Sites → Plugins.',
+					'After you install a plugin, it will appear in a list at My Sites → Plugins → Installed Plugins.',
 					__i18n_text_domain__
 				);
 			},


### PR DESCRIPTION
#### Proposed Changes

* update the article for managing plugins as the old one is:
1. outdated
2. private - only for a12s

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a non-a11n, visit `/plugins`
* Click the help icon in the masterbar
* Click "Managing Plugins", make sure content appears
* Click the external link icon on the top right, make sure that the content is the same as before

|Before as an a11n| After|
|-------|------|
|![CleanShot 2022-10-11 at 16 37 07](https://user-images.githubusercontent.com/12430020/195106169-036c02cc-de71-4b5d-8a09-a5ce8475af9e.gif)|![CleanShot 2022-10-11 at 16 37 50](https://user-images.githubusercontent.com/12430020/195106296-cc4ce001-6855-4695-9e97-b46e0699e39e.gif)|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65902
