### PR TITLE
Add track events to Atomic sites when editor suggests plugins

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -706,7 +706,7 @@ const trackSaveSpecifiedEntityEdits = ( kind, type, id, itemsToSave ) => {
  * @returns {void}
  */
 const trackInstallBlockType = ( block ) => {
-	tracksRecordEvent( 'wpcom_block_install', {
+	tracksRecordEvent( 'wpcom_block_directory_install', {
 		block_slug: block.id,
 	} );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -700,6 +700,18 @@ const trackSaveSpecifiedEntityEdits = ( kind, type, id, itemsToSave ) => {
 };
 
 /**
+ * Track block install.
+ *
+ * @param {object} block block instance object
+ * @returns {void}
+ */
+const trackInstallBlockType = ( block ) => {
+	tracksRecordEvent( 'wpcom_block_install', {
+		block_slug: block.id,
+	} );
+};
+
+/**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
  * - function - in case you need to load additional properties from the action.
@@ -725,6 +737,9 @@ const REDUX_TRACKING = {
 		editEntityRecord: trackEditEntityRecord,
 		saveEditedEntityRecord: trackSaveEditedEntityRecord,
 		__experimentalSaveSpecifiedEntityEdits: trackSaveSpecifiedEntityEdits,
+	},
+	'core/block-directory': {
+		installBlockType: trackInstallBlockType,
 	},
 	'core/block-editor': {
 		moveBlocksUp: getBlocksTracker( 'wpcom_block_moved_up' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -1,5 +1,6 @@
 import {
 	__unstableInserterMenuExtension,
+	// eslint-disable-next-line import/named
 	__experimentalInserterMenuExtension,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -42,11 +43,33 @@ const InserterMenuTrackingEvent = function () {
 		tracksRecordEvent( 'wpcom_block_picker_no_results', eventProperties );
 	}, 500 );
 
+	const debouncedSetFilterValueDiscovery = debounce( ( search_term ) => {
+		if ( search_term.length < 3 ) {
+			return;
+		}
+
+		const blockDirectoryResults = document.querySelectorAll(
+			'.block-directory-downloadable-block-list-item'
+		).length;
+
+		if ( blockDirectoryResults ) {
+			tracksRecordEvent( 'wpcom_block_discovery_results', {
+				search_term,
+				results: blockDirectoryResults,
+			} );
+		} else {
+			tracksRecordEvent( 'wpcom_block_discovery_no_results', {
+				search_term,
+			} );
+		}
+	}, 2000 );
+
 	return (
 		<InserterMenuExtension>
 			{ ( { filterValue, hasItems } ) => {
 				if ( searchTerm !== filterValue ) {
 					debouncedSetFilterValue( filterValue, hasItems );
+					debouncedSetFilterValueDiscovery( filterValue );
 				}
 
 				return null;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -43,25 +43,28 @@ const InserterMenuTrackingEvent = function () {
 		tracksRecordEvent( 'wpcom_block_picker_no_results', eventProperties );
 	}, 500 );
 
-	const debouncedSetFilterValueDiscovery = debounce( ( search_term ) => {
+	const debouncedSetFilterValueDirectory = debounce( ( search_term ) => {
 		if ( search_term.length < 3 ) {
 			return;
 		}
 
-		const blockDirectoryResults = document.querySelectorAll(
-			'.block-directory-downloadable-block-list-item'
-		).length;
-
-		if ( blockDirectoryResults ) {
-			tracksRecordEvent( 'wpcom_block_discovery_results', {
-				search_term,
-				results: blockDirectoryResults,
-			} );
-		} else {
-			tracksRecordEvent( 'wpcom_block_discovery_no_results', {
-				search_term,
-			} );
+		// This is to avoid record an event on sites with a Free plan
+		if (
+			document.querySelectorAll( '.block-directory-downloadable-blocks-panel' ).length < 1 &&
+			document.querySelectorAll( '.block-editor-inserter__tips' ).length < 1
+		) {
+			return;
 		}
+
+		const trackEventName = document.querySelectorAll(
+			'.block-directory-downloadable-block-list-item'
+		).length
+			? 'wpcom_block_directory_has_results'
+			: 'wpcom_block_directory_no_results';
+
+		tracksRecordEvent( trackEventName, {
+			search_term,
+		} );
 	}, 2000 );
 
 	return (
@@ -69,7 +72,7 @@ const InserterMenuTrackingEvent = function () {
 			{ ( { filterValue, hasItems } ) => {
 				if ( searchTerm !== filterValue ) {
 					debouncedSetFilterValue( filterValue, hasItems );
-					debouncedSetFilterValueDiscovery( filterValue );
+					debouncedSetFilterValueDirectory( filterValue, hasItems );
 				}
 
 				return null;


### PR DESCRIPTION
#### Proposed Changes

- Add a tracks event that fires when the Editor returns Blocks “Available to install.” Include a prop that displays the number of block plugins returned.
- Add a tracks event for clicks on those items with a prop for the block slug and/or name.

#### Testing Instructions

1. You need to see the track events. You can use  [Tracks vigilante](p7H4VZ-3cB-p2).
2. Make sure you are sandboxed (including `widgets.wp.com s0.wp.com s1.wp.com s2.wp.com`)
3. On terminal, go to the `apps/wpcom-block-editor`.
4. Run `yarn dev --sync` (this will compile the `wpcom-block-editor` and uploaded to your sandbox. Instructions [here](https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor#dev-workflow))
5. With an atomic site, go to `Appearance` -> `Editor (beta)`
6. Click on [+]
7. Search for a block (for example `Game`)
8. Install the suggested block
9. Check your track events, you should see `wpcom_block_install` with the `block_slug` of the selected block.

#### Screenshot
Block to install:
![image](https://user-images.githubusercontent.com/402286/195451935-094fd472-df47-4473-8ae1-738134ab2c9a.png)

Track event:
<img width="756" alt="image" src="https://user-images.githubusercontent.com/402286/195453046-f1ebd5bb-efe7-4d79-b26b-00992f237c10.png">


#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes #68541 