### PR TITLE
WPCOM SSH: Clarify SSH key is detached from sites on removal

### DIFF
--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -34,11 +34,16 @@ const SSHKeyAddedDate = styled.span( {
 const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 	const { __ } = useI18n();
 	const handleDeleteClick = () => {
-		accept( __( 'Are you sure you want to remove this SSH key?' ), ( accepted: boolean ) => {
-			if ( accepted ) {
-				onDelete( sshKey.name );
+		accept(
+			__(
+				'Are you sure you want to remove this SSH key? It will be removed from all attached sites.'
+			),
+			( accepted: boolean ) => {
+				if ( accepted ) {
+					onDelete( sshKey.name );
+				}
 			}
-		} );
+		);
 	};
 
 	return (

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -118,10 +118,15 @@ export const SecuritySSHKey = () => {
 							'Add a SSH key to your WordPress.com account to make it available for SFTP and SSH authentication.'
 						) }
 					</p>
+					<p>
+						{ __(
+							'Once added, attach the SSH key to a site with a Business or eCommerce plan to enable SSH key authentication for that site.'
+						) }
+					</p>
 					<p style={ hasKeys ? { marginBlockEnd: 0 } : undefined }>
 						{ createInterpolateElement(
 							__(
-								'Once added, attach the SSH key to a site with a Business or eCommerce plan to enable SSH key authentication for that site. <a>Read more.</a>'
+								'If the SSH key is removed from your WordPress.com account, it will also be removed from all attached sites. <a>Read more.</a>'
 							),
 							{
 								br: <br />,


### PR DESCRIPTION
## Proposed Changes

Updates SSH key intro and modal to clarify the SSH key is detached from sites upon removal.

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/36432/196544791-df72b31b-71a0-40cd-8be2-e9afd6a0ad93.png">

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/36432/196544831-9db48eb8-9f8d-4bc1-912e-e81023a369b8.png">


## Testing Instructions

1. Navigate to `/me/security/ssh-key`.
2. Verify the copy appears as expected.