### PR TITLE
Theme bundle: Check for Woo feature to check if bundle is included

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -530,6 +530,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		/>
 	);
 
+	const hasWoopFeature = site?.plan?.features.active.includes( 'woop' ); // WooCommerce on Plans
+
 	const stepContent = (
 		<UnifiedDesignPicker
 			generatedDesigns={ generatedDesigns }
@@ -543,6 +545,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			categorization={ categorization }
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			purchasedThemes={ purchasedThemes }
+			hasWoopFeature={ hasWoopFeature }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -530,7 +530,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		/>
 	);
 
-	const hasWoopFeature = site?.plan?.features.active.includes( 'woop' ); // WooCommerce on Plans
+	const currentPlanFeatures = site?.plan?.features.active ?? [];
 
 	const stepContent = (
 		<UnifiedDesignPicker
@@ -545,7 +545,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			categorization={ categorization }
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			purchasedThemes={ purchasedThemes }
-			hasWoopFeature={ hasWoopFeature }
+			currentPlanFeatures={ currentPlanFeatures }
 		/>
 	);
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -69,6 +69,7 @@ interface DesignButtonProps {
 	hasPurchasedTheme?: boolean;
 	onCheckout?: any;
 	verticalId?: string;
+	hasWoopFeature?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -79,12 +80,13 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasPurchasedTheme = false,
 	onCheckout,
 	verticalId,
+	hasWoopFeature = false,
 } ) => {
 	const { __ } = useI18n();
 	const { style_variations = [], is_premium: isPremium = false } = design;
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 
-	const showBundledBadge =
+	const designIsBundledWithWoo =
 		isEnabled( 'themes/plugin-bundling' ) && design.is_bundled_with_woo_commerce;
 
 	function getPricingDescription() {
@@ -123,6 +125,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			}
 		} else if ( isPremium && ! shouldUpgrade && hasPurchasedTheme ) {
 			text = __( 'Purchased on an annual subscription' );
+		} else if ( hasWoopFeature && designIsBundledWithWoo ) {
+			text = __( 'Included in your plan' );
+		} else if ( ! hasWoopFeature && designIsBundledWithWoo ) {
+			text = __( 'Available with Wordpress.com Business' );
 		} else if ( isPremium && ! shouldUpgrade && ! hasPurchasedTheme ) {
 			text = __( 'Included in your plan' );
 		} else if ( ! isPremium ) {
@@ -130,7 +136,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		}
 
 		let badge: React.ReactNode = null;
-		if ( showBundledBadge ) {
+		if ( designIsBundledWithWoo ) {
 			badge = <WooCommerceBundledBadge />;
 		} else if ( isPremium ) {
 			badge = (
@@ -224,6 +230,7 @@ export interface UnifiedDesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
+	hasWoopFeature?: boolean;
 }
 
 interface StaticDesignPickerProps {
@@ -236,6 +243,7 @@ interface StaticDesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
+	hasWoopFeature?: boolean;
 }
 
 interface GeneratedDesignPickerProps {
@@ -255,6 +263,7 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 	onCheckout,
 	verticalId,
 	purchasedThemes,
+	hasWoopFeature = false,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 
@@ -287,6 +296,7 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 						onCheckout={ onCheckout }
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
+						hasWoopFeature={ hasWoopFeature }
 					/>
 				) ) }
 			</div>
@@ -344,6 +354,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	onCheckout,
 	purchasedThemes,
+	hasWoopFeature = false,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const translate = useTranslate();
@@ -396,6 +407,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
 					onCheckout={ onCheckout }
 					purchasedThemes={ purchasedThemes }
+					hasWoopFeature={ hasWoopFeature }
 				/>
 			</div>
 		</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -86,7 +86,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const { __ } = useI18n();
 	const { style_variations = [], is_premium: isPremium = false } = design;
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
-	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP );
+	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 
 	const designIsBundledWithWoo =
 		isEnabled( 'themes/plugin-bundling' ) && design.is_bundled_with_woo_commerce;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { isEnabled } from '@automattic/calypso-config';
