### PR TITLE
SplitButton: Fix button styles precedence by increasing specificity

### DIFF
--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -3,7 +3,7 @@
 	display: inline-block;
 	--white-separator-color: rgba(255, 255, 255, 0.3);
 }
-.split-button__main {
+.button.split-button__main {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 	border-right: 0;
@@ -12,16 +12,16 @@
 		margin-right: 4px;
 	}
 }
-.split-button__toggle {
+.button.split-button__toggle {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
-}
-.button.split-button__toggle--white-separator,
-.split-button__toggle--white-separator {
-	&,
-	&:hover,
-	&:focus {
-		border-left-color: var(--white-separator-color);
+
+	&.split-button__toggle--white-separator {
+		&,
+		&:hover,
+		&:focus {
+			border-left-color: var(--white-separator-color);
+		}
 	}
 }
 .gridicon.split-button__toggle-icon {


### PR DESCRIPTION
#### Proposed Changes

In pretty much all environments, except production, the Calypso global component styles take precedence over the custom styles the `<SplitButton />` component is applying. This causes confusion because we're not sure the outcome is the same in development and production.

This PR takes care of it by increasing the specificity of the selectors. But honestly, what I really wanted to do was to refactor this component so that it uses CSS-in-JS: these problems wouldn't happen since CSS-in-JS styles are atomic, meaning there is no concept of precedence, specificity, and, putting it better: cascading. It's really CSS without the C!

#### Testing Instructions

Trunk:
1. Open the sites page DIRECTLY, without going through Calypso;
2. Check that borders are round.

This branch:
1. Open the sites page DIRECTLY, without going through Calypso;
2. Check that the borders are now square.

This happens because the code that sets the border-radius in the split button is preceded by the calypso primary button styles.

Check that production WPCOM and development WPCOM have visually matching split buttons -- the Sites page is a good place to check. Development environment:

| Before | After |
| ------- |----- |
| ![image](https://user-images.githubusercontent.com/26530524/195939269-8f4ccae3-7246-453b-ad0f-2e305018e153.png) | ![image](https://user-images.githubusercontent.com/26530524/195939360-271cb571-db2e-40e3-b6df-2781d1efbf8e.png) |