### PR TITLE
Add Plans Pages Codeowners for Autobots

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,3 +149,13 @@
 /packages/wpcom.js/src/lib/domain.email.js @Automattic/nomado
 /packages/wpcom.js/src/lib/domain.js @Automattic/nomado
 /packages/wpcom.js/src/lib/domains.js @Automattic/nomado
+
+#Plans
+/client/signup/steps/plans @Automattic/martech-autobots
+/client/lib/plans @Automattic/martech-autobots
+/client/my-sites/plan-features-comparison @Automattic/martech-autobots
+/client/my-sites/plan-features @Automattic/martech-autobots
+/client/my-sites/plans-comparison @Automattic/martech-autobots
+/client/my-sites/plans-features-main @Automattic/martech-autobots
+/client/my-sites/plan-price @Automattic/martech-autobots
+/packages/calypso-products/src/plans-list.tsx @Automattic/martech-autobots


### PR DESCRIPTION
#### Proposed Changes

* Add [MarTech Autobots](https://github.com/orgs/Automattic/teams/martech-autobots) as codeowners for all plans pages. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Inspect code.