### PR TITLE
Remove follow label from related cards

### DIFF
--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -341,6 +341,7 @@
 	position: relative;
 	padding: 0;
 	z-index: z-index(".reader-related-card__meta", ".follow-button");
+	left: 50px;
 
 	.reader-follow-feed {
 		fill: var(--color-primary);
@@ -351,11 +352,7 @@
 	}
 
 	.follow-button__label {
-		color: var(--color-primary);
-
-		@include breakpoint-deprecated( "<960px" ) {
-			display: none;
-		}
+		display: none;
 	}
 
 	.gridicon {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -172,6 +172,7 @@
 			margin-top: 0;
 			position: relative;
 			top: -2px;
+			left: 50px;
 
 			@include breakpoint-deprecated( "<480px" ) {
 				margin-right: 0;


### PR DESCRIPTION
This PR removes the `Follow` or `Following` label from the recommended/related posts in reader.

Examples can be found when you go to reader search - http://calypso.localhost:3000/read/search

... or when you click into a recommended post and view related cards at the bottom of the full view page

### Before
<img width="932" alt="Screenshot 2022-10-13 at 14 13 08" src="https://user-images.githubusercontent.com/5560595/195606090-458af247-5fb2-4fa9-8ce8-0f46e3ee0904.png">
<img width="750" alt="Screenshot 2022-10-13 at 14 12 10" src="https://user-images.githubusercontent.com/5560595/195606097-f86983da-c03d-47df-9dee-05b254aa9bf3.png">


### After
<img width="958" alt="Screenshot 2022-10-13 at 14 03 40" src="https://user-images.githubusercontent.com/5560595/195603824-58189d26-ff31-4df4-9bff-cb3c3ff86bc4.png">

<img width="762" alt="Screenshot 2022-10-13 at 14 04 19" src="https://user-images.githubusercontent.com/5560595/195603972-27994540-6a98-42ee-a219-d206cd4960c9.png">

Ref - https://github.com/Automattic/wp-calypso/issues/68982
