### PR TITLE
Launchpad: Add/Main task as CTA button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -23,7 +23,12 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 			} ) }
 		>
 			{ id === 'first_post_published' || id === 'link_in_bio_launched' ? (
-				<Button disabled={ taskDisabled } data-task={ id } onClick={ actionDispatch }>
+				<Button
+					className="launchpad__checklist-primary-button"
+					disabled={ taskDisabled }
+					data-task={ id }
+					onClick={ actionDispatch }
+				>
 					{ title }
 				</Button>
 			) : (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -22,34 +22,40 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				'not-completed': ! isCompleted && ! keepActive, // a task that hasn't been completed yet
 			} ) }
 		>
-			<Button
-				className="launchpad__checklist-item"
-				disabled={ taskDisabled }
-				data-task={ id }
-				onClick={ actionDispatch }
-			>
-				{ isCompleted && (
-					// show checkmark for completed tasks regardless if they are disabled or kept active
-					<div className="launchpad__checklist-item-checkmark-container">
+			{ id === 'first_post_published' || id === 'link_in_bio_launched' ? (
+				<Button disabled={ taskDisabled } data-task={ id } onClick={ actionDispatch }>
+					{ title }
+				</Button>
+			) : (
+				<Button
+					className="launchpad__checklist-item"
+					disabled={ taskDisabled }
+					data-task={ id }
+					onClick={ actionDispatch }
+				>
+					{ isCompleted && (
+						// show checkmark for completed tasks regardless if they are disabled or kept active
+						<div className="launchpad__checklist-item-checkmark-container">
+							<Gridicon
+								aria-label={ translate( 'Task complete' ) }
+								className="launchpad__checklist-item-checkmark"
+								icon="checkmark"
+								size={ 18 }
+							/>
+						</div>
+					) }
+					<p className="launchpad__checklist-item-text">{ title }</p>
+					{ task.badgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
+					{ shouldDisplayChevron && (
 						<Gridicon
-							aria-label={ translate( 'Task complete' ) }
-							className="launchpad__checklist-item-checkmark"
-							icon="checkmark"
+							aria-label={ translate( 'Task enabled' ) }
+							className="launchpad__checklist-item-chevron"
+							icon={ `chevron-${ isRtl ? 'left' : 'right' }` }
 							size={ 18 }
 						/>
-					</div>
-				) }
-				<p className="launchpad__checklist-item-text">{ title }</p>
-				{ task.badgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
-				{ shouldDisplayChevron && (
-					<Gridicon
-						aria-label={ translate( 'Task enabled' ) }
-						className="launchpad__checklist-item-chevron"
-						icon={ `chevron-${ isRtl ? 'left' : 'right' }` }
-						size={ 18 }
-					/>
-				) }
-			</Button>
+					) }
+				</Button>
+			) }
 		</li>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -5,7 +5,7 @@ import Badge from 'calypso/components/badge';
 import { isTaskDisabled, hasIncompleteDependencies } from './task-helper';
 import { Task } from './types';
 
-const ChecklistItem = ( { task }: { task: Task } ) => {
+const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction?: boolean } ) => {
 	const isRtl = useRtl();
 	const { id, isCompleted, keepActive, title, actionDispatch } = task;
 	const taskDisabled = isTaskDisabled( task );
@@ -22,7 +22,7 @@ const ChecklistItem = ( { task }: { task: Task } ) => {
 				'not-completed': ! isCompleted && ! keepActive, // a task that hasn't been completed yet
 			} ) }
 		>
