### PR TITLE
Add stylelint to teamcity

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -578,7 +578,7 @@ object CheckCodeStyleBranch : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 201
+		executionTimeoutMin = 20
 	}
 
 	features {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -557,14 +557,14 @@ object CheckCodeStyleBranch : BuildType({
 				fi
 			"""
 		}
-	}
 
-	bashNodeScript {
-		name = "Run stylelint"
-		scriptContent = """
-			# In the future, we may add the stylelint cache here.
-			yarn run lint:css
-		"""
+		bashNodeScript {
+			name = "Run stylelint"
+			scriptContent = """
+				# In the future, we may add the stylelint cache here.
+				yarn run lint:css
+			"""
+		}
 	}
 
 	triggers {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -537,7 +537,7 @@ object CheckCodeStyleBranch : BuildType({
 			"""
 		}
 		bashNodeScript {
-			name = "Run linters"
+			name = "Run eslint"
 			scriptContent = """
 				export NODE_ENV="test"
 
@@ -559,6 +559,14 @@ object CheckCodeStyleBranch : BuildType({
 		}
 	}
 
+	bashNodeScript {
+		name = "Run stylelint"
+		scriptContent = """
+			# In the future, we may add the stylelint cache here.
+			yarn run lint:css
+		"""
+	}
+
 	triggers {
 		vcs {
 			branchFilter = """
@@ -570,7 +578,7 @@ object CheckCodeStyleBranch : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 20
+		executionTimeoutMin = 201
 	}
 
 	features {


### PR DESCRIPTION
#### Proposed Changes
Work towards #67467

Run stylelint in our TeamCity linter task. @manzoorwanijk suggested enabling the linter (this PR) and then turning the existing broken rules into warnings (https://github.com/Automattic/wp-calypso/pull/68797). This way, we can start failing PRs for broken style rules, so we don't keep committing style files in the wrong style, while continuing to fix the remaining rules (which shouldn't take long)

Some more thoughts:
- If performance is bad, we should enable the cache and/or only run the linter for changed files. (update, it took 28s to run, which I think is reasonable performance. I think it'd be worth experimenting with the cache as well.)

#### Testing Instructions
1. Check that stylelint is running in the TeamCity style check task for this PR
2. It should probably fail until https://github.com/Automattic/wp-calypso/pull/68797 is merged.

