### PR TITLE
Promoted Posts advertising page - show tabs without a dropdown

### DIFF
--- a/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
@@ -14,7 +14,7 @@ export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
-		<SectionNav>
+		<SectionNav allowDropdown={ false } className="is-open">
 			<NavTabs>
 				{ tabs.map( ( { id, name } ) => {
 					return (

--- a/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
@@ -1,3 +1,4 @@
+import { isMobile } from '@automattic/viewport';
 import { useSelector } from 'react-redux';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -13,8 +14,10 @@ type Props = {
 export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
+	const sectionNavProps = isMobile() ? { allowDropdown: false, className: 'is-open' } : {};
+
 	return (
-		<SectionNav allowDropdown={ false } className="is-open">
+		<SectionNav { ...sectionNavProps }>
 			<NavTabs>
 				{ tabs.map( ( { id, name } ) => {
 					return (


### PR DESCRIPTION
#### Proposed Changes

Instead of showing a dropdown to select tabs, for better visibility, hide the dropdown and show the tab items by default.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. In a browser, navigate to https://wordpress.com/advertising/<site>.
2. Desktop view should still look like the following:

![image](https://user-images.githubusercontent.com/2396764/196510529-e33dfc70-b5ea-4357-b2e1-f386ba9da79d.png)

3. Switch to mobile view or emulator and refresh.
4. Verify the tabs should be displayed like the following:

<img src="https://user-images.githubusercontent.com/2396764/196510103-6c5b32f9-0b98-483a-aac1-0b10fea05df3.png" width="390" />

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
