### PR TITLE
Launchpad: Add copy to clipboard button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,6 +1,5 @@
 import { Gridicon, ProgressBar } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
@@ -109,7 +108,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 							<>
 								<ClipboardButton
 									text={ siteSlug }
-									className={ classNames( 'launchpad__clipboard-button' ) }
+									className="launchpad__clipboard-button"
 									borderless
 									compact
 									onCopy={ () => setClipboardCopied( true ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -56,7 +56,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 	const flow = useFlowParam();
 	const translate = useTranslate();
 	const site = useSite();
-	const clipboardButtonEl = useRef( null );
+	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 
 	const { flowName, title, launchTitle, subtitle } = getLaunchpadTranslations( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,5 +1,6 @@
 import { Gridicon, ProgressBar } from '@automattic/components';
-import { useRef } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
@@ -54,6 +55,10 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 	const flow = useFlowParam();
 	const translate = useTranslate();
 	const site = useSite();
+	const clipboardButtonEl = useRef( null );
+	const [ clipboardCopied, setClipboardCopied ] = useState( false );
+	const [ showClipboardButton, setShowClipboardButton ] = useState( false );
+
 	const { flowName, title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
 	const enhancedTasks =
@@ -63,7 +68,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 	const showLaunchTitle = launchTask && ! isTaskDisabled( launchTask );
 
-	const clipboardButtonEl = useRef( null );
 	if ( sidebarDomain ) {
 		[ siteName, topLevelDomain ] = getUrlInfo( sidebarDomain?.domain );
 	}
@@ -91,7 +95,11 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 					{ showLaunchTitle && launchTitle ? launchTitle : title }
 				</h1>
 				<p className="launchpad__sidebar-description">{ subtitle }</p>
-				<div className="launchpad__url-box">
+				<div
+					className="launchpad__url-box"
+					onMouseEnter={ () => setShowClipboardButton( true ) }
+					onMouseLeave={ () => setShowClipboardButton( false ) }
+				>
 					{ /* Google Chrome is adding an extra space after highlighted text. This extra wrapping div prevents that */ }
 					<div className="launchpad__url-box-domain-text">
 						<span>{ siteName }</span>
@@ -99,18 +107,23 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 					</div>
 					<ClipboardButton
 						text={ siteSlug }
-						className="launchpad__clipboard-button"
+						className={ classNames( 'launchpad__clipboard-button', {
+							hidden: ! showClipboardButton,
+						} ) }
 						borderless
 						compact
-						// TODO: Consider onCopy callback
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						onCopy={ () => {} }
+						onCopy={ () => setClipboardCopied( true ) }
+						onMouseLeave={ () => setClipboardCopied( false ) }
 						ref={ clipboardButtonEl }
 					>
 						<Gridicon icon="clipboard" />
 					</ClipboardButton>
-					<Tooltip context={ clipboardButtonEl.current } isVisible={ true } position="top">
-						{ 'Copy Codes' }
+					<Tooltip
+						context={ clipboardButtonEl.current }
+						isVisible={ clipboardCopied }
+						position="top"
+					>
+						{ translate( 'Copied to clipboard!' ) }
 					</Tooltip>
 					{ sidebarDomain?.isWPCOMDomain && (
 						<a href={ `/domains/add/${ siteSlug }` }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,7 +1,10 @@
-import { ProgressBar } from '@automattic/components';
+import { Gridicon, ProgressBar } from '@automattic/components';
+import { useRef } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import Tooltip from 'calypso/components/tooltip';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useFlowParam } from 'calypso/landing/stepper/hooks/use-flow-param';
@@ -60,6 +63,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 	const showLaunchTitle = launchTask && ! isTaskDisabled( launchTask );
 
+	const clipboardButtonEl = useRef( null );
 	if ( sidebarDomain ) {
 		[ siteName, topLevelDomain ] = getUrlInfo( sidebarDomain?.domain );
 	}
@@ -93,6 +97,21 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 						<span>{ siteName }</span>
 						<span className="launchpad__url-box-top-level-domain">{ topLevelDomain }</span>
 					</div>
+					<ClipboardButton
+						text={ siteSlug }
+						className="launchpad__clipboard-button"
+						borderless
+						compact
+						// TODO: Consider onCopy callback
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						onCopy={ () => {} }
+						ref={ clipboardButtonEl }
+					>
+						<Gridicon icon="clipboard" />
+					</ClipboardButton>
+					<Tooltip context={ clipboardButtonEl.current } isVisible={ true } position="top">
+						{ 'Copy Codes' }
+					</Tooltip>
 					{ sidebarDomain?.isWPCOMDomain && (
 						<a href={ `/domains/add/${ siteSlug }` }>
 							<Badge className="launchpad__domain-upgrade-badge" type="info-blue">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -115,6 +115,16 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+
+	.launchpad__clipboard-button {
+		padding-left: 10px;
+		padding-right: 10px;
+		visibility: visible;
+	}
+}
+
+.hidden {
+	visibility: hidden;
 }
 
 .launchpad__url-box-domain-text {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -121,16 +121,23 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
+		padding: 4px 0;
+		padding-right: 12px;
 	}
 
-	.launchpad__url-box-domain-domain:hover > .launchpad__clipboard-button {
-		visibility: visible;
+	.launchpad__url-box-domain:hover > .launchpad__url-box-domain-text {
+		padding-right: 0;
+	}
+
+	.launchpad__url-box-domain:hover > .launchpad__clipboard-button {
+		display: block;
 	}
 
 	.launchpad__clipboard-button {
-		padding-left: 10px;
-		padding-right: 10px;
-		// visibility: hidden;
+		padding-left: 8px;
+		padding-right: 8px;
+		display: none;
+		min-width: 34px;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -111,30 +111,27 @@
 	margin: 32px 0;
 	padding: 0 12px;
 
+	.launchpad__url-box-domain {
+		display: flex;
+		flex-grow: 1;
+		width: 0;
+	}
 
-	> div {
-		// truncate long domain names
+	.launchpad__url-box-domain-text {
+		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
-		text-overflow: ellipsis;
+	}
+
+	.launchpad__url-box-domain-domain:hover > .launchpad__clipboard-button {
+		visibility: visible;
 	}
 
 	.launchpad__clipboard-button {
 		padding-left: 10px;
 		padding-right: 10px;
-		visibility: visible;
+		// visibility: hidden;
 	}
-}
-
-.hidden {
-	visibility: hidden;
-}
-
-.launchpad__url-box-domain-text {
-	flex-grow: 1;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	overflow: hidden;
 }
 
 .launchpad__url-box-top-level-domain {
@@ -142,7 +139,6 @@
 }
 
 .launchpad__domain-upgrade-badge {
-
 	&:hover {
 		background: var(--studio-blue-10);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -111,10 +111,13 @@
 	margin: 32px 0;
 	padding: 0 12px;
 
-	// truncate long domain names
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+
+	> div {
+		// truncate long domain names
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 
 	.launchpad__clipboard-button {
 		padding-left: 10px;


### PR DESCRIPTION
### Proposed Changes

* Add copy to clipboard button
* Ensure that the button is not shown if a custom domain is still in the process of being registered with domain name systems
* Display the clipboard button when hovering url box

**TODOs ( To be handled in follow-ups ):**
* Make the button keyboard accessible
* Replace old clipboard icon with new one specified in [figma designs](9wpoYJrMlYKAKUYvVBMN74-fi-1086%3A16682)
* Create message underneath url box notifying user if custom domain is still being set up
* Unit tests

### GIFs
#### Normal Domain Name
![2022-10-17 18 03 32](https://user-images.githubusercontent.com/5414230/196311255-31ecf64c-4302-4335-8125-f0e648953b28.gif)

#### Normal Domain Name + Upgrade Badge
![2022-10-17 18 02 09](https://user-images.githubusercontent.com/5414230/196311145-0a843783-7a22-4318-b42a-0cda0f8b6d72.gif)

#### Extremely Long Domain Name
![2022-10-16 12 20 53](https://user-images.githubusercontent.com/5414230/196054192-d207bd1e-6519-4722-b3d5-46e0fecdd2b5.gif)

#### Extremely Long Domain Name + Upgrade Badge
![2022-10-17 17 59 43](https://user-images.githubusercontent.com/5414230/196310832-74459541-f792-4174-8f9b-e112c9f0dedf.gif)

#### Custom Domain Recently Purchased and Registry Still Resolving
![2022-10-19 11 19 06](https://user-images.githubusercontent.com/5414230/196772780-f39e7ef8-753c-4a17-9254-82b5fd7ecd4c.gif)

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Normal Domains
* Check out this PR
* Create new, _**free**_ site through tailored flow https://wordpress.com/hp-2022-tailored-flows/
* Complete steps until at the Launchpad screen
* Verify that the clipboard button behaves as expected
  * Copies url to clipboard
  * Displays tooltip to confirm when clipboard button is clicked
  * Only shows the clipboard button when hovering over url box
  * Hides the clipboard button when mouse leaves url box
  * Hides the tooltip when mouse leaves the clipboard button icon clickable area
* Repeat previous steps but with an excessively long domain name

#### Custom Domains
* Check out this PR
* Create new, _**free**_ site through tailored flow https://wordpress.com/hp-2022-tailored-flows/
* Create a custom domain for the site
* Choose, at minimum, a personal plan ( so that we can make a custom domain the primary domain )
* Complete steps until at the Launchpad screen
* Verify that the copy button _**does not**_ appear until ssl is active on the custom domain and the custom domain is set as as the primary domain
  * Go to the admin sidebar Upgrades > Domains
  * Click on the ellipses next to the custom domain
  * Click on "Make Primary Site Address" ( You will not see this unless you have a personal plan or better )
* Once the previous requirements have been met, verify that the clipboard button behaves as expected
  * Copies url to clipboard
  * Displays tooltip to confirm when clipboard button is clicked
  * Only shows the clipboard button when hovering over url box
  * Hides the clipboard button when mouse leaves url box
  * Hides the tooltip when mouse leaves the clipboard button icon clickable area

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68967