### PR TITLE
Fix broken test group link in e2e docs

### DIFF
--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -56,7 +56,7 @@ Use the `--group` arg to provide a suite to test `Jest`. For example, to run all
 yarn jest --group=calypso-pr
 ```
 
-See the [list of groups](docs/overview.md#what-is-tested).
+See the [list of groups](tests_ci.md#featuretest-groups).
 
 ## Advanced techniques
 


### PR DESCRIPTION
#### Proposed Changes

* Fixing the link for the list of test groups from the e2e documentation because it redirected to a non-existing page. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso docs on Calypso live
* From the **Running tests on your machine** > **Running tests** > **Test Group**, click the `list of groups` link

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
