### PR TITLE
Jetpack pricing: fix alternative texts in modals

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/locale-switcher/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/locale-switcher/index.tsx
@@ -65,7 +65,16 @@ const LocaleSwitcher: React.FC< Props > = ( { isVisible, onClose } ) => {
 					{ ( translations as Translations )[ selectedLocale ]?.translation ||
 						translate( 'Language' ) }
 				</h1>
-				<button className="locale-switcher__close-btn" onClick={ onClose }>
+				<button
+					className="locale-switcher__close-btn"
+					onClick={ onClose }
+					aria-label={
+						translate( 'Close language selector', {
+							comment:
+								'Text read by screen readers when the close button of the language selector gets focus.',
+						} ) as string
+					}
+				>
 					<Gridicon icon="cross" size={ 36 } />
 				</button>
 			</div>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -32,7 +32,7 @@ const TagItems: React.FC< { tags: JetpackTag[] } > = ( { tags } ) => (
 	<>
 		{ tags.map( ( tag ) => (
 			<div className="product-lightbox__detail-tags-tag" key={ tag.tag }>
-				<span>{ Tags[ tag.tag ] }</span>
+				<span aria-hidden="true">{ Tags[ tag.tag ] }</span>
 				<p>{ tag.label }</p>
 			</div>
 		) ) }
@@ -109,7 +109,17 @@ const ProductLightbox: React.FC< Props > = ( {
 			htmlOpenClassName="ReactModal__Html--open lightbox-mode"
 		>
 			<div className="product-lightbox__content-wrapper">
-				<Button className="product-lightbox__close-button" plain onClick={ close }>
+				<Button
+					className="product-lightbox__close-button"
+					plain
+					onClick={ close }
+					aria-label={
+						translate( 'Close', {
+							comment:
+								'Text read by screen readers when the close button of the lightbox gets focus.',
+						} ) as string
+					}
+				>
 					{ Icons.close }
 				</Button>
 				<div className="product-lightbox__detail">


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds an accessible name to the close button of the language selector, in the footer of the [Jetpack pricing page](https://cloud.jetpack.com/pricing), and the products lightbox. This way, visitors using a screen reader get proper context when the button gets focus (see video below).

### Implementation notes

Name is added via the `aria-label` HTML attribute.

### Testing instructions

- Spin up the pricing page, by running this branch locally, or by using the live link below
- Visit the pricing page, and open the language selector located in the footer
<img width="1178" alt="Screen Shot 2022-10-12 at 3 55 55 PM" src="https://user-images.githubusercontent.com/1620183/195435378-627a111a-ca6d-4775-a1c4-91c4649f6321.png">

- Using a screen reader, notice that the close button has an accessible name (see video below). Alternatively, check in the inspector that the HTML element has a `aria-label` attribute.
<img width="894" alt="Screen Shot 2022-10-12 at 3 59 12 PM" src="https://user-images.githubusercontent.com/1620183/195435926-0dfaacad-2772-451b-ad6f-97be998c1a36.png">

- Do the same with the products lightbox (click _More on X_).


### Screenshots

https://user-images.githubusercontent.com/1620183/195434516-37c3c07d-39ff-4158-acfe-39e0c7ae20e3.mov

_Voice Over gives information about the close button when it is given focus._


https://user-images.githubusercontent.com/1620183/195640231-95b6bc09-dcbb-4116-baca-f60378e25bd0.mov

_Same here. Besides, Voice Over ignores icons completely._

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203150321101696