### PR TITLE
WPCOM SSH: Enable for all environments

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -54,7 +53,7 @@ class SecurityCheckupComponent extends Component {
 					<SecurityCheckupTwoFactorBackupCodes />
 					<SecurityCheckupAccountRecoveryEmail />
 					<SecurityCheckupAccountRecoveryPhone />
-					{ isEnabled( 'hosting/ssh-keys' ) && <SecurityCheckupSSHKey /> }
+					<SecurityCheckupSSHKey />
 				</VerticalNav>
 
 				<SectionHeader label={ translate( 'Connections' ) } className="security-checkup__info" />

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -35,7 +35,5 @@ export default function () {
 
 	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
 
-	if ( isEnabled( 'hosting/ssh-keys' ) ) {
-		page( '/me/security/ssh-key', sidebar, sshKey, makeLayout, clientRender );
-	}
+	page( '/me/security/ssh-key', sidebar, sshKey, makeLayout, clientRender );
 }

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
 import { Card, Button, Gridicon, Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -387,7 +386,7 @@ export const SftpCard = ( {
 						<FormLabel className="sftp-card__ssh-label">{ translate( 'SSH Access' ) }</FormLabel>
 					) }
 					{ siteHasSshFeature && renderSshField() }
-					{ siteHasSshFeature && isSshAccessEnabled && isEnabled( 'hosting/ssh-keys' ) && (
+					{ siteHasSshFeature && isSshAccessEnabled && (
 						<SshKeys disabled={ disabled } siteId={ siteId } />
 					) }
 				</FormFieldset>

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,6 @@
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,
-		"hosting/ssh-keys": true,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,6 @@
 		"happychat": false,
 		"help": true,
 		"home/layout-dev": true,
-		"hosting/ssh-keys": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"inline-help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -44,7 +44,6 @@
 		"google-my-business": true,
 		"happychat": true,
 		"help": true,
-		"hosting/ssh-keys": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"inline-help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"happychat": true,
-		"hosting/ssh-keys": false,
 		"help": true,
 		"i18n/empathy-mode": true,
 		"inline-help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,6 @@
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,
-		"hosting/ssh-keys": true,
 		"i18n/translation-scanner": true,
 		"importers/substack": true,
 		"inline-help": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1068

## Proposed Changes

Enables SSH keys for all environments.

## Testing Instructions

1. Make sure you can add and attach SSH keys still.