### PR TITLE
Theme/Plugin Bundling: Add upsell banner for bundled premium themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -53,6 +53,7 @@ import {
 	isThemeActive,
 	isThemePremium,
 	isPremiumThemeAvailable,
+	isSiteEligibleForBundledSoftware,
 	isWpcomTheme as isThemeWpcom,
 	isWporgTheme,
 	getCanonicalTheme,
@@ -654,6 +655,7 @@ class ThemeSheet extends Component {
 			isAtomic,
 			isPremium,
 			isBundledSoftwareSet,
+			isSiteBundleEligible,
 			isJetpack,
 			isWpcomTheme,
 			isVip,
@@ -707,42 +709,42 @@ class ThemeSheet extends Component {
 
 		// Show theme upsell banner on Simple sites.
 		const hasWpComThemeUpsellBanner =
-			! isJetpack &&
-			isPremium &&
-			! isBundledSoftwareSet &&
-			! hasUnlimitedPremiumThemes &&
-			! isVip &&
-			! retired;
+			( ! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired ) ||
+			isBundledSoftwareSet;
 		// Show theme upsell banner on Jetpack sites.
 		const hasWpOrgThemeUpsellBanner =
 			! isAtomic && ! isWpcomTheme && ( ! siteId || ( ! isJetpack && ! canUserUploadThemes ) );
 		// Show theme upsell banner on Atomic sites.
 		const hasThemeUpsellBannerAtomic =
-			isAtomic &&
-			isPremium &&
-			! isBundledSoftwareSet &&
-			! canUserUploadThemes &&
-			! hasUnlimitedPremiumThemes;
+			isAtomic && isPremium && ! canUserUploadThemes && ! hasUnlimitedPremiumThemes;
 
 		const hasUpsellBanner =
 			hasWpComThemeUpsellBanner || hasWpOrgThemeUpsellBanner || hasThemeUpsellBannerAtomic;
 
 		if ( hasWpComThemeUpsellBanner ) {
+			const upsellTitle = isBundledSoftwareSet
+				? translate( 'Access this WooCommerce theme with a Business plan!' )
+				: translate( 'Access this theme for FREE with a Premium or Business plan!' );
+			const upsellDescription = isBundledSoftwareSet
+				? translate(
+						'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
+				  )
+				: translate(
+						'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
+				  );
+
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_PREMIUM }
 					className="theme__page-upsell-banner"
-					title={ translate( 'Access this theme for FREE with a Premium or Business plan!' ) }
-					description={ preventWidows(
-						translate(
-							'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
-						)
-					) }
+					title={ upsellTitle }
+					description={ preventWidows( upsellDescription ) }
 					event="themes_plan_particular_free_with_plan"
 					feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 					forceHref={ true }
 					href={ plansUrl }
 					showIcon={ true }
+					forceDisplay={ isBundledSoftwareSet && ! isSiteBundleEligible }
 				/>
 			);
 		}
@@ -910,6 +912,7 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, id ),
+			isSiteBundleEligible: isSiteEligibleForBundledSoftware( state, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
 			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			showTryAndCustomize: shouldShowTryAndCustomize( state, id, siteId ),


### PR DESCRIPTION
#### Proposed Changes

In #67444, we hid the upsell banner on the theme page for bundled premium themes since the wording doesn't make sense.

This PR restores the upsell banner with copy specific to bundled themes.

#### Testing Instructions

Go to `/theme/thriving-artist/[site-slug]` where `[site-slug]` is either a Free site or has a plan that's less than "Business". 

You should see the following banner:
![image](https://user-images.githubusercontent.com/917632/195182502-07980c09-c5a2-4bd5-85cf-89c48d6f75ef.png)

Non-bundled themes should show the original banner:
![image](https://user-images.githubusercontent.com/917632/195367126-2d21673f-6580-4c18-a1d1-b9e74a927b4b.png)



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67450
