### PR TITLE
Sites Management Page: Replace react-intersection-observer with IntersectionObserver

### DIFF
--- a/client/components/activity-card-list/visible-days-limit-upsell/hooks.ts
+++ b/client/components/activity-card-list/visible-days-limit-upsell/hooks.ts
@@ -1,58 +1,22 @@
-import { RefObject, useCallback, useEffect, useRef } from 'react';
+import { RefObject, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { useInView } from 'calypso/lib/use-in-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
 export const useTrackUpsellView = (
 	siteId: number | null
 ): RefObject< HTMLAnchorElement | HTMLButtonElement > => {
-	const viewedRef = useRef< boolean >( false );
-	const elementRef = useRef< HTMLAnchorElement | HTMLButtonElement >( null );
-	const observerRef = useRef< IntersectionObserver >();
-
 	const dispatch = useDispatch();
 
-	useEffect( () => {
-		// We can't do anything without a valid reference to an element on the page
-		if ( ! elementRef.current ) {
-			return;
-		}
+	const inViewCallback = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_activitylog_visiblelimit_upsell_view', {
+				site_id: siteId ?? undefined,
+			} )
+		);
+	}, [ siteId ] );
 
-		// If the observer is already defined, no need to continue
-		if ( observerRef.current ) {
-			return;
-		}
-
-		const handler = ( entries: IntersectionObserverEntry[] ) => {
-			// Only fire once per page load
-			if ( viewedRef.current ) {
-				return;
-			}
-
-			const [ entry ] = entries;
-			if ( ! entry.isIntersecting ) {
-				return;
-			}
-
-			dispatch(
-				recordTracksEvent( 'calypso_activitylog_visiblelimit_upsell_view', {
-					site_id: siteId ?? undefined,
-				} )
-			);
-
-			viewedRef.current = true;
-		};
-
-		observerRef.current = new IntersectionObserver( handler, {
-			// Only fire the event when 100% of the element becomes visible
-			threshold: [ 1 ],
-		} );
-		observerRef.current.observe( elementRef.current );
-
-		// When the effect is dismounted, stop observing
-		return () => observerRef.current?.disconnect?.();
-	}, [ dispatch, siteId ] );
-
-	return elementRef;
+	return useInView< HTMLAnchorElement | HTMLButtonElement >( inViewCallback );
 };
 
 export const useTrackUpgradeClick = ( siteId: number | null ): ( () => void ) => {

--- a/client/lib/use-in-view/index.ts
+++ b/client/lib/use-in-view/index.ts
@@ -1,0 +1,46 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+export function useInView< T extends Element >( oneTimeCallback: () => void ): RefObject< T > {
+	const viewedRef = useRef< boolean >( false );
+	const elementRef = useRef< T >( null );
+	const observerRef = useRef< IntersectionObserver >();
+
+	useEffect( () => {
+		// We can't do anything without a valid reference to an element on the page
+		if ( ! elementRef.current ) {
+			return;
+		}
+
+		// If the observer is already defined, no need to continue
+		if ( observerRef.current ) {
+			return;
+		}
+
+		const handler = ( entries: IntersectionObserverEntry[] ) => {
+			// Only fire once per page load
+			if ( viewedRef.current ) {
+				return;
+			}
+
+			const [ entry ] = entries;
+			if ( ! entry.isIntersecting ) {
+				return;
+			}
+
+			oneTimeCallback();
+
+			viewedRef.current = true;
+		};
+
+		observerRef.current = new IntersectionObserver( handler, {
+			// Only fire the event when 100% of the element becomes visible
+			threshold: [ 1 ],
+		} );
+		observerRef.current.observe( elementRef.current );
+
+		// When the effect is dismounted, stop observing
+		return () => observerRef.current?.disconnect?.();
+	}, [ oneTimeCallback ] );
+
+	return elementRef;
+}

--- a/client/lib/use-in-view/test/index.tsx
+++ b/client/lib/use-in-view/test/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { useInView } from '../index';
+
+function TestComponent( {
+	totalTimesInView,
+	callback,
+}: {
+	totalTimesInView: number;
+	callback: () => void;
+} ) {
+	const ref = useInView< HTMLDivElement >( callback );
+
+	useEffect( () => {
+		if ( ref ) {
+			Array.from( { length: totalTimesInView } ).forEach( () => {
+				// simulate the element appearing in view and fire the handler
+				( window as any ).intersectionObserverHandler();
+			} );
+		}
+	}, [ ref ] );
+
+	return <div ref={ ref } />;
+}
+
+describe( 'useInView suite', () => {
+	beforeEach( () => {
+		( window as any ).IntersectionObserver = class IO {
+			constructor( private handler: ( entries: { isIntersecting: boolean }[] ) => void ) {
+				// expose the handler so it can be called in tests
+				( window as any ).intersectionObserverHandler = () => {
+					handler( [ { isIntersecting: true } ] );
+				};
+			}
+
+			observe() {
+				return null;
+			}
+
+			disconnect() {
+				return null;
+			}
+		};
+	} );
+
+	it( 'Component is never in view so event never fires', () => {
+		let count = 0;
+		const callback = () => count++;
+		render( <TestComponent totalTimesInView={ 0 } callback={ callback } /> );
+		expect( count ).toBe( 0 );
+	} );
+
+	it( 'Component is in view once, event fires once', () => {
+		let count = 0;
+		const callback = () => count++;
+		render( <TestComponent totalTimesInView={ 1 } callback={ callback } /> );
+		expect( count ).toBe( 1 );
+	} );
+
+	it( 'Component is in view twice, event fires once', () => {
+		let count = 0;
+		const callback = () => count++;
+		render( <TestComponent totalTimesInView={ 2 } callback={ callback } /> );
+		expect( count ).toBe( 1 );
+	} );
+} );

--- a/client/package.json
+++ b/client/package.json
@@ -173,7 +173,6 @@
 		"react-day-picker": "^7.4.10",
 		"react-dom": "^17.0.2",
 		"react-element-to-jsx-string": "^14.3.2",
-		"react-intersection-observer": "^8.32.1",
 		"react-live": "^2.3.0",
 		"react-modal": "^3.14.3",
 		"react-query": "^3.32.1",

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,8 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
-import { useInView } from 'react-intersection-observer';
+import { useInView } from 'calypso/lib/use-in-view';
 import { getDashboardUrl, getLaunchpadUrl } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -74,15 +73,13 @@ const SiteLaunchDonut = () => {
 	);
 };
 
