### PR TITLE
Reader: fix issue with 404 not found posts showing in search

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -309,7 +309,7 @@ export default class InfiniteList extends Component {
 	}
 
 	boundsForRef = ( ref ) => {
-		if ( ref in this.refs ) {
+		if ( ref in this.refs && ReactDom.findDOMNode( this.refs[ ref ] ) ) {
 			return ReactDom.findDOMNode( this.refs[ ref ] ).getBoundingClientRect();
 		}
 		return null;

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -136,6 +136,7 @@ class SearchStream extends React.Component {
 				source="search"
 				sort={ sortOrder === 'date' ? sortOrder : undefined }
 				railcar={ suggestion.railcar }
+				key={ 'suggestion-' + suggestion.text }
 			/>,
 			', ',
 		] ).slice( 0, -1 );

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -54,7 +54,7 @@ class PostLifecycle extends Component {
 					<PostPlaceholder />
 				</Fragment>
 			);
-		} else if ( post._state === 'error' ) {
+		} else if ( post.is_error ) {
 			return <PostUnavailable post={ post } />;
 		} else if (
 			( ! post.is_external || post.is_jetpack ) &&

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -16,6 +16,8 @@ class PostUnavailable extends PureComponent {
 			return null;
 		}
 
+		const message = error.message || this.props.translate( 'An error occurred loading this post.' );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Card tagName="article" className="reader__card is-error">
@@ -29,7 +31,8 @@ class PostUnavailable extends PureComponent {
 
 				<div className="reader__post-excerpt">
 					<p>
-						{ error.status }: { error.message }
+						{ error.status ? `${ error.status }: ` : null }
+						{ message }
 					</p>
 					{ config.isEnabled( 'reader/full-errors' ) ? (
 						<pre>{ JSON.stringify( this.props.post, null, '  ' ) }</pre>

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -4,22 +4,14 @@ import { localize } from 'i18n-calypso';
 import { PureComponent } from 'react';
 
 class PostUnavailable extends PureComponent {
-	componentDidMount() {
-		this.errors = {
-			unauthorized: this.props.translate(
-				'This is a post on a private site that you’re following, but not currently a member of.' +
-					' ' +
-					'Please request membership to display these posts in Reader.'
-			),
-			default: this.props.translate( 'An error occurred loading this post.' ),
-		};
-	}
-
 	render() {
-		const errorMessage =
-			this.errors[ this.props.post.errorCode || 'default' ] || this.errors.default;
+		const error = this.props.post.error;
 
-		if ( this.props.post.statusCode === 404 ) {
+		if ( ! error ) {
+			return null;
+		}
+
+		if ( error.status === 404 ) {
 			// don't render a card for 404s. These are posts that we once had but were deleted.
 			return null;
 		}
@@ -36,7 +28,7 @@ class PostUnavailable extends PureComponent {
 				</div>
 
 				<div className="reader__post-excerpt">
-					<p>{ errorMessage }</p>
+					<p>{ error.message }</p>
 					{ config.isEnabled( 'reader/full-errors' ) ? (
 						<pre>{ JSON.stringify( this.props.post, null, '  ' ) }</pre>
 					) : null }

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -11,7 +11,7 @@ class PostUnavailable extends PureComponent {
 			return null;
 		}
 
-		if ( error.status === 404 ) {
+		if ( error.status === 404 || error.error === 404 ) {
 			// don't render a card for 404s. These are posts that we once had but were deleted.
 			return null;
 		}
@@ -28,7 +28,9 @@ class PostUnavailable extends PureComponent {
 				</div>
 
 				<div className="reader__post-excerpt">
-					<p>{ error.message }</p>
+					<p>
+						{ error.status }: { error.message }
+					</p>
 					{ config.isEnabled( 'reader/full-errors' ) ? (
 						<pre>{ JSON.stringify( this.props.post, null, '  ' ) }</pre>
 					) : null }


### PR DESCRIPTION
#### Proposed Changes

* Updates the logic of the `PostUnavailable` component to correctly skip posts that are not found.

#### Testing Instructions

Compare this branch with production:

- Go to `/read`
- Click on search and search for `houseofthedragon`
- On production, you will see empty posts that are not found. With this branch you should not see those posts

| **Before** | **After** |
| - | - |
| <img width="735" alt="image" src="https://user-images.githubusercontent.com/1699996/195384086-c2a6f1e7-ee93-4609-ac91-5a81299021f1.png"> | <img width="741" alt="image" src="https://user-images.githubusercontent.com/1699996/195384119-7b9d7112-efbc-4a7f-b582-3fa99921cf46.png"> |


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #68849
