### PR TITLE
Login via mobile app: update the Jetpack app link

### DIFF
--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -210,7 +210,13 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 				name: 'Jetpack',
 			},
 			components: {
-				link: <ExternalLink target="_blank" icon={ false } href="https://jetpack.com/app" />,
+				link: (
+					<ExternalLink
+						target="_blank"
+						icon={ false }
+						href="https://jetpack.com/app?campaign=login-qr-code"
+					/>
+				),
 			},
 		} ),
 		translate( 'Tap the My Site Tab.' ),

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -210,13 +210,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 				name: 'Jetpack',
 			},
 			components: {
-				link: (
-					<ExternalLink
-						target="_blank"
-						icon={ false }
-						href="https://apps.wordpress.com/get/?campaign=login-qr-code"
-					/>
-				),
+				link: <ExternalLink target="_blank" icon={ false } href="https://jetpack.com/app" />,
 			},
 		} ),
 		translate( 'Tap the My Site Tab.' ),


### PR DESCRIPTION
#### Proposed Changes

This PR changes the Jetpack App link within the Login via mobile app page from `apps.wordpress.com/get/?campaign=login-qr-code` to `jetpack.com/app?campaign=login-qr-code`.

Expected behavior
 - Link tapped on a mobile device:the user will be redirected into the Apple/Google play store. 
 - Link tapped on a desktop: the user will be redirected to `https://jetpack.com/mobile/`

#### Testing Instructions
![Screen Shot 2022-10-17 at 1 25 12 PM](https://user-images.githubusercontent.com/506707/196243719-68833601-2b74-40f2-9d1e-ea8b8fd6930d.png)

### Test A: Desktop
- Navigate to the log in page on a desktop
- Click on "Login via the mobile app"
- Click on the "Open the **Jetpack App** on your phone" link
- ✅ Verify that you are redirected to [Jetpack Mobile Page](https://jetpack.com/mobile/) 

### Test B: Mobile Device
- Set up your mobile device to work with a local or live instance of Calypso using Charles 
- Navigate to the log in page on a mobile device (iOS/Android) . 
- Tap on "Login via the mobile app"
- Tap on the "Open the **Jetpack App** on your phone" link 
OR
- Navigate to this PR on your mobile device and tap the following link.   https://jetpack.com/app?campaign=login-qr-code
- ✅ Verify that you are redirected to the Jetpack App download page on the Google/Apple Play store

 
#### Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

@renancarvalho - I hope you don't mind reviewing the change for me. Thanks

