### PR TITLE
DIFM: Log media upload errors to logstash

### DIFF
--- a/client/signup/steps/website-content/wordpress-media-upload.tsx
+++ b/client/signup/steps/website-content/wordpress-media-upload.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
@@ -6,6 +7,7 @@ import { MouseEvent, useState } from 'react';
 import placeholder from 'calypso/assets/images/difm/placeholder.svg';
 import FilePicker from 'calypso/components/file-picker';
 import { useAddMedia } from 'calypso/data/media/use-add-media';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { Label, SubLabel } from 'calypso/signup/accordion-form/form-components';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -133,6 +135,18 @@ export function WordpressMediaUpload( {
 			onMediaUploadFailed && onMediaUploadFailed( { mediaIndex } );
 			debug( 'Image upload failed' );
 			debug( e.message );
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: 'BBEX: Image upload failed',
+				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+				blog_id: site?.ID,
+				extra: {
+					filename: file.item( 0 )?.name,
+					filesize: file.item( 0 )?.size,
+					'files-picked': file.length,
+					'error-message': e.message + '; Stack: ' + e.stack,
+				},
+			} );
 		}
 	};
 


### PR DESCRIPTION
#### Proposed Changes

Ref: p1665496540083729-slack-C02KVCAL7GX

Log media upload errors to logstash on the website content step of the DIFM flow.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and complete the purchase.
* On the website content form, simulate an upload error. One way to do this is in the file picker dialog, go to Options and select "All Files". Then select a non-image file.
<img width="626" alt="image" src="https://user-images.githubusercontent.com/5436027/195273621-ebd4a1aa-93c7-4156-81f2-94292594bf00.png">

* Confirm that the network request to `/rest/v1.1/logstash` succeeded. 
* Additional testing instructions at 2ddef-pb/#plain


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
