### PR TITLE
Fix missing Publicize -> Jetpack Social changes

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -69,7 +69,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 						components: {
 							ExternalLink: (
 								<ExternalLink
-									href="https://jetpack.com/support/publicize/#re-sharing-your-content"
+									href="https://jetpack.com/support/jetpack-social/#re-sharing-your-content"
 									icon={ true }
 									onClick={ () =>
 										recordTracksEvent( 'calypso_publicize_post_share_learn_more_click' )

--- a/client/components/jetpack/jetpack-social-welcome/Step1.tsx
+++ b/client/components/jetpack/jetpack-social-welcome/Step1.tsx
@@ -6,9 +6,8 @@ export const Step1 = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	// TODO update the correct links when available
 	const downloadLink = 'https://wordpress.org/plugins/jetpack-social/';
-	const instructionsLink = 'https://jetpack.com/support/publicize/';
+	const instructionsLink = 'https://jetpack.com/support/jetpack-social/';
 
 	return (
 		<p>

--- a/client/jetpack-cloud/sections/jetpack-social/connections.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/connections.jsx
@@ -20,7 +20,7 @@ export const Connections = ( { siteId, translate } ) => {
 
 	const learnMoreLink = (
 		<a
-			href={ localizeUrl( 'https://jetpack.com/support/publicize/' ) }
+			href={ localizeUrl( 'https://jetpack.com/support/jetpack-social/' ) }
 			className="connections__support-link"
 			target="_blank"
 			rel="noopener noreferrer"

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -22,7 +22,7 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 			{ ! isP2Hub && (
 				<SharingServicesGroup
 					type="publicize"
-					title={ translate( 'Publicize posts {{learnMoreLink/}}', {
+					title={ translate( 'Share posts with Jetpack Social {{learnMoreLink/}}', {
 						components: {
 							learnMoreLink: <InlineSupportLink supportContext="publicize" showText={ false } />,
 						},


### PR DESCRIPTION
#### Proposed Changes

* Fix missing Publicize -> Jetpack Social rebrand changes.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to "Tools → Marketing → Connections" and make sure the header of the section says "Share posts with Jetpack Social"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screenshot 2022-10-18 at 18 06 52@2x](https://user-images.githubusercontent.com/1713699/196484342-0d5fcea6-652d-4a42-b912-66c2c29390f5.png)
