### PR TITLE
Checkout: make term selector accessible

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -35,7 +35,8 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	const options = variants.map( ( variant ) => ( {
 		key: variant.variantLabel,
-		name: <ItemVariantPrice variant={ variant } compareTo={ compareTo } />,
+		name: variant.variantLabel,
+		__experimentalHint: <ItemVariantPrice variant={ variant } compareTo={ compareTo } />,
 	} ) );
 
 	if ( isDisabled ) {
@@ -48,12 +49,12 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 			label={ translate( 'Pick a product term' ) }
 			describedBy={
 				selectedVariantIndex !== null && selectedVariantIndex >= 0
-					? translate( 'Currently selected term: %s', {
+					? ( translate( 'Currently selected term: %s', {
 							args: variants[ selectedVariantIndex ]?.variantLabel,
 							comment:
 								'%s represents the product currently selected term, e.g. `One year`, or `One month`.',
-					  } )
-					: translate( 'No selected term' )
+					  } ) as string )
+					: ( translate( 'No selected term' ) as string )
 			}
 			hideLabelFromVision
 			options={ options }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -1,91 +1,10 @@
-import { Gridicon } from '@automattic/components';
-import { css } from '@emotion/react';
-import styled from '@emotion/styled';
+import { CustomSelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { FunctionComponent, useCallback } from 'react';
 import { ItemVariantPrice } from './variant-price';
-import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
-import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import type { ItemVariationPickerProps } from './types';
 
-interface CurrentOptionProps {
-	open: boolean;
-}
-
-const CurrentOption = styled.button< CurrentOptionProps >`
-	align-items: center;
-	background: white;
-	border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
-	border-radius: 3px;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	padding: 14px 16px;
-	width: 100%;
-	cursor: pointer;
-
-	.gridicon {
-		fill: #a7aaad;
-		margin-left: 14px;
-	}
-
-	${ ( props ) =>
-		props.open &&
-		css`
-			border-radius: 3px 3px 0 0;
-		` }
-`;
-
-interface OptionProps {
-	selected: boolean;
-}
-
-const Option = styled.li< OptionProps >`
-	align-items: center;
-	background: white;
-	border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
-	color: #646970;
-	display: flex;
-	flex-direction: row;
-	font-size: ${ ( props ) => props.theme.fontSize.small };
-	font-weight: ${ ( props ) => props.theme.weights.normal };
-	justify-content: space-between;
-	/* the calc aligns the price with the price in CurrentOption */
-	padding: 10px calc( 14px + 24px + 16px ) 10px 16px;
-	cursor: pointer;
-
-	&:hover {
-		background: #e9f0f5;
-	}
-
-	&.item-variant-option--selected {
-		background: #055d9c;
-	}
-`;
-
-const Dropdown = styled.div`
-	position: relative;
-	width: 100%;
-	margin: 20px 0 0;
-	> ${ Option } {
-		border-radius: 3px;
-	}
-`;
-
-const OptionList = styled.ul`
-	position: absolute;
-	width: 100%;
-	z-index: 1;
-	margin: 0;
-
-	${ Option } {
-		margin-top: -1px;
-
-		&:last-child {
-			border-bottom-left-radius: 3px;
-			border-bottom-right-radius: 3px;
-		}
-	}
-`;
+import './styles.scss';
 
 export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps > = ( {
 	isDisabled,
@@ -95,178 +14,63 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 } ) => {
 	const translate = useTranslate();
 
-	const [ open, setOpen ] = useState( false );
-	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );
-
 	const selectedVariantIndexRaw = variants.findIndex(
 		( variant ) => variant.productId === selectedItem.product_id
 	);
 	// findIndex returns -1 if it fails and we want null.
 	const selectedVariantIndex = selectedVariantIndexRaw > -1 ? selectedVariantIndexRaw : null;
 
-	// reset the dropdown highlight when the selected product changes
-	useEffect( () => {
-		setHighlightedVariantIndex( selectedVariantIndex );
-	}, [ selectedVariantIndex ] );
-
 	// wrapper around onChangeItemVariant to close up dropdown on change
 	const handleChange = useCallback(
 		( uuid: string, productSlug: string, productId: number ) => {
 			onChangeItemVariant( uuid, productSlug, productId );
-			setOpen( false );
 		},
 		[ onChangeItemVariant ]
-	);
-
-	const selectNextVariant = useCallback( () => {
-		if ( highlightedVariantIndex !== null && highlightedVariantIndex < variants.length - 1 ) {
-			setHighlightedVariantIndex( highlightedVariantIndex + 1 );
-		}
-	}, [ highlightedVariantIndex, variants.length ] );
-
-	const selectPreviousVariant = useCallback( () => {
-		if ( highlightedVariantIndex !== null && highlightedVariantIndex > 0 ) {
-			setHighlightedVariantIndex( highlightedVariantIndex - 1 );
-		}
-	}, [ highlightedVariantIndex ] );
-
-	// reset highlight when dropdown is closed
-	const toggleDropDown = useCallback( () => {
-		setOpen( ! open );
-		setHighlightedVariantIndex( selectedVariantIndex );
-	}, [ open, selectedVariantIndex ] );
-
-	// arrow keys require onKeyDown for some browsers
-	const handleKeyDown: React.KeyboardEventHandler = useCallback(
-		( event ) => {
-			switch ( event.code ) {
-				case 'ArrowDown':
-					// prevent browser window from scrolling
-					event.preventDefault();
-					selectNextVariant();
-					break;
-				case 'ArrowUp':
-					// prevent browser window from scrolling
-					event.preventDefault();
-					selectPreviousVariant();
-					break;
-				case 'Enter':
-					event.preventDefault();
-					if (
-						highlightedVariantIndex !== null &&
-						highlightedVariantIndex !== selectedVariantIndex
-					) {
-						handleChange(
-							selectedItem.uuid,
-							variants[ highlightedVariantIndex ].productSlug,
-							variants[ highlightedVariantIndex ].productId
-						);
-					} else if ( highlightedVariantIndex === selectedVariantIndex ) {
-						toggleDropDown();
-					}
-					break;
-				case 'Space':
-					event.preventDefault();
-					toggleDropDown();
-					break;
-			}
-		},
-		[
-			handleChange,
-			highlightedVariantIndex,
-			selectedItem.uuid,
-			selectedVariantIndex,
-			selectNextVariant,
-			selectPreviousVariant,
-			toggleDropDown,
-			variants,
-		]
 	);
 
 	if ( variants.length < 2 ) {
 		return null;
 	}
 
+	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
+	const options = variants.map( ( variant ) => ( {
+		key: variant.variantLabel,
+		name: <ItemVariantPrice variant={ variant } compareTo={ compareTo } />,
+	} ) );
+
+	if ( isDisabled ) {
+		// TODO:
+	}
+
 	return (
-		<Dropdown aria-expanded={ open } aria-haspopup="listbox" onKeyDown={ handleKeyDown }>
-			<CurrentOption
-				aria-label={ translate( 'Pick a product term' ) }
-				disabled={ isDisabled }
-				onClick={ () => setOpen( ! open ) }
-				open={ open }
-				role="button"
-			>
-				{ selectedVariantIndex !== null ? (
-					<ItemVariantPrice variant={ variants[ selectedVariantIndex ] } />
-				) : (
-					<span>{ translate( 'Pick a product term' ) }</span>
-				) }
-				<Gridicon icon={ open ? 'chevron-up' : 'chevron-down' } />
-			</CurrentOption>
-			{ open && (
-				<ItemVariantOptionList
-					variants={ variants }
-					highlightedVariantIndex={ highlightedVariantIndex }
-					selectedItem={ selectedItem }
-					handleChange={ handleChange }
-				/>
+		<CustomSelectControl
+			className="item-variation-dropdown__select"
+			label={ translate( 'Pick a product term' ) }
+			describedBy={
+				selectedVariantIndex !== null && selectedVariantIndex >= 0
+					? translate( 'Currently selected term: %s', {
+							args: variants[ selectedVariantIndex ]?.variantLabel,
+							comment:
+								'%s represents the product currently selected term, e.g. `One year`, or `One month`.',
+					  } )
+					: translate( 'No selected term' )
+			}
+			hideLabelFromVision
+			options={ options }
+			value={ options.find(
+				( option ) =>
+					selectedVariantIndex !== null &&
+					option.key === variants[ selectedVariantIndex ]?.variantLabel
 			) }
-		</Dropdown>
+			onChange={ ( evt ) => {
+				const variant = variants.find(
+					( variant ) => variant.variantLabel === evt.selectedItem?.key
+				);
+
+				if ( variant ) {
+					handleChange( selectedItem.uuid, variant.productSlug, variant.productId );
+				}
+			} }
+		/>
 	);
 };
-
-function ItemVariantOptionList( {
-	variants,
-	highlightedVariantIndex,
-	selectedItem,
-	handleChange,
-}: {
-	variants: WPCOMProductVariant[];
-	highlightedVariantIndex: number | null;
-	selectedItem: ResponseCartProduct;
-	handleChange: ( uuid: string, productSlug: string, productId: number ) => void;
-} ) {
-	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
-	return (
-		<OptionList role="listbox" tabIndex={ -1 }>
-			{ variants.map( ( variant, index ) => (
-				<ItemVariantOption
-					key={ variant.productSlug + variant.variantLabel }
-					isSelected={ index === highlightedVariantIndex }
-					onSelect={ () =>
-						handleChange( selectedItem.uuid, variant.productSlug, variant.productId )
-					}
-					compareTo={ compareTo }
-					variant={ variant }
-				/>
-			) ) }
-		</OptionList>
-	);
-}
-
-function ItemVariantOption( {
-	isSelected,
-	onSelect,
-	compareTo,
-	variant,
-}: {
-	isSelected: boolean;
-	onSelect: () => void;
-	compareTo?: WPCOMProductVariant;
-	variant: WPCOMProductVariant;
-} ) {
-	const { variantLabel, productId, productSlug } = variant;
-	return (
-		<Option
-			id={ productId.toString() }
-			className={ isSelected ? 'item-variant-option--selected' : undefined }
-			aria-label={ variantLabel }
-			data-product-slug={ productSlug }
-			role="option"
-			onClick={ onSelect }
-			selected={ isSelected }
-		>
-			<ItemVariantPrice variant={ variant } compareTo={ compareTo } />
-		</Option>
-	);
-}

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/styles.scss
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/styles.scss
@@ -1,0 +1,54 @@
+.item-variation-dropdown__select.components-custom-select-control {
+	position: relative;
+
+	width: 100%;
+	margin: 1.25rem 0 0;
+
+	button.components-custom-select-control__button {
+		width: 100%;
+		height: auto;
+		min-height: 44px;
+		padding: 0.875em 2rem 0.875em 1em;
+
+		background: var(--color-surface);
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 4px;
+		color: var(--color-text);
+	}
+
+	.components-custom-select-control__menu {
+		box-sizing: border-box;
+		margin-inline-start: 0;
+
+		border: 1px solid var(--color-border-subtle);
+		border-bottom-left-radius: 4px;
+		border-bottom-right-radius: 4px;
+	}
+
+	.components-custom-select-control__item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		box-sizing: border-box;
+		min-height: 44px;
+		padding: 0.875em 0.25em 0.875em 1em;
+
+		color: var(--color-text-subtle);
+
+		font-size: 1rem;
+
+		&:hover {
+			background: var(--studio-blue-0);
+		}
+
+		&.is-highlighted {
+			background: var(--studio-blue-0);
+		}
+
+		> *:first-child {
+			// 24px is the width of the checkmark icon
+			width: calc(100% - 24px - 0.25em);
+		}
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/styles.scss
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/styles.scss
@@ -4,16 +4,18 @@
 	width: 100%;
 	margin: 1.25rem 0 0;
 
-	button.components-custom-select-control__button {
+	.components-custom-select-control__button {
 		width: 100%;
 		height: auto;
 		min-height: 44px;
-		padding: 0.875em 2rem 0.875em 1em;
+		padding: 0.875rem 2rem 0.875rem 0.75rem;
 
 		background: var(--color-surface);
 		border: 1px solid var(--color-border-subtle);
 		border-radius: 4px;
 		color: var(--color-text);
+
+		font-size: 0.875rem;
 	}
 
 	.components-custom-select-control__menu {
@@ -27,16 +29,17 @@
 
 	.components-custom-select-control__item {
 		display: flex;
-		justify-content: space-between;
+		justify-content: flex-start;
 		align-items: center;
+		flex-wrap: wrap;
 
 		box-sizing: border-box;
 		min-height: 44px;
-		padding: 0.875em 0.25em 0.875em 1em;
+		padding: 0.875rem 0.25rem 0.875em 0.75rem;
 
 		color: var(--color-text-subtle);
 
-		font-size: 1rem;
+		font-size: 0.875rem;
 
 		&:hover {
 			background: var(--studio-blue-0);
@@ -46,9 +49,15 @@
 			background: var(--studio-blue-0);
 		}
 
-		> *:first-child {
-			// 24px is the width of the checkmark icon
-			width: calc(100% - 24px - 0.25em);
+		// Align hints to the right in browsers that support the :has selector
+		&:not(:has(.components-custom-select-control__item-icon)) {
+			.components-custom-select-control__item-hint {
+				margin-inline-end: 1.5rem; // Width of the checkmark icon
+			}
 		}
+	}
+
+	.components-custom-select-control__item-hint {
+		flex: 1;
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -1,5 +1,4 @@
 import formatCurrency from '@automattic/format-currency';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -7,12 +6,6 @@ import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
 	color: ${ ( props ) => props.theme.colors.discount };
-	margin-right: 8px;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
 
 	.item-variant-option--selected & {
 		color: #b8e6bf;
@@ -25,13 +18,7 @@ const Discount = styled.span`
 
 const DoNotPayThis = styled.del`
 	text-decoration: line-through;
-	margin-right: 8px;
 	color: #646970;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
 
 	.item-variant-option--selected & {
 		color: #fff;
@@ -46,26 +33,11 @@ const Price = styled.span`
 	}
 `;
 
-const Variant = styled.div`
-	align-items: center;
+const Variant = styled.span`
 	display: flex;
-	font-size: 14px;
-	font-weight: 400;
-	justify-content: space-between;
-	line-height: 20px;
-	width: 100%;
-
-	.item-variant-option--selected & {
-		color: #fff;
-	}
-`;
-
-const Label = styled.span`
-	display: flex;
-	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
-	@media ( max-width: 480px ) {
-		flex-direction: column;
-	}
+	justify-content: flex-end;
+	flex-wrap: wrap;
+	column-gap: 0.5rem;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
@@ -85,7 +57,6 @@ export const ItemVariantPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
-	const isMobile = useMobileBreakpoint();
 	// This is the price that the compareTo variant would be if it was using the
 	// billing term of the variant. For example, if the price of the compareTo
 	// variant was 120 per year, and the variant we are displaying here is 5 per
@@ -109,21 +80,11 @@ export const ItemVariantPrice: FunctionComponent< {
 
 	return (
 		<Variant>
-			<Label>
-				{ variant.variantLabel }
-				{ discountPercentage > 0 && isMobile && (
-					<DiscountPercentage percent={ discountPercentage } />
-				) }
-			</Label>
-			<span>
-				{ discountPercentage > 0 && ! isMobile && (
-					<DiscountPercentage percent={ discountPercentage } />
-				) }
-				{ discountPercentage > 0 && (
-					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
-				) }
-				<Price>{ formattedCurrentPrice }</Price>
-			</span>
+			{ discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }
+			{ discountPercentage > 0 && (
+				<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
+			) }
+			<Price>{ formattedCurrentPrice }</Price>
 		</Variant>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the product term selector on the checkout page so that screen readers can interpret it as such.

### Implementation notes

The current selector implementation has been replaced by the [CustomSelectControl](https://github.com/Automattic/gutenberg/tree/trunk/packages/components/src/custom-select-control) Gutenberg component, that already implements accessibility features.

There are some things left to do, once this approach is validated:
- Fix the e2e tests
- Handle the disabled state
- Improve how prices are read by screen readers
- Test the experience with other popular screen readers (currently only tested with VoiceOver)

Swapping the current selector with `CustomSelectControl` has two consequences in terms of design:
- The hint (or price) is not shown in button part of the component. I don't think that's an issue, since the price is mentioned right above.
<img width="566" alt="Screen Shot 2022-10-19 at 2 00 17 PM" src="https://user-images.githubusercontent.com/1620183/196769517-3cfd9c06-c13f-4d9e-a3b2-5622ee901f40.png">


- The hint wraps slightly differently on mobile now.

| Before | After |
|--------|------|
| <img width="400" alt="Screen Shot 2022-10-18 at 11 41 38 AM" src="https://user-images.githubusercontent.com/1620183/196769186-9ce698df-72d1-4f77-a1b5-c81539ba02b0.png"> | <img width="400" alt="Screen Shot 2022-10-18 at 12 57 58 PM" src="https://user-images.githubusercontent.com/1620183/196769187-f948d106-0f98-4714-93ce-c3b0a2a741cf.png"> |

### Testing instructions

- Spin up this branch locally, or use the live link below.
- Visit `/checkout/jetpack/jetpack_backup_t1_yearly`.

#### Regression testing

- Check that the term selector behaves as expected and that any change is reflected in the rest of the page.

#### Accessibility testing

- Verify that you can select a term using the keyboard only.
- If you're familiar with a screen reader, use it and compare your experience to the one captured in the video below.

### Screencasts

Notice how users using a screen reader are currently lacking context and instructions, when interacting with the term selector.

You may have noticed that with the new implementation, the screen reader is not saying "X has been selected" as it should do (you can test `CustomSelectControl` in isolation [in Storybook](https://automattic.github.io/jetpack-storybook/?path=/story/gutenberg_components-customselectcontrol--default)). This may be because the `li` tag rendered by `WPOrderReviewListItem`—and therefore its children too, including the term selector—are re-rendered in the DOM, which seems to confuse VoiceOver.

_Before_

https://user-images.githubusercontent.com/1620183/198343063-2256bc09-7a8f-4739-826f-7235aec0b138.mov 

_After_

https://user-images.githubusercontent.com/1620183/198343037-9e144d84-f8ce-4d44-b9b0-f2a685c4aedd.mov





