### PR TITLE
Fix/tailored flow mobile styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -59,18 +59,11 @@ button {
 .patterns,
 .link-in-bio-setup,
 .link-in-bio-post-setup,
-.completing-purchase,
 .anchor-fm,
 .subscribers,
-.blazepress,
 .intro {
 	padding: 60px 0 0;
 	box-sizing: border-box;
-
-	// very narrow wide screens (mobile landscape)
-	@media screen and ( max-height: 512px ) {
-		padding: 5px 0 0;
-	}
 
 	&.courses {
 		padding: 0;
@@ -145,6 +138,27 @@ button {
 /**
  * Tailored flow stylings
  */
+.newsletter,
+.link-in-bio {
+	&:not(.launchpad):not(.subscribers) {
+		@include onboarding-break-mobile-landscape {
+			padding: 40px 0 0;
+		}
+	}
+
+	.step-container {
+		.step-container__content h1,
+		.step-container__header h1.formatted-header__title {
+			font-size: $font-title-medium;
+			line-height: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+
+			@include break-medium {
+				font-size: $font-headline-medium;
+			}
+		}
+	}
+}
+
 .newsletter,
 .link-in-bio,
 .setup-form__form {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -11,7 +11,7 @@
 		background-attachment: fixed;
 		/*!rtl:ignore*/
 		background-position-x: 0%, 100%;
-		background-position-y: 100%, 100px;
+		background-position-y: 100%, 80px;
 		background-size: auto 30%, auto 50%;
 
 
@@ -84,6 +84,10 @@
 
 		.step-container__jetpack-powered {
 			margin: 20px 0 60px;
+
+			@include onboarding-break-mobile-landscape {
+				margin: 5px 0 60px;
+			}
 		}
 	}
 
@@ -106,6 +110,10 @@
 		@include break-large {
 			font-size: 2.75rem;
 			line-height: 52px;
+		}
+
+		@include onboarding-break-mobile-landscape {
+			font-size: $font-title-medium;
 		}
 
 		span {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -12,13 +12,5 @@ $font-family: "SF Pro Text", $sans;
 
 	.link-in-bio-setup .step-container__header {
 		margin-bottom: 32px;
-
-		h1.formatted-header__title {
-			font-size: $font-title-medium;
-
-			@include break-medium {
-				font-size: $font-headline-medium;
-			}
-		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -12,13 +12,5 @@
 
 	.newsletter-setup .step-container__header {
 		margin-bottom: 32px;
-
-		h1.formatted-header__title {
-			font-size: $font-title-medium;
-
-			@include break-medium {
-				font-size: $font-headline-medium;
-			}
-		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
@@ -20,19 +20,6 @@
 			@media screen and ( max-height: 512px ) {
 				margin: 0;
 			}
-
-			h1.formatted-header__title {
-				font-size: $font-title-medium;
-
-				@include break-medium {
-					font-size: $font-headline-medium;
-				}
-
-				// very narrow wide screens (mobile land scape)
-				@media screen and ( max-height: 512px ) {
-					font-size: $font-title-medium;
-				}
-			}
 		}
 
 		.step-container__jetpack-powered {

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -124,6 +124,13 @@
 	}
 }
 
+@mixin onboarding-break-mobile-landscape() {
+	// very narrow wide screens (mobile landscape)
+	@media screen and ( max-height: 512px ) {
+		@content;
+	}
+}
+
 @mixin onboarding-modal-overlay {
 	// Absolute positioning allows the modal
 	// to reuse the <body> element's scrollbar.


### PR DESCRIPTION
#### Proposed Changes

* `blazepress` and `completing-purchase` got removed [here](https://github.com/Automattic/wp-calypso/pull/67756) and [here](https://github.com/Automattic/wp-calypso/pull/67399). The global style is updated to reflect this.
* The targeting for devices in landscape mode was added [here](https://github.com/Automattic/wp-calypso/pull/66504) and it targeted lots of different steps. This targeting was set as a mixin as part of the onboarding package and now it targets only the tailored flows `newsletter` and `link in bio` excluding the `subscribers` and `launchpad` steps where it is not needed.
* We were redefining the header styles for every step of a tailored flow. This custom targeting is now removed and replaced with a global one
* For devices with height >= `512px` we were getting broken UI for the tailored flows, and this PR fixes that.

### Visual Reference
| Before  | After |
| ------------- | ------------- |
|  <img width="413" alt="newletter intro before" src="https://user-images.githubusercontent.com/7000684/195562984-2fd05188-5da3-438e-a0df-882d279244ef.png"> |   <img width="557" alt="newletter intro after" src="https://user-images.githubusercontent.com/7000684/195563037-2a875023-9bea-43fa-a6be-6f6a6155bbd4.png"> |
|  <img width="514" alt="lib intro before" src="https://user-images.githubusercontent.com/7000684/195563095-07edc265-395c-4712-aebf-42409e339368.png"> | <img width="443" alt="lib intro after" src="https://user-images.githubusercontent.com/7000684/195563155-7d5d599c-b33f-4c3b-bbd5-9fcc9b0a124a.png"> |
| <img width="439" alt="newsletter setup before" src="https://user-images.githubusercontent.com/7000684/195563209-b8b1abb5-25e9-4374-8d0a-e65be884c4ab.png"> | <img width="451" alt="newsletter setup after" src="https://user-images.githubusercontent.com/7000684/195563253-7d009ef5-918f-4f33-84f9-b25489a2cd5e.png"> |
| <img width="472" alt="Screenshot 2022-10-13 at 10 43 04" src="https://user-images.githubusercontent.com/7000684/195563987-2018958b-cc77-455a-9ad3-82fa05535ae0.png"> | <img width="468" alt="Screenshot 2022-10-13 at 11 47 07" src="https://user-images.githubusercontent.com/7000684/195564050-6a5e84c8-ff98-4cd3-9b8e-31ade74c5e52.png"> |
| <img width="417" alt="lib patterns before" src="https://user-images.githubusercontent.com/7000684/195563313-5aba2c67-ef19-481e-8546-a76884f4e8b6.png"> | <img width="412" alt="lib patterns after" src="https://user-images.githubusercontent.com/7000684/195563368-2e84c1dc-6c17-4d1c-807c-4f92fb7237cb.png"> |
| <img width="549" alt="Screenshot 2022-10-13 at 10 09 14" src="https://user-images.githubusercontent.com/7000684/195563433-3aef1a38-3b42-4c6c-a78d-6c4bfaf03cad.png"> | <img width="461" alt="Screenshot 2022-10-13 at 10 32 58" src="https://user-images.githubusercontent.com/7000684/195563482-12f07173-6a62-4726-8849-54ea1230f84a.png"> |
| <img width="436" alt="Screenshot 2022-10-13 at 10 40 05" src="https://user-images.githubusercontent.com/7000684/195563580-39fe23c4-4583-4702-bcbb-4eeaba0f2806.png"> | <img width="411" alt="Screenshot 2022-10-13 at 10 39 39" src="https://user-images.githubusercontent.com/7000684/195563607-b49b959e-9ed7-4d60-823f-005301993bbb.png"> |








#### Testing Instructions
- Checkout this branch and run `yarn start` or use the PR links
- Follow the newsletter and link in bio flows with viewport height >= `512px`
- Check for styling issues and inconsistencies
- Test on other viewport for possible regressions

Related to #68956
