### PR TITLE
Seller Experience: Refactor upgrade modal and add 3rd-party subscription UI logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -177,4 +177,23 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		font-weight: 500;
 		margin-bottom: 5px;
 	}
+
+	.upgrade-modal__product-list {
+		width: 100%;
+		font-size: 0.875rem;
+
+		tr {
+			td {
+				padding: 15px 0;
+			}
+
+			&:first-child td {
+				border-bottom: 1px solid #ddd;
+			}
+
+			td:first-child {
+				width: 60%;
+			}
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -19,6 +19,13 @@ interface UpgradeModalProps {
 	checkout: () => void;
 }
 
+interface UpgradeModalContent {
+	header: JSX.Element;
+	text: JSX.Element;
+	price: JSX.Element | null;
+	action: JSX.Element;
+}
+
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
 	const theme = useThemeDetails( slug );
@@ -45,82 +52,91 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	//Wait until we have theme and product data to show content
 	const isLoading = ! themePrice || ! theme.data;
 
-	let header = (
-		<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
-	);
-
-	let text = (
-		<p>
-			{ translate(
-				'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
-			) }
-		</p>
-	);
-
-	const price = (
-		<div className="upgrade-modal__theme-price">
-			{ translate( '{{span}}%(themePrice)s{{/span}} per year', {
-				components: {
-					span: <span />,
-				},
-				args: {
-					themePrice,
-				},
-			} ) }
-		</div>
-	);
-
-	let action = (
-		<>
-			<div className="upgrade-modal__actions">
-				<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
-					{ translate( 'Buy and activate theme' ) }
-				</Button>
-			</div>
-			<p className="upgrade-modal__plan-nudge">
-				{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
-					components: {
-						button: <Button onClick={ () => checkout() } plain />,
-					},
-				} ) }
-			</p>
-		</>
-	);
-
-	if ( showBundleVersion ) {
-		header = (
-			<>
-				<img src={ wooCommerceImage } alt="WooCommerce" className="upgrade-modal__woo-logo" />
-				<h1 className="upgrade-modal__heading bundle">
-					{ translate( 'Unlock this WooCommerce theme' ) }
-				</h1>
-			</>
-		);
-
-		text = (
-			<p>
-				{ translate(
-					"This theme comes bundled with {{link}}WooCommerce{{/link}} plugin. Upgrade to a Business plan to select this theme and unlock all its features. It's %s per year with a 14-day money-back guarantee.",
-					{
+	const getStandardPurchaseModalData = (): UpgradeModalContent => {
+		return {
+			header: (
+				<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
+			),
+			text: (
+				<p>
+					{ translate(
+						'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
+					) }
+				</p>
+			),
+			price: (
+				<div className="upgrade-modal__theme-price">
+					{ translate( '{{span}}%(themePrice)s{{/span}} per year', {
 						components: {
-							link: <ExternalLink target="_blank" href="https://woocommerce.com/" />,
+							span: <span />,
 						},
-						args: themePrice,
-					}
-				) }
-			</p>
-		);
+						args: {
+							themePrice,
+						},
+					} ) }
+				</div>
+			),
+			action: (
+				<>
+					<div className="upgrade-modal__actions">
+						<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
+							{ translate( 'Buy and activate theme' ) }
+						</Button>
+					</div>
+					<p className="upgrade-modal__plan-nudge">
+						{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
+							components: {
+								button: <Button onClick={ () => checkout() } plain />,
+							},
+						} ) }
+					</p>
+				</>
+			),
+		};
+	};
 
