### PR TITLE
Subscriber form: provide property for sending invite email

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { useTranslate } from 'i18n-calypso';
+import { useIsEligibleSubscriberImporter } from 'calypso/landing/stepper/hooks/use-is-eligible-subscriber-importer';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
@@ -10,6 +11,7 @@ const Subscribers: Step = function ( { navigation } ) {
 	const __ = useTranslate();
 	const { submit } = navigation;
 	const site = useSite();
+	const isUserEligibleForSubscriberImporter = useIsEligibleSubscriberImporter();
 
 	const handleSubmit = () => {
 		submit?.();
@@ -32,7 +34,7 @@ const Subscribers: Step = function ( { navigation } ) {
 							submitBtnName={ __( 'Continue' ) }
 							onImportFinished={ handleSubmit }
 							allowEmptyFormSubmit={ true }
-							manualListEmailInviting={ true }
+							manualListEmailInviting={ ! isUserEligibleForSubscriberImporter }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -32,6 +32,7 @@ const Subscribers: Step = function ( { navigation } ) {
 							submitBtnName={ __( 'Continue' ) }
 							onImportFinished={ handleSubmit }
 							allowEmptyFormSubmit={ true }
+							manualListEmailInviting={ true }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 						/>

--- a/client/landing/stepper/hooks/use-is-eligible-subscriber-importer.ts
+++ b/client/landing/stepper/hooks/use-is-eligible-subscriber-importer.ts
@@ -1,0 +1,6 @@
+import { useSelector } from 'react-redux';
+import isEligibleForSubscriberImporter from 'calypso/state/selectors/is-eligible-for-subscriber-importer';
+
+export function useIsEligibleSubscriberImporter() {
+	return useSelector( ( state ) => isEligibleForSubscriberImporter( state ) );
+}

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -1,10 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-
 import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
@@ -140,7 +138,7 @@ class Followers extends Component {
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 									recordTracksEvent={ recordTracksEvent }
 									onImportFinished={ () => {
-										page.redirect( `/people/invites/${ this.props.site.slug }` );
+										this.props?.refetch?.();
 									} }
 								/>
 							</EmailVerificationGate>

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -52,6 +52,7 @@ const FollowersList = ( { site, search, type = 'wpcom' } ) => {
 			isFetching={ isLoading }
 			isFetchingNextPage={ isFetchingNextPage }
 			totalFollowers={ data?.total }
+			refetch={ refetch }
 			fetchNextPage={ fetchNextPage }
 			hasNextPage={ hasNextPage }
 			removeFollower={ removeFollower }

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -78,7 +78,7 @@ class PeopleInvites extends PureComponent {
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 							onImportFinished={ () => {
-								page.redirect( `/people/invites/${ this.props.site.slug }` );
+								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
 							} }
 						/>
 					</EmailVerificationGate>

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -35,7 +35,7 @@ export function createActions() {
 		job,
 	} );
 
-	function* importCsvSubscribers( siteId: number, file: File ) {
+	function* importCsvSubscribers( siteId: number, file?: File, emails: string[] = [] ) {
 		yield importCsvSubscribersStart( siteId );
 
 		try {
@@ -45,7 +45,8 @@ export function createActions() {
 				apiNamespace: 'wpcom/v2',
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
-				formData: [ [ 'import', file, file.name ] ],
+				formData: file && [ [ 'import', file, file.name ] ],
+				body: { emails },
 			} );
 
 			yield importCsvSubscribersStartSuccess( siteId, data.upload_id );

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -32,6 +32,7 @@ interface Props {
 	showCsvUpload?: boolean;
 	submitBtnName?: string;
 	allowEmptyFormSubmit?: boolean;
+	manualListEmailInviting?: boolean;
 	recordTracksEvent?: RecordTrackEvents;
 	onSkipBtnClick?: () => void;
 	onImportFinished?: () => void;
@@ -51,6 +52,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		showCsvUpload,
 		submitBtnName = __( 'Add subscribers' ),
 		allowEmptyFormSubmit,
+		manualListEmailInviting,
 		recordTracksEvent,
 		onSkipBtnClick,
 		onImportFinished,
@@ -114,13 +116,19 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		e.preventDefault();
 
 		const validEmails = isValidEmails
-			.map( ( x, i ) => {
-				if ( x ) return emails[ i ];
-			} )
+			.map( ( x, i ) => x && emails[ i ] )
 			.filter( ( x ) => !! x ) as string[];
 
-		validEmails.length && addSubscribers( siteId, validEmails );
-		selectedFile && importCsvSubscribers( siteId, selectedFile );
+		if ( manualListEmailInviting ) {
+			// add subscribers with invite email
+			validEmails.length && addSubscribers( siteId, validEmails );
+			// import subscribers providing only CSV list of emails
+			selectedFile && importCsvSubscribers( siteId, selectedFile );
+		} else {
+			// import subscribers proving CSV and manual list of emails
+			( selectedFile || validEmails.length ) &&
+				importCsvSubscribers( siteId, selectedFile, validEmails );
+		}
 
 		! validEmails.length && ! selectedFile && allowEmptyFormSubmit && onImportFinished?.();
 	}

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -2,7 +2,7 @@
 import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, NextButton, SkipButton } from '@automattic/onboarding';
-import { TextControl, FormFileUpload, Button, Notice } from '@wordpress/components';
+import { TextControl, FormFileUpload, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -348,10 +348,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			</div>
 
 			<div className={ 'add-subscriber__form--container' }>
-				{ inProgress && (
-					<Notice isDismissible={ false }>{ __( 'Your email list is being uploaded' ) }...</Notice>
-				) }
-
 				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>
 					{ emailFormControls.map( ( placeholder, i ) => {
 						const showError = isDirtyEmails[ i ] && ! isValidEmails[ i ] && emails[ i ];


### PR DESCRIPTION
#### Proposed Changes

- Introduced a new `manualListEmailInviting` property.
Now, in-product subscribers importer import directly into the subscribers lists instead of sending an invitation email.
- Fixed the issue of non-showing the most recent list of subscribers.
- Removed in-progress notification ( "Your email list is being uploaded..." )

#### Testing Instructions

**In-product integration:**
* Go to `people/email-followers/{SLUG}`
* Click on the `Add Subscribers` button
* Check if the list of subscribers is updated

**Onboarding flow:**
* Go to `setup/subscribers?flow=newsletter&siteSlug={SLUG}`
* Email from the manual list should send an invite email
(the behavior should remain the same as it is now)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #68831
Closes #68641