### PR TITLE
Sites Management Page: Improve 'Coming Soon' graphic sizing

### DIFF
--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -1,20 +1,24 @@
 import styled from '@emotion/styled';
 import { __ } from '@wordpress/i18n';
-import { CSSProperties } from 'react';
 
 type Props = {
 	siteName?: string;
 	className?: string;
-	style?: CSSProperties;
 	lang?: string;
+	width: number;
+	height: number;
 };
 
 const Root = styled.div( {
 	display: 'flex',
 	alignItems: 'center',
+	justifyContent: 'center',
 	backgroundColor: '#117ac9',
 	borderRadius: 4,
-	boxSizing: 'border-box',
+	boxSizing: 'content-box',
+	border: '1px solid rgb(238, 238, 238)',
+	position: 'relative',
+	overflow: 'hidden',
 } );
 
 const comingSoonTranslations: Record< string, string > = {
@@ -49,11 +53,17 @@ const getTranslation = ( lang?: string ) => {
 	return text;
 };
 
-export const SiteComingSoon = ( { siteName = '', lang, style }: Props ) => {
+export const SiteComingSoon = ( { siteName = '', className, lang, width, height }: Props ) => {
 	const comingSoon = getTranslation( lang );
 	return (
-		<Root style={ style }>
-			<svg width="100%" viewBox="0 0 375 272" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Root className={ className }>
+			<svg
+				width={ width }
+				height={ height }
+				viewBox="0 0 375 272"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
 				<title>{ comingSoon }</title>
 				<text
 					fill="white"

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -44,7 +44,15 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 			width: props.width || DEFAULT_THUMBNAIL_SIZE.width,
 			height: props.height || DEFAULT_THUMBNAIL_SIZE.height,
 		};
-		return <SiteComingSoon siteName={ site.name } style={ style } lang={ site.lang } />;
+		return (
+			<SiteComingSoon
+				{ ...props }
+				siteName={ site.name }
+				width={ style.width }
+				height={ style.height }
+				lang={ site.lang }
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/68886#issuecomment-1275933666

## Proposed Changes

* Applies some `<SiteThumbnail />` CSS.
* Assigns `width` and `height` to the `<svg>`, to more closely emulate `<img>` behavior.
* Applies the `className` to `<SiteComingSoon />` Root, so `aspect-ratio` is applied.

### Before

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/36432/195350340-3ba25eb4-cc2c-4474-8a2e-676c54b619fb.png">

<img width="674" alt="image" src="https://user-images.githubusercontent.com/36432/195350397-be91a30b-802c-472e-864a-fcad80d0848b.png">


### After

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/36432/195350087-b5de779c-e118-4534-b874-d56270008f67.png">

<img width="599" alt="image" src="https://user-images.githubusercontent.com/36432/195350024-50769d03-38be-4b11-a506-18531173dfc4.png">


## Testing Instructions

1. Navigate to `/sites`.
2. Verify 'Coming Soon' graphic appears as expected.