### PR TITLE
promote-post: Preserve BlazePress strings in production

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -5,11 +5,6 @@ import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
-// Import translatable strings so that translations get associated with the module and loaded properly.
-// The module will assign the placeholder component to `window.BlazePress.strings` as a side-effect,
-// in order to ensure that translate calls are not removed from the production build.
-import './string';
-
 declare global {
 	interface Window {
 		BlazePress?: {
@@ -41,6 +36,10 @@ export async function loadDSPWidgetJS(): Promise< void > {
 	const src =
 		config( 'dsp_widget_js_src' ) + '?ver=' + Math.round( Date.now() / ( 1000 * 60 * 60 ) );
 	await loadScript( src );
+	// Load the strings so that translations get associated with the module and loaded properly.
+	// The module will assign the placeholder component to `window.BlazePress.strings` as a side-effect,
+	// in order to ensure that translate calls are not removed from the production build.
+	await import( './string' );
 }
 
 export async function showDSP(

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -6,6 +6,8 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/ana
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 // Import translatable strings so that translations get associated with the module and loaded properly.
+// The module will assign the placeholder component to `window.BlazePress.strings` as a side-effect,
+// in order to ensure that translate calls are not removed from the production build.
 import './string';
 
 declare global {
@@ -26,6 +28,7 @@ declare global {
 				translateFn?: ( value: string, options?: any ) => string;
 				showDialog?: boolean;
 			} ) => void;
+			strings: any;
 		};
 	}
 }

--- a/client/lib/promote-post/package.json
+++ b/client/lib/promote-post/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": true
+}

--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const BlazePressStrings = () => {
 	const translate = useTranslate();
 	translate(
@@ -78,3 +77,7 @@ const BlazePressStrings = () => {
 	translate( 'Drop image here' );
 	translate( 'Click or Drag an image here' );
 };
+
+if ( window.BlazePress ) {
+	window.BlazePress.strings = BlazePressStrings;
+}


### PR DESCRIPTION
#### Proposed Changes

* This PR adds conditionally assigning the `BlazePressStrings` placeholder component to `window.BlazePress.strings` as a workaround for the tree shaking, that would otherwise remove the component and the translate calls used within from the production build. Despite not actually being rendered, the component code is needed in the build files in order to have the translations properly assigned with the JS chunk that loads the widget.

The script that generates the `strings.ts` module will be updated accordingly on BlazePress' end.

#### Testing Instructions

* Use calypso.live build.
* Change UI to a Mag-16 language.
* Go to `/posts/{site}` and open the BlazePress widget from "Promote post" post actions dropdown.
* Confirm that all strings that are currently translated in GlotPress are being rendered translated.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1666116829060879-slack-C74C3THK7
