### PR TITLE
Partner Portal: Add feature flag for the new multiple license issue form

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,0 +1,11 @@
+import type { IssueMultipleLicensesFormProps } from './types';
+
+const IssueMultipleLicensesForm: React.FC< IssueMultipleLicensesFormProps > = () => {
+	return (
+		<div>
+			<p>{ 'Hello there! 👋' }</p>
+		</div>
+	);
+};
+
+export default IssueMultipleLicensesForm;

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/types.ts
@@ -1,0 +1,3 @@
+export type IssueMultipleLicensesFormProps = {
+	// Coming soon!
+};

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -5,6 +6,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
+import IssueMultipleLicensesForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import { AssignLicenceProps } from '../../types';
 
@@ -29,7 +31,11 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			<AssignLicenseStepProgress currentStep="issueLicense" />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
+			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ? (
+				<IssueMultipleLicensesForm />
+			) : (
+				<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
+			) }
 		</Main>
 	);
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -40,6 +40,7 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/partner-portal-issue-multiple-licenses": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -34,6 +34,7 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/partner-portal-issue-multiple-licenses": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -37,6 +37,7 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/partner-portal-issue-multiple-licenses": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -37,6 +37,7 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/partner-portal-issue-multiple-licenses": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,


### PR DESCRIPTION
#### Proposed Changes

- This PR adds the new `jetpack/partner-portal-issue-multiple-licenses` feature flag, which will be used during the development of the new UI for issuing multiple licenses.

#### Testing Instructions
- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/partner-portal/issue-license
- Verify that component rendering `Hello there! 👋` is shown
- Open the Jetpack Cloud Live link below (i.e., horizon) and visit the same path: `/partner-portal/issue-license`
- Verify that you see the actual form for issuing a new license
- Open the `config/jetpack-cloud-development.json` file and verify that `jetpack/partner-portal-issue-multiple-licenses` flag is set to `true`
- Open the following files and verify that the value for `jetpack/partner-portal-issue-multiple-licenses` flag is set to `false`:
  - config/jetpack-cloud-horizon.json
  - config/jetpack-cloud-production.json
  - config/jetpack-cloud-stage.json

![image](https://user-images.githubusercontent.com/1749918/195148606-bdd5fe51-e8a7-449f-b42b-52521a69ca7a.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203143414726355