### PR TITLE
Dev Tools: Remove unnecessary disabling comments

### DIFF
--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -5,61 +5,46 @@ import ExternalLink from 'calypso/components/external-link';
 import './style.scss';
 
 export function ReactQueryDevtoolsHelper() {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-react-query-devtools" />;
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export function AccountSettingsHelper() {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-account-settings" />;
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export function PreferencesHelper() {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-prefs" />;
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export function FeaturesHelper() {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-features" />;
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export function AuthHelper() {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return <div className="environment is-auth" />;
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export function Branch( { branchName, commitChecksum } ) {
 	return branchName === 'trunk' ? null : (
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
 			{ branchName }
 		</span>
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 }
 
 export function DevDocsLink( { url } ) {
 	return (
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<span className="environment is-docs">
 			<a href={ url } title="DevDocs">
 				docs
 			</a>
 		</span>
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 }
 
 function EnvironmentBadge( { badge, feedbackURL, children } ) {
 	return (
 		<div className="environment-badge">
-			{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 			{ children }
 			<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
 			<ExternalLink
@@ -70,7 +55,6 @@ function EnvironmentBadge( { badge, feedbackURL, children } ) {
 			>
 				<Gridicon icon="bug" size={ 18 } />
 			</ExternalLink>
-			{ /* eslint-enable wpcalypso/jsx-classname-namespace */ }
 		</div>
 	);
 }


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/69026#discussion_r995697421

## Proposed Changes

These comments are no longer necessary.

## Testing Instructions

1. Verify linting passes.