### PR TITLE
Sites Management Page: Clip overflowing columns with ellipsis

### DIFF
--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -41,6 +41,12 @@ const SiteLaunchNagLink = styled.a( {
 	},
 } );
 
+const SiteLaunchNagText = styled.span( {
+	overflow: 'hidden',
+	whiteSpace: 'normal',
+	textOverflow: 'ellipsis',
+} );
+
 const SiteLaunchDonut = () => {
 	return (
 		<SiteLaunchDonutContainer>
@@ -111,7 +117,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 				recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_click' );
 			} }
 		>
-			<SiteLaunchDonut /> <span>{ text }</span>
+			<SiteLaunchDonut /> <SiteLaunchNagText>{ text }</SiteLaunchNagText>
 		</SiteLaunchNagLink>
 	);
 };

--- a/client/sites-dashboard/components/sites-site-url.ts
+++ b/client/sites-dashboard/components/sites-site-url.ts
@@ -12,6 +12,9 @@ export const SiteUrl = styled( ExternalLink )`
 	&:hover {
 		text-decoration: underline;
 	}
+	svg {
+		flex-shrink: 0;
+	}
 `;
 
 export const Truncated = styled.span`

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -37,6 +37,8 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	letter-spacing: -0.24px;
 	color: var( --studio-gray-60 );
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 
 	${ MEDIA_QUERIES.mediumOrSmaller } {
 		${ ( props ) => props.mobileHidden && 'display: none;' };

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -73,14 +73,16 @@ const ListTileSubtitle = styled.div`
 `;
 
 const SitePlan = styled.div`
-	display: inline-flex;
-	align-items: center;
+	display: inline;
+	> * {
+		vertical-align: middle;
+		line-height: normal;
+	}
 `;
 
 const SitePlanIcon = styled.div`
 	display: inline-block;
 	margin-inline-end: 6px;
-	max-height: 16px;
 `;
 
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
@@ -134,6 +136,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							<JetpackLogo size={ 16 } />
 						</SitePlanIcon>
 					) }
+
 					{ site.plan?.product_name_short }
 				</SitePlan>
 			</Column>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -73,12 +73,14 @@ const ListTileSubtitle = styled.div`
 `;
 
 const SitePlan = styled.div`
-	display: flex;
-	line-height: 16px;
+	display: inline-flex;
+	align-items: center;
 `;
 
 const SitePlanIcon = styled.div`
+	display: inline-block;
 	margin-inline-end: 6px;
+	max-height: 16px;
 `;
 
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -52,6 +52,8 @@ const Row = styled.tr`
 		letter-spacing: -0.24px;
 		font-weight: normal;
 		color: var( --studio-gray-60 );
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 `;
 


### PR DESCRIPTION
## Proposed Changes

Fixes overflowing columns by adding `overflow: hidden;` and `text-overflow: ellipsis;` to `th` and `td`. Also, switches the 'Launch checklist' text to `white-space: normal;` to allow it to wrap before clipping it.

### English

**Before**

<img width="549" alt="image" src="https://user-images.githubusercontent.com/36432/195912584-d0cf81be-60a0-4dbf-b2a1-ef61339b0f21.png">

**After**

<img width="530" alt="image" src="https://user-images.githubusercontent.com/36432/195912690-fa003635-4cc1-4522-9c64-86d1a54d5478.png">

### German

**Before**

<img width="514" alt="image" src="https://user-images.githubusercontent.com/36432/195912827-c65b8221-0ec1-436f-8236-ed1a8baaa726.png">

**After**

<img width="512" alt="image" src="https://user-images.githubusercontent.com/36432/195912777-4a9a4647-c1a2-4d34-9698-b05d3258d6c9.png">

### Japanese

**Before**

<img width="525" alt="image" src="https://user-images.githubusercontent.com/36432/195912970-583a419d-d66a-4586-a9d2-1f1b34cc42d9.png">

**After**

<img width="497" alt="image" src="https://user-images.githubusercontent.com/36432/195913804-413a5183-8b57-4642-8a4f-68bed89a35a6.png">

### Russian

**Before**

<img width="508" alt="image" src="https://user-images.githubusercontent.com/36432/195916619-7eab3f28-82dc-49a4-a309-058e8b9c2f15.png">

**After**

<img width="531" alt="image" src="https://user-images.githubusercontent.com/36432/195916467-e7c6f18e-6335-4149-9b01-9eeee6408205.png">

### Spanish

**Before**

<img width="502" alt="image" src="https://user-images.githubusercontent.com/36432/195916735-2ccb80e2-0bd5-4afa-9896-85c69c3daad6.png">

**After**

<img width="543" alt="image" src="https://user-images.githubusercontent.com/36432/195916814-ee12e4c4-64cd-4682-b070-10e3a39b6d1d.png">

## Testing Instructions

1. Review the `/sites` page with a variety of languages against a variety of browser widths.