### PR TITLE
Update Jetpack Cancellation form input

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -240,7 +240,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 	// Disable continuation button if "Other" is selected but no reason is written in
 	useEffect( () => {
-		if ( surveyAnswerId === 'another-reason' && surveyAnswerText === '' ) {
+		if ( surveyAnswerId === 'another-reason' && ( surveyAnswerText as string ).trim() === '' ) {
 			setDisableContinuation( true );
 		} else {
 			setDisableContinuation( false );

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -3,7 +3,7 @@ import { Button, Dialog } from '@automattic/components';
 import { Button as ButtonType } from '@automattic/components/dist/types/dialog/button-bar';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import page from 'page';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryPurchaseCancellationOffers from 'calypso/components/data/query-purchase-cancellation-offers';
@@ -67,10 +67,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		}
 
 		return steps.CANCELLATION_REASON_STEP;
-	}, [ flowType, purchase, steps ] );
+	}, [ flowType ] );
 	const [ cancellationStep, setCancellationStep ] = useState( initialCancellationStep ); // set initial state
 	const [ surveyAnswerId, setSurveyAnswerId ] = useState< string | null >( null );
 	const [ surveyAnswerText, setSurveyAnswerText ] = useState< TranslateResult | string >( '' );
+	const [ disableContinuation, setDisableContinuation ] = useState< boolean >( false );
 
 	const isAtomicSite = useSelector( ( state ) =>
 		isSiteAutomatedTransfer( state, purchase.siteId )
@@ -120,24 +121,27 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	 * Set the cancellation flow back to the beginning
 	 * Clear out stored state for the flow
 	 */
-	const resetSurveyState = () => {
+	const resetSurveyState = useCallback( () => {
 		setCancellationStep( initialCancellationStep );
 		setSurveyAnswerId( null );
 		setSurveyAnswerText( '' );
-	};
+	}, [ initialCancellationStep ] );
 
 	// Record an event for Tracks
-	const recordEvent = ( name: string, properties = {} ) => {
-		dispatch(
-			recordTracksEvent( name, {
-				cancellation_flow: flowType,
-				product_slug: purchase.productSlug,
-				is_atomic: isAtomicSite,
+	const recordEvent = useCallback(
+		( name: string, properties = {} ) => {
+			dispatch(
+				recordTracksEvent( name, {
+					cancellation_flow: flowType,
+					product_slug: purchase.productSlug,
+					is_atomic: isAtomicSite,
 
-				...properties,
-			} )
-		);
-	};
+					...properties,
+				} )
+			);
+		},
+		[ dispatch, flowType, isAtomicSite, purchase.productSlug ]
+	);
 
 	/**
 	 * Get possible steps for the survey
@@ -177,12 +181,8 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		}
 		return availableSteps;
 	}, [
-		CANCEL_FLOW_TYPE,
 		flowType,
-		steps,
 		purchase,
-		isPurchaseCancelable,
-		canReenableAutoRenewal,
 		cancellationOffer,
 		shouldProvideCancellationOffer,
 		isOfferPriceSameOrLowerThanPurchasePrice,
@@ -199,14 +199,14 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	// run on mount
 	useEffect( () => {
 		resetSurveyState();
-	}, [] );
+	}, [ resetSurveyState ] );
 
 	// if isVisible changes
 	useEffect( () => {
 		if ( isVisible && cancellationStep === firstStep ) {
 			recordEvent( 'calypso_purchases_cancel_form_start' );
 		}
-	}, [ isVisible, firstStep ] );
+	}, [ isVisible, firstStep, cancellationStep, recordEvent ] );
 
 	const handleCloseDialog = () => {
 		props.onClose();
@@ -225,15 +225,27 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		}
 	};
 
-	const setSurveyStep = ( stepFunction: ( step: string, steps: string[] ) => string ) => {
-		const newStep = stepFunction( cancellationStep, availableSurveySteps );
+	const setSurveyStep = useCallback(
+		( stepFunction: ( step: string, steps: string[] ) => string ) => {
+			const newStep = stepFunction( cancellationStep, availableSurveySteps );
 
-		setCancellationStep( newStep );
+			setCancellationStep( newStep );
 
-		// record tracks event
-		// since the steps used for the Jetpack cancellation flow are different, use a different event name for Tracks
-		recordEvent( 'calypso_purchases_cancel_jetpack_survey_step', { new_step: newStep } );
-	};
+			// record tracks event
+			// since the steps used for the Jetpack cancellation flow are different, use a different event name for Tracks
+			recordEvent( 'calypso_purchases_cancel_jetpack_survey_step', { new_step: newStep } );
+		},
+		[ availableSurveySteps, cancellationStep, recordEvent ]
+	);
+
+	// Disable continuation button if "Other" is selected but no reason is written in
+	useEffect( () => {
+		if ( surveyAnswerId === 'another-reason' && surveyAnswerText === '' ) {
+			setDisableContinuation( true );
+		} else {
+			setDisableContinuation( false );
+		}
+	}, [ surveyAnswerId, surveyAnswerText ] );
 
 	const clickNext = () => {
 		setSurveyStep( nextStep );
@@ -316,7 +328,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		};
 		const next = {
 			action: 'next',
-			disabled: disabled,
+			disabled: disabled || disableContinuation,
 			label: translate( 'Next step' ),
 			onClick: clickNext,
 		};
@@ -328,7 +340,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			flowType === CANCEL_FLOW_TYPE.REMOVE ? translate( 'Removing' ) : translate( 'Cancelling' );
 		const cancel = (
 			<Button
-				disabled={ disabled || applyingOffer }
+				disabled={ disabled || applyingOffer || disableContinuation }
 				busy={ disabled }
 				onClick={ onSubmit }
 				primary

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -77,7 +77,7 @@ export default function JetpackCancellationSurvey( {
 		const textAnswerLabel =
 			choice.id === 'another-reason'
 				? translate( 'Share your experience (required)' )
-				: translate( 'Are there any details you would like to share?' );
+				: translate( 'Please share any additional details.' );
 
 		return (
 			<Card

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -41,22 +41,25 @@ export default function JetpackCancellationSurvey( {
 			id: 'could-not-activate',
 			answerText: translate( 'I was unable to activate or use the product.' ),
 		},
+		{
+			id: 'dont-need-website',
+			answerText: translate( 'I no longer need a website.' ),
+		},
+		{
+			id: 'another-reason',
+			answerText: translate( 'Other' ),
+		},
 	];
-
-	const choiceOther: Choice = {
-		id: 'another-reason',
-		answerText: translate( 'Other:' ),
-	};
 
 	const selectAnswer = useCallback(
 		( answerId: string ) => {
-			// prevent from sending the answer text if it's not a custom answer
-			const surveyAnswerText =
-				choiceOther.id === answerId && customAnswerText ? customAnswerText : '';
+			// Reset custom answer text anytime an answer changes
+			const textFieldValue = selectedAnswerId === answerId ? customAnswerText : '';
 
-			onAnswerChange( answerId, surveyAnswerText );
+			onAnswerChange( answerId, textFieldValue );
+			setCustomAnswerText( textFieldValue );
 		},
-		[ choiceOther.id, customAnswerText, onAnswerChange ]
+		[ onAnswerChange, setCustomAnswerText, customAnswerText, selectedAnswerId ]
 	);
 
 	const onChangeCustomAnswerText = useCallback(
@@ -70,17 +73,41 @@ export default function JetpackCancellationSurvey( {
 	);
 
 	const renderChoiceCard = ( choice: Choice ) => {
+		const isSelected = choice.id === selectedAnswerId;
+		const textAnswerLabel =
+			choice.id === 'another-reason'
+				? translate( 'Share your experience (required)' )
+				: translate( 'Are there any details you would like to share?' );
+
 		return (
 			<Card
 				className={ classnames( 'jetpack-cancellation-survey__card', {
-					'is-selected': choice.id === selectedAnswerId,
+					'is-selected': isSelected,
 				} ) }
-				tagName="button"
-				onClick={ () => selectAnswer( choice.id ) }
+				id={ choice.id }
 				key={ choice.id }
+				onClick={ () => selectAnswer( choice.id ) }
+				tagName="button"
 			>
 				<div className="jetpack-cancellation-survey__card-content">
-					<span>{ choice.answerText }</span>
+					<p>{ choice.answerText }</p>
+					{ isSelected && (
+						<>
+							<label
+								className="jetpack-cancellation-survey__choice-item-text-input-label"
+								htmlFor={ `${ choice.id }-text-answer` }
+							>
+								{ textAnswerLabel }
+							</label>
+							<FormTextInput
+								className="jetpack-cancellation-survey__choice-item-text-input"
+								id={ `${ choice.id }-text-answer` }
+								inputRef={ customAnswerInputRef }
+								onChange={ onChangeCustomAnswerText }
+								value={ customAnswerText }
+							/>
+						</>
+					) }
 				</div>
 			</Card>
 		);
@@ -95,30 +122,6 @@ export default function JetpackCancellationSurvey( {
 				isSecondary={ true }
 			/>
 			{ choices.map( renderChoiceCard ) }
-
-			{ /* The card for the 'other' option */ }
-			<Card
-				key={ choiceOther.id }
-				className={ classnames( 'jetpack-cancellation-survey__card', {
-					'is-selected': choiceOther.id === selectedAnswerId,
-				} ) }
-				tagName="button"
-				onClick={ () => {
-					selectAnswer( choiceOther.id );
-					customAnswerInputRef?.current?.focus();
-				} }
-			>
-				<div className="jetpack-cancellation-survey__card-content">
-					<span>{ choiceOther.answerText }</span>
-					<FormTextInput
-						inputRef={ customAnswerInputRef }
-						className="jetpack-cancellation-survey__choice-item-text-input"
-						value={ customAnswerText }
-						onChange={ onChangeCustomAnswerText }
-						placeholder={ translate( 'share your experience' ) }
-					/>
-				</div>
-			</Card>
 		</>
 	);
 }

