### PR TITLE
get-current-theme-software-sets: request features before redirecting for lack of features

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -2,6 +2,9 @@ import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import getHasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
+import getIsRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
+import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
@@ -24,11 +27,18 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	const { goNext } = navigation;
 	useEffect( () => {
 		reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
+		reduxDispatch( fetchSiteFeatures( site?.ID || -1 ) );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ site?.ID ] );
 	const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
 	const currentTheme = useSelector( ( state ) =>
 		getCanonicalTheme( state, site?.ID || -1, currentThemeId )
+	);
+	const isRequestingSiteFeatures: boolean = useSelector( ( state ) =>
+		getIsRequestingSiteFeatures( state, site?.ID || -1 )
+	);
+	const hasLoadedSiteFeatures: boolean = useSelector( ( state ) =>
+		getHasLoadedSiteFeatures( state, site?.ID || -1 )
 	);
 	const { setBundledPluginSlug } = useDispatch( SITE_STORE );
 	useEffect( () => {
@@ -46,10 +56,10 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	}, [ currentTheme?.id ] );
 
 	useEffect( () => {
-		if ( ! isPluginBundleEligible ) {
+		if ( hasLoadedSiteFeatures && ! isRequestingSiteFeatures && ! isPluginBundleEligible ) {
 			window.location.replace( `/home/${ siteSlug }` );
 		}
-	}, [ isPluginBundleEligible, siteSlug ] );
+	}, [ isPluginBundleEligible, siteSlug, isRequestingSiteFeatures, hasLoadedSiteFeatures ] );
 
 	return null;
 };

--- a/client/state/selectors/has-loaded-site-features.js
+++ b/client/state/selectors/has-loaded-site-features.js
@@ -1,0 +1,9 @@
+import { initialSiteState } from 'calypso/state/sites/features/reducer';
+
+export default function hasLoadedSiteFeatures( state, siteId ) {
+	if ( ! state.sites.features?.[ siteId ] ) {
+		return initialSiteState.hasLoadedFromServer;
+	}
+
+	return state.sites.features[ siteId ].hasLoadedFromServer || initialSiteState.hasLoadedFromServer;
+}


### PR DESCRIPTION
#### Proposed Changes

* In the get-current-theme-software-sets stepper step, before we redirect a user away for having the correct site features, make sure to send a request to ask for the latest site features and wait for that to resolve.
  * I don't actually know if this will fix the bug we see of sometimes not proceeding through the flow, but it seems like a good thing to do anyway.

#### Testing Instructions

* Create a new site on the free plan.
* On the intent screen, choose skip to dashboard.
* Reload the dashboard when it loads.
* GO to theme showcase and find thriving artist. Click the three dots menu, and "Upgrade to activate"
* Proceed through checkout and land in the design picker
* Click "Start with Thriving Artist" in the top right
* You should proceed past the get-current-theme-software-sets step, if you did, you'll be asked to enter the address of your store.

See also p1666018957761669/1665999139.554629-slack-C0Q664T29

I did see the flags progress as expected:
![2022-10-17_11-06](https://user-images.githubusercontent.com/937354/196227566-4c36db65-1444-4bce-98f5-331f524cac1b.png)


Related to #