### PR TITLE
Improve cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -66,7 +66,7 @@ export const LAST_REASON: CancellationReason = {
 		return translate( 'Another reason…' );
 	},
 	get textPlaceholder() {
-		return translate( 'Can you please specify?' );
+		return translate( 'Why do you want to cancel?' );
 	},
 };
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -683,6 +683,8 @@ class CancelPurchaseForm extends Component {
 	render() {
 		const { isChatActive, isChatAvailable, purchase, site, supportVariation } = this.props;
 		const { surveyStep } = this.state;
+		const shouldShowChatButton =
+			( isChatAvailable || isChatActive ) && supportVariation === SUPPORT_HAPPYCHAT;
 
 		if ( ! surveyStep ) {
 			return null;
@@ -698,17 +700,27 @@ class CancelPurchaseForm extends Component {
 						<BlankCanvas.Header onBackClick={ this.closeDialog }>
 							{ this.getHeaderTitle() }
 							<span className="cancel-purchase-form__site-slug">{ site.slug }</span>
+							{ shouldShowChatButton && (
+								<PrecancellationChatButton
+									icon="chat_bubble"
+									onClick={ this.closeDialog }
+									purchase={ purchase }
+									surveyStep={ surveyStep }
+									atBottom={ false }
+								/>
+							) }
 						</BlankCanvas.Header>
 						<BlankCanvas.Content>{ this.surveyContent() }</BlankCanvas.Content>
 						<BlankCanvas.Footer>
 							<div className="cancel-purchase-form__actions">
 								<div className="cancel-purchase-form__buttons">{ this.renderStepButtons() }</div>
-								{ ( isChatAvailable || isChatActive ) && supportVariation === SUPPORT_HAPPYCHAT && (
+								{ shouldShowChatButton && (
 									<PrecancellationChatButton
 										icon="chat_bubble"
 										onClick={ this.closeDialog }
 										purchase={ purchase }
 										surveyStep={ surveyStep }
+										atBottom={ true }
 									/>
 								) }
 							</div>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -125,6 +125,7 @@ class CancelPurchaseForm extends Component {
 			questionTwoOrder,
 			questionThreeText: '',
 			isSubmitting: false,
+			solution: '',
 			upsell: '',
 			atomicRevertCheckOne: false,
 			atomicRevertCheckTwo: false,
@@ -291,6 +292,7 @@ class CancelPurchaseForm extends Component {
 
 		if ( ! isGSuiteOrGoogleWorkspace( purchase ) ) {
 			this.setState( {
+				solution: '',
 				isSubmitting: true,
 			} );
 
@@ -331,6 +333,7 @@ class CancelPurchaseForm extends Component {
 			this.props.downgradeClick( upsell );
 			this.recordEvent( 'calypso_purchases_downgrade_form_submit' );
 			this.setState( {
+				solution: 'downgrade',
 				isSubmitting: true,
 			} );
 		}
@@ -341,6 +344,7 @@ class CancelPurchaseForm extends Component {
 			this.props.freeMonthOfferClick();
 			this.recordEvent( 'calypso_purchases_free_month_offer_form_submit' );
 			this.setState( {
+				solution: 'free-month-offer',
 				isSubmitting: true,
 			} );
 		}
@@ -529,10 +533,6 @@ class CancelPurchaseForm extends Component {
 		}
 
 		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
-			if ( ! this.state.questionTwoRadio ) {
-				return false;
-			}
-
 			if ( this.state.questionTwoRadio === 'anotherReasonTwo' && ! this.state.questionTwoText ) {
 				return false;
 			}
@@ -545,11 +545,11 @@ class CancelPurchaseForm extends Component {
 
 	getFinalActionText() {
 		const { flowType, translate, disableButtons, purchase } = this.props;
-		const { isSubmitting } = this.state;
+		const { isSubmitting, solution } = this.state;
 		const isRemoveFlow = flowType === CANCEL_FLOW_TYPE.REMOVE;
 		const isCancelling = disableButtons || isSubmitting;
 
-		if ( isCancelling ) {
+		if ( isCancelling && ! solution ) {
 			return isRemoveFlow ? translate( 'Removing…' ) : translate( 'Cancelling…' );
 		}
 
@@ -572,8 +572,8 @@ class CancelPurchaseForm extends Component {
 
 	renderStepButtons = () => {
 		const { translate, disableButtons } = this.props;
-		const { isSubmitting, surveyStep } = this.state;
-		const isCancelling = disableButtons || isSubmitting;
+		const { isSubmitting, surveyStep, solution } = this.state;
+		const isCancelling = ( disableButtons || isSubmitting ) && ! solution;
 
 		const allSteps = this.getAllSurveySteps();
 		const isLastStep = surveyStep === allSteps[ allSteps.length - 1 ];
@@ -605,7 +605,8 @@ class CancelPurchaseForm extends Component {
 				</GutenbergButton>
 				{ surveyStep === UPSELL_STEP && (
 					<UpsellStep.Button
-						disabled={ isSubmitting }
+						disabled={ isCancelling }
+						isBusy={ isSubmitting && solution }
 						siteSlug={ this.props.site.slug }
 						upsell={ this.state.upsell }
 						closeDialog={ this.closeDialog }

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -13,21 +13,12 @@ import {
 import { WPCOM_FEATURES_BACKUPS } from '@automattic/calypso-products/src';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 import { SUPPORT_HAPPYCHAT } from '@automattic/help-center';
-import {
-	Button as GutenbergButton,
-	CheckboxControl,
-	SelectControl,
-	TextareaControl,
-	TextControl,
-} from '@wordpress/components';
+import { Button as GutenbergButton, CheckboxControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component, cloneElement } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
-import pluginsThemesImage from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
-import downgradeImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -53,23 +44,19 @@ import getSiteImportEngine from 'calypso/state/selectors/get-site-import-engine'
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import getSite from 'calypso/state/sites/selectors/get-site';
-import { getCancellationReasons } from './cancellation-reasons';
 import { CANCEL_FLOW_TYPE } from './constants';
 import enrichedSurveyData from './enriched-survey-data';
 import initialSurveyState from './initial-survey-state';
-import isSurveyFilledIn from './is-survey-filled-in';
 import nextStep from './next-step';
 import {
 	cancellationOptionsForPurchase,
 	nextAdventureOptionsForPurchase,
 } from './options-for-product';
 import PrecancellationChatButton from './precancellation-chat-button';
-import BusinessATStep from './step-components/business-at-step';
-import DowngradeStep from './step-components/downgrade-step';
-import FreeMonthOfferStep from './step-components/free-month-offer-step';
-import UpgradeATStep from './step-components/upgrade-at-step';
-import { ATOMIC_REVERT_STEP, FEEDBACK_STEP } from './steps';
-
+import FeedbackStep from './step-components/feedback-step';
+import NextAdventureStep from './step-components/next-adventure-step';
+import UpsellStep from './step-components/upsell-step';
+import { ATOMIC_REVERT_STEP, FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP } from './steps';
 import './style.scss';
 
 class CancelPurchaseForm extends Component {
@@ -91,8 +78,18 @@ class CancelPurchaseForm extends Component {
 	};
 
 	getAllSurveySteps() {
-		if ( this.props.willAtomicSiteRevert ) {
+		const { willAtomicSiteRevert } = this.props;
+
+		if ( willAtomicSiteRevert ) {
 			return [ FEEDBACK_STEP, ATOMIC_REVERT_STEP ];
+		}
+
+		if ( this.state.upsell ) {
+			return [ FEEDBACK_STEP, UPSELL_STEP ];
+		}
+
+		if ( this.state.questionTwoOrder.length ) {
+			return [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
 		}
 
 		return [ FEEDBACK_STEP ];
@@ -227,15 +224,6 @@ class CancelPurchaseForm extends Component {
 		const newState = {
 			...this.state,
 			questionOneText: value,
-		};
-		this.setState( newState );
-	};
-
-	onSelectOneChange = ( optionOrValue ) => {
-		const value = optionOrValue?.value ?? optionOrValue;
-		const newState = {
-			...this.state,
-			questionOneText: value,
 			upsell: this.getUpsellType( value ) || '',
 		};
 		this.setState( newState );
@@ -358,293 +346,6 @@ class CancelPurchaseForm extends Component {
 		}
 	};
 
-	showUpsell = () => {
-		const { isSubmitting, upsell } = this.state;
-
-		if ( ! upsell ) {
-			return null;
-		}
-
-		const {
-			downgradePlanPrice,
-			purchase,
-			site,
-			translate,
-			includedDomainPurchase,
-			cancelBundledDomain,
-		} = this.props;
-
-		const dismissUpsell = () => this.setState( { upsell: '' } );
-
-		const Upsell = ( { actionHref, actionText, actionOnClick, children, image } ) => (
-			<div className="cancel-purchase-form__upsell">
-				<img className="cancel-purchase-form__upsell-image" src={ image } alt="" />
-				<div className="cancel-purchase-form__upsell-description">
-					{ children }
-					<GutenbergButton
-						href={ actionHref }
-						isPrimary
-						onClick={ actionOnClick }
-						disabled={ isSubmitting }
-					>
-						{ actionText }
-					</GutenbergButton>
-					<GutenbergButton onClick={ dismissUpsell }>{ translate( 'Dismiss' ) }</GutenbergButton>
-				</div>
-			</div>
-		);
-
-		switch ( upsell ) {
-			case 'business-atomic':
-				return (
-					<Upsell
-						actionOnClick={ this.closeDialog }
-						actionText={ translate( 'Keep my plan' ) }
-						image={ pluginsThemesImage }
-					>
-						<BusinessATStep />
-					</Upsell>
-				);
-			case 'upgrade-atomic':
-				return (
-					<Upsell
-						actionHref={ `/checkout/${ site.slug }/business?coupon=BIZC25` }
-						actionOnClick={ () =>
-							this.props.recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' )
-						}
-						actionText={ translate( 'Upgrade my site' ) }
-						image={ pluginsThemesImage }
-					>
-						<UpgradeATStep selectedSite={ site } />
-					</Upsell>
-				);
-			case 'downgrade-personal':
-			case 'downgrade-monthly':
-				//test
-				// eslint-disable-next-line no-case-declarations
-				const { precision } = getCurrencyDefaults( purchase.currencyCode );
-				// eslint-disable-next-line no-case-declarations
-				const planCost = parseFloat( downgradePlanPrice ).toFixed( precision );
-
-				return (
-					<Upsell
-						actionOnClick={ () => this.downgradeClick( upsell ) }
-						actionText={
-							upsell === 'downgrade-monthly'
-								? translate( 'Switch to a monthly subscription' )
-								: translate( 'Switch to Personal' )
-						}
-						image={ downgradeImage }
-					>
-						<DowngradeStep
-							currencySymbol={ purchase.currencySymbol }
-							planCost={ planCost }
-							refundAmount={ this.getRefundAmount() }
-							upsell={ upsell }
-							cancelBundledDomain={ cancelBundledDomain }
-							includedDomainPurchase={ includedDomainPurchase }
-						/>
-					</Upsell>
-				);
-			case 'free-month-offer':
-				return (
-					<Upsell
-						actionOnClick={ this.freeMonthOfferClick }
-						actionText={ translate( 'Get a free month' ) }
-						image={ rocketImage }
-					>
-						<FreeMonthOfferStep productSlug={ purchase.productSlug } />
-					</Upsell>
-				);
-			default:
-				return null;
-		}
-	};
-
-	renderQuestionOne = () => {
-		const { translate } = this.props;
-		const { questionOneOrder, questionOneRadio, questionOneText } = this.state;
-		const { productSlug } = this.props.purchase; // Product being cancelled
-		const reasons = getCancellationReasons( questionOneOrder, { productSlug } );
-		const selectedOption = reasons.find( ( { value } ) => value === questionOneRadio );
-
-		return (
-			<div className="cancel-purchase-form__feedback-question">
-				<SelectControl
-					label={ translate( 'Why are you canceling?' ) }
-					value={ questionOneRadio }
-					options={ reasons }
-					onChange={ this.onRadioOneChange }
-				/>
-				{ selectedOption?.textPlaceholder && (
-					<TextControl
-						placeholder={ selectedOption.textPlaceholder }
-						value={ questionOneText }
-						onChange={ this.onTextOneChange }
-					/>
-				) }
-				{ selectedOption?.selectOptions && ! selectedOption?.textPlaceholder && (
-					<SelectControl
-						label={ selectedOption.selectLabel }
-						value={ questionOneText || selectedOption.selectInitialValue || '' }
-						options={ selectedOption.selectOptions }
-						onChange={ this.onSelectOneChange }
-					/>
-				) }
-				{ this.showUpsell() }
-			</div>
-		);
-	};
-
-	renderQuestionTwo = () => {
-		const { translate } = this.props;
-		const { questionTwoOrder, questionTwoRadio, questionTwoText } = this.state;
-
-		if ( questionTwoOrder.length === 0 ) {
-			return null;
-		}
-
-		const options = [
-			{
-				value: 'stayingHere',
-				label: translate( "I'm staying here and using the free plan." ),
-			},
-			{
-				value: 'otherWordPress',
-				label: translate( "I'm going to use WordPress somewhere else." ),
-				textPlaceholder: translate( 'Mind telling us where?' ),
-			},
-			{
-				value: 'differentService',
-				label: translate( "I'm going to use a different service for my website or blog." ),
-				textPlaceholder: translate( 'Mind telling us which one?' ),
-			},
-			{
-				value: 'noNeed',
-				label: translate( 'I no longer need a website or blog.' ),
-				textPlaceholder: translate( 'What will you do instead?' ),
-			},
-			{
-				value: 'otherPlugin',
-				label: translate( 'I found a better plugin or service.' ),
-				textPlaceholder: translate( 'Mind telling us which one(s)?' ),
-			},
-			{
-				value: 'leavingWP',
-				label: translate( "I'm moving my site off of WordPress." ),
-				textPlaceholder: translate( 'Any particular reason(s)?' ),
-			},
-			{
-				value: 'anotherReasonTwo',
-				label: translate( 'Another reason…' ),
-				textPlaceholder: translate( 'Can you please specify?' ),
-			},
-			{
-				value: '',
-				label: translate( 'Select an answer' ),
-			},
-		];
-
-		const optionKeys = [ ...questionTwoOrder ];
-		optionKeys.unshift( '' ); // Placeholder.
-
-		const selectedOption = options.find( ( option ) => option.value === questionTwoRadio );
-
-		return (
-			<div className="cancel-purchase-form__feedback-question">
-				<SelectControl
-					label={ translate( 'Where is your next adventure taking you?' ) }
-					value={ questionTwoRadio }
-					options={ optionKeys.map( ( key ) => {
-						const option = options.find( ( { value } ) => value === key );
-						return {
-							label: option.label,
-							value: option.value,
-							disabled: ! option.value,
-						};
-					} ) }
-					onChange={ this.onRadioTwoChange }
-				/>
-				{ selectedOption?.textPlaceholder && (
-					<TextControl
-						placeholder={ selectedOption.textPlaceholder }
-						value={ questionTwoText }
-						onChange={ this.onTextTwoChange }
-					/>
-				) }
-			</div>
-		);
-	};
-
-	renderImportQuestion = () => {
-		const { translate } = this.props;
-		const { importQuestionRadio } = this.state;
-
-		const options = [
-			{
-				value: 'happy',
-				label: translate( 'I was happy.' ),
-			},
-			{
-				value: 'look',
-				label: translate(
-					'Most of my content was imported, but it was too hard to get things looking right.'
-				),
-			},
-			{
-				value: 'content',
-				label: translate( 'Not enough of my content was imported.' ),
-			},
-			{
-				value: 'functionality',
-				label: translate( "I didn't have the functionality I have on my existing site." ),
-			},
-		];
-
-		// Add placeholder.
-		options.unshift( {
-			value: '',
-			label: translate( 'Select an answer' ),
-		} );
-
-		return (
-			<div className="cancel-purchase-form__feedback-question">
-				<SelectControl
-					label={ translate( 'You imported from another site. How did the import go?' ) }
-					value={ importQuestionRadio }
-					options={ options.map( ( { label, value } ) => ( {
-						label,
-						value,
-						disabled: ! value,
-					} ) ) }
-					onChange={ this.onImportRadioChange }
-				/>
-			</div>
-		);
-	};
-
-	renderFreeformQuestion = () => {
-		const { translate, isImport, purchase } = this.props;
-
-		if ( ! isSurveyFilledIn( this.state, isImport, isPlan( purchase ) ) ) {
-			// Do not display this question unless user has already answered previous questions.
-			return null;
-		}
-
-		return (
-			<div className="cancel-purchase-form__feedback-question">
-				<TextareaControl
-					label={ translate( "What's one thing we could have done better?" ) }
-					value={ this.state.questionThreeText }
-					onChange={ this.onTextThreeChange }
-					placeholder={ translate( 'Optional' ) }
-					name="improvementInput"
-					id="improvementInput"
-				/>
-			</div>
-		);
-	};
-
 	getRefundAmount = () => {
 		const { purchase } = this.props;
 		const { refundOptions, currencyCode } = purchase;
@@ -661,32 +362,41 @@ class CancelPurchaseForm extends Component {
 		const { atomicTransfer, translate, isImport, moment, purchase, site, hasBackupsFeature } =
 			this.props;
 		const { atomicRevertCheckOne, atomicRevertCheckTwo, surveyStep } = this.state;
-		const productName = translate( 'WordPress.com' );
 
 		if ( surveyStep === FEEDBACK_STEP ) {
 			return (
-				<div className="cancel-purchase-form__feedback">
-					<FormattedHeader
-						brandFont
-						headerText={ translate( 'Share your feedback' ) }
-						subHeaderText={ translate(
-							'Before you go, please answer a few quick questions to help us improve %(productName)s.',
-							{
-								args: { productName },
-							}
-						) }
-					/>
-					<div className="cancel-purchase-form__feedback-questions">
-						{ isPlan( purchase ) && (
-							<>
-								{ this.renderQuestionOne() }
-								{ isImport && this.renderImportQuestion() }
-								{ this.renderQuestionTwo() }
-							</>
-						) }
-						{ this.renderFreeformQuestion() }
-					</div>
-				</div>
+				<FeedbackStep
+					purchase={ purchase }
+					isImport={ isImport }
+					cancellationReasonCodes={ this.state.questionOneOrder }
+					onChangeCancellationReason={ this.onRadioOneChange }
+					onChangeCancellationReasonDetails={ this.onTextOneChange }
+					onChangeImportFeedback={ this.onImportRadioChange }
+				/>
+			);
+		}
+
+		if ( surveyStep === UPSELL_STEP ) {
+			return (
+				<UpsellStep
+					purchase={ purchase }
+					site={ site }
+					disabled={ this.state.isSubmitting }
+					downgradePlanPrice={ this.props.downgradePlanPrice }
+					downgradeClick={ this.downgradeClick }
+					cancelBundledDomain={ this.props.cancelBundledDomain }
+				/>
+			);
+		}
+
+		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
+			return (
+				<NextAdventureStep
+					adventureOptions={ this.state.questionTwoOrder }
+					onSelectNextAdventure={ this.onRadioTwoChange }
+					onChangeNextAdventureDetails={ this.onTextTwoChange }
+					onChangeText={ this.onTextThreeChange }
+				/>
 			);
 		}
 
@@ -801,63 +511,90 @@ class CancelPurchaseForm extends Component {
 		this.changeSurveyStep( nextStep );
 	};
 
-	getStepButtons = () => {
-		const { flowType, translate, disableButtons, isImport, purchase } = this.props;
-		const { atomicRevertCheckOne, atomicRevertCheckTwo, isSubmitting, surveyStep } = this.state;
+	canGoNext() {
+		const { surveyStep, isSubmitting } = this.state;
+		const { disableButtons, isImport } = this.props;
+
+		if ( surveyStep === FEEDBACK_STEP ) {
+			if ( isImport && ! this.state.importQuestionRadio ) {
+				return false;
+			}
+
+			return Boolean( this.state.questionOneRadio && this.state.questionOneText );
+		}
+
+		if ( surveyStep === ATOMIC_REVERT_STEP ) {
+			return Boolean( this.state.atomicRevertCheckOne && this.state.atomicRevertCheckTwo );
+		}
+
+		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
+			if ( ! this.state.questionTwoRadio ) {
+				return false;
+			}
+
+			if ( this.state.questionTwoRadio === 'anotherReasonTwo' && ! this.state.questionTwoText ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		return ! disableButtons && ! isSubmitting;
+	}
+
+	getFinalActionText() {
+		const { flowType, translate, disableButtons, purchase } = this.props;
+		const { isSubmitting } = this.state;
+		const isRemoveFlow = flowType === CANCEL_FLOW_TYPE.REMOVE;
+		const isCancelling = disableButtons || isSubmitting;
+
+		if ( isCancelling ) {
+			return isRemoveFlow ? translate( 'Removing…' ) : translate( 'Cancelling…' );
+		}
+
+		if ( isPlan( purchase ) ) {
+			return isRemoveFlow
+				? translate( 'Submit and remove plan' )
+				: translate( 'Submit and cancel plan' );
+		}
+
+		return isRemoveFlow
+			? translate( 'Submit and remove product' )
+			: translate( 'Submit and cancel product' );
+	}
+
+	renderStepButton = () => {
+		const { translate, disableButtons } = this.props;
+		const { isSubmitting, surveyStep } = this.state;
 		const isCancelling = disableButtons || isSubmitting;
 
 		const allSteps = this.getAllSurveySteps();
 		const isLastStep = surveyStep === allSteps[ allSteps.length - 1 ];
-		const buttons = [];
-
-		let canGoNext = ! isCancelling;
-		if ( surveyStep === FEEDBACK_STEP ) {
-			canGoNext = isSurveyFilledIn( this.state, isImport, isPlan( purchase ) );
-		} else if ( surveyStep === ATOMIC_REVERT_STEP ) {
-			canGoNext = atomicRevertCheckOne && atomicRevertCheckTwo;
-		}
-
-		let closeText = translate( 'Keep my product' );
-		if ( isPlan( purchase ) ) {
-			closeText = translate( 'Keep my plan' );
-		}
-		buttons.push(
-			<GutenbergButton disabled={ isCancelling } isPrimary onClick={ this.closeDialog }>
-				{ closeText }
-			</GutenbergButton>
-		);
 
 		if ( ! isLastStep ) {
-			buttons.push(
-				<GutenbergButton disabled={ ! canGoNext } isDefault onClick={ this.clickNext }>
-					{ translate( 'Next' ) }
-				</GutenbergButton>
-			);
-		}
-
-		if ( isLastStep ) {
-			let actionText;
-			const isRemoveFlow = flowType === CANCEL_FLOW_TYPE.REMOVE;
-			if ( isCancelling ) {
-				actionText = isRemoveFlow ? translate( 'Removing…' ) : translate( 'Cancelling…' );
-			} else if ( isPlan( purchase ) ) {
-				actionText = isRemoveFlow ? translate( 'Remove plan' ) : translate( 'Cancel plan' );
-			} else {
-				actionText = isRemoveFlow ? translate( 'Remove product' ) : translate( 'Cancel product' );
-			}
-			buttons.push(
+			return (
 				<GutenbergButton
+					isPrimary
 					isDefault
-					isBusy={ isCancelling }
-					disabled={ ! canGoNext }
-					onClick={ this.onSubmit }
+					disabled={ ! this.canGoNext() }
+					onClick={ this.clickNext }
 				>
-					{ actionText }
+					{ translate( 'Submit' ) }
 				</GutenbergButton>
 			);
 		}
 
-		return buttons;
+		return (
+			<GutenbergButton
+				isPrimary
+				isDefault
+				isBusy={ isCancelling }
+				disabled={ ! this.canGoNext() }
+				onClick={ this.onSubmit }
+			>
+				{ this.getFinalActionText() }
+			</GutenbergButton>
+		);
 	};
 
 	fetchPurchaseExtendedStatus = async ( purchaseId ) => {
@@ -957,11 +694,7 @@ class CancelPurchaseForm extends Component {
 						<BlankCanvas.Content>{ this.surveyContent() }</BlankCanvas.Content>
 						<BlankCanvas.Footer>
 							<div className="cancel-purchase-form__actions">
-								<div className="cancel-purchase-form__buttons">
-									{ this.getStepButtons().map( ( button, key ) =>
-										cloneElement( button, { key } )
-									) }
-								</div>
+								<div className="cancel-purchase-form__buttons">{ this.renderStepButton() }</div>
 								{ ( isChatAvailable || isChatActive ) && supportVariation === SUPPORT_HAPPYCHAT && (
 									<PrecancellationChatButton
 										icon="chat_bubble"

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
@@ -17,6 +17,7 @@ class PrecancellationChatButton extends Component {
 		surveyStep: PropTypes.string,
 		onClick: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
+		atBottom: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -38,15 +39,15 @@ class PrecancellationChatButton extends Component {
 	};
 
 	render() {
-		const { isAvailable, icon, translate } = this.props;
+		const { isAvailable, icon, translate, atBottom } = this.props;
 
 		if ( ! isAvailable ) {
-			return null;
+			// 	return null;
 		}
 
 		return (
 			<HappychatButton
-				className="precancellation-chat-button__main-button"
+				className={ `precancellation-chat-button__main-button ${ atBottom && 'at-bottom' }` }
 				onClick={ this.handleClick }
 			>
 				{ icon && <MaterialIcon icon={ icon } /> }

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
@@ -42,7 +42,7 @@ class PrecancellationChatButton extends Component {
 		const { isAvailable, icon, translate, atBottom } = this.props;
 
 		if ( ! isAvailable ) {
-			// 	return null;
+			return null;
 		}
 
 		return (

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/style.scss
@@ -1,14 +1,36 @@
-.precancellation-chat-button__main-button {
-	display: block;
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
-	@include breakpoint-deprecated( ">480px" ) {
-		float: left;
+.precancellation-chat-button__main-button {
+	display: none;
+	position: absolute;
+	right: 1rem;
+	font-size: inherit;
+
+	&.at-bottom {
+		display: inline-block;
+		font-size: 0;
+	}
+
+	@include break-small {
+		display: inline-block;
+		transform: translateY(-4px);
+
+		&.at-bottom {
+			display: none;
+		}
 	}
 
 	.material-icon {
-		width: 1rem;
-		height: 1rem;
+		fill: var(--studio-gray-50);
+		width: 1.5rem;
+		height: 1.5rem;
 		margin-right: 0.5rem;
 		vertical-align: middle;
+
+		@include break-small {
+			width: 1rem;
+			height: 1rem;
+		}
 	}
 }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -1,0 +1,154 @@
+import { isPlan } from '@automattic/calypso-products';
+import { SelectControl, TextareaControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { getCancellationReasons } from '../cancellation-reasons';
+import { toSelectOption } from '../to-select-options';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+type ChangeCallback = ( value: string ) => void;
+
+type CancellationReasonProps = {
+	purchase: Purchase;
+	reasonCodes: string[];
+	onChange: ChangeCallback;
+	onDetailsChange: ChangeCallback;
+};
+
+function CancellationReason( { purchase, reasonCodes, ...props }: CancellationReasonProps ) {
+	const translate = useTranslate();
+	const [ value, setValue ] = useState( '' );
+	const [ details, setDetails ] = useState( '' );
+	const reasons = getCancellationReasons( reasonCodes, { productSlug: purchase.productSlug } );
+	const selectedReason = reasons.find( ( reason ) => reason.value === value );
+
+	const onDetailsChange = ( val: string ) => {
+		setDetails( val );
+		props.onDetailsChange( val );
+	};
+
+	return (
+		<>
+			<div className="cancel-purchase-form__feedback-question">
+				<SelectControl
+					label={ translate( 'Why would you like to cancel?' ) }
+					value={ value }
+					options={ reasons.map( toSelectOption ) }
+					onChange={ ( val ) => {
+						onDetailsChange( '' );
+						setValue( val );
+						props.onChange( val );
+					} }
+				/>
+			</div>
+			{ selectedReason?.textPlaceholder && (
+				<div className="cancel-purchase-form__feedback-question">
+					<TextareaControl
+						label={ translate( 'Can you please specify?' ) }
+						placeholder={ String( selectedReason.textPlaceholder ) }
+						value={ details }
+						onChange={ onDetailsChange }
+					/>
+				</div>
+			) }
+			{ ! selectedReason?.textPlaceholder && selectedReason?.selectOptions && (
+				<div className="cancel-purchase-form__feedback-question">
+					<SelectControl
+						label={ translate( 'Why is that?' ) }
+						value={ details }
+						options={ selectedReason.selectOptions.map( toSelectOption ) }
+						onChange={ onDetailsChange }
+					/>
+				</div>
+			) }
+		</>
+	);
+}
+
+function ImportQuestion( { onChange }: { onChange?: ChangeCallback } ) {
+	const translate = useTranslate();
+	const [ value, setValue ] = useState( '' );
+	const answers = [
+		// placeholder {{
+		{
+			value: '',
+			label: translate( 'Select an answer' ),
+		},
+		// }} placeholder
+		{
+			value: 'happy',
+			label: translate( 'I was happy.' ),
+		},
+		{
+			value: 'look',
+			label: translate(
+				'Most of my content was imported, but it was too hard to get things looking right.'
+			),
+		},
+		{
+			value: 'content',
+			label: translate( 'Not enough of my content was imported.' ),
+		},
+		{
+			value: 'functionality',
+			label: translate( "I didn't have the functionality I have on my existing site." ),
+		},
+	];
+	const options = answers.map( ( answer ) => ( { ...answer, disabled: ! answer.value } ) );
+
+	return (
+		<div className="cancel-purchase-form__feedback-question">
+			<SelectControl
+				label={ translate( 'You imported from another site. How did the import go?' ) }
+				value={ value }
+				options={ options }
+				onChange={ ( value ) => {
+					setValue( value );
+					onChange?.( value );
+				} }
+			/>
+		</div>
+	);
+}
+
+type FeedbackStepProps = {
+	purchase: Purchase;
+	isImport: boolean;
+	cancellationReasonCodes: string[];
+	onChangeCancellationReason: ChangeCallback;
+	onChangeCancellationReasonDetails: ChangeCallback;
+	onChangeImportFeedback?: ChangeCallback;
+};
+
+export default function FeedbackStep( { purchase, isImport, ...props }: FeedbackStepProps ) {
+	const translate = useTranslate();
+	const productName = translate( 'WordPress.com' );
+	const isPlanPurchase = isPlan( purchase );
+
+	return (
+		<div className="cancel-purchase-form__feedback">
+			<FormattedHeader
+				brandFont
+				headerText={ translate( 'Share your feedback' ) }
+				subHeaderText={ translate(
+					'Before you go, please answer a few quick questions to help us improve %(productName)s.',
+					{
+						args: { productName },
+					}
+				) }
+			/>
+			<div className="cancel-purchase-form__feedback-questions">
+				{ isPlanPurchase && (
+					<CancellationReason
+						purchase={ purchase }
+						reasonCodes={ props.cancellationReasonCodes }
+						onChange={ props.onChangeCancellationReason }
+						onDetailsChange={ props.onChangeCancellationReasonDetails }
+					/>
+				) }
+				{ isPlanPurchase && isImport && <ImportQuestion /> }
+			</div>
+		</div>
+	);
+}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/feedback-step.tsx
@@ -147,7 +147,9 @@ export default function FeedbackStep( { purchase, isImport, ...props }: Feedback
 						onDetailsChange={ props.onChangeCancellationReasonDetails }
 					/>
 				) }
-				{ isPlanPurchase && isImport && <ImportQuestion /> }
+				{ isPlanPurchase && isImport && (
+					<ImportQuestion onChange={ props.onChangeImportFeedback } />
+				) }
 			</div>
 		</div>
 	);

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/next-adventure-step.tsx
@@ -1,0 +1,113 @@
+import { TextareaControl, TextControl, SelectControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { toSelectOption } from '../to-select-options';
+
+interface Props {
+	adventureOptions: string[];
+	onChangeText?: ( text: string ) => void;
+	onSelectNextAdventure?: ( nextAdventure: string ) => void;
+	onChangeNextAdventureDetails?: ( details: string ) => void;
+}
+
+export default function NextAdventureStep( props: Props ) {
+	const translate = useTranslate();
+	const [ text, setText ] = useState( '' );
+	const [ nextAdventure, setNextAdventure ] = useState( '' );
+	const [ nextAdventureDetails, setNextAdventureDetails ] = useState( '' );
+
+	const allOptions = [
+		{
+			value: '', // placeholder
+			label: translate( 'Select an answer' ),
+		},
+		{
+			value: 'stayingHere',
+			label: translate( "I'm staying here and using the free plan." ),
+		},
+		{
+			value: 'otherWordPress',
+			label: translate( "I'm going to use WordPress somewhere else." ),
+			textPlaceholder: translate( 'Mind telling us where?' ),
+		},
+		{
+			value: 'differentService',
+			label: translate( "I'm going to use a different service for my website or blog." ),
+			textPlaceholder: translate( 'Mind telling us which one?' ),
+		},
+		{
+			value: 'noNeed',
+			label: translate( 'I no longer need a website or blog.' ),
+			textPlaceholder: translate( 'What will you do instead?' ),
+		},
+		{
+			value: 'otherPlugin',
+			label: translate( 'I found a better plugin or service.' ),
+			textPlaceholder: translate( 'Mind telling us which one(s)?' ),
+		},
+		{
+			value: 'leavingWP',
+			label: translate( "I'm moving my site off of WordPress." ),
+			textPlaceholder: translate( 'Any particular reason(s)?' ),
+		},
+		{
+			value: 'anotherReasonTwo',
+			label: translate( 'Another reason…' ),
+			textPlaceholder: translate( 'Can you please specify?' ),
+		},
+	];
+
+	const options = allOptions
+		.filter( ( { value } ) => ! value || props.adventureOptions.includes( value ) )
+		.map( toSelectOption );
+
+	const selectedAdventureOption = allOptions.find( ( { value } ) => value === nextAdventure );
+
+	const onDetailsChange = ( details: string ) => {
+		setNextAdventureDetails( details );
+		props.onChangeNextAdventureDetails?.( details );
+	};
+
+	return (
+		<div className="cancel-purchase-form__feedback">
+			<FormattedHeader
+				brandFont
+				headerText={ translate( 'Sorry to see you go' ) }
+				subHeaderText={ translate( 'One last thing', {
+					context: 'This is the last step before cancelling the plan.',
+				} ) }
+			/>
+			<div className="cancel-purchase-form__feedback-questions">
+				<TextareaControl
+					label={ translate( "What's one thing we could have done better?" ) }
+					value={ text }
+					onChange={ ( value: string ) => {
+						setText( value );
+						props.onChangeText?.( value );
+					} }
+					placeholder={ translate( 'Optional' ) }
+					name="improvementInput"
+					id="improvementInput"
+				/>
+				<SelectControl
+					label={ translate( 'Where is your next adventure taking you?' ) }
+					value={ nextAdventure }
+					options={ options }
+					onChange={ ( value: string ) => {
+						onDetailsChange( '' );
+						setNextAdventure( value );
+						props.onSelectNextAdventure?.( value );
+					} }
+				/>
+				{ selectedAdventureOption?.textPlaceholder && (
+					<TextControl
+						placeholder={ selectedAdventureOption.textPlaceholder }
+						value={ nextAdventureDetails }
+						onChange={ onDetailsChange }
+					/>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -86,6 +86,7 @@ type ButtonProps = {
 	upsell: string;
 	label: string;
 	disabled: boolean;
+	isBusy: boolean;
 	siteSlug: string;
 	closeDialog: () => void;
 	freeMonthOfferClick?: () => void;
@@ -98,6 +99,7 @@ export function UpsellStepButton( { disabled, upsell, siteSlug, ...props }: Butt
 		disabled,
 		isPrimary: true,
 		isDefault: true,
+		isBusy: props.isBusy || false,
 	};
 
 	if ( upsell === 'business-atomic' ) {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import pluginsThemesImage from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
 import downgradeImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
+import FormattedHeader from 'calypso/components/formatted-header';
 import BusinessATStep from './business-at-step';
 import DowngradeStep from './downgrade-step';
 import FreeMonthOfferStep from './free-month-offer-step';
@@ -18,10 +19,15 @@ type UpsellProps = {
 };
 
 function Upsell( { children, image }: UpsellProps ) {
+	const translate = useTranslate();
+
 	return (
-		<div className="cancel-purchase-form__upsell">
-			<img className="cancel-purchase-form__upsell-image" src={ image } alt="" />
-			<div className="cancel-purchase-form__upsell-description">{ children }</div>
+		<div className="cancel-purchase-form__upsell-container">
+			<FormattedHeader brandFont headerText={ translate( 'Here is an idea' ) } />
+			<div className="cancel-purchase-form__upsell">
+				<img className="cancel-purchase-form__upsell-image" src={ image } alt="" />
+				<div className="cancel-purchase-form__upsell-description">{ children }</div>
+			</div>
 		</div>
 	);
 }

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -1,0 +1,130 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { getCurrencyDefaults } from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
+import pluginsThemesImage from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
+import downgradeImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
+import BusinessATStep from './business-at-step';
+import DowngradeStep from './downgrade-step';
+import FreeMonthOfferStep from './free-month-offer-step';
+import UpgradeATStep from './upgrade-at-step';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+type UpsellProps = {
+	href?: string;
+	buttonText: string;
+	disabled: boolean;
+	onClick?: () => void;
+	onDismiss?: () => void;
+	children: React.ReactChild;
+	image: string;
+};
+
+function Upsell( { buttonText, children, image, onDismiss, ...buttonProps }: UpsellProps ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="cancel-purchase-form__upsell">
+			<img className="cancel-purchase-form__upsell-image" src={ image } alt="" />
+			<div className="cancel-purchase-form__upsell-description">
+				{ children }
+				<Button { ...buttonProps } isPrimary>
+					{ buttonText }
+				</Button>
+				<Button onClick={ onDismiss }>{ translate( 'Dismiss' ) }</Button>
+			</div>
+		</div>
+	);
+}
+
+type StepProps = {
+	upsell: string;
+	purchase: Purchase;
+	site: SiteDetails;
+	disabled: boolean;
+	refundAmount: string;
+	downgradePlanPrice: number | null;
+	cancelBundledDomain: boolean;
+	includedDomainPurchase: object;
+	freeMonthOfferClick?: () => void;
+	downgradeClick?: ( upsell: string ) => void;
+};
+
+export default function UpsellStep( { upsell, purchase, site, disabled, ...props }: StepProps ) {
+	const translate = useTranslate();
+
+	if ( ! upsell ) {
+		return null;
+	}
+
+	if ( upsell === 'business-atomic' ) {
+		return (
+			<Upsell
+				// onClick={ this.closeDialog }
+				buttonText={ translate( 'Keep my plan' ) }
+				image={ pluginsThemesImage }
+				disabled={ disabled }
+			>
+				<BusinessATStep />
+			</Upsell>
+		);
+	}
+
+	if ( upsell === 'upgrade-atomic' ) {
+		return (
+			<Upsell
+				href={ `/checkout/${ site.slug }/business?coupon=BIZC25` }
+				onClick={ () => recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' ) }
+				buttonText={ translate( 'Upgrade my site' ) }
+				image={ pluginsThemesImage }
+				disabled={ disabled }
+			>
+				<UpgradeATStep selectedSite={ site } />
+			</Upsell>
+		);
+	}
+
+	if ( upsell === 'free-month-offer' ) {
+		return (
+			<Upsell
+				onClick={ props.freeMonthOfferClick }
+				buttonText={ translate( 'Get a free month' ) }
+				image={ rocketImage }
+				disabled={ disabled }
+			>
+				<FreeMonthOfferStep productSlug={ purchase.productSlug } />
+			</Upsell>
+		);
+	}
+
+	if ( upsell === 'downgrade-personal' || upsell === 'downgrade-monthly' ) {
+		const { precision } = getCurrencyDefaults( purchase.currencyCode );
+		const planCost = ( props.downgradePlanPrice || 0 ).toFixed( precision );
+		const buttonText =
+			upsell === 'downgrade-monthly'
+				? translate( 'Switch to a monthly subscription' )
+				: translate( 'Switch to Personal' );
+
+		return (
+			<Upsell
+				onClick={ () => props.downgradeClick?.( upsell ) }
+				buttonText={ buttonText }
+				image={ downgradeImage }
+				disabled={ disabled }
+			>
+				<DowngradeStep
+					currencySymbol={ purchase.currencySymbol }
+					planCost={ planCost }
+					refundAmount={ props.refundAmount }
+					upsell={ upsell }
+					cancelBundledDomain={ props.cancelBundledDomain }
+					includedDomainPurchase={ props.includedDomainPurchase }
+				/>
+			</Upsell>
+		);
+	}
+
+	return null;
+}

--- a/client/components/marketing-survey/cancel-purchase-form/steps.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps.js
@@ -2,3 +2,5 @@ export const ATOMIC_REVERT_STEP = 'atomic_revert_step';
 export const FEEDBACK_STEP = 'feedback_step';
 export const FINAL_STEP = 'final_step';
 export const INITIAL_STEP = 'initial_step';
+export const UPSELL_STEP = 'upsell_step';
+export const NEXT_ADVENTURE_STEP = 'next_adventure_step';

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -32,6 +32,7 @@
 	margin: 0 auto 3rem;
 }
 
+.cancel-purchase-form__upsell,
 .cancel-purchase-form__feedback-questions {
 	max-width: 540px;
 	margin: 0 auto;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -16,16 +16,6 @@
 	vertical-align: middle;
 }
 
-.cancel-purchase-form__step {
-	position: absolute;
-	right: 1.5rem;
-	display: none;
-
-	@include break-small {
-		display: inline-block;
-	}
-}
-
 .cancel-purchase-form__feedback,
 .cancel-purchase-form__atomic-revert {
 	max-width: 730px;
@@ -149,39 +139,13 @@
 	}
 }
 
-.cancel-purchase-form__actions .precancellation-chat-button__main-button {
-	font-size: 0;
-	float: none;
-	right: 1rem;
-	color: var(--studio-gray-50);
-	display: inline-block;
-	position: absolute;
-
-	@include break-small {
-		margin: 1rem auto;
-		font-size: inherit;
-		position: relative;
-		display: block;
-	}
-
-	.material-icon {
-		fill: var(--studio-gray-50);
-		width: 1.5rem;
-		height: 1.5rem;
-
-		@include break-small {
-			width: 1rem;
-			height: 1rem;
-		}
-	}
-}
-
 .cancel-purchase-form__upsell {
 	padding: 1.5rem;
 	background-color: var(--studio-green-0);
 	border: 1px solid var(--studio-green-5);
 	border-radius: 5px; /* stylelint-disable-line scales/radii */
 	display: flex;
+	margin-bottom: 3rem;
 
 	.cancel-purchase-form__upsell-image {
 		display: none;
@@ -233,4 +197,8 @@
 		// Hide buttons rendered by old components, so we can still re-use them for rendering rest of content.
 		display: none;
 	}
+}
+
+.blank-canvas.cancel-purchase-form .blank-canvas__header-title {
+	z-index: 0;
 }

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -19,7 +19,7 @@
 .cancel-purchase-form__feedback,
 .cancel-purchase-form__atomic-revert {
 	max-width: 730px;
-	margin: 0 auto 3rem;
+	margin: 0 auto 2rem;
 }
 
 .cancel-purchase-form__upsell,
@@ -197,6 +197,10 @@
 		// Hide buttons rendered by old components, so we can still re-use them for rendering rest of content.
 		display: none;
 	}
+}
+
+.blank-canvas.cancel-purchase-form .blank-canvas__back {
+	z-index: 1;
 }
 
 .blank-canvas.cancel-purchase-form .blank-canvas__header-title {

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -136,30 +136,6 @@
 	display: inline-block;
 	position: relative;
 
-	@include break-small {
-		// Line decorations.
-		&::before,
-		&::after {
-			content: "";
-			display: block;
-			width: 730px;
-			height: 0;
-			border-top: 1px solid var(--studio-gray-5);
-			top: 50%;
-			position: absolute;
-		}
-
-		&::before {
-			right: 100%;
-			margin-right: 1rem;
-		}
-
-		&::after {
-			left: 100%;
-			margin-left: 1rem;
-		}
-	}
-
 	.components-button {
 		margin-right: 1rem;
 		padding: 0.625rem 1rem;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -145,7 +145,7 @@
 	border: 1px solid var(--studio-green-5);
 	border-radius: 5px; /* stylelint-disable-line scales/radii */
 	display: flex;
-	margin-bottom: 3rem;
+	margin-bottom: 2rem;
 
 	.cancel-purchase-form__upsell-image {
 		display: none;

--- a/client/components/marketing-survey/cancel-purchase-form/to-select-options.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/to-select-options.ts
@@ -1,0 +1,16 @@
+import type { ReactChild } from 'react';
+
+type TranslateReturnType = ReactChild | string;
+
+type OptionLike = {
+	label: TranslateReturnType;
+	value: string | number;
+};
+
+export function toSelectOption( { label, value }: OptionLike ) {
+	return {
+		label: String( label ),
+		value: String( value ),
+		disabled: ! value,
+	};
+}


### PR DESCRIPTION
#### Proposed Changes

* This PR improves the cancellation flow as part of the Cancellation Flow project. See pebzTe-kA-p2 for more details.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a dotcom plan.
* Try to cancel it by clicking `Remove plan` on `My Home > Purchases`.
  <img width="1087" alt="Purchase_Settings_‹_Cancel_Test_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/195392169-d937c51f-b07d-4fa6-a270-b3fc4fc406c6.png">
* Pick options and fill all forms.
  * You may see an additional form to ask your next adventure.
     <img width="800" alt="Purchase_Settings_‹_Cancel_Test_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/195393028-ad68b31a-b34e-43d0-b762-8f978d052f4f.png">
  * Or the upsell form will show up instead. Try to cancel Premium plan and pick `Price/Bugdget` and `It's too expensive.`
    <img width="788" alt="Cancel_Purchase_‹_Cancel_Test_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/195798788-2696338e-6c46-4dbb-b14d-a0546ad6a975.png">

    
* This flow should work with Atomic sites as well.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #