### PR TITLE
Sites page: Disallow image selection

### DIFF
--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -1,8 +1,10 @@
 import { SiteThumbnail, DEFAULT_THUMBNAIL_SIZE } from '@automattic/components';
 import { getSiteLaunchStatus } from '@automattic/sites';
+import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
+import classNames from 'classnames';
 import { ComponentProps } from 'react';
 import Image from 'calypso/components/image';
 import { SiteComingSoon } from './sites-site-coming-soon';
@@ -11,6 +13,9 @@ import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 const NoIcon = styled.div( {
 	fontSize: 'xx-large',
 	textTransform: 'uppercase',
+} );
+
+const disallowSelection = css( {
 	userSelect: 'none',
 } );
 
@@ -21,6 +26,7 @@ interface SiteItemThumbnailProps extends Omit< ComponentProps< typeof SiteThumbn
 
 export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) => {
 	const { __ } = useI18n();
+	const classes = classNames( props.className, disallowSelection );
 
 	const shouldUseScreenshot = getSiteLaunchStatus( site ) === 'public';
 
@@ -47,6 +53,7 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 		return (
 			<SiteComingSoon
 				{ ...props }
+				className={ classes }
 				siteName={ site.name }
 				width={ style.width }
 				height={ style.height }
@@ -58,6 +65,7 @@ export const SiteItemThumbnail = ( { site, ...props }: SiteItemThumbnailProps ) 
 	return (
 		<SiteThumbnail
 			{ ...props }
+			className={ classes }
 			mShotsUrl={ shouldUseScreenshot ? siteUrl : undefined }
 			alt={ site.title || __( 'Site thumbnail' ) }
 			bgColorImgUrl={ site.icon?.img }

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -31,7 +31,7 @@ type Props = {
 export const SiteThumbnail = ( {
 	backgroundColor,
 	children,
-	className = DEFAULT_CLASSNAME,
+	className,
 	alt,
 	mShotsUrl = '',
 	bgColorImgUrl,
@@ -59,6 +59,7 @@ export const SiteThumbnail = ( {
 	const classes = classnames(
 		'site-thumbnail',
 		isLoading ? 'site-thumbnail-loading' : 'site-thumbnail-visible',
+		DEFAULT_CLASSNAME,
 		className
 	);
 


### PR DESCRIPTION
#### Proposed Changes

It was possible to select the text from the "Coming Soon" sites, which is probably not what we wanted since it should behave like a thumbnail and not actual text on the page. This PR takes care of that by disabling selection from all images in the sites list/grid.

My original idea was to disallow selecting only coming soon thumbnails, but the inconsistency did not grow on me, so I just opted to disallow selecting all of them. Let me know if you think this is not a good idea -- it's still possible to right-click the image.

#### Testing Instructions

Open the Sites page and check that when you select a range of text inside the page that contains a thumbnail, the thumbnail itself is not included.