-		action = (
-			<div className="upgrade-modal__actions bundle">
-				<Button className="upgrade-modal__cancel" onClick={ () => closeModal() }>
-					{ translate( 'Cancel' ) }
-				</Button>
-				<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>
-					{ translate( 'Upgrade Plan' ) }
-				</Button>
-			</div>
-		);
+	const getBundledFirstPartyPurchaseModalData = (): UpgradeModalContent => {
+		return {
+			header: (
+				<>
+					<img src={ wooCommerceImage } alt="WooCommerce" className="upgrade-modal__woo-logo" />
+					<h1 className="upgrade-modal__heading bundle">
+						{ translate( 'Unlock this WooCommerce theme' ) }
+					</h1>
+				</>
+			),
+			text: (
+				<p>
+					{ translate(
+						"This theme comes bundled with {{link}}WooCommerce{{/link}} plugin. Upgrade to a Business plan to select this theme and unlock all its features. It's %s per year with a 14-day money-back guarantee.",
+						{
+							components: {
+								link: <ExternalLink target="_blank" href="https://woocommerce.com/" />,
+							},
+							args: themePrice,
+						}
+					) }
+				</p>
+			),
+			price: null,
+			action: (
+				<div className="upgrade-modal__actions bundle">
+					<Button className="upgrade-modal__cancel" onClick={ () => closeModal() }>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>
+						{ translate( 'Upgrade Plan' ) }
+					</Button>
+				</div>
+			),
+		};
+	};
+
+	let modalData = null;
+	if ( showBundleVersion ) {
+		modalData = getBundledFirstPartyPurchaseModalData();
+	} else {
+		modalData = getStandardPurchaseModalData();
 	}
 
 	return (
@@ -134,10 +150,10 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			{ ! isLoading && (
 				<>
 					<div className="upgrade-modal__col">
-						{ header }
-						{ text }
-						{ ! showBundleVersion && price }
-						{ action }
+						{ modalData.header }
+						{ modalData.text }
+						{ modalData.price }
+						{ modalData.action }
 					</div>
 					<div className="upgrade-modal__col">
 						<div className="upgrade-modal__included">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -52,6 +52,10 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	//Wait until we have theme and product data to show content
 	const isLoading = ! themePrice || ! theme.data;
 
+	// TODO: This is placeholder logic for determining whether the theme is a third party premium theme
+	// change to "true" to test
+	const isThirdParty = true;
+
 	const getStandardPurchaseModalData = (): UpgradeModalContent => {
 		return {
 			header: (
@@ -132,8 +136,64 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 		};
 	};
 
+	const getThirdPartyPurchaseModalData = (): UpgradeModalContent => {
+		return {
+			header: (
+				<>
+					<h1 className="upgrade-modal__heading bundle">{ translate( 'Upgrade to Buy' ) }</h1>
+				</>
+			),
+			text: (
+				<>
+					<p>
+						{ translate(
+							'This premium theme is only available to buy on the Business or eCommerce plans.'
+						) }
+					</p>
+					<p>
+						<strong>To activate this theme, you need:</strong>
+					</p>
+				</>
+			),
+			price: (
+				<>
+					<table className="upgrade-modal__product-list">
+						<tr className="upgrade-modal__product-list-item">
+							<td className="upgrade-modal__product-list-product">{ theme?.data?.name }</td>
+							<td className="upgrade-modal__product-list-price">
+								<strong>{ translate( '%s per year', { args: themePrice } ) }</strong>
+							</td>
+						</tr>
+						<tr className="upgrade-modal__product-list-item">
+							<td className="upgrade-modal__product-list-product">
+								{ translate( 'Business plan' ) }
+							</td>
+							{ /* TODO: Figure out how to fetch this info  */ }
+							<td className="upgrade-modal__product-list-price">
+								<strong>{ translate( '%s per year', { args: 'TBD' } ) }</strong>
+							</td>
+						</tr>
+					</table>
+				</>
+			),
+			action: (
+				<div className="upgrade-modal__actions bundle">
+					<Button className="upgrade-modal__cancel" onClick={ () => closeModal() }>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>
+						{ translate( 'Continue' ) }
+					</Button>
+				</div>
+			),
+		};
+	};
+
 	let modalData = null;
-	if ( showBundleVersion ) {
+
+	if ( isThirdParty ) {
+		modalData = getThirdPartyPurchaseModalData();
+	} else if ( showBundleVersion ) {
 		modalData = getBundledFirstPartyPurchaseModalData();
 	} else {
 		modalData = getStandardPurchaseModalData();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -42,21 +42,15 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'business-bundle' )
 	);
 
-	let themePrice;
-	if ( showBundleVersion ) {
-		themePrice = businessPlanProduct?.combined_cost_display;
-	} else {
-		themePrice = premiumPlanProduct?.combined_cost_display;
-	}
-
 	//Wait until we have theme and product data to show content
-	const isLoading = ! themePrice || ! theme.data;
+	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
 
 	// TODO: This is placeholder logic for determining whether the theme is a third party premium theme
-	// change to "true" to test
-	const isThirdParty = true;
+	// Change `false` to `true` in order to test this UI with any premium theme's upgrade modal.
+	const isThirdParty = isEnabled( 'themes/subscription-purchases' ) || false;
 
 	const getStandardPurchaseModalData = (): UpgradeModalContent => {
+		const premiumPlanPrice = premiumPlanProduct?.combined_cost_display;
 		return {
 			header: (
 				<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
@@ -70,12 +64,12 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			),
 			price: (
 				<div className="upgrade-modal__theme-price">
-					{ translate( '{{span}}%(themePrice)s{{/span}} per year', {
+					{ translate( '{{span}}%(premiumPlanPrice)s{{/span}} per year', {
 						components: {
 							span: <span />,
 						},
 						args: {
-							themePrice,
+							premiumPlanPrice,
 						},
 					} ) }
 				</div>
@@ -100,6 +94,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	};
 
 	const getBundledFirstPartyPurchaseModalData = (): UpgradeModalContent => {
+		const businessPlanPrice = businessPlanProduct?.combined_cost_display;
 		return {
 			header: (
 				<>
@@ -117,7 +112,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 							components: {
 								link: <ExternalLink target="_blank" href="https://woocommerce.com/" />,
 							},
-							args: themePrice,
+							args: businessPlanPrice,
 						}
 					) }
 				</p>
@@ -137,6 +132,8 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	};
 
 	const getThirdPartyPurchaseModalData = (): UpgradeModalContent => {
+		const themePrice = premiumPlanProduct?.combined_cost_display;
+		const businessPlanPrice = businessPlanProduct?.combined_cost_display;
 		return {
 			header: (
 				<>
@@ -168,9 +165,8 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 							<td className="upgrade-modal__product-list-product">
 								{ translate( 'Business plan' ) }
 							</td>
-							{ /* TODO: Figure out how to fetch this info  */ }
 							<td className="upgrade-modal__product-list-price">
-								<strong>{ translate( '%s per year', { args: 'TBD' } ) }</strong>
+								<strong>{ translate( '%s per year', { args: businessPlanPrice } ) }</strong>
 							</td>
 						</tr>
 					</table>

--- a/client/landing/stepper/hooks/use-theme-details.ts
+++ b/client/landing/stepper/hooks/use-theme-details.ts
@@ -8,6 +8,7 @@ type Theme = {
 	author_uri: string;
 	description: string;
 	date_updated: string;
+	price: string;
 	taxonomies: Record< string, [] >;
 };
 


### PR DESCRIPTION
This PR refactors the existing logic for the premium theme upgrade modal to a pattern hopefully more friendly to the continued addition of more possible cases. It also adds a scenario based on the existence of the `themes/subscription-purchases` for third-party premium theme subscription purchases and implements initial UI for that scenario.

We do not yet have a property on theme data indicating whether the theme is a third party premium theme or not. As such, testing this PR currently depends on manually setting a value to true or false; that value being set to `true` will temporarily force all themes to be treated as third-party premium themes by the modal, so the UI can be verified.

When that value is set to `false`, existing user-facing behavior for first-party premium themes (both "simple" and "bundled") should be unchanged.

**Testing Instructions:**
* Check out this PR to a local Calypso install.
* Verify pre-existing scenarios:
    * "Simple" premium theme upgrade prompt for users on a free/personal plan:
    <img width="849" alt="image" src="https://user-images.githubusercontent.com/13437011/197030287-4922b20e-2640-4bc5-96ba-8790de70f5fb.png">
    * Bundled theme account upgrade prompt for users below Business plan:
     <img width="887" alt="image" src="https://user-images.githubusercontent.com/13437011/197030434-ff2fd192-9b93-4a77-900e-b6d8a495d3c0.png">
* Edit the file `client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx`, changing the line
```
	const isThirdParty = isEnabled( 'themes/subscription-purchases' ) || false;
```
to
```
	const isThirdParty = isEnabled( 'themes/subscription-purchases' ) || true;
```
* Triggering either of the above scenarios should now force display of the third party subscription purchase modal design instead, based on the designs provided by Saxon at pdgAPm-qE-p2#comment-401
<img width="821" alt="image" src="https://user-images.githubusercontent.com/13437011/197031942-8c5720c3-01f9-4fdb-9254-3a4b9f367212.png">


**NOTE THAT** this does not fix the logic determining what goes into the cart from this modal; that will be addressed in a separate issue.

(Also note that since the refactoring does not change the logic for any pre-existing scenarios, it maintains the bug described in https://github.com/Automattic/wp-calypso/issues/69296, which should also be addressed separately.)