### PR TITLE
Hide write button in masterbar for Ecommerce plan

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { isEcommerce } from '@automattic/calypso-products/src';
+import { isEcommercePlan } from '@automattic/calypso-products/src';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
@@ -31,7 +31,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
-import { getSiteSlug, isJetpackSite, getSitePlan } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -65,7 +65,7 @@ class MasterbarLoggedIn extends Component {
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
-		isEcommercePlan: PropTypes.bool,
+		isEcommerce: PropTypes.bool,
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
@@ -324,8 +324,8 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderPublish() {
-		const { domainOnlySite, translate, isMigrationInProgress, isEcommercePlan } = this.props;
-		if ( ! domainOnlySite && ! isMigrationInProgress && ! isEcommercePlan ) {
+		const { domainOnlySite, translate, isMigrationInProgress, isEcommerce } = this.props;
+		if ( ! domainOnlySite && ! isMigrationInProgress && ! isEcommerce ) {
 			return (
 				<AsyncLoad
 					require="./publish"
@@ -559,16 +559,15 @@ export default connect(
 		// by the user yet
 		const currentSelectedSiteId = getSelectedSiteId( state );
 		const siteId = currentSelectedSiteId || getPrimarySiteId( state );
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
 		const isMigrationInProgress =
 			isSiteMigrationInProgress( state, currentSelectedSiteId ) ||
 			isSiteMigrationActiveRoute( state );
-		// Default object state is needed here to protect the isEcommerce() type definitions.
-		const sitePlan = getSitePlan( state, siteId ) || { product_slug: '' };
 
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
-			isEcommercePlan: isEcommerce( sitePlan ),
+			isEcommerce: isEcommercePlan( sitePlanSlug ),
 			siteSlug: getSiteSlug( state, siteId ),
 			sectionGroup,
 			domainOnlySite: isDomainOnlySite( state, siteId ),

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isEcommerce } from '@automattic/calypso-products/src';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
@@ -30,7 +31,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite, getSitePlan } from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -64,6 +65,7 @@ class MasterbarLoggedIn extends Component {
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
+		isEcommercePlan: PropTypes.bool,
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
@@ -322,8 +324,8 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderPublish() {
-		const { domainOnlySite, translate, isMigrationInProgress } = this.props;
-		if ( ! domainOnlySite && ! isMigrationInProgress ) {
+		const { domainOnlySite, translate, isMigrationInProgress, isEcommercePlan } = this.props;
+		if ( ! domainOnlySite && ! isMigrationInProgress && ! isEcommercePlan ) {
 			return (
 				<AsyncLoad
 					require="./publish"
@@ -560,10 +562,13 @@ export default connect(
 		const isMigrationInProgress =
 			isSiteMigrationInProgress( state, currentSelectedSiteId ) ||
 			isSiteMigrationActiveRoute( state );
+		// Default object state is needed here to protect the isEcommerce() type definitions.
+		const sitePlan = getSitePlan( state, siteId ) || { product_slug: '' };
 
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
+			isEcommercePlan: isEcommerce( sitePlan ),
 			siteSlug: getSiteSlug( state, siteId ),
 			sectionGroup,
 			domainOnlySite: isDomainOnlySite( state, siteId ),


### PR DESCRIPTION
#### Proposed Changes

This PR aims to hide the "Write" button in the masterbar of Calypso of Ecommerce sites. 

You may notice that I've introduced a new `isEcommercePlan` prop in the logged-in component. The original idea was to add a more generic prop, such as the `sitePlan` object and call the `isEcommerce()` helper directly inside the `renderPublish()` method. 

This approach created some unwanted results and errors, which I'm unsure how to explain. The case was either React complaining about memory leaks or a generic error that shuts down the whole system and says that the `window.appBoot()` is not a function.

Also, looking at [this line](https://github.com/Automattic/wp-calypso/pull/69077/files#diff-27374a70c13059756839dabb3fedf4c59c75444f93497261a45b2804e989cc89R566):
```js
const sitePlan = getSitePlan( state, siteId ) || { product_slug: '' };
```
seems that the `isCommerce()` type definitions were causing fatal errors when the resolver was returning `null` here, so I thought to "fix" the object structure with a default value. 

Please let me know if there is a better way to approach this!

**Update**: We ended up using the `sitePlanSlug` in conjunction with the `isEcommercePlan()`, which seems more lightweight and clear.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the Calypso dashboard of an Ecommerce site
- Ensure that the "Write" button in the masterbar doesn't exist

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69068
