### PR TITLE
WPCOM SSH: Use `<username>-<key-name>` consistently in UI

### DIFF
--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -3,7 +3,9 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import i18n from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import accept from 'calypso/lib/accept';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { SSHKeyData } from './use-ssh-key-query';
 
 type SSHKeyProps = { sshKey: SSHKeyData } & Pick<
@@ -14,6 +16,13 @@ type SSHKeyProps = { sshKey: SSHKeyData } & Pick<
 const SSHKeyItemCard = styled( CompactCard )( {
 	display: 'flex',
 	alignItems: 'center',
+} );
+
+const SSHKeyName = styled.span( {
+	display: 'block',
+	fontWeight: 'bold',
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
 } );
 
 const SSHPublicKey = styled.code( {
@@ -33,6 +42,7 @@ const SSHKeyAddedDate = styled.span( {
 
 const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 	const { __ } = useI18n();
+	const currentUser = useSelector( getCurrentUser );
 	const handleDeleteClick = () => {
 		accept( __( 'Are you sure you want to remove this SSH key?' ), ( accepted: boolean ) => {
 			if ( accepted ) {
@@ -44,6 +54,9 @@ const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 	return (
 		<SSHKeyItemCard>
 			<div style={ { marginRight: '1rem' } }>
+				<SSHKeyName>
+					{ currentUser.username }-{ sshKey.name }
+				</SSHKeyName>
 				<SSHPublicKey>{ sshKey.sha256 }</SSHPublicKey>
 				<SSHKeyAddedDate>
 					{ sprintf(

--- a/client/me/security-ssh-key/manage-ssh-keys.tsx
+++ b/client/me/security-ssh-key/manage-ssh-keys.tsx
@@ -3,14 +3,12 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import i18n from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import accept from 'calypso/lib/accept';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { SSHKeyData } from './use-ssh-key-query';
 
 type SSHKeyProps = { sshKey: SSHKeyData } & Pick<
 	ManageSSHKeyProps,
-	'onDelete' | 'keyBeingDeleted'
+	'userLogin' | 'onDelete' | 'keyBeingDeleted'
 >;
 
 const SSHKeyItemCard = styled( CompactCard )( {
@@ -40,9 +38,8 @@ const SSHKeyAddedDate = styled.span( {
 	color: 'var( --color-text-subtle )',
 } );
 
-const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
+const SSHKey = ( { userLogin, sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 	const { __ } = useI18n();
-	const currentUser = useSelector( getCurrentUser );
 	const handleDeleteClick = () => {
 		accept( __( 'Are you sure you want to remove this SSH key?' ), ( accepted: boolean ) => {
 			if ( accepted ) {
@@ -55,7 +52,7 @@ const SSHKey = ( { sshKey, onDelete, keyBeingDeleted }: SSHKeyProps ) => {
 		<SSHKeyItemCard>
 			<div style={ { marginRight: '1rem' } }>
 				<SSHKeyName>
-					{ currentUser.username }-{ sshKey.name }
+					{ userLogin }-{ sshKey.name }
 				</SSHKeyName>
 				<SSHPublicKey>{ sshKey.sha256 }</SSHPublicKey>
 				<SSHKeyAddedDate>
@@ -88,14 +85,21 @@ interface ManageSSHKeyProps {
 	sshKeys: SSHKeyData[];
 	onDelete( name: string ): void;
 	keyBeingDeleted: string | null;
+	userLogin: string;
 }
 
-export const ManageSSHKeys = ( { sshKeys, onDelete, keyBeingDeleted }: ManageSSHKeyProps ) => {
+export const ManageSSHKeys = ( {
+	userLogin,
+	sshKeys,
+	onDelete,
+	keyBeingDeleted,
+}: ManageSSHKeyProps ) => {
 	return (
 		<>
 			{ sshKeys.map( ( sshKey ) => (
 				<SSHKey
 					key={ sshKey.key }
+					userLogin={ userLogin }
 					sshKey={ sshKey }
 					onDelete={ onDelete }
 					keyBeingDeleted={ keyBeingDeleted }

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -150,7 +150,7 @@ export const SecuritySSHKey = () => {
 					/>
 				) : null }
 			</CompactCard>
-			{ hasKeys && currentUser && (
+			{ hasKeys && currentUser?.username && (
 				<ManageSSHKeys
 					userLogin={ currentUser.username }
 					sshKeys={ data }

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
@@ -14,6 +14,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { AddSSHKeyForm } from './add-ssh-key-form';
 import { ManageSSHKeys } from './manage-ssh-keys';
@@ -46,6 +47,7 @@ const sshKeySaveFailureNoticeId = 'ssh-key-save-failure';
 export const SecuritySSHKey = () => {
 	const { data, isLoading } = useSSHKeyQuery();
 	const dispatch = useDispatch();
+	const currentUser = useSelector( getCurrentUser );
 	const { __ } = useI18n();
 
 	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
@@ -148,8 +150,9 @@ export const SecuritySSHKey = () => {
 					/>
 				) : null }
 			</CompactCard>
-			{ hasKeys && (
+			{ hasKeys && currentUser && (
 				<ManageSSHKeys
+					userLogin={ currentUser.username }
 					sshKeys={ data }
 					onDelete={ ( sshKeyName ) => deleteSSHKey( { sshKeyName } ) }
 					keyBeingDeleted={ keyBeingDeleted }

--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -18,7 +18,9 @@ function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
 	return (
 		<Card className="ssh-keys-card">
 			<div className="ssh-keys-card__info">
-				<span className="ssh-keys-card__name">{ user_login }</span>
+				<span className="ssh-keys-card__name">
+					{ user_login }-{ name }
+				</span>
 				<code className="ssh-keys-card__fingerprint">{ sha256 }</code>
 				<span className="ssh-keys-card__date">
 					{ sprintf(

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -70,7 +70,7 @@ function SshKeys( { siteId, username, disabled }: SshKeysProps ) {
 					>
 						{ userKeys?.map( ( key ) => (
 							<option value={ key.name } key={ key.sha256 }>
-								{ key.name }
+								{ username }-{ key.name }
 							</option>
 						) ) }
 					</FormSelect>


### PR DESCRIPTION
See pdKhl6-UP-p2#comment-948

## Proposed Changes

Applies consistent use of `<username>-<key-name>` in the UI.

| Before | After |
|---|---|
| <img width="1145" alt="image" src="https://user-images.githubusercontent.com/36432/196552137-bc54ff68-edee-4840-97f6-df50a60d1d55.png"> | <img width="1132" alt="image" src="https://user-images.githubusercontent.com/36432/196551946-6e41e024-7e47-402c-b00c-d4f5dec851d5.png"> |
| <img width="780" alt="image" src="https://user-images.githubusercontent.com/36432/196552164-dda10747-3989-4d88-a5d1-dfe1962436b9.png"> | <img width="778" alt="image" src="https://user-images.githubusercontent.com/36432/196551994-017c1bd3-c98b-425e-9bf4-e49c5ef11a59.png"> |
| <img width="808" alt="image" src="https://user-images.githubusercontent.com/36432/196552199-e0e1a39d-d72f-46ae-92d8-0096080e3ef2.png"> | <img width="755" alt="image" src="https://user-images.githubusercontent.com/36432/196551966-f2e86bb5-161f-430f-9d3d-7d5b9e8b35e5.png"> |


## Testing Instructions

1. Navigate to `/me/security/ssh-key` and verify SSH key UI appears as expected.
2. Navigate to `/hosting-config/<sitename>` and verify SSH key UI appears as expected.