-			{ id === 'first_post_published' || id === 'link_in_bio_launched' ? (
+			{ isPrimaryAction ? (
 				<Button
 					className="launchpad__checklist-primary-button"
 					disabled={ taskDisabled }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist.tsx
@@ -8,7 +8,14 @@ interface ChecklistProps {
 const Checklist = ( { tasks }: ChecklistProps ) => {
 	return (
 		<ul className="launchpad__checklist" aria-label="Launchpad Checklist">
-			{ tasks && tasks.map( ( task: Task ) => <ChecklistItem key={ task.id } task={ task } /> ) }
+			{ tasks &&
+				tasks.map( ( task: Task, index: number ) => (
+					<ChecklistItem
+						key={ task.id }
+						task={ task }
+						isPrimaryAction={ tasks.length - 1 === index }
+					/>
+				) ) }
 		</ul>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -188,7 +188,7 @@
 		border-color: var(--color-primary);
 		color: var(--color-text-inverted);
 
-		&:hover {
+		&:hover:not([disabled]) {
 			background-color: var(--color-primary-60);
 			border-color: var(--color-primary-60);
 			color: var(--color-text-inverted);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -193,6 +193,12 @@
 			border-color: var(--color-primary-60);
 			color: var(--color-text-inverted);
 		}
+
+		&[disabled] {
+			background-color: var(--color-primary-10);
+			border-color: var(--color-primary-10);
+			color: var(--color-text-inverted);
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -178,6 +178,22 @@
 	@include break-large {
 		margin: 20px auto;
 	}
+
+	&-primary-button {
+		width: 100%;
+		font-weight: 500;
+		padding: 11px;
+		margin-top: 12px;
+		background-color: var(--color-primary);
+		border-color: var(--color-primary);
+		color: var(--color-text-inverted);
+
+		&:hover {
+			background-color: var(--color-primary-60);
+			border-color: var(--color-primary-60);
+			color: var(--color-text-inverted);
+		}
+	}
 }
 
 .launchpad__checklist-item {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -247,6 +247,15 @@
 	font-weight: 600;
 }
 
+.launchpad__task:nth-last-child(2) {
+	// remove bottom border for last checklist item before the primary button
+	.launchpad__checklist-item,
+	.launchpad__checklist-item:hover,
+	.launchpad__checklist-item:focus {
+		border-bottom: none;
+	}
+}
+
 // completed tasks
 .launchpad__task.completed-and-inactive,
 .launchpad__task.completed-and-active {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -89,4 +89,14 @@ describe( 'ChecklistItem', () => {
 			} );
 		} );
 	} );
+
+	describe( 'when a task is a primary action', () => {
+		it( 'displays a primary button', () => {
+			render(
+				<ChecklistItem task={ buildTask( { isCompleted: false } ) } isPrimaryAction={ true } />
+			);
+			const taskButton = screen.queryByRole( 'button' );
+			expect( taskButton?.className ).toContain( 'launchpad__checklist-primary-button' );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* Convert main task in checklist into CTA button for both Newsletter and Link in Bio flows. 

#### Testing Instructions

##### Newsletter Flow

* Run Calypso locally and visit [Launchpad: Newsletter Flow](http://calypso.localhost:3000/setup/intro?flow=newsletter&ref=logged-out-homepage-lp) in your browser
* `Write your first post` should appear as a CTA button
    * It should always be active
* Last checklist item and main CTA button should have an additional `12px` margin between them
    * Last checklist item should also have no bottom border
* Clicking the button should take you to the Editor to create your newsletter

**Before:**
<img width="400" alt="Screen Shot 2022-10-14 at 4 59 29 PM" src="https://user-images.githubusercontent.com/102400653/195943939-9ad877c9-246b-404b-8d74-48eec7cd7642.png">
**After:**
<img width="400" alt="Screen Shot 2022-10-14 at 4 59 17 PM" src="https://user-images.githubusercontent.com/102400653/195944003-7a6f0541-8616-4d9d-867d-23bee34b9f81.png">


##### Link in Bio Flow
* Run Calypso locally and visit [Launchpad: Newsletter Flow](http://calypso.localhost:3000/setup/intro?flow=link-in-bio&ref=logged-out-homepage-lp) in your browser and follow the steps until you reach the checklist/preview screen
* `Launch Link in Bio` should be in disabled state until all items are complete
    * It should become enabled once all items are completed
* Last checklist item and main CTA button should have an additional `12px` margin between them
    * Last checklist item should also have no bottom border
* Clicking the button should take you to the Editor to create your link in bio

**Before:**
<img width="400" alt="Screen Shot 2022-10-14 at 4 59 44 PM" src="https://user-images.githubusercontent.com/102400653/195944071-104a14ba-ea37-477e-874e-70566d1ced16.png">
<img width="400" alt="Screen Shot 2022-10-14 at 5 00 47 PM" src="https://user-images.githubusercontent.com/102400653/195944077-f35b5f62-6ade-4826-ac5f-c195d5a512db.png">

**After:**
<img width="400" alt="Screen Shot 2022-10-14 at 4 52 38 PM" src="https://user-images.githubusercontent.com/102400653/195944111-20596a72-bc3d-4d6f-beae-b66f003cb835.png">
<img width="400" alt="Screen Shot 2022-10-14 at 4 59 06 PM" src="https://user-images.githubusercontent.com/102400653/195944116-5fb14999-539a-4491-9cc3-78e46a862196.png">

##### General
* Test on multiple screen sizes
* Test in Chrome, Mozilla, Safari
* Test with VoiceOver

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? **Relevant changes are in Simple sites and were tested in Simple.**
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) **N/A**
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **N/A**



Related to [Launchpad: Main task should be a CTA #68970](https://github.com/Automattic/wp-calypso/issues/68970)
