### PR TITLE
Language Picker: Introduces `isLoading` prop to trigger loading state when loading user settings

### DIFF
--- a/client/components/language-picker/README.md
+++ b/client/components/language-picker/README.md
@@ -61,6 +61,8 @@ when its value changes.
 
 ### Props
 
+`isLoading` - Whether or not the language picker should display its loading context.
+
 `languages` - **required** Array with information about languages, their names, language
 slugs, popularity etc. It's exported by `config` module under the `languages` key.
 

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -13,6 +13,7 @@ const noop = () => {};
 
 export class LanguagePicker extends PureComponent {
 	static propTypes = {
+		isLoading: PropTypes.bool,
 		languages: PropTypes.array.isRequired,
 		valueKey: PropTypes.string,
 		value: PropTypes.any,
@@ -24,6 +25,7 @@ export class LanguagePicker extends PureComponent {
 	};
 
 	static defaultProps = {
+		isLoading: false,
 		languages: [],
 		valueKey: 'value',
 		onChange: noop,
@@ -147,7 +149,7 @@ export class LanguagePicker extends PureComponent {
 
 	render() {
 		const language = this.state.selectedLanguage;
-		if ( ! language ) {
+		if ( ! language || this.props.isLoading ) {
 			return this.renderPlaceholder();
 		}
 

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -5,6 +5,7 @@ import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import LanguagePicker from 'calypso/components/language-picker';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { setUserSetting } from 'calypso/state/user-settings/actions';
+import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 
 import './style.scss';
@@ -12,6 +13,7 @@ import './style.scss';
 export function AccountSettingsHelper() {
 	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings ) ?? {};
+	const isFetching = useSelector( isFetchingUserSettings );
 	const updateLanguage = ( event ) => {
 		const { value, empathyMode, useFallbackForIncompleteLanguages } = event.target;
 		if ( typeof empathyMode !== 'undefined' ) {
@@ -33,6 +35,9 @@ export function AccountSettingsHelper() {
 			window.location.reload();
 		} );
 	};
+	const currentLanguage = isFetching
+		? null
+		: userSettings?.locale_variant || userSettings.language || '';
 	return (
 		<>
 			<QueryUserSettings />
@@ -41,7 +46,7 @@ export function AccountSettingsHelper() {
 				<LanguagePicker
 					languages={ languages }
 					valueKey="langSlug"
-					value={ userSettings?.locale_variant || userSettings.language || '' }
+					value={ currentLanguage }
 					empathyMode={ userSettings?.i18n_empathy_mode }
 					useFallbackForIncompleteLanguages={ userSettings?.use_fallback_for_incomplete_languages }
 					onChange={ updateLanguage }

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -35,18 +35,16 @@ export function AccountSettingsHelper() {
 			window.location.reload();
 		} );
 	};
-	const currentLanguage = isFetching
-		? null
-		: userSettings?.locale_variant || userSettings.language || '';
 	return (
 		<>
 			<QueryUserSettings />
 			<div>Account Settings</div>
 			<div className="account-settings-helper__popover">
 				<LanguagePicker
+					isLoading={ isFetching }
 					languages={ languages }
 					valueKey="langSlug"
-					value={ currentLanguage }
+					value={ userSettings?.locale_variant || userSettings.language || '' }
 					empathyMode={ userSettings?.i18n_empathy_mode }
 					useFallbackForIncompleteLanguages={ userSettings?.use_fallback_for_incomplete_languages }
 					onChange={ updateLanguage }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -57,6 +57,7 @@ import {
 	removeUnsavedUserSetting,
 	setUserSetting,
 } from 'calypso/state/user-settings/actions';
+import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import AccountSettingsCloseLink from './close-link';
 
@@ -861,9 +862,13 @@ class Account extends Component {
 	};
 
 	render() {
-		const { markChanged, translate } = this.props;
+		const { isFetching, markChanged, translate } = this.props;
 		// Is a username change in progress?
 		const renderUsernameForm = this.hasUnsavedUserSetting( 'user_login' );
+
+		const currentLanguage = isFetching
+			? null
+			: this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || '';
 
 		return (
 			<Main wideLayout className="account">
@@ -935,9 +940,7 @@ class Account extends Component {
 								languages={ languages }
 								onClick={ this.getClickHandler( 'Interface Language Field' ) }
 								valueKey="langSlug"
-								value={
-									this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
-								}
+								value={ currentLanguage }
 								empathyMode={ this.getUserSetting( 'i18n_empathy_mode' ) }
 								useFallbackForIncompleteLanguages={ this.getUserSetting(
 									'use_fallback_for_incomplete_languages'
@@ -987,6 +990,7 @@ export default compose(
 			currentUserDate: getCurrentUserDate( state ),
 			currentUserDisplayName: getCurrentUserDisplayName( state ),
 			currentUserName: getCurrentUserName( state ),
+			isFetching: isFetchingUserSettings( state ),
 			requestingMissingSites: isRequestingMissingSites( state ),
 			userSettings: getUserSettings( state ),
 			unsavedUserSettings: getUnsavedUserSettings( state ),

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -865,11 +865,6 @@ class Account extends Component {
 		const { isFetching, markChanged, translate } = this.props;
 		// Is a username change in progress?
 		const renderUsernameForm = this.hasUnsavedUserSetting( 'user_login' );
-
-		const currentLanguage = isFetching
-			? null
-			: this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || '';
-
 		return (
 			<Main wideLayout className="account">
 				<QueryUserSettings />
@@ -937,10 +932,13 @@ class Account extends Component {
 							</FormLabel>
 							<LanguagePicker
 								disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
+								isLoading={ isFetching }
 								languages={ languages }
 								onClick={ this.getClickHandler( 'Interface Language Field' ) }
 								valueKey="langSlug"
-								value={ currentLanguage }
+								value={
+									this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
+								}
 								empathyMode={ this.getUserSetting( 'i18n_empathy_mode' ) }
 								useFallbackForIncompleteLanguages={ this.getUserSetting(
 									'use_fallback_for_incomplete_languages'


### PR DESCRIPTION
## Proposed Changes

Adds a new `isLoading` prop to `<LanguagePicker />` so we can trigger the language picker loading state when loading user settings.

The `<LanguagePicker />` does support passing `value=undefined` to trigger the loading state. However, this seems a bit hacky.

Previously, the `<Language Picker />` would display an erroneous 'Unsupported language' state while user settings are loaded.

### Before

**<AccountSettingsHelper />**

https://user-images.githubusercontent.com/36432/195905376-418c11b9-0c2a-472a-aba7-ea2dc02c6541.mp4

**/me/account**

https://user-images.githubusercontent.com/36432/195905444-9079e1f8-b4c2-437b-b429-40859ed81d19.mp4

### After

**<AccountSettingsHelper />**

https://user-images.githubusercontent.com/36432/195905111-36de27ff-4efb-46b1-a147-5321c71182bb.mp4

**/me/account**

https://user-images.githubusercontent.com/36432/195905098-628e8787-d490-4816-89d2-cae2643db178.mp4

## Testing Instructions

1. Use the `<AccountSettingsHelper />` in Dev Tools and verify your language is displayed and saved as expected.
2. Use the language picker in `/me/account` and verify your language is displayed and saved as expected.
3. Use the language picker in General Settings and verify a language is displayed and saved as expected. You may still see 'Unsupported language' in this context.