### PR TITLE
Site Management: Sites Search: make input use 1 second debounce

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -128,6 +128,8 @@ export const SitesContentControls = ( {
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect={ true }
 				defaultValue={ initialSearch }
+				delaySearch
+				delayTimeout={ 1000 }
 			/>
 			<DisplayControls>
 				<ControlsSelectDropdown


### PR DESCRIPTION
#### Proposed Changes

* Add a one-second debounce to the `SitesSearch` to avoid poor UX. 

I am not the fastest typer but I am sure I can type quicker than many of our users. This `input` feels a bit uncomfortable to me as a user because the search runs and it messes with the focus of the input (I think) leading to a poor UX. 

Additionally, I think we should consider changing the domain search input which also suffers from the same problem. Do you agree?

Before

https://user-images.githubusercontent.com/6851384/196336234-54d8ff24-583f-40ad-8291-f82bf4d1954b.mp4

After

https://user-images.githubusercontent.com/6851384/196336252-5861bae2-a0f2-4d0c-a212-4c6d55840f35.mp4


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Compare wordpress.com with the Calypso Live here and see what you think. Add a comment about updating the domain search too. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #