### PR TITLE
Sites Page: update ref parameter for Link in Bio upsell

### DIFF
--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner-parts.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner-parts.tsx
@@ -88,7 +88,7 @@ export const CreateButton = () => {
 	useEffect( handleBannerViewed, [] );
 	return (
 		<LinkButton
-			href="/setup/intro?flow=link-in-bio&ref=logged-out-homepage-lp"
+			href="/setup/intro?flow=link-in-bio&ref=sites-dashboard"
 			className="create-button"
 			onClick={ handleBannerCtaClick }
 		>


### PR DESCRIPTION
#### Proposed Changes

Update the Link in Bio ref to make it easier to track the traffic this flow is getting from the Sites Page. Previously it was set to `logged-out-homepage-lp`, which should be used exclusively for traffic coming from logged-out landing pages.

I'm using the `sites-dashboard` ref for consistency with other tracking refs (e.g., in Jetpack Connect flow).

#### Testing Instructions

1. Use a test account with less than three associated sites.
2. Navigate to the `/sites` page.
3. Click on the `Create your bio site` button.
4. Verify that it takes you to `https://wordpress.com/setup/intro?flow=link-in-bio&ref=sites-dashboard`

<img width="1335" alt="Screenshot 2022-10-14 at 16 41 25" src="https://user-images.githubusercontent.com/1182160/195874535-9149f676-7762-4736-9da5-5a01dc9b5e5a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
