### PR TITLE
KPI: update `CalypsoPreReleaseDashboard` configuration with correct artifact dependencies.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1018,12 +1018,13 @@ object CalypsoPreReleaseDashboard : BuildType({
 		bashNodeScript {
 			name = "Install AWS CLI"
 			scriptContent = """
-				// curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-				// unzip awscliv2.zip \
-				// sudo ./aws/install
-
-				// aws --version
 				ls -la %teamcity.build.checkoutDir%/bin/
+				curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+				unzip awscliv2.zip \
+				sudo ./aws/install
+
+				aws --version
+
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -992,14 +992,25 @@ object CalypsoPreReleaseDashboard : BuildType({
 	name = "Calypso Pre-Release Dashboard"
 	description = "Generate Dashboard for Pre-Release Tests"
 
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = false
+	}
+
 	dependencies {
 		artifacts (KPIDashboardTests) {
+			artifactRules = """
+				allure-results.tgz!*.json => allure-results
+			"""
+		}
+		snapshot ( KPIDashboardTests) {
 		}
 	}
 
 	triggers {
 		finishBuildTrigger {
-	    	buildType = "Calypso_E2E_KPI_Dashboard"
+	    	buildType = "KPIDashboardTests"
+			branchFilter = "+:trunk"
 		}
 	}
 
@@ -1007,11 +1018,12 @@ object CalypsoPreReleaseDashboard : BuildType({
 		bashNodeScript {
 			name = "Install AWS CLI"
 			scriptContent = """
-				curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-				unzip awscliv2.zip \
-				sudo ./aws/install
+				// curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+				// unzip awscliv2.zip \
+				// sudo ./aws/install
 
-				aws --version
+				// aws --version
+				ls -la %teamcity.build.checkoutDir%/bin/
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -1,5 +1,6 @@
 /**
  * @group calypso-pr
+ * @group kpi
  */
 
 import { DataHelper } from '@automattic/calypso-e2e';


### PR DESCRIPTION
#### Proposed Changes

This is one part of many where I hope to construct a build chain consisting of KPIDashboardTests and CalypsoPreReleaseDashboard.

I am making a PR and merging to trunk for experimentation because TeamCity has been experiencing issues using VCS as the source of configuration truth. This means my changes are not actually loaded by TeamCity when I trigger a build, which is a problem as my experimentation for the KPI dashboard requires a build chain to be set up.

For context, see the [Systems Request](pMz3w-gcN-p2) and [Slack](p1666238516078539/1666118837.142499-slack-C1A1EKDGQ).

Key changes:
- updated artifact rules of CalypsoPreReleaseDashboard.
- added snapshot dependency for CalypsoPreReleaseDashboard.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #