### PR TITLE
DIFM Content Form: Fixes pages init bug

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -18,7 +18,6 @@ import {
 	updateWebsiteContentCurrentIndex,
 } from 'calypso/state/signup/steps/website-content/actions';
 import {
-	getSiteIdForSavedWebsiteContent,
 	getWebsiteContent,
 	getWebsiteContentDataCollectionIndex,
 	isImageUploadInProgress,
@@ -75,7 +74,6 @@ function WebsiteContentStep( {
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
 	const websiteContent = useSelector( getWebsiteContent );
-	const siteIdForSavedWebsiteContent = useSelector( getSiteIdForSavedWebsiteContent );
 	const currentIndex = useSelector( getWebsiteContentDataCollectionIndex );
 	const pageTitles = useSelector( ( state ) => getDIFMLiteSitePageTitles( state, siteId ) );
 	const isImageUploading = useSelector( ( state ) =>
@@ -86,15 +84,6 @@ function WebsiteContentStep( {
 	const translatedPageTitles = useTranslatedPageTitles();
 
 	useEffect( () => {
-		if (
-			websiteContent.pages.length &&
-			siteIdForSavedWebsiteContent &&
-			siteIdForSavedWebsiteContent === siteId
-		) {
-			// Already initialized.
-			return;
-		}
-
 		if ( siteId && pageTitles && pageTitles.length > 0 ) {
 			const pages = pageTitles.map( ( pageTitle ) => ( {
 				id: pageTitle,
@@ -102,14 +91,7 @@ function WebsiteContentStep( {
 			} ) );
 			dispatch( initializePages( pages, siteId ) );
 		}
-	}, [
-		dispatch,
-		pageTitles,
-		siteId,
-		siteIdForSavedWebsiteContent,
-		translatedPageTitles,
-		websiteContent.pages.length,
-	] );
+	}, [ dispatch, pageTitles, siteId, translatedPageTitles ] );
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -18,6 +18,7 @@ import {
 	updateWebsiteContentCurrentIndex,
 } from 'calypso/state/signup/steps/website-content/actions';
 import {
+	getSiteIdForSavedWebsiteContent,
 	getWebsiteContent,
 	getWebsiteContentDataCollectionIndex,
 	isImageUploadInProgress,
@@ -74,6 +75,7 @@ function WebsiteContentStep( {
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
 	const websiteContent = useSelector( getWebsiteContent );
+	const siteIdForSavedWebsiteContent = useSelector( getSiteIdForSavedWebsiteContent );
 	const currentIndex = useSelector( getWebsiteContentDataCollectionIndex );
 	const pageTitles = useSelector( ( state ) => getDIFMLiteSitePageTitles( state, siteId ) );
 	const isImageUploading = useSelector( ( state ) =>
@@ -84,19 +86,30 @@ function WebsiteContentStep( {
 	const translatedPageTitles = useTranslatedPageTitles();
 
 	useEffect( () => {
-		if ( websiteContent.pages.length > 0 ) {
+		if (
+			websiteContent.pages.length &&
+			siteIdForSavedWebsiteContent &&
+			siteIdForSavedWebsiteContent === siteId
+		) {
 			// Already initialized.
 			return;
 		}
 
-		if ( pageTitles && pageTitles.length > 0 ) {
+		if ( siteId && pageTitles && pageTitles.length > 0 ) {
 			const pages = pageTitles.map( ( pageTitle ) => ( {
 				id: pageTitle,
 				name: translatedPageTitles[ pageTitle ],
 			} ) );
-			dispatch( initializePages( pages ) );
+			dispatch( initializePages( pages, siteId ) );
 		}
-	}, [ dispatch, pageTitles, translatedPageTitles, websiteContent.pages.length ] );
+	}, [
+		dispatch,
+		pageTitles,
+		siteId,
+		siteIdForSavedWebsiteContent,
+		translatedPageTitles,
+		websiteContent.pages.length,
+	] );
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );

--- a/client/state/signup/steps/website-content/actions.ts
+++ b/client/state/signup/steps/website-content/actions.ts
@@ -15,6 +15,7 @@ import {
 } from 'calypso/state/action-types';
 import { ImageData } from './schema';
 import 'calypso/state/signup/init';
+import type { SiteId } from 'calypso/types';
 
 export function imageUploaded( data: { pageId: string; mediaIndex: number; image: ImageData } ) {
 	return {
@@ -94,7 +95,10 @@ export function updateWebsiteContentCurrentIndex( currentIndex: number ) {
 	};
 }
 
-export function initializePages( pageNames: Array< { id: string; name: TranslateResult } > ) {
+export function initializePages(
+	pageNames: Array< { id: string; name: TranslateResult } >,
+	siteId: SiteId
+) {
 	const generatedPages = pageNames.map( ( { id, name } ) => ( {
 		id,
 		title: name,
@@ -107,6 +111,9 @@ export function initializePages( pageNames: Array< { id: string; name: Translate
 	} ) );
 	return {
 		type: SIGNUP_STEPS_WEBSITE_CONTENT_INITIALIZE_PAGES,
-		payload: generatedPages,
+		payload: {
+			pages: generatedPages,
+			siteId,
+		},
 	};
 }

--- a/client/state/signup/steps/website-content/reducer.ts
+++ b/client/state/signup/steps/website-content/reducer.ts
@@ -33,7 +33,8 @@ export default withSchemaValidation(
 			case SIGNUP_STEPS_WEBSITE_CONTENT_INITIALIZE_PAGES: {
 				// When initializing page we need to leave pages that already exist alone
 				// so that persisted state can load correctly
-				const newPages = action.payload.map( ( page: PageData ) => ( {
+				const { pages, siteId } = action.payload;
+				const newPages = pages.map( ( page: PageData ) => ( {
 					...page,
 					...state.websiteContent.pages.find( ( oldPage ) => oldPage.id === page.id ),
 				} ) );
@@ -42,6 +43,7 @@ export default withSchemaValidation(
 					...state,
 					websiteContent: { ...state.websiteContent, pages: newPages },
 					imageUploadStates: {},
+					siteId,
 				};
 			}
 			case SIGNUP_STEPS_WEBSITE_CONTENT_UPDATE_CURRENT_INDEX:

--- a/client/state/signup/steps/website-content/reducer.ts
+++ b/client/state/signup/steps/website-content/reducer.ts
@@ -14,7 +14,7 @@ import {
 	SIGNUP_STEPS_WEBSITE_CONTENT_FEEDBACK_CHANGE,
 } from 'calypso/state/action-types';
 import { withSchemaValidation } from 'calypso/state/utils';
-import { schema, initialState, WebsiteContentCollection, PageData } from './schema';
+import { schema, initialState, WebsiteContentCollection } from './schema';
 import type { AnyAction } from 'redux';
 
 export const IMAGE_UPLOAD_STATES = {
@@ -31,18 +31,16 @@ export default withSchemaValidation(
 	( state = initialState, action: AnyAction ): WebsiteContentCollection => {
 		switch ( action.type ) {
 			case SIGNUP_STEPS_WEBSITE_CONTENT_INITIALIZE_PAGES: {
-				// When initializing page we need to leave pages that already exist alone
-				// so that persisted state can load correctly
 				const { pages, siteId } = action.payload;
-				const newPages = pages.map( ( page: PageData ) => ( {
-					...page,
-					...state.websiteContent.pages.find( ( oldPage ) => oldPage.id === page.id ),
-				} ) );
+
+				// If the persisted siteId is same as the siteId in the action, do nothing.
+				if ( siteId === state.siteId ) {
+					return state;
+				}
 
 				return {
-					...state,
-					websiteContent: { ...state.websiteContent, pages: newPages },
-					imageUploadStates: {},
+					...initialState,
+					websiteContent: { ...initialState.websiteContent, pages },
 					siteId,
 				};
 			}

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -1,3 +1,4 @@
+import type { SiteId } from 'calypso/types';
 export const schema = {
 	$schema: 'https://json-schema.org/draft/2020-12/schema',
 	title: 'Website content schema',
@@ -73,6 +74,9 @@ export const schema = {
 		imageUploadStates: {
 			type: 'object',
 		},
+		siteId: {
+			type: [ 'number', 'null' ],
+		},
 	},
 };
 
@@ -104,6 +108,7 @@ export interface WebsiteContentCollection {
 	currentIndex: number;
 	websiteContent: WebsiteContent;
 	imageUploadStates: Record< string, Record< string, string > >;
+	siteId: SiteId | null;
 }
 
 export const initialState: WebsiteContentCollection = {
@@ -114,4 +119,5 @@ export const initialState: WebsiteContentCollection = {
 		feedbackSection: { genericFeedback: '' },
 	},
 	imageUploadStates: {},
+	siteId: null,
 };

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -76,6 +76,7 @@ export const schema = {
 		},
 		siteId: {
 			type: [ 'number', 'null' ],
+			description: 'The siteId of the stored website content',
 		},
 	},
 };

--- a/client/state/signup/steps/website-content/selectors.ts
+++ b/client/state/signup/steps/website-content/selectors.ts
@@ -16,10 +16,6 @@ export function getWebsiteContent( state: WebsiteContentStateModel ) {
 	);
 }
 
-export function getSiteIdForSavedWebsiteContent( state: WebsiteContentStateModel ) {
-	return state.signup.steps.websiteContentCollection.siteId;
-}
-
 export function getWebsiteContentDataCollectionIndex( state: WebsiteContentStateModel ) {
 	return state.signup?.steps?.websiteContentCollection?.currentIndex || initialState.currentIndex;
 }

--- a/client/state/signup/steps/website-content/selectors.ts
+++ b/client/state/signup/steps/website-content/selectors.ts
@@ -15,6 +15,11 @@ export function getWebsiteContent( state: WebsiteContentStateModel ) {
 		state.signup?.steps?.websiteContentCollection?.websiteContent || initialState.websiteContent
 	);
 }
+
+export function getSiteIdForSavedWebsiteContent( state: WebsiteContentStateModel ) {
+	return state.signup.steps.websiteContentCollection.siteId;
+}
+
 export function getWebsiteContentDataCollectionIndex( state: WebsiteContentStateModel ) {
 	return state.signup?.steps?.websiteContentCollection?.currentIndex || initialState.currentIndex;
 }

--- a/client/state/signup/steps/website-content/test/reducer.ts
+++ b/client/state/signup/steps/website-content/test/reducer.ts
@@ -54,7 +54,7 @@ const initialTestState = {
 			},
 		],
 	},
-	siteId: 1337,
+	siteId: null,
 };
 
 describe( 'reducer', () => {
@@ -133,7 +133,36 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	test( 'When initializing page data existing page data should not be overridden', () => {
+	test( 'When initializing page data existing page data should not be overwritten if the site id is same', () => {
+		const existingState = {
+			...initialState,
+			siteId: 1234,
+		};
+		expect(
+			websiteContentCollectionReducer(
+				existingState,
+				initializePages(
+					[
+						{
+							id: 'page-2',
+							name: 'Page 2',
+						},
+						{
+							id: 'page-3',
+							name: 'Page 3',
+						},
+						{
+							id: 'page-4',
+							name: 'Page 4',
+						},
+					],
+					1234
+				)
+			)
+		).toEqual( existingState );
+	} );
+
+	test( 'When initializing page data existing page data should be overwritten if the site id is different', () => {
 		const existingState = {
 			...initialState,
 			websiteContent: {
@@ -171,6 +200,7 @@ describe( 'reducer', () => {
 					},
 				],
 			},
+			siteId: 1234,
 		};
 		expect(
 			websiteContentCollectionReducer(
@@ -190,7 +220,7 @@ describe( 'reducer', () => {
 							name: 'Page 4',
 						},
 					],
-					1234
+					1337
 				)
 			)
 		).toEqual( {
@@ -201,9 +231,9 @@ describe( 'reducer', () => {
 					{
 						id: 'page-2',
 						title: 'Page 2',
-						content: 'Some existing Page 2 content',
+						content: '',
 						images: [
-							{ caption: 'sample.jpg', url: 'sample.jpg' },
+							{ caption: '', url: '' },
 							{ caption: '', url: '' },
 							{ caption: '', url: '' },
 						],
@@ -211,9 +241,9 @@ describe( 'reducer', () => {
 					{
 						id: 'page-3',
 						title: 'Page 3',
-						content: 'Some existing Page 3 content',
+						content: '',
 						images: [
-							{ caption: 'sample.jpg', url: 'sample.jpg' },
+							{ caption: '', url: '' },
 							{ caption: '', url: '' },
 							{ caption: '', url: '' },
 						],
@@ -230,7 +260,7 @@ describe( 'reducer', () => {
 					},
 				],
 			},
-			siteId: 1234,
+			siteId: 1337,
 		} );
 	} );
 

--- a/client/state/signup/steps/website-content/test/reducer.ts
+++ b/client/state/signup/steps/website-content/test/reducer.ts
@@ -54,6 +54,7 @@ const initialTestState = {
 			},
 		],
 	},
+	siteId: 1337,
 };
 
 describe( 'reducer', () => {
@@ -73,20 +74,23 @@ describe( 'reducer', () => {
 		expect(
 			websiteContentCollectionReducer(
 				{ ...initialState },
-				initializePages( [
-					{
-						id: 'page-1',
-						name: 'Page 1',
-					},
-					{
-						id: 'page-2',
-						name: 'Page 2',
-					},
-					{
-						id: 'page-3',
-						name: 'Page 3',
-					},
-				] )
+				initializePages(
+					[
+						{
+							id: 'page-1',
+							name: 'Page 1',
+						},
+						{
+							id: 'page-2',
+							name: 'Page 2',
+						},
+						{
+							id: 'page-3',
+							name: 'Page 3',
+						},
+					],
+					1234
+				)
 			)
 		).toEqual( {
 			...initialTestState,
@@ -125,6 +129,7 @@ describe( 'reducer', () => {
 					},
 				],
 			},
+			siteId: 1234,
 		} );
 	} );
 
@@ -170,20 +175,23 @@ describe( 'reducer', () => {
 		expect(
 			websiteContentCollectionReducer(
 				existingState,
-				initializePages( [
-					{
-						id: 'page-2',
-						name: 'Page 2',
-					},
-					{
-						id: 'page-3',
-						name: 'Page 3',
-					},
-					{
-						id: 'page-4',
-						name: 'Page 4',
-					},
-				] )
+				initializePages(
+					[
+						{
+							id: 'page-2',
+							name: 'Page 2',
+						},
+						{
+							id: 'page-3',
+							name: 'Page 3',
+						},
+						{
+							id: 'page-4',
+							name: 'Page 4',
+						},
+					],
+					1234
+				)
 			)
 		).toEqual( {
 			...initialTestState,
@@ -222,6 +230,7 @@ describe( 'reducer', () => {
 					},
 				],
 			},
+			siteId: 1234,
 		} );
 	} );
 

--- a/client/state/signup/steps/website-content/test/schema.ts
+++ b/client/state/signup/steps/website-content/test/schema.ts
@@ -41,6 +41,7 @@ const initialTestState = {
 		feedbackSection: { genericFeedback: '' },
 	},
 	imageUploadStates: {},
+	siteId: 1337,
 };
 
 describe( 'schema', () => {

--- a/client/state/signup/steps/website-content/test/selectors.ts
+++ b/client/state/signup/steps/website-content/test/selectors.ts
@@ -1,6 +1,7 @@
 import { IMAGE_UPLOAD_STATES } from '../reducer';
 import { initialState } from '../schema';
 import {
+	getSiteIdForSavedWebsiteContent,
 	getWebsiteContent,
 	getWebsiteContentDataCollectionIndex,
 	isImageUploadInProgress,
@@ -77,5 +78,20 @@ describe( 'selectors', () => {
 				},
 			} )
 		).toEqual( false );
+	} );
+
+	test( 'should return the siteId from the state', () => {
+		expect(
+			getSiteIdForSavedWebsiteContent( {
+				signup: {
+					steps: {
+						websiteContentCollection: {
+							...initialState,
+							siteId: 123,
+						},
+					},
+				},
+			} )
+		).toEqual( 123 );
 	} );
 } );

--- a/client/state/signup/steps/website-content/test/selectors.ts
+++ b/client/state/signup/steps/website-content/test/selectors.ts
@@ -1,7 +1,6 @@
 import { IMAGE_UPLOAD_STATES } from '../reducer';
 import { initialState } from '../schema';
 import {
-	getSiteIdForSavedWebsiteContent,
 	getWebsiteContent,
 	getWebsiteContentDataCollectionIndex,
 	isImageUploadInProgress,
@@ -78,20 +77,5 @@ describe( 'selectors', () => {
 				},
 			} )
 		).toEqual( false );
-	} );
-
-	test( 'should return the siteId from the state', () => {
-		expect(
-			getSiteIdForSavedWebsiteContent( {
-				signup: {
-					steps: {
-						websiteContentCollection: {
-							...initialState,
-							siteId: 123,
-						},
-					},
-				},
-			} )
-		).toEqual( 123 );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

Bug report: p1666006928309779-slack-C028NRBP2AU

* Adds a new field, `siteId` to the `signup.steps.websiteContentCollection` redux slice. This tracks the `siteId`, which corresponds to the stored website content data. When initializing the store, we check if the existing(persisted) siteId matches the one in the request context. If both are the same, no action is taken. If both are different, we re-initialize the store and existing data is overwritten. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you already have a site with DIFM purchased and content not submitted, go to the next step. Else, go `/start/do-it-for-me` and purchase the product.
* Confirm that the form fields work correctly on the website content form.
* Refresh the page and confirm that the text fields show persisted content.
* Change the siteSlug in the URL to a different site. Confirm that the text fields are cleared.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->