### PR TITLE
Hide plugin collections from Jetpack non-Atomic sites

### DIFF
--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -1,7 +1,11 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export type Plugin = {
 	slug: string;
@@ -128,7 +132,16 @@ export default function CollectionListView( {
 	siteSlug: string;
 	sites: any;
 } ): ReactElement | null {
+	const selectedSite = useSelector( getSelectedSite );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
+	const isJetpackSelfHosted = isJetpack && ! isAtomic;
+
 	const collections = useCollections();
+
+	if ( isJetpackSelfHosted ) {
+		return null;
+	}
 
 	const plugins = collections[ collection ].plugins.slice( 0, 6 );
 


### PR DESCRIPTION
#### Proposed Changes

* This diff prevents plugin collections from being shown to non-Atomic Jetpack sites.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* View the Plugin Discover page http://calypso.localhost:3000/plugins/{site} and confirm the following site behaviors
  - [x] Atomic - Plugin Collection shows
  - [x] Simple - Plugin Collection shows
  - [x] Jetpack (non-Atomic) - Plugin Collection does NOT show

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68948