### PR TITLE
Temporary revert old implementation of paypal express processor.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -6,7 +6,6 @@ import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
-import { addUrlToPendingPageRedirect } from '../lib/pending-page';
 import { createTransactionEndpointCartFromResponseCart } from '../lib/translate-cart';
 import { createWpcomAccountBeforeTransaction } from './create-wpcom-account-before-transaction';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
@@ -44,15 +43,14 @@ export default async function payPalProcessor(
 	// endpoints. Otherwise we may end up with an incorrect URL like
 	// 'http://wordpress.com/checkout?cart=no-user#step2?paypal=ABCDEFG'.
 	currentUrl.hash = '';
+	const successUrl = thankYouUrl.startsWith( 'http' )
+		? thankYouUrl
+		: currentUrl.origin + thankYouUrl;
 	if ( createUserAndSiteBeforeTransaction ) {
 		// It's not clear if this is still required but it may be.
 		currentUrl.searchParams.set( 'cart', 'no-user' );
 	}
 	const cancelUrl = currentUrl.toString();
-	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
-		siteSlug,
-		urlType: 'absolute',
-	} );
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		responseCart,


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
