### PR TITLE
Checkout: add accessible name to PayPal submit button

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -10,7 +10,6 @@ import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
 import { Fragment, useMemo } from 'react';
 import TaxFields from 'calypso/my-sites/checkout/composite-checkout/components/tax-fields';
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
@@ -207,6 +206,7 @@ function PayPalSubmitButton( {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 } ) {
+	const { __ } = useI18n();
 	const { formStatus } = useFormStatus();
 	const { transactionStatus } = useTransactionStatus();
 	const postalCode = useSelect( ( select ) => select( storeKey )?.getPostalCode() );
@@ -230,7 +230,7 @@ function PayPalSubmitButton( {
 			buttonType="paypal"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
-			aria-label={ i18n.translate( 'Pay with PayPal' ) }
+			aria-label={ __( 'Pay with PayPal' ) }
 		>
 			<PayPalButtonContents formStatus={ formStatus } transactionStatus={ transactionStatus } />
 		</Button>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
+import i18n from 'i18n-calypso';
 import { Fragment, useMemo } from 'react';
 import TaxFields from 'calypso/my-sites/checkout/composite-checkout/components/tax-fields';
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
@@ -229,6 +230,7 @@ function PayPalSubmitButton( {
 			buttonType="paypal"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
+			aria-label={ i18n.translate( 'Pay with PayPal' ) }
 		>
 			<PayPalButtonContents formStatus={ formStatus } transactionStatus={ transactionStatus } />
 		</Button>


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the checkout flow, the PayPal submit button has no accessible name set. It is therefore read as "button" by screen readers, providing users with no further information.

### Implementation notes

Accessible name was added via the HTML `aria-label` attribute.

### Testing instructions

- Spin up this branch locally, or use the live link below.
- In a private window, visit `/checkout/jetpack/jetpack_backup_t1_yearly`.
- Enter your billing information, and choose the PayPal payment method (it might not be available for every country).
- Using a screen reader, check that the PayPal submit button is labeled `Pay with PayPal`. Alternatively, check its `aria-label` attribute in the inspector.
<img width="1654" alt="Screen Shot 2022-10-13 at 12 21 13 PM" src="https://user-images.githubusercontent.com/1620183/195654292-abedb754-23eb-4a73-a93f-535639aece5e.png">


### Screenshots

Here's how VoiceOver on Mac now describes the button.

https://user-images.githubusercontent.com/1620183/195653036-2de7bca9-4b7c-4bf9-8a63-e3f3395791f4.mov

