### PR TITLE
get-current-theme-software-sets: Ensure that the active theme request is sent and resolved before redirecting

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -1,13 +1,17 @@
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import getHasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import getIsRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
-import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import {
+	getActiveTheme,
+	getCanonicalTheme,
+	isRequestingActiveTheme as getIsRequestingActiveTheme,
+} from 'calypso/state/themes/selectors';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
@@ -25,13 +29,17 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	} else if ( site ) {
 		siteSlug = new URL( site.URL ).host;
 	}
+	const [ hasRequested, setHasRequested ] = useState( false );
 
 	const reduxDispatch = useReduxDispatch();
 	const { goNext } = navigation;
 	useEffect( () => {
-		debug( 'Dispatching requests for active theme and features' );
-		reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
-		reduxDispatch( fetchSiteFeatures( site?.ID || -1 ) );
+		if ( site?.ID ) {
+			debug( 'Dispatching requests for active theme and features' );
+			reduxDispatch( requestActiveTheme( site?.ID || -1 ) );
+			reduxDispatch( fetchSiteFeatures( site?.ID || -1 ) );
+			setHasRequested( true );
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ site?.ID ] );
 	const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
@@ -44,42 +52,69 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	const hasLoadedSiteFeatures: boolean = useSelector( ( state ) =>
 		getHasLoadedSiteFeatures( state, site?.ID || -1 )
 	);
+	const isRequestingActiveTheme: boolean = useSelector( ( state ) =>
+		getIsRequestingActiveTheme( state, site?.ID || -1 )
+	);
 	const { setBundledPluginSlug } = useDispatch( SITE_STORE );
 	useEffect( () => {
-		if ( currentTheme ) {
+		debug(
+			'Deciding to redirect, proceed, or wait',
+			JSON.stringify( { hasRequested, isRequestingActiveTheme, currentTheme } )
+		);
+		if ( hasRequested && ! isRequestingActiveTheme && currentTheme ) {
 			const theme_software_set = currentTheme?.taxonomies?.theme_software_set;
 			if ( theme_software_set && siteSlug ) {
 				setBundledPluginSlug( siteSlug, theme_software_set[ 0 ].slug ); // only install first software set
-				debug( 'Proceeding because theme has bundled software', {
-					currentTheme,
-					theme_software_set,
-					siteSlug,
-				} );
+				debug(
+					'Proceeding because theme has bundled software',
+					JSON.stringify( {
+						currentTheme,
+						theme_software_set,
+						siteSlug,
+					} )
+				);
 				goNext();
 			} else {
-				debug( 'Redirected because theme has no bundled software', {
-					currentTheme,
-					theme_software_set,
-					siteSlug,
-				} );
+				debug(
+					'Redirected because theme has no bundled software',
+					JSON.stringify( {
+						currentTheme,
+						theme_software_set,
+						siteSlug,
+					} )
+				);
 				// Current theme has no bundled plugins; they shouldn't be in this flow
 				window.location.replace( `/home/${ siteSlug }` );
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ currentTheme?.id ] );
+	}, [ currentTheme?.id, hasRequested, isRequestingActiveTheme ] );
 
 	useEffect( () => {
-		if ( hasLoadedSiteFeatures && ! isRequestingSiteFeatures && ! isPluginBundleEligible ) {
-			debug( 'Redirected because features missing', {
-				isPluginBundleEligible,
-				siteSlug,
-				isRequestingSiteFeatures,
-				hasLoadedSiteFeatures,
-			} );
+		if (
+			hasRequested &&
+			hasLoadedSiteFeatures &&
+			! isRequestingSiteFeatures &&
+			! isPluginBundleEligible
+		) {
+			debug(
+				'Redirected because features missing',
+				JSON.stringify( {
+					isPluginBundleEligible,
+					siteSlug,
+					isRequestingSiteFeatures,
+					hasLoadedSiteFeatures,
+				} )
+			);
 			window.location.replace( `/home/${ siteSlug }` );
 		}
-	}, [ isPluginBundleEligible, siteSlug, isRequestingSiteFeatures, hasLoadedSiteFeatures ] );
+	}, [
+		isPluginBundleEligible,
+		siteSlug,
+		isRequestingSiteFeatures,
+		hasLoadedSiteFeatures,
+		hasRequested,
+	] );
 
 	return null;
 };


### PR DESCRIPTION
#### Proposed Changes

* get-current-theme-software-sets: Ensure that the active theme request is sent and resolved before redirecting

#### Testing Instructions

* Run `localStorage.debug = 'calypso:plugin-bundle:*';`
* Create a new site on the free plan.
* On the intent screen, choose skip to dashboard.
* Reload the dashboard when it loads.
* GO to theme showcase and find thriving artist. Click the three dots menu, and "Upgrade to activate"
* Proceed through checkout and land in the design picker
* Click "Start with Thriving Artist" in the top right
* You should proceed past the get-current-theme-software-sets step, if you did, you'll be asked to enter the address of your store.
(Or your own steps)

The progression of the flags looks as expected to me:
![2022-10-17_14-55](https://user-images.githubusercontent.com/937354/196270677-484bbec3-9ceb-4938-b8c3-1ed35e6e60c0.png)


