### PR TITLE
Onboarding standalone installation: Update installation and activation instructions in the thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -9,7 +9,7 @@ const JetpackActivationInstructions: React.FC = () => {
 		<>
 			<p>{ translate( "If you don't have Jetpack installed, follow these instructions:" ) }</p>
 
-			<ul className="licensing-thank-you-manual-activation-instructions__list">
+			<ol className="licensing-thank-you-manual-activation-instructions__list">
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
 					<span>
@@ -44,7 +44,7 @@ const JetpackActivationInstructions: React.FC = () => {
 						) }
 					</span>
 				</li>
-			</ul>
+			</ol>
 
 			<p>
 				<ExternalLink

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -11,37 +11,28 @@ const JetpackActivationInstructions: React.FC = () => {
 
 			<ol className="licensing-thank-you-manual-activation-instructions__list">
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
-					<span>
-						{ translate(
-							'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.',
-							{
-								components: { strong: <strong /> },
-							}
-						) }
-					</span>
+					{ translate( 'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.', {
+						components: { strong: <strong /> },
+					} ) }
 				</li>
 
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
-					<span>
-						{ translate(
-							'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
-							{
-								components: {
-									strong: <strong />,
-									link: (
-										<Button
-											plain
-											href="https://wordpress.org/plugins/jetpack/"
-											target="_blank"
-											rel="noreferrer noopener"
-										/>
-									),
-								},
-							}
-						) }
-					</span>
+					{ translate(
+						'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
+						{
+							components: {
+								strong: <strong />,
+								link: (
+									<Button
+										plain
+										href="https://wordpress.org/plugins/jetpack/"
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							},
+						}
+					) }
 				</li>
 			</ol>
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -1,0 +1,48 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+
+const JetpackActivationInstructions: FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<p>{ translate( "If you don't have Jetpack installed, follow these instructions:" ) }</p>
+
+			<ul className="licensing-thank-you-manual-activation-instructions__list">
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
+					<span>
+						{ ' ' }
+						{ translate(
+							'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.',
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					</span>
+				</li>
+
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
+					<span>
+						{ translate( 'Search for {{strong}}Jetpack{{/strong}}, install and activate.', {
+							components: { strong: <strong /> },
+						} ) }
+					</span>
+				</li>
+			</ul>
+
+			<p>
+				<ExternalLink
+					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
+					icon
+				>
+					{ translate( 'Learn more about how to install Jetpack' ) }
+				</ExternalLink>
+			</p>
+		</>
+	);
+};
+
+export default JetpackActivationInstructions;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -1,8 +1,8 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 
-const JetpackActivationInstructions: FC = () => {
+const JetpackActivationInstructions: React.FC = () => {
 	const translate = useTranslate();
 
 	return (
@@ -26,9 +26,22 @@ const JetpackActivationInstructions: FC = () => {
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
 					<span>
-						{ translate( 'Search for {{strong}}Jetpack{{/strong}}, install and activate.', {
-							components: { strong: <strong /> },
-						} ) }
+						{ translate(
+							'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
+							{
+								components: {
+									strong: <strong />,
+									link: (
+										<Button
+											plain
+											href="https://wordpress.org/plugins/jetpack/"
+											target="_blank"
+											rel="noreferrer noopener"
+										/>
+									),
+								},
+							}
+						) }
 					</span>
 				</li>
 			</ul>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -13,7 +13,6 @@ const JetpackActivationInstructions: React.FC = () => {
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
 					<span>
-						{ ' ' }
 						{ translate(
 							'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.',
 							{

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -1,14 +1,18 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+import { getWPORGPluginLink } from './utils';
 
 interface Props {
 	product: SelectorProduct;
 }
 
-const JetpackStandaloneActivationInstructions: FC< Props > = ( { product } ) => {
+const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product } ) => {
 	const translate = useTranslate();
+
+	const wporgPluginLink = getWPORGPluginLink( product.productSlug );
+
 	return (
 		<>
 			<ul className="licensing-thank-you-manual-activation-instructions__list">
@@ -33,9 +37,19 @@ const JetpackStandaloneActivationInstructions: FC< Props > = ( { product } ) => 
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">3</span>
 					<span>
 						{ translate(
-							'Search for {{strong}}Jetpack %(pluginName)s{{/strong}}, install and activate.',
+							'Search for {{link}}{{strong}}Jetpack %(pluginName)s{{/strong}}{{/link}}, install and activate.',
 							{
-								components: { strong: <strong /> },
+								components: {
+									strong: <strong />,
+									link: (
+										<Button
+											plain
+											href={ wporgPluginLink }
+											target="_blank"
+											rel="noreferrer noopener"
+										/>
+									),
+								},
 								args: { pluginName: product.shortName },
 							}
 						) }

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -25,7 +25,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
 					<span>
 						{ translate(
-							'Go to {{strong}}Plugins > add New{{/strong}} in the admin menu on the left hand side.',
+							'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.',
 							{
 								components: { strong: <strong /> },
 							}

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -1,0 +1,60 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+interface Props {
+	product: SelectorProduct;
+}
+
+const JetpackStandaloneActivationInstructions: FC< Props > = ( { product } ) => {
+	const translate = useTranslate();
+	return (
+		<>
+			<ul className="licensing-thank-you-manual-activation-instructions__list">
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
+					<span>{ translate( 'Login to an existing Wordpress site as an administrator.' ) }</span>
+				</li>
+
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
+					<span>
+						{ translate(
+							'Go to {{strong}}Plugins > add New{{/strong}} in the admin menu on the left hand side.',
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					</span>
+				</li>
+
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">3</span>
+					<span>
+						{ translate(
+							'Search for {{strong}}Jetpack %(pluginName)s{{/strong}}, install and activate.',
+							{
+								components: { strong: <strong /> },
+								args: { pluginName: product.shortName },
+							}
+						) }
+					</span>
+				</li>
+			</ul>
+
+			<p>
+				<ExternalLink
+					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
+					icon
+				>
+					{ translate( 'Learn more about how to install Jetpack %(pluginName)s', {
+						args: { pluginName: product.shortName },
+					} ) }
+				</ExternalLink>
+			</p>
+		</>
+	);
+};
+
+export default JetpackStandaloneActivationInstructions;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -17,40 +17,33 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 		<>
 			<ol className="licensing-thank-you-manual-activation-instructions__list">
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
-					<span>{ translate( 'Login to an existing Wordpress site as an administrator.' ) }</span>
+					{ translate( 'Login to an existing Wordpress site as an administrator.' ) }
 				</li>
 
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
-					<span>
-						{ translate( 'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.', {
-							components: { strong: <strong /> },
-						} ) }
-					</span>
+					{ translate( 'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.', {
+						components: { strong: <strong /> },
+					} ) }
 				</li>
 
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">3</span>
-					<span>
-						{ translate(
-							'Search for {{link}}{{strong}}Jetpack %(pluginName)s{{/strong}}{{/link}}, install and activate.',
-							{
-								components: {
-									strong: <strong />,
-									link: (
-										<Button
-											plain
-											href={ wporgPluginLink }
-											target="_blank"
-											rel="noreferrer noopener"
-										/>
-									),
-								},
-								args: { pluginName: product.shortName },
-							}
-						) }
-					</span>
+					{ translate(
+						'Search for {{link}}{{strong}}Jetpack %(pluginName)s{{/strong}}{{/link}}, install and activate.',
+						{
+							components: {
+								strong: <strong />,
+								link: (
+									<Button
+										plain
+										href={ wporgPluginLink }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							},
+							args: { pluginName: product.shortName },
+						}
+					) }
 				</li>
 			</ol>
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -15,7 +15,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 
 	return (
 		<>
-			<ul className="licensing-thank-you-manual-activation-instructions__list">
+			<ol className="licensing-thank-you-manual-activation-instructions__list">
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
 					<span>{ translate( 'Login to an existing Wordpress site as an administrator.' ) }</span>
@@ -24,12 +24,9 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 				<li className="licensing-thank-you-manual-activation-instructions__list-item">
 					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
 					<span>
-						{ translate(
-							'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.',
-							{
-								components: { strong: <strong /> },
-							}
-						) }
+						{ translate( 'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.', {
+							components: { strong: <strong /> },
+						} ) }
 					</span>
 				</li>
 
@@ -55,7 +52,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 						) }
 					</span>
 				</li>
-			</ul>
+			</ol>
 
 			<p>
 				<ExternalLink

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -9,7 +9,7 @@ import ExternalLink from 'calypso/components/external-link';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { addQueryArgs } from 'calypso/lib/url';
-import { SELECTOR_PLANS } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import hasStandalonePlugin from 'calypso/my-sites/plans/jetpack-plans/has-standalone-plugin';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -122,16 +122,14 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const productWithStandalonePlugin = useMemo( () => {
-		if (
+	const productWithStandalonePlugin = useMemo(
+		() =>
 			isEnabled( 'jetpack/standalone-plugin-onboarding-update-v1' ) &&
-			! SELECTOR_PLANS.includes( productSlug ) // All bundles do not have a standalone plugin
-		) {
-			return slugToSelectorProduct( productSlug );
-		}
-
-		return null;
-	}, [ productSlug ] );
+			hasStandalonePlugin( productSlug )
+				? slugToSelectorProduct( productSlug )
+				: null,
+		[ productSlug ]
+	);
 
 	const onContinue = useCallback( () => {
 		dispatch(

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -29,18 +29,31 @@ const JetpackPluginActivationInstructions: FC = () => {
 	return (
 		<>
 			<p>{ translate( "If you don't have Jetpack installed, follow these instructions:" ) }</p>
-			<p>
-				<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
-				{ translate( 'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.', {
-					components: { strong: <strong /> },
-				} ) }
-			</p>
-			<p>
-				<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
-				{ translate( 'Search for {{strong}}Jetpack{{/strong}}, install and activate.', {
-					components: { strong: <strong /> },
-				} ) }
-			</p>
+
+			<ul className="licensing-thank-you-manual-activation-instructions__list">
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
+					<span>
+						{ ' ' }
+						{ translate(
+							'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.',
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					</span>
+				</li>
+
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
+					<span>
+						{ translate( 'Search for {{strong}}Jetpack{{/strong}}, install and activate.', {
+							components: { strong: <strong /> },
+						} ) }
+					</span>
+				</li>
+			</ul>
+
 			<p>
 				<ExternalLink
 					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
@@ -59,31 +72,37 @@ const JetpackStandaloneActivationInstructions: FC<
 	const translate = useTranslate();
 	return (
 		<>
-			<p>
-				<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
-				{ translate( 'Login to an existing Wordpress site as an administrator.' ) }
-			</p>
+			<ul className="licensing-thank-you-manual-activation-instructions__list">
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
+					<span>{ translate( 'Login to an existing Wordpress site as an administrator.' ) }</span>
+				</li>
 
-			<p>
-				<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
-				{ translate(
-					'Go to {{strong}}Plugins > add New{{/strong}} in the admin menu on the left hand side.',
-					{
-						components: { strong: <strong /> },
-					}
-				) }
-			</p>
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
+					<span>
+						{ translate(
+							'Go to {{strong}}Plugins > add New{{/strong}} in the admin menu on the left hand side.',
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					</span>
+				</li>
 
-			<p>
-				<span className="licensing-thank-you-manual-activation-instructions__step-number">3</span>
-				{ translate(
-					'Search for {{strong}}Jetpack %(pluginName)s{{/strong}}, install and activate.',
-					{
-						components: { strong: <strong /> },
-						args: { pluginName: product.shortName },
-					}
-				) }
-			</p>
+				<li className="licensing-thank-you-manual-activation-instructions__list-item">
+					<span className="licensing-thank-you-manual-activation-instructions__step-number">3</span>
+					<span>
+						{ translate(
+							'Search for {{strong}}Jetpack %(pluginName)s{{/strong}}, install and activate.',
+							{
+								components: { strong: <strong /> },
+								args: { pluginName: product.shortName },
+							}
+						) }
+					</span>
+				</li>
+			</ul>
 
 			<p>
 				<ExternalLink

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -9,7 +9,7 @@ import ExternalLink from 'calypso/components/external-link';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { addQueryArgs } from 'calypso/lib/url';
-import hasStandalonePlugin from 'calypso/my-sites/plans/jetpack-plans/has-standalone-plugin';
+import { isJetpackStandaloneProduct } from 'calypso/my-sites/plans/jetpack-plans/is-jetpack-standalone-product';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -122,10 +122,10 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const productWithStandalonePlugin = useMemo(
+	const jetpackStandaloneProduct = useMemo(
 		() =>
 			isEnabled( 'jetpack/standalone-plugin-onboarding-update-v1' ) &&
-			hasStandalonePlugin( productSlug )
+			isJetpackStandaloneProduct( productSlug )
 				? slugToSelectorProduct( productSlug )
 				: null,
 		[ productSlug ]
@@ -157,9 +157,9 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 			/>
 			<LicensingActivation
 				title={
-					productWithStandalonePlugin
+					jetpackStandaloneProduct
 						? translate( `Ok, let's install Jetpack %(pluginName)s`, {
-								args: { pluginName: productWithStandalonePlugin?.shortName },
+								args: { pluginName: jetpackStandaloneProduct?.shortName },
 						  } )
 						: translate( 'Be sure that you have the latest version of Jetpack' )
 				}
@@ -169,8 +169,8 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 				progressIndicatorValue={ 2 }
 				progressIndicatorTotal={ 3 }
 			>
-				{ productWithStandalonePlugin ? (
-					<JetpackStandaloneActivationInstructions product={ productWithStandalonePlugin } />
+				{ jetpackStandaloneProduct ? (
+					<JetpackStandaloneActivationInstructions product={ jetpackStandaloneProduct } />
 				) : (
 					<JetpackPluginActivationInstructions />
 				) }

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -5,118 +5,19 @@ import page from 'page';
 import { FC, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import licensingActivationPluginInstall from 'calypso/assets/images/jetpack/licensing-activation-plugin-install.svg';
-import ExternalLink from 'calypso/components/external-link';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { addQueryArgs } from 'calypso/lib/url';
 import { isJetpackStandaloneProduct } from 'calypso/my-sites/plans/jetpack-plans/is-jetpack-standalone-product';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
-import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import JetpackActivationInstructions from './jetpack-activation-instructions';
+import JetpackStandaloneActivationInstructions from './jetpack-standalone-activation-instructions';
 
 interface Props {
 	productSlug: string | 'no_product';
 	receiptId: number;
 }
-
-interface JetpackStandaloneActivationInstructionsProps {
-	product: SelectorProduct;
-}
-
-const JetpackPluginActivationInstructions: FC = () => {
-	const translate = useTranslate();
-
-	return (
-		<>
-			<p>{ translate( "If you don't have Jetpack installed, follow these instructions:" ) }</p>
-
-			<ul className="licensing-thank-you-manual-activation-instructions__list">
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
-					<span>
-						{ ' ' }
-						{ translate(
-							'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.',
-							{
-								components: { strong: <strong /> },
-							}
-						) }
-					</span>
-				</li>
-
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
-					<span>
-						{ translate( 'Search for {{strong}}Jetpack{{/strong}}, install and activate.', {
-							components: { strong: <strong /> },
-						} ) }
-					</span>
-				</li>
-			</ul>
-
-			<p>
-				<ExternalLink
-					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
-					icon
-				>
-					{ translate( 'Learn more about how to install Jetpack' ) }
-				</ExternalLink>
-			</p>
-		</>
-	);
-};
-
-const JetpackStandaloneActivationInstructions: FC<
-	JetpackStandaloneActivationInstructionsProps
-> = ( { product } ) => {
-	const translate = useTranslate();
-	return (
-		<>
-			<ul className="licensing-thank-you-manual-activation-instructions__list">
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">1</span>
-					<span>{ translate( 'Login to an existing Wordpress site as an administrator.' ) }</span>
-				</li>
-
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">2</span>
-					<span>
-						{ translate(
-							'Go to {{strong}}Plugins > add New{{/strong}} in the admin menu on the left hand side.',
-							{
-								components: { strong: <strong /> },
-							}
-						) }
-					</span>
-				</li>
-
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					<span className="licensing-thank-you-manual-activation-instructions__step-number">3</span>
-					<span>
-						{ translate(
-							'Search for {{strong}}Jetpack %(pluginName)s{{/strong}}, install and activate.',
-							{
-								components: { strong: <strong /> },
-								args: { pluginName: product.shortName },
-							}
-						) }
-					</span>
-				</li>
-			</ul>
-
-			<p>
-				<ExternalLink
-					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
-					icon
-				>
-					{ translate( 'Learn more about how to install Jetpack %(pluginName)s', {
-						args: { pluginName: product.shortName },
-					} ) }
-				</ExternalLink>
-			</p>
-		</>
-	);
-};
 
 const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId } ) => {
 	const translate = useTranslate();
@@ -172,7 +73,7 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 				{ jetpackStandaloneProduct ? (
 					<JetpackStandaloneActivationInstructions product={ jetpackStandaloneProduct } />
 				) : (
-					<JetpackPluginActivationInstructions />
+					<JetpackActivationInstructions />
 				) }
 
 				<Button

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -743,6 +743,17 @@
 	}
 }
 
+.licensing-thank-you-manual-activation-instructions__list {
+	list-style: none;
+	margin: 0;
+}
+
+.licensing-thank-you-manual-activation-instructions__list-item {
+	display: flex;
+	align-items: center;
+	margin-bottom: 24px;
+}
+
 .licensing-thank-you-manual-activation-instructions__step-number {
 	display: inline-flex;
 	justify-content: center;
@@ -758,7 +769,7 @@
 
 	border-radius: 24px; /* stylelint-disable-line scales/radii */
 
-	width: 28px;
+	min-width: 28px;
 	height: 28px;
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -744,33 +744,33 @@
 }
 
 .licensing-thank-you-manual-activation-instructions__list {
-	list-style: none;
 	margin: 0;
+
+	list-style: none;
+	counter-reset: item;
 }
 
 .licensing-thank-you-manual-activation-instructions__list-item {
-	display: flex;
-	align-items: center;
-	margin-bottom: 24px;
-}
+	margin-bottom: 1.5rem;
 
-.licensing-thank-you-manual-activation-instructions__step-number {
-	display: inline-flex;
-	justify-content: center;
-	align-items: center;
+	&::before {
+		content: counter(item);
+		counter-increment: item;
 
-	margin-right: 12px;
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
 
-	font-weight: bold;
-	text-align: center;
-	color: var(--color-text-inverted);
+		min-width: 1.75em;
+		height: 1.75em;
+		margin-inline-end: 0.75em;
 
-	background-color: var(--studio-jetpack-green-40);
+		background-color: var(--studio-jetpack-green-40);
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		color: var(--color-text-inverted);
 
-	border-radius: 24px; /* stylelint-disable-line scales/radii */
-
-	min-width: 28px;
-	height: 28px;
+		font-weight: 700;
+	}
 }
 
 .licensing-activation .licensing-thank-you-manual-activation-instructions__button.button {

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -1,4 +1,31 @@
+import {
+	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_BOOST_PRODUCTS,
+	JETPACK_SOCIAL_PRODUCTS,
+	JETPACK_SEARCH_PRODUCTS,
+} from '@automattic/calypso-products';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
+
+const setWPORGPluginSlug = ( productSlugs: ReadonlyArray< string >, wporgPluginSlug: string ) => {
+	return productSlugs.reduce(
+		( map, productSlug ) => ( { ...map, [ productSlug ]: wporgPluginSlug } ),
+		{}
+	);
+};
+
+const WPORG_PLUGIN_SLUG_MAP: Record< string, string > = {
+	...setWPORGPluginSlug( JETPACK_BACKUP_PRODUCTS, 'jetpack-backup' ),
+	...setWPORGPluginSlug( JETPACK_BOOST_PRODUCTS, 'jetpack-boost' ),
+	...setWPORGPluginSlug( JETPACK_SOCIAL_PRODUCTS, 'jetpack-social' ),
+	...setWPORGPluginSlug( JETPACK_SEARCH_PRODUCTS, 'jetpack-search' ),
+	// ...setWPORGPluginSlug( JETPACK_SCAN_PRODUCTS, 'jetpack-protect' ),
+};
+
+export function getWPORGPluginLink( productSlug: string ): string {
+	const wporgPluginSlug = WPORG_PLUGIN_SLUG_MAP[ productSlug ];
+
+	return wporgPluginSlug ? `https://wordpress.org/plugins/${ wporgPluginSlug }/` : '';
+}
 
 export function getDomainManagementUrl(
 	{ slug }: { slug: string },

--- a/client/my-sites/plans/jetpack-plans/has-standalone-plugin.ts
+++ b/client/my-sites/plans/jetpack-plans/has-standalone-plugin.ts
@@ -1,0 +1,28 @@
+import {
+	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_BOOST_PRODUCTS,
+	JETPACK_CRM_PRODUCTS,
+	JETPACK_SEARCH_PRODUCTS,
+	JETPACK_SOCIAL_PRODUCTS,
+} from '@automattic/calypso-products';
+
+const ALL_PRODUCTS_WITH_STANDALONE_PLUGIN = [
+	...JETPACK_BACKUP_PRODUCTS,
+	...JETPACK_BOOST_PRODUCTS,
+	...JETPACK_SOCIAL_PRODUCTS,
+	...JETPACK_CRM_PRODUCTS,
+	...JETPACK_SEARCH_PRODUCTS,
+] as ReadonlyArray< string >;
+
+/**
+ * Determines if a product slug has a standalone plugin.
+ *
+ * @example
+ * jetpack_backup_daily	      > true
+ * jetpack_security_t1_yearly > false
+ * @param {string} productSlug Product slug
+ * @returns {boolean} Parameters
+ */
+export default ( productSlug: string ): boolean => {
+	return ALL_PRODUCTS_WITH_STANDALONE_PLUGIN.includes( productSlug );
+};

--- a/client/my-sites/plans/jetpack-plans/is-jetpack-standalone-product.ts
+++ b/client/my-sites/plans/jetpack-plans/is-jetpack-standalone-product.ts
@@ -6,7 +6,7 @@ import {
 	JETPACK_SOCIAL_PRODUCTS,
 } from '@automattic/calypso-products';
 
-const ALL_PRODUCTS_WITH_STANDALONE_PLUGIN = [
+const ALL_JETPACK_STANDALONE_PRODUCTS = [
 	...JETPACK_BACKUP_PRODUCTS,
 	...JETPACK_BOOST_PRODUCTS,
 	...JETPACK_SOCIAL_PRODUCTS,
@@ -15,7 +15,7 @@ const ALL_PRODUCTS_WITH_STANDALONE_PLUGIN = [
 ] as ReadonlyArray< string >;
 
 /**
- * Determines if a product slug has a standalone plugin.
+ * Determines if a Jetpack product is a standalone product.
  *
  * @example
  * jetpack_backup_daily	      > true
@@ -23,6 +23,6 @@ const ALL_PRODUCTS_WITH_STANDALONE_PLUGIN = [
  * @param {string} productSlug Product slug
  * @returns {boolean} Parameters
  */
-export default ( productSlug: string ): boolean => {
-	return ALL_PRODUCTS_WITH_STANDALONE_PLUGIN.includes( productSlug );
+export const isJetpackStandaloneProduct = ( productSlug: string ): boolean => {
+	return ALL_JETPACK_STANDALONE_PRODUCTS.includes( productSlug );
 };


### PR DESCRIPTION
### Proposed Changes

* Update the Activation instruction page to display a standalone plugin specific installation and activation guide for all products **(Backup, Boost, Social, CRM, Search)** with equivalent standalone plugins.

_Note: The Learn more button will redirect you to the all-in-one Jetpack plugin installation support document. The correct links will be handled in a separate PR. The image will also be updated in a separate PR._

#### Current Installation guide
<img width="1226" alt="Screen Shot 2022-10-19 at 1 35 21 PM" src="https://user-images.githubusercontent.com/56598660/196605798-2e892b83-2517-4d40-bb9e-ecbf21299ca5.png">

#### Standalone plugin specific installation guide
<img width="1237" alt="Screen Shot 2022-10-20 at 2 02 41 PM" src="https://user-images.githubusercontent.com/56598660/196868631-33b37bcb-9839-482f-b9b3-509c4101cba1.png">

* Render hyperlinks to the Jetpack WP.org plugin directory.
<img width="1225" alt="Screen Shot 2022-10-20 at 2 01 50 PM" src="https://user-images.githubusercontent.com/56598660/196868440-96266fd5-20d4-4094-bb1a-2c0d7eaba61d.png">

### Testing Instructions

1. * Run `git fetch && git checkout add/new-standalone-plugin-activation-instruction`
    * Run `yarn start`
2. Confirm that the new standalone plugins installation guide displayed in the thank you page.
    * Go to `http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-manual-activate-instructions/<PRODUCT_SLUG>?flags=jetpack/standalone-plugin-onboarding-update-v1` or use the Calypso live link and goto `/checkout/jetpack/thank-you/licensing-manual-activate-instructions/<PRODUCT_SLUG>?flags=jetpack/standalone-plugin-onboarding-update-v1`.
     * Make sure you replace <PRODUCT_SLUG> with actual slugs. refer to the table below on which product slugs display the new instructions.
     
     | Product Slug        | Displayed instructions  |
     | ------------- |:-------------:| 
     |  jetpack_boost_yearly | Standalone |
     | jetpack_boost_monthly | Standalone |
     | jetpack_backup | Standalone |
     | jetpack_backup_t1_yearly | Standalone |
     | jetpack_backup_t1_monthly | Standalone |
     | jetpack_backup_t2_yearly | Standalone |
     | jetpack_backup_t2_monthly | Standalone |
     | jetpack_backup_daily | Standalone |
     | jetpack_backup_realtime | Standalone |
     | jetpack_backup_daily_monthly | Standalone |
     | jetpack_backup_realtime_monthly | Standalone |
     | jetpack_scan | old |
     | jetpack_scan_monthly | old |
     | jetpack_scan_realtime | old |
     | jetpack_scan_realtime_monthly | old |
     | jetpack_anti_spam | old |
     | jetpack_anti_spam_monthly | old |
     | jetpack_search | Standalone |
     | jetpack_search_free | Standalone |
     | jetpack_search_monthly | Standalone |
     | jetpack_crm | Standalone |
     | jetpack_crm_monthly | Standalone |
     | jetpack_videopress | old |
     | jetpack_videopress_monthly | old |
     | jetpack_social_basic_yearly | Standalone |
     | jetpack_social_basic_monthly | Standalone |
     | jetpack_personal | old |
     | jetpack_personal_monthly | old |
     | jetpack_premium | old |
     | jetpack_premium_monthly | old |
     | jetpack_business | old |
     | jetpack_business_monthly | old |
     | jetpack_security_t1_yearly | old |
     | jetpack_security_t1_monthly | old |
     | jetpack_security_t2_yearly | old |
     | jetpack_security_t2_monthly | old |
     | jetpack_complete | old |
     | jetpack_complete_monthly | old |
     | jetpack_security_daily | old |
     | jetpack_security_daily_monthly | old |
     | jetpack_security_realtime | old |
     | jetpack_security_realtime_monthly | old |
3. Confirm that the page renders a hyperlink that redirects to the appropriate plugin directory. (eg. Jetpack Boost redirects to https://wordpress.org/plugins/jetpack-boost/)
 
<img width="954" alt="Screen Shot 2022-10-20 at 2 07 25 PM" src="https://user-images.githubusercontent.com/56598660/196869190-cf6f3f89-d96d-4b72-9234-b371ae36f799.png">


### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203097885147382-as-1203171921722447

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203159154260037
  - 0-as-1203171921722447