### PR TITLE
Signup Plans Step: Launch FAQ section as the new control

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -169,23 +169,6 @@ import {
 	FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
 	FEATURE_UNLIMITED_TRAFFIC,
 	FEATURE_MANAGED_HOSTING,
-	/* START - condensed_plan_features_v1 test */
-	FEATURE_HOSTING_TEST,
-	FEATURE_PRIORITY_SUPPORT_TEST,
-	FEATURE_PLUGINS_TEST,
-	FEATURE_SFTP_DATABASE_TEST,
-	FEATURE_FREE_NEWSLETTER_V1,
-	FEATURE_PAID_NEWSLETTER_V1,
-	FEATURE_REPUBLICIZE_V3,
-	FEATURE_MONETISE_V2,
-	FEATURE_EDGE_CACHING_V2,
-	FEATURE_UPLOAD_THEMES_V3,
-	FEATURE_ADVANCED_SEO_EXPANDED_ABBR_V2,
-	FEATURE_SITE_STATS_V2,
-	FEATURE_COLLECT_PAYMENTS_V3,
-	FEATURE_FREE_THEMES_V2,
-	FEATURE_VIDEO_UPLOADS_V2,
-	/* END - condensed_plan_features_v1 test */
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import i18n from 'i18n-calypso';
@@ -1585,105 +1568,6 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
 		getTitle: () => i18n.translate( 'Advanced link in bio themes and customization' ),
 	},
