### PR TITLE
Jetpack Backup: Disable confirm restore button if credentials are invalid

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -339,6 +339,7 @@ class ActivityLogItem extends Component {
 			moment,
 			timezone,
 			translate,
+			disableRestore,
 		} = this.props;
 		const { activityIcon, activityStatus, activityTs } = activity;
 
@@ -362,7 +363,7 @@ class ActivityLogItem extends Component {
 						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
 						title={ translate( 'Restore Site' ) }
-						disableButton={ this.state.disableRestoreButton }
+						disableButton={ this.state.disableRestoreButton || disableRestore }
 					>
 						{ translate( '{{time/}} is the selected point for your site restore.', {
 							components: {

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
+import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack-credentials-status';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
@@ -91,6 +92,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 
 	const renderConfirm = () => (
 		<>
+			{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
 			<div className="rewind-flow__header">
 				<Gridicon icon="history" size={ 48 } />
 			</div>


### PR DESCRIPTION
#### Proposed Changes

* Disable `Confirm restore` button on Restore Site flow when Jetpack credentials are marked as invalid.

#### Screenshots

Component | Valid credentials | Invalid credentials
--- | --- | ---
Jetpack Cloud | ![image](https://user-images.githubusercontent.com/1488641/196559171-254cf692-9834-444d-b5be-79ead8b937fb.png) | ![image](https://user-images.githubusercontent.com/1488641/196559186-29aadc45-4e73-437e-a057-e9fe4c097fbf.png)
Calypso Blue | ![image](https://user-images.githubusercontent.com/1488641/196561737-69b811a6-b245-498b-98ef-538f76addb41.png) | ![image](https://user-images.githubusercontent.com/1488641/196561749-7adc32f0-0c0f-4370-98ff-1a4cc2c3b467.png)
Calypso Blue (Activity Log v1) | ![image](https://user-images.githubusercontent.com/1488641/196565856-441efde1-645d-431c-9637-98c1778c5011.png) | ![image](https://user-images.githubusercontent.com/1488641/196565871-656d7259-8d42-4bba-a928-64515a8dba1f.png)


#### Testing Instructions

* **Self-hosted Jetpack Sites**
  * Go to Jetpack Cloud
  * Grab a site with a Jetpack Backup plan. Preferable, a site you can modify the SSH/SFTP password.
  * Ensure you have working SSH/SFTP credentials on `Settings` page.
  * Navigate to `Activity Log` and `Backup` sections and ensure you can see the `Restore to this point` buttons in green color (that means they are enabled).
  * Modify the SSH/SFTP password on your site server (not on Jetpack Cloud settings).
  * Navigate again to `Backup` page and try to click a `Restore to this point` button quickly to enter `Restore Site` flow.
  * Validate the `Confirm restore` button in Restore Site flow is now greyed out.
  * You can repeat the same test procedure on Calypso Blue.

* **Atomic Sites** _(this is mostly to validate they are not impacted)_
  * Go to Calypso Blue
  * Grab an Atomic Site at WordPress.com with available backups.
  * To break credentials for backups, open the Atomic Site's VPMC and change the site's URL to an invalid URL (it just needs to differ from the actual Atomic site's address, which will break the credentials for backups).
  * Navigate to Jetpack > Backup, click on `Restore to this point` button to enter `Restore Site` flow.
  * Wait a few seconds. The `Confirm restore` button should never be greyed out.

* **Simple Sites**
  * Simple Sites are not impacted by this change.

#### Pre-merge Checklist
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

#### References
* 1202586245449203-as-1203146045571664/f