### PR TITLE
Dev Tools: Add Dashboard Colour Scheme picker to `<AccountSettingsHelper/>`

### DIFF
--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -1,8 +1,10 @@
 import languages from '@automattic/languages';
 import ReactDom from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import LanguagePicker from 'calypso/components/language-picker';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { setUserSetting } from 'calypso/state/user-settings/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
@@ -14,6 +16,8 @@ export function AccountSettingsHelper() {
 	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings ) ?? {};
 	const isFetching = useSelector( isFetchingUserSettings );
+	const colorSchemePreference = useSelector( ( state ) => getPreference( state, 'colorScheme' ) );
+
 	const updateLanguage = ( event ) => {
 		const { value, empathyMode, useFallbackForIncompleteLanguages } = event.target;
 		if ( typeof empathyMode !== 'undefined' ) {
@@ -40,6 +44,7 @@ export function AccountSettingsHelper() {
 			<QueryUserSettings />
 			<div>Account Settings</div>
 			<div className="account-settings-helper__popover">
+				<div>Language Picker</div>
 				<LanguagePicker
 					isLoading={ isFetching }
 					languages={ languages }
@@ -49,6 +54,8 @@ export function AccountSettingsHelper() {
 					useFallbackForIncompleteLanguages={ userSettings?.use_fallback_for_incomplete_languages }
 					onChange={ updateLanguage }
 				/>
+				<div>Dashboard color scheme</div>
+				<ColorSchemePicker defaultSelection={ colorSchemePreference } />
 			</div>
 		</>
 	);

--- a/client/lib/account-settings-helper/style.scss
+++ b/client/lib/account-settings-helper/style.scss
@@ -3,10 +3,19 @@
 }
 
 .environment.is-account-settings:hover .account-settings-helper__popover {
-	display: block;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 	position: absolute;
 	bottom: 100%;
-	padding: 4px;
+	padding: 8px;
+	max-height: 80vh;
 	background: var(--color-surface);
 	box-shadow: 0 0 0 1px var(--color-border-subtle);
+}
+
+.account-settings-helper__popover .color-scheme-picker {
+	display: flex;
+	flex: 1;
+	overflow: auto;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/69084

#### Proposed Changes

* Allow changing the Dashboard Colour Scheme via Dev Tools.

**Note**: in the video, you can see a minor issue where the picker selection and dashboard theme are sometimes out of sync. I opted not to deal with this as it's only a problem when you change the colour scheme rapidly. Let me know if you think it's worth the trouble. Another thing, we might want to delay closing the menu when the mouse exists as it's a bit awkward to use currently. 

https://user-images.githubusercontent.com/6851384/196612046-e8f31d49-3f42-4b95-a408-b8f05edec374.mp4



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it out and see what you think. Can you think of any improvements?

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #