### PR TITLE
Launchpad: Default to Desktop View

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,15 +1,18 @@
+import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
+import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
-	const defaultDevice = DEVICE_TYPE.COMPUTER;
+	const flow = useFlowParam();
 	const devicesToShow: Device[] = [ DEVICE_TYPE.COMPUTER, DEVICE_TYPE.PHONE ];
+	const defaultDevice = flow === NEWSLETTER_FLOW ? DEVICE_TYPE.COMPUTER : DEVICE_TYPE.PHONE;
 
 	function formatPreviewUrl() {
 		if ( ! previewUrl ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,5 +1,6 @@
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
 import PreviewToolbar from '../design-setup/preview-toolbar';
@@ -7,8 +8,8 @@ import PreviewToolbar from '../design-setup/preview-toolbar';
 const LaunchpadSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
 	const translate = useTranslate();
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
-	const defaultDevice = 'phone';
-	const devicesToShow: Device[] = [ 'computer', 'phone' ];
+	const defaultDevice = DEVICE_TYPE.COMPUTER;
+	const devicesToShow: Device[] = [ DEVICE_TYPE.COMPUTER, DEVICE_TYPE.PHONE ];
 
 	function formatPreviewUrl() {
 		if ( ! previewUrl ) {


### PR DESCRIPTION
#### Proposed Changes
Currently we are showing the phone view by default but we want to show the desktop view for newsletter flow

![grUOw7.png](https://user-images.githubusercontent.com/20927667/195134803-40fd546f-e04b-4305-80a1-d06556593efc.png)

#### Testing Instructions
1. Go to Launchpad newsletter
2. You should see the desktop web preview selected by default
3. Go to Launchpad link-in-bio
4. You should see the phone web preview selected by default

https://user-images.githubusercontent.com/20927667/195137203-6898b873-139f-44bc-8c2f-d5b3f1d7d432.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related p1665499735161149-slack-CHN6J22MP