### PR TITLE
Partner Portal: implement assign multiple licenses flow

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -135,9 +135,10 @@ export default function SitesOverview() {
 	const issueLicenseRedirectUrl = useMemo( () => {
 		return addQueryArgs( `/partner-portal/issue-license/`, {
 			site_id: selectedLicensesSiteId,
-			product_slug: selectedLicenses?.map( ( type: string ) =>
-				getProductSlugFromProductType( type )
-			),
+			product_slug: selectedLicenses
+				?.map( ( type: string ) => getProductSlugFromProductType( type ) )
+				// If multiple products are selected, pass them as a comma-separated list.
+				.join( ',' ),
 			source: 'dashboard',
 		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -17,7 +17,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import {
 	checkIfJetpackSiteGotDisconnected,
-	getPurchasedLicense,
 	getSelectedLicenses,
 	getSelectedLicensesSiteId,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
@@ -37,7 +36,7 @@ export default function SitesOverview() {
 	const isMobile = useMobileBreakpoint();
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
-	const purchasedLicense = useSelector( getPurchasedLicense );
+
 	const selectedLicenses = useSelector( getSelectedLicenses );
 	const selectedLicensesSiteId = useSelector( getSelectedLicensesSiteId );
 
@@ -178,9 +177,7 @@ export default function SitesOverview() {
 				<div className="sites-overview__tabs">
 					<div className="sites-overview__content-wrapper">
 						<SiteWelcomeBanner isDashboardView />
-						{ purchasedLicense && data?.sites && (
-							<SiteAddLicenseNotification purchasedLicense={ purchasedLicense } />
-						) }
+						{ data?.sites && <SiteAddLicenseNotification /> }
 						<div className="sites-overview__page-title-container">
 							<div className="sites-overview__page-heading">
 								<h2 className="sites-overview__page-title">{ pageTitle }</h2>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -45,8 +45,8 @@ export default function SiteAddLicenseNotification() {
 				<div className="site-add-license-notification__license-banner">
 					<Notice onDismissClick={ () => clearLicenses( 'fulfilled' ) } status="is-success">
 						{ translate(
-							'{{strong}}%(assignedLicenses)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow few minutes for your features to activate.',
-							'{{strong}}%(assignedLicenses)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please all a few minutes for your features to activate.',
+							'{{strong}}%(assignedLicenses)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+							'{{strong}}%(assignedLicenses)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
 
 							{
 								count: assignedLicenses.length,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -31,7 +31,7 @@ export default function SiteAddLicenseNotification() {
 	const assignedLicenses = selectedProducts.filter( ( product ) => product.status === 'fulfilled' );
 	const rejectedLicenses = selectedProducts.filter( ( product ) => product.status === 'rejected' );
 
-	const clearLicenses = ( type: string ) => {
+	const clearLicenses = ( type: 'fulfilled' | 'rejected' ) => {
 		const license = {
 			...licenseInfo,
 			selectedProducts: selectedProducts.filter( ( product ) => product.status !== type ),
@@ -51,7 +51,9 @@ export default function SiteAddLicenseNotification() {
 							{
 								count: assignedLicenses.length,
 								args: {
-									assignedLicenses: assignedLicenses.map( ( l ) => l.name ).join( ', ' ),
+									assignedLicenses: assignedLicenses
+										.map( ( license ) => license.name )
+										.join( ', ' ),
 									selectedSite,
 								},
 								components: {
@@ -72,7 +74,9 @@ export default function SiteAddLicenseNotification() {
 							{
 								count: rejectedLicenses.length,
 								args: {
-									rejectedLicenses: rejectedLicenses.map( ( l ) => l.name ).join( ', ' ),
+									rejectedLicenses: rejectedLicenses
+										.map( ( license ) => license.name )
+										.join( ', ' ),
 									selectedSite,
 								},
 								components: {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -1,21 +1,17 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import Banner from 'calypso/components/banner';
+import { useDispatch, useSelector } from 'react-redux';
+import Notice from 'calypso/components/notice';
 import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
-import type { PurchasedProduct } from '../types';
+import { getPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/selectors';
 
 import './style.scss';
 
-export default function SiteAddLicenseNotification( {
-	purchasedLicense,
-}: {
-	purchasedLicense: PurchasedProduct;
-} ) {
+export default function SiteAddLicenseNotification() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedSite, selectedProduct } = purchasedLicense;
+	const licenseInfo = useSelector( getPurchasedLicense );
 
 	const dismissBanner = useCallback( () => {
 		dispatch( setPurchasedLicense() );
@@ -27,34 +23,67 @@ export default function SiteAddLicenseNotification( {
 		};
 	}, [ dismissBanner ] );
 
-	if ( ! selectedSite || ! selectedProduct?.name ) {
+	if ( ! licenseInfo || ! licenseInfo.selectedSite ) {
 		return null;
 	}
 
+	const { selectedSite, selectedProducts } = licenseInfo;
+	const assignedLicenses = selectedProducts.filter( ( product ) => product.status === 'fulfilled' );
+	const rejectedLicenses = selectedProducts.filter( ( product ) => product.status === 'rejected' );
+
+	const clearLicenses = ( type: string ) => {
+		const license = {
+			...licenseInfo,
+			selectedProducts: selectedProducts.filter( ( product ) => product.status !== type ),
+		};
+		dispatch( setPurchasedLicense( license.selectedProducts.length ? license : undefined ) );
+	};
+
 	return (
-		<div className="site-add-license-notification__license-banner">
-			<Banner
-				title={ translate(
-					'A {{strong}}%(selectedProduct)s{{/strong}} license was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
-					{
-						args: {
-							selectedProduct: selectedProduct.name,
-							selectedSite,
-						},
-						components: {
-							strong: <strong />,
-							em: <em />,
-						},
-					}
-				) }
-				disableCircle
-				horizontal
-				dismissWithoutSavingPreference
-				onDismiss={ dismissBanner }
-				icon="info-outline"
-				callToAction={ translate( 'View License Details' ) }
-				href={ `/partner-portal/licenses?highlight=${ selectedProduct.key }` }
-			/>
-		</div>
+		<>
+			{ assignedLicenses.length > 0 && (
+				<div className="site-add-license-notification__license-banner">
+					<Notice onDismissClick={ () => clearLicenses( 'fulfilled' ) } status="is-success">
+						{ translate(
+							'{{strong}}%(assignedLicenses)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow few minutes for your features to activate.',
+							'{{strong}}%(assignedLicenses)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please all a few minutes for your features to activate.',
+
+							{
+								count: assignedLicenses.length,
+								args: {
+									assignedLicenses: assignedLicenses.map( ( l ) => l.name ).join( ', ' ),
+									selectedSite,
+								},
+								components: {
+									strong: <strong />,
+									em: <em />,
+								},
+							}
+						) }
+					</Notice>
+				</div>
+			) }
+			{ rejectedLicenses.length > 0 && (
+				<div className="site-add-license-notification__license-banner">
+					<Notice onDismissClick={ () => clearLicenses( 'rejected' ) } status="is-error">
+						{ translate(
+							`An error occurred and your {{strong}}%(rejectedLicenses)s{{/strong}} wasn't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+							`An error occurred and your {{strong}}%(rejectedLicenses)s{{/strong}} weren't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+							{
+								count: rejectedLicenses.length,
+								args: {
+									rejectedLicenses: rejectedLicenses.map( ( l ) => l.name ).join( ', ' ),
+									selectedSite,
+								},
+								components: {
+									strong: <strong />,
+									em: <em />,
+								},
+							}
+						) }
+					</Notice>
+				</div>
+			) }
+		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -123,9 +123,9 @@ export type AgencyDashboardFilter = {
 	showOnlyFavorites: boolean;
 };
 
-export type PurchasedProduct = {
+export type PurchasedProductsInfo = {
 	selectedSite: string;
-	selectedProduct: { name: string; key: string };
+	selectedProducts: Array< { name: string; key: string; status: 'rejected' | 'fulfilled' } >;
 };
 
 export interface APIError {

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -353,7 +353,7 @@ export function useIssueMultipleLicenses(
 
 		dispatch(
 			recordTracksEvent( 'calypso_partner_portal_issue_mutiple_licenses_submit', {
-				products: selectedProducts,
+				products: selectedProducts.join( ',' ),
 			} )
 		);
 
@@ -405,7 +405,7 @@ export function useIssueMultipleLicenses(
 
 		dispatch(
 			recordTracksEvent( 'calypso_partner_portal_multiple_linceses_issued', {
-				products: assignedProducts,
+				products: assignedProducts.join( ',' ),
 			} )
 		);
 
@@ -428,6 +428,11 @@ export function useIssueMultipleLicenses(
 				allSelectedProducts.push( item );
 			}
 		} );
+		const assignLicenseStatus = {
+			selectedSite: selectedSite?.domain || '',
+			selectedProducts: allSelectedProducts,
+		};
+		dispatch( setPurchasedLicense( assignLicenseStatus ) );
 		if ( fromDashboard ) {
 			return page.redirect( '/dashboard' );
 		}

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -13,7 +13,7 @@ import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
+import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import useAssignLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-assign-license-mutation';
 import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
@@ -432,6 +432,7 @@ export function useIssueMultipleLicenses(
 			selectedSite: selectedSite?.domain || '',
 			selectedProducts: allSelectedProducts,
 		};
+		dispatch( resetSite() );
 		dispatch( setPurchasedLicense( assignLicenseStatus ) );
 		if ( fromDashboard ) {
 			return page.redirect( '/dashboard' );

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -146,10 +146,13 @@ export function useLicenseIssuing(
 			dispatch(
 				setPurchasedLicense( {
 					selectedSite: selectedSite?.domain,
-					selectedProduct: {
-						name: getProductTitle( selectedProduct.name ),
-						key: licenseKey,
-					},
+					selectedProducts: [
+						{
+							name: getProductTitle( selectedProduct.name ),
+							key: licenseKey,
+							status: 'fulfilled',
+						},
+					],
 				} )
 			);
 		}

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -360,7 +360,7 @@ export function useIssueMultipleLicenses(
 		if ( paymentMethodRequired ) {
 			const nextStep = addQueryArgs(
 				{
-					product: selectedProducts.join( ',' ),
+					products: selectedProducts.join( ',' ),
 				},
 				partnerPortalBasePath( '/payment-methods/add' )
 			);

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -70,7 +70,7 @@ export default function IssueLicenseForm( { selectedSite, suggestedProduct }: As
 						<p className="issue-license-form__description">
 							{ selectedSiteDomain
 								? translate(
-										'Select the Jetpack product you would like to add to {{strong}}%(selectedSiteDomian)s{{/strong}}',
+										'Select the Jetpack product you would like to add to {{strong}}%(selectedSiteDomain)s{{/strong}}',
 										{
 											args: { selectedSiteDomain },
 											components: { strong: <strong /> },

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -44,11 +44,16 @@ export default function IssueMultipleLicensesForm( {
 					product: product.slug,
 				} )
 			);
-			const allProducts = [ ...selectedProducts ];
-			selectedProducts.indexOf( product.slug ) === -1
-				? allProducts.push( product.slug )
-				: allProducts.splice( selectedProducts.indexOf( product.slug ), 1 );
-			setSelectedProducts( allProducts );
+
+			setSelectedProducts( ( previousValue ) => {
+				const allProducts = [ ...previousValue ];
+
+				! allProducts.includes( product.slug )
+					? allProducts.push( product.slug )
+					: allProducts.splice( selectedProducts.indexOf( product.slug ), 1 );
+
+				return allProducts;
+			} );
 		},
 		[ dispatch, selectedProducts ]
 	);

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -33,9 +33,7 @@ export default function IssueMultipleLicensesForm( {
 
 	const defaultProducts = getQueryArg( window.location.href, 'product' )?.toString().split( ',' );
 
-	const [ selectedProducts, setSelectedProducts ] = useState(
-		defaultProducts ? defaultProducts : []
-	);
+	const [ selectedProducts, setSelectedProducts ] = useState( defaultProducts ?? [] );
 
 	const [ issueLicense, isLoading ] = useIssueMultipleLicenses( selectedProducts, selectedSite );
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useLicenseIssuing } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { useIssueMultipleLicenses } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import {
@@ -12,13 +12,14 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import type { IssueMultipleLicensesFormProps } from './types';
+import { AssignLicenceProps } from '../types';
 
 import './style.scss';
 
 export default function IssueMultipleLicensesForm( {
 	selectedSite,
-}: IssueMultipleLicensesFormProps ) {
+	suggestedProduct,
+}: AssignLicenceProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery( {
@@ -30,29 +31,39 @@ export default function IssueMultipleLicensesForm( {
 	const products =
 		allProducts?.filter( ( { family_slug } ) => family_slug !== 'jetpack-packs' ) || [];
 
-	const defaultProduct = ( getQueryArg( window.location.href, 'product' ) || '' ).toString();
-	const [ product, setProduct ] = useState( defaultProduct );
-	const [ issueLicense, isLoading ] = useLicenseIssuing( product, selectedSite );
+	const defaultProducts = getQueryArg( window.location.href, 'product' )?.toString().split( ',' );
+
+	const [ selectedProducts, setSelectedProducts ] = useState(
+		defaultProducts ? defaultProducts : []
+	);
+
+	const [ issueLicense, isLoading ] = useIssueMultipleLicenses( selectedProducts, selectedSite );
 
 	const onSelectProduct = useCallback(
 		( product ) => {
 			dispatch(
-				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select', {
+				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select_multiple', {
 					product: product.slug,
 				} )
 			);
-			setProduct( product.slug );
+			const allProducts = [ ...selectedProducts ];
+			selectedProducts.indexOf( product.slug ) === -1
+				? allProducts.push( product.slug )
+				: allProducts.splice( selectedProducts.indexOf( product.slug ), 1 );
+			setSelectedProducts( allProducts );
 		},
-		[ dispatch, setProduct ]
+		[ dispatch, selectedProducts ]
 	);
 
 	useEffect( () => {
 		// In the case of a bundle, we want to take the user immediately to the next step since
 		// they can't select any additional item after selecting a bundle.
-		if ( isJetpackBundle( product ) ) {
-			issueLicense();
-		}
-	}, [ issueLicense, product ] );
+		selectedProducts.forEach( ( product ) => {
+			if ( isJetpackBundle( product ) ) {
+				issueLicense();
+			}
+		} );
+	}, [ issueLicense, selectedProducts ] );
 
 	const selectedSiteDomain = selectedSite?.domain;
 
@@ -80,7 +91,7 @@ export default function IssueMultipleLicensesForm( {
 							<Button
 								primary
 								className="issue-multiple-licenses-form__select-license"
-								disabled={ ! product }
+								disabled={ ! selectedProducts.length }
 								busy={ isLoading }
 								onClick={ issueLicense }
 							>
@@ -92,11 +103,13 @@ export default function IssueMultipleLicensesForm( {
 						{ products &&
 							products.map( ( productOption, i ) => (
 								<LicenseProductCard
+									isMultiSelect
 									key={ productOption.slug }
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
-									isSelected={ productOption.slug === product }
+									isSelected={ selectedProducts.includes( productOption.slug ) }
 									tabIndex={ 100 + i }
+									suggestedProduct={ suggestedProduct }
 								/>
 							) ) }
 					</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -80,7 +80,7 @@ export default function IssueMultipleLicensesForm( {
 						<p className="issue-multiple-licenses-form__description">
 							{ selectedSiteDomain
 								? translate(
-										'Select the Jetpack products you would like to add to {{strong}}%(selectedSiteDomian)s{{/strong}}:',
+										'Select the Jetpack products you would like to add to {{strong}}%(selectedSiteDomain)s{{/strong}}:',
 										{
 											args: { selectedSiteDomain },
 											components: { strong: <strong /> },

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/types.ts
@@ -1,4 +1,0 @@
-export type IssueMultipleLicensesFormProps = {
-	selectedSite?: { ID: number; domain: string } | null;
-	selectedProductSlugs?: string[];
-};

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -43,6 +43,7 @@ export default function LicenseProductCard( props: Props ) {
 
 	useEffect( () => {
 		if ( suggestedProduct ) {
+			// Transform the comma-separated list of products to array.
 			const suggestedProducts = suggestedProduct.split( ',' );
 
 			if ( suggestedProducts.includes( product.slug ) ) {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { getProductTitle } from '../utils';
+
 import './style.scss';
 
 interface Props {
@@ -14,10 +15,11 @@ interface Props {
 	isSelected: boolean;
 	onSelectProduct: ( value: APIProductFamilyProduct | string ) => void | null;
 	suggestedProduct?: string | null;
+	isMultiSelect?: boolean;
 }
 
 export default function LicenseProductCard( props: Props ) {
-	const { tabIndex, product, isSelected, onSelectProduct, suggestedProduct } = props;
+	const { tabIndex, product, isSelected, onSelectProduct, suggestedProduct, isMultiSelect } = props;
 	const productTitle = getProductTitle( product.name );
 	const translate = useTranslate();
 
@@ -45,13 +47,13 @@ export default function LicenseProductCard( props: Props ) {
 				onSelect();
 			}
 		}
-	}, [ onSelect, product, suggestedProduct ] );
+	}, [] );
 
 	return (
 		<div
 			onClick={ onSelect }
 			onKeyDown={ onKeyDown }
-			role="radio"
+			role={ isMultiSelect ? 'checkbox' : 'radio' }
 			tabIndex={ tabIndex }
 			aria-checked={ isSelected }
 			className={ classNames( {
@@ -62,7 +64,11 @@ export default function LicenseProductCard( props: Props ) {
 			<div className="license-product-card__inner">
 				<div className="license-product-card__details">
 					<h3 className="license-product-card__title">{ productTitle }</h3>
-					<div className="license-product-card__radio">
+					<div
+						className={ classNames( 'license-product-card__select-button', {
+							'license-product-card_multi-select': isMultiSelect,
+						} ) }
+					>
 						{ isSelected && <Gridicon icon="checkmark" /> }
 					</div>
 					<div className="license-product-card__pricing">

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -43,7 +43,9 @@ export default function LicenseProductCard( props: Props ) {
 
 	useEffect( () => {
 		if ( suggestedProduct ) {
-			if ( product.slug === suggestedProduct ) {
+			const suggestedProducts = suggestedProduct.split( ',' );
+
+			if ( suggestedProducts.includes( product.slug ) ) {
 				onSelect();
 			}
 		}

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -49,43 +49,47 @@
 	color: var(--studio-gray-80);
 }
 
-@mixin license-product-card-block__radio {
+@mixin license-product-card-block__select-button {
 	order: initial;
 	margin-right: 0;
 }
 
-@mixin license-product-card-line__radio {
+@mixin license-product-card-line__select-button {
 	order: -1;
 	margin-right: 1rem;
 }
 
-.license-product-card__radio {
+.license-product-card__select-button {
 	width: 20px;
 	height: 20px;
 	border: 2px solid var(--studio-black);
 	border-radius: 12px; /* stylelint-disable-line scales/radii */
 	text-align: center;
 
-	@include license-product-card-block__radio;
+	@include license-product-card-block__select-button;
 
 	@include break-mobile {
-		@include license-product-card-line__radio;
+		@include license-product-card-line__select-button;
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
-		@include license-product-card-block__radio;
+		@include license-product-card-block__select-button;
 	}
 
 	@include break-medium {
-		@include license-product-card-line__radio;
+		@include license-product-card-line__select-button;
 	}
 
 	@include break-xlarge {
-		@include license-product-card-block__radio;
+		@include license-product-card-block__select-button;
 	}
 }
 
-.license-product-card__radio .gridicon {
+.license-product-card_multi-select {
+	border-radius: 2px;
+}
+
+.license-product-card__select-button .gridicon {
 	color: #fff;
 	position: relative;
 	top: -2px;
@@ -93,7 +97,7 @@
 	width: 14px;
 }
 
-.license-product-card.selected .license-product-card__radio {
+.license-product-card.selected .license-product-card__select-button {
 	border: 2px solid var(--studio-jetpack-green-50);
 	background: var(--studio-jetpack-green-50);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -13,8 +12,6 @@ import { AssignLicenceProps } from '../../types';
 
 export default function IssueLicense( { selectedSite, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
-
-	const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
 
 	useEffect( () => {
 		const layoutClass = 'layout__content--partner-portal-issue-license';
@@ -35,7 +32,10 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ? (
-				<IssueMultipleLicensesForm selectedSite={ selectedSite } selectedProductSlugs={ [] } />
+				<IssueMultipleLicensesForm
+					selectedSite={ selectedSite }
+					suggestedProduct={ suggestedProduct }
+				/>
 			) : (
 				<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 			) }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -12,6 +13,8 @@ import { AssignLicenceProps } from '../../types';
 
 export default function IssueLicense( { selectedSite, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
+
+	const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
 
 	useEffect( () => {
 		const layoutClass = 'layout__content--partner-portal-issue-license';

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -84,16 +84,18 @@ function PaymentMethodAdd() {
 	);
 
 	const siteId = useMemo(
-		() => getQueryArg( window.location.href, 'site_id' ) || '',
+		() => ( getQueryArg( window.location.href, 'site_id' ) || '' ).toString(),
 		[]
-	).toString();
+	);
 
 	const source = useMemo(
-		() => getQueryArg( window.location.href, 'source' ) || '',
+		() => ( getQueryArg( window.location.href, 'source' ) || '' ).toString(),
 		[]
-	).toString();
+	);
 
-	const isMulti = isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' );
+	const isMultipleLicenseIssueEnabled = isEnabled(
+		'jetpack/partner-portal-issue-multiple-licenses'
+	);
 
 	const [ issueLicense, isLoading ] = useLicenseIssuing( product );
 	const [ issueMultipleLicense, isIssuingMultipleLicenses ] = useIssueMultipleLicenses(
@@ -158,7 +160,7 @@ function PaymentMethodAdd() {
 	}, [ paymentMethodRequired, product ] );
 
 	useEffect( () => {
-		if ( isMulti && ! paymentMethodRequired && products ) {
+		if ( isMultipleLicenseIssueEnabled && ! paymentMethodRequired && products ) {
 			issueMultipleLicense();
 		}
 	}, [ paymentMethodRequired ] );

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -24,5 +24,5 @@ export enum LicenseSortDirection {
 
 export interface AssignLicenceProps {
 	selectedSite?: { ID: number; domain: string } | null;
-	suggestedProduct?: string | null;
+	suggestedProduct?: string;
 }

--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -2,7 +2,7 @@ import page from 'page';
 import { AnyAction } from 'redux';
 import {
 	AgencyDashboardFilterOption,
-	PurchasedProduct,
+	PurchasedProductsInfo,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import './init';
@@ -34,8 +34,8 @@ export const updateFilter = ( filterOptions: AgencyDashboardFilterOption[] ) => 
 	navigateToFilter( filterOptions );
 };
 
-export function setPurchasedLicense( product?: PurchasedProduct ): AnyAction {
-	return { type: JETPACK_AGENCY_DASHBOARD_PURCHASED_LICENSE_CHANGE, payload: product };
+export function setPurchasedLicense( productsInfo?: PurchasedProductsInfo ): AnyAction {
+	return { type: JETPACK_AGENCY_DASHBOARD_PURCHASED_LICENSE_CHANGE, payload: productsInfo };
 }
 
 export function selectLicense( siteId: number, license: string ): AnyAction {

--- a/client/state/jetpack-agency-dashboard/reducer.ts
+++ b/client/state/jetpack-agency-dashboard/reducer.ts
@@ -8,15 +8,15 @@ import {
 	JETPACK_AGENCY_DASHBOARD_UNSELECT_LICENSE,
 	JETPACK_AGENCY_DASHBOARD_RESET_SITE,
 } from './action-types';
-import type { PurchasedProduct } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import type { PurchasedProductsInfo } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
-const purchasedLicense: Reducer< { purchasedLicense: PurchasedProduct | null }, AnyAction > = (
-	state = { purchasedLicense: null },
-	action: AnyAction
-): AppState => {
+const purchasedLicense: Reducer<
+	{ purchasedLicenseInfo: PurchasedProductsInfo | null },
+	AnyAction
+> = ( state = { purchasedLicenseInfo: null }, action: AnyAction ): AppState => {
 	switch ( action?.type ) {
 		case JETPACK_AGENCY_DASHBOARD_PURCHASED_LICENSE_CHANGE:
-			return { ...state, purchasedLicense: action.payload };
+			return { ...state, purchasedLicenseInfo: action.payload };
 	}
 	return state;
 };

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -28,7 +28,7 @@ export function checkIfJetpackSiteGotDisconnected( state: AppState ): boolean {
 }
 
 export function getPurchasedLicense( state: AppState ): PurchasedProductsInfo | null {
-	return state.agencyDashboard.purchasedLicense.purchasedLicenseInfo;
+	return state.agencyDashboard.purchasedLicense?.purchasedLicenseInfo;
 }
 
 /**

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -1,8 +1,8 @@
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type {
 	Preference,
-	PurchasedProduct,
 	AllowedTypes,
+	PurchasedProductsInfo,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import type { AppState } from 'calypso/types';
 
@@ -27,8 +27,8 @@ export function checkIfJetpackSiteGotDisconnected( state: AppState ): boolean {
 	return !! state.sites.jetpackSiteDisconnected;
 }
 
-export function getPurchasedLicense( state: AppState ): PurchasedProduct | null {
-	return state.agencyDashboard.purchasedLicense;
+export function getPurchasedLicense( state: AppState ): PurchasedProductsInfo | null {
+	return state.agencyDashboard.purchasedLicenseInfo;
 }
 
 /**

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -28,7 +28,7 @@ export function checkIfJetpackSiteGotDisconnected( state: AppState ): boolean {
 }
 
 export function getPurchasedLicense( state: AppState ): PurchasedProductsInfo | null {
-	return state.agencyDashboard.purchasedLicenseInfo;
+	return state.agencyDashboard.purchasedLicense.purchasedLicenseInfo;
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

This PR implements assigning multiple licenses flow, where the issue license process begins from the dashboard. If you visit directly the `/issue-license` page, this might not work as expected because we don't yet have the ID of the site.

This patch is built on top of https://github.com/Automattic/wp-calypso/issues/69183, which is the mutation that handles issuing of multiple licenses. In theory, it should completely replace `useLicenseIssuing`, but I have decided to keep the latter to avoid breaking the existing flows on production.

This PR includes:
- Transform radio buttons to checkboxes to avoid multiple product selection
- Display correct feedback notices when the user issues multiple licenses

This PR does not include the following:
- Incompatible product validations

**Prerequisite**
- Make sure your partner account is set to an agency and your partner key's billable type is set to Stripe.


#### Testing Instructions

- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Create a few news JN sites
- Make sure your partner account is set to an agency and your partner key's billable type is set to non-billable.
- Apply D91613-code on your sandbox for easier testing
- Connect Jetpack
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Select backup and scan for your new JN site
- On the page for issuing licenses, make sure that you can select multiple licenses and deselect them
- Verify that both licenses were issued and the feedback notice is correct
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Select the backup license
- On the page for issuing licenses, make sure that you select bundle, and not a product
- Verify that the bundle license is issued and that the feedback notices are correct

**Important**
- Visit the Jetpack Cloud live link (horizon environment) in this PR and verify this PR isn't causing any regression. You must test various flows there, including setting your partner account billing type to Stripe. The basic flows are listed here: pdpAdu-v0-p2

**Screenshots**

Multiple products(Success)

<img width="1454" alt="Screenshot 2022-11-08 at 5 01 13 PM" src="https://user-images.githubusercontent.com/10586875/200553696-61607280-8cb6-4175-b0ff-c57edc6fd032.png">

Single product(Success)

<img width="1454" alt="Screenshot 2022-11-08 at 5 02 12 PM" src="https://user-images.githubusercontent.com/10586875/200553721-21979dea-bb73-4d94-9f9b-fb0b9f597911.png">

Multiple products(Failure)

<img width="1454" alt="Screenshot 2022-11-08 at 5 01 38 PM" src="https://user-images.githubusercontent.com/10586875/200553710-9fee7eef-8154-4932-ab99-28ac4875aa3c.png">

Single Product(Failure)

<img width="1454" alt="Screenshot 2022-11-08 at 5 01 53 PM" src="https://user-images.githubusercontent.com/10586875/200553717-a0c4b174-4436-4b3f-8ca8-d2f6c2245551.png">



#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Related to 1203126240279377-as-1203126240279405 & 1203126240279377-as-1203188906065242