### PR TITLE
ListTile: Stop playing with line height

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -45,7 +45,6 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 `;
 
 const SiteListTile = styled( ListTile )`
-	line-height: initial;
 	margin-inline-end: 0;
 
 	${ MEDIA_QUERIES.mediumOrSmaller } {

--- a/packages/components/src/list-tile/style.scss
+++ b/packages/components/src/list-tile/style.scss
@@ -1,7 +1,6 @@
 .list-tile {
 	display: flex;
 	align-items: center;
-	line-height: 1;
 	margin-right: 20px;
 }
 


### PR DESCRIPTION
#### Proposed Changes

Do not try to override line height in order to not cut characters in `<ListTile />` instances, like the ones on the Sites page.

Unfortunately, the order that pages are loaded causes some impacts on the order that the styles get applied. Precedence and specificity are really tricky to get right, so the fewer rules we add, the better. Removing the `line-height` property both from the `ListTile` component and its override fixed the cut character's problem if the user is browsing the Sites page coming from Calypso.

#### Testing Instructions

1. Open Calypso;
2. Open the Site Switcher;
3. Click "Manage Sites";
4. Switch to list view mode.

Check that the site title and URL letters are not cropped.

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/26530524/195945852-08f4ae5f-90a2-4e8e-8a9f-3825217b4852.png) | ![image](https://user-images.githubusercontent.com/26530524/195945889-5de71cbe-c437-4803-b361-5f7b68c5b534.png) |