### PR TITLE
Add eslint curly rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,6 +87,7 @@ module.exports = {
 					'brace-style': 'off',
 					'comma-dangle': 'off',
 					'comma-spacing': 'off',
+					curly: 'error', // The base curly rule does not seem to apply to TS files as well.
 					'default-param-last': 'off',
 					'dot-notation': 'off',
 					'func-call-spacing': 'off',
@@ -293,6 +294,9 @@ module.exports = {
 	rules: {
 		// REST API objects include underscores
 		camelcase: 'off',
+
+		//
+		curly: 'error',
 
 		'no-constant-condition': [ 'error', { checkLoops: false } ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,7 @@ module.exports = {
 					'brace-style': 'off',
 					'comma-dangle': 'off',
 					'comma-spacing': 'off',
-					curly: 'error', // The base curly rule does not seem to apply to TS files as well.
+					curly: 'error', // The base curly rule does not seem to apply to TS files.
 					'default-param-last': 'off',
 					'dot-notation': 'off',
 					'func-call-spacing': 'off',
@@ -295,7 +295,7 @@ module.exports = {
 		// REST API objects include underscores
 		camelcase: 'off',
 
-		//
+		// Curly is not added by existing presets and is needed for WordPress style compatibility.
 		curly: 'error',
 
 		'no-constant-condition': [ 'error', { checkLoops: false } ],


### PR DESCRIPTION
#### Proposed Changes
In [this PR](https://github.com/Automattic/wp-calypso/pull/68835#discussion_r992316864), we noticed that the eslint curly rule isn't used by Calypso, allowing examples like this to pass a lint check:

```js
if ( foo === 'bar' ) return true;
```

Since this is incompatible with the WordPress code styles, this PR adds it back. @jsnajdr says this about why it was removed:

> I think checking these if one-liners fell through the cracks when we started to use Prettier and then removed all formatting-related ESLint rules. One of them was the [curly](https://eslint.org/docs/latest/rules/curly) rule. We should reintroduce curly if we want to enforce this style (good idea IMO). It doesn't conflict with Prettier, which accepts and formats both forms (IfStatement + ReturnStatement AST vs IfStatement + Block + ReturnStatement), just adds on top of it.


#### Testing Instructions
1. Check out this branch locally
2. Make a change in each of these types of files: .js, .jsx, .ts, .tsx. This change should remove curly braces as shown in the example. You should get an eslint warning about the change:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/6265975/195166108-53e57b4c-854c-419e-9fdf-04c8cdc4d22c.png">

3. eslint should auto-fix the error and add back the curly braces. (e.g. on save, if you have auto-fix on save set up)

