### PR TITLE
Stats: Restore nested visitor bars

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -102,6 +102,7 @@ class StatsSite extends Component {
 	// getDerivedStateFromProps will set the state both on init and tab switch
 	state = {
 		activeTab: null,
+		activeLegend: null,
 	};
 
 	static getDerivedStateFromProps( props, state ) {
@@ -112,9 +113,15 @@ class StatsSite extends Component {
 		if ( activeTab !== state.activeTab ) {
 			return {
 				activeTab,
+				activeLegend: activeTab.legendOptions || [],
 			};
 		}
 		return null;
+	}
+
+	getAvailableLegend() {
+		const activeTab = getActiveTab( this.props.chartTab );
+		return activeTab.legendOptions || [];
 	}
 
 	barClick = ( bar ) => {
@@ -122,6 +129,8 @@ class StatsSite extends Component {
 		const updatedQs = stringifyQs( updateQueryString( { startDate: bar.data.period } ) );
 		page.redirect( `${ window.location.pathname }?${ updatedQs }` );
 	};
+
+	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
 	switchChart = ( tab ) => {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
@@ -208,7 +217,9 @@ class StatsSite extends Component {
 				<div id="my-stats-content">
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
-						activeLegend={ [] } // previously used by chart legend, now only needed to maintain memoization of `buildChartData()`
+						activeLegend={ this.state.activeLegend }
+						availableLegend={ this.getAvailableLegend() }
+						onChangeLegend={ this.onChangeLegend }
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }
 						charts={ CHARTS }

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -1,8 +1,6 @@
 // Module Tabs
 // (currently only used for the bar chart module at the top)
 
-$stats-chart-top-spacing: 16px;
-
 ul.module-tabs {
 	@include clear-fix;
 	border-top: 1px solid var(--color-neutral-0);
@@ -230,11 +228,5 @@ ul.module-tabs {
 		a {
 			background: var(--color-neutral-0);
 		}
-	}
-}
-
-.is-chart-tabs {
-	.chart {
-		padding-top: $stats-chart-top-spacing;
 	}
 }

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -35,11 +35,6 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 }
 
 const EMPTY_RESULT = [];
-
-// `activeLegend` is used to display a (chart) bar in a bar. After deleting a legend on the Stats page, the property is redudnant and
-// always receives an empty array. I didn't remove the argument in case other places use it.
-// Side note: passing an empty array in a connect() method breaks the memoization, it has to come as a prop, not from within connect() - otherwise,
-// chart's x-axis width or the amount of visible points is calclulated incorrectly
 export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period, queryDate ) => {
 	if ( ! data ) {
 		return EMPTY_RESULT;

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Chart from 'calypso/components/chart';
+import Legend from 'calypso/components/chart/legend';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import compareProps from 'calypso/lib/compare-props';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -29,6 +30,7 @@ const ChartTabShape = PropTypes.shape( {
 class WordAdsChartTabs extends Component {
 	static propTypes = {
 		activeTab: ChartTabShape,
+		availableLegend: PropTypes.arrayOf( PropTypes.string ),
 		charts: PropTypes.arrayOf( ChartTabShape ),
 		data: PropTypes.arrayOf(
 			PropTypes.shape( {
@@ -41,6 +43,7 @@ class WordAdsChartTabs extends Component {
 			} )
 		),
 		isActiveTabLoading: PropTypes.bool,
+		onChangeLegend: PropTypes.func.isRequired,
 	};
 
 	buildTooltipData( item ) {
@@ -121,6 +124,11 @@ class WordAdsChartTabs extends Component {
 				{ siteId && <QuerySiteStats statType="statsAds" siteId={ siteId } query={ query } /> }
 
 				<Card className={ classNames( ...classes ) }>
+					<Legend
+						activeCharts={ this.props.activeLegend }
+						activeTab={ this.props.activeTab }
+						tabs={ this.props.charts }
+					/>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
 					<Chart

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -72,6 +72,7 @@ class WordAds extends Component {
 	// getDerivedStateFromProps will set the state both on init and tab switch
 	state = {
 		activeTab: null,
+		activeLegend: null,
 	};
 
 	static getDerivedStateFromProps( props, state ) {
@@ -82,9 +83,15 @@ class WordAds extends Component {
 		if ( activeTab !== state.activeTab ) {
 			return {
 				activeTab,
+				activeLegend: activeTab.legendOptions || [],
 			};
 		}
 		return null;
+	}
+
+	getAvailableLegend() {
+		const activeTab = getActiveTab( this.props.chartTab );
+		return activeTab.legendOptions || [];
 	}
 
 	barClick = ( bar ) => {
@@ -92,6 +99,8 @@ class WordAds extends Component {
 		const updatedQs = stringifyQs( updateQueryString( { startDate: bar.data.period } ) );
 		page.redirect( `${ window.location.pathname }?${ updatedQs }` );
 	};
+
+	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
 	switchChart = ( tab ) => {
 		if ( ! tab.loading && tab.attr !== this.state.chartTab ) {
@@ -155,6 +164,9 @@ class WordAds extends Component {
 						<div id="my-stats-content" className="wordads">
 							<WordAdsChartTabs
 								activeTab={ getActiveTab( this.props.chartTab ) }
+								activeLegend={ this.state.activeLegend }
+								availableLegend={ this.getAvailableLegend() }
+								onChangeLegend={ this.onChangeLegend }
 								barClick={ this.barClick }
 								switchTab={ this.switchChart }
 								charts={ CHARTS }


### PR DESCRIPTION
This reverts 9609c459f3b9c098bbb97b5736f04c8fedcd94b1.

#### Proposed Changes

Reverts #68696.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the visitor bars have been restored to the Stats page
* Verify that the chart behaves as expected
* Ensure that the clickable legend on the top right has been restored.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
