### PR TITLE
Jetpack Backup: Fix preventing restores for Atomic Sites if credentials are invalid

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -14,6 +14,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { Activity } from '../types';
 import downloadIcon from './download-icon.svg';
@@ -55,6 +56,8 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 	const isRestoreDisabled =
 		doesRewindNeedCredentials || isRestoreInProgress || areCredentialsInvalid;
 
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+
 	return (
 		<>
 			<Button
@@ -80,7 +83,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 				>
 					{ translate( 'Restore to this point' ) }
 				</Button>
-				{ ( doesRewindNeedCredentials || areCredentialsInvalid ) && (
+				{ ! isAtomic && ( doesRewindNeedCredentials || areCredentialsInvalid ) && (
 					<div className="toolbar__credentials-warning">
 						<img src={ missingCredentialsIcon } alt="" role="presentation" />
 						<div className="toolbar__credentials-warning-text">

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -138,6 +138,8 @@ function AdminContent( { selectedDate } ) {
 		[ siteSlug ]
 	);
 
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+
 	return (
 		<>
 			<QuerySiteSettings siteId={ siteId } />
@@ -160,6 +162,7 @@ function AdminContent( { selectedDate } ) {
 						selectedDate={ selectedDate }
 						needCredentials={ needCredentials }
 						areCredentialsInvalid={ areCredentialsInvalid }
+						isAtomic={ isAtomic }
 					/>
 				</>
 			) }
@@ -167,7 +170,13 @@ function AdminContent( { selectedDate } ) {
 	);
 }
 
-function BackupStatus( { selectedDate, needCredentials, onDateChange, areCredentialsInvalid } ) {
+function BackupStatus( {
+	selectedDate,
+	needCredentials,
+	onDateChange,
+	areCredentialsInvalid,
+	isAtomic,
+} ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 
@@ -183,7 +192,7 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange, areCredent
 	return (
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
-				{ ( needCredentials || areCredentialsInvalid ) && <EnableRestoresBanner /> }
+				{ ! isAtomic && ( needCredentials || areCredentialsInvalid ) && <EnableRestoresBanner /> }
 				{ ! needCredentials && ! areCredentialsInvalid && hasRealtimeBackups && (
 					<BackupsMadeRealtimeBanner />
 				) }


### PR DESCRIPTION
 #### Proposed Changes

* Hide `Add your server credentials banner` and the message `Enter your server credentials to enable one-click restores from our backups` for Atomic sites if credentials are invalid. 

#### Screenshots
Scenario | Before | After
--- | --- | ---
Atomic site with invalid credentials | ![image](https://user-images.githubusercontent.com/1488641/195458622-1a6ad965-7bcd-48b7-b875-cf3e947c97b6.png) | ![image](https://user-images.githubusercontent.com/1488641/195458864-1357ed95-5e59-44ac-8416-8c40ff110ed4.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Atomic sites
Ideally, follow steps to reproduce the issue explained by @ash1eygrace in #69006

> * Have an Atomic Site at WordPress.com with available backups.
> * To break credentials for backups, open the Atomic Site's VPMC and change the site's URL to an invalid URL (it just needs to differ from the actual Atomic site's address which will break the credentials for backups).
> * On WordPress.com, Navigate to My Site > Atomic Site > Jetpack > Backups

##### Self-hosted Jetpack sites
To ensure self-hosted sites still working as expected, you can:
> * Grab a site with a Jetpack Backup plan. Preferable, a site you can modify the SSH/SFTP password.
> * Ensure you have working SSH/SFTP credentials on Settings page.
> * Navigate to Activity Log and Backup sections and ensure you can see the Restore to this point buttons in green color (that means they are enabled).
> * Also you should see the banner with the message “Every change you make will be backed up” on top of Backup page.
> * Modify the SSH/SFTP password on your site server (not on Jetpack Cloud settings).
> * Navigate again to Activity Log or Backup page and validate the same buttons are now disabled. It may take a couple of seconds as it is trying to test credentials using an API.



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69006