--- a/client/components/marketing-survey/cancel-jetpack-form/style.scss
+++ b/client/components/marketing-survey/cancel-jetpack-form/style.scss
@@ -74,21 +74,28 @@
 	}
 
 	&__card-content {
-		display: flex;
 		align-items: center;
+		display: flex;
+		flex-direction: column;
 		justify-content: center;
+
 		width: 100%;
+
+		text-align: left;
 
 		@include break-medium {
 			justify-content: flex-start;
 		}
 	}
+
+	&__choice-item-text-input-label {
+		font-size: 0.875rem;
+		width: 100%;
+	}
 }
 
 input[type="text"].form-text-input.jetpack-cancellation-survey__choice-item-text-input {
-	border: none;
-	padding: 0;
-	margin-left: 1rem;
+	margin-top: 0.5em;
 }
 
 // Cancellation offer step

--- a/client/components/marketing-survey/cancel-jetpack-form/style.scss
+++ b/client/components/marketing-survey/cancel-jetpack-form/style.scss
@@ -84,7 +84,7 @@
 		text-align: left;
 
 		@include break-medium {
-			justify-content: flex-start;
+			align-items: flex-start;
 		}
 	}
 

--- a/client/components/marketing-survey/cancel-jetpack-form/test/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/test/jetpack-cancellation-survey.tsx
@@ -12,7 +12,7 @@ const customAnswerText = {
 
 describe( 'JetpackCancellationSurvey', () => {
 	test( 'should hide text field if no answer is selected', () => {
-		render( <JetpackCancellationSurvey onAnswerChange={ () => null } selectedAnswerId={ '' } /> );
+		render( <JetpackCancellationSurvey onAnswerChange={ () => null } selectedAnswerId="" /> );
 
 		expect( screen.queryByLabelText( customAnswerText.other ) ).not.toBeInTheDocument();
 		expect( screen.queryByLabelText( customAnswerText.rest ) ).not.toBeInTheDocument();
@@ -22,7 +22,7 @@ describe( 'JetpackCancellationSurvey', () => {
 		render(
 			<JetpackCancellationSurvey
 				onAnswerChange={ () => null }
-				selectedAnswerId={ 'want-to-downgrade' }
+				selectedAnswerId="want-to-downgrade"
 			/>
 		);
 
@@ -32,10 +32,7 @@ describe( 'JetpackCancellationSurvey', () => {
 
 	test( 'should show "Other" text field if "Other" is selected', () => {
 		render(
-			<JetpackCancellationSurvey
-				onAnswerChange={ () => null }
-				selectedAnswerId={ 'another-reason' }
-			/>
+			<JetpackCancellationSurvey onAnswerChange={ () => null } selectedAnswerId="another-reason" />
 		);
 
 		expect( screen.getByLabelText( customAnswerText.other ) ).toBeInTheDocument();

--- a/client/components/marketing-survey/cancel-jetpack-form/test/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/test/jetpack-cancellation-survey.tsx
@@ -7,7 +7,7 @@ import JetpackCancellationSurvey from '../jetpack-cancellation-survey';
 
 const customAnswerText = {
 	other: 'Share your experience (required)',
-	rest: 'Are there any details you would like to share?',
+	rest: 'Please share any additional details.',
 };
 
 describe( 'JetpackCancellationSurvey', () => {

--- a/client/components/marketing-survey/cancel-jetpack-form/test/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/test/jetpack-cancellation-survey.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import JetpackCancellationSurvey from '../jetpack-cancellation-survey';
+
+const customAnswerText = {
+	other: 'Share your experience (required)',
+	rest: 'Are there any details you would like to share?',
+};
+
+describe( 'JetpackCancellationSurvey', () => {
+	test( 'should hide text field if no answer is selected', () => {
+		render( <JetpackCancellationSurvey onAnswerChange={ () => null } selectedAnswerId={ '' } /> );
+
+		expect( screen.queryByLabelText( customAnswerText.other ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( customAnswerText.rest ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'should show text field if answer is selected', () => {
+		render(
+			<JetpackCancellationSurvey
+				onAnswerChange={ () => null }
+				selectedAnswerId={ 'want-to-downgrade' }
+			/>
+		);
+
+		expect( screen.queryByLabelText( customAnswerText.other ) ).not.toBeInTheDocument();
+		expect( screen.getByLabelText( customAnswerText.rest ) ).toBeInTheDocument();
+	} );
+
+	test( 'should show "Other" text field if "Other" is selected', () => {
+		render(
+			<JetpackCancellationSurvey
+				onAnswerChange={ () => null }
+				selectedAnswerId={ 'another-reason' }
+			/>
+		);
+
+		expect( screen.getByLabelText( customAnswerText.other ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( customAnswerText.rest ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Add new answer for cancellation form: "I no longer need a website"
* Add optional text field to all answers of the form
* Make "Other" text field required so they have to fill out a reason before cancelling

#### Discussion

P2s:
p1HpG7-hcM-p2
p1HpG7-hzP-p2
pbNhbs-3MF-p2

Asana:
1161179020265237-as-1202940054684628/f

#### Testing Instructions

1. Checkout this branch via `git switch update/jetpack-cancellation-form-input`
2. Purchase any Jetpack plan on whichever site you would like.
3. Start Jetpack Cloud via `yarn start-jetpack-cloud`
4. Go to http://jetpack.cloud.localhost:3000/purchases/subscriptions/{site}
5. Select a subscription and then select "Remove Subscription"
![Screen Shot 2022-10-12 at 1 30 34 PM](https://user-images.githubusercontent.com/65001528/195431816-8d0ada79-2df1-49de-a6b9-7b880882ae2f.jpg)
6. Select "Next Step"
![Screen Shot 2022-10-12 at 11 01 42 AM](https://user-images.githubusercontent.com/65001528/195404422-57754578-8420-4271-9abf-624fd0327b45.jpg)
7. Go through and select all of the answers, and notice the optional text field that shows up underneath them. Also notice the "Remove Subscription" button is NOT disabled or greyed out. Also notice the new "I no longer need a website" answer
![image](https://user-images.githubusercontent.com/65001528/195674471-86f230a4-c1c9-40d0-912d-6fafb070ecea.png)
8. Select "Other" and notice the different wording and the "(required)" indicator
![image](https://user-images.githubusercontent.com/65001528/195443657-d372f4ed-eebb-4450-af40-e71ef7c8d5f4.png)
9. With "Other" selected and the text box empty, notice that the "Remove Subscription" button is greyed out and disabled
![image](https://user-images.githubusercontent.com/65001528/195443677-07df033a-bab9-408c-bb4f-cd868ed39940.png)
10. Type some text into the "Other" text field and notice the "Remove Subscription" button become enabled and its regular color
![image](https://user-images.githubusercontent.com/65001528/195443724-b0ca55ce-5eb9-43aa-a2d0-830a03376f13.png)
11. Test the survey on mobile and desktop to make sure the layout looks good in all widths.
12. Next, cancel the jetpack cloud local environment and start regular calypso via `yarn start`
13. Navigate to http://calypso.localhost:3000/me/purchases/{site}/
14. Repeat steps 5-11 on this page to test out Calypso Blue. The behavior should be exactly the same except the "Remove Subscription" button will stay "Next Step" instead
![image](https://user-images.githubusercontent.com/65001528/195674662-834e9579-7488-4b6a-953a-0bd58ee180ed.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-spproach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
