### PR TITLE
CI: update TeamCity setting version and use correct prefix for ids.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -270,7 +270,7 @@ object BuildDockerImage : BuildType({
 })
 
 object RunAllUnitTests : BuildType({
-	id = id("calypso_WebApp_Run_All_Unit_Tests")
+	id("calypso_WebApp_Run_All_Unit_Tests")
 	uuid = "beb75760-2786-472b-8909-ec33457bdece"
 	name = "Unit tests"
 	description = "Run unit tests (client + server + packages)"
@@ -505,7 +505,7 @@ object RunAllUnitTests : BuildType({
 })
 
 object CheckCodeStyleBranch : BuildType({
-	id = id("calypso_WebApp_Check_Code_Style_Branch")
+	id("calypso_WebApp_Check_Code_Style_Branch")
 	uuid = "dfee7987-6bbc-4250-bb10-ef9dd7322bd2"
 	name = "Code style"
 	description = "Check code style"
@@ -616,7 +616,7 @@ object CheckCodeStyleBranch : BuildType({
 })
 
 object Translate : BuildType({
-	id = id("calypso_WebApp_Translate")
+	id("calypso_WebApp_Translate")
 	name = "Translate"
 	description = "Extract translatable strings from the source code and build POT file"
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -270,6 +270,7 @@ object BuildDockerImage : BuildType({
 })
 
 object RunAllUnitTests : BuildType({
+	id = id("calypso_WebApp_Run_All_Unit_Tests")
 	uuid = "beb75760-2786-472b-8909-ec33457bdece"
 	name = "Unit tests"
 	description = "Run unit tests (client + server + packages)"
@@ -504,6 +505,7 @@ object RunAllUnitTests : BuildType({
 })
 
 object CheckCodeStyleBranch : BuildType({
+	id = id("calypso_WebApp_Check_Code_Style_Branch")
 	uuid = "dfee7987-6bbc-4250-bb10-ef9dd7322bd2"
 	name = "Code style"
 	description = "Check code style"
@@ -614,6 +616,7 @@ object CheckCodeStyleBranch : BuildType({
 })
 
 object Translate : BuildType({
+	id = id("calypso_WebApp_Translate")
 	name = "Translate"
 	description = "Extract translatable strings from the source code and build POT file"
 
@@ -725,7 +728,7 @@ object Translate : BuildType({
 
 fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildType {
 	return E2EBuildType(
-		buildId = "Calypso_E2E_Playwright_$targetDevice",
+		buildId = "calypso_WebApp_Calypso_E2E_Playwright_$targetDevice",
 		buildUuid = buildUuid,
 		buildName = "E2E Tests ($targetDevice)",
 		buildDescription = "Runs Calypso e2e tests on $targetDevice size",
@@ -773,7 +776,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 }
 
 object PreReleaseE2ETests : E2EBuildType(
-	buildId = "Calypso_E2E_Pre_Release",
+	buildId = "calypso_WebApp_Calypso_E2E_Pre_Release",
 	buildUuid = "9c2f634f-6582-4245-bb77-fb97d9f16533",
 	buildName = "Pre-Release E2E Tests",
 	buildDescription = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production.",
@@ -802,7 +805,7 @@ object PreReleaseE2ETests : E2EBuildType(
 )
 
 object AuthenticationE2ETests : E2EBuildType(
-	buildId = "Calypso_E2E_Authentication",
+	buildId = "calypso_WebApp_Calypso_E2E_Authentication",
 	buildUuid = "f5036e29-f400-49ea-b5c5-4aba9307c5e8",
 	buildName = "Authentication E2E Tests",
 	buildDescription = "Runs a suite of Authentication E2E tests.",
@@ -840,7 +843,7 @@ object AuthenticationE2ETests : E2EBuildType(
 )
 
 object HelpCentreE2ETests : E2EBuildType(
-	buildId = "Calypso_E2E_Help_Centre",
+	buildId = "calypso_WebApp_Calypso_E2E_Help_Centre",
 	buildUuid = "a0e62582-8598-483e-8b82-9de540288f6d",
 	buildName = "Help Centre E2E Tests",
 	buildDescription = "Runs a suite of Help Centre E2E tests.",
@@ -877,7 +880,7 @@ object HelpCentreE2ETests : E2EBuildType(
 )
 
 object KPIDashboardTests : BuildType({
-	id("Calypso_E2E_KPI_Dashboard")
+	id("calypso_WebApp_Calypso_E2E_KPI_Dashboard")
 	uuid = "441efac5-721a-4557-9448-9234e89fb6b1"
 	name = "Test build for KPI Dashboard project"
 	description = "Test build configuration for KPI dashboard."
@@ -987,7 +990,7 @@ object KPIDashboardTests : BuildType({
 })
 
 object CalypsoPreReleaseDashboard : BuildType({
-	id("Calypso_Dashboard_Pre_Release_Dashboard")
+	id("calypso_WebApp_Calypso_Dashboard_Pre_Release_Dashboard")
 	uuid = "e07c2ff3-2a9f-416e-9a03-637690334da8"
 	name = "Calypso Pre-Release Dashboard"
 	description = "Generate Dashboard for Pre-Release Tests"
@@ -1019,7 +1022,7 @@ object CalypsoPreReleaseDashboard : BuildType({
 })
 
 object QuarantinedE2ETests: E2EBuildType(
-	buildId = "Quarantined_E2E_Tests",
+	buildId = "calypso_WebApp_Quarantined_E2E_Tests",
 	buildUuid = "14083675-b6de-419f-b2f6-ec89c06d3a8c",
 	buildName = "Quarantined E2E Tests",
 	buildDescription = "E2E tests quarantined due to intermittent failures.",

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -42,7 +42,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2021.1"
+version = "2022.04"
 
 project {
 


### PR DESCRIPTION
#### Proposed Changes

This PR updates the TeamCity setting version to the newest available version as well as fix the prefix for Calypso > Web App subprojects.

Due to recent issues with TeamCity and VCS settings (noted in pMz3w-gcN-p2), it is hoped that by correcting the prefix we can return to using the `use settings from VCS` option.

Key changes:
- update setting version to 2022.04.
- apply calypso_WebApp_ prefix to all build configurations under Calypso > Web App.

![image](https://user-images.githubusercontent.com/6549265/196829521-d91d55cc-59ff-421a-a2c8-52085d3eb3bf.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #