### PR TITLE
Checkout: Remove siteSelection controller from no-site pending page

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -96,7 +96,6 @@ export default function () {
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
 		redirectLoggedOut,
-		siteSelection,
 		checkoutPending,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
#### Proposed Changes

Each calypso Single Page Application route is managed by `page` using a series of "controller" or "middleware" functions (modeled on the [middleware system used by express](https://expressjs.com/en/guide/using-middleware.html)). Each function in this chain can chose to take actions including rendering something to the page; if they render something they often will also break the chain by returning without calling `next()` so that no further middleware functions will be called.

Here's an example of the chain:

https://github.com/Automattic/wp-calypso/blob/2dbbd0a9b64eb73d3c08da63d8972d7770af7f8b/client/my-sites/checkout/index.js#L96-L103

When checkout completes, all users are sent to the "pending" page which will confirm the transaction and redirect them to their final destination. This page is rendered by the [checkoutPending](https://github.com/Automattic/wp-calypso/blob/2dbbd0a9b64eb73d3c08da63d8972d7770af7f8b/client/my-sites/checkout/controller.jsx#L202) middleware. There are several routes that reach the pending page, like `/checkout/thank-you/:site/pending/:orderId` ([here](https://github.com/Automattic/wp-calypso/blob/2dbbd0a9b64eb73d3c08da63d8972d7770af7f8b/client/my-sites/checkout/index.js#L115)) but for purchases which do not have an associated site, there is also `/checkout/thank-you/no-site/pending/:orderId` ([here](https://github.com/Automattic/wp-calypso/blob/2dbbd0a9b64eb73d3c08da63d8972d7770af7f8b/client/my-sites/checkout/index.js#L97)).

One of the middleware functions in the `no-site` pending page route is `siteSelection` which has a clause that [breaks the middleware chain and renders](https://github.com/Automattic/wp-calypso/blob/2dbbd0a9b64eb73d3c08da63d8972d7770af7f8b/client/my-sites/controller.js#L442-L447) a "no sites" message if the user has no sites. Since it's very possible for a `no-site` route to be reached when the user has no sites, this middleware will likely prevent the pending page from ever being rendered, ignoring the post-checkout redirect and resulting in a very poor UX.

As it's likely that the functionality added by the `siteSelection` middleware is not necessary for the pending page, this PR removes it from the chain for the `no-site` route.

Fixes https://github.com/Automattic/wp-calypso/issues/68988

#### Screenshots

Before; note that the URL is for the pending page, but the "no sites" page is showing instead:

<img width="939" alt="Screen Shot 2022-10-12 at 3 51 33 PM" src="https://user-images.githubusercontent.com/2036909/195435142-13a58109-1b00-43d5-aa48-6b2f309ed6f8.png">

After, on the pending page:

<img width="936" alt="Screen Shot 2022-10-12 at 3 51 52 PM" src="https://user-images.githubusercontent.com/2036909/195435222-0e0c8e8c-cffb-4a90-8aa2-992f0273ae07.png">

After, once the pending page redirects:

<img width="935" alt="Screen Shot 2022-10-12 at 3 52 06 PM" src="https://user-images.githubusercontent.com/2036909/195435243-5ca677eb-0734-435e-b06b-c5ce8dad69c3.png">

#### Testing Instructions

- Use a logged-out browser (eg: incognito).
- On this branch, visit `/checkout/jetpack/jetpack_backup_t1_yearly?source=jetpack-plans`.
- Complete the purchase.
- After checkout, verify that you are redirected to the pending page briefly (it may not actually be visible because of the speed of the single page redirect) and then to a post-checkout page.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203136098411116