### PR TITLE
Stop showing the upsell banner when site features are not fully loaded

### DIFF
--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -54,6 +54,7 @@ jest.mock( 'calypso/state/purchases/selectors', () => ( {
 } ) );
 
 import {
+	FEATURE_INSTALL_PLUGINS,
 	PLAN_FREE,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
@@ -122,7 +123,10 @@ describe( 'Upsell Nudge should get appropriate plan constant', () => {
 		`Business 1 year for (%s)`,
 		( product_slug ) => {
 			const initialState = {
-				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
+				sites: {
+					items: { 1: { jetpack: false, plan: { product_slug } } },
+					features: { 1: { data: [ FEATURE_INSTALL_PLUGINS ] } },
+				},
 			};
 			render( <PluginsBrowser />, { initialState } );
 			const nudge = screen.getByTestId( 'upsell-nudge' );

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -16,6 +16,7 @@ import { useSelector } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -31,6 +32,9 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 	);
 	const isVip = useSelector( ( state ) => isVipSite( state, selectedSite?.ID ) );
 
+	const siteFeaturesLoaded = useSelector( ( state ) =>
+		getFeaturesBySiteId( state, selectedSite?.ID )
+	);
 	const hasInstallPlugins = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_PLUGINS )
 	);
@@ -63,6 +67,7 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 		! sitePlan ||
 		isVip ||
 		hasInstallPlugins ||
+		! siteFeaturesLoaded ||
 		( paidPlugins && hasInstallPurchasedPlugins )
 	) {
 		return null;


### PR DESCRIPTION
#### Proposed Changes

Stop showing the upsell banner when site features are not fully loaded, it will avoid flashing the banner when not needed.

| Before  | After |
| ------------- | ------------- |
|![Kapture 2022-10-18 at 10 09 03](https://user-images.githubusercontent.com/5039531/196470088-35cd226a-2197-43df-b3c5-07301f06583f.gif)|![Kapture 2022-10-18 at 10 10 12](https://user-images.githubusercontent.com/5039531/196470370-c2911956-ba5f-4a04-a1e3-7c658d4c8102.gif)|

#### Testing Instructions



* Load the Plugins browser page with an atomic site (`/plugins/{atomic_site}`)
* Check if the banner is not shown

* Load the Plugins Browser page with a free site (`/plugins/{free_site}`) 
* The banner will be shown after some time



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #66736