### PR TITLE
Videomaker theme: Customize onboarding tour images and text

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -54,9 +54,10 @@ function WelcomeTour() {
 		return new URLSearchParams( document.location.search ).has( 'welcome-tour-next' );
 	};
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
+	const currentTheme = useSelect( ( select ) => select( 'core' ).getCurrentTheme() );
+	const themeName = currentTheme?.name?.raw?.toLowerCase() ?? null;
 
-	const theme = 'videomaker';
-	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor, theme );
+	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor, themeName );
 
 	// Only keep Payment block step if user comes from seller simple flow
 	if ( ! ( 'sell' === intent && sitePlan && 'ecommerce-bundle' !== sitePlan.product_slug ) ) {
@@ -169,6 +170,11 @@ function WelcomeTour() {
 			portalParentElement: document.getElementById( 'wpwrap' ),
 		},
 	};
+
+	// Theme isn't immediately available, so we prevent rendering so the content doesn't switch after it is presented, since some content is based on theme
+	if ( null === themeName ) {
+		return null;
+	}
 
 	return <WpcomTourKit config={ tourConfig } />;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -54,6 +54,9 @@ function WelcomeTour() {
 		return new URLSearchParams( document.location.search ).has( 'welcome-tour-next' );
 	};
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore Until `@types/wordpress__editor` (which has `@types/wordpress__core-data` as a dependency) can be upgraded to a version that includes `getCurrentTheme`
+	// the function has existed for many years, and works as expected on wpcom and atomic
 	const currentTheme = useSelect( ( select ) => select( 'core' ).getCurrentTheme() );
 	const themeName = currentTheme?.name?.raw?.toLowerCase() ?? null;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -55,7 +55,8 @@ function WelcomeTour() {
 	};
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
 
