### PR TITLE
fix like button hover state

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -545,6 +545,28 @@
 			@include hide-content-accessibly();
 		}
 	}
+
+	&:hover,
+	button.is-active,
+	.like-button.is-liked {
+		svg.reader-external path {
+			fill: var(--color-link);
+		}
+
+		svg.reader-comment path,
+		svg.reader-share path {
+			stroke: var(--color-link);
+		}
+		svg.reader-star path {
+			stroke: var(--color-link);
+		}
+	}
+
+	.like-button.is-liked {
+		svg.reader-star path {
+			fill: var(--color-link);
+		}
+	}
 }
 
 // Follow button for stream cards


### PR DESCRIPTION
#### Proposed Changes
It looks like there was a regression in 30a755744d where like button "liked" state is no longer filled in report: p1665525551699339-slack-C03NLNTPZ2T

<img width="192" alt="Screen Shot 2022-10-12 at 6 49 52 pm" src="https://user-images.githubusercontent.com/22446385/195296641-424d32ee-4499-426c-8ce4-f5c4b52d7cde.png">


#### Testing Instructions
* Test like button "liked" state on reader post card view