### PR TITLE
Add wrapper to img tags in post content

### DIFF
--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -57,7 +57,7 @@ const ReaderFeaturedImage = ( {
 };
 
 ReaderFeaturedImage.propTypes = {
-	canonicalMedia: PropTypes.object.isRequired,
+	canonicalMedia: PropTypes.object,
 	href: PropTypes.string,
 	onClick: PropTypes.func,
 };

--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -13,3 +13,19 @@
 		object-fit: cover;
 	}
 }
+
+.reader-full-post__content .reader-featured-image {
+	margin-bottom: 24px;
+	position: relative;
+	&::after {
+		content: "";
+		position: absolute;
+		pointer-events: none;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
+	}
+}

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -67,7 +67,8 @@
 	}
 	.wp-block-gallery .wp-block-image,
 	.image-wrapper.two-three,
-	.image-wrapper.three-two {
+	.image-wrapper.three-two,
+	.image-wrapper.wide {
 		position: relative;
 		&::after {
 			content: "";

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -66,7 +66,8 @@
 		display: inherit;
 	}
 	.wp-block-gallery .wp-block-image,
-	.image-wrapper {
+	.image-wrapper.two-three,
+	.image-wrapper.three-two {
 		position: relative;
 		&::after {
 			content: "";
@@ -80,7 +81,7 @@
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
 		}
 
-		&.two-three img {
+		img {
 			width: 100%;
 		}
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -80,6 +80,10 @@
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
 		}
 
+		&.two-three img {
+			width: 100%;
+		}
+
 		figcaption {
 			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -65,7 +65,8 @@
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		display: inherit;
 	}
-	.wp-block-gallery .wp-block-image {
+	.wp-block-gallery .wp-block-image,
+	.image-wrapper {
 		position: relative;
 		&::after {
 			content: "";
@@ -83,6 +84,9 @@
 			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */
 		}
+	}
+	.image-wrapper img {
+		display: inherit;
 	}
 }
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -13,7 +13,7 @@ import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import DailyPostButton from 'calypso/blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/helper';
-import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -38,12 +38,8 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
 import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
 import { READER_FULL_POST } from 'calypso/reader/follow-sources';
-import {
-	canBeMarkedAsSeen,
-	getSiteName,
-	isEligibleForUnseen,
-	getFeaturedImageAlt,
-} from 'calypso/reader/get-helpers';
+import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import readerContentWidth from 'calypso/reader/lib/content-width';
 import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
@@ -473,7 +469,7 @@ export class FullPostView extends Component {
 		const startingCommentId = this.getCommentIdFromUrl();
 		const commentCount = get( post, 'discussion.comment_count' );
 		const postKey = { blogId, feedId, postId };
-		const featuredImageAlt = getFeaturedImageAlt( post );
+		const contentWidth = readerContentWidth();
 
 		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
 
@@ -553,7 +549,13 @@ export class FullPostView extends Component {
 						<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
 
 						{ post.featured_image && ! isFeaturedImageInContent( post ) && (
-							<FeaturedImage src={ post.featured_image } alt={ featuredImageAlt } />
+							<ReaderFeaturedImage
+								canonicalMedia={ null }
+								imageUrl={ post.featured_image }
+								href={ getStreamUrlFromPost( post ) }
+								imageWidth={ contentWidth }
+								children={ <div style={ { width: contentWidth } } /> }
+							/>
 						) }
 						{ isLoading && <ReaderFullPostContentPlaceholder /> }
 						{ post.use_excerpt ? (

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -164,8 +164,6 @@
 }
 
 .reader-full-post__story-content img {
-	margin-bottom: 12px;
-
 	&.latex {
 		margin-bottom: 0;
 	}

--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -1,5 +1,56 @@
 import { forEach } from 'lodash';
 
+/**
+ * Gets the image width and height from an img attribute
+ * We can get the aspect ratio with the width and height
+ * With the ratio, return a class to help with displaying images within aspect ratio ranges
+ *
+ * @param  {object} image - the img element
+ * @returns string
+ */
+const getImageAspectRatioClass = ( image ) => {
+	let sizes = image.getAttribute( 'data-orig-size' ) || '';
+	if ( sizes.length === 0 ) {
+		return '';
+	}
+
+	sizes = sizes.split( ',' );
+	const imageWidth = parseInt( sizes[ 0 ] ?? 0 );
+	const imageHeight = parseInt( sizes[ 1 ] ?? 0 );
+
+	if ( imageWidth === 0 ) {
+		return '';
+	}
+
+	if ( imageHeight === 0 ) {
+		return '';
+	}
+
+	const ratio = parseFloat( imageWidth / imageHeight );
+	if ( ratio === 1.0 ) {
+		return 'square';
+	} else if ( ratio > 0 && ratio < 9 / 16 ) {
+		return 'wide';
+	} else if ( ratio >= 9 / 16 && ratio < 2 / 3 ) {
+		return 'nine-sixteen';
+	} else if ( ratio >= 2 / 3 && ratio < 4 / 5 ) {
+		return 'two-three';
+	} else if ( ratio >= 4 / 5 && ratio < 1 ) {
+		return 'four-five';
+	} else if ( ratio > 1 && ratio <= 5 / 4 ) {
+		return 'five-four';
+	} else if ( ratio > 5 / 4 && ratio <= 3 / 2 ) {
+		return 'three-two';
+	} else if ( ratio > 3 / 2 && ratio <= 16 / 9 ) {
+		return 'sixteen-nine';
+	} else if ( ratio > 16 / 9 ) {
+		return 'tall';
+	}
+
+	// Not sure we can get here but...
+	return '';
+};
+
 export default function addImageWrapperElement( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
@@ -10,7 +61,8 @@ export default function addImageWrapperElement( post, dom ) {
 		// Add container wrapper for img elements
 		const parent = image.parentNode;
 		const imageWrapper = document.createElement( 'div' );
-		imageWrapper.className = 'image-wrapper';
+		const aspectRatioClass = getImageAspectRatioClass( image );
+		imageWrapper.className = 'image-wrapper ' + aspectRatioClass;
 		// set the wrapper as child (instead of the element)
 		parent.replaceChild( imageWrapper, image );
 		// set element as child of wrapper

--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -1,0 +1,21 @@
+import { forEach } from 'lodash';
+
+export default function addImageWrapperElement( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	const images = dom.querySelectorAll( 'img[src]' );
+	forEach( images, ( image ) => {
+		// Add container wrapper for img elements
+		const parent = image.parentNode;
+		const imageWrapper = document.createElement( 'div' );
+		imageWrapper.className = 'image-wrapper';
+		// set the wrapper as child (instead of the element)
+		parent.replaceChild( imageWrapper, image );
+		// set element as child of wrapper
+		imageWrapper.appendChild( image );
+	} );
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -30,7 +30,7 @@ const getImageAspectRatioClass = ( image ) => {
 	if ( ratio === 1.0 ) {
 		return 'square';
 	} else if ( ratio > 0 && ratio < 9 / 16 ) {
-		return 'wide';
+		return 'tall';
 	} else if ( ratio >= 9 / 16 && ratio < 2 / 3 ) {
 		return 'nine-sixteen';
 	} else if ( ratio >= 2 / 3 && ratio < 4 / 5 ) {
@@ -44,7 +44,7 @@ const getImageAspectRatioClass = ( image ) => {
 	} else if ( ratio > 3 / 2 && ratio <= 16 / 9 ) {
 		return 'sixteen-nine';
 	} else if ( ratio > 16 / 9 ) {
-		return 'tall';
+		return 'wide';
 	}
 
 	// Not sure we can get here but...

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -110,7 +110,17 @@ const makeImagesSafe = ( maxWidth ) => ( post, dom ) => {
 	}
 
 	const images = dom.querySelectorAll( 'img[src]' );
-	forEach( images, ( image ) => makeImageSafe( post, image, maxWidth ) );
+	forEach( images, ( image ) => {
+		makeImageSafe( post, image, maxWidth );
+		// Add container wrapper for img elements
+		const parent = image.parentNode;
+		const imageWrapper = document.createElement( 'div' );
+		imageWrapper.className = 'image-wrapper';
+		// set the wrapper as child (instead of the element)
+		parent.replaceChild( imageWrapper, image );
+		// set element as child of wrapper
+		imageWrapper.appendChild( image );
+	} );
 
 	return post;
 };

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -110,17 +110,7 @@ const makeImagesSafe = ( maxWidth ) => ( post, dom ) => {
 	}
 
 	const images = dom.querySelectorAll( 'img[src]' );
-	forEach( images, ( image ) => {
-		makeImageSafe( post, image, maxWidth );
-		// Add container wrapper for img elements
-		const parent = image.parentNode;
-		const imageWrapper = document.createElement( 'div' );
-		imageWrapper.className = 'image-wrapper';
-		// set the wrapper as child (instead of the element)
-		parent.replaceChild( imageWrapper, image );
-		// set element as child of wrapper
-		imageWrapper.appendChild( image );
-	} );
+	forEach( images, ( image ) => makeImageSafe( post, image, maxWidth ) );
 
 	return post;
 };

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,5 +1,6 @@
 import { filter, flow } from 'lodash';
 import addDiscoverProperties from 'calypso/lib/post-normalizer/rule-add-discover-properties';
+import addImageWrapperElement from 'calypso/lib/post-normalizer/rule-add-image-wrapper-element';
 import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'calypso/lib/post-normalizer/rule-content-detect-polls';
 import detectSurveys from 'calypso/lib/post-normalizer/rule-content-detect-surveys';
@@ -125,6 +126,7 @@ const fastPostNormalizationRules = flow( [
 		detectPolls,
 		detectSurveys,
 		linkJetpackCarousels,
+		addImageWrapperElement,
 	] ),
 	createBetterExcerpt,
 	pickCanonicalImage,


### PR DESCRIPTION
We would like to tidy up how images are displayed in Reader.

We plan to use box-shadow inset on all images but this has to be done on the image container element. In most cases this is ok but if the image has a caption, then the container is bigger than the image and whitespace is included (to allow for the caption).

![image](https://user-images.githubusercontent.com/5634774/195627406-a91930d1-edb9-4fbc-b9bb-4292869ea9ad.png)

This PR adds a rule to add a image wrapper div to images in the post content. The divs will have a class of `image-wraper`. This should allow us more control on how the image is displayed in reader.

Ref - https://github.com/Automattic/wp-calypso/issues/68994