### PR TITLE
Plugin bundle flow: Add debugging

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -13,7 +13,7 @@ import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 
-const debug = debugFactory( 'calypso:stepper:get-current-theme-software-sets' );
+const debug = debugFactory( 'calypso:plugin-bundle:stepper:get-current-theme-software-sets' );
 
 const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep( { navigation } ) {
 	const site = useSite();
@@ -50,6 +50,11 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 			const theme_software_set = currentTheme?.taxonomies?.theme_software_set;
 			if ( theme_software_set && siteSlug ) {
 				setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first software set
+				debug( 'Proceeding because theme has bundled software', {
+					currentTheme,
+					theme_software_set,
+					siteSlug,
+				} );
 				goNext();
 			} else {
 				debug( 'Redirected because theme has no bundled software', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -1,4 +1,5 @@
 import { useDispatch } from '@wordpress/data';
+import debugFactory from 'debug';
 import { useEffect } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -11,6 +12,8 @@ import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundl
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
+
+const debug = debugFactory( 'calypso:stepper:get-current-theme-software-sets' );
 
 const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep( { navigation } ) {
 	const site = useSite();
@@ -26,6 +29,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	const reduxDispatch = useReduxDispatch();
 	const { goNext } = navigation;
 	useEffect( () => {
+		debug( 'Dispatching requests for active theme and features' );
 		reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
 		reduxDispatch( fetchSiteFeatures( site?.ID || -1 ) );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -48,6 +52,11 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 				setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first software set
 				goNext();
 			} else {
+				debug( 'Redirected because theme has no bundled software', {
+					currentTheme,
+					theme_software_set,
+					siteSlug,
+				} );
 				// Current theme has no bundled plugins; they shouldn't be in this flow
 				window.location.replace( `/home/${ siteSlug }` );
 			}
@@ -57,6 +66,12 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 
 	useEffect( () => {
 		if ( hasLoadedSiteFeatures && ! isRequestingSiteFeatures && ! isPluginBundleEligible ) {
+			debug( 'Redirected because features missing', {
+				isPluginBundleEligible,
+				siteSlug,
+				isRequestingSiteFeatures,
+				hasLoadedSiteFeatures,
+			} );
 			window.location.replace( `/home/${ siteSlug }` );
 		}
 	}, [ isPluginBundleEligible, siteSlug, isRequestingSiteFeatures, hasLoadedSiteFeatures ] );

--- a/client/landing/stepper/hooks/use-is-plugin-bundle-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-plugin-bundle-eligible.ts
@@ -1,7 +1,10 @@
 import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
+import debugFactory from 'debug';
 import { SITE_STORE } from '../stores';
 import { useSite } from './use-site';
+
+const debug = debugFactory( 'calypso:plugin-bundle:use-is-plugin-bundle-eligible' );
 
 export function useIsPluginBundleEligible(): boolean | null {
 	const site = useSite();
@@ -11,6 +14,7 @@ export function useIsPluginBundleEligible(): boolean | null {
 	const hasAtomicFeature = useSelect( ( select ) =>
 		select( SITE_STORE ).siteHasFeature( site?.ID, WPCOM_FEATURES_ATOMIC )
 	);
+	debug( 'useIsPluginBundleEligible: Found ', { site, hasWooFeature, hasAtomicFeature } );
 
 	return hasWooFeature && hasAtomicFeature;
 }


### PR DESCRIPTION
#### Proposed Changes

* Plugin bundle flow: Add debugging
  *  Have get-current-theme-software-sets explain why it is redirecting the user away

#### Testing Instructions

* In console, type `localStorage.debug = 'calypso:plugin-bundle:*';`
* Reload
* Choose the "Persist logs"  option in the console, so it doesn't get wiped on page navigation
* With a simple business plan site, choose thriving artist in the design picker to try to go through the plugin bundle flow
* You should now see debugging messages in console
![2022-10-17_13-19](https://user-images.githubusercontent.com/937354/196252853-13c2f782-85b0-4835-905a-107a17ea850a.png)



