### PR TITLE
Pattern Assembler - Pattern previews improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -6,7 +6,7 @@ import type { Pattern } from './types';
 
 type PatternLayoutProps = {
 	header: Pattern | null;
-	sections: Pattern[] | null;
+	sections: Pattern[];
 	footer: Pattern | null;
 	onAddHeader: () => void;
 	onReplaceHeader: () => void;
@@ -72,15 +72,15 @@ const PatternLayout = ( {
 							</Button>
 						</li>
 					) }
-					<AsyncLoad require="./animate-list" featureName="domMax">
+					<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
 						{ ( m: any ) =>
-							sections?.map( ( section, index ) => {
+							sections.map( ( section, index ) => {
 								const { name, key } = section as Pattern;
 								return (
 									<m.li
+										key={ key }
 										layout="position"
 										exit={ { opacity: 0, x: -50, transition: { duration: 0.2 } } }
-										key={ `${ key }` }
 										className="pattern-layout__list-item pattern-layout__list-item--section"
 									>
 										<span className="pattern-layout__list-item-text" title={ name }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-preview-auto-height.tsx
@@ -2,7 +2,9 @@ import { addQueryArgs } from '@wordpress/url';
 import { cloneElement, ReactElement, useEffect, useState } from 'react';
 
 // Same ratio as in the CSS transform in .pattern-selector__block-list iframe
-const iframeScaleRatio = 0.2705;
+const iframeScaleRatio = 0.268;
+const initialHeight = 140;
+const verticalPaddingValue = 10;
 
 const PatternPreviewAutoHeight = ( {
 	children,
@@ -15,8 +17,9 @@ const PatternPreviewAutoHeight = ( {
 	patternName: string;
 	patternId: number;
 } ) => {
-	const [ height, setHeight ] = useState( 300 );
+	const [ height, setHeight ] = useState( initialHeight );
 	const calypso_token = patternId;
+	const verticalPadding = height < initialHeight ? verticalPaddingValue : 0;
 
 	useEffect( () => {
 		const handleMessage = ( event: MessageEvent ) => {
@@ -43,13 +46,20 @@ const PatternPreviewAutoHeight = ( {
 
 	const wrapper = cloneElement(
 		children,
-		{ style: { minHeight: height * iframeScaleRatio } },
+		{
+			style: {
+				minHeight: Math.round( height * iframeScaleRatio ) + verticalPadding,
+			},
+		},
 		<iframe
 			title={ patternName }
 			frameBorder="0"
 			aria-hidden
 			tabIndex={ -1 }
-			style={ { height } }
+			style={ {
+				height,
+				top: verticalPadding / 2,
+			} }
 			src={ addQueryArgs( url, { calypso_token } ) }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -272,6 +272,7 @@ $font-family: "SF Pro Text", $sans;
 				position: absolute;
 				border-radius: 4px;
 				pointer-events: none;
+				overflow: hidden;
 			}
 
 			div {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -267,7 +267,7 @@ $font-family: "SF Pro Text", $sans;
 			iframe {
 				width: 1024px;
 				height: 665px;
-				transform: scale(0.2705);
+				transform: scale(0.268);
 				transform-origin: top left;
 				position: absolute;
 				border-radius: 4px;
@@ -283,6 +283,7 @@ $font-family: "SF Pro Text", $sans;
 				overflow: hidden;
 				user-select: none;
 				cursor: pointer;
+				background: #fff;
 
 				&:not(:last-child) {
 					margin-bottom: 16px;

--- a/packages/components/src/animation/features/index.ts
+++ b/packages/components/src/animation/features/index.ts
@@ -8,6 +8,6 @@ export const loadFramerFeatures = async ( feature: string ) => {
 			featurePath = './domMax';
 			break;
 	}
-	const mod = await import( featurePath );
+	const mod = await import( `${ featurePath }` );
 	return mod.default;
 };

--- a/packages/components/src/animation/features/index.ts
+++ b/packages/components/src/animation/features/index.ts
@@ -8,6 +8,6 @@ export const loadFramerFeatures = async ( feature: string ) => {
 			featurePath = './domMax';
 			break;
 	}
-	const mod = await import( `${ featurePath }` );
+	const mod = await import( featurePath );
 	return mod.default;
 };


### PR DESCRIPTION
#### Proposed Changes

* Disable scrolling within the pattern preview iframe
* Remove a scrollbar added by the async load placeholder
* Add some vertical padding to the pattern preview iframe 
* Improve the pattern preview scale and min-height

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the URL wordpress.com/setup?siteSlug=[YOUR SITE]&flags=signup/design-picker-pattern-assembler
* Don't choose any goal or vertical
* On the design picker, click on the blank canvas CTA
* Click to choose a header, sections, and footer
* Check that the pattern previews look good and everything works as expected ;)
* You should not be able to scroll within a pattern preview

https://user-images.githubusercontent.com/1881481/195523689-65be36c5-aada-43e2-8928-bdd75f4219e8.mov

* Shortly, while the Pattern Assembler is loading, you should not see the following scrollbar on the top of the text `Add a first section`.
<img width="298" alt="Screen Shot 2565-10-13 at 10 35 05" src="https://user-images.githubusercontent.com/1881481/195525418-ea7778f6-ad07-4120-822c-448eac4e8ec5.png">

* You should see vertical padding on short height patterns. This fix applies mainly to headers (patterns shorter than `140px`).

|Before|After|
|-------|-----|
|<img width="603" alt="Screen Shot 2565-10-13 at 11 18 04" src="https://user-images.githubusercontent.com/1881481/195524100-c6da9a7e-f53d-4508-b6bb-8e772877c03c.png">|<img width="518" alt="Screen Shot 2565-10-13 at 14 02 26" src="https://user-images.githubusercontent.com/1881481/195525137-9e037e5f-d848-4dec-a200-bcee62858a03.png">|

* You should see other pattern preview improvements related to better scaling. For instance, check the padding on the right of the text `Contact` in the following pattern. 

|Before|After|
|-------|-----|
|<img width="508" alt="Screen Shot 2565-10-13 at 14 10 07" src="https://user-images.githubusercontent.com/1881481/195526944-fb4f3b3a-0cd6-4456-8dc0-0ba7241e57e4.png">|<img width="510" alt="Screen Shot 2565-10-13 at 14 09 32" src="https://user-images.githubusercontent.com/1881481/195526966-3df95819-c5b6-448a-b11f-5800624d254b.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69012