+import { FEATURE_WOOP } from '@automattic/calypso-products';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -69,7 +70,7 @@ interface DesignButtonProps {
 	hasPurchasedTheme?: boolean;
 	onCheckout?: any;
 	verticalId?: string;
-	hasWoopFeature?: boolean;
+	currentPlanFeatures?: string[];
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -80,18 +81,24 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasPurchasedTheme = false,
 	onCheckout,
 	verticalId,
-	hasWoopFeature = false,
+	currentPlanFeatures,
 } ) => {
 	const { __ } = useI18n();
 	const { style_variations = [], is_premium: isPremium = false } = design;
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
+	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP );
 
 	const designIsBundledWithWoo =
 		isEnabled( 'themes/plugin-bundling' ) && design.is_bundled_with_woo_commerce;
 
 	function getPricingDescription() {
 		let text: React.ReactNode = null;
-		if ( isPremium && shouldUpgrade ) {
+
+		if ( designIsBundledWithWoo ) {
+			text = currentSiteCanInstallWoo
+				? __( 'Included in your plan' )
+				: __( 'Available with WordPress.com Business' );
+		} else if ( isPremium && shouldUpgrade ) {
 			if ( isEnabled( 'signup/seller-upgrade-modal' ) ) {
 				text = createInterpolateElement(
 					sprintf(
@@ -125,10 +132,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			}
 		} else if ( isPremium && ! shouldUpgrade && hasPurchasedTheme ) {
 			text = __( 'Purchased on an annual subscription' );
-		} else if ( hasWoopFeature && designIsBundledWithWoo ) {
-			text = __( 'Included in your plan' );
-		} else if ( ! hasWoopFeature && designIsBundledWithWoo ) {
-			text = __( 'Available with Wordpress.com Business' );
 		} else if ( isPremium && ! shouldUpgrade && ! hasPurchasedTheme ) {
 			text = __( 'Included in your plan' );
 		} else if ( ! isPremium ) {
@@ -230,7 +233,7 @@ export interface UnifiedDesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
-	hasWoopFeature?: boolean;
+	currentPlanFeatures?: string[];
 }
 
 interface StaticDesignPickerProps {
@@ -243,7 +246,7 @@ interface StaticDesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	onCheckout?: any;
 	purchasedThemes?: string[];
-	hasWoopFeature?: boolean;
+	currentPlanFeatures?: string[];
 }
 
 interface GeneratedDesignPickerProps {
@@ -263,7 +266,7 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 	onCheckout,
 	verticalId,
 	purchasedThemes,
-	hasWoopFeature = false,
+	currentPlanFeatures,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 
@@ -296,7 +299,7 @@ const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
 						onCheckout={ onCheckout }
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
-						hasWoopFeature={ hasWoopFeature }
+						currentPlanFeatures={ currentPlanFeatures }
 					/>
 				) ) }
 			</div>
@@ -354,7 +357,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	onCheckout,
 	purchasedThemes,
-	hasWoopFeature = false,
+	currentPlanFeatures,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const translate = useTranslate();
@@ -407,7 +410,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
 					onCheckout={ onCheckout }
 					purchasedThemes={ purchasedThemes }
-					hasWoopFeature={ hasWoopFeature }
+					currentPlanFeatures={ currentPlanFeatures }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
#### Proposed Changes

* Adds a check for `woop` feature in order to tell if WooCommerce is included in the current plan.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site using `/start`
* Enable flags: `themes/plugin-bundling,signup/seller-upgrade-modal`
* With a Premium Plan, check the text for Premium Themes and Bundled Themes:
![image](https://user-images.githubusercontent.com/3801502/195865402-d977acf5-7e1e-47bf-93ca-fd9d90961916.png)
* Repeat with the Business Plan and check the text:
![image](https://user-images.githubusercontent.com/3801502/195865634-7c6d6fa4-e390-42c0-8ed3-0c9dcfb34df9.png)
* Repeat with the Free Plan and check the text:
![image](https://user-images.githubusercontent.com/3801502/195865906-a5b54f82-25bc-48c2-a5bc-dbc6ad172c5c.png)


Closes #68838
