### PR TITLE
Jetpack Licensing Portal: Add explicit USD description for pricing

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -65,8 +65,8 @@ export default function LicenseProductCard( props: Props ) {
 							{ formatCurrency( product.amount, product.currency ) }
 						</div>
 						<div className="license-product-card__price-interval">
-							{ product.price_interval === 'day' && translate( '/per license per day' ) }
-							{ product.price_interval === 'month' && translate( '/per license per month' ) }
+							{ product.price_interval === 'day' && translate( '/USD per license per day' ) }
+							{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
#### Proposed Changes

* We are not explicit enough when describing the cost of licenses in the licensing portal. This PR adds `USD` to the description of license cost.

#### Testing Instructions

* Check the license issue page. It should say `/per license per month` without this PR. With this PR, it should say `/USD per license per month`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
