### PR TITLE
Redux: Do not use a complex object as parameter for the getSites selector

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -561,7 +561,7 @@ const mapState = ( state ) => {
 
 	return {
 		hasLoadedSites: hasLoadedSites( state ),
-		sites: getSites( state, { shouldSort: false } ),
+		sites: getSites( state, false ),
 		siteCount: getUserSiteCountForPlatform( user ),
 		visibleSiteCount: getUserVisibleSiteCountForPlatform( user ),
 		selectedSite: getSelectedSite( state ),

--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -13,7 +13,7 @@ const sortByNameAndUrl = ( list ) => sortBy( list, [ 'name', 'URL' ] );
  * @returns {Array}        Sites objects
  */
 export default createSelector(
-	( state, { shouldSort = true } = {} ) => {
+	( state, shouldSort = true ) => {
 		const primarySiteId = getPrimarySiteId( state );
 		const [ primarySite, sites ] = partition( getSitesItems( state ), { ID: primarySiteId } );
 


### PR DESCRIPTION
#### Proposed Changes

Use a primitive instead of an object as a parameter for `getSites` selector because otherwise memoizing might not work as expected. Got a warning from the developer tools:

![image](https://user-images.githubusercontent.com/26530524/196255483-7a593750-f414-4458-a43e-6e28eebc7189.png)

#### Testing Instructions

The Site Selector should still work as intended. Nothing changed from a behavior point of view, I'm just updating the code to remove the object and use a simple boolean instead.