### PR TITLE
Jetpack Backup: Add button to "go back" on restore site flow

### DIFF
--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -110,6 +110,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					/>
 				) }
 			</>
+			<Button className="rewind-flow__back-button">{ translate( 'Go back' ) }</Button>
 			<Button
 				className="rewind-flow__primary-button"
 				primary

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -114,17 +114,19 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					/>
 				) }
 			</>
-			<Button className="rewind-flow__back-button" href={ backupMainPath( siteSlug ) }>
-				{ translate( 'Go back' ) }
-			</Button>
-			<Button
-				className="rewind-flow__primary-button"
-				primary
-				onClick={ onConfirm }
-				disabled={ Object.values( rewindConfig ).every( ( setting ) => ! setting ) }
-			>
-				{ translate( 'Confirm restore' ) }
-			</Button>
+			<div className="rewind-flow__btn-group">
+				<Button className="rewind-flow__back-button" href={ backupMainPath( siteSlug ) }>
+					{ translate( 'Go back' ) }
+				</Button>
+				<Button
+					className="rewind-flow__primary-button"
+					primary
+					onClick={ onConfirm }
+					disabled={ Object.values( rewindConfig ).every( ( setting ) => ! setting ) }
+				>
+					{ translate( 'Confirm restore' ) }
+				</Button>
+			</div>
 			<Interval onTick={ refreshBackups } period={ EVERY_FIVE_SECONDS } />
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -14,6 +14,8 @@ import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { backupMainPath } from '../paths';
 import Error from './error';
 import Loading from './loading';
 import ProgressBar from './progress-bar';
@@ -70,6 +72,8 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		requestRestore();
 	}, [ dispatch, setUserHasRequestedRestore, requestRestore ] );
 
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
 	const loading = rewindState.state === 'uninitialized';
 	const { restoreId } = rewindState.rewind || {};
 
@@ -110,7 +114,9 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					/>
 				) }
 			</>
-			<Button className="rewind-flow__back-button">{ translate( 'Go back' ) }</Button>
+			<Button className="rewind-flow__back-button" href={ backupMainPath( siteSlug ) }>
+				{ translate( 'Go back' ) }
+			</Button>
 			<Button
 				className="rewind-flow__primary-button"
 				primary

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -124,6 +124,10 @@ a.rewind-flow-notice__title-warning:visited {
 	}
 }
 
+.rewind-flow__btn-group {
+	margin-top: 2.5em;
+}
+
 .rewind-flow__primary-button {
 	margin-bottom: 22.5px;
 	text-align: center;

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -135,6 +135,18 @@ a.rewind-flow-notice__title-warning:visited {
 	}
 }
 
+.rewind-flow__back-button {
+	margin-bottom: 10px;
+	text-align: center;
+	width: 100%;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		width: auto;
+		text-align: auto;
+		margin-right: 1rem;
+	}
+}
+
 .rewind-flow__progress-bar {
 	margin-bottom: 22.5px;
 


### PR DESCRIPTION
#### Proposed Changes

* Add a new `Go back` on restore site flow
* Increase the vertical space before the buttons as suggested by design team

#### Tasks
- [x] Add `Go back` button using a secondary CTA style
- [x] Validate clicking on it dismiss the restore site flow
- [x] Validate in Calypso Blue
- [x] Validate in Calypso Green

#### Screenshots
Component | Before | After
--- | --- | ---
Jetpack Cloud | ![image](https://user-images.githubusercontent.com/1488641/195188657-157c1cef-fd06-4e69-8fc4-aedfb83edd99.png) | ![image](https://user-images.githubusercontent.com/1488641/195669518-9d9337ca-43f4-45ed-a112-dd3c3fba3cf1.png)
Jetpack Cloud (Smaller screens) | ![image](https://user-images.githubusercontent.com/1488641/195189392-970b9757-4822-4c57-b7b3-b888003fb458.png) | ![image](https://user-images.githubusercontent.com/1488641/195669646-ee86cc50-198d-49dd-9f73-ee0c3849aa9c.png)
Calypso Blue | ![image](https://user-images.githubusercontent.com/1488641/195202409-ce4af279-36a3-445e-8802-902cd4179cd2.png) | ![image](https://user-images.githubusercontent.com/1488641/195669772-9cb58234-020e-4d37-9f76-c443adaf3338.png)
Calypso Blue (Smaller screens) | ![image](https://user-images.githubusercontent.com/1488641/195202373-08f7a5b6-3e1d-4def-962b-bd72e6ec8a61.png) | ![image](https://user-images.githubusercontent.com/1488641/195669707-6c11687b-8742-4844-9edf-d0d2a144937e.png)

#### Known issues
* If a user navigate to the Restore Site screen from Activity Log, the `Go back` button will redirect them to the main backup page, instead of Activity Log page. This only impacts Jetpack Cloud. Calypso Blue will work as usual.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Grab a site with a Jetpack Backup plan and valid credentials
* Access Jetpack Cloud and choose that site
* Navigate to `Backup` page on left menu
* Click on `Restore to this point`. You should see the Restore Site page.
* Click on `Go back` button. It should dismiss this page and return you to the previous page.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### References
* 1170120475965554-as-1201595612955689/f