### PR TITLE
Shuffle plugin collections

### DIFF
--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -1,5 +1,6 @@
+import { shuffle } from '@automattic/js-utils';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
@@ -139,17 +140,20 @@ export default function CollectionListView( {
 
 	const collections = useCollections();
 
+	const plugins = useRef< Array< Plugin > >();
+	useEffect( () => {
+		plugins.current = shuffle( collections[ collection ].plugins.slice( 0, 6 ) );
+	}, [] );
+
 	if ( isJetpackSelfHosted ) {
 		return null;
 	}
 
-	const plugins = collections[ collection ].plugins.slice( 0, 6 );
-
 	return (
 		<PluginsBrowserList
 			listName={ 'collection-' + collection }
-			plugins={ plugins }
-			size={ plugins.length }
+			plugins={ plugins.current || [] }
+			size={ plugins.current?.length }
 			title={ collections[ collection ].name }
 			subtitle={ collections[ collection ].description }
 			site={ siteSlug }


### PR DESCRIPTION
#### Proposed Changes

* This diff uses `shuffle` in '@automattic/js-utils' to shuffle the order of the plugins in a collection.
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the PR
* Go to the Plugins Discovery page http://calypso.localhost:3000/plugins/example.wordpress.com
* Observe the order of the plugins in the plugin collection sections.
* Refresh the page and the order of the plugins should change.

![shuffle-collection](https://user-images.githubusercontent.com/140841/195388645-47047d7a-b7b3-4a29-afc5-80e12e08465c.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68947
