### PR TITLE
Remove the terms text from the bottom of the advertising page

### DIFF
--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -122,20 +122,6 @@ export default function PromotedPosts( { tab }: Props ) {
 				/>
 			) }
 			{ selectedTab === 'posts' && <PostsList /> }
-
-			<div className="promote-post__footer">
-				<p>
-					{ translate(
-						'By promoting your post you agree to {{tosLink}}WordPress.com Terms{{/tosLink}} and {{advertisingTerms}}Advertising Terms{{/advertisingTerms}}.',
-						{
-							components: {
-								tosLink: <a href="https://wordpress.com/tos/" target="_blank" rel="noreferrer" />,
-								advertisingTerms: <a href="https://automattic.com/privacy/" target="blank" />,
-							},
-						}
-					) }
-				</p>
-			</div>
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

Remove the legal text from the bottom of the advertising page (as per this [issue](https://github.tumblr.net/Tumblr/wordads-picard/issues/1062))

before version 

![Screenshot 2022-10-18 at 17 04 31](https://user-images.githubusercontent.com/1416426/196452579-ac4a38b2-10bb-4bfc-9d10-4922bb6ee30b.png)

after version 

![Screenshot 2022-10-18 at 17 04 13](https://user-images.githubusercontent.com/1416426/196452618-d4cd479e-b8cd-4775-862a-ca60be0b601b.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
