### PR TITLE
Add support for 2FA in SSH keys form

### DIFF
--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -11,6 +11,8 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { AddSSHKeyForm } from './add-ssh-key-form';
@@ -99,6 +101,7 @@ export const SecuritySSHKey = () => {
 	return (
 		<Main wideLayout className="security">
 			<PageViewTracker path="/me/security/ssh-key" title="Me > SSH Key" />
+			<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
 			<FormattedHeader brandFont headerText={ __( 'Security' ) } align="left" />
 


### PR DESCRIPTION
#### Proposed Changes

In this PR, I'm adding 2FA support for the form that allows managing users' SSH keys.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply patch D89092-code and sandbox the API
2. Start local Calypso
3. Load `/me/security/ssh-key` page
4. Remove the `twostep_auth` cookie using the Application tab in Chrome dev tools
5. Refresh the page
6. Confirm that the 2FA form displayed
7. Authenticate using 2FA
8. Confirm that the 2FA form is gone and that SSH key forms works

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 967-gh-Automattic/dotcom-forge
Fixes 1049-gh-Automattic/dotcom-forge