### PR TITLE
[Bug] Site Management Page: Don't show Link in Bio banner when filtering down to 1-2 sites. 

### DIFF
--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
@@ -1,13 +1,13 @@
 import { useDesktopBreakpoint, useMobileBreakpoint } from '@automattic/viewport-react';
 import { useSelector } from 'react-redux';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { LINK_IN_BIO_BANNER_PREFERENCE } from './link-in-bio-banner-parts';
 import { BannerType, LinkInBioBanners } from './link-in-bio-banners';
 
 type Props = {
 	displayMode: 'row' | 'grid';
-	sites: SiteExcerptData[];
 };
 
 const hasLinkInBioSite = ( sites: SiteExcerptData[] ) => {
@@ -20,7 +20,9 @@ const hasLinkInBioSite = ( sites: SiteExcerptData[] ) => {
 };
 
 export const LinkInBioBanner = ( props: Props ) => {
-	const { displayMode, sites } = props;
+	const { displayMode } = props;
+	const { data: sites = [], isLoading } = useSiteExcerptsQuery();
+
 	const siteCount = sites.length;
 	const doesNotAlreadyHaveALinkInBioSite = ! hasLinkInBioSite( sites );
 	const isMobile = useMobileBreakpoint();
@@ -29,7 +31,9 @@ export const LinkInBioBanner = ( props: Props ) => {
 		getPreference( state, LINK_IN_BIO_BANNER_PREFERENCE )
 	);
 	const showBanner =
-		doesNotAlreadyHaveALinkInBioSite && ( isBannerVisible == null || isBannerVisible );
+		! isLoading &&
+		doesNotAlreadyHaveALinkInBioSite &&
+		( isBannerVisible == null || isBannerVisible );
 
 	let bannerType: BannerType = 'none';
 	if ( showBanner ) {

--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
@@ -21,7 +21,7 @@ const hasLinkInBioSite = ( sites: SiteExcerptData[] ) => {
 
 export const LinkInBioBanner = ( props: Props ) => {
 	const { displayMode } = props;
-	const { data: sites = [], isLoading } = useSiteExcerptsQuery();s
+	const { data: sites = [], isLoading } = useSiteExcerptsQuery();
 	const siteCount = sites.length;
 	const doesNotAlreadyHaveALinkInBioSite = ! hasLinkInBioSite( sites );
 	const isMobile = useMobileBreakpoint();

--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
@@ -21,8 +21,7 @@ const hasLinkInBioSite = ( sites: SiteExcerptData[] ) => {
 
 export const LinkInBioBanner = ( props: Props ) => {
 	const { displayMode } = props;
-	const { data: sites = [], isLoading } = useSiteExcerptsQuery();
-
+	const { data: sites = [], isLoading } = useSiteExcerptsQuery();s
 	const siteCount = sites.length;
 	const doesNotAlreadyHaveALinkInBioSite = ! hasLinkInBioSite( sites );
 	const isMobile = useMobileBreakpoint();

--- a/client/sites-dashboard/components/link-in-bio-banner/test/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/test/link-in-bio-banner.tsx
@@ -4,9 +4,9 @@
 import * as viewport from '@automattic/viewport-react';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { createReduxStore } from 'calypso/state/index';
-import getSites from 'calypso/state/selectors/get-sites';
 import { LinkInBioBanner } from '../link-in-bio-banner';
 import { LINK_IN_BIO_BANNER_PREFERENCE } from '../link-in-bio-banner-parts';
 
@@ -50,11 +50,14 @@ describe( '<LinkInBioBanner>', () => {
 			jest.spyOn( viewport, 'useDesktopBreakpoint' ).mockReturnValue( isDesktop );
 
 			const store = createTestStore( visible, siteCount, siteIntent );
-			const sites = getSites( store.getState() );
+			const queryClient = new QueryClient();
+
 			render(
-				<Provider store={ store }>
-					<LinkInBioBanner sites={ sites } displayMode={ type } />
-				</Provider>
+				<QueryClientProvider client={ queryClient }>
+					<Provider store={ store }>
+						<LinkInBioBanner displayMode={ type } />
+					</Provider>
+				</QueryClientProvider>
 			);
 			if ( expectValue ) {
 				// eslint-disable-next-line jest/no-conditional-expect

--- a/client/sites-dashboard/components/link-in-bio-banner/test/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/test/link-in-bio-banner.tsx
@@ -50,7 +50,14 @@ describe( '<LinkInBioBanner>', () => {
 			jest.spyOn( viewport, 'useDesktopBreakpoint' ).mockReturnValue( isDesktop );
 
 			const store = createTestStore( visible, siteCount, siteIntent );
-			const queryClient = new QueryClient();
+			const queryClient = new QueryClient( {
+				defaultOptions: {
+					queries: {
+						// No need to fetch because default site data will come from Redux store.
+						enabled: false,
+					},
+				},
+			} );
 
 			render(
 				<QueryClientProvider client={ queryClient }>

--- a/client/sites-dashboard/components/sites-grid.tsx
+++ b/client/sites-dashboard/components/sites-grid.tsx
@@ -37,7 +37,7 @@ export const SitesGrid = ( { sites, isLoading, className }: SitesGridProps ) => 
 						.fill( null )
 						.map( ( _, i ) => <SitesGridItemLoading key={ i } delayMS={ i * 150 } /> )
 				: sites.map( ( site ) => <SitesGridItem site={ site } key={ site.ID } /> ) }
-			<LinkInBioBanner sites={ sites } displayMode="grid" />
+			<LinkInBioBanner displayMode="grid" />
 		</div>
 	);
 };

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -179,7 +179,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 					) ) }
 				</tbody>
 			</Table>
-			<LinkInBioBanner sites={ sites } displayMode="row" />
+			<LinkInBioBanner displayMode="row" />
 		</>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

* The logic that decides whether to show the Link in Bio banner or not should only consider _total sites_ and not _filtered sites_.

I just went with the most straightforward solution for now: make the `LinkInBioBanner` use the `useSiteExcerptsQuery` hook directly. This makes the component harder to reuse, but I think that's a problem we can fix later should we ever need to reuse it. 

https://user-images.githubusercontent.com/6851384/196327672-3d36c840-04ad-4c0d-b55e-b59bc15aafec.mp4

Slack discussion [here](p1666004122582409-slack-C0347E545HR).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Do a before/after with trunk and this branch. On trunk, if you filter to 1-2 rows you still might see the Link in Bio banner because the previous logic only considered the filtered sites and not the total sites. Try the same filtering test on the Calypso Live link and verify the issue is fixed. 

I also noted that the search input needs a debounce. I will fix that in another PR. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

There is an error in the Console but I chose to ignore it, because [this misleading warning is removed in React 18](https://github.com/reactwg/react-18/discussions/82). 
```
Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
SiteThumbnail@app:///../packages/components/src/site-thumbnail/index.tsx:26:23
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #