### PR TITLE
Fix cancellation offer discount rounding

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -105,11 +105,11 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	const offerDiscountBasedFromPurchasePrice = useMemo( () => {
 		if ( cancellationOffer ) {
 			// Get the percentage difference in the price of the offer over the price of the purchase.
-			// toFixed will round to the 3rd decimal place here.
-			// This will catch floats like .1999, and round them up.
+			// toFixed will round to the 2nd decimal place here.
+			// This will catch floats like .199, and round them up.
 			const offerPercentageOfPurchaseAmount = Number(
 				1 - cancellationOffer.rawPrice / purchase.amount
-			).toFixed( 3 );
+			).toFixed( 2 );
 			// Since toFixed returns a string, we use parseFloat here to get the decimal value.
 			// floor is used to get a whole percentage number value.
 			return Math.floor( Number.parseFloat( offerPercentageOfPurchaseAmount ) * 100 );

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -104,15 +104,8 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 	const offerDiscountBasedFromPurchasePrice = useMemo( () => {
 		if ( cancellationOffer ) {
-			// Get the percentage difference in the price of the offer over the price of the purchase.
-			// toFixed will round to the 2nd decimal place here.
-			// This will catch floats like .199, and round them up.
-			const offerPercentageOfPurchaseAmount = Number(
-				1 - cancellationOffer.rawPrice / purchase.amount
-			).toFixed( 2 );
-			// Since toFixed returns a string, we use parseFloat here to get the decimal value.
-			// floor is used to get a whole percentage number value.
-			return Math.floor( Number.parseFloat( offerPercentageOfPurchaseAmount ) * 100 );
+			// Round the cancellation offer discount percentage to the nearest whole number
+			return Math.round( ( 1 - cancellationOffer.rawPrice / purchase.amount ) * 100 );
 		}
 		return 0;
 	}, [ cancellationOffer, purchase ] );

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -104,8 +104,10 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 	const offerDiscountBasedFromPurchasePrice = useMemo( () => {
 		if ( cancellationOffer ) {
+			const offerDiscountPercentage = ( 1 - cancellationOffer.rawPrice / purchase.amount ) * 100;
+
 			// Round the cancellation offer discount percentage to the nearest whole number
-			return Math.round( ( 1 - cancellationOffer.rawPrice / purchase.amount ) * 100 );
+			return Math.round( offerDiscountPercentage );
 		}
 		return 0;
 	}, [ cancellationOffer, purchase ] );

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-offer.tsx
@@ -143,7 +143,15 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 			dispatch( applyCancellationOffer( siteId, purchase.id ) );
 			onGetDiscount(); // Takes care of analytics.
 		}
-	}, [ isApplyingOffer, offerApplySuccess, offerApplyError, siteId, purchase.id, onGetDiscount ] );
+	}, [
+		isApplyingOffer,
+		offerApplySuccess,
+		offerApplyError,
+		siteId,
+		purchase.id,
+		onGetDiscount,
+		dispatch,
+	] );
 
 	const getErrorOutput = useMemo( () => {
 		if ( offerApplyError ) {
@@ -162,7 +170,7 @@ const JetpackCancellationOffer: FC< Props > = ( props ) => {
 		}
 
 		return null;
-	}, [ offerApplyError ] );
+	}, [ offerApplyError, translate ] );
 
 	return (
 		<>


### PR DESCRIPTION
#### Proposed Changes

This PR slightly changes the way the cancellation offer percentage off is rounded. There was an error where a 49.9% was being rounded down to 49%, but in this case we want it to round up to 50%.

We discovered this error ( p1666122224803319/1666115352.263449-slack-C02LK1W8T4Z ) when testing the new cancellation offer discount: pbNhbs-46F-p2

#### Testing Instructions

1) Get your sandbox up and running since we are testing prices that are not live yet
2) Add the following line to your `0-sandbox.php` file: `define( 'USE_STORE_SANDBOX', true );`
3) Sandbox `public-api.wordpress.com`
4) Purchase Jetpack Backup monthly with credits
![image](https://user-images.githubusercontent.com/65001528/196531420-62a6bb01-109f-41fb-8af3-fd6e51bbf482.png)
5) Head to http://calypso.localhost:3000/me/purchases/ and find your backup purchase. Select it and then select "Remove Subscription"
![image](https://user-images.githubusercontent.com/65001528/196531600-302e05b7-7dcb-454d-b9d9-6caa1cb6f97a.png)
6) Click "Next step" twice until you get to the cancellation offer
7) Notice the correct discount price, but incorrect percentage
![image](https://user-images.githubusercontent.com/65001528/196531899-efc7e70b-0fb1-40eb-b8e1-034a104ee86c.png)
8) Now checkout this branch via `git switch fix/cancellation-offer-rounding-error`
9) Get back to the cancellation plan offer and notice the updated percentage
![image](https://user-images.githubusercontent.com/65001528/196531807-dd53af48-2dca-4050-92c4-d0b84b32ccdb.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
