### PR TITLE
SPF: Send forum topics to test.forums if dev/wpcalypso

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -276,6 +276,8 @@ class HelpContact extends Component {
 			locale: currentUserLocale,
 			client: config( 'client_slug' ),
 			hide_blog_info: userRequestsHidingUrl,
+			should_use_test_forums:
+				config( 'env_id' ) === 'wpcalypso' || config( 'env_id' ) === 'development',
 		};
 
 		if ( site ) {


### PR DESCRIPTION
In this PR, we send the support forum topics created on https://wordpress.com/help/contact to test.forums if the current Calypso environment is development or wpcalypso.

## Testing instructions

Test with D89857-code.