### PR TITLE
Fix reader excerpt - display custom excerpt by default

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -3,44 +3,53 @@ import AutoDirection from 'calypso/components/auto-direction';
 
 import './style.scss';
 
+// Excerpt is set to use webkit-line-clamp to limit number of lines of text to show inside container
+// If we use an excerpt with no html, then text that contains <br> will appear on the same line with incorrect spacing.
+// If we use an excerpt with html, we need to remove the paragraph tags to avoid multiple containers that are subject to webkit-line-clamp
+const convertExcerptNewlinesToBreaks = ( excerpt ) => {
+	const paragraphs = excerpt.split( '<p>' );
+	const lines = [];
+
+	if ( paragraphs.length > 0 ) {
+		// Split html text into paragraphs
+		paragraphs.forEach( ( paragraph ) => {
+			if ( paragraph.length !== 0 ) {
+				// Remove paragraph closing tag
+				let p = paragraph.replaceAll( '</p>', '' );
+				// Clean up any newline chars
+				p = p.replaceAll( '\n', '' );
+				// Replace <br> tags with proper break tag
+				p = p.replaceAll( '<br>', '<br />' );
+
+				// Now split this text into lines based on break tags
+				const breaks = p.split( '<br />' );
+
+				// Append lines to array
+				breaks.map( ( line ) => {
+					lines.push( line );
+				} );
+			}
+		} );
+
+		// Re-join the lines into a html string with breaks
+		excerpt = lines.join( '<br />' );
+	}
+	return excerpt;
+};
+
 const ReaderExcerpt = ( { post } ) => {
-	let excerpt = post.better_excerpt || post.excerpt;
+	// post.excerpt - custom excerpt
+	// post.better_excerpt - HTML excerpt generated from post content
+	let excerpt = post.excerpt || post.better_excerpt;
 
 	if ( excerpt !== undefined ) {
-		// Excerpt is set to use webkit-line-clamp to limit number of lines of text to show inside container
-		// If we use an excerpt with no html, then text that contains <br> will appear on the same line with incorrect spacing.
-		// If we use an excerpt with html, we need to remove the paragraph tags to avoid multiple containers that are subject to webkit-line-clamp
-		const paragraphs = excerpt.split( '<p>' );
-		const lines = [];
-
-		if ( paragraphs.length > 0 ) {
-			// Split html text into paragraphs
-			paragraphs.forEach( ( paragraph ) => {
-				if ( paragraph.length !== 0 ) {
-					// Remove paragraph closing tag
-					let p = paragraph.replaceAll( '</p>', '' );
-					// Clean up any newline chars
-					p = p.replaceAll( '\n', '' );
-					// Replace <br> tags with proper break tag
-					p = p.replaceAll( '<br>', '<br />' );
-
-					// Now split this text into lines based on break tags
-					const breaks = p.split( '<br />' );
-
-					// Append lines to array
-					breaks.map( ( line ) => {
-						lines.push( line );
-					} );
-				}
-			} );
-
-			// Re-join the lines into a html string with breaks
-			excerpt = lines.join( '<br />' );
-		}
+		// Update excerpt to work with webkit-line-clamp
+		excerpt = convertExcerptNewlinesToBreaks( excerpt );
 	}
 
+	// If no valid excerpt, use either `content_no_html` or null
 	if ( excerpt === undefined ) {
-		excerpt = post.content_no_html || '';
+		excerpt = post.content_no_html || null;
 	}
 
 	return (

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -41,7 +41,9 @@ const chooseExcerpt = ( post ) => {
 	// Need to figure out if custom excerpt is different to better_excerpt
 	if ( post.excerpt.length > 0 ) {
 		if ( post.short_excerpt !== undefined ) {
+			// Remove … from short_excerpt
 			const short_excerpt = post.short_excerpt.replaceAll( '…', '' );
+			// Remove any non-alphanumeric chars to avoid string comparison issues and trim
 			const short_excerpt_chars = trim( short_excerpt.replace( /\W/g, '' ) );
 			const custom_excerpt_chars = trim(
 				post.excerpt.substring( 0, short_excerpt_chars.length ).replace( /\W/g, '' )

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -40,19 +40,21 @@ const convertExcerptNewlinesToBreaks = ( excerpt ) => {
 const chooseExcerpt = ( post ) => {
 	// Need to figure out if custom excerpt is different to better_excerpt
 	if ( post.excerpt.length > 0 ) {
-		if ( post.short_excerpt !== undefined ) {
-			// Remove … from short_excerpt
-			const short_excerpt = post.short_excerpt.replaceAll( '…', '' );
-			// Remove any non-alphanumeric chars to avoid string comparison issues and trim
-			const short_excerpt_chars = trim( short_excerpt.replace( /\W/g, '' ) );
-			const custom_excerpt_chars = trim(
-				post.excerpt.substring( 0, short_excerpt_chars.length ).replace( /\W/g, '' )
-			);
-			if ( short_excerpt_chars !== custom_excerpt_chars ) {
-				// In this case, the post excerpt is different to the short excerpt (which is a shortened version of the better_excerpt)
-				// This is an indication of a custom excerpt which we should default to when display excerpts in the reader
-				return post.excerpt;
-			}
+		if ( post.short_excerpt === undefined ) {
+			// If there is no short_excerpt, then there is no better_excerpt
+			return post.excerpt;
+		}
+		// Remove … from short_excerpt
+		const short_excerpt = post.short_excerpt.replaceAll( '…', '' );
+		// Remove any non-alphanumeric chars to avoid string comparison issues, then trim
+		const short_excerpt_chars = trim( short_excerpt.replace( /\W/g, '' ) );
+		const custom_excerpt_chars = trim(
+			post.excerpt.substring( 0, short_excerpt.length ).replace( /\W/g, '' )
+		);
+		if ( short_excerpt_chars !== custom_excerpt_chars ) {
+			// In this case, the post excerpt is different to the short excerpt (which is a shortened version of the better_excerpt)
+			// This is an indication of a custom excerpt which we should default to when display excerpts in the reader
+			return post.excerpt;
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue where the reader was not using the custom excerpt available in a post by default, but rather prior to recent changes it used the post's `content_no_html` and after the reader refresh, we used the `better_excerpt`.

This PR refactors how reader chooses an excerpt to display;

We want to prioritize showing a custom excerpt if the post has one.
If not, then we should show the `better_excerpt` that works well with the `webkit-line-clamp` CSS property.
Failing that, we should show the `content_no_html`.
Failing that, we shouldn't display an excerpt at all.

There is no good way to determine if a post excerpt is custom (at least nothing I could find). The best I can do is to compare the post excerpt, with the `short_excerpt` to check if there is a difference... if there is, this indicates that the post excerpt is custom and should be used.

This PR should fix issue raised in https://github.com/Automattic/wp-calypso/issues/64563.

This PR also follows up on https://github.com/Automattic/wp-calypso/pull/68849 where we found a bug where the excerpt should be null if no excerpt or post content found, to avoid creating a broken link in reader.

### Test

Create a post with a custom excerpt
View it in reader
The custom excerpt should be displayed in reader

Example can be found with http://calypso.localhost:3000/read/feeds/108002187/posts/4313195239