### PR TITLE
Only show the plan navigation bar when there are at least two tabs to navigate

### DIFF
--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -16,7 +16,7 @@ class PlansNavigation extends Component {
 	static propTypes = {
 		isJetpack: PropTypes.bool,
 		path: PropTypes.string.isRequired,
-		shouldShowMyPlan: PropTypes.bool,
+		shouldShowNavigation: PropTypes.bool,
 		site: PropTypes.object,
 	};
 
@@ -36,23 +36,22 @@ class PlansNavigation extends Component {
 	}
 
 	render() {
-		const { site, shouldShowMyPlan, translate } = this.props;
+		const { site, shouldShowNavigation, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = Boolean( site ) && isMobile();
 
 		return (
-			site && (
+			site &&
+			shouldShowNavigation && (
 				<SectionNav hasPinnedItems={ hasPinnedItems } selectedText={ sectionTitle }>
 					<NavTabs label="Section" selectedText={ sectionTitle }>
-						{ shouldShowMyPlan && (
-							<NavItem
-								path={ `/plans/my-plan/${ site.slug }` }
-								selected={ path === '/plans/my-plan' }
-							>
-								{ translate( 'My Plan' ) }
-							</NavItem>
-						) }
+						<NavItem
+							path={ `/plans/my-plan/${ site.slug }` }
+							selected={ path === '/plans/my-plan' }
+						>
+							{ translate( 'My Plan' ) }
+						</NavItem>
 						<NavItem
 							path={ `/plans/${ site.slug }` }
 							selected={
@@ -77,7 +76,7 @@ export default connect( ( state ) => {
 
 	return {
 		isJetpack,
-		shouldShowMyPlan: ! isOnFreePlan || ( isJetpack && ! isAtomic ),
+		shouldShowNavigation: ! isOnFreePlan || ( isJetpack && ! isAtomic ),
 		site,
 	};
 } )( localize( PlansNavigation ) );


### PR DESCRIPTION
#### Proposed Changes

This PR addresses what @ianstewart found, that we show the plan navigation bar even when there is nothing to navigate. In this PR, the bar only shows when both My Plan and Plans tabs are present.

Before:
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/1842898/195260068-bede8d01-6a81-4dbb-a672-2faf4931499a.png">

After:
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/1842898/195260524-e04cd458-9888-4627-801b-0ef2cebfedd0.png">


#### Testing Instructions
1. Logging in and picking a site that has a paid plan, the navigation bar should show.
2. Logging in and picking a site that uses the Free plan, the navigation bar should not show.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
