### PR TITLE
Purchases: Set label for domain connections to 'included with plan'

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -421,6 +421,10 @@ class PurchaseItem extends Component {
 	getPaymentMethod() {
 		const { purchase, translate } = this.props;
 
+		if ( isIncludedWithPlan( purchase ) ) {
+			return translate( 'Included with Plan' );
+		}
+
 		if (
 			purchase.isAutoRenewEnabled &&
 			! hasPaymentMethod( purchase ) &&


### PR DESCRIPTION
#### Proposed Changes

Domain connections are always included with a plan. When adding a domain connection from Store Admin, you'll see "You don't have a payment method to renew this subscription" shown in the Purchases section of Calypso. Domain connections do not need a payment method to be listed if they are included in the plan.

This change will add an early condition to ensure that 'included' purchases like domain connections will be properly labeled as 'Included with plan'.

Before:

![image](https://user-images.githubusercontent.com/16580129/195949904-996f2201-2d97-4293-9c1d-f9581554894a.png)

After:

![image](https://user-images.githubusercontent.com/16580129/195949915-2aadf77e-f667-4e5a-8ab5-de946bd9c391.png)


#### Testing Instructions

* Add a plan to a site
* Add a domain mapping from SA, make sure the expiry shows "Inherited from the site's plan" (this only shows if the target site has a plan)
* Go to http://calypso.localhost:3000/purchases/subscriptions/[YOUR-SITE-WITH-PLAN]
* Check that the payment method column is set to "included with plan" for any domain connections



Related to https://github.com/Automattic/wp-calypso/issues/67516
