### PR TITLE
plugin-bundle-flow: Clean up debugging

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -59,7 +59,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	useEffect( () => {
 		debug(
 			'Deciding to redirect, proceed, or wait',
-			JSON.stringify( { hasRequested, isRequestingActiveTheme, currentTheme } )
+			JSON.stringify( { hasRequested, isRequestingActiveTheme, currentThemeId: currentTheme?.id } )
 		);
 		if ( hasRequested && ! isRequestingActiveTheme && currentTheme ) {
 			const theme_software_set = currentTheme?.taxonomies?.theme_software_set;
@@ -68,7 +68,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 				debug(
 					'Proceeding because theme has bundled software',
 					JSON.stringify( {
-						currentTheme,
+						currentThemeId: currentTheme?.id,
 						theme_software_set,
 						siteSlug,
 					} )
@@ -78,7 +78,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 				debug(
 					'Redirected because theme has no bundled software',
 					JSON.stringify( {
-						currentTheme,
+						currentThemeId: currentTheme?.id,
 						theme_software_set,
 						siteSlug,
 					} )

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -41,12 +41,6 @@ export const pluginBundleFlow: Flow = {
 			window.location.replace( `/home/${ siteSlugParam }` );
 		}
 
-		// FIXME - Need to not redirect when getCurrentThemeSoftwareSets is still running
-		//
-		// if ( ! pluginSlug || ! pluginBundleData.hasOwnProperty( pluginSlug ) ) {
-		// 	window.location.replace( `/home/${ siteSlugParam }` );
-		// }
-
 		const steps: StepPath[] = [ 'getCurrentThemeSoftwareSets' ];
 		let bundlePluginSteps: StepPath[] = [];
 

--- a/client/landing/stepper/hooks/use-is-plugin-bundle-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-plugin-bundle-eligible.ts
@@ -1,10 +1,7 @@
 import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
-import debugFactory from 'debug';
 import { SITE_STORE } from '../stores';
 import { useSite } from './use-site';
-
-const debug = debugFactory( 'calypso:plugin-bundle:use-is-plugin-bundle-eligible' );
 
 export function useIsPluginBundleEligible(): boolean | null {
 	const site = useSite();
@@ -14,7 +11,6 @@ export function useIsPluginBundleEligible(): boolean | null {
 	const hasAtomicFeature = useSelect( ( select ) =>
 		select( SITE_STORE ).siteHasFeature( site?.ID, WPCOM_FEATURES_ATOMIC )
 	);
-	debug( 'useIsPluginBundleEligible: Found ', { site, hasWooFeature, hasAtomicFeature } );
 
 	return hasWooFeature && hasAtomicFeature;
 }


### PR DESCRIPTION
#### Proposed Changes

* Remove debugging in `use-is-plugin-bundle-eligible.ts` related to features, we never saw problems in that area.
* Keep debugging in `get-current-theme-software-sets/index.tsx` for now, but scale down the amount of text: `currentTheme` is changed to `currentTheme?.id`.
* Remove outdated WIP code commented out.

#### Testing Instructions

* Run `localStorage.debug = 'calypso:plugin-bundle:*';`
* Create a new site on the free plan.
* On the intent screen, choose skip to dashboard.
* Reload the dashboard when it loads.
* GO to theme showcase and find thriving artist. Click the three dots menu, and "Upgrade to activate"
* Proceed through checkout and land in the design picker
* Click "Start with Thriving Artist" in the top right
* You should proceed past the get-current-theme-software-sets step, if you did, you'll be asked to enter the address of your store.
(Or your own steps)

![2022-10-17_15-30](https://user-images.githubusercontent.com/937354/196277662-ad5a7482-4260-4da1-91e8-d13c1312ba29.png)

