### PR TITLE
Redirect to primary site if user goes to /advertising url

### DIFF
--- a/client/my-sites/promote-post/controller.js
+++ b/client/my-sites/promote-post/controller.js
@@ -1,7 +1,22 @@
+import page from 'page';
+import { getSiteFragment } from 'calypso/lib/route';
 import PromotedPosts from 'calypso/my-sites/promote-post/main';
+import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 
 export const promotedPosts = ( context, next ) => {
 	const { tab } = context.params;
 	context.primary = <PromotedPosts tab={ tab } />;
 	next();
+};
+
+export const redirectToPrimarySite = ( context, next ) => {
+	const siteFragment = context.params.site || getSiteFragment( context.path );
+
+	if ( siteFragment ) {
+		return next();
+	}
+
+	const state = context.store.getState();
+	const primarySiteSlug = getPrimarySiteSlug( state );
+	page( `/advertising/${ primarySiteSlug }` );
 };

--- a/client/my-sites/promote-post/index.js
+++ b/client/my-sites/promote-post/index.js
@@ -1,13 +1,14 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
-import { promotedPosts } from './controller';
+import { promotedPosts, redirectToPrimarySite } from './controller';
 
 export default () => {
-	page( '/advertising', siteSelection, sites, makeLayout, clientRender );
+	page( '/advertising/', redirectToPrimarySite, sites, makeLayout, clientRender );
 
 	page(
 		'/advertising/:site?/:tab?',
+		redirectToPrimarySite,
 		siteSelection,
 		navigation,
 		promotedPosts,


### PR DESCRIPTION
#### Proposed Changes

* If the user goes to wordpress.com/advertising it will redirect to the primary site of the selected user

#### Testing Instructions

- open wordpress.com/advertising
- It should redirect automatically to the user primary site and show the campaign/post list correctly

#### Pre-merge Checklist
- [] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
