### PR TITLE
Site Switcher: Display icon instead of count for `<AllSites>`

### DIFF
--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -18,7 +18,7 @@ const IconContainer = styled.div( {
 	alignSelf: 'center',
 	borderRadius: 0,
 	display: 'inline-flex',
-	marginRight: '8px',
+	marginInlineEnd: '8px',
 	padding: 0,
 	height: '32px',
 	width: '32px',

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -12,6 +13,19 @@ import './style.scss';
 
 const noop = () => {};
 
+const IconContainer = styled.div( {
+	alignItems: 'center',
+	alignSelf: 'center',
+	borderRadius: 0,
+	display: 'inline-flex',
+	marginRight: '8px',
+	padding: 0,
+	height: '32px',
+	width: '32px',
+	justifyContent: 'center',
+	color: 'var(--color-sidebar-text)',
+} );
+
 class AllSites extends Component {
 	static defaultProps = {
 		onSelect: noop,
@@ -19,6 +33,7 @@ class AllSites extends Component {
 		isSelected: false,
 		isHighlighted: false,
 		showCount: true,
+		showIcon: false,
 		domain: '',
 	};
 
@@ -28,7 +43,9 @@ class AllSites extends Component {
 		isSelected: PropTypes.bool,
 		isHighlighted: PropTypes.bool,
 		showCount: PropTypes.bool,
+		showIcon: PropTypes.bool,
 		count: PropTypes.number,
+		icon: PropTypes.node,
 		title: PropTypes.string,
 		domain: PropTypes.string,
 		onMouseEnter: PropTypes.func,
@@ -39,12 +56,20 @@ class AllSites extends Component {
 		this.props.onSelect( event );
 	};
 
+	renderIcon() {
+		if ( ! this.props.icon ) {
+			return null;
+		}
+		return <IconContainer>{ this.props.icon }</IconContainer>;
+	}
+
 	renderSiteCount() {
 		return <Count count={ this.props.count } />;
 	}
 
 	render() {
-		const { title, href, domain, translate, isHighlighted, isSelected, showCount } = this.props;
+		const { title, href, domain, translate, isHighlighted, isSelected, showCount, showIcon } =
+			this.props;
 
 		// Note: Update CSS selectors in SiteSelector.scrollToHighlightedSite() if the class names change.
 		const allSitesClass = classNames( {
@@ -63,6 +88,7 @@ class AllSites extends Component {
 					onClick={ this.onSelect }
 				>
 					{ showCount && this.renderSiteCount() }
+					{ showIcon && this.renderIcon() }
 					<div className="all-sites__info site__info">
 						<span className="all-sites__title site__title">
 							{ title || translate( 'All My Sites' ) }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -351,6 +351,11 @@ export class SiteSelector extends Component {
 				isHighlighted={ isHighlighted }
 				isSelected={ this.isSelected( ALL_SITES ) }
 				title={ multiSiteContext && multiSiteContext.navigationLabel }
+				showCount={ false }
+				showIcon={ true }
+				icon={
+					<span className={ 'dashicons-before ' + multiSiteContext.icon } aria-hidden={ true } />
+				}
 			/>
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

Displays an icon instead of the visible site count in the Site Switcher. The latter causes some amount of confusion (https://github.com/Automattic/wp-calypso/issues/68455#issuecomment-1280867027, https://github.com/Automattic/wp-calypso/issues/68919#issuecomment-1274911563).

| Before | After |
|---|---|
| <img width="381" alt="image" src="https://user-images.githubusercontent.com/36432/196212522-cf4849cc-891d-4886-af27-0b8d5a56b769.png"> | <img width="394" alt="image" src="https://user-images.githubusercontent.com/36432/196212215-c451bbfe-7bb8-4004-88d4-56283291f3e4.png"> |
| <img width="360" alt="image" src="https://user-images.githubusercontent.com/36432/196212651-8d3fb31b-5e7f-4560-b2ee-c8dc3766662a.png"> | <img width="463" alt="image" src="https://user-images.githubusercontent.com/36432/196211858-a3dc9333-dd3a-406f-992b-f4f303cd067e.png"> |

## Testing Instructions

1. Verify the change in a variety of browsers and browser widths.
2. Verify icon for each multisite context https://github.com/Automattic/wp-calypso/blob/33f7745d3960eda2ef10874428fe08082b285e0e/client/my-sites/sidebar/static-data/all-sites-menu.js
