### PR TITLE
update advertising support context link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -4,7 +4,7 @@ const contextLinks = {
 		post_id: 80368,
 	},
 	advertising: {
-		link: 'https://wordpress.com/advertising/',
+		link: 'https://wordpress.com/support/promote-a-post/',
 		post_id: 213203,
 	},
 	autorenewal: {


### PR DESCRIPTION
#### Proposed Changes

The "Visit Article" button in the inline support dialog should link to the Promoted Posts support page.

#### Testing Instructions

1. Click on the "Learn More" link on the `/advertising` page

![image](https://user-images.githubusercontent.com/2396764/195930060-79c7c4b8-ecec-4143-8e00-128a9fe9a811.png)

2. Click on the "Visit Article" button in the dialog.

![image](https://user-images.githubusercontent.com/2396764/195929806-f1caf2b6-334b-4e1f-9124-a764d0669c08.png)

3. Verify that the button links to the [Promoted Posts support page](https://wordpress.com/support/promote-a-post/).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
