### PR TITLE
Pattern assembler: create custom Home template

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -11,13 +12,14 @@ import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
-import { encodePatternId } from './utils';
+import { encodePatternId, createCustomHomeTemplateContent } from './utils';
 import type { Step } from '../../types';
 import type { Pattern } from './types';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 const PatternAssembler: Step = ( { navigation } ) => {
+	const translate = useTranslate();
 	const [ showPatternSelectorType, setShowPatternSelectorType ] = useState< string | null >( null );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
 	const [ footer, setFooter ] = useState< Pattern | null >( null );
@@ -26,7 +28,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const incrementIndexRef = useRef( 0 );
 	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
 	const { goBack, goNext, submit } = navigation;
-	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const { setDesignOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -82,16 +84,6 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				footer_pattern_ids: footer ? [ encodePatternId( footer.id ) ] : undefined,
 			} as DesignRecipe,
 		} as Design );
-
-	const getPageTemplate = () => {
-		let pageTemplate = 'footer-only';
-
-		if ( header ) {
-			pageTemplate = 'header-footer-only';
-		}
-
-		return pageTemplate;
-	};
 
 	const setScrollToSelectorByPosition = ( position: number ) => {
 		const patternPosition = header ? position + 1 : position;
@@ -242,12 +234,18 @@ const PatternAssembler: Step = ( { navigation } ) => {
 						onContinueClick={ () => {
 							if ( siteSlugOrId ) {
 								const design = getDesign();
-								const pageTemplate = getPageTemplate();
+								const stylesheet = design.recipe!.stylesheet!;
 
 								setPendingAction( () =>
-									setDesignOnSite( siteSlugOrId, design, { pageTemplate } ).then( () =>
-										reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
+									createCustomTemplate(
+										siteSlugOrId,
+										stylesheet,
+										'home',
+										translate( 'Home' ),
+										createCustomHomeTemplateContent( stylesheet, !! header, !! footer )
 									)
+										.then( () => setDesignOnSite( siteSlugOrId, design ) )
+										.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 								);
 
 								trackEventContinue();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -20,3 +20,31 @@ export const handleKeyboard =
 			callback();
 		}
 	};
+
+export function createCustomHomeTemplateContent(
+	stylesheet: string,
+	hasHeader: boolean,
+	hasFooter: boolean
+) {
+	const content: string[] = [];
+
+	if ( hasHeader ) {
+		content.push(
+			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
+		);
+	}
+
+	content.push( `
+<!-- wp:group {"tagName":"main"} -->
+	<main class="wp-block-group">
+	</main>
+<!-- /wp:group -->` );
+
+	if ( hasFooter ) {
+		content.push(
+			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
+		);
+	}
+
+	return content.join( '\n' );
+}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -356,7 +356,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			path: `/sites/${ encodeURIComponent( siteSlug ) }/templates`,
 			apiNamespace: 'wp/v2',
 			body: {
-				id: `${ stylesheet }//wp-custom-template-${ slug }`,
 				slug,
 				theme: stylesheet,
 				title,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -334,10 +334,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				themeSetupOptions.footer_pattern_ids = recipe?.footer_pattern_ids;
 			}
 
-			if ( options?.pageTemplate ) {
-				themeSetupOptions.page_template = options?.pageTemplate;
-			}
-
 			const response: { blog: string } = yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',
@@ -347,6 +343,29 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 			return response;
 		}
+	}
+
+	function* createCustomTemplate(
+		siteSlug: string,
+		stylesheet: string,
+		slug: string,
+		title: string,
+		content: string
+	) {
+		yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/templates`,
+			apiNamespace: 'wp/v2',
+			body: {
+				id: `${ stylesheet }//wp-custom-template-${ slug }`,
+				slug,
+				theme: stylesheet,
+				title,
+				content,
+				status: 'publish',
+				is_wp_suggestion: true,
+			},
+			method: 'POST',
+		} );
 	}
 
 	const setSiteSetupError = ( error: string, message: string ) => ( {
@@ -545,6 +564,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		resetNewSiteFailed,
 		setThemeOnSite,
 		setDesignOnSite,
+		createCustomTemplate,
 		createSite,
 		receiveSite,
 		receiveSiteFailed,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -462,5 +462,4 @@ export interface ThemeSetupOptions {
 	pattern_ids?: number[] | string[];
 	header_pattern_ids?: number[] | string[];
 	footer_pattern_ids?: number[] | string[];
-	page_template?: string;
 }


### PR DESCRIPTION
#### Proposed Changes

As discussed [here](pbxlJb-2t3-p2#comment-1875), we will create a custom Home template. The template consists of:

- header template part (if the user selects a header)
- selected content/section patterns
- footer template part (if the user selects a header)

The selected content/section patterns will be populated by the actual pattern html during Headstart.

#### Testing Instructions

This PR assumes that the PA flow uses the new "Clean Slate" theme, which:

- sets the Reading settings to `latest posts`
- does not come with default Home template
- does not create a Home page

Because the new theme is not released, we can work around it by following these instructions:

1. Sandbox your public-api.
2. Modify the following in `wp-content/themes/pub/blank-canvas-blocks/inc/headstart/en.json`:

```diff
-             "show_on_front": "page",
+             "show_on_front": "posts",
```

```diff
-     "content": [
-         {
-             "post_type": "page",
-             "post_title": "Home",
-             "post_content": "<!-- wp:cover {\"overlayColor\":\"background\",\"minHeight\":50,\"minHeightUnit\":\"vh\",\"isDark\":false} -->\n<div class=\"wp-block-cover is-light\" style=\"min-height:50vh;\"><span aria-hidden=\"true\" class=\"has-background-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim\"><\/span><div class=\"wp-block-cover__inner-container\"><!-- wp:spacer -->\n<div style=\"height:100px;\" aria-hidden=\"true\" class=\"wp-block-spacer\"><\/div>\n<!-- \/wp:spacer --><\/div><\/div>\n<!-- \/wp:cover -->\n\n<!-- wp:paragraph -->\n<p><\/p>\n<!-- \/wp:paragraph -->",
-             "post_name": "home-2",
-             "post_excerpt": "",
-             "menu_order": 1,
-             "post_status": "publish",
-             "comment_status": "closed",
-             "ping_status": "closed",
-             "_starter_page_template": "",
-             "hs_old_id": 17,
-             "hs_post_parent": 0,
-             "hs_taxonomies": [],
-             "hs_custom_meta": "_hs_front_page",
-             "page_template": "footer-only"
-         }
-     ],
+     "content": [],
```

3. Rename `wp-content/themes/pub/blank-canvas-blocks/block-templates/home.html` to something else for backup, e.g. `old-home.html`.
4. Run this PR locally or via the Calypso Live link.
5. Finish the PA flow. Don't forget to also add header and footer.
6. You will land in the Site Editor.
7. Verify that the Home template is used, and the Site Editor shows your header, content, and footer:
    
   <img width="1223" alt="image" src="https://user-images.githubusercontent.com/1525580/196630338-6c5e4625-06f5-44e8-925c-a8d98db9f892.png">

8. Go to the Templates list, make sure that the Home template is listed and created by you:

   <img width="884" alt="image" src="https://user-images.githubusercontent.com/1525580/196630808-f5877d69-380e-4c22-9f05-e30d97284eda.png">

9. Visit the site, and verify that the homepage is shown correctly.

   <img width="1221" alt="image" src="https://user-images.githubusercontent.com/1525580/196631021-c3ec3de8-4bc0-4080-825a-3896b94b0483.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- #69015