### PR TITLE
Marketplace: Add current route to browse all / plugin click tracks events

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -101,6 +101,7 @@ const PluginsBrowserListElement = ( props ) => {
 			site: site,
 			plugin: plugin.slug,
 			list_name: props.listName,
+			list_type: props.listType,
 			grid_position: props.gridPosition,
 			blog_id: selectedSite?.ID,
 		} );

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -21,6 +21,7 @@ const PluginsBrowserList = ( {
 	site,
 	currentSites,
 	listName,
+	listType,
 	browseAllLink,
 	size,
 	search,
@@ -39,6 +40,7 @@ const PluginsBrowserList = ( {
 					plugin={ plugin }
 					currentSites={ currentSites }
 					listName={ listName }
+					listType={ listType }
 					variant={
 						extended ? PluginsBrowserElementVariant.Extended : PluginsBrowserElementVariant.Compact
 					}

--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -39,6 +39,7 @@ export default function CollectionListView( {
 	return (
 		<PluginsBrowserList
 			listName={ 'collection-' + category }
+			listType="collection"
 			plugins={ plugins.current || [] }
 			size={ plugins.current?.length }
 			title={ categories[ category ].title }

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -65,6 +65,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) =>
 		<PluginsBrowserList
 			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
 			listName={ category }
+			listType="discovery"
 			title={ categoryName }
 			subtitle={ categoryDescription }
 			site={ siteSlug }

--- a/client/my-sites/plugins/plugins-category-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-category-results-page/index.jsx
@@ -37,6 +37,7 @@ const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
 				resultCount={ resultCount }
 				plugins={ plugins }
 				listName={ category }
+				listType="browse"
 				site={ siteSlug }
 				showPlaceholders={ isFetching }
 				currentSites={ sites }

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -117,6 +117,7 @@ const PluginsSearchResultPage = ( {
 				<PluginsBrowserList
 					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
 					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
+					listType="search"
 					title={ translate( 'Search Results' ) }
 					subtitle={
 						<>


### PR DESCRIPTION
#### Proposed Changes

We identified the need for adding current path / route to plugin click events.

#### Tasks
- [x] Add a list_type property to plugin click event properties calypso_plugin_browser_item_click
- [x] Set "browse", "collection", "discover", and "search" appropriately. (This probably requires some prop drilling along the same path listName/list_name takes.)

#### Testing Instructions

- You need to see the `calypso_plugin_browser_item_click` track events. You can follow [this guide](PCYsg-cae-p2), or use [Tracks vigilante](p7H4VZ-3cB-p2)
- Go to [/plugins](http://calypso.localhost:3000/plugins/)
- Click on any plugin from `Must-have premium plugins`, `Our developers’ favorites`, or `The free essentials`sections, and you should receive the `discover` as a `list-type` 
<img width="1524" alt="image" src="https://user-images.githubusercontent.com/402286/196836673-fa72ba8b-aeef-4e86-8eb9-8bce088e6c87.png">

- Try searching, browsing a category or clicking on a plugin in a `collection`. You should see these `list-type`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69051