### PR TITLE
Added track event for Browse all buttons

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -90,6 +90,7 @@ const PluginsBrowserList = ( {
 					subtitle={ subtitle }
 					resultCount={ resultCount }
 					browseAllLink={ browseAllLink }
+					listName={ listName }
 				/>
 			) }
 			{ listName === 'paid' && (

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -1,6 +1,9 @@
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { useSelector } from 'react-redux';
 import { TranslateResult } from 'calypso/../packages/i18n-calypso/types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -10,14 +13,17 @@ export default function PluginsResultsHeader( {
 	subtitle,
 	browseAllLink,
 	resultCount,
+	listName,
 }: {
 	title: TranslateResult;
 	subtitle: TranslateResult;
 	browseAllLink?: string;
 	resultCount?: string;
 	className: string;
+	listName?: string;
 } ) {
 	const { __ } = useI18n();
+	const selectedSite = useSelector( getSelectedSite );
 
 	return (
 		<div className={ classnames( 'plugins-results-header', className ) }>
@@ -30,7 +36,17 @@ export default function PluginsResultsHeader( {
 			{ ( browseAllLink || resultCount ) && (
 				<div className="plugins-results-header__actions">
 					{ browseAllLink && (
-						<a className="plugins-results-header__action" href={ browseAllLink }>
+						<a
+							className="plugins-results-header__action"
+							href={ browseAllLink }
+							onClick={ () => {
+								recordTracksEvent( 'calypso_plugin_browser_all_click', {
+									site: selectedSite?.domain,
+									list_name: listName,
+									blog_id: selectedSite?.ID,
+								} );
+							} }
+						>
 							{ __( 'Browse All' ) }
 						</a>
 					) }


### PR DESCRIPTION
Fix #68944

#### Proposed Changes

* Added track event `calypso_plugin_browser_all_click` for Browse all buttons passing the `list_name`, `site` and `blog_id` as parameters

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* At the Network tab of your dev console, add the event `calypso_plugin_browser_all_click` as a filter for the connections 
* Enter on [/plugins page](http://calypso.localhost:3000/plugins) and click at one of the `Browse All` category buttons
* You should see a new event being fired:

	<img width="1168" alt="image" src="https://user-images.githubusercontent.com/1044309/195376878-ba812bd6-0830-492c-b5b6-5489a4952de9.png">

* After a while, you should see the event at the Tracks Live View page:

	<img width="796" alt="image" src="https://user-images.githubusercontent.com/1044309/195378227-31354337-7743-4049-ac81-d4b64b84ac01.png">


* Make sure the event was correctly registered with a good description

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68944