+const recordNagView = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_inview' );
+};
+
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const { __ } = useI18n();
-	const { ref, inView: inViewOnce } = useInView( { triggerOnce: true } );
-
-	useEffect( () => {
-		if ( inViewOnce ) {
-			recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_inview' );
-		}
-	}, [ inViewOnce ] );
+	const ref = useInView< HTMLAnchorElement >( recordNagView );
 
 	// Don't show nag to all Coming Soon sites, only those that are "unlaunched"
 	// That's because sites that have been previously launched before going back to

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -81,8 +81,8 @@ const SitePlanIcon = styled.div`
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
-	const [ hasViewed, setHasViewed ] = useState( false );
-	const ref = useInView< HTMLTableDataCellElement >( () => setHasViewed( true ) );
+	const [ inViewOnce, setInViewOnce ] = useState( false );
+	const ref = useInView< HTMLTableDataCellElement >( () => setInViewOnce( true ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 
@@ -141,7 +141,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
 			<Column ref={ ref } mobileHidden>
-				{ hasViewed && (
+				{ inViewOnce && (
 					<a href={ `/stats/day/${ site.slug }` }>
 						<StatsSparkline siteId={ site.ID } showLoader={ true }></StatsSparkline>
 					</a>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -3,11 +3,11 @@ import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { memo } from 'react';
-import { useInView } from 'react-intersection-observer';
+import { memo, useState } from 'react';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
+import { useInView } from 'calypso/lib/use-in-view/index';
 import { displaySiteUrl, getDashboardUrl, isNotAtomicJetpack, MEDIA_QUERIES } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
@@ -81,7 +81,8 @@ const SitePlanIcon = styled.div`
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
-	const { ref, inView: inViewOnce } = useInView( { triggerOnce: true } );
+	const [ hasViewed, setHasViewed ] = useState( false );
+	const ref = useInView< HTMLTableDataCellElement >( () => setHasViewed( true ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 
@@ -140,7 +141,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
 			<Column ref={ ref } mobileHidden>
-				{ inViewOnce && (
+				{ hasViewed && (
 					<a href={ `/stats/day/${ site.slug }` }>
 						<StatsSparkline siteId={ site.ID } showLoader={ true }></StatsSparkline>
 					</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12740,7 +12740,6 @@ __metadata:
     react-day-picker: ^7.4.10
     react-dom: ^17.0.2
     react-element-to-jsx-string: ^14.3.2
-    react-intersection-observer: ^8.32.1
     react-live: ^2.3.0
     react-modal: ^3.14.3
     react-query: ^3.32.1
@@ -28719,16 +28718,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-intersection-observer@npm:^8.32.1":
-  version: 8.32.1
-  resolution: "react-intersection-observer@npm:8.32.1"
-  peerDependencies:
-    react: ^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0
-  checksum: a555a32c581361dc71954df47329f007f5cc8280b79c24377b5b03622e036749fd4a8cc80489f6956a084faf49532621af8715a540c42d7bb37686951359f661
-  languageName: node
-  linkType: hard
-
-"react-intersection-observer@npm:^9.4.0":
+"react-intersection-observer@npm:9.4.0":
   version: 9.4.0
   resolution: "react-intersection-observer@npm:9.4.0"
   peerDependencies:
@@ -35862,7 +35852,7 @@ swiper@4.5.1:
     prettier: "npm:wp-prettier@2.6.2"
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-intersection-observer: ^9.4.0
+    react-intersection-observer: 9.4.0
     readline-sync: ^1.4.10
     reakit-utils: ^0.15.1
     recursive-copy: ^2.0.14

--- a/yarn.lock
+++ b/yarn.lock
@@ -28718,7 +28718,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-intersection-observer@npm:9.4.0":
+"react-intersection-observer@npm:^9.4.0":
   version: 9.4.0
   resolution: "react-intersection-observer@npm:9.4.0"
   peerDependencies:
@@ -35852,7 +35852,7 @@ swiper@4.5.1:
     prettier: "npm:wp-prettier@2.6.2"
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-intersection-observer: 9.4.0
+    react-intersection-observer: ^9.4.0
     readline-sync: ^1.4.10
     reakit-utils: ^0.15.1
     recursive-copy: ^2.0.14


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68625

#### Proposed Changes

* Remove `react-intersection-observer` and reuse some existing logic elsewhere in the codebase

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This hook is used on the `/sites` page and at for a nudge at `/activity-log/:business-or-pro-site-with-jetpack`. 

* To test, go to `/sites` with one or more unlaunched sites. Note how many Tracks events fire with `calypso_sites_dashboard_site_launch_nag_inview` in both **list** and **grid** views. Repeat the process on the Calypso Live site and verify the new code produces the same output. The events should only ever fire one and you can verify this by scrolling the nag UI in and out of the screen. 
* Testing `/activity-log/:business-or-pro-site-with-jetpack` is a bit awkward. The easiest way to check is to modify the code to force the banner to display. You can do this like so:
    - go to `client/my-sites/activity/activity-log/index.jsx` and change line `551` so that `<VisibleDaysLimitUpsell/>` always get rendered. 
    - Next, go to `<VisibleDaysLimitUpsell/>` and change line `60` so it doesn't return `null`. Finally, go to `/activity-log/business-or-pro-site-with-jetpack` and scroll to the bottom and should see the banner. As before, ensure the Tracks event only fires one per page load after switching from `trunk` to `remove/react-intersection-observer-dep`

![image](https://user-images.githubusercontent.com/6851384/196109518-a0e9ba7a-3be8-4fad-9195-4b8a291c3e8e.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
