### PR TITLE
Site Management Page: Coming Soon Tile: make it work in RTL mode

### DIFF
--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -24,6 +24,7 @@ const Root = styled.div( {
 const comingSoonTranslations: Record< string, string > = {
 	ar: 'قريبًا',
 	de: 'Demnächst verfügbar',
+	en: 'Coming Soon',
 	es: 'Próximamente',
 	fr: 'Bientôt disponible',
 	he: 'בקרוב',

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 
 type Props = {
 	siteName?: string;
@@ -55,6 +55,8 @@ const getTranslation = ( lang?: string ) => {
 
 export const SiteComingSoon = ( { siteName = '', className, lang, width, height }: Props ) => {
 	const comingSoon = getTranslation( lang );
+	const isRtl = isRTL();
+	const x = isRtl ? 375 - 31 : 31;
 	return (
 		<Root className={ className }>
 			<svg
@@ -63,6 +65,7 @@ export const SiteComingSoon = ( { siteName = '', className, lang, width, height 
 				viewBox="0 0 375 272"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
+				textAnchor={ 'start' }
 			>
 				<title>{ comingSoon }</title>
 				<text
@@ -70,7 +73,7 @@ export const SiteComingSoon = ( { siteName = '', className, lang, width, height 
 					fontFamily="Recoleta, Georgia, 'Times New Roman', Times, serif"
 					fontSize="30"
 				>
-					<tspan x="31" y="153.016">
+					<tspan x={ x } y="153.016">
 						{ comingSoon }
 					</tspan>
 				</text>
@@ -79,7 +82,7 @@ export const SiteComingSoon = ( { siteName = '', className, lang, width, height 
 					fontFamily='-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif'
 					fontSize="14"
 				>
-					<tspan x="31" y="120.102">
+					<tspan x={ x } y="120.102">
 						{ siteName }
 					</tspan>
 				</text>

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -44,18 +44,21 @@ const comingSoonTranslations: Record< string, string > = {
 
 const getTranslation = ( lang?: string ) => {
 	let text = __( 'Coming Soon' );
+	let isRtl = isRTL();
+
 	if ( lang ) {
 		lang = lang.split( '-' )[ 0 ];
 		if ( comingSoonTranslations[ lang ] ) {
 			text = comingSoonTranslations[ lang ];
+			isRtl = lang === 'ar' || lang === 'he';
 		}
 	}
-	return text;
+
+	return { text, isRtl };
 };
 
 export const SiteComingSoon = ( { siteName = '', className, lang, width, height }: Props ) => {
-	const comingSoon = getTranslation( lang );
-	const isRtl = isRTL();
+	const { text: comingSoon, isRtl } = getTranslation( lang );
 	const x = isRtl ? 375 - 31 : 31;
 	return (
 		<Root className={ className }>
@@ -66,6 +69,7 @@ export const SiteComingSoon = ( { siteName = '', className, lang, width, height 
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 				textAnchor={ 'start' }
+				direction={ isRtl ? 'rtl' : 'ltr' }
 			>
 				<title>{ comingSoon }</title>
 				<text


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68951

#### Proposed Changes

* Make the tile support RTL mode

**Note**: I figured this would be possible with CSS but I wasn't able to get it working after trying a bunch of things. So I opted for flipping the `x` coordinate manually. If you know of a better solution feel free to push a commit. 

![image](https://user-images.githubusercontent.com/6851384/195508331-3817d7a2-4bbf-41b3-a5e5-9a65663d2663.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it with a RTL language like Hebrew.
* Verify it still works ok in LTR mode

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
