### PR TITLE
Theme bundle: Add Business Plan to cart when theme has WooCommerce

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -290,7 +290,16 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			} );
 		}
 
-		const plan = isEligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';
+		const themeHasWooCommerce = selectedDesign?.software_sets?.find(
+			( set ) => set.slug === 'woo-on-plans'
+		);
+
+		let plan;
+		if ( isEnabled( 'themes/plugin-bundling' ) && themeHasWooCommerce ) {
+			plan = 'business-bundle';
+		} else {
+			plan = isEligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';
+		}
 
 		if ( siteSlugOrId ) {
 			const params = new URLSearchParams();


### PR DESCRIPTION
#### Proposed Changes

* When a theme bundled with WooCommerce is chosen, add Business Plan to the cart instead of Premium Plan.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site using /start
* Enable flags: `themes/plugin-bundling,signup/seller-upgrade-modal`
* Choose the theme Thriving Artist
* Client on "Unlock theme"
* Click on "Upgrade Plan"
* Check that Business Plan was added to the cart

![image](https://user-images.githubusercontent.com/3801502/195419503-cb45c50e-9a80-4066-b102-8ce2c8ba18d5.png)


Closes #68976
