### PR TITLE
Jetpack Backup: Exclude Atomic sites from testing credentials and preventing restores if they are invalid

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -19,6 +19,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-rewind-policies-request-status';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import VisibleDaysLimitUpsell from './visible-days-limit-upsell';
 
@@ -311,7 +312,8 @@ class ActivityCardList extends Component {
 	}
 
 	render() {
-		const { requestingRewindPolicies, rewindPoliciesRequestError, siteId, logs } = this.props;
+		const { requestingRewindPolicies, rewindPoliciesRequestError, siteId, logs, isAtomic } =
+			this.props;
 
 		if ( rewindPoliciesRequestError ) {
 			return this.renderLoading();
@@ -322,7 +324,7 @@ class ActivityCardList extends Component {
 				<QueryRewindPolicies siteId={ siteId } />
 				<QueryRewindCapabilities siteId={ siteId } />
 				<QueryRewindState siteId={ siteId } />
-				<QueryJetpackCredentialsStatus siteId={ siteId } role="main" />
+				{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
 
 				{ ( ! logs || requestingRewindPolicies ) && this.renderLoading() }
 				{ logs && this.renderData() }
@@ -341,6 +343,8 @@ const mapStateToProps = ( state ) => {
 
 	const rewindPoliciesRequestStatus = getRewindPoliciesRequestStatus( state, siteId );
 
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+
 	return {
 		filter,
 		requestingRewindPolicies: rewindPoliciesRequestStatus === 'pending',
@@ -349,6 +353,7 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		siteSlug,
 		userLocale,
+		isAtomic,
 	};
 };
 

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -53,10 +53,10 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 
 	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
-	const isRestoreDisabled =
-		doesRewindNeedCredentials || isRestoreInProgress || areCredentialsInvalid;
-
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+
+	const isRestoreDisabled =
+		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
 
 	return (
 		<>

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -7,6 +7,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -47,10 +48,12 @@ const RestoreButton = ( { disabled, rewindId, primary } ) => {
 		areJetpackCredentialsInvalid( state, siteId, 'main' )
 	);
 
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+
 	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
 	const isRestoreDisabled =
-		disabled || needsCredentials || isRestoreInProgress || areCredentialsInvalid;
+		disabled || needsCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
 	const href = ! isRestoreDisabled ? backupRestorePath( siteSlug, rewindId ) : undefined;
 	const onRestore = () =>
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore', { rewind_id: rewindId } ) );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -436,7 +436,7 @@ class ActivityLog extends Component {
 		const disableRestore =
 			! enableRewind ||
 			[ 'queued', 'running' ].includes( get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
-			areCredentialsInvalid ||
+			( ! isAtomic && areCredentialsInvalid ) ||
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -476,7 +476,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<QueryRewindBackups siteId={ siteId } />
-				<QueryJetpackCredentialsStatus siteId={ siteId } role="main" />
+				{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
 
 				{ isJetpackCloud() && <SidebarNavigation /> }
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -148,7 +148,7 @@ function AdminContent( { selectedDate } ) {
 				siteId={ siteId } /* The policies inform the max visible limit for backups */
 			/>
 			<QueryRewindState siteId={ siteId } />
-			<QueryJetpackCredentialsStatus siteId={ siteId } role="main" />
+			{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
 
 			{ isFiltering && <SearchResults /> }
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -193,7 +193,7 @@ function BackupStatus( {
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
 				{ ! isAtomic && ( needCredentials || areCredentialsInvalid ) && <EnableRestoresBanner /> }
-				{ ! needCredentials && ! areCredentialsInvalid && hasRealtimeBackups && (
+				{ ! needCredentials && ( ! areCredentialsInvalid || isAtomic ) && hasRealtimeBackups && (
 					<BackupsMadeRealtimeBanner />
 				) }
 


### PR DESCRIPTION
We introduced in #68552 a functionality to test and disable restore buttons when credentials are invalid. Given atomic sites has managed credentials, we don't require testing them, so we can disable this functionality for Atomic sites.

#### Proposed Changes

* Exclude the following buttons to be disabled when credentials are invalid for Atomic sites:
  - [x] `Restore` button on Activity Log v1. Available in Calypso Blue.
  - [x] `Restore to this point` button in main backups page
  - [x] `Restore to this point` button in action toolbar in Activity Log v2. It is currently displayed on Activity Log and Backup pages in Jetpack Cloud.
* Disable credentials testing for Atomic sites. This will avoid calling the test credential API unnecessarily. For this purpose, we will not render [QueryJetpackCredentialsStatus](https://github.com/Automattic/wp-calypso/tree/trunk/client/components/data/query-jetpack-credentials-status) for Atomic sites. 
  - [x] Conditional rendering on `ActivityCardList` component
  - [x] Conditional rendering on `ActivityLog` component. This is the v1 available on Calypso Blue.
  - [x] Conditional rendering on `Backup` page

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* **Self-hosted Jetpack Sites**
  * Go to Jetpack Cloud
  * Grab a site with a Jetpack Backup plan. Preferable, a site you can modify the SSH/SFTP password.
  * Ensure you have working SSH/SFTP credentials on `Settings` page.
  * Navigate to `Activity Log` and `Backup` sections and ensure you can see the `Restore to this point` buttons in green color (that means they are enabled).
    * Also, you should see the banner with the message _“Every change you make will be backed up”_ on top of Backup page.
  * Modify the SSH/SFTP password on your site server (not on Jetpack Cloud settings).
  * Navigate again to `Activity Log` or `Backup` page and validate the same buttons are now disabled. It may take a couple of seconds as it is trying to test credentials using an API.
  * You can repeat the same test procedure on Calypso Blue.

* **Atomic Sites**
  * Go to Calypso Blue
  * Grab an Atomic Site at WordPress.com with available backups.
  * To break credentials for backups, open the Atomic Site's VPMC and change the site's URL to an invalid URL (it just needs to differ from the actual Atomic site's address, which will break the credentials for backups).
  * Navigate Jetpack > Activity Log, you should see the `Restore` buttons enabled (not greyed out).
  * Navigate to Jetpack > Backup, you should see all `Restore to this point` buttons enabled (not greyed out).
    * Also, you should always see the banner with the message _“Every change you make will be backed up”_ on top of Backup page.
  * Also you can verify your in Developer Console > Network tab that there's no requests with name `test?_envelope=1&role=main` being executed when accessing `Activity Log` and `Backup` page.

* **Simple Sites**
  * Simple Sites are not impacted by this change.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->