### PR TITLE
Limit Global Styles: Remove user styles with `theme_json_user` filter

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -125,8 +125,8 @@ function wpcom_block_global_styles_frontend( $theme_json ) {
 
 	/*
 	 * If both `WP_Theme_JSON_Data` and `WP_Theme_JSON_Data_Gutenberg` are missing,
-	 * then the site is running and old version of WordPress and Gutenberg where we
-	 * cannot actually block the user styles.
+	 * then the site is running an old version of WordPress and Gutenberg where we
+	 * cannot block the user styles properly.
 	 */
 	return $theme_json;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -109,14 +109,26 @@ add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_
 /**
  * Removes the data provided by the user from a site with limited global styles.
  *
- * @param WP_Theme_JSON_Data_Gutenberg $theme_json Class to access and update the underlying data.
- * @return WP_Theme_JSON_Data_Gutenberg Filtered data.
+ * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Class to access and update the underlying data.
+ * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg Filtered data.
  */
 function wpcom_block_global_styles_frontend( $theme_json ) {
 	if ( ! wpcom_should_limit_global_styles() ) {
 		return $theme_json;
 	}
-	return new WP_Theme_JSON_Data_Gutenberg( array(), 'custom' );
+
+	if ( class_exists( 'WP_Theme_JSON_Data' ) ) {
+		return new WP_Theme_JSON_Data( array(), 'custom' );
+	} elseif ( class_exists( 'WP_Theme_JSON_Data_Gutenberg' ) ) {
+		return new WP_Theme_JSON_Data_Gutenberg( array(), 'custom' );
+	}
+
+	/*
+	 * If both `WP_Theme_JSON_Data` and `WP_Theme_JSON_Data_Gutenberg` are missing,
+	 * then the site is running and old version of WordPress and Gutenberg where we
+	 * cannot actually block the user styles.
+	 */
+	return $theme_json;
 }
 add_filter( 'theme_json_user', 'wpcom_block_global_styles_frontend' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -107,7 +107,7 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_and_styles' );
 
 /**
- * Removes the data provided by the user from a site with limited global styles.
+ * Removes the user styles from a site with limited global styles.
  *
  * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Class to access and update the underlying data.
  * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg Filtered data.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -118,7 +118,7 @@ function wpcom_block_global_styles_frontend( $theme_json ) {
 	}
 	return new WP_Theme_JSON_Data_Gutenberg( array(), 'custom' );
 }
-add_filter( 'theme_json_user', 'wpcom_block_global_styles_frontend', 10, 3 );
+add_filter( 'theme_json_user', 'wpcom_block_global_styles_frontend' );
 
 /**
  * Tracks when global styles are updated or reset after the post has actually been saved.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1045

#### Proposed Changes

Prevents the user styles from being added to a site with limited global styles by filtering them with [the new `theme_json_user` filter](https://developer.wordpress.org/block-editor/reference-guides/filters/global-styles-filters/).

The previous approach was a bit fragile since it didn't work for [styles applied to specific blocks](https://github.com/WordPress/gutenberg/blob/f3995af131cc0832b3194b8fc6a658e4fa876f33/lib/compat/wordpress-6.1/get-global-styles-and-settings.php#L52).

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh etk update/limit-global-styles-blocks`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Make some shames
- Click on the "Blocks" button
- Choose a block and change its typography
- Save the styles
- Visit the frontend
- Make sure none of your style changes are applied (including the block styles).
