### PR TITLE
Clean up the add-on code from the sign-up.

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,7 +16,6 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
-	getAddOnsStep = noop,
 } = {} ) {
 	const flows = [
 		{
@@ -72,7 +71,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'free',
-			steps: getAddOnsStep( [ 'user', 'domains' ] ),
+			steps: [ 'user', 'domains' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2020-08-11',
@@ -102,11 +101,9 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding',
-			steps: getAddOnsStep(
-				isEnabled( 'signup/professional-email-step' )
-					? [ 'user', 'domains', 'emails', 'plans' ]
-					: [ 'user', 'domains', 'plans' ]
-			),
+			steps: isEnabled( 'signup/professional-email-step' )
+				? [ 'user', 'domains', 'emails', 'plans' ]
+				: [ 'user', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
@@ -151,7 +148,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-with-email',
-			steps: getAddOnsStep( [ 'user', 'mailbox-domain', 'mailbox', 'mailbox-plan' ] ),
+			steps: [ 'user', 'mailbox-domain', 'mailbox', 'mailbox-plan' ],
 			destination: getEmailSignupFlowDestination,
 			description:
 				'Copy of the onboarding flow that includes non-skippable domain and email steps; the flow is used by the Professional Email landing page',
@@ -160,7 +157,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-registrationless',
-			steps: getAddOnsStep( [ 'domains', 'plans-new', 'user-new' ] ),
+			steps: [ 'domains', 'plans-new', 'user-new' ],
 			destination: getSignupDestination,
 			description: 'Checkout without user account or site. Read more https://wp.me/pau2Xa-1hW',
 			lastModified: '2020-06-26',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -27,13 +27,6 @@ function dependenciesContainCartItem( dependencies ) {
 	return dependencies.cartItem || dependencies.domainItem || dependencies.themeItem;
 }
 
-function getAddOnsStep( steps ) {
-	if ( isEnabled( 'signup/add-ons' ) ) {
-		return [ ...steps, 'add-ons' ];
-	}
-	return steps;
-}
-
 function getSiteDestination( dependencies ) {
 	let protocol = 'https';
 
@@ -176,7 +169,6 @@ const flows = generateFlows( {
 	getDestinationFromIntent,
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
-	getAddOnsStep,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,11 +1,9 @@
 import config from '@automattic/calypso-config';
-import debugModule from 'debug';
 import { isEmpty } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
 import store from 'store';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
 import flows from 'calypso/signup/config/flows';
@@ -40,8 +38,6 @@ import {
 	shouldForceLogin,
 	isReskinnedFlow,
 } from './utils';
-
-const debug = debugModule( 'calypso:signup' );
 
 /**
  * Constants
@@ -294,25 +290,12 @@ export default {
 			context.store.dispatch( updateDependencies( { refParameter } ) );
 		}
 
-		let actualFlowName = flowName;
-		if ( 'onboarding' === flowName ) {
-			const experimentAssignment = await loadExperimentAssignment( 'wpcom_calypso_signup_addons' );
-
-			debug(
-				`wpcom_calypso_signup_addons experiment variation: ${ experimentAssignment?.variationName }`
-			);
-
-			if ( 'treatment' === experimentAssignment?.variationName ) {
-				actualFlowName = 'with-add-ons';
-			}
-		}
-
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,
 			initialContext,
 			locale: context.params.lang,
-			flowName: actualFlowName,
+			flowName,
 			queryObject: query,
 			refParameter,
 			stepName,

--- a/config/development.json
+++ b/config/development.json
@@ -147,7 +147,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/add-ons": false,
 		"signup/anchor-fm": true,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-categories": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,7 +92,6 @@
 		"settings/featured-image-template-toggle": false,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
-		"signup/add-ons": false,
 		"signup/anchor-fm": true,
 		"signup/design-picker-pattern-assembler": false,
 		"signup/design-picker-categories": true,

--- a/config/production.json
+++ b/config/production.json
@@ -111,7 +111,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/add-ons": false,
 		"signup/anchor-fm": true,
 		"signup/design-picker-pattern-assembler": false,
 		"signup/design-picker-categories": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,7 +109,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/add-ons": false,
 		"signup/anchor-fm": true,
 		"signup/design-picker-pattern-assembler": false,
 		"signup/design-picker-categories": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,7 +118,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/add-ons": false,
 		"signup/anchor-fm": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-premium-themes-checkout": true,


### PR DESCRIPTION
#### Proposed Changes

This PR cleans up the add-on code that is no longer necessary from the signup, namely:

* The `wpcom_calypso_signup_addons` experiment.
* The feature flag `signup/add-ons` and the accompanied conditional statements and functions.

The signup step and the flow is intentionally kept, since they won't introduce overhead to end users.

#### Testing Instructions

Go through the sign-up flow and make sure it works as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
