### PR TITLE
Purchase Management: Fix visual consistency across purchase management section

### DIFF
--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -11,6 +11,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import titles from 'calypso/me/purchases/titles';
@@ -71,7 +72,7 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 	}, [ stoppingStatus, dispatch, translate, isProduct ] );
 
 	return (
-		<Main wideLayout className="memberships__subscription">
+		<Main wideLayout className="manage-purchase memberships__subscription">
 			<DocumentHead
 				title={ isProduct ? translate( 'Product Details' ) : translate( 'Subscription Details' ) }
 			/>
@@ -135,13 +136,14 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 					</Card>
 					<CompactCard
 						tagName="button"
-						className="memberships__subscription-remove"
+						className="remove-purchase__card"
 						onClick={ stopSubscription }
 					>
+						<MaterialIcon icon="delete" className="card__icon" />
 						{ isProduct
-							? translate( 'Remove %s product.', { args: subscription.title } )
-							: translate( 'Stop %s subscription.', { args: subscription.title } ) }
-						<Gridicon className="card__link-indicator" icon="trash" />
+							? translate( 'Remove %s product', { args: subscription.title } )
+							: translate( 'Stop %s subscription', { args: subscription.title } ) }
+						<Gridicon className="card__link-indicator" icon="chevron-right" />
 					</CompactCard>
 				</>
 			) }

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -115,20 +115,3 @@
 		font-size: 0.75rem;
 	}
 }
-
-.memberships__subscription-remove {
-	color: var(--color-error);
-	text-align: left;
-	width: 100%;
-	cursor: hand;
-
-	&:active,
-	&:focus,
-	&:hover {
-		color: var(--color-error-60);
-	}
-
-	.accessible-focus &:focus {
-		box-shadow: 0 0 0 2px var(--color-error-light);
-	}
-}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -318,7 +318,7 @@ class ManagePurchase extends Component {
 		);
 		return this.renderRenewalNavItem(
 			<div>
-				{ translate( 'Renew Annually' ) }
+				{ translate( 'Renew annually' ) }
 				<Badge className="manage-purchase__savings-badge" type="success">
 					{ translate( '%(savings)d%% cheaper than monthly', {
 						args: {
@@ -333,7 +333,7 @@ class ManagePurchase extends Component {
 
 	renderRenewMonthlyNavItem() {
 		const { translate } = this.props;
-		return this.renderRenewalNavItem( translate( 'Renew Monthly' ), this.handleRenewMonthly );
+		return this.renderRenewalNavItem( translate( 'Renew monthly' ), this.handleRenewMonthly );
 	}
 
 	handleUpgradeClick = () => {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -386,7 +386,7 @@ class ManagePurchase extends Component {
 				: translate( 'Pick another product' );
 		} else {
 			iconName = 'upload';
-			buttonText = translate( 'Upgrade plan' );
+			buttonText = isUpgradeablePlan ? translate( 'Upgrade plan' ) : translate( 'Upgrade product' );
 		}
 
 		const upgradeUrl = this.getUpgradeUrl();


### PR DESCRIPTION
#### Proposed Changes

This PR fixes a number of small visual issues reported in https://github.com/Automattic/wp-calypso/issues/68921

They include:

**Payment block 'Stop %s Subscription' spacing** 

![image](https://user-images.githubusercontent.com/16580129/196832754-73731943-535a-4f37-b01c-b4ef0e8473de.png)

**Match the capitalization of 'Renew Annually/Monthly' to match other button text casing**

![image](https://user-images.githubusercontent.com/16580129/196832873-e242de85-1800-4f1f-96ac-a4570f086c7a.png)

**Change text for products to show 'Upgrade product' rather than 'plan'**

![image](https://user-images.githubusercontent.com/16580129/196832929-88165453-e989-426e-a191-22f6f0130550.png)


#### Testing Instructions

You can [sandbox Store](PCYsg-IA-p2) for all three tests.

**Payment block 'Stop %s Subscription' spacing** 
- Sandbox store and add a payment block following these steps PCYsg-lW4-p2
- Make a test donation so that it shows in your Purchases section
- Click through to the singular Subscription management page (the URL should look like http://calypso.localhost:3000/me/purchases/other/12105566)
- Visually check that the `Stop %s Subscription` button matches the button styling shown below

![image](https://user-images.githubusercontent.com/16580129/196833688-177669ae-d8cf-430a-942c-f6dd60814a29.png)

**Match the capitalization of 'Renew Annually/Monthly' to match other button text casing**
- Add an annual WordPress.com subscription
- Go to Store Admin and change its expiration so it is within a day or two of expiration
- Go to Purchases and click on the subscription, under its plan management page you should see 'Renew annually' and 'Renew monthly' where the second word is lowercase.

![image](https://user-images.githubusercontent.com/16580129/196834364-c8fee7c8-0794-46f7-afb6-5239964eb0df.png)

**Change text for products to show 'Upgrade product' rather than 'plan'**
- This may require you to have a pressable site, or just a self-hosted site, in order to add a Jetpack product that is not already bundled in our plans
- Go to self-hosted site and connect Jetpack, then under My Jetpack, add Jetpack Backup
- Now, go to WordPress.com -> Purchases and click on the Backup product (re: product, not plan)
- On the product management page, the 'Upgrade' option should read 'Upgrade product'

![image](https://user-images.githubusercontent.com/16580129/196835446-a47b26bb-1d85-4673-bd0e-ef3d2d148d47.png)

Note: It also reads 'Remove subscription'. I figure this is okay because the product _is_ a subscription (i.e. it can renew regularly) whereas it is not technically a plan.


Related to https://github.com/Automattic/wp-calypso/issues/68921