### PR TITLE
Apppromo: Add a more inclusive en locale check

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -32,7 +32,7 @@ class MeSidebar extends Component {
 		const { currentUser } = this.props;
 
 		// If user is using en locale, redirect to app promo page on sign out
-		const isEnLocale = currentUser && currentUser.localeSlug === 'en';
+		const isEnLocale = config( 'english_locales' ).includes( currentUser?.localeSlug );
 
 		let redirectTo = null;
 


### PR DESCRIPTION
#### Proposed Changes

* The apppromo landing page is currently not shown to some english variants like `en-gb`. This PR adds a more inclusive check that covers all `en` variants.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out of an account and verify that you are redirected to `/?apppromo`. If you are running Calypso locally, you just need to check the URL in the browser. 