-	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor );
+	const theme = 'videomaker';
+	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor, theme );
 
 	// Only keep Payment block step if user comes from seller simple flow
 	if ( ! ( 'sell' === intent && sitePlan && 'ecommerce-bundle' !== sitePlan.product_slug ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -63,7 +63,7 @@ function getTourSteps(
 	isSiteEditor = false,
 	themeName: string | null = null
 ): WpcomStep[] {
-	const isVideoMaker = [ 'videomaker', 'videomaker white' ].indexOf( themeName ) >= 0;
+	const isVideoMaker = [ 'videomaker', 'videomaker white' ].includes( themeName ?? '' );
 	return [
 		{
 			slug: 'welcome',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -61,8 +61,9 @@ function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
 	isSiteEditor = false,
-	theme: string | null = null
+	themeName: string | null = null
 ): WpcomStep[] {
+	const isVideoMaker = [ 'videomaker', 'videomaker white' ].indexOf( themeName ) >= 0;
 	return [
 		{
 			slug: 'welcome',
@@ -75,7 +76,7 @@ function getTourSteps(
 					),
 					mobile: null,
 				},
-				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomakerWelcome' : 'welcome' ),
+				imgSrc: getTourAssets( isVideoMaker ? 'videomakerWelcome' : 'welcome' ),
 			},
 			options: {
 				classNames: {
@@ -140,19 +141,18 @@ function getTourSteps(
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
 				descriptions: {
-					desktop:
-						'videomaker' === theme
-							? __(
-									'Use the toolbar to change the appearance of a selected block. Try replacing a video!',
-									'full-site-editing'
-							  )
-							: __(
-									'Use the toolbar to change the appearance of a selected block. Try making it bold.',
-									'full-site-editing'
-							  ),
+					desktop: isVideoMaker
+						? __(
+								'Use the toolbar to change the appearance of a selected block. Try replacing a video!',
+								'full-site-editing'
+						  )
+						: __(
+								'Use the toolbar to change the appearance of a selected block. Try making it bold.',
+								'full-site-editing'
+						  ),
 					mobile: null,
 				},
-				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomakerEdit' : 'makeBold' ),
+				imgSrc: getTourAssets( isVideoMaker ? 'videomakerEdit' : 'makeBold' ),
 			},
 			options: {
 				classNames: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -61,7 +61,7 @@ function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
 	isSiteEditor = false,
-	theme = null
+	theme: string | null = null
 ): WpcomStep[] {
 	return [
 		{
@@ -75,7 +75,7 @@ function getTourSteps(
 					),
 					mobile: null,
 				},
-				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomaker-welcome' : 'welcome' ),
+				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomakerWelcome' : 'welcome' ),
 			},
 			options: {
 				classNames: {
@@ -140,13 +140,19 @@ function getTourSteps(
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
 				descriptions: {
-					desktop: __(
-						'Use the toolbar to change the appearance of a selected block. Try making it bold.',
-						'full-site-editing'
-					),
+					desktop:
+						'videomaker' === theme
+							? __(
+									'Use the toolbar to change the appearance of a selected block. Try replacing a video!',
+									'full-site-editing'
+							  )
+							: __(
+									'Use the toolbar to change the appearance of a selected block. Try making it bold.',
+									'full-site-editing'
+							  ),
 					mobile: null,
 				},
-				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomaker-edit' : 'makeBold' ),
+				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomakerEdit' : 'makeBold' ),
 			},
 			options: {
 				classNames: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -46,6 +46,12 @@ function getTourAssets( key: string ): TourAsset | undefined {
 				type: 'image/gif',
 			},
 		},
+		videomakerWelcome: {
+			desktop: { src: `${ CDN_PREFIX }/slide-videomaker-welcome.png`, type: 'image/png' },
+		},
+		videomakerEdit: {
+			desktop: { src: `${ CDN_PREFIX }/slide-videomaker-edit.png`, type: 'image/png' },
+		},
 	} as { [ key: string ]: TourAsset };
 
 	return tourAssets[ key ];
@@ -54,7 +60,8 @@ function getTourAssets( key: string ): TourAsset | undefined {
 function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
-	isSiteEditor = false
+	isSiteEditor = false,
+	theme = null
 ): WpcomStep[] {
 	return [
 		{
@@ -68,7 +75,7 @@ function getTourSteps(
 					),
 					mobile: null,
 				},
-				imgSrc: getTourAssets( 'welcome' ),
+				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomaker-welcome' : 'welcome' ),
 			},
 			options: {
 				classNames: {
@@ -139,7 +146,7 @@ function getTourSteps(
 					),
 					mobile: null,
 				},
-				imgSrc: getTourAssets( 'makeBold' ),
+				imgSrc: getTourAssets( 'videomaker' === theme ? 'videomaker-edit' : 'makeBold' ),
 			},
 			options: {
 				classNames: {


### PR DESCRIPTION
#### Proposed Changes

* Adjust the onboarding tour to have Video specific images and text when the Videomaker or Videomaker White themes are installed

**For Translators**
<img width="511" alt="Screen Shot 2022-10-24 at 1 31 05 PM" src="https://user-images.githubusercontent.com/4081020/197589185-c737a510-a2d1-492a-bb8e-8adc16c8af44.png">


#### Testing Instructions
**FYI:** This might not work great while testing onboarding unless you sandbox the new domain after it is created (**I THINK**) Testing instructions are based on just running a known site directly. We can deploy this separately if it makes sense to do so.

- apply diff to sandbox (for new assets) D89705-code
- sandbox `s0.wp.com`
- pull PR
- `cd apps/editing-toolkit`
- ensure your wpcom sandbox ssh alias is called `wpcom-sandbox` (**OR** edit it to your alias in `packages/calypso-apps-builder/index.js` **OR** figure out how the `remotePath` param works)
- `yarn dev --sync`
- visit a sandboxed site, ensure your theme is one of the `videomaker` variants (make sure to test both, since they are detected differently)
- visit the Full Site, Post or Page editor
- open the side menu (3 dots icon in upper right)
- Under Tools, select Welcome Guide
- Move through the cards, the 1st and 4th items should match the designs in Automattic/greenhouse#1301
- visit a sandboxed site on a different theme (or change your current theme)
- visit the editor again and launch the Welcome Guide
- the cards should appear as they do in prod

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #