### PR TITLE
Unified Pages: Show virtual pages in /pages list

### DIFF
--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -5,7 +5,7 @@ import { getActiveTheme } from 'calypso/state/themes/selectors';
 
 type HomeTemplateSettings = {
 	postType: string | null;
-	postId: number | null;
+	postId: string | null;
 };
 
 // is_fse_active property has been deprecated. Refer to the withIsFSEActive HOC to use the isFSEActive to determine if a theme is FSE enabled.

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -816,8 +816,15 @@ const mapStateToProps = (
 
 	// Add new Site Editor params introduced in https://github.com/WordPress/gutenberg/pull/38817.
 	if ( 'site' === editorType && blockEditorSettings?.home_template?.postType ) {
-		queryArgs.postType = blockEditorSettings.home_template.postType;
-		queryArgs.postId = blockEditorSettings.home_template.postId;
+		const templateType = getQueryArg( window.location.href, 'templateType' );
+		const templateId = getQueryArg( window.location.href, 'templateId' );
+		if ( templateType && templateId ) {
+			queryArgs.postType = templateType;
+			queryArgs.postId = templateId;
+		} else if ( blockEditorSettings?.home_template?.postType ) {
+			queryArgs.postType = blockEditorSettings.home_template.postType;
+			queryArgs.postId = blockEditorSettings.home_template.postId;
+		}
 	}
 
 	const noticePattern = /[&?]notice=([\w_-]+)/;

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -25,6 +25,7 @@ import BlogPostsPage from './blog-posts-page';
 import { sortPagesHierarchically } from './helpers';
 import Page from './page';
 import Placeholder from './placeholder';
+import VirtualPages from './virtual-pages';
 
 export default class PageList extends Component {
 	static propTypes = {
@@ -258,6 +259,16 @@ class Pages extends Component {
 		);
 	}
 
+	renderPostsPages() {
+		const { site } = this.props;
+
+		if ( config.isEnabled( 'unified-pages/virtual-pages' ) ) {
+			return <VirtualPages key="virtual-pages" site={ site } />;
+		}
+
+		return <BlogPostsPage key="blog-posts-page" site={ site } />;
+	}
+
 	renderPagesList( { pages } ) {
 		const { site, lastPage, query, showPublishedStatus } = this.props;
 
@@ -295,7 +306,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				<BlogPostsPage key="blog-posts-page" site={ site } />
+				{ this.renderPostsPages() }
 				{ site && this.renderSectionHeader() }
 				{ rows }
 				{ this.renderListEnd() }
@@ -332,7 +343,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				{ showBlogPostsPage && <BlogPostsPage key="blog-posts-page" site={ site } /> }
+				{ showBlogPostsPage && this.renderPostsPages() }
 				{ site && this.renderSectionHeader() }
 				{ rows }
 				<InfiniteScroll nextPageMethod={ this.fetchPages } />
@@ -349,7 +360,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				{ showBlogPostsPage && <BlogPostsPage key="blog-posts-page" site={ site } /> }
+				{ showBlogPostsPage && this.renderPostsPages() }
 				<div key="page-list-no-results">{ this.getNoContentMessage() }</div>
 			</div>
 		);

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -27,53 +27,6 @@ import Page from './page';
 import Placeholder from './placeholder';
 import VirtualPages from './virtual-pages';
 
-export default class PageList extends Component {
-	static propTypes = {
-		search: PropTypes.string,
-		siteId: PropTypes.number,
-		status: PropTypes.string,
-		query: PropTypes.shape( {
-			author: PropTypes.number, // User ID
-			status: PropTypes.string,
-			type: PropTypes.string.isRequired,
-		} ),
-	};
-
-	state = {
-		page: 1,
-	};
-
-	incrementPage = () => {
-		this.setState( { page: this.state.page + 1 } );
-	};
-
-	render() {
-		const { search, siteId, query } = this.props;
-		const { page } = this.state;
-
-		if ( config.isEnabled( 'page/export' ) ) {
-			// we need the raw content of the pages to be able to export them
-			query.context = 'edit';
-		}
-
-		// Since searches are across all statuses, the status needs to be shown
-		// next to each post.
-		const showPublishedStatus = Boolean( search );
-
-		return (
-			<div>
-				<QueryPosts siteId={ siteId } query={ { ...query, page } } />
-				<ConnectedPages
-					incrementPage={ this.incrementPage }
-					query={ { ...query, page } }
-					siteId={ siteId }
-					showPublishedStatus={ showPublishedStatus }
-				/>
-			</div>
-		);
-	}
-}
-
 class Pages extends Component {
 	static propTypes = {
 		incrementPage: PropTypes.func.isRequired,
@@ -393,3 +346,50 @@ const mapState = ( state, { query, siteId } ) => ( {
 } );
 
 const ConnectedPages = flowRight( connect( mapState ), localize, withLocalizedMoment )( Pages );
+
+export default class PageList extends Component {
+	static propTypes = {
+		search: PropTypes.string,
+		siteId: PropTypes.number,
+		status: PropTypes.string,
+		query: PropTypes.shape( {
+			author: PropTypes.number, // User ID
+			status: PropTypes.string,
+			type: PropTypes.string.isRequired,
+		} ),
+	};
+
+	state = {
+		page: 1,
+	};
+
+	incrementPage = () => {
+		this.setState( { page: this.state.page + 1 } );
+	};
+
+	render() {
+		const { search, siteId, query } = this.props;
+		const { page } = this.state;
+
+		if ( config.isEnabled( 'page/export' ) ) {
+			// we need the raw content of the pages to be able to export them
+			query.context = 'edit';
+		}
+
+		// Since searches are across all statuses, the status needs to be shown
+		// next to each post.
+		const showPublishedStatus = Boolean( search );
+
+		return (
+			<div>
+				<QueryPosts siteId={ siteId } query={ { ...query, page } } />
+				<ConnectedPages
+					incrementPage={ this.incrementPage }
+					query={ { ...query, page } }
+					siteId={ siteId }
+					showPublishedStatus={ showPublishedStatus }
+				/>
+			</div>
+		);
+	}
+}

--- a/client/my-sites/pages/virtual-pages/index.tsx
+++ b/client/my-sites/pages/virtual-pages/index.tsx
@@ -1,0 +1,61 @@
+import { CompactCard, Gridicon } from '@automattic/components';
+import { useTemplates } from '@automattic/data-stores';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { useBlockEditorSettingsQuery } from 'calypso/data/block-editor/use-block-editor-settings-query';
+import { addQueryArgs } from 'calypso/lib/route';
+import { getSiteFrontPageType } from 'calypso/state/sites/selectors';
+import './style.scss';
+
+interface Props {
+	site: any;
+}
+
+const VirtualPages = ( { site }: Props ) => {
+	const translate = useTranslate();
+	const frontPageType = useSelector( ( state ) => getSiteFrontPageType( state, site.ID ) );
+	const isFrontPage = frontPageType === 'posts';
+	const { data: templates } = useTemplates( site.ID, { enabled: isFrontPage } );
+	const { data: blockEditorSettings } = useBlockEditorSettingsQuery( site.ID, isFrontPage );
+
+	if ( ! isFrontPage || ! templates ) {
+		return null;
+	}
+
+	return (
+		<div className="virtual-pages">
+			{ templates
+				.filter( ( template ) => ! template.is_custom )
+				.map( ( { id, type, title, slug, description } ) => (
+					<CompactCard
+						key={ id }
+						className="virtual-pages__page"
+						href={ addQueryArgs(
+							{ templateId: id, templateType: type },
+							`/site-editor/${ site.slug }`
+						) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<div className="virtual-pages__page-title">
+							<span>{ decodeEntities( title.rendered || slug ) }</span>
+							{ id === blockEditorSettings?.home_template?.postId && (
+								<span className="virtual-pages__page-badge">
+									<Gridicon icon="house" size={ 12 } className="virtual-pages__page-badge-icon" />
+									<span className="virtual-pages__page-badge-text">
+										{ translate( 'Homepage' ) }
+									</span>
+								</span>
+							) }
+						</div>
+						<div className="virtual-pages__page-info">
+							<span>{ description }</span>
+						</div>
+					</CompactCard>
+				) ) }
+		</div>
+	);
+};
+
+export default VirtualPages;

--- a/client/my-sites/pages/virtual-pages/style.scss
+++ b/client/my-sites/pages/virtual-pages/style.scss
@@ -1,0 +1,35 @@
+.virtual-pages {
+	margin-bottom: 16px;
+}
+
+.virtual-pages__page-title,
+.virtual-pages__page-title:visited {
+	font-size: 1.25rem;
+	font-weight: 600;
+	line-height: 1.2;
+	color: var(--color-neutral-70);
+}
+
+.virtual-pages__page-info {
+	font-size: 0.75rem;
+	color: var(--color-text-subtle);
+}
+
+.virtual-pages__page-badge {
+	display: inline-block;
+	padding: 2px 10px;
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
+	font-size: 0.75rem;
+	font-weight: 500;
+	color: var(--color-neutral);
+	background: var(--color-neutral-0);
+
+	&:not(:first-child) {
+		margin-left: 5px;
+	}
+
+	.virtual-pages__page-badge-icon {
+		margin-right: 4px;
+		margin-bottom: -1px;
+	}
+}

--- a/client/package.json
+++ b/client/package.json
@@ -85,6 +85,7 @@
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/format-library": "^3.7.0",
 		"@wordpress/hooks": "^3.9.0",
+		"@wordpress/html-entities": "^3.9.0",
 		"@wordpress/i18n": "^4.9.0",
 		"@wordpress/icons": "^9.0.0",
 		"@wordpress/is-shallow-equal": "^4.9.0",

--- a/config/development.json
+++ b/config/development.json
@@ -174,6 +174,7 @@
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
 		"titan/iframe-control-panel": false,
+		"unified-pages/virtual-pages": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,6 +117,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,
+		"unified-pages/virtual-pages": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,6 +136,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,
+		"unified-pages/virtual-pages": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,6 +134,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": false,
 		"themes/premium": true,
+		"unified-pages/virtual-pages": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -140,6 +140,7 @@
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"unified-pages/virtual-pages": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -28,6 +28,7 @@ export { useSubmitForumsMutation } from './support-queries/use-submit-forums-top
 export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';
 export * from './site/types';
+export * from './templates';
 
 export {
 	Analyzer,

--- a/packages/data-stores/src/templates/index.ts
+++ b/packages/data-stores/src/templates/index.ts
@@ -1,0 +1,2 @@
+export { default as useTemplates } from './use-templates';
+export type { Template } from './types';

--- a/packages/data-stores/src/templates/types.ts
+++ b/packages/data-stores/src/templates/types.ts
@@ -1,0 +1,23 @@
+export type Template = {
+	author: number;
+	content: {
+		block_version: number;
+		raw: string;
+	};
+	description: string;
+	has_theme_file: boolean;
+	id: string;
+	/** Whether the template is custom or not. Custom template is able to be assigned to a page */
+	is_custom: boolean;
+	slug: string;
+	/** Whether the template is from. If the value is custom, then it's created by the user */
+	source: 'theme' | 'custom';
+	status: 'publish';
+	theme: string;
+	title: {
+		raw: string;
+		rendered: string;
+	};
+	type: 'wp_template';
+	wp_id: number;
+};

--- a/packages/data-stores/src/templates/use-templates.ts
+++ b/packages/data-stores/src/templates/use-templates.ts
@@ -1,0 +1,28 @@
+import { useQuery, UseQueryResult, QueryOptions } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { Template } from './types';
+
+interface Options extends QueryOptions< Template[], unknown > {
+	enabled?: boolean;
+}
+
+const useTemplates = (
+	siteId: string,
+	queryOptions: Options = {}
+): UseQueryResult< Template[] > => {
+	return useQuery< Template[] >(
+		[ siteId, 'templates' ],
+		() =>
+			wpcomRequest( {
+				path: `/sites/${ siteId }/templates`,
+				apiNamespace: 'wp/v2',
+			} ),
+		{
+			refetchOnMount: 'always',
+			staleTime: Infinity,
+			...queryOptions,
+		}
+	);
+};
+
+export default useTemplates;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12646,6 +12646,7 @@ __metadata:
     "@wordpress/element": ^4.7.0
     "@wordpress/format-library": ^3.7.0
     "@wordpress/hooks": ^3.9.0
+    "@wordpress/html-entities": ^3.9.0
     "@wordpress/i18n": ^4.9.0
     "@wordpress/icons": ^9.0.0
     "@wordpress/is-shallow-equal": ^4.9.0


### PR DESCRIPTION
#### Proposed Changes

* Render the virtual pages (templates) in the `/pages` list and clicking on it will open the site editor to edit the relative template.
* Use the `unified-pages/virtual-pages` flag to control the feature

![image](https://user-images.githubusercontent.com/13596067/195753637-fff61c7f-bcf0-487f-88d6-989c4068be8e.png)

TODOs

- [ ] Do we need a “title” or “description” for this kind of page to let the user know what’s different from the “Pages” below?
- [ ] Do we need to count this kind of page? It’s a little weird that “Published (2)” only shows there are 2 published pages
- [ ] Do we need to hide part of them? People might not need to see all of them

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to "Settings > Readings", and set "Your homepage displays" to "Your latest posts"
* Go to "Pages", and you will see this kind of virtual pages under “Published” tabs

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