-	/* START - condensed_plan_features_v1 test */
-	[ FEATURE_HOSTING_TEST ]: {
-		getSlug: () => FEATURE_HOSTING_TEST,
-		getTitle: () => i18n.translate( 'Fully managed web hosting & CDN' ),
-		getDescription: () => {},
-	},
-	[ FEATURE_PRIORITY_SUPPORT_TEST ]: {
-		getSlug: () => FEATURE_PRIORITY_SUPPORT_TEST,
-		getTitle: () => '24/7 live chat support',
-		getDescription: () => {},
-	},
-	[ FEATURE_PLUGINS_TEST ]: {
-		getSlug: () => FEATURE_PLUGINS_TEST,
-		getTitle: () => 'Install WordPress plugins',
-		getDescription: () => {},
-	},
-	[ FEATURE_SFTP_DATABASE_TEST ]: {
-		getSlug: () => FEATURE_SFTP_DATABASE_TEST,
-		getTitle: () => 'SFTP and Database Access',
-		getDescription: () => {},
-	},
-	[ FEATURE_FREE_NEWSLETTER_V1 ]: {
-		getSlug: () => FEATURE_FREE_NEWSLETTER_V1,
-		getTitle: () => 'Free newsletter w/ unlimited subscribers.',
-		getDescription: () => {},
-	},
-	[ FEATURE_PAID_NEWSLETTER_V1 ]: {
-		getSlug: () => FEATURE_PAID_NEWSLETTER_V1,
-		getTitle: () => 'Paid newsletter w/ unlimited subscribers.',
-		getDescription: () => {},
-	},
-	[ FEATURE_REPUBLICIZE_V3 ]: {
-		getSlug: () => FEATURE_REPUBLICIZE,
-		getTitle: () => 'Advanced social media tools',
-		getDescription: () => {},
-	},
-	[ FEATURE_MONETISE_V2 ]: {
-		getSlug: () => FEATURE_MONETISE,
-		getTitle: () => 'Earn money from ads',
-		getDescription: () => {},
-	},
-	[ FEATURE_UPLOAD_THEMES_V3 ]: {
-		getSlug: () => FEATURE_UPLOAD_THEMES_V3,
-		getTitle: () => 'Upload custom WordPress themes',
-		getDescription: () => {},
-	},
-	[ FEATURE_EDGE_CACHING_V2 ]: {
-		getSlug: () => FEATURE_EDGE_CACHING_V2,
-		getTitle: () => 'High-performance edge caching',
-		getDescription: () => {},
-	},
-	[ FEATURE_ADVANCED_SEO_EXPANDED_ABBR_V2 ]: {
-		getSlug: () => FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
-		getTitle: () => i18n.translate( 'Advanced SEO tools' ),
-		getDescription: () => {},
-	},
-	[ FEATURE_SITE_STATS_V2 ]: {
-		getSlug: () => FEATURE_SITE_STATS,
-		getTitle: () => i18n.translate( 'Built-in site stats' ),
-		getDescription: () => i18n.translate( 'The most important metrics for your site.' ),
-	},
-	[ FEATURE_COLLECT_PAYMENTS_V3 ]: {
-		getSlug: () => FEATURE_COLLECT_PAYMENTS_V2,
-		getTitle: () => i18n.translate( 'Collect payments and donations' ),
-		getDescription: () =>
-			i18n.translate(
-				'Accept payments from credit or debit cards via Stripe. Sell products, collect donations, and set up recurring payments for subscriptions or memberships. {{link}}Learn more{{/link}}.',
-				{
-					components: {
-						link: (
-							<ExternalLink
-								icon
-								href="https://jetpack.com/support/jetpack-blocks/payments-block/"
-							/>
-						),
-					},
-				}
-			),
-	},
-	[ FEATURE_FREE_THEMES_V2 ]: {
-		getSlug: () => FEATURE_FREE_THEMES,
-		getTitle: () => i18n.translate( 'Dozens of free themes and design patterns' ),
-		getDescription: () =>
-			i18n.translate(
-				'Access to a wide range of professional themes ' +
-					"so you can find a design that's just right for your site."
-			),
-	},
-	[ FEATURE_VIDEO_UPLOADS_V2 ]: {
-		getSlug: () => FEATURE_VIDEO_UPLOADS,
-		getTitle: () => i18n.translate( 'High-quality video hosting with VideoPress' ),
-		getDescription: () =>
-			i18n.translate(
-				'The easiest way to upload videos to your website and display them ' +
-					'using a fast, unbranded, customizable player with rich stats.'
-			),
-		getStoreSlug: () => 'videopress',
-	},
-	/* END - condensed_plan_features_v1 test */
 	[ FEATURE_UNLIMITED_TRAFFIC ]: {
 		getSlug: () => FEATURE_UNLIMITED_TRAFFIC,
 		getTitle: () => i18n.translate( 'Unlimited traffic' ),

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -9,7 +9,6 @@ import {
 	isFreePlan,
 	isMonthly,
 	TERM_MONTHLY,
-	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -55,7 +54,7 @@ export class PlanFeaturesComparison extends Component {
 	}
 
 	render() {
-		const { isInSignup, planProperties, translate, isFAQCondensedExperiment } = this.props;
+		const { isInSignup, planProperties, translate } = this.props;
 		const tableClasses = classNames(
 			'plan-features-comparison__table',
 			`has-${ planProperties.length }-cols`
@@ -80,9 +79,7 @@ export class PlanFeaturesComparison extends Component {
 								<tbody>
 									<tr>{ this.renderPlanHeaders() }</tr>
 									<tr>{ this.renderTopButtons() }</tr>
-									{ isFAQCondensedExperiment
-										? this.renderPlanFeatureRowsTest()
-										: this.renderPlanFeatureRows() }
+									{ this.renderPlanFeatureRows() }
 								</tbody>
 							</table>
 						</div>
@@ -219,19 +216,6 @@ export class PlanFeaturesComparison extends Component {
 		} );
 	}
 
-	renderPlanFeatureRowsTest() {
-		return (
-			<>
-				<tr className="plan-features-comparison__row">
-					{ this.renderPlanUniqueFeatureColumnsTest() }
-				</tr>
-				<tr className="plan-features-comparison__row">
-					{ this.renderPlanCommonFeatureColumnsTest() }
-				</tr>
-			</>
-		);
-	}
-
 	renderAnnualPlansFeatureNotice( feature ) {
 		const { translate, isInSignup } = this.props;
 
@@ -301,76 +285,6 @@ export class PlanFeaturesComparison extends Component {
 			);
 		} );
 	}
-
-	renderPlanFeatures( features, planName, mapIndex ) {
-		const { selectedFeature } = this.props;
-
-		return map( features, ( currentFeature, featureIndex ) => {
-			const classes = classNames( '', getPlanClass( planName ), {
-				'is-last-feature': featureIndex + 1 === features.length,
-				'is-highlighted':
-					selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
-				'is-bold': currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN,
-			} );
-
-			if ( currentFeature.isUniqueFeature ) {
-				return (
-					<li key={ `${ currentFeature.getSlug() }-${ featureIndex }` } className={ classes }>
-						{ this.renderFeatureItem( currentFeature, mapIndex ) }
-					</li>
-				);
-			}
-
-			return (
-				<div key={ `${ currentFeature.getSlug() }-${ featureIndex }` } className={ classes }>
-					{ this.renderFeatureItem( currentFeature, mapIndex ) }
-				</div>
-			);
-		} );
-	}
-
-	renderPlanUniqueFeatureColumnsTest() {
-		const { planProperties } = this.props;
-		return map( planProperties, ( properties, mapIndex ) => {
-			const { planName } = properties;
-			const features = properties.features.filter( ( feature ) => feature.isUniqueFeature );
-
-			return (
-				<td
-					key={ `${ planName }-unique-${ mapIndex }` }
-					className="plan-features-comparison__table-item plan-features-comparison__unique-features"
-				>
-					<ul>{ this.renderPlanFeatures( features, planName, mapIndex ) }</ul>
-				</td>
-			);
-		} );
-	}
-
-	renderPlanCommonFeatureColumnsTest() {
-		const { planProperties } = this.props;
-		let previousPlanName = 'Free';
-		let currentPlanName = 'Free';
-
-		return map( planProperties, ( properties, mapIndex ) => {
-			const { planName, planObject } = properties;
-			previousPlanName = currentPlanName;
-			currentPlanName = planObject.product_name_short;
-			const features = properties.features.filter( ( feature ) => ! feature.isUniqueFeature );
-			const planFeatureTitle =
-				mapIndex === 0
-					? `Get basic features with ${ currentPlanName }:`
-					: `Everything in ${ previousPlanName }, plus:`;
-
-			return (
-				<td key={ `${ planName }-${ mapIndex }` } className="plan-features-comparison__table-item">
-					<div className="plan-features-comparison__item plan-features-comparison__common-title is-bold">
-						{ planFeatureTitle }
-					</div>
-					{ this.renderPlanFeatures( features, planName, mapIndex ) }
-				</td>
-			);
-		} );
-	}
 }
 
 PlanFeaturesComparison.propTypes = {
@@ -416,16 +330,8 @@ const hasPlaceholders = ( planProperties ) =>
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 export default connect(
 	( state, ownProps ) => {
-		const {
-			isInSignup,
-			placeholder,
-			plans,
-			isLandingPage,
-			siteId,
-			visiblePlans,
-			popularPlanSpec,
-			isFAQCondensedExperiment,
-		} = ownProps;
+		const { isInSignup, placeholder, plans, isLandingPage, siteId, visiblePlans, popularPlanSpec } =
+			ownProps;
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
 		const flowName = getCurrentFlowName( state );
@@ -459,10 +365,6 @@ export default connect(
 					planFeatures = getPlanFeaturesObject( featureAccessor() );
 				}
 
-				if ( isFAQCondensedExperiment && planConstantObj.getCondensedExperimentFeatures ) {
-					planFeatures = getPlanFeaturesObject( planConstantObj.getCondensedExperimentFeatures() );
-				}
-
 				const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
 				const discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
@@ -491,19 +393,16 @@ export default connect(
 				// This is the per month price of a monthly plan. E.g. $14 for Premium monthly.
 				const rawPriceForMonthlyPlan = getPlanRawPrice( state, monthlyPlanProductId, true );
 				const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
-				const planUniqueFeatures = planConstantObj.getCondensedExperimentUniqueFeatures?.() || [];
 				if ( annualPlansOnlyFeatures.length > 0 ) {
 					planFeatures = planFeatures.map( ( feature ) => {
 						const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
 							feature.getSlug()
 						);
-						const isUniqueFeature = planUniqueFeatures.includes( feature.getSlug() );
 
 						return {
 							...feature,
 							availableOnlyForAnnualPlans,
 							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-							isUniqueFeature,
 						};
 					} );
 				}

--- a/client/my-sites/plan-features-comparison/style.scss
+++ b/client/my-sites/plan-features-comparison/style.scss
@@ -35,26 +35,6 @@ $plan-features-sidebar-width: 272px;
 	padding-top: 8px;
 }
 
-.plan-features-comparison__table-item.plan-features-comparison__unique-features {
-	padding-bottom: 0.5rem;
-	ul {
-		margin-bottom: 0;
-	}
-
-	& .is-last-feature {
-		.plan-features-comparison__item {
-			padding-bottom: 0;
-
-			margin-left: 0;
-			padding-left: 0;
-
-			svg {
-				display: none;
-			}
-		}
-	}
-}
-
 .plan-features-comparison__header {
 	position: relative;
 	display: flex;
@@ -146,7 +126,6 @@ $plan-features-sidebar-width: 272px;
 		background-color: var(--color-surface);
 		position: relative;
 
-		.is-bold,
 		&.is-bold {
 			font-weight: bold;
 		}
@@ -326,10 +305,6 @@ $plan-features-sidebar-width: 272px;
 
 		.plan-features-comparison__item-cross {
 			fill: #a7aaad;
-		}
-
-		&.is-bold {
-			font-weight: bold;
 		}
 	}
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -1,4 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	findPlansKeys,
@@ -117,7 +117,6 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isReskinned,
-			isFAQCondensedExperiment,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -158,7 +157,6 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 					isReskinned={ isReskinned }
-					isFAQCondensedExperiment={ isFAQCondensedExperiment }
 				/>
 			</div>
 		);
@@ -460,17 +458,21 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	mayRenderFAQ() {
-		const { isInSignup, titanMonthlyRenewalCost, isFAQExperiment, showFAQ } = this.props;
-
-		if ( isInSignup ) {
-			if ( isFAQExperiment ) {
-				return <PlanFAQ titanMonthlyRenewalCost={ titanMonthlyRenewalCost } />;
-			}
-			return null;
-		}
+		const { isInSignup, titanMonthlyRenewalCost, showFAQ, locale } = this.props;
 
 		if ( ! showFAQ ) {
 			return;
+		}
+
+		if ( isInSignup ) {
+			const isEnglish = config( 'english_locales' ).includes( locale );
+
+			// Remove this check after translations are completed for the PlanFAQ component.
+			if ( ! isEnglish ) {
+				return null;
+			}
+
+			return <PlanFAQ titanMonthlyRenewalCost={ titanMonthlyRenewalCost } />;
 		}
 
 		return <WpcomFAQ />;

--- a/client/my-sites/plans-features-main/plansStepFaq.jsx
+++ b/client/my-sites/plans-features-main/plansStepFaq.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
@@ -19,6 +20,7 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 
 const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 	const onFaqToggle = useCallback(
 		( faqArgs ) => {
 			const { id, isExpanded } = faqArgs;
@@ -42,108 +44,174 @@ const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
 			<FAQHeader className="wp-brand-font">{ 'Frequently Asked Questions' }</FAQHeader>
 			<FoldableFAQ
 				id="faq-1"
-				question={ 'Is hosting included?' }
+				question={ translate( 'Is hosting included?' ) }
 				expanded={ true }
 				onToggle={ onFaqToggle }
 			>
-				Yes! All our plans include fast and reliable hosting that’s optimized for creating and
-				scaling a WordPress site.
+				{ translate(
+					'Yes! All our plans include fast and reliable hosting that’s optimized for creating and scaling a WordPress site.'
+				) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-2"
-				question={ 'Can I import content from another service?' }
+				question={ translate( 'Can I import content from another service?' ) }
 				onToggle={ onFaqToggle }
 			>
-				It is possible to import your blog content from a variety of other blogging platforms,
-				including Blogger, GoDaddy, Wix, Squarespace, and more. You can also easily import your
-				content from a self-hosted WordPress site.
+				{ translate(
+					'It is possible to import your blog content from a variety of other blogging platforms, including Blogger, ' +
+						'GoDaddy, Wix, Squarespace, and more. You can also easily import your content from a self-hosted WordPress site.'
+				) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-3"
-				question={ 'Are traffic and bandwidth really unlimited?' }
+				question={ translate( 'Are traffic and bandwidth really unlimited?' ) }
 				onToggle={ onFaqToggle }
 			>
-				Absolutely, and you will never be hit with any surprise usage fees. With WordPress.com,
-				you’ll be hosted on our infinitely scalable and globally distributed server infrastructure,
-				which means your site will always be available and load fast, no matter how popular your
-				site becomes.
+				{ translate(
+					'Absolutely, and you will never be hit with any surprise usage fees. With WordPress.com, ' +
+						'you’ll be hosted on our infinitely scalable and globally distributed server infrastructure, ' +
+						'which means your site will always be available and load fast, no matter how popular your site becomes.'
+				) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-4"
-				question={ 'Can I use a domain I already own?' }
+				question={ translate( 'Can I use a domain I already own?' ) }
 				onToggle={ onFaqToggle }
 			>
-				Yes! You can connect your domain for free to any WordPress.com paid plan (we won’t charge
-				you a separate domain registration fee). You may either keep the domain at your current
-				registrar or transfer it to us, whichever you prefer.
+				{ translate(
+					'Yes! You can connect your domain for free to any WordPress.com paid plan (we won’t charge ' +
+						'you a separate domain registration fee). You may either keep the domain at your current ' +
+						'registrar or transfer it to us, whichever you prefer.'
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-5" question={ 'Can I host multiple sites?' } onToggle={ onFaqToggle }>
-				Yes, you can host as many sites as you like, but they each need a separate plan. You can
-				choose the appropriate plan for each site individually so you’ll pay for only the features
-				you need. <br /> <br />
-				We have a dashboard that helps you manage all your WordPress.com and Jetpack-connected
-				websites, all from one simple and centralized admin tool.
+			<FoldableFAQ
+				id="faq-5"
+				question={ translate( 'Can I host multiple sites?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					'Yes, you can host as many sites as you like, but they each need a separate plan. You can ' +
+						'choose the appropriate plan for each site individually so you’ll pay for only the features ' +
+						'you need.{{br /}}{{br /}}We have a dashboard that helps you manage all your WordPress.com and Jetpack-connected ' +
+						'websites, all from one simple and centralized admin tool.',
+					{
+						components: { br: <br /> },
+					}
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-6" question={ 'What is your refund policy?' } onToggle={ onFaqToggle }>
-				If you aren't satisfied with our product, you can cancel anytime within the refund period
-				for a prompt and courteous refund, no questions asked. The refund timeframes are:{ ' ' }
-				<ul>
-					<li>14 days for annual WordPress.com plans</li>
-					<li>7 days for monthly WordPress.com plans</li>
-					<li>96 hours for new domain registrations</li>
-				</ul>
+			<FoldableFAQ
+				id="faq-6"
+				question={ translate( 'What is your refund policy?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					"If you aren't satisfied with our product, you can cancel anytime within the refund period " +
+						'for a prompt and courteous refund, no questions asked. The refund timeframes are:{{br /}}' +
+						'{{ul}}' +
+						'{{li}}14 days for annual WordPress.com plans{{/li}}' +
+						'{{li}}7 days for monthly WordPress.com plans{{/li}}' +
+						'{{li}}96 hours for new domain registrations{{/li}}' +
+						'{{/ul}}',
+					{
+						components: { br: <br />, ul: <ul />, li: <li /> },
+					}
+				) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-7"
-				question={ 'I want to transfer an existing site, will purchasing a plan now break it?' }
+				question={ translate(
+					'I want to transfer an existing site, will purchasing a plan now break it?'
+				) }
 				onToggle={ onFaqToggle }
 			>
-				No it won’t! You’re welcome to create your new site with us before pointing the domain here.
-				That way your current site can stay “live” until your new one is ready.
-				<br /> <br />
-				We recommend getting a plan now because they have other features you might find useful,
-				including direct live chat and email support. Just avoid using the domain options until
-				you’re ready, and then you can connect or transfer the domain.
+				{ translate(
+					'No it won’t! You’re welcome to create your new site with us before pointing the domain here. ' +
+						'That way your current site can stay “live” until your new one is ready.{{br /}}{{br /}}' +
+						'We recommend getting a plan now because they have other features you might find useful, ' +
+						'including direct live chat and email support. Just avoid using the domain options until ' +
+						'you’re ready, and then you can connect or transfer the domain.',
+					{
+						components: { br: <br /> },
+					}
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-8" question={ 'Can I get an email account?' } onToggle={ onFaqToggle }>
-				Absolutely! We offer a few different options to meet your needs. For most customers, our
-				Professional Email service is the smart choice. This robust hosted email solution is
-				available for any domain hosted with WordPress.com and starts at just{ ' ' }
-				{ titanMonthlyRenewalCost }/mo per mailbox.
-				<br /> <br />
-				We also offer a Google Workspace integration, and for users who need something simpler, you
-				can set up email forwarding for free.
+			<FoldableFAQ
+				id="faq-8"
+				question={ translate( 'Can I get an email account?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					'Absolutely! We offer a few different options to meet your needs. For most customers, our ' +
+						'Professional Email service is the smart choice. This robust hosted email solution is ' +
+						'available for any domain hosted with WordPress.com and starts at just %(titanMonthlyRenewalCost)s/mo per mailbox.{{br /}}{{br /}}' +
+						'We also offer a Google Workspace integration, and for users who need something simpler, you ' +
+						'can set up email forwarding for free.',
+					{
+						components: { br: <br /> },
+						args: { titanMonthlyRenewalCost },
+					}
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-9" question={ 'Can I install plugins?' } onToggle={ onFaqToggle }>
-				Yes! When you subscribe to the WordPress.com Business or eCommerce plans, you’ll be able to
-				search for and install over 50,000 available plugins in the WordPress repository.
+			<FoldableFAQ
+				id="faq-9"
+				question={ translate( 'Can I install plugins?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					'Yes! When you subscribe to the WordPress.com Business or eCommerce plans, you’ll be able to ' +
+						'search for and install over 50,000 available plugins in the WordPress repository.'
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-10" question={ 'Can I install my own theme?' } onToggle={ onFaqToggle }>
-				Yes! All plans give you access to our directory of free and premium themes that have been
-				handpicked and reviewed for quality by our team. With the WordPress.com Business or
-				eCommerce plan, you can upload and install any theme you'd like.
+			<FoldableFAQ
+				id="faq-10"
+				question={ translate( 'Can I install my own theme?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					'Yes! All plans give you access to our directory of free and premium themes that have been ' +
+						'handpicked and reviewed for quality by our team. With the WordPress.com Business or ' +
+						"eCommerce plan, you can upload and install any theme you'd like."
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-11" question={ 'Can you build a site for me?' } onToggle={ onFaqToggle }>
-				We sure can! If you need a hand launching your website, take a look at Built By
-				WordPress.com Express, our white glove site setup service. Our in-house experts will create
-				your site, and you’ll be ready to go live in four business days or less. To learn more,{ ' ' }
-				<ExternalLinkWithTracking
-					icon={ true }
-					href="https://wordpress.com/do-it-for-me/"
-					tracksEventName="calypso_signup_step_plans_faq_difm_lp"
-				>
-					click here
-				</ExternalLinkWithTracking>
-				.
+			<FoldableFAQ
+				id="faq-11"
+				question={ translate( 'Can you build a site for me?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					'We sure can! If you need a hand launching your website, take a look at Built By ' +
+						'WordPress.com Express, our white glove site setup service. Our in-house experts will create ' +
+						'your site, and you’ll be ready to go live in four business days or less. ' +
+						'To learn more, {{ExternalLinkWithTracking}}click here{{/ExternalLinkWithTracking}}.',
+					{
+						components: {
+							ExternalLinkWithTracking: (
+								<ExternalLinkWithTracking
+									icon={ true }
+									href="https://wordpress.com/do-it-for-me/"
+									tracksEventName="calypso_signup_step_plans_faq_difm_lp"
+								/>
+							),
+						},
+					}
+				) }
 			</FoldableFAQ>
-			<FoldableFAQ id="faq-12" question={ 'Can I talk to a live person?' } onToggle={ onFaqToggle }>
-				We’d love to chat with you! All paid plans include access to one-on-one support from our
-				team of WordPress experts (we call them Happiness Engineers). The Personal plan includes
-				email support while the Premium plan and above all include live chat support.
-				<br /> <br />
-				If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan
-				that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer”
-				link on the next page.
+			<FoldableFAQ
+				id="faq-12"
+				question={ translate( 'Can I talk to a live person?' ) }
+				onToggle={ onFaqToggle }
+			>
+				{ translate(
+					'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
+						'team of WordPress experts (we call them Happiness Engineers). The Personal plan includes ' +
+						'email support while the Premium plan and above all include live chat support.{{br /}}{{br /}}' +
+						'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
+						'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
+						'link on the next page.',
+					{
+						components: { br: <br /> },
+					}
+				) }
 			</FoldableFAQ>
 		</div>
 	);

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -24,7 +24,6 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import wp from 'calypso/lib/wp';
 import PlansComparison, {
@@ -183,7 +182,6 @@ export class PlansStep extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 			eligibleForProPlan,
-			locale,
 		} = this.props;
 
 		let errorDisplay;
@@ -228,51 +226,25 @@ export class PlansStep extends Component {
 		return (
 			<div>
 				{ errorDisplay }
-				<ProvideExperimentData
-					name="calypso_signup_plans_step_faq_202209_v2"
-					options={ {
-						isEligible:
-							[ 'en-gb', 'en' ].includes( locale ) &&
-							'onboarding' === flowName &&
-							this.state.isDesktop,
-					} }
-				>
-					{ ( isLoading, experimentAssignment ) => {
-						if ( isLoading ) {
-							return this.renderLoading();
-						}
-
-						return (
-							<PlansFeaturesMain
-								site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-								hideFreePlan={ hideFreePlan }
-								isInSignup={ true }
-								isLaunchPage={ isLaunchPage }
-								intervalType={ this.getIntervalType() }
-								onUpgradeClick={ this.onSelectPlan }
-								showFAQ={ false }
-								domainName={ this.getDomainName() }
-								customerType={ this.getCustomerType() }
-								disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-								plansWithScroll={ this.state.isDesktop }
-								planTypes={ planTypes }
-								flowName={ flowName }
-								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-								isAllPaidPlansShown={ true }
-								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-								isReskinned={ isReskinned }
-								isFAQCondensedExperiment={
-									experimentAssignment?.variationName === 'treatment_condensed'
-								}
-								isFAQExperiment={
-									experimentAssignment?.variationName === 'treatment_expanded' ||
-									experimentAssignment?.variationName === 'treatment_condensed'
-								}
-							/>
-						);
-					} }
-				</ProvideExperimentData>
+				<PlansFeaturesMain
+					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+					hideFreePlan={ hideFreePlan }
+					isInSignup={ true }
+					isLaunchPage={ isLaunchPage }
+					intervalType={ this.getIntervalType() }
+					onUpgradeClick={ this.onSelectPlan }
+					domainName={ this.getDomainName() }
+					customerType={ this.getCustomerType() }
+					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+					plansWithScroll={ this.state.isDesktop }
+					planTypes={ planTypes }
+					flowName={ flowName }
+					showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+					isAllPaidPlansShown={ true }
+					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+					isReskinned={ isReskinned }
+				/>
 			</div>
 		);
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -228,6 +228,7 @@ export class PlansStep extends Component {
 				{ errorDisplay }
 				<PlansFeaturesMain
 					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+					showFAQ={ this.state.isDesktop && ! this.isTailoredFlow() }
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
@@ -349,9 +350,11 @@ export class PlansStep extends Component {
 
 		return subHeaderText || translate( 'Choose a plan. Upgrade as you grow.' );
 	}
+
 	isTailoredFlow() {
 		return isNewsletterOrLinkInBioFlow( this.props.flowName );
 	}
+
 	plansFeaturesSelection() {
 		const { flowName, stepName, positionInFlow, translate, hasInitializedSitesBackUrl, steps } =
 			this.props;

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -96,24 +96,6 @@ export const FEATURE_SITE_BACKUPS_AND_RESTORE = 'site-backups-and-restore';
 export const FEATURE_SECURITY_SETTINGS = 'security-settings';
 export const FEATURE_WOOP = 'woop';
 export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
-
-//condensed_plan_features_v1 test
-export const FEATURE_HOSTING_TEST = 'hosting-test';
-export const FEATURE_PRIORITY_SUPPORT_TEST = 'priority-support-test';
-export const FEATURE_PLUGINS_TEST = 'plugins-test';
-export const FEATURE_SFTP_DATABASE_TEST = 'sftp-database-test';
-export const FEATURE_FREE_NEWSLETTER_V1 = 'free-newsletter';
-export const FEATURE_PAID_NEWSLETTER_V1 = 'paid-newsletter';
-export const FEATURE_MONETISE_V2 = 'monetize-v2';
-export const FEATURE_REPUBLICIZE_V3 = 'republicize-v3';
-export const FEATURE_UPLOAD_THEMES_V3 = 'upload-themes-v3';
-export const FEATURE_EDGE_CACHING_V2 = 'edge-caching-v2';
-export const FEATURE_ADVANCED_SEO_EXPANDED_ABBR_V2 = 'seo-v2';
-export const FEATURE_SITE_STATS_V2 = 'site-stats-v2';
-export const FEATURE_COLLECT_PAYMENTS_V3 = 'collect-payments-v3';
-export const FEATURE_FREE_THEMES_V2 = 'free-themes-v2';
-export const FEATURE_VIDEO_UPLOADS_V2 = 'video-upload-v2';
-
 // Jetpack features constants
 export const FEATURE_BLANK = 'blank-feature';
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -221,27 +221,10 @@ import {
 	FEATURE_TRACK_VIEWS_CLICKS,
 	FEATURE_LINK_IN_BIO_THEMES_CUSTOMIZATION,
 	FEATURE_REAL_TIME_ANALYTICS,
-	/* START - condensed_plan_features_v1 test */
-	FEATURE_HOSTING_TEST,
-	FEATURE_PRIORITY_SUPPORT_TEST,
-	FEATURE_PLUGINS_TEST,
-	FEATURE_SFTP_DATABASE_TEST,
-	FEATURE_FREE_NEWSLETTER_V1,
-	FEATURE_SITE_STATS_V2,
-	FEATURE_MONETISE_V2,
-	FEATURE_REPUBLICIZE_V3,
-	FEATURE_PAID_NEWSLETTER_V1,
-	FEATURE_EDGE_CACHING_V2,
-	FEATURE_UPLOAD_THEMES_V3,
-	FEATURE_ADVANCED_SEO_EXPANDED_ABBR_V2,
-	FEATURE_COLLECT_PAYMENTS_V3,
-	FEATURE_FREE_THEMES_V2,
-	FEATURE_VIDEO_UPLOADS_V2,
 	JETPACK_TAG_FOR_WOOCOMMERCE_STORES,
 	JETPACK_TAG_FOR_NEWS_ORGANISATIONS,
 	JETPACK_TAG_FOR_MEMBERSHIP_SITES,
 	JETPACK_TAG_FOR_ONLINE_FORUMS,
-	/* END - condensed_plan_features_v1 test */
 } from './constants';
 import type {
 	BillingTerm,
@@ -293,7 +276,6 @@ const getDotcomPlanDetails = () => ( {
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 		FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
-		FEATURE_PRIORITY_SUPPORT_TEST,
 	],
 } );
 
@@ -456,18 +438,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_CUSTOMIZE_THEMES_BUTTONS_COLORS,
 		FEATURE_TRACK_VIEWS_CLICKS,
 	],
-	getCondensedExperimentFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_HOSTING_TEST,
-		FEATURE_UNLIMITED_TRAFFIC,
-		FEATURE_COLLECT_PAYMENTS_V3,
-		FEATURE_SITE_STATS_V2,
-		FEATURE_FREE_THEMES_V2,
-		FEATURE_FREE_NEWSLETTER_V1,
-		FEATURE_EMAIL_SUPPORT_SIGNUP,
-		FEATURE_6GB_STORAGE,
-	],
-	getCondensedExperimentUniqueFeatures: () => [ FEATURE_6GB_STORAGE ],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
 	getInferiorFeatures: () => [],
@@ -570,14 +540,6 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SHIPPING_CARRIERS,
 			PREMIUM_DESIGN_FOR_STORES,
 		].filter( isValueTruthy ),
-	getCondensedExperimentFeatures: () => [
-		FEATURE_ACCEPT_PAYMENTS,
-		FEATURE_SHIPPING_CARRIERS,
-		PREMIUM_DESIGN_FOR_STORES,
-		FEATURE_ECOMMERCE_MARKETING,
-		FEATURE_200GB_STORAGE,
-	],
-	getCondensedExperimentUniqueFeatures: () => [ FEATURE_200GB_STORAGE ],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
@@ -726,18 +688,6 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 			FEATURE_GOOGLE_ANALYTICS,
 		].filter( isValueTruthy ),
-	getCondensedExperimentFeatures: () =>
-		[
-			FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
-			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
-			FEATURE_MONETISE_V2,
-			FEATURE_REPUBLICIZE_V3,
-			FEATURE_PAID_NEWSLETTER_V1,
-			FEATURE_NO_ADS,
-			FEATURE_VIDEO_UPLOADS_V2,
-			FEATURE_13GB_STORAGE,
-		].filter( isValueTruthy ),
-	getCondensedExperimentUniqueFeatures: () => [ FEATURE_13GB_STORAGE ],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
@@ -837,18 +787,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SITE_BACKUPS_AND_RESTORE,
 			FEATURE_SFTP_DATABASE,
 		].filter( isValueTruthy ),
-	getCondensedExperimentFeatures: () =>
-		[
-			FEATURE_PRIORITY_SUPPORT_TEST,
-			FEATURE_PLUGINS_TEST,
-			FEATURE_UPLOAD_THEMES_V3,
-			FEATURE_ADVANCED_SEO_EXPANDED_ABBR_V2,
-			FEATURE_SITE_BACKUPS_AND_RESTORE,
-			FEATURE_SFTP_DATABASE_TEST,
-			FEATURE_EDGE_CACHING_V2,
-			FEATURE_200GB_STORAGE,
-		].filter( isValueTruthy ),
-	getCondensedExperimentUniqueFeatures: () => [ FEATURE_200GB_STORAGE ],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -123,8 +123,6 @@ export type Plan = BillingTerm & {
 	type: string;
 	availableFor?: ( plan: PlanSlug ) => boolean;
 	getSignupCompareAvailableFeatures?: () => string[];
-	getCondensedExperimentFeatures?: () => string[];
-	getCondensedExperimentUniqueFeatures?: () => string[];
 	getProductId: () => number;
 	getPathSlug?: () => string;
 	getStoreSlug: () => PlanSlug;


### PR DESCRIPTION
#### Proposed Changes

* As discussed in pbxNRc-1YF#comment-3804, this PR launches the FAQ section to the plans step of signup.
* The FAQ section will be launched to EN locale first, and after the translations are complete, I'll follow up with another PR to deploy to all locales.

![calypso localhost_3000_start_plans (2)](https://user-images.githubusercontent.com/1269602/195277617-24299a2b-425a-4f67-8429-a0ceeb239418.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow and verify that you can see the FAQ section in the plans step of the signup flow in desktop viewports.
* Go through a fresh signup flow and verify that there's no FAQ section in the plans step of the signup flow in mobile viewports. Note: Resizing the window at the plans step won't work, you'd have to load the plans step in mobile viewport.
* Verify that Calypso `/plans` is unaffected.
* Verify that the site launch flow has the FAQ section (you'd have to click on "Launch Site" in `My Home` to enter the site launch flow).
* Verify that newsletter and link-in-bio flows are unaffected.
* Verify that the FAQ section does not show in non-EN. I will follow up with another PR after about a week, once the translations are completed, to launch this to all locales.

