### PR TITLE
Import flows: Fix redirection issues

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -60,7 +60,10 @@ export const importFlow: Flow = {
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( _currentStep ) {
 				case 'importReady': {
+					const depUrl = ( providedDependencies?.url as string ) || '';
+
 					if (
+						depUrl.startsWith( 'http' ) ||
 						[ 'blogroll', 'ghost', 'tumblr', 'livejournal', 'movabletype', 'xanga' ].indexOf(
 							providedDependencies?.platform as ImporterMainPlatform
 						) !== -1

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -48,7 +48,9 @@ export const importFlow: Flow = {
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
 				return new Promise( () => {
-					if ( ! siteSlugParam ) return;
+					if ( ! siteSlugParam ) {
+						return;
+					}
 
 					window.location.assign( to );
 				} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -55,8 +55,11 @@ export function generateStepPath(
 	stepName: string | StepPath,
 	stepSectionName?: string
 ): StepPath {
-	if ( stepName === 'intent' ) return 'goals';
-	else if ( stepName === 'capture' ) return BASE_ROUTE;
+	if ( stepName === 'intent' ) {
+		return 'goals';
+	} else if ( stepName === 'capture' ) {
+		return BASE_ROUTE;
+	}
 
 	const routes = [ BASE_ROUTE, stepName, stepSectionName ];
 	const path = routes.join( '_' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -32,7 +32,10 @@ export function getFinalImporterUrl(
 		} )
 	) {
 		importerUrl = getWpComOnboardingUrl( targetSlug, platform, fromSite, framework );
-		if ( platform === 'wordpress' && ! fromSite ) {
+
+		if ( platform === 'wordpress' && ! fromSite && isAtomicSite ) {
+			importerUrl = getWpOrgImporterUrl( targetSlug, platform );
+		} else if ( platform === 'wordpress' && ! fromSite ) {
 			importerUrl = addQueryArgs( importerUrl, {
 				option: WPImportOption.CONTENT_ONLY,
 			} );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -133,7 +133,9 @@ export const siteSetupFlow: Flow = {
 				 * because the exitFlow itself is called more than once on actual flow exits.
 				 */
 				return new Promise( () => {
-					if ( ! siteSlug ) return;
+					if ( ! siteSlug ) {
+						return;
+					}
 
 					const pendingActions = [ setIntentOnSite( siteSlug, intent ) ];
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -394,7 +394,10 @@ export const siteSetupFlow: Flow = {
 				}
 
 				case 'importReady': {
+					const depUrl = ( providedDependencies?.url as string ) || '';
+
 					if (
+						depUrl.startsWith( 'http' ) ||
 						[ 'blogroll', 'ghost', 'tumblr', 'livejournal', 'movabletype', 'xanga' ].indexOf(
 							providedDependencies?.platform as ImporterMainPlatform
 						) !== -1


### PR DESCRIPTION
#### Proposed Changes

* Fixed issue: [import content only fail on Atomic site in onboarding flow](https://github.com/Automattic/wp-calypso/issues/68431)
   * When the source site is Atomic, we can not use the WordPress migration feature and instead of that show the WordPress importer plugin
* [Fixed issue with redirecting (wrong path) to the picked platform importer](https://github.com/Automattic/wp-calypso/issues/69069)
(It was the case with Blogger, Medium, and Squarespace importers)


Since the logic of generating the selected importer URL, even if it is an onboarding or plugin URL, is too complex. I've created a ticket to simplify it and put it in the backlog.
https://github.com/Automattic/wp-calypso/issues/69075

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import?siteSlug={ATOMIC_SLUG}
* Click on `Don't have a site address?`
* Select `WordPress` | `Blogger` | `Medium` | `Squarespace`
* Press the Import your content` button
* Check if it redirects to the `wp-admin` plugin's page

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #69069
Closes #68431
