### PR TITLE
Remove overlay for subscriber input text and checkmark

### DIFF
--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -129,6 +129,8 @@
 		box-sizing: border-box;
 		font-size: 0.875rem;
 		padding: 0.875rem 1rem;
+		/* We need to allow space for the SVG checkmark */
+		padding-right: calc(0.5rem + 24px);
 
 		&::placeholder {
 			color: var(--studio-gray-20);
@@ -150,7 +152,7 @@
 	.components-base-control__help {
 		position: absolute;
 		top: 3px;
-		right: 10px;
+		right: 0.5rem;
 
 		svg {
 			fill: var(--color-success-50);


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a small overlay issue I tripped over in the Newsletter tailored flow, where the checkmark for valid inputs overlays the text in the corresponding input. In addition to adding more padding to cater for the SVG checkmark, this PR also reduces the right padding for the checkmark slightly (from 10px to 8px/0.5rem) to match the units for the input control.

#### Screenshots

##### Before

###### Empty subscriber form

<img width="420" alt="Screenshot 2022-10-18 at 11 22 33" src="https://user-images.githubusercontent.com/3376401/196393218-15184151-c2aa-4d64-9635-d2e8a296c081.png">

###### Form with long email and checkmark overlap

<img width="420" alt="Screenshot 2022-10-18 at 11 23 19" src="https://user-images.githubusercontent.com/3376401/196393236-aeecd955-5d70-4345-9314-c910edec60ac.png">

##### After

###### Form with input not selected

<img width="420" alt="Screenshot 2022-10-18 at 11 24 20" src="https://user-images.githubusercontent.com/3376401/196393233-e7de075b-8181-42a4-a10f-b5b8e2bb30ba.png">

###### Form with input text scrolled to right

<img width="420" alt="Screenshot 2022-10-18 at 11 24 27" src="https://user-images.githubusercontent.com/3376401/196393228-d0de4cc2-eb55-44b6-818e-f58389a09a73.png">


#### Testing Instructions

* Create a new Newsletter site via `/setup?flow=newsletter` (or use an existing Newsletter site)
  - If you have a new site, work through the flow until after you purchase a plan (or choose not to)
  - If you are starting from an existing newsletter site, navigate to `/setup/subscribers?flow=newsletter&siteSlug=[your_site_slug]`
* Enter a really long, valid email address in one of the input fields
  - Verify that the checkmark and text don't overlay each other, and that the spacing looks OK
* Enter a valid, short email address in another input field
  - Verify that the spacing looks OK for this case as well

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?