### PR TITLE
Fix Jetpack banner positioning in /plugins

### DIFF
--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -65,3 +65,14 @@
 		margin: 48px 0 0;
 	}
 }
+
+// Jetpack injects a banner on the /plugins page for jetpack sites
+.is-section-plugins .layout__content > .banner {
+	// This moves it down out from under our sticky header
+	margin-top: 50px;
+
+	// And removes the extra padding on the main content
+	+ .layout__secondary + .layout__primary main {
+		padding-top: 0;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* Move the Jetpack banner down and content up

#### Testing Instructions

- [x] Load [/plugins](https://wordpress.com/plugins) with a Jetpack site, the banner shown should be completely visible.
- [ ] Load /plugins with a non Jetpack site, the header should be in the same place as without this patch applied.


Before
![Screenshot(43)](https://user-images.githubusercontent.com/811776/195777429-0644cb1d-62d2-4539-a866-85060433474c.png)

After
![Screenshot(42)](https://user-images.githubusercontent.com/811776/195777438-b33a2572-8bf0-4f7a-9d40-54b7f13134dc.png)


Fixes https://github.com/Automattic/wp-calypso/issues/68937

