### PR TITLE
Help Center: remove endpoints from index

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -30,11 +30,10 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base,
 			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_post' ),
-					'permission_callback' => array( $this, 'permission_callback' ),
-				),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_post' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'show_in_index'       => false,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -17,9 +17,8 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 	 * WP_REST_Help_Center_Fetch_Post constructor.
 	 */
 	public function __construct() {
-		$this->namespace                       = 'wpcom/v2';
-		$this->rest_base                       = 'help-center/fetch-post';
-		$this->wpcom_is_site_specific_endpoint = false;
+		$this->namespace = 'help-center';
+		$this->rest_base = '/fetch-post';
 	}
 
 	/**
@@ -28,23 +27,13 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 	public function register_rest_route() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base,
+			$this->rest_base,
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_post' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
-				'show_in_index'       => false,
 			)
 		);
-	}
-
-	/**
-	 * Callback to determine whether the request can proceed.
-	 *
-	 * @return boolean
-	 */
-	public function permission_callback() {
-		return is_user_logged_in();
 	}
 
 	/**
@@ -67,5 +56,14 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -17,9 +17,8 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 	 * WP_REST_Help_Center_Search constructor.
 	 */
 	public function __construct() {
-		$this->namespace                       = 'wpcom/v2';
-		$this->rest_base                       = 'help-center/search';
-		$this->wpcom_is_site_specific_endpoint = false;
+		$this->namespace = 'help-center';
+		$this->rest_base = '/search';
 	}
 
 	/**
@@ -33,7 +32,6 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_search_results' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
-				'show_in_index'       => false,
 				'args'                => array(
 					'query'  => array(
 						'type' => 'string',
@@ -45,15 +43,6 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 				),
 			)
 		);
-	}
-
-	/**
-	 * Callback to determine whether the request can proceed.
-	 *
-	 * @return boolean
-	 */
-	public function permission_callback() {
-		return is_user_logged_in();
 	}
 
 	/**
@@ -82,5 +71,14 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -30,18 +30,17 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base,
 			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_search_results' ),
-					'permission_callback' => array( $this, 'permission_callback' ),
-					'args'                => array(
-						'query'  => array(
-							'type' => 'string',
-						),
-						'locale' => array(
-							'type'    => 'string',
-							'default' => 'en',
-						),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_search_results' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'show_in_index'       => false,
+				'args'                => array(
+					'query'  => array(
+						'type' => 'string',
+					),
+					'locale' => array(
+						'type'    => 'string',
+						'default' => 'en',
 					),
 				),
 			)

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -30,11 +30,10 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/all',
 			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_all_support_eligibility' ),
-					'permission_callback' => array( $this, 'permission_callback' ),
-				),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_all_support_eligibility' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'show_in_index'       => false,
 			)
 		);
 
@@ -42,11 +41,10 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/chat',
 			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_chat_support_eligibility' ),
-					'permission_callback' => array( $this, 'permission_callback' ),
-				),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_chat_support_eligibility' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'show_in_index'       => false,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -17,9 +17,8 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	 * WP_REST_Help_Center_Support_Availability constructor.
 	 */
 	public function __construct() {
-		$this->namespace                       = 'wpcom/v2';
-		$this->rest_base                       = 'help-center/support-availability';
-		$this->wpcom_is_site_specific_endpoint = false;
+		$this->namespace = 'help-center';
+		$this->rest_base = '/support-availability';
 	}
 
 	/**
@@ -33,7 +32,6 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_all_support_eligibility' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
-				'show_in_index'       => false,
 			)
 		);
 
@@ -44,18 +42,23 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_chat_support_eligibility' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
-				'show_in_index'       => false,
 			)
 		);
 	}
 
 	/**
-	 * Callback to determine whether the request can proceed.
+	 * Should return the chat eligibility
 	 *
-	 * @return boolean
+	 * @return WP_REST_Response
 	 */
-	public function permission_callback() {
-		return is_user_logged_in();
+	public function get_chat_support_eligibility() {
+		$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/chat/mine' );
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
 	}
 
 	/**
@@ -86,17 +89,11 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	}
 
 	/**
-	 * Should return the chat eligibility
+	 * Callback to determine whether the request can proceed.
 	 *
-	 * @return WP_REST_Response
+	 * @return boolean
 	 */
-	public function get_chat_support_eligibility() {
-		$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/chat/mine' );
-		if ( is_wp_error( $body ) ) {
-			return $body;
-		}
-		$response = json_decode( wp_remote_retrieve_body( $body ) );
-
-		return rest_ensure_response( $response );
+	public function permission_callback() {
+		return is_user_logged_in();
 	}
 }

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -46,7 +46,7 @@ function fetchForKey( postKey, isHelpCenter = false ) {
 				  } )
 				: apiFetch( {
 						global: true,
-						path: `/wpcom/v2/help-center/fetch-post?post_id=${ encodeURIComponent(
+						path: `/help-center/fetch-post?post_id=${ encodeURIComponent(
 							postKey.postId
 						) }&blog_id=${ encodeURIComponent( postKey.blogId ) }`,
 				  } );

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -26,7 +26,7 @@ export const useHelpSearchQuery = (
 				  } )
 				: apiFetch( {
 						global: true,
-						path: `/wpcom/v2/help-center/search?query=${ search }&locale=${ locale }`,
+						path: `/help-center/search?query=${ search }&locale=${ locale }`,
 				  } as APIFetchOptions ),
 		{
 			onSuccess: async ( data ) => {
@@ -41,7 +41,7 @@ export const useHelpSearchQuery = (
 								  } )
 								: await apiFetch( {
 										global: true,
-										path: `/wpcom/v2/help-center/fetch-post?blog_id=${ result.blog_id }&post_id=${ result.post_id }`,
+										path: `/help-center/fetch-post?blog_id=${ result.blog_id }&post_id=${ result.post_id }`,
 								  } as APIFetchOptions );
 							return { ...result, content: article.content };
 						} )


### PR DESCRIPTION
## Proposed Changes

We are registering the Help Center endpoints to the WPCOM namespace. This would not be a problem if the plugin itself wasn't on WordPress.com. This is making the endpoint available to all WordPress.com which is not necessary.

This changes the namespace to be limited to `/help-center` and updates the uses of it across Help Center.

<img width="791" alt="Markup 2022-10-12 at 13 36 04" src="https://user-images.githubusercontent.com/33258733/195346231-77b1131f-73b6-464d-a76f-1938e7873d32.png">

## Testing Instructions

1. Pull branch and ` cd apps/editing-toolkit/ && yarn dev --sync`
2. Sandbox a test site and launch local calypso
3. Test Help Center in wp-admin and calyspo
4. Specifically browsing articles and opening contact form.