### PR TITLE
Style selection: Updated design preview's style section text

### DIFF
--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -35,8 +35,8 @@ const Sidebar: React.FC< SidebarProps > = ( {
 
 			{ variations.length > 0 && (
 				<div className="design-preview__sidebar-variations">
-					<h2>{ translate( 'Style variations' ) }</h2>
-					<p>{ translate( 'Choose a variation to change the look of the site.' ) }</p>
+					<h2>{ translate( 'Choose your style' ) }</h2>
+					<p>{ translate( 'You can change your style at any time.' ) }</p>
 					<div className="design-preview__sidebar-variations-grid">
 						<StyleVariationPreviews
 							variations={ variations }


### PR DESCRIPTION
#### Proposed Changes

This PR updates the styles section of the design preview.
| Before | After |
| --- | --- |
|  ![Screen Shot 2022-10-19 at 5 38 28 PM](https://user-images.githubusercontent.com/797888/196655761-83d38bd7-bb7d-4f9d-ac91-1d7ed898f967.png)  |  ![Screen Shot 2022-10-19 at 5 39 48 PM](https://user-images.githubusercontent.com/797888/196655967-afd4e562-0d0f-47ad-a77c-e066daddbf4c.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Preview any design with style variations.
* Ensure that the copy is updated as described above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
