### PR TITLE
SSH: disable the react queries persistence for SSH queries

### DIFF
--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -25,8 +25,15 @@ export interface SSHKeyData {
 export const SSH_KEY_QUERY_KEY = [ 'me', 'ssh-keys' ];
 
 export const useSSHKeyQuery = () =>
-	useQuery( SSH_KEY_QUERY_KEY, (): SSHKeyData[] =>
-		wp.req.get( '/me/ssh-keys', {
-			apiNamespace: 'wpcom/v2',
-		} )
+	useQuery(
+		SSH_KEY_QUERY_KEY,
+		(): SSHKeyData[] =>
+			wp.req.get( '/me/ssh-keys', {
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			meta: {
+				persist: false,
+			},
+		}
 	);

--- a/client/my-sites/hosting/sftp-card/use-atomic-ssh-keys.ts
+++ b/client/my-sites/hosting/sftp-card/use-atomic-ssh-keys.ts
@@ -23,6 +23,9 @@ export const useAtomicSshKeys = ( siteId: number, options: UseQueryOptions ) => 
 			select: ( data ) => {
 				return data.ssh_keys;
 			},
+			meta: {
+				persist: false,
+			},
 		}
 	);
 };


### PR DESCRIPTION
#### Issue

Our current configuration of React Query Client is saving the "latest" state of the queries in IndexDB.
This was showing an incorrect state when you added or removed an SSH key and refreshed the page immediately.

p1666182783182739-slack-C0347E545HR

The React Query persistence was introduced in these PRs.
- https://github.com/Automattic/wp-calypso/pull/56828
- https://github.com/Automattic/wp-calypso/pull/68187

To avoid persisting a given query, we can add a meta property `persist: false` which was introduced on React Query by @zaguiini in https://github.com/TanStack/query/pull/2818

#### Proposed Changes

* Add the option : `{ meta: { persist: false } }` in the SSH queries.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**SSH on user profile**
1. Go to `/me/security/ssh-key`
2. add or remove a SSH key
3. Refresh the browser
4. Observe the placeholder loading state appears. Before this PR it was showing an incorrect state while the query was fetching.

**SSH on an atomic site**
1. Select an atomic site
2. Go to `Preferences > Hosting Configuration`
3. Enable SSH
4. Add or remove a SSH Key
5. Refresh the browser
6. Observe a spinner while the query is loading. Before this PR it was showing an incorrect state while the query was fetching.

**Alternatively, you can check that the queries `` and `` are not saved on `indexedDB`.**
1. Go to `/me/security/ssh-key` or Hosting Configuration.
2. Open Chrome Dev Tools.
3. Go to Application > IndexedDB > Calypso Store.
4. Open `query-state-*`.
5. Observe that the queries with queryHash `["me","ssh-keys"]` and `["atomic-ssh-keys", *]` don't exist anymore.

<img width="1269" alt="Screenshot 2022-10-19 at 19 08 32" src="https://user-images.githubusercontent.com/779993/196771231-31064200-d567-4fa7-86af-80d93e0d5ed2.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->