### PR TITLE
Revert "Use ES results to display popular plugins section"

### DIFF
--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -32,7 +32,6 @@ function generateApiQueryString( {
 	query,
 	author,
 	groupId,
-	category,
 	pageHandle,
 	pageSize,
 	locale,
@@ -47,7 +46,6 @@ function generateApiQueryString( {
 		sort: string;
 		size: number;
 		group_id: string;
-		category?: string;
 		from?: number;
 		lang: string;
 	} = {
@@ -58,7 +56,6 @@ function generateApiQueryString( {
 		size: pageSize,
 		lang: locale,
 		group_id: groupId,
-		category: category,
 	};
 
 	if ( author ) {

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -52,6 +52,7 @@ export type ESIndexResult = {
 	'plugin.tested'?: string;
 	'plugin.support_threads'?: number;
 	'plugin.support_threads_resolved'?: number;
+	'plugin.active_installs'?: number;
 	plugin: {
 		author: string;
 		title: string;
@@ -59,7 +60,6 @@ export type ESIndexResult = {
 		icons: string;
 		rating: number;
 		num_ratings: number;
-		active_installs: number;
 	};
 };
 
@@ -83,7 +83,6 @@ export type ESDateRangeFilter = { range: Record< string, { gte: string; lt: stri
 export type SearchParams = {
 	query: string | undefined;
 	author: string | undefined;
-	category: string | undefined;
 	groupId: string;
 	pageHandle: string | undefined;
 	pageSize: number;

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -77,7 +77,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			num_ratings: hit.plugin.num_ratings,
 			support_threads: hit[ 'plugin.support_threads' ],
 			support_threads_resolved: hit[ 'plugin.support_threads_resolved' ],
-			active_installs: hit.plugin.active_installs,
+			active_installs: hit[ 'plugin.active_installs' ],
 			last_updated: hit.modified,
 			short_description: hit.plugin.excerpt, // TODO: add localization
 			icon: createIconUrl( hit.slug, hit.plugin.icons ),
@@ -116,7 +116,6 @@ export const useESPluginsInfinite = (
 				query: searchTerm,
 				author,
 				groupId: 'wporg',
-				category: options.category,
 				pageHandle: pageParam,
 				pageSize,
 				locale: getWpLocaleBySlug( options.locale || locale ),

--- a/client/my-sites/plugins/plugins-category-results-page/header.tsx
+++ b/client/my-sites/plugins/plugins-category-results-page/header.tsx
@@ -7,13 +7,13 @@ const Header = ( {
 }: {
 	title: string;
 	subtitle: string;
-	count?: string;
+	count: string;
 } ) => {
 	return (
 		<div className="plugin-category-results-header">
 			<h1 className="plugin-category-results-header__title">{ title }</h1>
 			{ subtitle && <h2 className="plugin-category-results-header__subtitle">{ subtitle }</h2> }
-			{ count && <div className="plugin-category-results-header__count">{ count }</div> }
+			<div className="plugin-category-results-header__count">{ count }</div>
 		</div>
 	);
 };

--- a/client/my-sites/plugins/plugins-category-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-category-results-page/index.jsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import UpgradeNudge from 'calypso/my-sites/plugins/plugins-discovery-page/upgrade-nudge';
@@ -6,19 +7,31 @@ import usePlugins from '../use-plugins';
 import Header from './header';
 
 const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
-	const { plugins, isFetching, fetchNextPage } = usePlugins( {
+	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
 		category,
 		infinite: true,
 	} );
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || category;
-	const categoryDescription = categories[ category ]?.categoryDescription;
+	const categoryDescription = categories[ category ]?.description;
+	const translate = useTranslate();
+
+	let title = '';
+	if ( categoryName && pagination ) {
+		title = translate( '%(total)s plugin', '%(total)s plugins', {
+			count: pagination.results,
+			textOnly: true,
+			args: {
+				total: pagination.results.toLocaleString(),
+			},
+		} );
+	}
 
 	return (
 		<>
 			<UpgradeNudge siteSlug={ siteSlug } paidPlugins={ true } />
-			<Header title={ categoryName } subtitle={ categoryDescription } />
+			<Header title={ categoryName } count={ title } subtitle={ categoryDescription } />
 
 			<FullListView
 				plugins={ plugins }

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -74,9 +74,10 @@ const usePlugins = ( {
 	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
-	const searchHook = isEnabled( 'marketplace-jetpack-plugin-search' )
-		? useESPluginsInfinite
-		: useWPORGInfinitePlugins;
+	const searchHook =
+		isEnabled( 'marketplace-jetpack-plugin-search' ) && search
+			? useESPluginsInfinite
+			: useWPORGInfinitePlugins;
 
 	const { localeSlug = '' } = useTranslate();
 	const wporgPluginsOptions = {


### PR DESCRIPTION
#68083 contains a bug that prevents categories from loading.

Slack thread here: p1665496735972609-slack-C029JEQRVRT

![image](https://user-images.githubusercontent.com/11555574/195118968-c0b15d4c-bd88-4306-b418-ae41c737c84b.png)

Reverts Automattic/wp-calypso#68083