### PR TITLE
CI: update installed fonts in the ci-e2e docker image.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -72,6 +72,7 @@ RUN apt update \
 		fonts-liberation \
 		# fonts-noto \
 		fonts-noto-cjk \
+		fonts-noto-core \
 		git-restore-mtime \
 		gtk2-engines-pixbuf \
 		libappindicator3-1 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -70,7 +70,8 @@ ENV DISPLAY=:99
 RUN apt update \
 	&& apt install -y --no-install-recommends \
 		fonts-liberation \
-		fonts-noto \
+		# fonts-noto \
+		fonts-noto-cjk \
 		git-restore-mtime \
 		gtk2-engines-pixbuf \
 		libappindicator3-1 \
@@ -88,12 +89,13 @@ RUN apt update \
 		libxtst6 \
 		openssl \
 		xauth \
-		xdg-utils \
-		xfonts-100dpi \
-		xfonts-75dpi \
-		xfonts-base \
-		xfonts-cyrillic \
-		xfonts-scalable \
+		# xdg-utils \
+		# xfonts-intl-arabic \
+		# xfonts-100dpi \
+		# xfonts-75dpi \
+		# xfonts-base \
+		# xfonts-cyrillic \
+		# xfonts-scalable \
 		xvfb \
 	&& apt autoremove --purge \
 	&& apt autoclean \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -70,7 +70,7 @@ ENV DISPLAY=:99
 RUN apt update \
 	&& apt install -y --no-install-recommends \
 		fonts-liberation \
-		# fonts-noto \
+		# Install non-Latin fonts
 		fonts-noto-cjk \
 		fonts-noto-core \
 		git-restore-mtime \
@@ -90,13 +90,6 @@ RUN apt update \
 		libxtst6 \
 		openssl \
 		xauth \
-		# xdg-utils \
-		# xfonts-intl-arabic \
-		# xfonts-100dpi \
-		# xfonts-75dpi \
-		# xfonts-base \
-		# xfonts-cyrillic \
-		# xfonts-scalable \
 		xvfb \
 	&& apt autoremove --purge \
 	&& apt autoclean \


### PR DESCRIPTION
#### Proposed Changes

This PR updates the packages that are installed to support various fonts in the `ci-e2e` docker image.

Key changes:
- removal of xfonts packages, replaced by `noto` packages.
- removal of `xdg-utils` package, which appeared to be superfluous.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Pre-Release E2E
  - [x] i18n E2E
  - [x] ToS Screenshots

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
