### PR TITLE
Goals Capture: Prioritize sell over build and write flow.

### DIFF
--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -13,7 +13,7 @@ describe( 'Test onboard utils', () => {
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote ],
-			expectedIntent: SiteIntent.Write,
+			expectedIntent: SiteIntent.Sell,
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Write, SiteGoal.Promote ],
@@ -21,7 +21,7 @@ describe( 'Test onboard utils', () => {
 		},
 		{
 			goals: [ SiteGoal.Promote, SiteGoal.Sell, SiteGoal.Write ],
-			expectedIntent: SiteIntent.Build,
+			expectedIntent: SiteIntent.Sell,
 		},
 	] )( 'Should map the $goals to $expectedIntent intent', ( { goals, expectedIntent } ) => {
 		expect( goalsToIntent( goals ) ).toBe( expectedIntent );

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -19,6 +19,11 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 		return SiteIntent.Import;
 	}
 
+	// Prioritize Sell over Build and Write
+	if ( goals.includes( SiteGoal.Sell ) ) {
+		return SiteIntent.Sell;
+	}
+
 	const intentDecidingGoal = ( goals as IntentDecidingGoal[] ).find( ( goal ) =>
 		INTENT_DECIDING_GOALS.includes( goal )
 	);


### PR DESCRIPTION
#### Proposed Changes

* When Sell goal is picked, it is prioritized over Build and Write flow.'
* Context: paYKcK-298-p2#comment-1637

#### Testing Instructions

* Go to `/start`.
* When you land in Goals screen, pick any combination with Sell.
* Apart from DIFM & Import, Sell should take precedence.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #