### PR TITLE
Custom Domain Dialog: Wrap the install plugin button content when its too long

### DIFF
--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -42,6 +42,7 @@ export const PluginCustomDomainDialog = ( {
 			label: translate( 'Manage domains' ),
 		},
 		{
+			className: 'plugin-custom-domain-dialog__install_plugin',
 			action: 'install-plugin',
 			label: translate( 'Install %(pluginName)s', {
 				args: { pluginName: plugin.name },

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
@@ -20,3 +20,10 @@
 		margin: 0;
 	}
 }
+
+.plugin-custom-domain-dialog__install_plugin {
+	max-width: 200px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}


### PR DESCRIPTION
#### Proposed Changes

Add a max width and wrap the content of the install plugin button when the plugin name is too long.

#### Testing Instructions
* Go to a plugin page with custom domain and that has a long name. Ex: `plugins/import-xml-csv-settings-to-rank-math-seo/{site}`
* Click on `Install and activate`
* Check if the button is not too big and the button content has ellipsis.

| Before  | After |
| ------------- | ------------- |
|<img width="930" alt="Screen Shot 2022-10-18 at 13 45 21" src="https://user-images.githubusercontent.com/5039531/196519080-856b3a46-a2f8-4f23-9d68-7afde6e9fe61.png">|<img width="930" alt="Screen Shot 2022-10-18 at 13 46 01" src="https://user-images.githubusercontent.com/5039531/196519179-771fea70-cf61-4505-9708-9266f69f7b04.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67745
