### PR TITLE
Update site editor ID used in editor tracking

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -12,7 +12,7 @@ export const getEditorType = () => {
 		return 'post';
 	}
 
-	if ( document.querySelector( '#edit-site-editor' ) ) {
+	if ( document.querySelector( '#site-editor' ) ) {
 		return 'site';
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Update the ID used to determine if we are in the site editor. This must have been changed by core sometime in the past couple months from #edit-site-editor to #site-editor.
* The above fixes properties on tracking events used in the site editor such as `editor_type` and `entity_context`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build and sync this wpcom-block-editor app build to your sandbox
* sandbox the public api, widgets, and the site you will test on
* enter the site editor and insert a block, verify that both props mentioned above are found in the event (tracks vigilante is helpful, otherwise network request filter on t.gif)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
