### PR TITLE
Site Switcher:   Use auto for .site-selector height on mobile devices to avoid cutting off the action buttons

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -213,6 +213,7 @@ body.is-focus-sites {
 		@include breakpoint-deprecated( "<660px" ) {
 			-webkit-overflow-scrolling: touch;
 			transform: translateX(-100%);
+			height: auto;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1054

#### Proposed Changes

* Use `auto` for height of `.site-selector` on mobile devices. 

This PR undoes a regression introduced by https://github.com/Automattic/wp-calypso/pull/68257. In that PR, I changed the `.site-selector` height to `calc(100vh - var(--masterbar-height));` which fixed a bug on larger screens but breaks the UI on some mobile devices. 

![image](https://user-images.githubusercontent.com/6851384/195767317-384a455e-afd6-41a7-9586-38266efd88f6.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* First reproduce the issue on wordpress.com using a mobile device: from the Side Menu, press "Switch site" and verify that the buttons are cut off as per  https://github.com/Automattic/dotcom-forge/issues/1054
* Using the Calypso Live link, verify the issue is fixed on mobile
* Check for regressions: verify that the menu works on larger screens and that https://github.com/Automattic/wp-calypso/issues/68251 remains fixed. 
* On mobile, I tested with my Pixel 6 android phone using Chrome. Please try other phones and browsers. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
