### PR TITLE
Help Center: fix Help Center support variationn name

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -284,7 +284,7 @@ export const HelpCenterContactForm = () => {
 					} )
 						.then( () => {
 							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
-								support_variation: 'kayako',
+								support_variation: 'email',
 								location: 'help-center',
 								section: sectionName,
 							} );


### PR DESCRIPTION
#### Proposed Changes

* Change the support variation name in track events to `email` to unify with Calypso.

