### PR TITLE
Agency Dashboard: Add the current site connection health to the /test-connection endpoint

### DIFF
--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -4,7 +4,11 @@ import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 
-const useFetchTestConnection = ( isPartnerOAuthTokenLoaded: boolean, siteId: number ) => {
+const useFetchTestConnection = (
+	isPartnerOAuthTokenLoaded: boolean,
+	isConnectionHealthy: boolean,
+	siteId: number
+) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -17,7 +21,7 @@ const useFetchTestConnection = ( isPartnerOAuthTokenLoaded: boolean, siteId: num
 					apiNamespace: 'rest/v1.1',
 				},
 				{
-					is_stale_connection_healthy: 1,
+					is_stale_connection_healthy: Number( isConnectionHealthy ),
 				}
 			),
 		{

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -21,7 +21,7 @@ const useFetchTestConnection = (
 					apiNamespace: 'rest/v1.1',
 				},
 				{
-					is_stale_connection_healthy: Number( isConnectionHealthy ),
+					is_stale_connection_healthy: Boolean( isConnectionHealthy ),
 				}
 			),
 		{

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -21,6 +21,7 @@ const useFetchTestConnection = (
 					apiNamespace: 'rest/v1.1',
 				},
 				{
+					// We call the current health state "stale", as it might be different than the actual state.
 					is_stale_connection_healthy: Boolean( isConnectionHealthy ),
 				}
 			),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -23,8 +23,9 @@ export default function SiteCard( { rows, columns }: Props ) {
 
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const blogId = rows.site.value.blog_id;
+	const isConnectionHealthy = rows.site.value?.is_connection_healthy;
 
-	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, blogId );
+	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
 
 	const isSiteConnected = data ? data.connected : true;
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -14,7 +14,7 @@ import type { SiteData } from '../../types';
 describe( '<SiteCard>', () => {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()
-		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=1' )
+		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=true' )
 		.reply( 200, {
 			connected: true,
 		} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -18,7 +18,7 @@ jest.mock( '@automattic/viewport-react', () => ( {
 describe( '<SiteContent>', () => {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()
-		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=1' )
+		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=true' )
 		.reply( 200, {
 			connected: true,
 		} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -18,12 +18,13 @@ interface Props {
 export default function SiteTableRow( { columns, item }: Props ) {
 	const site = item.site;
 	const blogId = site.value.blog_id;
+	const isConnectionHealthy = site.value?.is_connection_healthy;
 	const siteError = site.error || item.monitor.error;
 	const isFavorite = item.isFavorite;
 
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
-	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, blogId );
+	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
 
 	const isSiteConnected = data ? data.connected : true;
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -15,7 +15,7 @@ import type { SiteData } from '../../types';
 describe( '<SiteTableRow>', () => {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()
-		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=1' )
+		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=true' )
 		.reply( 200, {
 			connected: false,
 		} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -15,7 +15,7 @@ import type { SiteData } from '../../types';
 describe( '<SiteTable>', () => {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()
-		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=1' )
+		.get( '/rest/v1.1/jetpack-blogs/1234/test-connection?is_stale_connection_healthy=true' )
 		.reply( 200, {
 			connected: true,
 		} );


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up of https://github.com/Automattic/wp-calypso/pull/68837

We need to pass down the actual connection status to the `/test-connection` endpoint in order to audit the site only in case there's a difference between the reported status from the UI and the actual status (checked by the endpoint itself).

#### Testing Instructions

Follow the same instructions: https://github.com/Automattic/wp-calypso/pull/68837

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203164110743138