### PR TITLE
Search: Do not apply input-end overlay if focused

### DIFF
--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -66,7 +66,9 @@ export const WithOverlayStyling = () => {
 	return <BoxedSearch overlayStyling={ overlayStyling } />;
 };
 
-export const WithDefaultValue = () => <BoxedSearch defaultValue="a default search value" />;
+export const WithDefaultValue = () => (
+	<BoxedSearch defaultValue="a default search value overflowing the input box" />
+);
 
 export const WithCustomSearchIcon = () => {
 	const customIcon = (

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -228,6 +228,22 @@ $input-z-index: 20;
 		}
 	}
 
+	// Removes the fade overlay when the search is open and focused
+	&.has-focus {
+		.search-component__input-fade {
+
+			&::before {
+				display: none;
+			}
+
+			&.rtl {
+				&::before {
+					display: none;
+				}
+			}
+		}
+	}
+
 	&.has-open-icon {
 		.search-component__input-fade {
 			padding-left: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/66364. Supersedes https://github.com/Automattic/wp-calypso/pull/66590.

Fixes overlay hiding end characters issue in the search input. It does so by removing the overlay when the input is in a focus state.

#### Screen recording

https://user-images.githubusercontent.com/4111723/184789322-7ed859d7-5734-4b41-8be1-b5cc588f95e8.mov

#### Testing Instructions

1. Run yarn workspace @automattic/search run storybook
2. Once running, visit http://localhost:49901/?path=/story/search--with-different-color
3. Type a lot of text into the search input box, such that it overflows the input