### PR TITLE
Fix props in wpcom_pattern_inserted event

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -248,13 +248,14 @@ const getBlocksTracker = ( eventName ) => ( blockIds, fromRootClientId, toRootCl
  * inserted pattern replaced blocks.
  *
  * @param {Array} actionData Data supplied to block insertion or replacement tracking functions.
+ * @param {object} additionalData Additional information.
  * @returns {string} Pattern name being inserted if available.
  */
-const maybeTrackPatternInsertion = ( actionData ) => {
+const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 	const meta = find( actionData, ( item ) => item?.patternName );
 	let patternName = meta?.patternName;
 
-	const rootClientId = actionData[ 1 ];
+	const { rootClientId, blocks_replaced } = additionalData;
 	const context = getBlockEventContextProperties( rootClientId );
 
 	// Quick block inserter doesn't use an object to store the patternName
@@ -278,7 +279,7 @@ const maybeTrackPatternInsertion = ( actionData ) => {
 		tracksRecordEvent( 'wpcom_pattern_inserted', {
 			pattern_name: patternName,
 			pattern_category: patternCategory,
-			blocks_replaced: actionData?.blocks_replaced,
+			blocks_replaced,
 			...context,
 		} );
 	}
@@ -294,9 +295,8 @@ const maybeTrackPatternInsertion = ( actionData ) => {
  * @returns {void}
  */
 const trackBlockInsertion = ( blocks, ...args ) => {
-	const patternName = maybeTrackPatternInsertion( { ...args, blocks_replaced: false } );
-
 	const [ , rootClientId ] = args;
+	const patternName = maybeTrackPatternInsertion( args, { rootClientId, blocks_replaced: false } );
 	const context = getBlockEventContextProperties( rootClientId );
 
 	const insert_method = getBlockInserterUsed();
@@ -341,11 +341,10 @@ const trackBlockReplacement = ( originalBlockIds, blocks, ...args ) => {
 		return;
 	}
 
-	const patternName = maybeTrackPatternInsertion( { ...args, blocks_replaced: true } );
-
 	const rootClientId = select( 'core/block-editor' ).getBlockRootClientId(
 		Array.isArray( originalBlockIds ) ? originalBlockIds[ 0 ] : originalBlockIds
 	);
+	const patternName = maybeTrackPatternInsertion( args, { rootClientId, blocks_replaced: true } );
 	const context = getBlockEventContextProperties( rootClientId );
 
 	const insert_method = getBlockInserterUsed( originalBlockIds );

--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -8,11 +8,11 @@ import tracksRecordEvent from './tracking/track-record-event';
  * @returns {(string|undefined)} editor's type
  */
 export const getEditorType = () => {
-	if ( document.querySelector( '.edit-post-layout' ) ) {
+	if ( document.querySelector( '#editor .edit-post-layout' ) ) {
 		return 'post';
 	}
 
-	if ( document.querySelector( '#edit-site-editor' ) ) {
+	if ( document.querySelector( '#site-editor' ) ) {
 		return 'site';
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Fix the `getEditorType` function because the id of site editor is `site-editor` instead of `edit-site-editor`
* Fix the `rootClientId` used in the `maybeTrackPatternInsertion` function. When doing the replacement, the `rootClientId` won't be `actionData[ 1 ];` and it should be derived from the `getBlockRootClientId` selector. As a result, modify the usage of the `maybeTrackPatternInsertion` function to separate `rootClientId` from `actionData` argument to avoid getting the incorrect value.

| Editor | Results |
| - | - |
| Site Editor (Header) | ![image](https://user-images.githubusercontent.com/13596067/196415158-f3a19ee1-e6c0-4e67-9b79-6e930793c426.png) |
| Site Editor (Content) | ![image](https://user-images.githubusercontent.com/13596067/196408945-02f1d709-c785-462f-8207-ba3a392fbce3.png) |
| Post/Page Editor | ![image](https://user-images.githubusercontent.com/13596067/196587759-0e61d06d-c68e-45b1-8a57-4fa93271ccb0.png) |

Note that we cannot insert a pattern via either widget or customizer editor

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proxy `<your_site>` and `widgets.wp.com` to your sandbox
* cd `apps/wpcom-block-editor` and run `yarn dev --sync`
* Go to the site editor
* Insert patterns anywhere, you have to see the `editor_type` is `site` in the `wpcom_pattern_inserted` event
* Insert patterns into the header, you have to see the `template_part_id` is correct in that event

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69052
