### PR TITLE
MIgrate date-picker test from enzyme to testing-library

### DIFF
--- a/client/my-sites/backup/backup-date-picker/index.tsx
+++ b/client/my-sites/backup/backup-date-picker/index.tsx
@@ -23,8 +23,8 @@ const CALENDAR_DATE_CLICK = recordTracksEvent( 'calypso_jetpack_backup_date_cale
 
 const onSpace =
 	( fn: () => void ) =>
-	( { key }: { key?: string } ) => {
-		if ( key === ' ' ) {
+	( { code }: { code?: string } ) => {
+		if ( code === 'Space' ) {
 			fn();
 		}
 	};

--- a/client/my-sites/backup/backup-date-picker/index.tsx
+++ b/client/my-sites/backup/backup-date-picker/index.tsx
@@ -165,7 +165,7 @@ const BackupDatePicker: FC< Props > = ( { selectedDate, onDateChange } ) => {
 							compact
 							borderless
 							className="backup-date-picker__button--previous"
-							aria-label="Go to previous date"
+							aria-label={ translate( 'Go to previous date' ) }
 						>
 							<Gridicon
 								icon="chevron-left"
@@ -206,7 +206,7 @@ const BackupDatePicker: FC< Props > = ( { selectedDate, onDateChange } ) => {
 								compact
 								borderless
 								className="backup-date-picker__button--next"
-								aria-label="Go to next date"
+								aria-label={ translate( 'Go to next date' ) }
 							>
 								<Gridicon
 									icon="chevron-right"

--- a/client/my-sites/backup/backup-date-picker/index.tsx
+++ b/client/my-sites/backup/backup-date-picker/index.tsx
@@ -161,7 +161,12 @@ const BackupDatePicker: FC< Props > = ( { selectedDate, onDateChange } ) => {
 						onClick={ goToPreviousDate }
 						onKeyDown={ onSpace( goToPreviousDate ) }
 					>
-						<Button compact borderless className="backup-date-picker__button--previous">
+						<Button
+							compact
+							borderless
+							className="backup-date-picker__button--previous"
+							aria-label="Go to previous date"
+						>
 							<Gridicon
 								icon="chevron-left"
 								className={ ! canGoToPreviousDate ? 'disabled' : undefined }
@@ -197,7 +202,12 @@ const BackupDatePicker: FC< Props > = ( { selectedDate, onDateChange } ) => {
 								{ nextDisplayDate }
 							</span>
 
-							<Button compact borderless className="backup-date-picker__button--next">
+							<Button
+								compact
+								borderless
+								className="backup-date-picker__button--next"
+								aria-label="Go to next date"
+							>
 								<Gridicon
 									icon="chevron-right"
 									className={ ! canGoToNextDate ? 'disabled' : undefined }

--- a/client/my-sites/backup/backup-date-picker/test/__snapshots__/index.jsx.snap
+++ b/client/my-sites/backup/backup-date-picker/test/__snapshots__/index.jsx.snap
@@ -108,7 +108,7 @@ exports[`BackupDatePicker Shows 'Yesterday' as the previous date if the current 
 `;
 
 exports[`BackupDatePicker Shows month and date for the next date if it's in the same year as today 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="backup-date-picker"
   >
@@ -211,7 +211,7 @@ exports[`BackupDatePicker Shows month and date for the next date if it's in the 
       </button>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`BackupDatePicker Shows month, date, and year for the next date if it's not the same year as today 1`] = `

--- a/client/my-sites/backup/backup-date-picker/test/__snapshots__/index.jsx.snap
+++ b/client/my-sites/backup/backup-date-picker/test/__snapshots__/index.jsx.snap
@@ -1,0 +1,526 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BackupDatePicker Shows 'Yesterday' as the previous date if the current date is today 1`] = `
+<DocumentFragment>
+  <div
+    class="backup-date-picker"
+  >
+    <div
+      class="backup-date-picker__select-date-container"
+    >
+      <div
+        class="backup-date-picker__select-date backup-date-picker__select-date--with-date-calendar-picker"
+      >
+        <div
+          class="backup-date-picker__select-date--previous"
+          role="button"
+          tabindex="0"
+        >
+          <button
+            class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
+            locale="en"
+            type="submit"
+          >
+            <svg
+              class="gridicon gridicons-chevron-left"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="gridicons.svg#gridicons-chevron-left"
+              />
+            </svg>
+          </button>
+          <span
+            class="backup-date-picker__display-date"
+          >
+            Yesterday
+          </span>
+        </div>
+        <div
+          class="backup-date-picker__current-date"
+        >
+          <b>
+            Today
+          </b>
+        </div>
+        <div
+          class="backup-date-picker__select-date--next"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="backup-date-picker__next-date-link"
+          >
+            <span
+              class="backup-date-picker__display-date"
+            >
+              Dec 5
+            </span>
+            <button
+              class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
+              locale="en"
+              type="submit"
+            >
+              <svg
+                class="gridicon gridicons-chevron-right"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="gridicons.svg#gridicons-chevron-right"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="backup-date-picker__date-button-container"
+    >
+      <button
+        class="button backup-date-picker__date-button-button"
+        type="button"
+      >
+        <svg
+          class="gridicon gridicons-calendar"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-calendar"
+          />
+        </svg>
+        Select Date
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BackupDatePicker Shows month and date for the next date if it's in the same year as today 1`] = `
+<DocumentFragment>
+  <div
+    class="backup-date-picker"
+  >
+    <div
+      class="backup-date-picker__select-date-container"
+    >
+      <div
+        class="backup-date-picker__select-date backup-date-picker__select-date--with-date-calendar-picker"
+      >
+        <div
+          class="backup-date-picker__select-date--previous"
+          role="button"
+          tabindex="0"
+        >
+          <button
+            class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
+            locale="en"
+            type="submit"
+          >
+            <svg
+              class="gridicon gridicons-chevron-left"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="gridicons.svg#gridicons-chevron-left"
+              />
+            </svg>
+          </button>
+          <span
+            class="backup-date-picker__display-date"
+          >
+            Yesterday
+          </span>
+        </div>
+        <div
+          class="backup-date-picker__current-date"
+        >
+          <b>
+            Today
+          </b>
+        </div>
+        <div
+          class="backup-date-picker__select-date--next"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="backup-date-picker__next-date-link"
+          >
+            <span
+              class="backup-date-picker__display-date"
+            >
+              Dec 5
+            </span>
+            <button
+              class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
+              locale="en"
+              type="submit"
+            >
+              <svg
+                class="gridicon gridicons-chevron-right"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="gridicons.svg#gridicons-chevron-right"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="backup-date-picker__date-button-container"
+    >
+      <button
+        class="button backup-date-picker__date-button-button"
+        type="button"
+      >
+        <svg
+          class="gridicon gridicons-calendar"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-calendar"
+          />
+        </svg>
+        Select Date
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BackupDatePicker Shows month, date, and year for the next date if it's not the same year as today 1`] = `
+<DocumentFragment>
+  <div
+    class="backup-date-picker"
+  >
+    <div
+      class="backup-date-picker__select-date-container"
+    >
+      <div
+        class="backup-date-picker__select-date backup-date-picker__select-date--with-date-calendar-picker"
+      >
+        <div
+          class="backup-date-picker__select-date--previous"
+          role="button"
+          tabindex="0"
+        >
+          <button
+            class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
+            locale="en"
+            type="submit"
+          >
+            <svg
+              class="gridicon gridicons-chevron-left"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="gridicons.svg#gridicons-chevron-left"
+              />
+            </svg>
+          </button>
+          <span
+            class="backup-date-picker__display-date"
+          >
+            Dec 3, 2018
+          </span>
+        </div>
+        <div
+          class="backup-date-picker__current-date"
+        >
+          <b>
+            Dec 4, 2018
+          </b>
+        </div>
+        <div
+          class="backup-date-picker__select-date--next"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="backup-date-picker__next-date-link"
+          >
+            <span
+              class="backup-date-picker__display-date"
+            >
+              Dec 5, 2018
+            </span>
+            <button
+              class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
+              locale="en"
+              type="submit"
+            >
+              <svg
+                class="gridicon gridicons-chevron-right"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="gridicons.svg#gridicons-chevron-right"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="backup-date-picker__date-button-container"
+    >
+      <button
+        class="button backup-date-picker__date-button-button"
+        type="button"
+      >
+        <svg
+          class="gridicon gridicons-calendar"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-calendar"
+          />
+        </svg>
+        Select Date
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BackupDatePicker Shows month, date, and year for the previous date if it's not the same year as today 1`] = `
+<DocumentFragment>
+  <div
+    class="backup-date-picker"
+  >
+    <div
+      class="backup-date-picker__select-date-container"
+    >
+      <div
+        class="backup-date-picker__select-date backup-date-picker__select-date--with-date-calendar-picker"
+      >
+        <div
+          class="backup-date-picker__select-date--previous"
+          role="button"
+          tabindex="0"
+        >
+          <button
+            class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
+            locale="en"
+            type="submit"
+          >
+            <svg
+              class="gridicon gridicons-chevron-left"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="gridicons.svg#gridicons-chevron-left"
+              />
+            </svg>
+          </button>
+          <span
+            class="backup-date-picker__display-date"
+          >
+            Dec 3, 2019
+          </span>
+        </div>
+        <div
+          class="backup-date-picker__current-date"
+        >
+          <b>
+            Dec 4, 2019
+          </b>
+        </div>
+        <div
+          class="backup-date-picker__select-date--next"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="backup-date-picker__next-date-link"
+          >
+            <span
+              class="backup-date-picker__display-date"
+            >
+              Dec 5, 2019
+            </span>
+            <button
+              class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
+              locale="en"
+              type="submit"
+            >
+              <svg
+                class="gridicon gridicons-chevron-right"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="gridicons.svg#gridicons-chevron-right"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="backup-date-picker__date-button-container"
+    >
+      <button
+        class="button backup-date-picker__date-button-button"
+        type="button"
+      >
+        <svg
+          class="gridicon gridicons-calendar"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-calendar"
+          />
+        </svg>
+        Select Date
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BackupDatePicker Shows only the month and date for the previous date if it's the same year as today 1`] = `
+<DocumentFragment>
+  <div
+    class="backup-date-picker"
+  >
+    <div
+      class="backup-date-picker__select-date-container"
+    >
+      <div
+        class="backup-date-picker__select-date backup-date-picker__select-date--with-date-calendar-picker"
+      >
+        <div
+          class="backup-date-picker__select-date--previous"
+          role="button"
+          tabindex="0"
+        >
+          <button
+            class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
+            locale="en"
+            type="submit"
+          >
+            <svg
+              class="gridicon gridicons-chevron-left"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="gridicons.svg#gridicons-chevron-left"
+              />
+            </svg>
+          </button>
+          <span
+            class="backup-date-picker__display-date"
+          >
+            Nov 3
+          </span>
+        </div>
+        <div
+          class="backup-date-picker__current-date"
+        >
+          <b>
+            Nov 4
+          </b>
+        </div>
+        <div
+          class="backup-date-picker__select-date--next"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="backup-date-picker__next-date-link"
+          >
+            <span
+              class="backup-date-picker__display-date"
+            >
+              Nov 5
+            </span>
+            <button
+              class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
+              locale="en"
+              type="submit"
+            >
+              <svg
+                class="gridicon gridicons-chevron-right"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="gridicons.svg#gridicons-chevron-right"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="backup-date-picker__date-button-container"
+    >
+      <button
+        class="button backup-date-picker__date-button-button"
+        type="button"
+      >
+        <svg
+          class="gridicon gridicons-calendar"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-calendar"
+          />
+        </svg>
+        Select Date
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/client/my-sites/backup/backup-date-picker/test/__snapshots__/index.jsx.snap
+++ b/client/my-sites/backup/backup-date-picker/test/__snapshots__/index.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BackupDatePicker Shows 'Yesterday' as the previous date if the current date is today 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="backup-date-picker"
   >
@@ -17,6 +17,7 @@ exports[`BackupDatePicker Shows 'Yesterday' as the previous date if the current 
           tabindex="0"
         >
           <button
+            aria-label="Go to previous date"
             class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
             locale="en"
             type="submit"
@@ -60,6 +61,7 @@ exports[`BackupDatePicker Shows 'Yesterday' as the previous date if the current 
               Dec 5
             </span>
             <button
+              aria-label="Go to next date"
               class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
               locale="en"
               type="submit"
@@ -102,7 +104,7 @@ exports[`BackupDatePicker Shows 'Yesterday' as the previous date if the current 
       </button>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`BackupDatePicker Shows month and date for the next date if it's in the same year as today 1`] = `
@@ -122,6 +124,7 @@ exports[`BackupDatePicker Shows month and date for the next date if it's in the 
           tabindex="0"
         >
           <button
+            aria-label="Go to previous date"
             class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
             locale="en"
             type="submit"
@@ -165,6 +168,7 @@ exports[`BackupDatePicker Shows month and date for the next date if it's in the 
               Dec 5
             </span>
             <button
+              aria-label="Go to next date"
               class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
               locale="en"
               type="submit"
@@ -211,7 +215,7 @@ exports[`BackupDatePicker Shows month and date for the next date if it's in the 
 `;
 
 exports[`BackupDatePicker Shows month, date, and year for the next date if it's not the same year as today 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="backup-date-picker"
   >
@@ -227,6 +231,7 @@ exports[`BackupDatePicker Shows month, date, and year for the next date if it's 
           tabindex="0"
         >
           <button
+            aria-label="Go to previous date"
             class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
             locale="en"
             type="submit"
@@ -270,6 +275,7 @@ exports[`BackupDatePicker Shows month, date, and year for the next date if it's 
               Dec 5, 2018
             </span>
             <button
+              aria-label="Go to next date"
               class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
               locale="en"
               type="submit"
@@ -312,11 +318,11 @@ exports[`BackupDatePicker Shows month, date, and year for the next date if it's 
       </button>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`BackupDatePicker Shows month, date, and year for the previous date if it's not the same year as today 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="backup-date-picker"
   >
@@ -332,6 +338,7 @@ exports[`BackupDatePicker Shows month, date, and year for the previous date if i
           tabindex="0"
         >
           <button
+            aria-label="Go to previous date"
             class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
             locale="en"
             type="submit"
@@ -375,6 +382,7 @@ exports[`BackupDatePicker Shows month, date, and year for the previous date if i
               Dec 5, 2019
             </span>
             <button
+              aria-label="Go to next date"
               class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
               locale="en"
               type="submit"
@@ -417,11 +425,11 @@ exports[`BackupDatePicker Shows month, date, and year for the previous date if i
       </button>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`BackupDatePicker Shows only the month and date for the previous date if it's the same year as today 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="backup-date-picker"
   >
@@ -437,6 +445,7 @@ exports[`BackupDatePicker Shows only the month and date for the previous date if
           tabindex="0"
         >
           <button
+            aria-label="Go to previous date"
             class="button backup-date-picker__button--previous form-button is-compact is-primary is-borderless"
             locale="en"
             type="submit"
@@ -480,6 +489,7 @@ exports[`BackupDatePicker Shows only the month and date for the previous date if
               Nov 5
             </span>
             <button
+              aria-label="Go to next date"
               class="button backup-date-picker__button--next form-button is-compact is-primary is-borderless"
               locale="en"
               type="submit"
@@ -522,5 +532,5 @@ exports[`BackupDatePicker Shows only the month and date for the previous date if
       </button>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -202,9 +202,7 @@ describe( 'BackupDatePicker', () => {
 		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ () => {} } /> );
 
 		await user.click( screen.getByText( 'Dec 31, 2019' ) );
-		expect( dispatchMock.mock.calls[ 0 ][ 0 ].meta.analytics[ 0 ].payload.name ).toEqual(
-			'calypso_jetpack_backup_date_previous'
-		);
+
 		expect( dispatchMock ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				meta: {
@@ -228,9 +226,6 @@ describe( 'BackupDatePicker', () => {
 		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ () => {} } /> );
 
 		await user.click( screen.getByText( 'Jan 2, 2020' ) );
-		expect( dispatchMock.mock.calls[ 0 ][ 0 ].meta.analytics[ 0 ].payload.name ).toEqual(
-			'calypso_jetpack_backup_date_next'
-		);
 
 		expect( dispatchMock ).toHaveBeenCalledWith(
 			expect.objectContaining( {

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -97,11 +97,11 @@ describe( 'BackupDatePicker', () => {
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const december4Of2020 = moment();
 
-		const { asFragment } = render(
+		const { container } = render(
 			<BackupDatePicker selectedDate={ december4Of2020 } onDateChange={ () => {} } />
 		);
 
-		expect( asFragment() ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( "Does not show the next date as 'Yesterday' even if it is yesterday", () => {

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * Default mock implementations
  */
 const mockUseDispatch = () => () => null;
@@ -28,7 +32,8 @@ jest.mock( '../hooks', () => ( {
 } ) );
 jest.mock( 'calypso/state/selectors/get-rewind-backups' );
 
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useQuery } from 'react-query';
@@ -37,7 +42,6 @@ import BackupDatePicker from '..';
 import { useCanGoToDate } from '../hooks';
 
 const realDateNow = Date.now;
-const getTracksEventName = ( event ) => event.meta.analytics[ 0 ].payload.name;
 
 describe( 'BackupDatePicker', () => {
 	beforeEach( () => {
@@ -55,206 +59,189 @@ describe( 'BackupDatePicker', () => {
 	// --- DATE DISPLAY ---
 
 	test( "Shows 'Yesterday' as the previous date if the current date is today", () => {
+		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
+
 		const today = moment();
-
-		const picker = shallow( <BackupDatePicker selectedDate={ today } onDateChange={ () => {} } /> );
-
-		const previousDate = picker.find(
-			'.backup-date-picker__select-date--previous .backup-date-picker__display-date'
+		const { asFragment } = render(
+			<BackupDatePicker selectedDate={ today } onDateChange={ () => {} } />
 		);
-		expect( previousDate.text() ).toEqual( 'Yesterday' );
+
+		expect( asFragment() ).toMatchSnapshot();
 	} );
 
 	test( "Shows only the month and date for the previous date if it's the same year as today", () => {
 		// Mock the definition of 'now,' so that our test date is always in the same year
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const november4Of2020 = moment().subtract( 1, 'month' );
-		expect( november4Of2020.isSame( moment( '2020-11-04' ), 'day' ) ).toEqual( true );
 
-		const picker = shallow(
+		const { asFragment } = render(
 			<BackupDatePicker selectedDate={ november4Of2020 } onDateChange={ () => {} } />
 		);
 
-		const previousDate = picker.find(
-			'.backup-date-picker__select-date--previous .backup-date-picker__display-date'
-		);
-
-		const expectedText = moment( november4Of2020 ).subtract( 1, 'day' ).format( 'MMM D' );
-		expect( previousDate.text() ).toEqual( expectedText );
+		expect( asFragment() ).toMatchSnapshot();
 	} );
 
 	test( "Shows month, date, and year for the previous date if it's not the same year as today", () => {
+		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const oneYearAgo = moment().subtract( 1, 'year' );
 
-		const picker = shallow(
+		const { asFragment } = render(
 			<BackupDatePicker selectedDate={ oneYearAgo } onDateChange={ () => {} } />
 		);
 
-		const previousDate = picker.find(
-			'.backup-date-picker__select-date--previous .backup-date-picker__display-date'
-		);
-
-		const expectedText = moment( oneYearAgo ).subtract( 1, 'day' ).format( 'MMM D, YYYY' );
-		expect( previousDate.text() ).toEqual( expectedText );
+		expect( asFragment() ).toMatchSnapshot();
 	} );
 
 	test( "Shows month and date for the next date if it's in the same year as today", () => {
 		// Mock the definition of 'now,' so that our test date is always in the same year
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const december4Of2020 = moment();
-		expect( december4Of2020.isSame( moment( '2020-12-04' ), 'day' ) ).toEqual( true );
 
-		const picker = shallow(
+		const { asFragment } = render(
 			<BackupDatePicker selectedDate={ december4Of2020 } onDateChange={ () => {} } />
 		);
 
-		const nextDate = picker.find(
-			'.backup-date-picker__select-date--next .backup-date-picker__display-date'
-		);
-
-		const expectedText = moment( december4Of2020 ).add( 1, 'day' ).format( 'MMM D' );
-		expect( nextDate.text() ).toEqual( expectedText );
+		expect( asFragment() ).toMatchSnapshot();
 	} );
 
 	test( "Does not show the next date as 'Yesterday' even if it is yesterday", () => {
-		const today = moment();
+		const twoDaysBefore = moment().subtract( 2, 'days' );
+		render( <BackupDatePicker selectedDate={ twoDaysBefore } onDateChange={ () => {} } /> );
 
-		const picker = shallow( <BackupDatePicker selectedDate={ today } onDateChange={ () => {} } /> );
-
-		const previousDate = picker.find(
-			'.backup-date-picker__select-date--next .backup-date-picker__display-date'
-		);
-		expect( previousDate.text() ).not.toEqual( 'Yesterday' );
+		expect( screen.queryByText( 'Yesterday' ) ).not.toBeInTheDocument();
 	} );
 
 	test( "Does not show the next date as 'Today', even if it is today", () => {
 		const yesterday = moment().subtract( 1, 'day' );
 
-		const picker = shallow(
-			<BackupDatePicker selectedDate={ yesterday } onDateChange={ () => {} } />
-		);
+		render( <BackupDatePicker selectedDate={ yesterday } onDateChange={ () => {} } /> );
 
-		const previousDate = picker.find(
-			'.backup-date-picker__select-date--next .backup-date-picker__display-date'
-		);
-		expect( previousDate.text() ).not.toEqual( 'Today' );
+		expect( screen.queryByText( 'Today' ) ).not.toBeInTheDocument();
 	} );
 
 	test( "Shows month, date, and year for the next date if it's not the same year as today", () => {
+		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const twoYearsAgo = moment().subtract( 2, 'years' );
 
-		const picker = shallow(
+		const { asFragment } = render(
 			<BackupDatePicker selectedDate={ twoYearsAgo } onDateChange={ () => {} } />
 		);
 
-		const previousDate = picker.find(
-			'.backup-date-picker__select-date--next .backup-date-picker__display-date'
-		);
-
-		const expectedText = moment( twoYearsAgo ).add( 1, 'day' ).format( 'MMM D, YYYY' );
-		expect( previousDate.text() ).toEqual( expectedText );
+		expect( asFragment() ).toMatchSnapshot();
 	} );
 
 	// --- NAVIGATION ---
 
-	test( 'Navigates backward when the previous date is clicked', () =>
-		new Promise( ( done ) => {
-			const selectedDate = moment( '2020-01-01' );
-			const onDateChange = ( date ) => {
-				expect( date.diff( selectedDate, 'days' ) ).toEqual( -1 );
-				done();
-			};
+	test( 'Navigates backward when the previous date is clicked', async () => {
+		const user = userEvent.setup();
 
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } />
-			);
+		const selectedDate = moment( '2020-01-01' );
+		const onDateChange = jest.fn();
 
-			const button = picker.find( '.backup-date-picker__select-date--previous' );
-			button.simulate( 'click' );
-		} ) );
+		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
 
-	test( 'Navigates forward when the next date is clicked', () =>
-		new Promise( ( done ) => {
-			const selectedDate = moment( '2020-01-01' );
-			const onDateChange = ( date ) => {
-				expect( date.diff( selectedDate, 'days' ) ).toEqual( 1 );
-				done();
-			};
+		const button = screen.getByText( 'Dec 31, 2019' );
+		await user.click( button );
 
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } />
-			);
+		expect( onDateChange ).toHaveBeenCalledWith( selectedDate.subtract( 1, 'day' ) );
+	} );
 
-			const button = picker.find( '.backup-date-picker__select-date--next' );
-			button.simulate( 'click' );
-		} ) );
+	test( 'Navigates forward when the next date is clicked', async () => {
+		const user = userEvent.setup();
 
-	test( 'Navigates backward when the previous date is focused and the spacebar is pressed', () =>
-		new Promise( ( done ) => {
-			const selectedDate = moment( '2020-01-01' );
-			const onDateChange = ( date ) => {
-				expect( date.diff( selectedDate, 'days' ) ).toEqual( -1 );
-				done();
-			};
+		const selectedDate = moment( '2020-01-01' );
+		const onDateChange = jest.fn();
 
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } />
-			);
+		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
 
-			const button = picker.find( '.backup-date-picker__select-date--previous' );
-			button.simulate( 'keydown', { key: ' ' } );
-		} ) );
+		const button = screen.getByText( 'Jan 2, 2020' );
+		await user.click( button );
 
-	test( 'Navigates forward when the next date is focused and the spacebar is pressed', () =>
-		new Promise( ( done ) => {
-			const selectedDate = moment( '2020-01-01' );
-			const onDateChange = ( date ) => {
-				expect( date.diff( selectedDate, 'days' ) ).toEqual( 1 );
-				done();
-			};
+		expect( onDateChange ).toHaveBeenCalledWith( selectedDate.add( 1, 'day' ) );
+	} );
 
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } />
-			);
+	test( 'Navigates backward when the previous date is focused and the spacebar is pressed', async () => {
+		const user = userEvent.setup();
 
-			const button = picker.find( '.backup-date-picker__select-date--next' );
-			button.simulate( 'keydown', { key: ' ' } );
-		} ) );
+		const selectedDate = moment( '2020-01-01' );
+		const onDateChange = jest.fn();
+
+		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
+
+		const button = screen.getAllByRole( 'button' )[ 0 ];
+		button.focus();
+		await user.keyboard( '[Space]' );
+
+		expect( onDateChange ).toHaveBeenCalledWith( selectedDate.subtract( 1, 'day' ) );
+	} );
+
+	test( 'Navigates forward when the next date is focused and the spacebar is pressed', async () => {
+		const user = userEvent.setup();
+
+		const selectedDate = moment( '2020-01-01' );
+		const onDateChange = jest.fn();
+
+		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
+
+		const button = screen.getAllByRole( 'button' )[ 2 ];
+		button.focus();
+		await user.keyboard( '[Space]' );
+
+		expect( onDateChange ).toHaveBeenCalledWith( selectedDate.add( 1, 'day' ) );
+	} );
 
 	// --- ANALYTICS ---
 
-	test( 'Records a Tracks event for backward navigation', () =>
-		new Promise( ( done ) => {
-			const checkPreviousDateTracksEvent = ( event ) => {
-				const name = getTracksEventName( event );
-				expect( name ).toEqual( 'calypso_jetpack_backup_date_previous' );
-				done();
-			};
+	test( 'Records a Tracks event for backward navigation', async () => {
+		const user = userEvent.setup();
+		const selectedDate = moment( '2020-01-01' );
 
-			useDispatch.mockImplementation( () => checkPreviousDateTracksEvent );
+		const dispatchMock = jest.fn();
+		useDispatch.mockImplementation( () => dispatchMock );
 
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ moment() } onDateChange={ () => {} } />
-			);
+		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ () => {} } /> );
 
-			picker.find( '.backup-date-picker__select-date--previous' ).simulate( 'click' );
-		} ) );
+		await user.click( screen.getByText( 'Dec 31, 2019' ) );
+		expect( dispatchMock.mock.calls[ 0 ][ 0 ].meta.analytics[ 0 ].payload.name ).toEqual(
+			'calypso_jetpack_backup_date_previous'
+		);
+		expect( dispatchMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				meta: {
+					analytics: [
+						expect.objectContaining( {
+							payload: expect.objectContaining( { name: 'calypso_jetpack_backup_date_previous' } ),
+						} ),
+					],
+				},
+			} )
+		);
+	} );
 
-	test( 'Records a Tracks event for forward navigation', () =>
-		new Promise( ( done ) => {
-			const checkNextDateTracksEvent = ( event ) => {
-				const name = getTracksEventName( event );
-				expect( name ).toEqual( 'calypso_jetpack_backup_date_next' );
-				done();
-			};
+	test( 'Records a Tracks event for forward navigation', async () => {
+		const user = userEvent.setup();
+		const selectedDate = moment( '2020-01-01' );
 
-			useDispatch.mockImplementation( () => checkNextDateTracksEvent );
+		const dispatchMock = jest.fn();
+		useDispatch.mockImplementation( () => dispatchMock );
 
-			const sometimeInThePast = moment().subtract( 1, 'year' );
-			const picker = shallow(
-				<BackupDatePicker selectedDate={ sometimeInThePast } onDateChange={ () => {} } />
-			);
+		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ () => {} } /> );
 
-			picker.find( '.backup-date-picker__select-date--next' ).simulate( 'click' );
-		} ) );
+		await user.click( screen.getByText( 'Jan 2, 2020' ) );
+		expect( dispatchMock.mock.calls[ 0 ][ 0 ].meta.analytics[ 0 ].payload.name ).toEqual(
+			'calypso_jetpack_backup_date_next'
+		);
+
+		expect( dispatchMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				meta: {
+					analytics: [
+						expect.objectContaining( {
+							payload: expect.objectContaining( { name: 'calypso_jetpack_backup_date_next' } ),
+						} ),
+					],
+				},
+			} )
+		);
+	} );
 } );

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -62,11 +62,11 @@ describe( 'BackupDatePicker', () => {
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 
 		const today = moment();
-		const { asFragment } = render(
+		const { container } = render(
 			<BackupDatePicker selectedDate={ today } onDateChange={ () => {} } />
 		);
 
-		expect( asFragment() ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( "Shows only the month and date for the previous date if it's the same year as today", () => {
@@ -74,22 +74,22 @@ describe( 'BackupDatePicker', () => {
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const november4Of2020 = moment().subtract( 1, 'month' );
 
-		const { asFragment } = render(
+		const { container } = render(
 			<BackupDatePicker selectedDate={ november4Of2020 } onDateChange={ () => {} } />
 		);
 
-		expect( asFragment() ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( "Shows month, date, and year for the previous date if it's not the same year as today", () => {
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const oneYearAgo = moment().subtract( 1, 'year' );
 
-		const { asFragment } = render(
+		const { container } = render(
 			<BackupDatePicker selectedDate={ oneYearAgo } onDateChange={ () => {} } />
 		);
 
-		expect( asFragment() ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( "Shows month and date for the next date if it's in the same year as today", () => {
@@ -123,11 +123,11 @@ describe( 'BackupDatePicker', () => {
 		Date.now = jest.fn().mockReturnValue( new Date( '2020-12-04T12:00:00.000Z' ) );
 		const twoYearsAgo = moment().subtract( 2, 'years' );
 
-		const { asFragment } = render(
+		const { container } = render(
 			<BackupDatePicker selectedDate={ twoYearsAgo } onDateChange={ () => {} } />
 		);
 
-		expect( asFragment() ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	// --- NAVIGATION ---
@@ -153,8 +153,8 @@ describe( 'BackupDatePicker', () => {
 		const onDateChange = jest.fn();
 
 		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
-
 		const button = screen.getByText( 'Jan 2, 2020' );
+
 		await user.click( button );
 
 		expect( onDateChange ).toHaveBeenCalledWith( selectedDate.add( 1, 'day' ) );
@@ -168,7 +168,8 @@ describe( 'BackupDatePicker', () => {
 
 		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
 
-		const button = screen.getAllByRole( 'button' )[ 0 ];
+		const button = screen.getByRole( 'button', { name: 'Go to previous date' } );
+
 		button.focus();
 		await user.keyboard( '[Space]' );
 
@@ -183,8 +184,9 @@ describe( 'BackupDatePicker', () => {
 
 		render( <BackupDatePicker selectedDate={ selectedDate } onDateChange={ onDateChange } /> );
 
-		const button = screen.getAllByRole( 'button' )[ 2 ];
+		const button = screen.getByRole( 'button', { name: 'Go to next date' } );
 		button.focus();
+
 		await user.keyboard( '[Space]' );
 
 		expect( onDateChange ).toHaveBeenCalledWith( selectedDate.add( 1, 'day' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the following test files to use `@testing-library/react` instead of `enzyme`.

- `client/my-sites/backup/backup-date-picker/test/index.jsx`

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/my-sites/backup/backup-date-picker/test/index.jsx`
