### PR TITLE
Overrides the Premium Badge css

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
@@ -4,6 +4,9 @@
 	justify-content: center;
 	.premium-badge {
 		font-family: $sans;
+		background: var(--studio-black);
+		padding: 0 10px 0 9px;
+		margin-left: 10px;
 	}
 	.woocommerce-bundled-badge {
 		margin-left: 10px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -254,6 +254,10 @@
 			margin: 0;
 		}
 	}
+	.design-picker__override-premium-badge .premium-badge {
+		background: var(--studio-black);
+		padding: 0 10px 0 9px;
+	}
 
 	.design-picker__button-link.components-button.is-link {
 		text-decoration: none;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -151,7 +151,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		}
 
 		return (
-			<div className="design-picker__pricing-description">
+			<div className="design-picker__pricing-description design-picker__override-premium-badge">
 				{ badge }
 				<span>{ text }</span>
 			</div>


### PR DESCRIPTION
#### Proposed Changes

* Overrides the Premium Badge CSS to mitigate a problem that was causing it to be transparent.

#### Testing Instructions
* Create a new site on `/start`.
* Go through the flow to the `setup/designSetup` step.
* Look for a premium theme. The premium badge should be visible.
* Click on the premium theme, on the theme preview, the premium badge should also be visible right next to the theme name.

Before:
![Screen Shot 2022-10-19 at 18 24 12](https://user-images.githubusercontent.com/1234758/196807448-aa5140d7-6e1a-4273-bc32-f258416207e5.png)
![Screen Shot 2022-10-19 at 18 24 08](https://user-images.githubusercontent.com/1234758/196807479-5049dd72-0314-448b-8ab2-44b0181c4481.png)

After:
![Screen Shot 2022-10-19 at 18 25 13](https://user-images.githubusercontent.com/1234758/196807574-0c7f8d01-0b40-4fbe-b0fb-4be60d4147ca.png)
![Screen Shot 2022-10-19 at 18 25 09](https://user-images.githubusercontent.com/1234758/196807582-3aadef04-5c97-4a05-95f1-a6be745e2f6d.png)

p1666211654846489-slack-C0Q664T29