### PR TITLE
Subscriber form: Replace redirection with resetting form state on import job submission

### DIFF
--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -81,7 +81,6 @@ class PeopleInvites extends PureComponent {
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 							recordTracksEvent={ recordTracksEvent }
 							onImportFinished={ () => {
-								page.redirect( `/people/email-followers/${ this.props.site.slug }` );
 								defer( () => {
 									this.props.successNotice(
 										this.props.translate(

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -210,8 +210,20 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		return !! allowEmptyFormSubmit || !! getValidEmails().length || !! selectedFile;
 	}
 
+	function resetFormState(): void {
+		setEmails( [] );
+		setSelectedFile( undefined );
+		importCsvSubscribersUpdate( undefined );
+		setIsSelectedFileValid( true );
+		setIsValidEmails( [] );
+		setIsDirtyEmails( [] );
+	}
+
 	function importFinishedRecognition() {
-		! importSelector?.error && prevInProgress.current && ! inProgress && onImportFinished?.();
+		if ( ! importSelector?.error && prevInProgress.current && ! inProgress ) {
+			resetFormState();
+			onImportFinished?.();
+		}
 	}
 
 	function includesHandledError() {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -47,7 +47,7 @@
 	.add-subscriber__form--container input {
 		&:focus {
 			border-color: var(--color-primary);
-			box-shadow: 0 0 0 2px var(--color-primary-10);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 			outline: none;
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

* Update input focus color
* Replace redirection with resetting form state on import job submission


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/email-followers/{SLUG}`
* Click on `Add Subscribers
* Check if the form resets on submitting the import job

#### Screenshot

<table>
<tr>
<td width="50%">Before:</td>
<td width="50%">After:</td>
</tr>
<tr>
<td width="50%">
<img width="741" alt="Screenshot 2022-10-19 at 16 46 43" src="https://user-images.githubusercontent.com/1241413/196724635-5205686d-95c5-43fe-9921-7e2c23f54b30.png">
</td>
<td width="50%">
<img width="737" alt="Screenshot 2022-10-19 at 16 46 51" src="https://user-images.githubusercontent.com/1241413/196724669-8b5a708b-f9b3-464a-8f37-af8471a39192.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
