### PR TITLE
WPCOM SSH: Fire Tracks events when attaching or detaching SSH keys

### DIFF
--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -2,6 +2,9 @@ import { Button, Card } from '@automattic/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import i18n from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { AtomicKey } from './use-atomic-ssh-keys';
 import { useDetachSshKeyMutation } from './use-detach-ssh-key';
 
@@ -11,9 +14,44 @@ interface SshKeyCardProps {
 	sshKey: AtomicKey;
 }
 
+const noticeOptions = {
+	duration: 3000,
+};
+
+const sshKeyDetachFailureNoticeId = 'ssh-key-detach-failure';
+
 function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
 	const { __ } = useI18n();
-	const { mutate: detachSshKey, isLoading } = useDetachSshKeyMutation( { siteId } );
+	const dispatch = useDispatch();
+	const { detachSshKey, isLoading } = useDetachSshKeyMutation(
+		{ siteId },
+		{
+			onMutate: () => {
+				dispatch( removeNotice( sshKeyDetachFailureNoticeId ) );
+			},
+			onSuccess: () => {
+				dispatch( recordTracksEvent( 'calypso_hosting_configuration_ssh_key_detach_success' ) );
+				dispatch( successNotice( __( 'SSH key detached from site.' ), noticeOptions ) );
+			},
+			onError: ( error ) => {
+				dispatch(
+					recordTracksEvent( 'calypso_hosting_configuration_ssh_key_detach_failure', {
+						code: error.code,
+					} )
+				);
+				dispatch(
+					errorNotice(
+						// translators: "reason" is why adding the ssh key failed.
+						sprintf( __( 'Failed to detach SSH key: %(reason)s' ), { reason: error.message } ),
+						{
+							...noticeOptions,
+							id: sshKeyDetachFailureNoticeId,
+						}
+					)
+				);
+			},
+		}
+	);
 	const { sha256, user_login, name, attached_at } = sshKey;
 	return (
 		<Card className="ssh-keys-card">

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -1,12 +1,15 @@
 import { Button, Spinner } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import { useSSHKeyQuery } from 'calypso/me/security-ssh-key/use-ssh-key-query';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import SshKeyCard from './ssh-key-card';
 import { useAtomicSshKeys } from './use-atomic-ssh-keys';
 import { useAttachSshKeyMutation } from './use-attach-ssh-key';
@@ -19,13 +22,45 @@ interface SshKeysProps {
 	disabled: boolean;
 }
 
+const noticeOptions = {
+	duration: 3000,
+};
+
+const sshKeyAttachFailureNoticeId = 'ssh-key-attach-failure';
+
 function SshKeys( { siteId, username, disabled }: SshKeysProps ) {
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 	const { data: keys, isLoading: isLoadingKeys } = useAtomicSshKeys( siteId, {
 		enabled: ! disabled,
 	} );
 	const { data: userKeys, isLoading: isLoadingUserKeys } = useSSHKeyQuery();
-	const { mutate: attachSshKey, isLoading: attachingKey } = useAttachSshKeyMutation( siteId );
+	const { attachSshKey, isLoading: attachingKey } = useAttachSshKeyMutation( siteId, {
+		onMutate: () => {
+			dispatch( removeNotice( sshKeyAttachFailureNoticeId ) );
+		},
+		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_ssh_key_attach_success' ) );
+			dispatch( successNotice( __( 'SSH key attached to site.' ), noticeOptions ) );
+		},
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_ssh_key_attach_failure', {
+					code: error.code,
+				} )
+			);
+			dispatch(
+				errorNotice(
+					// translators: "reason" is why adding the ssh key failed.
+					sprintf( __( 'Failed to attach SSH key: %(reason)s' ), { reason: error.message } ),
+					{
+						...noticeOptions,
+						id: sshKeyAttachFailureNoticeId,
+					}
+				)
+			);
+		},
+	} );
 
 	const [ selectedKey, setSelectedKey ] = useState( 'default' );
 	function onChangeSelectedKey( event: React.ChangeEvent< HTMLSelectElement > ) {

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -124,7 +124,16 @@ function SshKeys( { siteId, username, disabled }: SshKeysProps ) {
 					{ createInterpolateElement(
 						__( '<a>Add an SSH key to your account</a> in order to use it with this site.' ),
 						{
-							a: <a href="/me/security/ssh-key" />,
+							a: (
+								<a
+									href="/me/security/ssh-key"
+									onClick={ () => {
+										dispatch(
+											recordTracksEvent( 'calypso_hosting_configuration_add_ssh_key_link_click' )
+										);
+									} }
+								/>
+							),
 						}
 					) }
 				</div>

--- a/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
 import wp from 'calypso/lib/wp';
 import { USE_ATOMIC_SSH_KEYS_QUERY_KEY } from './use-atomic-ssh-keys';
@@ -6,13 +7,22 @@ interface MutationVariables {
 	name: string;
 }
 
+interface MutationResponse {
+	message: string;
+}
+
+interface MutationError {
+	code: string;
+	message: string;
+}
+
 export const useAttachSshKeyMutation = (
 	siteId: number,
-	options: UseMutationOptions< void, void, MutationVariables > = {}
+	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	return useMutation(
-		( { name }: MutationVariables ) =>
+	const mutation = useMutation(
+		async ( { name }: MutationVariables ) =>
 			wp.req.post( {
 				path: `/sites/${ siteId }/hosting/ssh-keys`,
 				apiNamespace: 'wpcom/v2',
@@ -26,4 +36,10 @@ export const useAttachSshKeyMutation = (
 			},
 		}
 	);
+
+	const { mutate, isLoading } = mutation;
+
+	const attachSshKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
+
+	return { attachSshKey, isLoading };
 };

--- a/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
 import wp from 'calypso/lib/wp';
 import { USE_ATOMIC_SSH_KEYS_QUERY_KEY } from './use-atomic-ssh-keys';
@@ -7,13 +8,22 @@ interface MutationVariables {
 	name: string;
 }
 
+interface MutationResponse {
+	message: string;
+}
+
+interface MutationError {
+	code: string;
+	message: string;
+}
+
 export const useDetachSshKeyMutation = (
 	{ siteId }: { siteId: number },
-	options: UseMutationOptions< void, void, MutationVariables > = {}
+	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
-	return useMutation(
-		( { user_login, name }: MutationVariables ) => {
+	const mutation = useMutation(
+		async ( { user_login, name }: MutationVariables ) => {
 			return wp.req.post( {
 				path: `/sites/${ siteId }/hosting/ssh-keys/${ user_login }/${ name }`,
 				apiNamespace: 'wpcom/v2',
@@ -28,4 +38,9 @@ export const useDetachSshKeyMutation = (
 			},
 		}
 	);
+	const { mutate, isLoading } = mutation;
+
+	const detachSshKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
+
+	return { detachSshKey, isLoading };
 };


### PR DESCRIPTION
See #68204

## Proposed Changes

Fires Tracks events when clicking the 'Add an SSH key to your account' link, or attaching/detaching SSH keys:
* `calypso_hosting_configuration_add_ssh_key_link_click`
* `calypso_hosting_configuration_ssh_key_attach_success`
* `calypso_hosting_configuration_ssh_key_attach_failure` - `{ code: error.code }`
* `calypso_hosting_configuration_ssh_key_detach_success`
* `calypso_hosting_configuration_ssh_key_detach_failure` - `{ code: error.code }`

It also adds notices for various events:

<img width="1515" alt="image" src="https://user-images.githubusercontent.com/36432/196792288-22e71c6e-2016-4078-a621-e8e2507bc918.png">

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/36432/196791877-99b1f6ef-4e41-4d04-b1b7-26ea0a821fce.png">

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/36432/196791994-1aecc914-686f-4392-bd2b-c83b2c123587.png">

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/36432/196792166-ebf9644c-7742-4007-a1bc-e954abb4a651.png">


## Testing Instructions

1. Click around in `/hosting-config` and make sure you see the events you expect.