### PR TITLE
Update AddSubsribersForm style to support in-product context

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -135,7 +135,9 @@ class Followers extends Component {
 								<AddSubscriberForm
 									siteId={ this.props.site.ID }
 									flowName="people"
+									showSubtitle={ true }
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
+									showFormManualListLabel={ true }
 									recordTracksEvent={ recordTracksEvent }
 									onImportFinished={ () => {
 										this.props?.refetch?.();

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -75,6 +75,8 @@ class PeopleInvites extends PureComponent {
 						<AddSubscriberForm
 							siteId={ this.props.site.ID }
 							flowName="people"
+							showTitle={ false }
+							showFormManualListLabel={ true }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 							onImportFinished={ () => {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -27,7 +27,6 @@ import './style.scss';
 interface Props {
 	siteId: number;
 	flowName?: string;
-	showTitleEmoji?: boolean;
 	showSkipBtn?: boolean;
 	showCsvUpload?: boolean;
 	submitBtnName?: string;
@@ -47,7 +46,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const {
 		siteId,
 		flowName,
-		showTitleEmoji,
 		showSkipBtn,
 		showCsvUpload,
 		submitBtnName = __( 'Add subscribers' ),
@@ -343,7 +341,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	return (
 		<div className={ 'add-subscriber' }>
 			<div className={ 'add-subscriber__title-container' }>
-				{ showTitleEmoji && <h2 className={ 'add-subscriber__title-emoji' }>🤝</h2> }
 				<Title>{ __( 'Let’s add your first subscribers' ) }</Title>
 			</div>
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -83,6 +83,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ isValidEmails, setIsValidEmails ] = useState< boolean[] >( [] );
 	const [ isDirtyEmails, setIsDirtyEmails ] = useState< boolean[] >( [] );
 	const [ emailFormControls, setEmailFormControls ] = useState( emailControlPlaceholder );
+	const [ submitBtnReady, setIsSubmitBtnReady ] = useState( isSubmitButtonReady() );
 	const importSelector = useSelect( ( s ) => s( SUBSCRIBER_STORE ).getImportSubscribersSelector() );
 	const [ formFileUploadElement ] = useState(
 		createElement( FormFileUpload, {
@@ -107,6 +108,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	useEffect( () => {
 		prevInProgress.current = inProgress;
 	}, [ inProgress ] );
+	useEffect( () => {
+		setIsSubmitBtnReady( isSubmitButtonReady() );
+	}, [ isValidEmails, selectedFile, allowEmptyFormSubmit ] );
 
 	useRecordAddFormEvents( recordTracksEvent, flowName );
 
@@ -116,9 +120,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	function onFormSubmit( e: FormEvent ) {
 		e.preventDefault();
 
-		const validEmails = isValidEmails
-			.map( ( x, i ) => x && emails[ i ] )
-			.filter( ( x ) => !! x ) as string[];
+		const validEmails = getValidEmails();
 
 		if ( manualListEmailInviting ) {
 			// add subscribers with invite email
@@ -156,6 +158,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		const _isDirtyEmails = Array.from( isDirtyEmails );
 		_isDirtyEmails[ index ] = !! value;
 		setIsDirtyEmails( _isDirtyEmails );
+	}
+
+	function getValidEmails(): string[] {
+		return isValidEmails.map( ( x, i ) => x && emails[ i ] ).filter( ( x ) => !! x ) as string[];
 	}
 
 	function isValidExtension( fileName: string ) {
@@ -198,6 +204,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 			setEmailFormControls( controls );
 		}
+	}
+
+	function isSubmitButtonReady(): boolean {
+		return !! allowEmptyFormSubmit || !! getValidEmails().length || !! selectedFile;
 	}
 
 	function importFinishedRecognition() {
@@ -402,7 +412,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						type="submit"
 						className="add-subscriber__form-submit-btn"
 						isBusy={ inProgress }
-						disabled={ inProgress }
+						disabled={ inProgress || ! submitBtnReady }
 					>
 						{ submitBtnName }
 					</NextButton>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -54,7 +54,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		allowEmptyFormSubmit,
 		manualListEmailInviting,
 		recordTracksEvent,
-		onSkipBtnClick,
 		onImportFinished,
 	} = props;
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -27,6 +27,7 @@ import './style.scss';
 interface Props {
 	siteId: number;
 	flowName?: string;
+	showTitle?: boolean;
 	showSkipBtn?: boolean;
 	showCsvUpload?: boolean;
 	submitBtnName?: string;
@@ -46,6 +47,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const {
 		siteId,
 		flowName,
+		showTitle = true,
 		showSkipBtn,
 		showCsvUpload,
 		submitBtnName = __( 'Add subscribers' ),
@@ -340,9 +342,11 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<div className={ 'add-subscriber' }>
-			<div className={ 'add-subscriber__title-container' }>
-				<Title>{ __( 'Let’s add your first subscribers' ) }</Title>
-			</div>
+			{ showTitle && (
+				<div className={ 'add-subscriber__title-container' }>
+					<Title>{ __( 'Let’s add your first subscribers' ) }</Title>
+				</div>
+			) }
 
 			<div className={ 'add-subscriber__form--container' }>
 				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -412,7 +412,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						type="submit"
 						className="add-subscriber__form-submit-btn"
 						isBusy={ inProgress }
-						disabled={ inProgress || ! submitBtnReady }
+						disabled={ ! submitBtnReady }
 					>
 						{ submitBtnName }
 					</NextButton>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -344,9 +344,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<div className={ 'add-subscriber' }>
-			{ showTitle && (
+			{ ( showTitle || showSubtitle ) && (
 				<div className={ 'add-subscriber__title-container' }>
-					<Title>{ __( 'Let’s add your first subscribers' ) }</Title>
+					{ showTitle && <Title>{ __( 'Let’s add your first subscribers' ) }</Title> }
 					{ showSubtitle && (
 						<SubTitle>
 							{ __(

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Title, SubTitle, NextButton, SkipButton } from '@automattic/onboarding';
+import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { TextControl, FormFileUpload, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -29,7 +29,6 @@ interface Props {
 	flowName?: string;
 	showTitle?: boolean;
 	showSubtitle?: boolean;
-	showSkipBtn?: boolean;
 	showCsvUpload?: boolean;
 	submitBtnName?: string;
 	allowEmptyFormSubmit?: boolean;
@@ -50,7 +49,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		flowName,
 		showTitle = true,
 		showSubtitle,
-		showSkipBtn,
 		showCsvUpload,
 		submitBtnName = __( 'Add subscribers' ),
 		allowEmptyFormSubmit,
@@ -400,14 +398,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					>
 						{ submitBtnName }
 					</NextButton>
-					{ showSkipBtn && (
-						<SkipButton
-							className={ 'add-subscriber__form-skip-btn' }
-							onClick={ () => onSkipBtnClick?.() }
-						>
-							{ __( 'Not yet' ) }
-						</SkipButton>
-					) }
 				</form>
 			</div>
 		</div>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -30,6 +30,7 @@ interface Props {
 	showTitle?: boolean;
 	showSubtitle?: boolean;
 	showCsvUpload?: boolean;
+	showFormManualListLabel?: boolean;
 	submitBtnName?: string;
 	allowEmptyFormSubmit?: boolean;
 	manualListEmailInviting?: boolean;
@@ -50,6 +51,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		showTitle = true,
 		showSubtitle,
 		showCsvUpload,
+		showFormManualListLabel,
 		submitBtnName = __( 'Add subscribers' ),
 		allowEmptyFormSubmit,
 		manualListEmailInviting,
@@ -361,6 +363,11 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 						return (
 							<div key={ i }>
+								{ showFormManualListLabel && i === 0 && (
+									<label className={ 'add-subscriber__form-label-emails' }>
+										<strong>{ __( 'Emails' ) }</strong>
+									</label>
+								) }
 								<TextControl
 									className={ showError ? 'is-error' : '' }
 									disabled={ inProgress }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Title, NextButton, SkipButton } from '@automattic/onboarding';
+import { Title, SubTitle, NextButton, SkipButton } from '@automattic/onboarding';
 import { TextControl, FormFileUpload, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -28,6 +28,7 @@ interface Props {
 	siteId: number;
 	flowName?: string;
 	showTitle?: boolean;
+	showSubtitle?: boolean;
 	showSkipBtn?: boolean;
 	showCsvUpload?: boolean;
 	submitBtnName?: string;
@@ -48,6 +49,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		siteId,
 		flowName,
 		showTitle = true,
+		showSubtitle,
 		showSkipBtn,
 		showCsvUpload,
 		submitBtnName = __( 'Add subscribers' ),
@@ -345,6 +347,13 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			{ showTitle && (
 				<div className={ 'add-subscriber__title-container' }>
 					<Title>{ __( 'Let’s add your first subscribers' ) }</Title>
+					{ showSubtitle && (
+						<SubTitle>
+							{ __(
+								'Your subscribers will receive an email notification whenever you publish a new post.'
+							) }
+						</SubTitle>
+					) }
 				</div>
 			) }
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -168,7 +168,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 	function onFileInputChange( e: ChangeEvent< HTMLInputElement > ) {
 		const f = e.target.files;
-		if ( ! f || ! f.length ) return;
+		if ( ! f || ! f.length ) {
+			return;
+		}
 
 		const file = f[ 0 ];
 		const isValid = isValidExtension( file.name );
@@ -214,7 +216,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 		return (
 			error && (
-				<FormInputValidation icon={ 'tip' } isError={ false } isWarning={ true } text={ '' }>
+				<FormInputValidation icon="tip" isError={ false } isWarning={ true } text="">
 					<Icon icon={ tip } />
 					{ ( () => {
 						switch ( error.code ) {
@@ -243,7 +245,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	function renderFileValidationMsg() {
 		return (
 			! isSelectedFileValid && (
-				<FormInputValidation isError={ true } text={ '' }>
+				<FormInputValidation isError={ true } text="">
 					{ createInterpolateElement(
 						__(
 							'Sorry, you can only upload CSV files right now. Most providers will let you export this from your settings. <uploadBtn>Select another file</uploadBtn>'
@@ -258,7 +260,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	function renderEmailListInfoMsg() {
 		return (
 			emailControlMaxNum === isValidEmails.filter( ( x ) => x ).length && (
-				<FormInputValidation icon={ 'tip' } isError={ false } text={ '' }>
+				<FormInputValidation icon="tip" isError={ false } text="">
 					<Icon icon={ tip } />
 					{ __( 'Great start! You’ll be able to add more subscribers after setup.' ) }
 				</FormInputValidation>
@@ -270,7 +272,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		return (
 			isSelectedFileValid &&
 			selectedFile && (
-				<p className={ 'add-subscriber__form--disclaimer' }>
+				<p className="add-subscriber__form--disclaimer">
 					{ createInterpolateElement(
 						sprintf(
 							/* translators: the first string variable shows CTA button name */
@@ -318,7 +320,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		return (
 			isSelectedFileValid &&
 			selectedFile && (
-				<label className={ 'add-subscriber__form-label-links' }>
+				<label className="add-subscriber__form-label-links">
 					{ createInterpolateElement(
 						sprintf(
 							/* translators: the first string variable shows a selected file name, Replace and Remove are links */
@@ -342,9 +344,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}
 
 	return (
-		<div className={ 'add-subscriber' }>
+		<div className="add-subscriber">
 			{ ( showTitle || showSubtitle ) && (
-				<div className={ 'add-subscriber__title-container' }>
+				<div className="add-subscriber__title-container">
 					{ showTitle && <Title>{ __( 'Let’s add your first subscribers' ) }</Title> }
 					{ showSubtitle && (
 						<SubTitle>
@@ -356,15 +358,15 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 				</div>
 			) }
 
-			<div className={ 'add-subscriber__form--container' }>
-				<form onSubmit={ onFormSubmit } autoComplete={ 'off' }>
+			<div className="add-subscriber__form--container">
+				<form onSubmit={ onFormSubmit } autoComplete="off">
 					{ emailFormControls.map( ( placeholder, i ) => {
 						const showError = isDirtyEmails[ i ] && ! isValidEmails[ i ] && emails[ i ];
 
 						return (
 							<div key={ i }>
 								{ showFormManualListLabel && i === 0 && (
-									<label className={ 'add-subscriber__form-label-emails' }>
+									<label className="add-subscriber__form-label-emails">
 										<strong>{ __( 'Emails' ) }</strong>
 									</label>
 								) }
@@ -397,8 +399,8 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
 
 					<NextButton
-						type={ 'submit' }
-						className={ 'add-subscriber__form-submit-btn' }
+						type="submit"
+						className="add-subscriber__form-submit-btn"
 						isBusy={ inProgress }
 						disabled={ inProgress }
 					>

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -195,8 +195,12 @@
 
 		a,
 		button {
-			color: var(--studio-gray-100);
+			color: var(--color-text);
 			text-decoration: underline;
+
+			&:hover {
+				color: var(--color-text-subtle);
+			}
 		}
 	}
 }

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -44,6 +44,14 @@
 		}
 	}
 
+	.add-subscriber__form--container input {
+		&:focus {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			outline: none;
+		}
+	}
+
 	.add-subscriber__form-submit-btn {
 		margin-top: 0.5rem;
 	}

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -141,7 +141,7 @@
 
 	.components-base-control__help {
 		position: absolute;
-		top: 5px;
+		top: 3px;
 		right: 10px;
 
 		svg {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -1,5 +1,52 @@
+// On-boarding flow
 .step-container.subscribers {
 	padding: 0 1.5rem;
+
+	.add-subscriber__title-container,
+	.add-subscriber__form--container {
+		margin: auto;
+	}
+
+	.add-subscriber .add-subscriber__title-container {
+		max-width: 376px;
+		text-align: center;
+
+		.onboarding-subtitle {
+			margin-bottom: 1.5rem;
+			font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+		}
+	}
+
+	.add-subscriber .add-subscriber__form--container {
+		max-width: 368px;
+	}
+
+	.add-subscriber__form-submit-btn {
+		display: block;
+		width: 100%;
+		margin: 2rem 0;
+	}
+}
+
+// People section
+.is-section-people {
+	.add-subscriber .add-subscriber__title-container {
+		.onboarding-title {
+			font-size: 2rem;
+			line-height: 2.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			margin-bottom: 1.5rem;
+		}
+	}
+
+	.add-subscriber .add-subscriber__form--container form > div:first-child {
+		.components-base-control__field {
+			margin-top: 0;
+		}
+	}
+
+	.add-subscriber__form-submit-btn {
+		margin-top: 0.5rem;
+	}
 }
 
 .add-subscriber {
@@ -12,49 +59,12 @@
 	}
 }
 
-.add-subscriber__title-container,
-.add-subscriber__form--container,
-.add-subscriber__progress--container {
-	margin: auto;
-}
-
-.add-subscriber__progress--container {
-	max-width: 520px;
-	text-align: center;
-
-	.onboarding-title {
-		font-size: 2rem;
-		margin-bottom: 1rem;
-	}
-
-	.onboarding-subtitle {
-		font-size: 0.875rem;
-	}
-
-	.onboarding-progress .progress-bar {
-		margin-bottom: 1rem;
-	}
-}
-
 .add-subscriber .add-subscriber__title-container {
-	text-align: center;
 	margin-bottom: 1rem;
-	max-width: 376px;
 
-	.add-subscriber__title-emoji {
-		font-size: 2.5rem; /* stylelint-disable-line scales/font-sizes */
-		margin-bottom: 0.75em;
-	}
-
-	.onboarding-title {
-		margin-bottom: 1.5rem;
-		font-size: 2.75rem;
-		line-height: 3.5rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
-	}
-
+	.onboarding-title,
 	.onboarding-subtitle {
 		margin-bottom: 1.5rem;
-		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 	}
 }
 
@@ -79,8 +89,6 @@
 }
 
 .add-subscriber .add-subscriber__form--container {
-	max-width: 368px;
-
 	label {
 		display: block;
 		width: 100%;
@@ -92,6 +100,10 @@
 			.components-button {
 				margin: 0 0.2rem;
 			}
+		}
+
+		&.add-subscriber__form-label-emails {
+			margin-bottom: 0.5rem;
 		}
 	}
 
@@ -121,22 +133,6 @@
 
 	.components-form-file-upload {
 		display: inline-block;
-	}
-
-	.add-subscriber__form-submit-btn,
-	.add-subscriber__form-skip-btn {
-		display: block;
-		width: 100%;
-		margin: 2rem 0;
-	}
-
-	.add-subscriber__form-skip-btn {
-		box-shadow: none !important;
-		text-decoration: underline;
-
-		&:hover {
-			text-decoration: none;
-		}
 	}
 
 	.components-base-control {


### PR DESCRIPTION
#### Proposed Changes

* Import subscriber form style adjustments inside in-product integration (see screenshots)

#### Testing Instructions

* Go to `/people/email-followers/{SLUG}`
* Check if the design looks like as provided screenshot presentation.

#### Screenshots
<table>
<tr>
<td width="50%">
Before:
</td>
<td width="50%">
After:
</td>
</tr>
<tr>
<td width="50%">
<img width="758" alt="Screenshot 2022-10-18 at 10 30 20" src="https://user-images.githubusercontent.com/1241413/196378914-0540cc8f-49e0-4fc2-a26e-ade6f0edb97d.png">
</td>
<td width="50%">
<img width="765" alt="Screenshot 2022-10-18 at 10 02 15" src="https://user-images.githubusercontent.com/1241413/196378970-6405e513-8653-40bb-9dd0-7802b01136b7.png">
</td>
</tr>
<tr>
<td width="50%">
<img width="748" alt="Screenshot 2022-10-18 at 10 30 05" src="https://user-images.githubusercontent.com/1241413/196379205-5673c318-cc06-4cbd-8107-4f07bc250597.png">
</td>
<td width="50%">
<img width="770" alt="Screenshot 2022-10-18 at 10 02 40" src="https://user-images.githubusercontent.com/1241413/196379280-4c554a9c-2785-4a73-b59a-cd02ba4ed0f2.png">
</td>
</tr>

</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #69123
