### PR TITLE
Dev Tools: Add Language Picker for dev and wpcalypso environments

### DIFF
--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -10,6 +10,12 @@ export function ReactQueryDevtoolsHelper() {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
+export function AccountSettingsHelper() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return <div className="environment is-account-settings" />;
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}
+
 export function PreferencesHelper() {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-prefs" />;

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { Component } from 'react';
 import EnvironmentBadge, {
 	Branch,
+	AccountSettingsHelper,
 	AuthHelper,
 	DevDocsLink,
 	PreferencesHelper,
@@ -23,6 +24,7 @@ class Document extends Component {
 	render() {
 		const {
 			app,
+			accountSettingsHelper,
 			authHelper,
 			chunkFiles,
 			commitSha,
@@ -154,6 +156,7 @@ class Document extends Component {
 					{ badge && (
 						<EnvironmentBadge badge={ badge } feedbackURL={ feedbackURL }>
 							{ reactQueryDevtoolsHelper && <ReactQueryDevtoolsHelper /> }
+							{ accountSettingsHelper && <AccountSettingsHelper /> }
 							{ preferencesHelper && <PreferencesHelper /> }
 							{ featuresHelper && <FeaturesHelper /> }
 							{ authHelper && <AuthHelper /> }

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -1,0 +1,43 @@
+import languages from '@automattic/languages';
+import ReactDom from 'react-dom';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import LanguagePicker from 'calypso/components/language-picker';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { setUserSetting } from 'calypso/state/user-settings/actions';
+import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
+
+import './style.scss';
+
+export function AccountSettingsHelper() {
+	const dispatch = useDispatch();
+	const userSettings = useSelector( getUserSettings ) ?? {};
+	const updateLanguage = async ( event ) => {
+		const { value } = event.target;
+		dispatch( setUserSetting( 'language', value ) );
+		dispatch( saveUnsavedUserSettings( [ 'language' ] ) ).then( () => {
+			window.location.reload();
+		} );
+	};
+	return (
+		<>
+			<QueryUserSettings />
+			<div>Account Settings</div>
+			<div className="account-settings-helper__popover">
+				<LanguagePicker
+					languages={ languages }
+					valueKey="langSlug"
+					value={ userSettings?.locale_variant || userSettings.language || '' }
+					onChange={ updateLanguage }
+				/>
+			</div>
+		</>
+	);
+}
+export default ( element, store ) =>
+	ReactDom.render(
+		<Provider store={ store }>
+			<AccountSettingsHelper />
+		</Provider>,
+		element
+	);

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 export function AccountSettingsHelper() {
 	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings ) ?? {};
-	const updateLanguage = async ( event ) => {
+	const updateLanguage = ( event ) => {
 		const { value } = event.target;
 		dispatch( setUserSetting( 'language', value ) );
 		dispatch( saveUnsavedUserSettings( [ 'language' ] ) ).then( () => {

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -13,12 +13,23 @@ export function AccountSettingsHelper() {
 	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings ) ?? {};
 	const updateLanguage = ( event ) => {
-		const { value, empathyMode } = event.target;
+		const { value, empathyMode, useFallbackForIncompleteLanguages } = event.target;
 		if ( typeof empathyMode !== 'undefined' ) {
-			setUserSetting( 'i18n_empathy_mode', empathyMode );
+			dispatch( setUserSetting( 'i18n_empathy_mode', empathyMode ) );
+		}
+		if ( typeof useFallbackForIncompleteLanguages !== 'undefined' ) {
+			dispatch(
+				setUserSetting( 'use_fallback_for_incomplete_languages', useFallbackForIncompleteLanguages )
+			);
 		}
 		dispatch( setUserSetting( 'language', value ) );
-		dispatch( saveUnsavedUserSettings( [ 'language' ] ) ).then( () => {
+		dispatch(
+			saveUnsavedUserSettings( [
+				'i18n_empathy_mode',
+				'use_fallback_for_incomplete_languages',
+				'language',
+			] )
+		).then( () => {
 			window.location.reload();
 		} );
 	};
@@ -32,6 +43,7 @@ export function AccountSettingsHelper() {
 					valueKey="langSlug"
 					value={ userSettings?.locale_variant || userSettings.language || '' }
 					empathyMode={ userSettings?.i18n_empathy_mode }
+					useFallbackForIncompleteLanguages={ userSettings?.use_fallback_for_incomplete_languages }
 					onChange={ updateLanguage }
 				/>
 			</div>

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -13,7 +13,10 @@ export function AccountSettingsHelper() {
 	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings ) ?? {};
 	const updateLanguage = ( event ) => {
-		const { value } = event.target;
+		const { value, empathyMode } = event.target;
+		if ( typeof empathyMode !== 'undefined' ) {
+			setUserSetting( 'i18n_empathy_mode', empathyMode );
+		}
 		dispatch( setUserSetting( 'language', value ) );
 		dispatch( saveUnsavedUserSettings( [ 'language' ] ) ).then( () => {
 			window.location.reload();
@@ -28,6 +31,7 @@ export function AccountSettingsHelper() {
 					languages={ languages }
 					valueKey="langSlug"
 					value={ userSettings?.locale_variant || userSettings.language || '' }
+					empathyMode={ userSettings?.i18n_empathy_mode }
 					onChange={ updateLanguage }
 				/>
 			</div>

--- a/client/lib/account-settings-helper/style.scss
+++ b/client/lib/account-settings-helper/style.scss
@@ -1,0 +1,12 @@
+.account-settings-helper__popover {
+	display: none;
+}
+
+.environment.is-account-settings:hover .account-settings-helper__popover {
+	display: block;
+	position: absolute;
+	bottom: 100%;
+	padding: 4px;
+	background: var(--color-surface);
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+}

--- a/client/lib/load-dev-helpers/index.js
+++ b/client/lib/load-dev-helpers/index.js
@@ -1,6 +1,14 @@
 import config from '@automattic/calypso-config';
 
 export default function loadDevHelpers( reduxStore ) {
+	// account settings helper requires a Redux store.
+	if ( reduxStore && config.isEnabled( 'dev/account-settings-helper' ) ) {
+		const el = document.querySelector( '.environment.is-account-settings' );
+		if ( el ) {
+			asyncRequire( 'calypso/lib/account-settings-helper', ( helper ) => helper( el, reduxStore ) );
+		}
+	}
+
 	if ( config.isEnabled( 'dev/auth-helper' ) ) {
 		const el = document.querySelector( '.environment.is-auth' );
 		if ( el ) {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -550,7 +550,9 @@ const renderServerError =
 	( err, req, res, next ) => {
 		// If the response is not writable it means someone else already rendered a page, do nothing
 		// Hopefully they logged the error as well.
-		if ( res.writableEnded ) return;
+		if ( res.writableEnded ) {
+			return;
+		}
 
 		try {
 			req.logger.error( err );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -142,6 +142,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 
 	const reactQueryDevtoolsHelper = config.isEnabled( 'dev/react-query-devtools' );
 	const authHelper = config.isEnabled( 'dev/auth-helper' );
+	const accountSettingsHelper = config.isEnabled( 'dev/account-settings-helper' );
 	// preferences helper requires a Redux store, which doesn't exist in Gutenboarding
 	const preferencesHelper =
 		config.isEnabled( 'dev/preferences-helper' ) && entrypoint !== 'entry-gutenboarding';
@@ -162,6 +163,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		entrypoint: request.getFilesForEntrypoint( entrypoint ),
 		manifests: request.getAssets().manifests,
 		reactQueryDevtoolsHelper,
+		accountSettingsHelper,
 		authHelper,
 		preferencesHelper,
 		featuresHelper,

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"current-site/stale-cart-notice": false,
 		"desktop-promo": true,
 		"dev/auth-helper": true,
+		"dev/account-settings-helper": true,
 		"dev/features-helper": true,
 		"dev/preferences-helper": true,
 		"dev/react-query-devtools": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -26,6 +26,7 @@
 		"current-site/stale-cart-notice": false,
 		"desktop-promo": true,
 		"dev/auth-helper": true,
+		"dev/account-settings-helper": true,
 		"dev/preferences-helper": true,
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,


### PR DESCRIPTION
Fixes #69024

## Proposed Changes

To make it easier for developers to vet interfaces across a variety of languages, I'd like to add a Language Picker to Dev Tools:

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/36432/195602993-77c1dfa8-4eeb-411e-95a2-aa2e079bc615.png">

When you click on it, it loads a modal for you to select a language:

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/36432/195603308-2fdebc37-8406-4ea9-b654-6d09046ccd29.png">

After you select a language, the page refreshes to load the new strings.

## Testing Instructions

1. Open 'Account Settings' in Dev Tools and choose a different language from the modal.
2. Verify your account switches to the specified language.
3. Verify nothing else breaks.