### PR TITLE
Add subscribers: Show notification once the import job is successfully submitted

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -17,6 +17,7 @@ import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import isEligibleForSubscriberImporter from 'calypso/state/selectors/is-eligible-for-subscriber-importer';
 import InviteButton from '../invite-button';
 
@@ -141,6 +142,11 @@ class Followers extends Component {
 									recordTracksEvent={ recordTracksEvent }
 									onImportFinished={ () => {
 										this.props?.refetch?.();
+										this.props?.successNotice(
+											this.props.translate(
+												'Your subscriber list is being processed. Please check your email for status.'
+											)
+										);
 									} }
 								/>
 							</EmailVerificationGate>
@@ -263,4 +269,7 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps, { recordGoogleEvent } )( localize( Followers ) );
+export default connect( mapStateToProps, {
+	recordGoogleEvent,
+	successNotice,
+} )( localize( Followers ) );

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, defer } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -20,6 +20,7 @@ import {
 	getNumberOfInvitesFoundForSite,
 	isDeletingAnyInvite,
 } from 'calypso/state/invites/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -81,6 +82,13 @@ class PeopleInvites extends PureComponent {
 							recordTracksEvent={ recordTracksEvent }
 							onImportFinished={ () => {
 								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
+								defer( () => {
+									this.props.successNotice(
+										this.props.translate(
+											'Your subscriber list is being processed. Please check your email for status.'
+										)
+									);
+								} );
 							} }
 						/>
 					</EmailVerificationGate>
@@ -90,19 +98,24 @@ class PeopleInvites extends PureComponent {
 	}
 }
 
-export default connect( ( state ) => {
-	const site = getSelectedSite( state );
-	const siteId = site && site.ID;
+export default connect(
+	( state ) => {
+		const site = getSelectedSite( state );
+		const siteId = site && site.ID;
 
-	return {
-		site,
-		isJetpack: isJetpackSite( state, siteId ),
-		isPrivate: isPrivateSite( state, siteId ),
-		requesting: isRequestingInvitesForSite( state, siteId ),
-		pendingInvites: getPendingInvitesForSite( state, siteId ),
-		acceptedInvites: getAcceptedInvitesForSite( state, siteId ),
-		totalInvitesFound: getNumberOfInvitesFoundForSite( state, siteId ),
-		deleting: isDeletingAnyInvite( state, siteId ),
-		canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
-	};
-} )( localize( PeopleInvites ) );
+		return {
+			site,
+			isJetpack: isJetpackSite( state, siteId ),
+			isPrivate: isPrivateSite( state, siteId ),
+			requesting: isRequestingInvitesForSite( state, siteId ),
+			pendingInvites: getPendingInvitesForSite( state, siteId ),
+			acceptedInvites: getAcceptedInvitesForSite( state, siteId ),
+			totalInvitesFound: getNumberOfInvitesFoundForSite( state, siteId ),
+			deleting: isDeletingAnyInvite( state, siteId ),
+			canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
+		};
+	},
+	{
+		successNotice: successNotice,
+	}
+)( localize( PeopleInvites ) );


### PR DESCRIPTION
#### Proposed Changes

Show notification once the import job is successfully submitted.

Changes are tested against the `D90024`, and all looks OK.

#### Testing Instructions

* Go to `/people/team/{SLUG}`
* Select the `Email Subscribers` tab
* Try to import the subscribers' list
* Check if there is a notification in the top right corner saying `Your subscriber list is being processed. Please check your email for status.`

#### Screenshots

![Screen Capture on 2022-10-19 at 14-47-43](https://user-images.githubusercontent.com/1241413/196696390-3700a272-8828-49de-8b25-770c5b9fbf92.gif)

![Screen Capture on 2022-10-19 at 14-49-09](https://user-images.githubusercontent.com/1241413/196696352-8d8801b9-3f27-4430-97f4-bff6aa8e2d60.gif)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #68986
