### PR TITLE
Jetpack Dashboard: Update the dashboard link to have no default filter

### DIFF
--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -5,10 +5,10 @@ import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetp
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { jetpackDashboardRedirectLink } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import {
 	hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector,
 	showAgencyDashboard,
@@ -29,7 +29,6 @@ export default function PortalNav( { className = '' }: Props ) {
 	const translate = useTranslate();
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 	const isPrimarySiteJetpackSite = useSelector( getPrimarySiteIsJetpack );
-	const dashboardLink = useSelector( jetpackDashboardRedirectLink );
 	const currentUser = useSelector( getCurrentUser );
 	const currentRoute = useSelector( getCurrentRoute );
 	const showDashboard = useSelector( showAgencyDashboard );
@@ -43,6 +42,8 @@ export default function PortalNav( { className = '' }: Props ) {
 	if ( ! isSectionNameEnabled( 'jetpack-cloud-partner-portal' ) ) {
 		return null;
 	}
+
+	const dashboardLink = dashboardPath();
 
 	const onNavItemClick = ( menuItem: string ) => {
 		dispatch(

--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -3,9 +3,9 @@ import Debug from 'debug';
 import { translate } from 'i18n-calypso';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import { sites, siteSelection } from 'calypso/my-sites/controller';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { jetpackDashboardRedirectLink } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import getPrimarySiteIsJetpack from 'calypso/state/selectors/get-primary-site-is-jetpack';
 import Landing from './sections/landing';
@@ -36,7 +36,7 @@ const redirectToPrimarySiteLanding = ( context, next ) => {
 	const isPrimarySiteJetpackSite = getPrimarySiteIsJetpack( state );
 	const isAgency = isAgencyUser( state );
 	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
-	const dashboardRedirectLink = jetpackDashboardRedirectLink( state );
+	const dashboardRedirectLink = dashboardPath();
 
 	if ( isAgency && isAgencyEnabled ) {
 		page.redirect( dashboardRedirectLink );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -3,12 +3,12 @@ import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import tipIcon from 'calypso/assets/images/jetpack/tip-icon.svg';
 import Banner from 'calypso/components/banner';
+import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE,
 	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE as homePagePreferenceName,
 	getJetpackDashboardWelcomeBannerPreference as getPreference,
-	jetpackDashboardRedirectLink,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import type { PreferenceType } from '../types';
@@ -73,7 +73,7 @@ export default function SiteWelcomeBanner( {
 		);
 	}, [ handleTrackEvents, isDashboardView, savePreferenceType ] );
 
-	const dashboardHref = useSelector( jetpackDashboardRedirectLink );
+	const dashboardHref = dashboardPath();
 
 	// Hide the banner if the banner is already viewed
 	// on the dashboard page or the banner is dismissed

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -2,9 +2,9 @@ import AdvancedCredentials from 'calypso/components/advanced-credentials';
 import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
+import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import DisconnectSite from 'calypso/my-sites/site-settings/disconnect-site';
 import ConfirmDisconnection from 'calypso/my-sites/site-settings/disconnect-site/confirm';
-import { jetpackDashboardRedirectLink } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoSitesPurchasesMessage from './empty-content';
 import HasSiteCredentialsSwitch from './has-site-credentials-switch';
@@ -59,7 +59,7 @@ export const disconnectSite: PageJS.Callback = ( context, next ) => {
 			//@ts-ignore
 			reason={ context.params.reason }
 			type={ context.query.type }
-			backHref={ jetpackDashboardRedirectLink( context.state ) }
+			backHref={ dashboardPath() }
 		/>
 	);
 	next();
@@ -67,7 +67,7 @@ export const disconnectSite: PageJS.Callback = ( context, next ) => {
 
 export const disconnectSiteConfirm: PageJS.Callback = ( context, next ) => {
 	const { reason, type, text } = context.query;
-	const dashboardHref = jetpackDashboardRedirectLink( context.state );
+	const dashboardHref = dashboardPath();
 	context.primary = (
 		<ConfirmDisconnection
 			// Ignore type checking because TypeScript is incorrectly inferring the prop type due to the redirectNonJetpack HOC.

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -46,3 +46,5 @@ export const pluginsPath = ( siteSlug?: string, query = {} ): string => {
 	const path = siteSlug ? `${ pluginsBasePath }/${ siteSlug }` : pluginsBasePath;
 	return addQueryArgs( query, path );
 };
+
+export const dashboardPath = () => '/dashboard';

--- a/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
+++ b/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
@@ -2,8 +2,6 @@ import { localize, translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateFilter } from 'calypso/state/jetpack-agency-dashboard/actions';
-import { JETPACK_AGENCY_DASHBOARD_DEFAULT_FILTER_CLEARED_KEY } from 'calypso/state/jetpack-agency-dashboard/selectors';
-import { savePreference } from 'calypso/state/preferences/actions';
 import { TypeSelector } from './type-selector';
 
 interface Props {
@@ -53,12 +51,6 @@ const IssueTypeSelector: React.FunctionComponent< Props > = ( props ) => {
 };
 
 const selectIssueType = ( types: any ) => ( dispatch: any ) => {
-	dispatch(
-		savePreference(
-			JETPACK_AGENCY_DASHBOARD_DEFAULT_FILTER_CLEARED_KEY,
-			! types.includes( parentTypeKey )
-		)
-	);
 	if ( types.length ) {
 		const eventObj = types.reduce(
 			( acc: any, obj: any ) => ( {

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -11,9 +11,6 @@ export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE =
 export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE =
 	'jetpack-dashboard-welcome-banner-preference-home-page';
 
-export const JETPACK_AGENCY_DASHBOARD_DEFAULT_FILTER_CLEARED_KEY =
-	'jetpack-dashboard-default-filter-cleared';
-
 /**
  * Returns preference associated with the welcome banner.
  */
@@ -31,15 +28,4 @@ export function checkIfJetpackSiteGotDisconnected( state: AppState ): boolean {
 
 export function getPurchasedLicense( state: AppState ): PurchasedProduct | null {
 	return state.agencyDashboard.purchasedLicense;
-}
-
-/**
- * Returns the Jetpack dashboard link based on the filter status
- */
-export function jetpackDashboardRedirectLink( state: AppState ): string {
-	const isDefaultFilterCleared = getPreference(
-		state,
-		JETPACK_AGENCY_DASHBOARD_DEFAULT_FILTER_CLEARED_KEY
-	);
-	return isDefaultFilterCleared ? '/dashboard' : '/dashboard?issue_types=all_issues';
 }


### PR DESCRIPTION
#### Proposed Changes

This PR updates the default dashboard redirect link so that it does not include the `all_types` filter by default. That filter did not provide a great user experience because users with no issues on their sites would see nothing in the dashboard by default.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. With an agency account visit `jetpack.cloud.localhost:3001/` and verify that you are redirected to `jetpack.cloud.localhost:3001/` instead of `https://cloud.jetpack.com/dashboard?issue_types=all_issues`
2. Visit `/partner-portal/`, click "Dashboard" on the nav bar, and verify that you are redirected to the dashboard with no filters.
3. Comment out [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx#L81) and visit `/partner-portal/`, click on the banner which shows on the top, and verify that you are redirected to the dashboard with no filters.
4. Visit `/settings/disconnect-site/:site` and click back, verify that you are redirected to the dashboard with no filters.
5. Visit `/settings/disconnect-site/confirm/:site` and verify that both "Stay Connected" and "Disconnect" take you back to the dashboard with no filters.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
