### PR TITLE
Fix Reader cancel comment reply

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -44,7 +44,7 @@ class PostCommentForm extends Component {
 		if ( event.keyCode === 27 ) {
 			if ( this.props.placeholderId ) {
 				// sync the text to the upper level so it won't be lost
-				this.props.onUpdateCommentText( this.props.commentText );
+				this.props.onUpdateCommentText( this.getCommentText() );
 				// remove the comment
 				this.props.deleteComment(
 					this.props.post.site_ID,
@@ -68,7 +68,7 @@ class PostCommentForm extends Component {
 		event.preventDefault();
 
 		const post = this.props.post;
-		const commentText = this.props.commentText.trim();
+		const commentText = this.getCommentText().trim();
 
 		if ( ! commentText ) {
 			this.resetCommentText(); // Clean up any newlines
@@ -104,8 +104,12 @@ class PostCommentForm extends Component {
 		this.props.onUpdateCommentText( '' );
 	}
 
+	getCommentText() {
+		return this.props.commentText ?? '';
+	}
+
 	hasCommentText() {
-		return this.props.commentText.trim().length > 0;
+		return this.getCommentText().trim().length > 0;
 	}
 
 	render() {
@@ -141,7 +145,7 @@ class PostCommentForm extends Component {
 				<FormFieldset>
 					<Gravatar user={ this.props.currentUser } />
 					<AutoresizingFormTextarea
-						value={ this.props.commentText }
+						value={ this.getCommentText() }
 						placeholder={ translate( 'Enter your comment here…' ) }
 						onKeyUp={ this.handleKeyUp }
 						onKeyDown={ this.handleKeyDown }
@@ -152,7 +156,7 @@ class PostCommentForm extends Component {
 					/>
 					<Button
 						className={ buttonClasses }
-						disabled={ this.props.commentText.length === 0 }
+						disabled={ this.getCommentText().length === 0 }
 						onClick={ this.handleSubmit }
 					>
 						{ this.props.error ? translate( 'Resend' ) : translate( 'Send' ) }


### PR DESCRIPTION
This PR fixes a bug that causes the calypso to crash when you click on the cancel reply in the reader full view page comment section.

https://user-images.githubusercontent.com/5560595/195617438-da36ca86-fa68-46ef-9a9f-2c9b8e861793.mov

The `commentText` can be null which means when string functions are called on it, it crashes. The PR creates a `getCommentText` function to always return a string so that we can persist in treating the commentText as a string.

### Test

Go to full view page of a reader post
Reply to comment and click the cancel reply link, it should not crash
Reply with a comment, it should save comment as expected
