### PR TITLE
Marketplace: align plugin collection styles

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -76,6 +76,7 @@
 		}
 
 		@include break-wide {
+			// select first row for a 3 column grid
 			&:first-of-type,
 			&:nth-of-type(2),
 			&:nth-of-type(3) {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -10,7 +10,7 @@
 	cursor: pointer;
 	display: block;
 	float: left;
-	margin: 20px 0 0 0;
+	margin: 16px 0 0 0;
 	position: relative;
 	overflow: hidden;
 
@@ -67,10 +67,20 @@
 		}
 
 		@include break-medium {
+			// select first row for a 2 column grid
+			&:first-of-type,
+			&:nth-of-type(2) {
+				margin-top: 24px;
+			}
 			width: calc(50% - 10px); // 2 column grid with 20px gutter
 		}
 
 		@include break-wide {
+			&:first-of-type,
+			&:nth-of-type(2),
+			&:nth-of-type(3) {
+				margin-top: 24px;
+			}
 			width: calc(33% - 10px); // 3 column grid with 20px gutter
 		}
 	}

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -10,7 +10,7 @@
 
 		.plugins-results-header__title {
 			@extend .wp-brand-font;
-			font-size: rem(26px); //typography-exception
+			font-size: $font-title-medium;
 			font-weight: 500;
 		}
 

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -10,7 +10,7 @@
 
 		.plugins-results-header__title {
 			@extend .wp-brand-font;
-			font-size: $font-title-medium;
+			font-size: rem(26px); //typography-exception
 			font-weight: 500;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Aligned margins/paddings font sizes with the design as mentioned [here](https://github.com/Automattic/wp-calypso/issues/68946#issuecomment-1277368180)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins
* Check styles on Mobile and Desktop resolutions

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] ~Have you checked for TypeScript, React or other console errors?~
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68946 
