### PR TITLE
Support filtering by category

### DIFF
--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -1,4 +1,5 @@
 import wpcom from 'calypso/lib/wp';
+import { categories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { RETURNABLE_FIELDS } from './constants';
 import type { SearchParams } from './types';
 
@@ -16,7 +17,11 @@ const SORT_QUERY_MAP = new Map( [
  */
 function mapSortToApiValue( sort: string ) {
 	// Some sorts don't need to be mapped
-	if ( [ 'price_asc', 'price_desc', 'rating_desc' ].includes( sort ) ) {
+	if (
+		[ 'price_asc', 'price_desc', 'rating_desc', 'active_installs', 'plugin_modified' ].includes(
+			sort
+		)
+	) {
 		return sort;
 	}
 
@@ -32,6 +37,7 @@ function generateApiQueryString( {
 	query,
 	author,
 	groupId,
+	category,
 	pageHandle,
 	pageSize,
 	locale,
@@ -40,14 +46,16 @@ function generateApiQueryString( {
 
 	const params: {
 		fields: string[];
-		filter?: { bool: { must: object[] } };
+		filter?: { bool: object };
 		page_handle?: string;
 		query: string;
 		sort: string;
 		size: number;
 		group_id: string;
+		category?: string;
 		from?: number;
 		lang: string;
+		track_total_hits: boolean;
 	} = {
 		fields: [ ...RETURNABLE_FIELDS ],
 		page_handle: pageHandle,
@@ -56,10 +64,31 @@ function generateApiQueryString( {
 		size: pageSize,
 		lang: locale,
 		group_id: groupId,
+		track_total_hits: false,
 	};
 
 	if ( author ) {
 		params.filter = getFilterbyAuthor( author );
+	}
+	if ( category ) {
+		switch ( category ) {
+			case 'featured':
+				params.filter = getFilterFeaturedPlugins();
+				break;
+			case 'popular':
+				params.sort = 'active_installs';
+				params.track_total_hits = true;
+				break;
+			case 'new':
+				params.sort = 'date_desc';
+				break;
+			case 'updated':
+				params.sort = 'plugin_modified';
+				break;
+			default:
+				params.filter = getFilterByCategory( category );
+				params.sort = 'active_installs';
+		}
 	}
 
 	return params;
@@ -93,6 +122,33 @@ function getFilterbyAuthor( author: string ): {
 	return {
 		bool: {
 			must: [ { term: { 'plugin.author.raw': author } } ],
+		},
+	};
+}
+
+function getFilterByCategory( category: string ): {
+	bool: object;
+} {
+	const categoryTags = categories[ category ]?.tags;
+
+	return {
+		bool: {
+			should: [
+				{ term: { 'taxonomy.plugin_category.slug': category } },
+				{ terms: { 'taxonomy.plugin_tags.slug': categoryTags } },
+			],
+		},
+	};
+}
+
+function getFilterFeaturedPlugins(): {
+	bool: {
+		must: { term: object }[];
+	};
+} {
+	return {
+		bool: {
+			must: [ { term: { 'taxonomy.plugin_section.slug': 'featured' } } ],
 		},
 	};
 }

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -83,6 +83,7 @@ export type ESDateRangeFilter = { range: Record< string, { gte: string; lt: stri
 export type SearchParams = {
 	query: string | undefined;
 	author: string | undefined;
+	category: string | undefined;
 	groupId: string;
 	pageHandle: string | undefined;
 	pageSize: number;

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -52,7 +52,6 @@ export type ESIndexResult = {
 	'plugin.tested'?: string;
 	'plugin.support_threads'?: number;
 	'plugin.support_threads_resolved'?: number;
-	'plugin.active_installs'?: number;
 	plugin: {
 		author: string;
 		title: string;
@@ -60,6 +59,7 @@ export type ESIndexResult = {
 		icons: string;
 		rating: number;
 		num_ratings: number;
+		active_installs: number;
 	};
 };
 

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -77,7 +77,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			num_ratings: hit.plugin.num_ratings,
 			support_threads: hit[ 'plugin.support_threads' ],
 			support_threads_resolved: hit[ 'plugin.support_threads_resolved' ],
-			active_installs: hit[ 'plugin.active_installs' ],
+			active_installs: hit.plugin.active_installs,
 			last_updated: hit.modified,
 			short_description: hit.plugin.excerpt, // TODO: add localization
 			icon: createIconUrl( hit.slug, hit.plugin.icons ),

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -20,7 +20,9 @@ import type { ESHits, ESResponse, Plugin, PluginQueryOptions, Icon } from './typ
  */
 const createIconUrl = ( pluginSlug: string, icons?: string ): string => {
 	const defaultIconUrl = buildDefaultIconUrl( pluginSlug );
-	if ( ! icons ) return defaultIconUrl;
+	if ( ! icons ) {
+		return defaultIconUrl;
+	}
 
 	let iconsObject: Record< string, Icon > = {};
 	try {
@@ -47,7 +49,9 @@ const createIconUrl = ( pluginSlug: string, icons?: string ): string => {
 		iconByResolution.svg ||
 		iconByResolution.default;
 
-	if ( ! icon ) return defaultIconUrl;
+	if ( ! icon ) {
+		return defaultIconUrl;
+	}
 
 	return buildIconUrl( pluginSlug, icon.location, icon.filename, icon.revision );
 };
@@ -63,7 +67,9 @@ function buildDefaultIconUrl( pluginSlug: string ) {
 const mapStarRatingToPercent = ( starRating?: number ) => ( ( starRating ?? 0 ) / 5 ) * 100;
 
 const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
-	if ( ! results ) return [];
+	if ( ! results ) {
+		return [];
+	}
 	return results.map( ( { fields: hit, railcar } ) => {
 		const plugin: Plugin = {
 			name: hit.plugin.title, // TODO: add localization

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -116,6 +116,7 @@ export const useESPluginsInfinite = (
 				query: searchTerm,
 				author,
 				groupId: 'wporg',
+				category: options.category,
 				pageHandle: pageParam,
 				pageSize,
 				locale: getWpLocaleBySlug( options.locale || locale ),

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -1,4 +1,4 @@
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -33,10 +33,180 @@ export const ALLOWED_CATEGORIES = [
 	'paid',
 ];
 
+export const categories: Record< string, Category > = {
+	discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
+	paid: {
+		name: __( 'Must-have premium plugins' ),
+		description: __( 'Add the best-loved plugins on WordPress.com' ),
+		slug: 'paid',
+		tags: [],
+	},
+	popular: {
+		name: __( 'The free essentials' ),
+		description: __( 'Add and install the very best free plugins' ),
+		slug: 'popular',
+		tags: [],
+	},
+	featured: {
+		name: __( 'Our developers’ favorites' ),
+		description: __( 'Start fast with these WordPress.com team picks' ),
+		slug: 'featured',
+		tags: [],
+	},
+	seo: {
+		name: __( 'Search Engine Optimization' ),
+		description: __( 'Fine-tune your site’s content and metadata for search engine success.' ),
+		icon: 'grid',
+		slug: 'seo',
+		tags: [ 'seo' ],
+	},
+	ecommerce: {
+		name: __( 'Ecommerce & Business' ),
+		description: __( 'Turn your site into a powerful online store.' ),
+		icon: 'grid',
+		slug: 'ecommerce',
+		tags: [ 'ecommerce', 'e-commerce', 'woocommerce', 'business', 'business-directory' ],
+	},
+	booking: {
+		name: __( 'Booking & Scheduling' ),
+		description: __( 'Take bookings and manage your availability right from your site.' ),
+		icon: 'grid',
+		slug: 'booking',
+		tags: [ 'booking', 'scheduling', 'appointment', 'reservation', 'booking-calendar' ],
+	},
+	events: {
+		name: __( 'Events Calendar' ),
+		description: __( 'Build buzz and set the scene with an on-site events calendar.' ),
+		icon: 'grid',
+		slug: 'events',
+		tags: [ 'events-calendar', 'calendar', 'calendar-event' ],
+	},
+
+	social: {
+		name: __( 'Social' ),
+		description: __( 'Connect to your audience and amplify your content on social.' ),
+		icon: 'grid',
+		slug: 'social',
+		tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
+	},
+	email: {
+		name: __( 'Email' ),
+		description: __( 'Forge a direct connection with your readers through email.' ),
+		icon: 'grid',
+		slug: 'email',
+		tags: [ 'email' ],
+	},
+	security: {
+		name: __( 'Security' ),
+		description: __( 'Take advanced control of your site’s security.' ),
+		icon: 'grid',
+		slug: 'security',
+		tags: [ 'security' ],
+	},
+	finance: {
+		name: __( 'Finance & Payments' ),
+		description: __(
+			'Sell products, subscriptions, and services while keeping on top of every transaction.'
+		),
+		icon: 'grid',
+		slug: 'finance',
+		tags: [ 'finance', 'payment', 'credit-card', 'payment-gateway' ],
+	},
+	shipping: {
+		name: __( 'Shipping & Delivery' ),
+		description: __( 'Create a seamless shipping experience with advanced delivery integrations.' ),
+		icon: 'grid',
+		slug: 'shipping',
+		tags: [
+			'shipping',
+			'usps',
+			'woocommerce-shipping',
+			'delivery',
+			'shipment-tracking',
+			'food-delivery',
+			'food-pickup',
+			'courier',
+		],
+	},
+	analytics: {
+		name: __( 'Analytics' ),
+		description: __( 'Go deeper and learn faster with site visitor and performance insights.' ),
+		icon: 'grid',
+		slug: 'analytics',
+		tags: [ 'analytics' ],
+	},
+	marketing: {
+		name: __( 'Marketing' ),
+		description: __( 'Bring in new business and shine a spotlight on your projects or products.' ),
+		icon: 'grid',
+		slug: 'marketing',
+		tags: [ 'marketing' ],
+	},
+	design: {
+		name: __( 'Design' ),
+		description: __( 'Finesse your site’s design with advanced customization tools.' ),
+		icon: 'grid',
+		slug: 'design',
+		tags: [ 'design', 'blocks', 'editor' ],
+	},
+	photo: {
+		name: __( 'Photo & Video' ),
+		description: __(
+			'Create, share, edit, and manage beautiful images and video {with added precision and flexibility.'
+		),
+		icon: 'grid',
+		slug: 'photo',
+		tags: [ 'photo', 'video', 'media' ],
+	},
+	customer: {
+		name: __( 'CRM & Live Chat' ),
+		description: __( 'Create stand-out customer service experiences for your site visitors.' ),
+		icon: 'grid',
+		slug: 'customer',
+		tags: [ 'customer-service', 'live-chat', 'crm' ],
+	},
+	donations: {
+		name: __( 'Crowdfunding' ),
+		description: __( 'Launch and run crowdfunding campaigns right from your site.' ),
+		icon: 'grid',
+		slug: 'donations',
+		tags: [
+			'donation',
+			'donation-plugin',
+			'donations',
+			'donate',
+			'fundraising',
+			'crowdfunding',
+			'recurring-donations',
+			'charity',
+		],
+	},
+	education: {
+		name: __( 'Learning Management Systems' ),
+		description: __( 'Create, run, and manage interactive courses and learning experiences.' ),
+		icon: 'grid',
+		slug: 'education',
+		tags: [ 'education', 'lms', 'learning-management-systems', 'elearning' ],
+	},
+	widgets: {
+		name: __( 'Widgets' ),
+		description: __( 'Take widgets to the next level with advanced control and customization.' ),
+		icon: 'grid',
+		slug: 'widgets',
+		tags: [ 'widgets' ],
+	},
+	posts: {
+		name: __( 'Posts & Posting' ),
+		description: __( 'Unlock advanced content planning, publishing, and scheduling features.' ),
+		icon: 'grid',
+		slug: 'posts',
+		tags: [ 'posts', 'post', 'page', 'pages' ],
+	},
+};
+
 export function useCategories(
 	allowedCategories = ALLOWED_CATEGORIES
 ): Record< string, Category > {
-	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	const isJetpack = useSelector(
@@ -50,181 +220,6 @@ export function useCategories(
 	if ( isJetpack && allowed.indexOf( 'paid' ) >= 0 ) {
 		allowed.splice( allowed.indexOf( 'paid' ), 1 );
 	}
-
-	const categories = {
-		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
-		paid: {
-			name: __( 'Must-have premium plugins' ),
-			description: __( 'Add the best-loved plugins on WordPress.com' ),
-			slug: 'paid',
-			tags: [],
-		},
-		popular: {
-			name: __( 'The free essentials' ),
-			description: __( 'Add and install the very best free plugins' ),
-			slug: 'popular',
-			tags: [],
-		},
-		featured: {
-			name: __( 'Our developers’ favorites' ),
-			description: __( 'Start fast with these WordPress.com team picks' ),
-			slug: 'featured',
-			tags: [],
-		},
-		seo: {
-			name: __( 'Search Engine Optimization' ),
-			description: __( 'Fine-tune your site’s content and metadata for search engine success.' ),
-			icon: 'grid',
-			slug: 'seo',
-			tags: [ 'seo' ],
-		},
-		ecommerce: {
-			name: __( 'Ecommerce & Business' ),
-			description: __( 'Turn your site into a powerful online store.' ),
-			icon: 'grid',
-			slug: 'ecommerce',
-			tags: [ 'ecommerce', 'e-commerce', 'woocommerce', 'business', 'business-directory' ],
-		},
-		booking: {
-			name: __( 'Booking & Scheduling' ),
-			description: __( 'Take bookings and manage your availability right from your site.' ),
-			icon: 'grid',
-			slug: 'booking',
-			tags: [ 'booking', 'scheduling', 'appointment', 'reservation', 'booking-calendar' ],
-		},
-		events: {
-			name: __( 'Events Calendar' ),
-			description: __( 'Build buzz and set the scene with an on-site events calendar.' ),
-			icon: 'grid',
-			slug: 'events',
-			tags: [ 'events-calendar', 'calendar', 'calendar-event' ],
-		},
-
-		social: {
-			name: __( 'Social' ),
-			description: __( 'Connect to your audience and amplify your content on social.' ),
-			icon: 'grid',
-			slug: 'social',
-			tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
-		},
-		email: {
-			name: __( 'Email' ),
-			description: __( 'Forge a direct connection with your readers through email.' ),
-			icon: 'grid',
-			slug: 'email',
-			tags: [ 'email' ],
-		},
-		security: {
-			name: __( 'Security' ),
-			description: __( 'Take advanced control of your site’s security.' ),
-			icon: 'grid',
-			slug: 'security',
-			tags: [ 'security' ],
-		},
-		finance: {
-			name: __( 'Finance & Payments' ),
-			description: __(
-				'Sell products, subscriptions, and services while keeping on top of every transaction.'
-			),
-			icon: 'grid',
-			slug: 'finance',
-			tags: [ 'finance', 'payment', 'credit-card', 'payment-gateway' ],
-		},
-		shipping: {
-			name: __( 'Shipping & Delivery' ),
-			description: __(
-				'Create a seamless shipping experience with advanced delivery integrations.'
-			),
-			icon: 'grid',
-			slug: 'shipping',
-			tags: [
-				'shipping',
-				'usps',
-				'woocommerce-shipping',
-				'delivery',
-				'shipment-tracking',
-				'food-delivery',
-				'food-pickup',
-				'courier',
-			],
-		},
-		analytics: {
-			name: __( 'Analytics' ),
-			description: __( 'Go deeper and learn faster with site visitor and performance insights.' ),
-			icon: 'grid',
-			slug: 'analytics',
-			tags: [ 'analytics' ],
-		},
-		marketing: {
-			name: __( 'Marketing' ),
-			description: __(
-				'Bring in new business and shine a spotlight on your projects or products.'
-			),
-			icon: 'grid',
-			slug: 'marketing',
-			tags: [ 'marketing' ],
-		},
-		design: {
-			name: __( 'Design' ),
-			description: __( 'Finesse your site’s design with advanced customization tools.' ),
-			icon: 'grid',
-			slug: 'design',
-			tags: [ 'design', 'blocks', 'editor' ],
-		},
-		photo: {
-			name: __( 'Photo & Video' ),
-			description: __(
-				'Create, share, edit, and manage beautiful images and video {with added precision and flexibility.'
-			),
-			icon: 'grid',
-			slug: 'photo',
-			tags: [ 'photo', 'video', 'media' ],
-		},
-		customer: {
-			name: __( 'CRM & Live Chat' ),
-			description: __( 'Create stand-out customer service experiences for your site visitors.' ),
-			icon: 'grid',
-			slug: 'customer',
-			tags: [ 'customer-service', 'live-chat', 'crm' ],
-		},
-		donations: {
-			name: __( 'Crowdfunding' ),
-			description: __( 'Launch and run crowdfunding campaigns right from your site.' ),
-			icon: 'grid',
-			slug: 'donations',
-			tags: [
-				'donation',
-				'donation-plugin',
-				'donations',
-				'donate',
-				'fundraising',
-				'crowdfunding',
-				'recurring-donations',
-				'charity',
-			],
-		},
-		education: {
-			name: __( 'Learning Management Systems' ),
-			description: __( 'Create, run, and manage interactive courses and learning experiences.' ),
-			icon: 'grid',
-			slug: 'education',
-			tags: [ 'education', 'lms', 'learning-management-systems', 'elearning' ],
-		},
-		widgets: {
-			name: __( 'Widgets' ),
-			description: __( 'Take widgets to the next level with advanced control and customization.' ),
-			icon: 'grid',
-			slug: 'widgets',
-			tags: [ 'widgets' ],
-		},
-		posts: {
-			name: __( 'Posts & Posting' ),
-			description: __( 'Unlock advanced content planning, publishing, and scheduling features.' ),
-			icon: 'grid',
-			slug: 'posts',
-			tags: [ 'posts', 'post', 'page', 'pages' ],
-		},
-	};
 
 	return Object.fromEntries(
 		Object.entries( categories ).filter( ( [ key ] ) => allowed.includes( key ) )

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -41,7 +41,9 @@ interface WPCOMResponse {
  * @returns
  */
 function updateWpComRating( plugin: Plugin ) {
-	if ( ! plugin || ! plugin.rating ) return plugin;
+	if ( ! plugin || ! plugin.rating ) {
+		return plugin;
+	}
 
 	plugin.rating *= 20;
 

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -74,10 +74,9 @@ const usePlugins = ( {
 	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
-	const searchHook =
-		isEnabled( 'marketplace-jetpack-plugin-search' ) && search
-			? useESPluginsInfinite
-			: useWPORGInfinitePlugins;
+	const searchHook = isEnabled( 'marketplace-jetpack-plugin-search' )
+		? useESPluginsInfinite
+		: useWPORGInfinitePlugins;
 
 	const { localeSlug = '' } = useTranslate();
 	const wporgPluginsOptions = {


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/68083 had to be reverted because the solution didn't work for categories apart from `popular`, `featured` and `new`. This PR addresses these issues.

#### Proposed Changes

* moves some logic from D87985-code to Calypso
* filters plugins based on both the `plugin_tags` and `plugin_category` taxonomies, this results in more potential results
* https://github.com/Automattic/wp-calypso/pull/68083 has removed category counts from lists, this PR adds these back via `track_total_hits` (WPCOM diff TBD)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Setup
* patch <WPCOM diff> and sandbox `public-api`
* in calypso, visit `/plugins`

#### For each category
* verify that the network request is made to the search API instead of the WP.org API, that based on the categories object, the correct `taxonomy.plugin_tags.slug` and `taxonomy.plugin_category.slug` parameters are passed
* verify that the results count are equal or higher compared to the WP.org API request

#### Verify total hit counts
* Patch D89845-code and sandbox `public-api`
* Visit `/plugins/browse/popular`
* Verify that the result count is higher than 10000

| | Before (WP.org API) | After (Search API) |
| --- | ------ | ----- |
| Request URL | <img width="862" alt="CleanShot 2022-10-13 at 12 55 09@2x" src="https://user-images.githubusercontent.com/11555574/195579005-03c3de3a-e109-4530-9f88-3b97af59e052.png"> | <img width="857" alt="CleanShot 2022-10-13 at 13 03 30@2x" src="https://user-images.githubusercontent.com/11555574/195580376-7d188a3b-91c5-4e44-ab92-0043b4e50485.png"> |
| Request parameters | <img width="862" alt="CleanShot 2022-10-13 at 13 06 24@2x" src="https://user-images.githubusercontent.com/11555574/195580838-294a07db-65e0-4e90-8316-3377cfefd451.png"> | ![CleanShot 2022-10-13 at 13 03 37@2x](https://user-images.githubusercontent.com/11555574/195580335-5db03b5b-33b7-44c1-a4d5-6e68928c4c60.png) | 
| Results count | ![CleanShot 2022-10-13 at 12 55 33@2x](https://user-images.githubusercontent.com/11555574/195579101-efd5b48f-f189-40a1-85aa-32b7fad15eb4.png) | ![CleanShot 2022-10-13 at 13 04 51@2x](https://user-images.githubusercontent.com/11555574/195580561-3a68806c-e5d0-4965-8b48-4776050e19b0.png) | 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Realted to #63167