### PR TITLE
design-picker: After upgrade checkout, return to selected theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -303,7 +303,19 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		if ( siteSlugOrId ) {
 			const params = new URLSearchParams();
-			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
+
+			// When the user is done with checkout, send them back to the current url
+			const destUrl = new URL( window.location.href );
+			const destSearchP = destUrl.searchParams;
+
+			// If we have a theme selected, add &theme=slug to the query params
+			if ( selectedDesign?.slug ) {
+				destSearchP.set( 'theme', selectedDesign?.slug );
+				destUrl.search = destSearchP.toString();
+			}
+
+			const destString = destUrl.toString().replace( window.location.origin, '' );
+			params.append( 'redirect_to', destString );
 
 			// The theme upsell link does not work with siteId and requires a siteSlug.
 			// See https://github.com/Automattic/wp-calypso/pull/64899


### PR DESCRIPTION
#### Proposed Changes

* When the design picker sends you off to checkout to buy a plan upgrade in the middle of picking a theme, when you are done with checkout, you will now be sent back to that theme's page. 
  * Previously, you would be brought to the gallery and would have to find the theme again.
* This is an expansion of #68538 which adds this fix for the theme showcase.

#### Testing Instructions

* Make sure the seller upgrade modal is on
```diff
diff --git a/config/development.json b/config/development.json
index 9448a7d5dc..4600e408dd 100644
--- a/config/development.json
+++ b/config/development.json
@@ -160,7 +160,7 @@
                "signup/inline-help": false,
                "signup/professional-email-step": false,
                "signup/reskin": true,
-               "signup/seller-upgrade-modal": false,
+               "signup/seller-upgrade-modal": true,
                "signup/site-vertical-step": true,
                "signup/social": true,
                "signup/starting-point-courses": true,
```
* Visit `/start`, create a new site, choose the free plan, choose sell intent
* Find Thriving Artist in the theme list, it should ask you to upgrade
![2022-10-13_17-14](https://user-images.githubusercontent.com/937354/195721078-2753a526-0388-4472-b8ad-b256055ee16f.png)
![2022-10-13_17-22](https://user-images.githubusercontent.com/937354/195721745-1e87406c-46ed-4080-a3aa-cc17963fb81d.png)
* Click unlock theme and buy it
* When purchase is over, you'll be sent directly back to the Thriving Artist page 
![2022-10-13_17-13](https://user-images.githubusercontent.com/937354/195721188-c0122934-3086-4107-ad0c-e41dcfb21c4e.png)
* Before this PR you would be sent to the gallery and would have to locate the theme again.
 



Related to #
