### PR TITLE
TimeSince: Update hover content on locale change

### DIFF
--- a/client/components/time-since/index.tsx
+++ b/client/components/time-since/index.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useHumanDate } from 'calypso/lib/human-date';
 
@@ -10,7 +9,7 @@ interface TimeSinceProps {
 
 function TimeSince( { className, date, dateFormat = 'll' }: TimeSinceProps ) {
 	const moment = useLocalizedMoment();
-	const fullDate = useMemo( () => moment( date ).format( 'llll' ), [ moment, date ] );
+	const fullDate = moment( date ).format( 'llll' );
 	const humanDate = useHumanDate( date, dateFormat );
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

`TimeSince` was memoizing the `moment` instance. The problem with that is regardless of locale changes, the same instance is reused, so no update is triggered, causing the issue.

Removing the `useMemo` hook call fixes the issue.

#### Testing Instructions

1. Open the Sites page in English;
2. Check that the hover title and the content for the `Last Published` date match;
3. Change locale to anything that's not English;
4. Check that both places' translations still match after the locale is loaded.

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/26530524/195935337-0d3423e4-21fc-4288-bb04-888e99c89ce7.png) | ![image](https://user-images.githubusercontent.com/26530524/195935840-a43f4a8e-8ec8-46dd-a402-c439fb52a492.png) |