### PR TITLE
Update ExPlat README to use loadExperimentAssignment

### DIFF
--- a/client/lib/explat/README.md
+++ b/client/lib/explat/README.md
@@ -12,7 +12,7 @@ This package exposes the API for using Automattic's ExPlat (Experimentation Plat
 
 ## Outside React
 
-- `loadExperiment` - Load experiment data as a promise.
+- `loadExperimentAssignment` - Load experiment data as a promise.
 - `dangerouslyGetExperimentAssignment` - Try and get an experiment assignment even if it hasn't loaded yet.
 
 [See the `explat-client` package for details](https://github.com/Automattic/wp-calypso/blob/trunk/packages/explat-client/README.md)
@@ -20,5 +20,5 @@ This package exposes the API for using Automattic's ExPlat (Experimentation Plat
 ## Tips
 
 - Mix and match as much as you need :-)
-- `loadExperiment` can be added at Calypso boot to prefetch the experiment and avoid loading state.
+- `loadExperimentAssignment` can be added at Calypso boot to prefetch the experiment and avoid loading state.
 - Everything but `dangerouslyGetExperimentAssignment` can be used to prefetch an experiment assignment.

--- a/packages/explat-client-react-helpers/README.md
+++ b/packages/explat-client-react-helpers/README.md
@@ -46,7 +46,7 @@ if ( isLoadingExperimentAssignment ) {
 
 - Can use it on it's own, as much and wherever you would like (but it won't work in SSR)
 - Won't obey TTL - will retain the same experience for the life of the component.
-- Tip: Can use `loadExperiment('experiment_name')` to prefetch an experiment.
+- Tip: Can use `loadExperimentAssignment('experiment_name')` to prefetch an experiment.
 
 ### ExperimentOptions
 

--- a/packages/explat-client/README.md
+++ b/packages/explat-client/README.md
@@ -67,7 +67,7 @@ This is an "asyncronous escape hatch", allowing you to use ExPlat in more synchr
 
 Checklist for use:
 
-- [ ] Does `loadExperiment` get called before `dangerouslyGetExperimentAssignment` gets called.
-- [ ] Does `loadExperiment` get called significantly before it (minimum 2 seconds looking at perf data, 5-10 seconds is best).
+- [ ] Does `loadExperimentAssignment` get called before `dangerouslyGetExperimentAssignment` gets called.
+- [ ] Does `loadExperimentAssignment` get called significantly before it (minimum 2 seconds looking at perf data, 5-10 seconds is best).
 - [ ] ~~Is `dangerouslyGetExperimentAssignment` wrapped in a try-catch block~~
 - [ ] Are there no `console.log` errors being emitted?


### PR DESCRIPTION
#### Proposed Changes

* Updates the reference in README from `loadExperiment` to `loadExperimentAssignment`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No testing required. README changes only.

Related to p1665750027476129-slack-C02KVCAL7GX